### PR TITLE
PFHCALDenseIdNavigator update

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -36,6 +36,7 @@ public:
         hcalToken_(cc.esConsumes<edm::Transition::BeginRun>()),
         geomToken_(cc.esConsumes<edm::Transition::BeginRun>()) {}
 
+  // Initialization
   void init(const edm::EventSetup& iSetup) override {
     bool check = theRecNumberWatcher_.check(iSetup);
     if (!check)
@@ -68,7 +69,6 @@ public:
     neighboursHcal_.resize(denseIdHcalMax_ - denseIdHcalMin_ + 1);
 
     for (auto denseid : vDenseIdHcal) {
-      
       std::vector<DetId> neighbours(9, DetId(0));
 
       // the centre
@@ -93,8 +93,16 @@ public:
       unsigned index = getIdx(denseid_c);
       neighboursHcal_[index] = neighbours;
 
-    }
+    }  // for denseid vDenseIdHcal
 
+    if (debug) {
+      backwardCompatibilityCheck(vDenseIdHcal);
+      printNeighbourInfo(vDenseIdHcal);
+    }
+  }
+
+  // Check neighbour
+  void backwardCompatibilityCheck(const std::vector<unsigned int> vDenseIdHcal) {
     //
     // Check backward compatibility (does a neighbour of a channel have the channel as a neighbour?)
     //
@@ -102,17 +110,17 @@ public:
       DetId detid = topology_.get()->denseId2detId(denseid);
       HcalDetId hid = HcalDetId(detid);
       if (detid == DetId(0)) {
-        std::cout << "WARNING SHOULD NOT HAPPEN1" << std::endl;
+        edm::LogWarning("PFHCALDenseIdNavigator") << "Found an invalid DetId";
         continue;
       }
       if (!validNeighbours(denseid)) {
-        std::cout << "WARNING SHOULD NOT HAPPEN2" << std::endl;
+        edm::LogWarning("PFHCALDenseIdNavigator") << "The vector for neighbour information has an invalid length";
         continue;
       }
       std::vector<DetId> neighbours(9, DetId(0));
       unsigned index = getIdx(denseid);
       if (index >= neighboursHcal_.size()) {
-        std::cout << "WARNING SHOULD NOT HAPPEN3" << std::endl;
+        edm::LogWarning("PFHCALDenseIdNavigator") << "The vector for neighbour information is not found";
         continue;  // Skip if not found
       }
       neighbours = neighboursHcal_.at(index);
@@ -124,13 +132,19 @@ public:
         ineighbour++;
         if (neighbour == DetId(0))
           continue;
-	HcalDetId hidn = HcalDetId(neighbour);
+        HcalDetId hidn = HcalDetId(neighbour);
         std::vector<DetId> neighboursOfNeighbour(9, DetId(0));
         std::unordered_set<unsigned int> listOfNeighboursOfNeighbour;  // list of neighbours of neighbour
         unsigned denseidNeighbour = topology_.get()->detId2denseId(neighbour);
 
-        if (!validNeighbours(denseidNeighbour))
+        if (!validNeighbours(denseidNeighbour)) {
+          edm::LogWarning("PFHCALDenseIdNavigator")
+              << "This neighbour does not have a valid neighbour information (another subdetector?). Ignore: "
+              << detid.det() << " " << hid.ieta() << " " << hid.iphi() << " " << hid.depth() << " " << neighbour.det()
+              << " " << hidn.ieta() << " " << hidn.iphi() << " " << hidn.depth();
+          neighboursHcal_[index][ineighbour] = DetId(0);  // not a valid neighbour. set to a DetId(0)
           continue;
+        }
         if (getIdx(denseidNeighbour) >= neighboursHcal_.size())
           continue;
         neighboursOfNeighbour = neighboursHcal_.at(getIdx(denseidNeighbour));
@@ -148,18 +162,20 @@ public:
 
         //
         if (listOfNeighboursOfNeighbour.find(denseid) == listOfNeighboursOfNeighbour.end()) {
-          // this neighbour is not backward compatible. ignore in the canse of HE phi segmentation change boundary
-          if (hid.subdet() == HcalBarrel || hid.subdet() == HcalEndcap) {
-	    std::cout << "This neighbor does not have the original channel as its neighbor. Ignore: "
-		      << detid.det() << " " << hid.ieta() << " " << hid.iphi() << " " << hid.depth() << " "
-		      << neighbour.det() << " " << hidn.ieta() << " " << hidn.iphi() << " " << hidn.depth()
-		      << std::endl;
-            neighboursHcal_[index][ineighbour] = DetId(0);
-          }
+          // This neighbour is not backward compatible.
+          edm::LogWarning("PFHCALDenseIdNavigator")
+              << "This neighbour does not have the original channel as its neighbour. Ignore: " << detid.det() << " "
+              << hid.ieta() << " " << hid.iphi() << " " << hid.depth() << " " << neighbour.det() << " " << hidn.ieta()
+              << " " << hidn.iphi() << " " << hidn.depth();
+          neighboursHcal_[index][ineighbour] = DetId(0);
         }
+
       }  // loop over neighbours
     }    // loop over denseId_
+  }
 
+  // Print out neighbour DetId's
+  void printNeighbourInfo(const std::vector<unsigned int> vDenseIdHcal) {
     //
     // Print final neighbour definitions
     //
@@ -172,6 +188,7 @@ public:
       CaloNavigator<DET> navigator(detid_c, topology_.get());
 
       unsigned index = getIdx(denseid_c);
+
       neighbours = neighboursHcal_[index];
 
       const DetId N = neighbours.at(NORTH);
@@ -179,135 +196,136 @@ public:
       const DetId E = neighbours.at(EAST);
       const DetId W = neighbours.at(WEST);
 
-      DetId NE = neighbours.at(NORTHEAST); if (NE==E && E!=DetId(0)){ NE = DetId(0); printf("Duplicate A\n");}
-      DetId SW = neighbours.at(SOUTHWEST); if (SW==W && W!=DetId(0)){ SW = DetId(0); printf("Duplicate B\n");}
-      DetId SE = neighbours.at(SOUTHEAST); if (SE==E && E!=DetId(0)){ SE = DetId(0); printf("Duplicate C\n");}
-      DetId NW = neighbours.at(NORTHWEST); if (NW==W && W!=DetId(0)){ NW = DetId(0); printf("Duplicate D\n");}
-      
-      printf("navi: %d %d %d %d: %d %d %d %d, %d %d %d %d, %d %d %d %d, %d %d %d %d:  %d %d %d %d, %d %d %d %d, %d %d %d %d, %d %d %d %d\n",
-	     HcalDetId(detid_c).ieta(),HcalDetId(detid_c).iphi(),HcalDetId(detid_c).depth(),HcalDetId(detid_c).subdetId(),
-	     HcalDetId(N).ieta(),HcalDetId(N).iphi(),HcalDetId(N).depth(),HcalDetId(N).subdetId(),
-	     HcalDetId(E).ieta(),HcalDetId(E).iphi(),HcalDetId(E).depth(),HcalDetId(E).subdetId(),
-	     HcalDetId(S).ieta(),HcalDetId(S).iphi(),HcalDetId(S).depth(),HcalDetId(S).subdetId(),
-	     HcalDetId(W).ieta(),HcalDetId(W).iphi(),HcalDetId(W).depth(),HcalDetId(W).subdetId(),
-	     HcalDetId(NE).ieta(),HcalDetId(NE).iphi(),HcalDetId(NE).depth(),HcalDetId(NE).subdetId(),
-	     HcalDetId(SW).ieta(),HcalDetId(SW).iphi(),HcalDetId(SW).depth(),HcalDetId(SW).subdetId(),
-	     HcalDetId(SE).ieta(),HcalDetId(SE).iphi(),HcalDetId(SE).depth(),HcalDetId(SE).subdetId(),
-	     HcalDetId(NW).ieta(),HcalDetId(NW).iphi(),HcalDetId(NW).depth(),HcalDetId(NW).subdetId()
-	     );
-    } // print ends
+      const DetId NE = neighbours.at(NORTHEAST);
+      const DetId SW = neighbours.at(SOUTHWEST);
+      const DetId SE = neighbours.at(SOUTHEAST);
+      const DetId NW = neighbours.at(NORTHWEST);
 
+      edm::LogPrint("PFHCALDenseIdNavigator")
+          << "PFHCALDenseIdNavigator: " << HcalDetId(detid_c).ieta() << " " << HcalDetId(detid_c).iphi() << " "
+          << HcalDetId(detid_c).depth() << " " << HcalDetId(detid_c).subdetId() << ": " << HcalDetId(N).ieta() << " "
+          << HcalDetId(N).iphi() << " " << HcalDetId(N).depth() << " " << HcalDetId(N).subdetId() << ", "
+          << HcalDetId(E).ieta() << " " << HcalDetId(E).iphi() << " " << HcalDetId(E).depth() << " "
+          << HcalDetId(E).subdetId() << ", " << HcalDetId(S).ieta() << " " << HcalDetId(S).iphi() << " "
+          << HcalDetId(S).depth() << " " << HcalDetId(S).subdetId() << ", " << HcalDetId(W).ieta() << " "
+          << HcalDetId(W).iphi() << " " << HcalDetId(W).depth() << " " << HcalDetId(W).subdetId() << ", "
+          << HcalDetId(NE).ieta() << " " << HcalDetId(NE).iphi() << " " << HcalDetId(NE).depth() << " "
+          << HcalDetId(NE).subdetId() << ", " << HcalDetId(SW).ieta() << " " << HcalDetId(SW).iphi() << " "
+          << HcalDetId(SW).depth() << " " << HcalDetId(SW).subdetId() << ", " << HcalDetId(SE).ieta() << " "
+          << HcalDetId(SE).iphi() << " " << HcalDetId(SE).depth() << " " << HcalDetId(SE).subdetId() << ", "
+          << HcalDetId(NW).ieta() << " " << HcalDetId(NW).iphi() << " " << HcalDetId(NW).depth() << " "
+          << HcalDetId(NW).subdetId();
+
+    }  // print ends
   }
 
-  //
-  const bool checkSameSubDet(const DetId detId, const DetId detId2)
-  {
+  // Check if two DetId's have the same subdetId
+  const bool checkSameSubDet(const DetId detId, const DetId detId2) {
     HcalDetId hid = HcalDetId(detId);
     HcalDetId hid2 = HcalDetId(detId2);
-    return hid.subdetId()==hid2.subdetId();
+    return hid.subdetId() == hid2.subdetId();
   }
 
   //https://cmssdt.cern.ch/lxr/source/DataFormats/HcalDetId/interface/HcalDetId.h#0141
-  static constexpr int getZside(const DetId detId) {
-    return ((detId & HcalDetId::kHcalZsideMask2) ? (1) : (-1));
-  }
+  static constexpr int getZside(const DetId detId) { return ((detId & HcalDetId::kHcalZsideMask2) ? (1) : (-1)); }
 
-  //
+  // Obtain the neighbour's DetId
   const uint32_t getNeighbourDetId(const DetId detId, const uint32_t direction) {
-
     // desired order for PF: NORTH, SOUTH, EAST, WEST, NORTHEAST, SOUTHWEST, SOUTHEAST, NORTHWEST
-    if(detId == 0)
+    if (detId == 0)
       return 0;
 
-    if(direction == 0)  // NORTH
+    if (direction == 0)                        // NORTH
       return topology_.get()->goNorth(detId);  // larger iphi values (except phi boundary)
 
-    if(direction == 1)  // SOUTH
+    if (direction == 1)                        // SOUTH
       return topology_.get()->goSouth(detId);  // smaller iphi values (except phi boundary)
 
-    if(direction == 2 && checkSameSubDet(detId, topology_.get()->goEast(detId)))  // EAST
-      return topology_.get()->goEast(detId);  // smaller ieta values
+    // In the case of East/West, make sure we are not moving to another subdetector
+    if (direction == 2 && checkSameSubDet(detId, topology_.get()->goEast(detId)))  // EAST
+      return topology_.get()->goEast(detId);                                       // smaller ieta values
 
-    if(direction == 3 && checkSameSubDet(detId, topology_.get()->goWest(detId)))  // WEST
-      return topology_.get()->goWest(detId);  // larger ieta values
+    if (direction == 3 && checkSameSubDet(detId, topology_.get()->goWest(detId)))  // WEST
+      return topology_.get()->goWest(detId);                                       // larger ieta values
 
-    if(direction == 4) { // NORTHEAST
-      if (getZside(detId) > 0){  // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
-        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 2);
-	const DetId E = getNeighbourDetId(detId, 2);
-	const DetId NE = getNeighbourDetId(E, 0);
-	if (getNeighbourDetId(NE, 1) == E && NE != E) return NE; //
-      }
-      else { // negative eta: move in phi first then move to east (coarser phi granularity)
-        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 2);
- 	const DetId N = getNeighbourDetId(detId, 0);
-	const DetId NE = getNeighbourDetId(N, 2);
-	const DetId E = getNeighbourDetId(detId, 2);
-	if (getNeighbourDetId(NE, 3) == N && NE != E) return NE;
-      }
-    }
-    if(direction == 5) {  // SOUTHWEST
-      if (getZside(detId) > 0){  // positive eta: move in phi first then move to west (coarser phi granularity)
-        //return getNeighbourDetId(getNeighbourDetId(detId, 1), 3);
-	const DetId S = getNeighbourDetId(detId, 1);
-	const DetId SW = getNeighbourDetId(S, 3);
-	const DetId W = getNeighbourDetId(detId, 3);
-	if (getNeighbourDetId(SW, 2) == S && SW != W) return SW;
-      }
-      else { // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
-        //return getNeighbourDetId(getNeighbourDetId(detId, 3), 1);
-	const DetId W = getNeighbourDetId(detId, 3);
-	const DetId SW = getNeighbourDetId(W, 1);
-	if (getNeighbourDetId(SW, 0) == W && SW != W) return SW;
+    // In the case of cornor cells, ensure backward compatibility.
+    // Also make sure it's not already defined as E(ast) or W(est)
+    if (direction == 4) {         // NORTHEAST
+      if (getZside(detId) > 0) {  // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
+        const DetId E = getNeighbourDetId(detId, 2);
+        const DetId NE = getNeighbourDetId(E, 0);
+        if (getNeighbourDetId(NE, 1) == E && NE != E)
+          return NE;  //
+      } else {        // negative eta: move in phi first then move to east (coarser phi granularity)
+        const DetId N = getNeighbourDetId(detId, 0);
+        const DetId NE = getNeighbourDetId(N, 2);
+        const DetId E = getNeighbourDetId(detId, 2);
+        if (getNeighbourDetId(NE, 3) == N && NE != E)
+          return NE;
       }
     }
-    if(direction == 6) {  // SOUTHEAST
-      if (getZside(detId) > 0) { // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
-        //return getNeighbourDetId(getNeighbourDetId(detId, 2), 1);
-	const DetId E = getNeighbourDetId(detId, 2);
-	const DetId SE = getNeighbourDetId(E, 1);
-	if (getNeighbourDetId(SE, 0) == E && SE != E) return SE;
-      }
-      else { // negative eta: move in phi first then move to east (coarser phi granularity)
-        //return getNeighbourDetId(getNeighbourDetId(detId, 1), 2);
-	const DetId S = getNeighbourDetId(detId, 1);
-	const DetId SE = getNeighbourDetId(S, 2);
-	const DetId E = getNeighbourDetId(detId, 2);
-	if (getNeighbourDetId(SE, 3) == S && SE != E) return SE;
+    if (direction == 5) {         // SOUTHWEST
+      if (getZside(detId) > 0) {  // positive eta: move in phi first then move to west (coarser phi granularity)
+        const DetId S = getNeighbourDetId(detId, 1);
+        const DetId SW = getNeighbourDetId(S, 3);
+        const DetId W = getNeighbourDetId(detId, 3);
+        if (getNeighbourDetId(SW, 2) == S && SW != W)
+          return SW;
+      } else {  // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
+        const DetId W = getNeighbourDetId(detId, 3);
+        const DetId SW = getNeighbourDetId(W, 1);
+        if (getNeighbourDetId(SW, 0) == W && SW != W)
+          return SW;
       }
     }
-    if(direction == 7) {  // NORTHWEST
-      if (getZside(detId) > 0) { // positive eta: move in phi first then move to west (coarser phi granularity)
-        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 3);
-	const DetId N = getNeighbourDetId(detId, 0);
-	const DetId NW = getNeighbourDetId(N, 3);
-	const DetId W = getNeighbourDetId(detId, 3);
-	if (getNeighbourDetId(NW, 2) == N && NW != W) return NW;
+    if (direction == 6) {         // SOUTHEAST
+      if (getZside(detId) > 0) {  // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
+        const DetId E = getNeighbourDetId(detId, 2);
+        const DetId SE = getNeighbourDetId(E, 1);
+        if (getNeighbourDetId(SE, 0) == E && SE != E)
+          return SE;
+      } else {  // negative eta: move in phi first then move to east (coarser phi granularity)
+        const DetId S = getNeighbourDetId(detId, 1);
+        const DetId SE = getNeighbourDetId(S, 2);
+        const DetId E = getNeighbourDetId(detId, 2);
+        if (getNeighbourDetId(SE, 3) == S && SE != E)
+          return SE;
       }
-      else {  // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
-        //return getNeighbourDetId(getNeighbourDetId(detId, 3), 0);
-	const DetId W = getNeighbourDetId(detId, 3);
-	const DetId NW = getNeighbourDetId(W, 0);
-	if (getNeighbourDetId(NW, 1) == W && NW != W) return NW;
+    }
+    if (direction == 7) {         // NORTHWEST
+      if (getZside(detId) > 0) {  // positive eta: move in phi first then move to west (coarser phi granularity)
+        const DetId N = getNeighbourDetId(detId, 0);
+        const DetId NW = getNeighbourDetId(N, 3);
+        const DetId W = getNeighbourDetId(detId, 3);
+        if (getNeighbourDetId(NW, 2) == N && NW != W)
+          return NW;
+      } else {  // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
+        const DetId W = getNeighbourDetId(detId, 3);
+        const DetId NW = getNeighbourDetId(W, 0);
+        if (getNeighbourDetId(NW, 1) == W && NW != W)
+          return NW;
       }
     }
     return 0;
-
   }
 
+  // Associate neighbour PFRecHits
   void associateNeighbours(reco::PFRecHit& hit,
                            std::unique_ptr<reco::PFRecHitCollection>& hits,
                            edm::RefProd<reco::PFRecHitCollection>& refProd) override {
     DetId detid(hit.detId());
+    HcalDetId hid(detid);
     unsigned denseid = topology_.get()->detId2denseId(detid);
 
     std::vector<DetId> neighbours(9, DetId(0));
 
     if (denseid < denseIdHcalMin_ || denseid > denseIdHcalMax_) {
-      edm::LogWarning("PFRecHitHCALCachedNavigator") << " DenseId for this cell is out of the range." << std::endl;
+      edm::LogWarning("PFRecHitHCALCachedNavigator")
+          << " DenseId for this cell is out of the expected range." << std::endl;
     } else if (!validNeighbours(denseid)) {
       edm::LogWarning("PFRecHitHCALCachedNavigator")
-          << " DenseId for this cell does not have the neighbour information." << std::endl;
+          << " DenseId for this cell does not have the neighbour information. " << hid.ieta() << " " << hid.iphi()
+          << " " << hid.depth() << " " << hid.subdetId();
     } else {
       unsigned index = getIdx(denseid);
       neighbours = neighboursHcal_.at(index);
@@ -323,15 +341,21 @@ public:
     associateNeighbour(neighbours.at(NORTHWEST), hit, hits, refProd, -1, 1, 0);   // NW
   }
 
+  // Check if we can get the valid neighbour vector for a given denseid
   const bool validNeighbours(const unsigned int denseid) const {
-    bool ok = true;
+    if (denseid < denseIdHcalMin_ || denseid > denseIdHcalMax_)
+      return false;  // neighbour denseid is out of the expected range
     unsigned index = getIdx(denseid);
     if (neighboursHcal_.at(index).size() != 9)
-      ok = false;  // the neighbour vector size should be 3x3
-    return ok;
+      return false;  // the neighbour vector size should be 3x3
+    return true;
   }
 
+  // Get the index of neighboursHcal_ for a given denseid
   const unsigned int getIdx(const unsigned int denseid) const {
+    if (denseid < denseIdHcalMin_ || denseid > denseIdHcalMax_)
+      return unsigned(denseIdHcalMax_ - denseIdHcalMin_ +
+                      1);  // out-of-bounce (different subdetector groups. give a dummy number.)
     unsigned index = denseid - denseIdHcalMin_;
     return index;
   }
@@ -347,6 +371,7 @@ protected:
 private:
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+  const bool debug = false;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -176,7 +176,6 @@ public:
 
   // Print out neighbour DetId's
   void printNeighbourInfo(const std::vector<unsigned int> vDenseIdHcal) {
-
     // Print neighbour definitions
     for (auto denseid : vDenseIdHcal) {
       std::vector<DetId> neighbours(9, DetId(0));

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -230,7 +230,7 @@ public:
   // Obtain the neighbour's DetId
   const uint32_t getNeighbourDetId(const DetId detId, const uint32_t direction) {
     // desired order for PF: NORTH, SOUTH, EAST, WEST, NORTHEAST, SOUTHWEST, SOUTHEAST, NORTHWEST
-    if (detId == 0)
+    if (detId == DetId(0))
       return 0;
 
     if (direction == 0)                        // NORTH

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -68,14 +68,7 @@ public:
     neighboursHcal_.resize(denseIdHcalMax_ - denseIdHcalMin_ + 1);
 
     for (auto denseid : vDenseIdHcal) {
-      DetId N(0);
-      DetId E(0);
-      DetId S(0);
-      DetId W(0);
-      DetId NW(0);
-      DetId NE(0);
-      DetId SW(0);
-      DetId SE(0);
+      
       std::vector<DetId> neighbours(9, DetId(0));
 
       // the centre
@@ -87,57 +80,219 @@ public:
       // Order: CENTER(NONE),SOUTH,SOUTHEAST,SOUTHWEST,EAST,WEST,NORTHEAST,NORTHWEST,NORTH
       neighbours.at(NONE) = detid_c;
 
-      navigator.home();
-      N = navigator.north();
-      neighbours.at(NORTH) = N;
-      if (N != DetId(0)) {
-        NE = navigator.east();
-      } else {
-        navigator.home();
-        E = navigator.east();
-        NE = navigator.north();
-      }
-      neighbours.at(NORTHEAST) = NE;
+      neighbours.at(NORTH) = getNeighbourDetId(detid_c, 0);
+      neighbours.at(SOUTH) = getNeighbourDetId(detid_c, 1);
+      neighbours.at(EAST) = getNeighbourDetId(detid_c, 2);
+      neighbours.at(WEST) = getNeighbourDetId(detid_c, 3);
 
-      navigator.home();
-      S = navigator.south();
-      neighbours.at(SOUTH) = S;
-      if (S != DetId(0)) {
-        SW = navigator.west();
-      } else {
-        navigator.home();
-        W = navigator.west();
-        SW = navigator.south();
-      }
-      neighbours.at(SOUTHWEST) = SW;
-
-      navigator.home();
-      E = navigator.east();
-      neighbours.at(EAST) = E;
-      if (E != DetId(0)) {
-        SE = navigator.south();
-      } else {
-        navigator.home();
-        S = navigator.south();
-        SE = navigator.east();
-      }
-      neighbours.at(SOUTHEAST) = SE;
-
-      navigator.home();
-      W = navigator.west();
-      neighbours.at(WEST) = W;
-      if (W != DetId(0)) {
-        NW = navigator.north();
-      } else {
-        navigator.home();
-        N = navigator.north();
-        NW = navigator.west();
-      }
-      neighbours.at(NORTHWEST) = NW;
+      neighbours.at(NORTHEAST) = getNeighbourDetId(detid_c, 4);
+      neighbours.at(SOUTHWEST) = getNeighbourDetId(detid_c, 5);
+      neighbours.at(SOUTHEAST) = getNeighbourDetId(detid_c, 6);
+      neighbours.at(NORTHWEST) = getNeighbourDetId(detid_c, 7);
 
       unsigned index = getIdx(denseid_c);
       neighboursHcal_[index] = neighbours;
+
     }
+
+    //
+    // Check backward compatibility (does a neighbour of a channel have the channel as a neighbour?)
+    //
+    for (auto denseid : vDenseIdHcal) {
+      DetId detid = topology_.get()->denseId2detId(denseid);
+      HcalDetId hid = HcalDetId(detid);
+      if (detid == DetId(0)) {
+        std::cout << "WARNING SHOULD NOT HAPPEN1" << std::endl;
+        continue;
+      }
+      if (!validNeighbours(denseid)) {
+        std::cout << "WARNING SHOULD NOT HAPPEN2" << std::endl;
+        continue;
+      }
+      std::vector<DetId> neighbours(9, DetId(0));
+      unsigned index = getIdx(denseid);
+      if (index >= neighboursHcal_.size()) {
+        std::cout << "WARNING SHOULD NOT HAPPEN3" << std::endl;
+        continue;  // Skip if not found
+      }
+      neighbours = neighboursHcal_.at(index);
+
+      //
+      // Loop over neighbours
+      int ineighbour = -1;
+      for (auto neighbour : neighbours) {
+        ineighbour++;
+        if (neighbour == DetId(0))
+          continue;
+	HcalDetId hidn = HcalDetId(neighbour);
+        std::vector<DetId> neighboursOfNeighbour(9, DetId(0));
+        std::unordered_set<unsigned int> listOfNeighboursOfNeighbour;  // list of neighbours of neighbour
+        unsigned denseidNeighbour = topology_.get()->detId2denseId(neighbour);
+
+        if (!validNeighbours(denseidNeighbour))
+          continue;
+        if (getIdx(denseidNeighbour) >= neighboursHcal_.size())
+          continue;
+        neighboursOfNeighbour = neighboursHcal_.at(getIdx(denseidNeighbour));
+
+        //
+        // Loop over neighbours of neighbours
+        for (auto neighbourOfNeighbour : neighboursOfNeighbour) {
+          if (neighbourOfNeighbour == DetId(0))
+            continue;
+          unsigned denseidNeighbourOfNeighbour = topology_.get()->detId2denseId(neighbourOfNeighbour);
+          if (!validNeighbours(denseidNeighbourOfNeighbour))
+            continue;
+          listOfNeighboursOfNeighbour.insert(denseidNeighbourOfNeighbour);
+        }
+
+        //
+        if (listOfNeighboursOfNeighbour.find(denseid) == listOfNeighboursOfNeighbour.end()) {
+          // this neighbour is not backward compatible. ignore in the canse of HE phi segmentation change boundary
+          if (hid.subdet() == HcalBarrel || hid.subdet() == HcalEndcap) {
+	    std::cout << "This neighbor does not have the original channel as its neighbor. Ignore: "
+		      << detid.det() << " " << hid.ieta() << " " << hid.iphi() << " " << hid.depth() << " "
+		      << neighbour.det() << " " << hidn.ieta() << " " << hidn.iphi() << " " << hidn.depth()
+		      << std::endl;
+            neighboursHcal_[index][ineighbour] = DetId(0);
+          }
+        }
+      }  // loop over neighbours
+    }    // loop over denseId_
+
+    //
+    // Print final neighbour definitions
+    //
+    for (auto denseid : vDenseIdHcal) {
+      std::vector<DetId> neighbours(9, DetId(0));
+
+      // the centre
+      unsigned denseid_c = denseid;
+      DetId detid_c = topology_.get()->denseId2detId(denseid_c);
+      CaloNavigator<DET> navigator(detid_c, topology_.get());
+
+      unsigned index = getIdx(denseid_c);
+      neighbours = neighboursHcal_[index];
+
+      const DetId N = neighbours.at(NORTH);
+      const DetId S = neighbours.at(SOUTH);
+      const DetId E = neighbours.at(EAST);
+      const DetId W = neighbours.at(WEST);
+
+      DetId NE = neighbours.at(NORTHEAST); if (NE==E && E!=DetId(0)){ NE = DetId(0); printf("Duplicate A\n");}
+      DetId SW = neighbours.at(SOUTHWEST); if (SW==W && W!=DetId(0)){ SW = DetId(0); printf("Duplicate B\n");}
+      DetId SE = neighbours.at(SOUTHEAST); if (SE==E && E!=DetId(0)){ SE = DetId(0); printf("Duplicate C\n");}
+      DetId NW = neighbours.at(NORTHWEST); if (NW==W && W!=DetId(0)){ NW = DetId(0); printf("Duplicate D\n");}
+      
+      printf("navi: %d %d %d %d: %d %d %d %d, %d %d %d %d, %d %d %d %d, %d %d %d %d:  %d %d %d %d, %d %d %d %d, %d %d %d %d, %d %d %d %d\n",
+	     HcalDetId(detid_c).ieta(),HcalDetId(detid_c).iphi(),HcalDetId(detid_c).depth(),HcalDetId(detid_c).subdetId(),
+	     HcalDetId(N).ieta(),HcalDetId(N).iphi(),HcalDetId(N).depth(),HcalDetId(N).subdetId(),
+	     HcalDetId(E).ieta(),HcalDetId(E).iphi(),HcalDetId(E).depth(),HcalDetId(E).subdetId(),
+	     HcalDetId(S).ieta(),HcalDetId(S).iphi(),HcalDetId(S).depth(),HcalDetId(S).subdetId(),
+	     HcalDetId(W).ieta(),HcalDetId(W).iphi(),HcalDetId(W).depth(),HcalDetId(W).subdetId(),
+	     HcalDetId(NE).ieta(),HcalDetId(NE).iphi(),HcalDetId(NE).depth(),HcalDetId(NE).subdetId(),
+	     HcalDetId(SW).ieta(),HcalDetId(SW).iphi(),HcalDetId(SW).depth(),HcalDetId(SW).subdetId(),
+	     HcalDetId(SE).ieta(),HcalDetId(SE).iphi(),HcalDetId(SE).depth(),HcalDetId(SE).subdetId(),
+	     HcalDetId(NW).ieta(),HcalDetId(NW).iphi(),HcalDetId(NW).depth(),HcalDetId(NW).subdetId()
+	     );
+    } // print ends
+
+  }
+
+  //
+  const bool checkSameSubDet(const DetId detId, const DetId detId2)
+  {
+    HcalDetId hid = HcalDetId(detId);
+    HcalDetId hid2 = HcalDetId(detId2);
+    return hid.subdetId()==hid2.subdetId();
+  }
+
+  //https://cmssdt.cern.ch/lxr/source/DataFormats/HcalDetId/interface/HcalDetId.h#0141
+  static constexpr int getZside(const DetId detId) {
+    return ((detId & HcalDetId::kHcalZsideMask2) ? (1) : (-1));
+  }
+
+  //
+  const uint32_t getNeighbourDetId(const DetId detId, const uint32_t direction) {
+
+    // desired order for PF: NORTH, SOUTH, EAST, WEST, NORTHEAST, SOUTHWEST, SOUTHEAST, NORTHWEST
+    if(detId == 0)
+      return 0;
+
+    if(direction == 0)  // NORTH
+      return topology_.get()->goNorth(detId);  // larger iphi values (except phi boundary)
+
+    if(direction == 1)  // SOUTH
+      return topology_.get()->goSouth(detId);  // smaller iphi values (except phi boundary)
+
+    if(direction == 2 && checkSameSubDet(detId, topology_.get()->goEast(detId)))  // EAST
+      return topology_.get()->goEast(detId);  // smaller ieta values
+
+    if(direction == 3 && checkSameSubDet(detId, topology_.get()->goWest(detId)))  // WEST
+      return topology_.get()->goWest(detId);  // larger ieta values
+
+    if(direction == 4) { // NORTHEAST
+      if (getZside(detId) > 0){  // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
+        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 2);
+	const DetId E = getNeighbourDetId(detId, 2);
+	const DetId NE = getNeighbourDetId(E, 0);
+	if (getNeighbourDetId(NE, 1) == E && NE != E) return NE; //
+      }
+      else { // negative eta: move in phi first then move to east (coarser phi granularity)
+        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 2);
+ 	const DetId N = getNeighbourDetId(detId, 0);
+	const DetId NE = getNeighbourDetId(N, 2);
+	const DetId E = getNeighbourDetId(detId, 2);
+	if (getNeighbourDetId(NE, 3) == N && NE != E) return NE;
+      }
+    }
+    if(direction == 5) {  // SOUTHWEST
+      if (getZside(detId) > 0){  // positive eta: move in phi first then move to west (coarser phi granularity)
+        //return getNeighbourDetId(getNeighbourDetId(detId, 1), 3);
+	const DetId S = getNeighbourDetId(detId, 1);
+	const DetId SW = getNeighbourDetId(S, 3);
+	const DetId W = getNeighbourDetId(detId, 3);
+	if (getNeighbourDetId(SW, 2) == S && SW != W) return SW;
+      }
+      else { // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
+        //return getNeighbourDetId(getNeighbourDetId(detId, 3), 1);
+	const DetId W = getNeighbourDetId(detId, 3);
+	const DetId SW = getNeighbourDetId(W, 1);
+	if (getNeighbourDetId(SW, 0) == W && SW != W) return SW;
+      }
+    }
+    if(direction == 6) {  // SOUTHEAST
+      if (getZside(detId) > 0) { // positive eta: east -> move to smaller |ieta| (finner phi granularity) first
+        //return getNeighbourDetId(getNeighbourDetId(detId, 2), 1);
+	const DetId E = getNeighbourDetId(detId, 2);
+	const DetId SE = getNeighbourDetId(E, 1);
+	if (getNeighbourDetId(SE, 0) == E && SE != E) return SE;
+      }
+      else { // negative eta: move in phi first then move to east (coarser phi granularity)
+        //return getNeighbourDetId(getNeighbourDetId(detId, 1), 2);
+	const DetId S = getNeighbourDetId(detId, 1);
+	const DetId SE = getNeighbourDetId(S, 2);
+	const DetId E = getNeighbourDetId(detId, 2);
+	if (getNeighbourDetId(SE, 3) == S && SE != E) return SE;
+      }
+    }
+    if(direction == 7) {  // NORTHWEST
+      if (getZside(detId) > 0) { // positive eta: move in phi first then move to west (coarser phi granularity)
+        //return getNeighbourDetId(getNeighbourDetId(detId, 0), 3);
+	const DetId N = getNeighbourDetId(detId, 0);
+	const DetId NW = getNeighbourDetId(N, 3);
+	const DetId W = getNeighbourDetId(detId, 3);
+	if (getNeighbourDetId(NW, 2) == N && NW != W) return NW;
+      }
+      else {  // negative eta: west -> move to smaller |ieta| (finner phi granularity) first
+        //return getNeighbourDetId(getNeighbourDetId(detId, 3), 0);
+	const DetId W = getNeighbourDetId(detId, 3);
+	const DetId NW = getNeighbourDetId(W, 0);
+	if (getNeighbourDetId(NW, 1) == W && NW != W) return NW;
+      }
+    }
+    return 0;
+
   }
 
   void associateNeighbours(reco::PFRecHit& hit,
@@ -168,7 +323,7 @@ public:
     associateNeighbour(neighbours.at(NORTHWEST), hit, hits, refProd, -1, 1, 0);   // NW
   }
 
-  bool validNeighbours(const unsigned int denseid) const {
+  const bool validNeighbours(const unsigned int denseid) const {
     bool ok = true;
     unsigned index = getIdx(denseid);
     if (neighboursHcal_.at(index).size() != 9)
@@ -176,7 +331,7 @@ public:
     return ok;
   }
 
-  unsigned int getIdx(const unsigned int denseid) const {
+  const unsigned int getIdx(const unsigned int denseid) const {
     unsigned index = denseid - denseIdHcalMin_;
     return index;
   }

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -93,7 +93,7 @@ public:
       unsigned index = getIdx(denseid_c);
       neighboursHcal_[index] = neighbours;
 
-    }  // for denseid vDenseIdHcal
+    }  // loop over vDenseIdHcal
 
     if (debug) {
       backwardCompatibilityCheck(vDenseIdHcal);
@@ -176,9 +176,8 @@ public:
 
   // Print out neighbour DetId's
   void printNeighbourInfo(const std::vector<unsigned int> vDenseIdHcal) {
-    //
-    // Print final neighbour definitions
-    //
+
+    // Print neighbour definitions
     for (auto denseid : vDenseIdHcal) {
       std::vector<DetId> neighbours(9, DetId(0));
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
@@ -142,7 +142,7 @@ public:
               << "This neighbour does not have a valid neighbour information (another subdetector?). Ignore: "
               << detid.det() << " " << hid.ieta() << " " << hid.iphi() << " " << hid.depth() << " " << neighbour.det()
               << " " << hidn.ieta() << " " << hidn.iphi() << " " << hidn.depth();
-          neighboursHcal_[index][ineighbour] = DetId(0);  // not a valid neighbour. set to a DetId(0)
+          neighboursHcal_[index][ineighbour] = DetId(0);  // Not a valid neighbour. Set to DetId(0)
           continue;
         }
         if (getIdx(denseidNeighbour) >= neighboursHcal_.size())


### PR DESCRIPTION
### PR description:

Updating the PFHCALDenseIdNavigator's neighbor definitions, addressing some unexpected neighbor definitions as illustrated here:
https://docs.google.com/presentation/d/1vVlIjjBnjWC2Qo1Eg7kxW51XuCnHxaqiAbLULc_RK1o/edit#slide=id.gca99572dd3_1_48
Also, ensure that neighbour are neighbours in both ways, which becomes important when running clustering in parallel operation.

#### PR validation:

Ran the standard PF validation tool.
https://hep.baylor.edu/hatake/PFval/PFNavi_13_3_X/plots/
Negligible impact on physics quantities as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.

@jsamudio @fllor