### PR TITLE
Update 2022 MC GTs for new ecal timing calibrations - 13_2_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,11 +64,11 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '132X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '132X_mcRun3_2022_realistic_v1',
+    'phase1_2022_realistic'        : '132X_mcRun3_2022_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '132X_mcRun3_2022_realistic_postEE_v1',
+    'phase1_2022_realistic_postEE' : '132X_mcRun3_2022_realistic_postEE_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '132X_mcRun3_2022cosmics_realistic_deco_v1',
+    'phase1_2022_cosmics'          : '132X_mcRun3_2022cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '132X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion


### PR DESCRIPTION
#### PR description:

This PR updates in the release the 132X GTs for Run3 2022 MC.

There updated condition is:
- ECAL time calibration conditions compatible with the new CC timing algorithm:
EcalTimeOffsetConstantRcd: EcalTimeOffsetConstant_cctiming_v01_mc
CMS Talk post in https://cms-talk.web.cern.ch/t/full-track-validation-ecal-time-calibration-conditions-for-cc-timing-algorithm/28247/6
GT Differences:

phase1_2022_realistic:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2022_realistic_v1/132X_mcRun3_2022_realistic_v2
phase1_2022_realistic_postEE:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2022_realistic_postEE_v1/132X_mcRun3_2022_realistic_postEE_v2
phase1_2022_cosmics:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/132X_mcRun3_2022cosmics_realistic_deco_v1/132X_mcRun3_2022cosmics_realistic_deco_v2

#### PR validation:

Validated running a few upgrade workflows which access those GTs

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #42761
