### PR TITLE
MTD Validation: fixes to tracks checks

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -56,8 +56,8 @@ private:
   MonitorElement* meExtraEtaEff_;
   MonitorElement* meExtraEtaEtl2Eff_;
   MonitorElement* meExtraPhiAtBTLEff_;
-  MonitorElement* meExtraBTLfailExtenderEtaEff_;
-  MonitorElement* meExtraBTLfailExtenderPtEff_;
+  MonitorElement* meExtraMTDfailExtenderEtaEff_;
+  MonitorElement* meExtraMTDfailExtenderPtEff_;
 };
 
 // ------------ constructor and destructor --------------
@@ -146,8 +146,8 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meExtraPhiAtBTL = igetter.get(folder_ + "ExtraPhiAtBTL");
   MonitorElement* meExtraPhiAtBTLmatched = igetter.get(folder_ + "ExtraPhiAtBTLmatched");
   MonitorElement* meExtraBTLeneInCone = igetter.get(folder_ + "ExtraBTLeneInCone");
-  MonitorElement* meExtraBTLfailExtenderEta = igetter.get(folder_ + "ExtraBTLfailExtenderEta");
-  MonitorElement* meExtraBTLfailExtenderPt = igetter.get(folder_ + "ExtraBTLfailExtenderPt");
+  MonitorElement* meExtraMTDfailExtenderEta = igetter.get(folder_ + "ExtraMTDfailExtenderEta");
+  MonitorElement* meExtraMTDfailExtenderPt = igetter.get(folder_ + "ExtraMTDfailExtenderPt");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
@@ -491,8 +491,8 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
   }
 
-  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone && meExtraBTLfailExtenderEta &&
-      meExtraBTLfailExtenderPt) {
+  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone && meExtraMTDfailExtenderEta &&
+      meExtraMTDfailExtenderPt) {
     meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
                                        "Efficiency to match hits at BTL surface",
                                        meExtraPhiAtBTL->getNbinsX(),
@@ -503,23 +503,23 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
 
     normalize(meExtraBTLeneInCone, 1.);
 
-    meExtraBTLfailExtenderEtaEff_ =
-        ibook.book1D("ExtraBTLfailExtenderEtaEff",
-                     "Track extrapolated at BTL surface no extender efficiency VS Eta;Eta;Efficiency",
+    meExtraMTDfailExtenderEtaEff_ =
+        ibook.book1D("ExtraMTDfailExtenderEtaEff",
+                     "Track extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
                      meTrackMatchedTPEffEtaTot->getNbinsX(),
                      meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
                      meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraBTLfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraBTLfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraBTLfailExtenderEtaEff_);
+    meExtraMTDfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraMTDfailExtenderEtaEff_);
 
-    meExtraBTLfailExtenderPtEff_ =
-        ibook.book1D("ExtraBTLfailExtenderPtEff",
-                     "Track extrapolated at BTL surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
+    meExtraMTDfailExtenderPtEff_ =
+        ibook.book1D("ExtraMTDfailExtenderPtEff",
+                     "Track extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
                      meTrackMatchedTPEffPtTot->getNbinsX(),
                      meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
                      meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraBTLfailExtenderPtEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraBTLfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraBTLfailExtenderPtEff_);
+    meExtraMTDfailExtenderPtEff_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraMTDfailExtenderPtEff_);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -160,7 +160,9 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
       !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd || !meTrackMatchedTPmtdEffPtTot ||
       !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaMtd ||
       !meTrackMatchedTPEffEtaEtl2Mtd || !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd ||
-      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot) {
+      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd ||
+      !meExtraEtaMtd || !meExtraEtaEtl2Mtd || !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone ||
+      !meExtraMTDfailExtenderEta || !meExtraMTDfailExtenderPt) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -287,39 +289,37 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meEtlPtEff2_[1]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffPt2MtdZpos, meETLTrackEffPtTotZpos, meEtlPtEff2_[1]);
 
-  if (meExtraPtMtd && meExtraPtEtl2Mtd && meExtraEtaMtd && meExtraEtaEtl2Mtd) {
-    meExtraPtEff_ = ibook.book1D("ExtraPtEff",
-                                 "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                                 meMVATrackEffPtTot->getNbinsX(),
-                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraPtEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
+  meExtraPtEff_ = ibook.book1D("ExtraPtEff",
+                               "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                               meMVATrackEffPtTot->getNbinsX(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraPtEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
 
-    meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
-                                     "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                                     meMVATrackEffPtTot->getNbinsX(),
-                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
+  meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
+                                   "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
+                                   meMVATrackEffPtTot->getNbinsX(),
+                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
 
-    meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
-                                  "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
-                                  meMVATrackEffEtaTot->getNbinsX(),
-                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraEtaEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
+  meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
+                                "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
+                                meMVATrackEffEtaTot->getNbinsX(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraEtaEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
 
-    meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
-                                      "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
-                                      meMVATrackEffEtaTot->getNbinsX(),
-                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
-  }
+  meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
+                                    "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
+                                    meMVATrackEffEtaTot->getNbinsX(),
+                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
 
   meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
                                 "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
@@ -457,70 +457,33 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
   meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
 
-  if (meExtraPtMtd && meExtraPtEtl2Mtd && meExtraEtaMtd && meExtraEtaEtl2Mtd) {
-    meExtraPtEff_ = ibook.book1D("ExtraPtEff",
-                                 "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                                 meMVATrackEffPtTot->getNbinsX(),
-                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                 meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraPtEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
+  meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
+                                     "Efficiency to match hits at BTL surface",
+                                     meExtraPhiAtBTL->getNbinsX(),
+                                     meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmin(),
+                                     meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmax());
+  meExtraPhiAtBTLEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraPhiAtBTLmatched, meExtraPhiAtBTL, meExtraPhiAtBTLEff_);
 
-    meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
-                                     "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                                     meMVATrackEffPtTot->getNbinsX(),
-                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                     meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
+  normalize(meExtraBTLeneInCone, 1.);
 
-    meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
-                                  "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
-                                  meMVATrackEffEtaTot->getNbinsX(),
-                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraEtaEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
+  meExtraMTDfailExtenderEtaEff_ =
+      ibook.book1D("ExtraMTDfailExtenderEtaEff",
+                   "Track extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
+                   meTrackMatchedTPEffEtaTot->getNbinsX(),
+                   meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraMTDfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraMTDfailExtenderEtaEff_);
 
-    meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
-                                      "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
-                                      meMVATrackEffEtaTot->getNbinsX(),
-                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                      meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
-  }
-
-  if (meExtraPhiAtBTL && meExtraPhiAtBTLmatched && meExtraBTLeneInCone && meExtraMTDfailExtenderEta &&
-      meExtraMTDfailExtenderPt) {
-    meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
-                                       "Efficiency to match hits at BTL surface",
-                                       meExtraPhiAtBTL->getNbinsX(),
-                                       meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmin(),
-                                       meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmax());
-    meExtraPhiAtBTLEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraPhiAtBTLmatched, meExtraPhiAtBTL, meExtraPhiAtBTLEff_);
-
-    normalize(meExtraBTLeneInCone, 1.);
-
-    meExtraMTDfailExtenderEtaEff_ =
-        ibook.book1D("ExtraMTDfailExtenderEtaEff",
-                     "Track extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
-                     meTrackMatchedTPEffEtaTot->getNbinsX(),
-                     meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                     meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraMTDfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraMTDfailExtenderEtaEff_);
-
-    meExtraMTDfailExtenderPtEff_ =
-        ibook.book1D("ExtraMTDfailExtenderPtEff",
-                     "Track extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
-                     meTrackMatchedTPEffPtTot->getNbinsX(),
-                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                     meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
-    meExtraMTDfailExtenderPtEff_->getTH1()->SetMinimum(0.);
-    computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraMTDfailExtenderPtEff_);
-  }
+  meExtraMTDfailExtenderPtEff_ =
+      ibook.book1D("ExtraMTDfailExtenderPtEff",
+                   "Track extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
+                   meTrackMatchedTPEffPtTot->getNbinsX(),
+                   meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraMTDfailExtenderPtEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraMTDfailExtenderPtEff_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -611,7 +611,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             }
             meExtraEtaMtd_->Fill(std::abs(trackGen.eta()));
             if (nlayers == 2) {
-              meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
+              meExtraEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
             }
             if (accept.first && accept.second && !(isBTL || isETL)) {
               edm::LogInfo("MtdTracksValidation")

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -226,8 +226,8 @@ private:
   MonitorElement* meExtraPhiAtBTL_;
   MonitorElement* meExtraPhiAtBTLmatched_;
   MonitorElement* meExtraBTLeneInCone_;
-  MonitorElement* meExtraBTLfailExtenderEta_;
-  MonitorElement* meExtraBTLfailExtenderPt_;
+  MonitorElement* meExtraMTDfailExtenderEta_;
+  MonitorElement* meExtraMTDfailExtenderPt_;
 };
 
 // ------------ constructor and destructor --------------
@@ -613,13 +613,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             if (nlayers == 2) {
               meExtraEtaEtl2Mtd_->Fill(trackGen.eta());
             }
-            if (accept.first && accept.second && !isBTL) {
+            if (accept.first && accept.second && !(isBTL || isETL)) {
               edm::LogInfo("MtdTracksValidation")
                   << "MtdTracksValidation: extender fail in " << iEvent.id().run() << " " << iEvent.id().event()
                   << " pt= " << trackGen.pt() << " eta= " << trackGen.eta();
-              meExtraBTLfailExtenderEta_->Fill(std::abs(trackGen.eta()));
+              meExtraMTDfailExtenderEta_->Fill(std::abs(trackGen.eta()));
               if (noCrack) {
-                meExtraBTLfailExtenderPt_->Fill(trackGen.pt());
+                meExtraMTDfailExtenderPt_->Fill(trackGen.pt());
               }
             }
           }
@@ -1005,16 +1005,16 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                      180.);
     meExtraBTLeneInCone_ = ibook.book1D(
         "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
-    meExtraBTLfailExtenderEta_ =
-        ibook.book1D("ExtraBTLfailExtenderEta",
-                     "Eta of tracks extrapolated to BTL with no track extender match to hits; track eta",
+    meExtraMTDfailExtenderEta_ =
+        ibook.book1D("ExtraMTDfailExtenderEta",
+                     "Eta of tracks extrapolated to MTD with no track extender match to hits; track eta",
                      66,
                      0.,
                      3.3);
     ;
-    meExtraBTLfailExtenderPt_ =
-        ibook.book1D("ExtraBTLfailExtenderPt",
-                     "Pt of tracks extrapolated to BTL with no track extender match to hits; track pt [GeV] ",
+    meExtraMTDfailExtenderPt_ =
+        ibook.book1D("ExtraMTDfailExtenderPt",
+                     "Pt of tracks extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
                      110,
                      0.,
                      11.);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -126,8 +126,6 @@ private:
   static constexpr double etaMatchCut_ = 0.05;
   static constexpr double cluDRradius_ = 0.05;  // to cluster rechits around extrapolated track
 
-  bool optionalPlots_;
-
   const reco::RecoToSimCollection* r2s_;
   const reco::SimToRecoCollection* s2r_;
 
@@ -236,8 +234,7 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
       trackMinPt_(iConfig.getParameter<double>("trackMinimumPt")),
       trackMaxBtlEta_(iConfig.getParameter<double>("trackMaximumBtlEta")),
       trackMinEtlEta_(iConfig.getParameter<double>("trackMinimumEtlEta")),
-      trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")),
-      optionalPlots_(iConfig.getUntrackedParameter<bool>("optionalPlots")) {
+      trackMaxEtlEta_(iConfig.getParameter<double>("trackMaximumEtlEta")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTagV"));
@@ -588,39 +585,37 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
 
-        if (optionalPlots_) {
-          size_t nlayers(0);
-          float extrho(0.);
-          float exteta(0.);
-          float extphi(0.);
-          float selvar(0.);
-          auto accept = checkAcceptance(trackGen, iEvent, iSetup, nlayers, extrho, exteta, extphi, selvar);
-          if (accept.first && std::abs(exteta) < trackMaxBtlEta_) {
-            meExtraPhiAtBTL_->Fill(angle_units::operators::convertRadToDeg(extphi));
-            meExtraBTLeneInCone_->Fill(selvar);
+        size_t nlayers(0);
+        float extrho(0.);
+        float exteta(0.);
+        float extphi(0.);
+        float selvar(0.);
+        auto accept = checkAcceptance(trackGen, iEvent, iSetup, nlayers, extrho, exteta, extphi, selvar);
+        if (accept.first && std::abs(exteta) < trackMaxBtlEta_) {
+          meExtraPhiAtBTL_->Fill(angle_units::operators::convertRadToDeg(extphi));
+          meExtraBTLeneInCone_->Fill(selvar);
+        }
+        if (accept.second) {
+          if (std::abs(exteta) < trackMaxBtlEta_) {
+            meExtraPhiAtBTLmatched_->Fill(angle_units::operators::convertRadToDeg(extphi));
           }
-          if (accept.second) {
-            if (std::abs(exteta) < trackMaxBtlEta_) {
-              meExtraPhiAtBTLmatched_->Fill(angle_units::operators::convertRadToDeg(extphi));
-            }
-            if (noCrack) {
-              meExtraPtMtd_->Fill(trackGen.pt());
-              if (nlayers == 2) {
-                meExtraPtEtl2Mtd_->Fill(trackGen.pt());
-              }
-            }
-            meExtraEtaMtd_->Fill(std::abs(trackGen.eta()));
+          if (noCrack) {
+            meExtraPtMtd_->Fill(trackGen.pt());
             if (nlayers == 2) {
-              meExtraEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
+              meExtraPtEtl2Mtd_->Fill(trackGen.pt());
             }
-            if (accept.first && accept.second && !(isBTL || isETL)) {
-              edm::LogInfo("MtdTracksValidation")
-                  << "MtdTracksValidation: extender fail in " << iEvent.id().run() << " " << iEvent.id().event()
-                  << " pt= " << trackGen.pt() << " eta= " << trackGen.eta();
-              meExtraMTDfailExtenderEta_->Fill(std::abs(trackGen.eta()));
-              if (noCrack) {
-                meExtraMTDfailExtenderPt_->Fill(trackGen.pt());
-              }
+          }
+          meExtraEtaMtd_->Fill(std::abs(trackGen.eta()));
+          if (nlayers == 2) {
+            meExtraEtaEtl2Mtd_->Fill(std::abs(trackGen.eta()));
+          }
+          if (accept.first && accept.second && !(isBTL || isETL)) {
+            edm::LogInfo("MtdTracksValidation")
+                << "MtdTracksValidation: extender fail in " << iEvent.id().run() << " " << iEvent.id().event()
+                << " pt= " << trackGen.pt() << " eta= " << trackGen.eta();
+            meExtraMTDfailExtenderEta_->Fill(std::abs(trackGen.eta()));
+            if (noCrack) {
+              meExtraMTDfailExtenderPt_->Fill(trackGen.pt());
             }
           }
         }
@@ -942,11 +937,9 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffPtMtd_ = ibook.book1D(
       "MVAMatchedEffPtMtd", "Pt of tracks associated to LV matched to GEN with time; track pt [GeV] ", 110, 0., 11.);
 
-  if (optionalPlots_) {
-    meExtraPtMtd_ = ibook.book1D("ExtraPtMtd", "Pt of tracks extrapolated to hits; track pt [GeV] ", 110, 0., 11.);
-    meExtraPtEtl2Mtd_ = ibook.book1D(
-        "ExtraPtEtl2Mtd", "Pt of tracks extrapolated to hits, 2 ETL layers; track pt [GeV] ", 110, 0., 11.);
-  }
+  meExtraPtMtd_ = ibook.book1D("ExtraPtMtd", "Pt of tracks extrapolated to hits; track pt [GeV] ", 110, 0., 11.);
+  meExtraPtEtl2Mtd_ =
+      ibook.book1D("ExtraPtEtl2Mtd", "Pt of tracks extrapolated to hits, 2 ETL layers; track pt [GeV] ", 110, 0., 11.);
 
   meTrackPtTot_ = ibook.book1D("TrackPtTot", "Pt of tracks ; track pt [GeV] ", 110, 0., 11.);
   meTrackMatchedTPEffPtTot_ =
@@ -967,11 +960,9 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Eta of tracks associated to LV matched to GEN with time; track eta ", 66, 0., 3.3);
 
-  if (optionalPlots_) {
-    meExtraEtaMtd_ = ibook.book1D("ExtraEtaMtd", "Eta of tracks extrapolated to hits; track eta ", 66, 0., 3.3);
-    meExtraEtaEtl2Mtd_ =
-        ibook.book1D("ExtraEtaEtl2Mtd", "Eta of tracks extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
-  }
+  meExtraEtaMtd_ = ibook.book1D("ExtraEtaMtd", "Eta of tracks extrapolated to hits; track eta ", 66, 0., 3.3);
+  meExtraEtaEtl2Mtd_ =
+      ibook.book1D("ExtraEtaEtl2Mtd", "Eta of tracks extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
 
   meTrackEtaTot_ = ibook.book1D("TrackEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
   meTrackMatchedTPEffEtaTot_ =
@@ -994,31 +985,28 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackZposResTot_ = ibook.book1D(
       "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for associated tracks;Z_{PCA} - Z_{sim} [cm] ", 100, -0.1, 0.1);
 
-  if (optionalPlots_) {
-    meExtraPhiAtBTL_ =
-        ibook.book1D("ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks; phi [deg]", 720, -180., 180.);
-    meExtraPhiAtBTLmatched_ =
-        ibook.book1D("ExtraPhiAtBTLmatched",
-                     "Phi at BTL surface of extrapolated tracksi matched with BTL hits; phi [deg]",
-                     720,
-                     -180.,
-                     180.);
-    meExtraBTLeneInCone_ = ibook.book1D(
-        "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
-    meExtraMTDfailExtenderEta_ =
-        ibook.book1D("ExtraMTDfailExtenderEta",
-                     "Eta of tracks extrapolated to MTD with no track extender match to hits; track eta",
-                     66,
-                     0.,
-                     3.3);
-    ;
-    meExtraMTDfailExtenderPt_ =
-        ibook.book1D("ExtraMTDfailExtenderPt",
-                     "Pt of tracks extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
-                     110,
-                     0.,
-                     11.);
-  }
+  meExtraPhiAtBTL_ =
+      ibook.book1D("ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks; phi [deg]", 720, -180., 180.);
+  meExtraPhiAtBTLmatched_ = ibook.book1D("ExtraPhiAtBTLmatched",
+                                         "Phi at BTL surface of extrapolated tracksi matched with BTL hits; phi [deg]",
+                                         720,
+                                         -180.,
+                                         180.);
+  meExtraBTLeneInCone_ = ibook.book1D(
+      "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
+  meExtraMTDfailExtenderEta_ =
+      ibook.book1D("ExtraMTDfailExtenderEta",
+                   "Eta of tracks extrapolated to MTD with no track extender match to hits; track eta",
+                   66,
+                   0.,
+                   3.3);
+  ;
+  meExtraMTDfailExtenderPt_ =
+      ibook.book1D("ExtraMTDfailExtenderPt",
+                   "Pt of tracks extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
+                   110,
+                   0.,
+                   11.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------


### PR DESCRIPTION
#### PR description:

This PR collects a number of fixes related to the ```MtdTracksValidation``` class, and its corresponding ```MtdTracksHarvester```:

- the condition to estimate the fraction of tracks with a helix extrapolation matching MTD hits but no hit attached by the track extender has been updated (ETL hits in the track extender were overlooked);
- a missing ```std::abs()``` has been added to the calculation of the number of tracks extrapolated to ETL matching hits in two layers (doubling effectively the efficiency);
- the ```optionalPlots``` flag, set to ```True``` by default, has been removed, and the ```MtdTracksHarvester`` has been adapted accordingly;
- a duplicated calculation of efficiency for plots related to track extrapolation to MTD surface has been removed.

#### PR validation:

Code compiles and runs without evident issues, the efficiency to match ETL hits to the extrapolated track on both layers doubles as expected. 