### PR TITLE
Update Phase2 MC GT to clean up unused Phase1 pixel conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '132X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '131X_mcRun4_realistic_v6'
+    'phase2_realistic'             : '132X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This is a follow-up on https://github.com/cms-AlCaDB/AlCaTools/issues/88.

With https://github.com/cms-sw/cmssw/pull/42612 now merged, we have updated and cut the official versioned Phase2 GT `132X_mcRun4_realistic_v1` that removes the following currently unused Phase-1 pixel conditions:
|Record | Label | 131X_mcRun4_realistic_v6 | 132X_mcRun4_realistic_v1 |
|-- | -- | -- | -- |
| SiPixelDynamicInefficiencyRcd | - | SiPixelDynamicInefficiency_13TeV_v3_mc | - |
| SiPixelFedCablingMapRcd | - | SiPixelFedCablingMap_mc | - | 
| SiPixelGainCalibrationForHLTRcd | - | SiPixelGainCalibrationForHLT_split_smeared_mc | - |
| SiPixelGainCalibrationOfflineRcd | - | SiPixelGainCalibration_split_smeared_mc | - | 
| SiPixelTemplateDBObjectRcd | 0T | SiPixelTemplateDBObject_0T_v3_mc | - |

The difference between the new GT from the last one is here: 
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun4_realistic_v6/132X_mcRun4_realistic_v1

#### PR validation:

Successfully tested locally with `runTheMatrix.py -l 22034.0, 23234.0, 24834.0 -j 8 --ibeos` which consumes the `auto:phase2_realistic` key

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Clean-up for future GTs, so no backport is expected so far. 