### PR TITLE
Enable Laser 4 plots in ECAL DQM [13_2_X]

### DIFF
--- a/DQM/EcalCommon/python/CommonParams_cfi.py
+++ b/DQM/EcalCommon/python/CommonParams_cfi.py
@@ -5,7 +5,7 @@ ecalCommonParams = cms.untracked.PSet(
     willConvertToEDM = cms.untracked.bool(True)
 )
 
-ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3)
+ecaldqmLaserWavelengths = cms.untracked.vint32(1, 2, 3, 4)
 ecaldqmLedWavelengths = cms.untracked.vint32(1, 2)
 ecaldqmMGPAGains = cms.untracked.vint32(12)
 ecaldqmMGPAGainsPN = cms.untracked.vint32(16)


### PR DESCRIPTION
#### PR description:

This PR is to enable the new commissioned green laser plots, named Laser 4 in the ECAL DQM.

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 13_2_X which is in production at the moment.
The master PR is https://github.com/cms-sw/cmssw/pull/42805


