### PR TITLE
Fix noisy HLT BTV DQM

### DIFF
--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -76,7 +76,8 @@ hltBTVmonitoring = topMonitoring.clone(
     electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
     muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !     
     
-    btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
+    #btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
+    btagAlgos = ['pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probbb'], 
     workingpoint = -1., #no cut applied
     
     HTdefinition = 'pt>30 & abs(eta)<2.5',

--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -76,7 +76,6 @@ hltBTVmonitoring = topMonitoring.clone(
     electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
     muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !     
     
-    #btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
     btagAlgos = ['pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probbb'], 
     workingpoint = -1., #no cut applied
     

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -114,7 +114,7 @@ BTagMu_AK8Jet170_DoubleMu5 = hltBTVmonitoring.clone(
 )
 
 # PFJet AK4
-PFJet40 = hltBTVmonitoring.clone(
+BTagMonitor_PFJet40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/PFJet40',
     nmuons = 0,
     nelectrons = 0,
@@ -126,7 +126,7 @@ PFJet40 = hltBTVmonitoring.clone(
 )
 
 # PFJet AK8
-AK8PFJet40 = hltBTVmonitoring.clone(
+BTagMonitor_AK8PFJet40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJet40',
     nmuons = 0,
     nelectrons = 0,
@@ -139,7 +139,7 @@ AK8PFJet40 = hltBTVmonitoring.clone(
 )
 
 # PFJetFwd AK4
-PFJetFwd40 = hltBTVmonitoring.clone(
+BTagMonitor_PFJetFwd40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/PFJetFwd40',
     nmuons = 0,
     nelectrons = 0,
@@ -156,7 +156,7 @@ PFJetFwd40 = hltBTVmonitoring.clone(
 )
 
 # PFJetFwd AK8
-AK8PFJetFwd40 = hltBTVmonitoring.clone(
+BTagMonitor_AK8PFJetFwd40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd40',
     nmuons = 0,
     nelectrons = 0,
@@ -188,8 +188,8 @@ btagMonitorHLT = cms.Sequence(
 )
 
 btvHLTDQMSourceExtra = cms.Sequence(
-    PFJet40
-  + AK8PFJet40
-  + PFJetFwd40
-  + AK8PFJetFwd40
+    BTagMonitor_PFJet40
+  + BTagMonitor_AK8PFJet40
+  + BTagMonitor_PFJetFwd40
+  + BTagMonitor_AK8PFJetFwd40
 )


### PR DESCRIPTION
#### PR description:
As mentioned in https://github.com/cms-sw/cmssw/issues/42342, I found that the noisy does not come from TOP, but from HLT BTV. It reuses TopMonitor. The fix in this PR just updates `btagAlgo` as done in https://github.com/cms-sw/cmssw/pull/28067 for TOP.

This should confirm with @cms-sw/hlt-l2 if btagAlgo used in this PR is set properly. FYI @missirol 

#### PR validation:
Try to run workflow 12434.0 and check DQM. I don't see noisy complain anymore, and DQM is filled.
Before this PR, BTV HLT is empty: https://tinyurl.com/ynfp3xj6
With this PR, histograms are filled: https://tinyurl.com/ymxs5emx

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport