### PR TITLE
PPS Conddb dump for mapping and mask

### DIFF
--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -284,6 +284,8 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(SiStripPedestals);
   PAYLOAD_2XML_CLASS(SiStripThreshold);
   PAYLOAD_2XML_CLASS(DTCELinkId);
+  PAYLOAD_2XML_CLASS(TotemAnalysisMask);
+  PAYLOAD_2XML_CLASS(TotemDAQMapping);
   PAYLOAD_2XML_CLASS(TrackerDetToDTCELinkCablingMap);
   //PAYLOAD_2XML_CLASS( StorableDoubleMap<AbsOOTPileupCorrection> );
   PAYLOAD_2XML_CLASS(TrackProbabilityCalibration);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -305,6 +305,8 @@ namespace cond {
       FETCH_PAYLOAD_CASE(SiStripPedestals)
       FETCH_PAYLOAD_CASE(SiStripThreshold)
       FETCH_PAYLOAD_CASE(DTCELinkId)
+      FETCH_PAYLOAD_CASE(TotemAnalysisMask)
+      FETCH_PAYLOAD_CASE(TotemDAQMapping)
       FETCH_PAYLOAD_CASE(TrackerDetToDTCELinkCablingMap)
       FETCH_PAYLOAD_CASE(TrackProbabilityCalibration)
       FETCH_PAYLOAD_CASE(cond::BaseKeyed)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -331,6 +331,8 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(SiStripPedestals)
         IMPORT_PAYLOAD_CASE(SiStripThreshold)
         IMPORT_PAYLOAD_CASE(DTCELinkId)
+        IMPORT_PAYLOAD_CASE(TotemAnalysisMask)
+        IMPORT_PAYLOAD_CASE(TotemDAQMapping)
         IMPORT_PAYLOAD_CASE(TrackerDetToDTCELinkCablingMap)
         IMPORT_PAYLOAD_CASE(TrackProbabilityCalibration)
         IMPORT_PAYLOAD_CASE(cond::BaseKeyed)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -277,6 +277,8 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayload.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h"
+#include "CondFormats/PPSObjects/interface/TotemAnalysisMask.h"
+#include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"


### PR DESCRIPTION
#### PR description:
In this PR I added `TotemAnalysisMask` and `TotemDAQMapping` to CondCore/Utilities code to dump payloads of this types from CondDB.

#### PR validation:

To validate changes I dumped payloads to files:
* TotemDAQMapping 
```
conddb dump d0c9a029cbeeec4f98eeae9f85e65cd4feffdef7 > mapping.xml
```
* TotemAnalysisMask
```
conddb dump e3a0d6d9a32b104096e4b5d3c7c6d3576692896b > mask.xml
```

----
@grzanka for your attention