### PR TITLE
Include 4 Hits Seeds in Phase2 HLT Menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/initialStepSeeds_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/initialStepSeeds_cfi.py
@@ -11,5 +11,6 @@ initialStepSeeds = cms.EDProducer("SeedGeneratorFromProtoTracksEDProducer",
     originRadius = cms.double(0.1),
     useEventsWithNoVertex = cms.bool(True),
     usePV = cms.bool(False),
-    useProtoTrackKinematics = cms.bool(False)
+    useProtoTrackKinematics = cms.bool(False),
+    includeFourthHit = cms.bool(True)
 )


### PR DESCRIPTION
#### PR description:

In `SeedGeneratorFromProtoTracksEDProducer` by default `includeFourthHit = cms.bool(False)` so, as it is, in the Phase2 HLT Menu we truncate pixel seeds (tracks) to 3 hits. This PR fixes this.

Backported to 13_1_X for HLT Upgrade in #42821. 