### PR TITLE
Fix usage of sys.argv in cmsRun configs

### DIFF
--- a/Alignment/MuonAlignment/python/convertXMLtoSQLite_cfg.py
+++ b/Alignment/MuonAlignment/python/convertXMLtoSQLite_cfg.py
@@ -29,7 +29,7 @@ process.CSCGeometryAlInputXML = cms.ESProducer("CSCGeometryESModule",
 
 process.MuonGeometryDBConverter = cms.EDAnalyzer("MuonGeometryDBConverter",
     input = cms.string("xml"),
-    fileName = cms.string(str(sys.argv[2])),
+    fileName = cms.string(str(sys.argv[1])),
     shiftErr = cms.double(1000.),
     angleErr = cms.double(6.28),
     output = cms.string("db"))
@@ -37,7 +37,7 @@ process.MuonGeometryDBConverter = cms.EDAnalyzer("MuonGeometryDBConverter",
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDBSetup,
-    connect = cms.string("sqlite_file:"+str(sys.argv[2])[:-3]+"db"),
+    connect = cms.string("sqlite_file:"+str(sys.argv[1])[:-3]+"db"),
     toPut = cms.VPSet(
         cms.PSet(record = cms.string("DTAlignmentRcd"), tag = cms.string("DTAlignmentRcd")),
         cms.PSet(record = cms.string("DTAlignmentErrorExtendedRcd"), tag = cms.string("DTAlignmentErrorExtendedRcd")),

--- a/CalibPPS/ESProducers/test/print_alignment_info_DB_cfg.py
+++ b/CalibPPS/ESProducers/test/print_alignment_info_DB_cfg.py
@@ -3,8 +3,8 @@ process = cms.Process("GeometryInfo")
 
 import sys
 
-if len(sys.argv) >2:
-    runno = int(sys.argv[2])
+if len(sys.argv) >1:
+    runno = int(sys.argv[1])
 else:
     runno = 1
 

--- a/CondTools/BTau/python/bTagCalibrationDbCreation.py
+++ b/CondTools/BTau/python/bTagCalibrationDbCreation.py
@@ -3,9 +3,9 @@ import os
 import sys
 import FWCore.ParameterSet.Config as cms
 
-if len(sys.argv) < 3:
+if len(sys.argv) < 2:
     raise RuntimeError('\nERROR: Need csv-filename as first argument.\n')
-csv_file = sys.argv[2]
+csv_file = sys.argv[1]
 db_file = csv_file.replace('.csv', '.db')
 tagger = os.path.basename(csv_file).split('.')[0]
 print("Using file:", csv_file)

--- a/CondTools/CTPPS/test/retrieve-sqlite-rpalignment_cfg.py
+++ b/CondTools/CTPPS/test/retrieve-sqlite-rpalignment_cfg.py
@@ -1,23 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-if len(sys.argv)>2:
-    sqlitename =sys.argv[2]
+if len(sys.argv)>1:
+    sqlitename =sys.argv[1]
 else:
     sqlitename = "CTPPSRPRealAlignment.db"
 
-if len(sys.argv) > 3:
-    runno = int(sys.argv[3])
+if len(sys.argv) > 2:
+    runno = int(sys.argv[2])
 else:
     runno=1
 
-if len(sys.argv) >4 :
-    tagname = sys.argv[4]
+if len(sys.argv) >3 :
+    tagname = sys.argv[3]
 else:
     tagname="CTPPSRPAlignment_real"
 
-if len(sys.argv) > 5:
-    rcdname=sys.argv[5]
+if len(sys.argv) > 4:
+    rcdname=sys.argv[4]
 else:
     rcdname="RPRealAlignmentRecord"
 

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_singletest.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('test')
 
 import sys
-if len(sys.argv)>2:
-    startrun = int(sys.argv[2])
+if len(sys.argv)>1:
+    startrun = int(sys.argv[1])
 else:
     startrun = 1
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_cfg.py
@@ -4,9 +4,9 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('test')
 
 import sys
-if len(sys.argv) > 3:
-    startrun = sys.argv[2]
-    subdir = sys.argv[3]+"/"
+if len(sys.argv) > 2:
+    startrun = sys.argv[1]
+    subdir = sys.argv[2]+"/"
 else:
     print("not able to run")
     exit()

--- a/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
+++ b/CondTools/CTPPS/test/write-ctpps-rprealalignment_table_test.py
@@ -4,9 +4,9 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('test')
 
 # import sys
-# if len(sys.argv) > 3:
-#     startrun = sys.argv[2]
-#     path = sys.argv[3]+"/"
+# if len(sys.argv) > 2:
+#     startrun = sys.argv[1]
+#     path = sys.argv[2]+"/"
 # else:
 #     print("not able to run")
 #     exit()

--- a/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixel2DTemplateDBObjectReader_cfg.py
@@ -7,8 +7,8 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 #process.load("CalibTracker.SiPixelESProducers.SiPixel2DTemplateDBObjectESProducer_cfi")
 
 #magfield and version are argument #1 and #2
-#magfield = float(sys.argv[2])
-#version = sys.argv[3]
+#magfield = float(sys.argv[1])
+#version = sys.argv[2]
 
 #magfield and version are hardcoded for the record
 magfield = 38

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2018_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2018_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2019_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2019_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2021_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2018_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2018_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2019_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2019_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2021_cfg.py
@@ -24,10 +24,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_LASER_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_LASER_era2021_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_LED_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_LED_era2021_cfg.py
@@ -24,10 +24,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_PEDESTAL_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_MIXED_PEDESTAL_era2021_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2018_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2018_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2019_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2019_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2021_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_PEDESTAL_era2021_cfg.py
@@ -23,10 +23,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/scripts/psm/PSM_Global_2018_cfg.py
+++ b/DPGAnalysis/HcalTools/scripts/psm/PSM_Global_2018_cfg.py
@@ -24,10 +24,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-#runnumber = sys.argv[2]
-#rundir = sys.argv[3]
-#histodir = sys.argv[4]
+#runnumber = sys.argv[1]
+#rundir = sys.argv[2]
+#histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DPGAnalysis/HcalTools/test/remoteMonitoring_LED_eraTEST2019_cfg.py
+++ b/DPGAnalysis/HcalTools/test/remoteMonitoring_LED_eraTEST2019_cfg.py
@@ -29,10 +29,9 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-##runnumber = sys.argv[2][4:-5] 
-runnumber = sys.argv[2]
-rundir = sys.argv[3]
-histodir = sys.argv[4]
+runnumber = sys.argv[1]
+rundir = sys.argv[2]
+histodir = sys.argv[3]
 
 #print 'RUN = '+runnumber
 #print 'Input file = '+rundir+'/run'+runnumber+'/USC_'+runnumber+'.root'

--- a/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
+++ b/DQM/BeamMonitor/test/beamspotdip_dqm_sourceclient-file_cfg.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 import sys
 import os
 from shutil import copy
-configFile = os.path.dirname(sys.argv[1]) + "/log4cplus.properties"
+configFile = os.path.dirname(sys.argv[0]) + "/log4cplus.properties"
 print("copying " + configFile + " to local")
 copy(configFile,".")
 

--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -5,7 +5,7 @@ import FWCore.ParameterSet.Config as cms
 import sys
 import os
 from shutil import copy
-configFile = os.path.dirname(sys.argv[1]) + "/log4cplus.properties"
+configFile = os.path.dirname(sys.argv[0]) + "/log4cplus.properties"
 print("copying " + configFile + " to local")
 copy(configFile,".")
 

--- a/DQMOffline/Trigger/test/harvesting_cfg.py
+++ b/DQMOffline/Trigger/test/harvesting_cfg.py
@@ -19,10 +19,7 @@ parser.add_argument('-s', '--nStreams', type = int, help = 'Number of EDM stream
 parser.add_argument('-i', '--inputFiles', nargs = '+', help = 'List of DQMIO input files',
                     default = ['file:testHLTFiltersDQMonitor_DQMIO.root'])
 
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove('--')
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 # Process
 process = cms.Process('HARVESTING')

--- a/DQMOffline/Trigger/test/readme.md
+++ b/DQMOffline/Trigger/test/readme.md
@@ -20,11 +20,11 @@ Test of the DQM plugin `HLTFiltersDQMonitor`.
 
   - To execute cmsRun with `testHLTFiltersDQMonitor_cfg.py` (example)
     ```sh
-    cmsRun "${CMSSW_BASE}"/src/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py -- -t 4 -s 0 -o tmp.root -n 100
+    cmsRun "${CMSSW_BASE}"/src/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py -t 4 -s 0 -o tmp.root -n 100
     ```
 
   - To create a bare ROOT file from the DQMIO output of `testHLTFiltersDQMonitor_cfg.py`,
     run the harvesting step as follows
     ```sh
-    cmsRun "${CMSSW_BASE}"/src/DQMOffline/Trigger/test/harvesting_cfg.py -- -i file:tmp.root
+    cmsRun "${CMSSW_BASE}"/src/DQMOffline/Trigger/test/harvesting_cfg.py -i file:tmp.root
     ```

--- a/DQMOffline/Trigger/test/testHLTFiltersDQMonitor.sh
+++ b/DQMOffline/Trigger/test/testHLTFiltersDQMonitor.sh
@@ -9,5 +9,5 @@ function die {
 # run test job
 TESTDIR="${LOCALTOP}"/src/DQMOffline/Trigger/test
 
-cmsRun "${TESTDIR}"/testHLTFiltersDQMonitor_cfg.py -- -t 4 -n 128 \
+cmsRun "${TESTDIR}"/testHLTFiltersDQMonitor_cfg.py -t 4 -n 128 \
   || die "Failure running testHLTFiltersDQMonitor_cfg.py" $?

--- a/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py
+++ b/DQMOffline/Trigger/test/testHLTFiltersDQMonitor_cfg.py
@@ -31,10 +31,7 @@ parser.add_argument('--wantSummary', action = 'store_true', help = 'Value of pro
 parser.add_argument('-d', '--debugMode', action = 'store_true', help = 'Enable debug info (requires recompiling first with \'USER_CXXFLAGS="-DEDM_ML_DEBUG" scram b\')',
                     default = False)
 
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove('--')
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 ## Process
 process = cms.Process('TEST')

--- a/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest_cfg.py
+++ b/DQMServices/StreamerIO/test/DQMStreamerOutputRepackerTest_cfg.py
@@ -19,7 +19,7 @@ from Configuration.Applications.ConfigBuilder import filesFromDASQuery
 #dataset = "/RelValZMM_13/CMSSW_9_0_0_pre2-PU25ns_90X_mcRun2_asymptotic_v0-v1/GEN-SIM-DIGI-RAW-HLTDEBUG"
 #dataset = "/SinglePhoton/Run2016C-v2/RAW"
 #read, sec = filesFromDASQuery("file dataset=%s" % dataset, option=" --limit 10000 ")
-read, sec = ["file:%s" % sys.argv[2]], []
+read, sec = ["file:%s" % sys.argv[1]], []
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(read),

--- a/DataFormats/Common/test/test_readTriggerResults_cfg.py
+++ b/DataFormats/Common/test/test_readTriggerResults_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 process.maxEvents.input = 1
 
 process.testReadTriggerResults = cms.EDAnalyzer("TestReadTriggerResults",

--- a/DataFormats/DetId/test/test_readVectorDetId_cfg.py
+++ b/DataFormats/DetId/test/test_readVectorDetId_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 
 process.testReadVectorDetId = cms.EDAnalyzer("TestReadVectorDetId",
     expectedTestValue = cms.uint32(21),

--- a/DataFormats/FEDRawData/test/test_readFEDRawDataCollection_cfg.py
+++ b/DataFormats/FEDRawData/test/test_readFEDRawDataCollection_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 process.maxEvents.input = 1
 
 process.testReadFEDRawDataCollection = cms.EDAnalyzer("TestReadFEDRawDataCollection",

--- a/DataFormats/HLTReco/test/test_readTriggerEvent_cfg.py
+++ b/DataFormats/HLTReco/test/test_readTriggerEvent_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 process.maxEvents.input = 1
 
 process.testReadTriggerEvent = cms.EDAnalyzer("TestReadTriggerEvent",

--- a/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
+++ b/DataFormats/L1TGlobal/test/test_readGlobalObjectMapRecord_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 process.maxEvents.input = 1
 
 process.testReadGlobalObjectMapRecord = cms.EDAnalyzer("TestReadGlobalObjectMapRecord",

--- a/DataFormats/Scouting/test/TestRun2ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun2ScoutingFormats.sh
@@ -63,17 +63,17 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun2Scouting_cfg.py || die "Failure using test
 
 file=testRun2Scouting_v3_v2_v2_v3_v2_v2_v2_CMSSW_8_0_7.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="-- --inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_8_0_7.root --muonVersion 2 --trackVersion 0 --vertexVersion 2"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_8_0_7.root --muonVersion 2 --trackVersion 0 --vertexVersion 2"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun2Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 file=testRun2Scouting_v3_v2_v3_v3_v2_v2_v3_CMSSW_9_4_0.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="-- --inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_9_4_0.root --muonVersion 3 --trackVersion 0 --vertexVersion 3"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_9_4_0.root --muonVersion 3 --trackVersion 0 --vertexVersion 3"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun2Scouting_cfg.py  $argsPassedToPython || die "Failed to read old file $file" $?
 
 file=testRun2Scouting_v3_v2_v3_v3_v2_v2_v2_v3_CMSSW_10_2_0.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="-- --inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_10_2_0.root --muonVersion 3 --trackVersion 2 --vertexVersion 3"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun2Scouting2_CMSSW_10_2_0.root --muonVersion 3 --trackVersion 2 --vertexVersion 3"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun2Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 exit 0

--- a/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
@@ -48,12 +48,12 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py || die "Failure using test
 
 file=testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="-- --inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 file=testRun3Scouting_v3_v6_v3_v4_v5_v3_v5_v3_v3_CMSSW_13_0_3.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="-- --inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_13_0_3.root --electronVersion 6"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_13_0_3.root --electronVersion 6"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 exit 0

--- a/DataFormats/Scouting/test/test_readRun2Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun2Scouting_cfg.py
@@ -9,10 +9,7 @@ parser.add_argument("--trackVersion", type=int, help="track data format version 
 parser.add_argument("--vertexVersion", type=int, help="vertex data format version (default: 3)", default=3)
 parser.add_argument("--inputFile", type=str, help="Input file name (default: testRun2Scouting.root)", default="testRun2Scouting.root")
 parser.add_argument("--outputFileName", type=str, help="Output file name (default: testRun2Scouting2.root)", default="testRun2Scouting2.root")
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 process = cms.Process("READ")
 

--- a/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
@@ -7,10 +7,7 @@ parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test Run 3 Scout
 parser.add_argument("--electronVersion", type=int, help="electron data format version (default: 6)", default=6)
 parser.add_argument("--inputFile", type=str, help="Input file name (default: testRun3Scouting.root)", default="testRun3Scouting.root")
 parser.add_argument("--outputFileName", type=str, help="Output file name (default: testRun3Scouting2.root)", default="testRun3Scouting2.root")
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 process = cms.Process("READ")
 

--- a/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
+++ b/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
@@ -3,7 +3,7 @@ import sys
 
 process = cms.Process("READ")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 
 process.testReadSiStripApproximateClusterCollection = cms.EDAnalyzer("TestReadSiStripApproximateClusterCollection",
     expectedIntegralValues = cms.vuint32(11, 21, 31, 41, 51, 62, 73),

--- a/GeneratorInterface/Core/test/test_FailingGeneratorFilter_cfg.py
+++ b/GeneratorInterface/Core/test/test_FailingGeneratorFilter_cfg.py
@@ -10,8 +10,8 @@ process.maxEvents.input=10
 from GeneratorInterface.Core.ExternalGeneratorFilter import *
 process.generator = ExternalGeneratorFilter(
     cms.EDFilter("FailingGeneratorFilter",
-                 failAt=cms.int32(int(sys.argv[2])),
-                 failureType = cms.int32(int(sys.argv[3]))),
+                 failAt=cms.int32(int(sys.argv[1])),
+                 failureType = cms.int32(int(sys.argv[2]))),
     _external_process_waitTime_ = cms.untracked.uint32(5),
     _external_process_verbose_ = cms.untracked.bool(True),
     _external_process_components_ =cms.vstring()

--- a/GeneratorInterface/LHEInterface/test/testMerge_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testMerge_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 #find the path to the config file
-path = "/".join(sys.argv[1].split('/')[0:-1])
+path = "/".join(sys.argv[0].split('/')[0:-1])
 if not path:
     path = '.'
 

--- a/GeneratorInterface/LHEInterface/test/testNoMerge_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testNoMerge_cfg.py
@@ -5,7 +5,7 @@ import sys
 process = cms.Process("LHE")
 
 #find the path to the config file
-path = "/".join(sys.argv[1].split('/')[0:-1])
+path = "/".join(sys.argv[0].split('/')[0:-1])
 if not path:
     path = '.'
 

--- a/IOPool/Input/test/PoolGUIDTest_cfg.py
+++ b/IOPool/Input/test/PoolGUIDTest_cfg.py
@@ -3,14 +3,6 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-argv = []
-foundpy = False
-for a in sys.argv:
-    if foundpy:
-        argv.append(a)
-    if ".py" in a:
-        foundpy = True
-
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
@@ -20,7 +12,7 @@ process.Analysis = cms.EDAnalyzer("OtherThingAnalyzer")
 
 process.source = cms.Source("PoolSource",
     setRunNumber = cms.untracked.uint32(621),
-    fileNames = cms.untracked.vstring(argv[0]),
+    fileNames = cms.untracked.vstring(sys.argv[1]),
     enforceGUIDInFileName = cms.untracked.bool(True)
 )
 

--- a/IOPool/Input/test/PrePoolInputTest_cfg.py
+++ b/IOPool/Input/test/PrePoolInputTest_cfg.py
@@ -5,35 +5,27 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-argv = []
-foundpy = False
-for a in sys.argv:
-    if foundpy:
-        argv.append(a)
-    if ".py" in a:
-        foundpy = True
-
 useOtherThing = False
-if len(argv) > 6:
-  if argv[6] == "useOtherThing":
+if len(sys.argv) > 7:
+  if sys.argv[7] == "useOtherThing":
     useOtherThing = True
 
 process = cms.Process("TESTPROD")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents.input = int(argv[1])
+process.maxEvents.input = int(sys.argv[2])
 
 process.Thing = cms.EDProducer("ThingProducer")
 
 process.output = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string(argv[0])
+    fileName = cms.untracked.string(sys.argv[1])
 )
 
 process.source = cms.Source("EmptySource",
-    firstRun = cms.untracked.uint32(int(argv[2])),
-    numberEventsInRun = cms.untracked.uint32(int(argv[3])),
-    firstLuminosityBlock = cms.untracked.uint32(int(argv[4])),
-    numberEventsInLuminosityBlock = cms.untracked.uint32(int(argv[5]))
+    firstRun = cms.untracked.uint32(int(sys.argv[3])),
+    numberEventsInRun = cms.untracked.uint32(int(sys.argv[4])),
+    firstLuminosityBlock = cms.untracked.uint32(int(sys.argv[5])),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(int(sys.argv[6]))
 )
 
 process.p = cms.Path(process.Thing)

--- a/IOPool/Input/test/RunPerLumiTest_cfg.py
+++ b/IOPool/Input/test/RunPerLumiTest_cfg.py
@@ -8,7 +8,7 @@ from sys import argv
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents.input = int(argv[2])
+process.maxEvents.input = int(argv[1])
 
 runToLumi = [111,222,333,444,555]
 

--- a/IOPool/Input/test/firstLuminosityBlockForEachRunTest_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRunTest_cfg.py
@@ -5,31 +5,19 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-import sys
-
-#ignore script name and anything before it
-argv = []
-foundpy = False
-for a in sys.argv:
-    if foundpy:
-        argv.append(a)
-    if ".py" in a:
-        foundpy = True
-
-
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(int(argv[1]))
+    input = cms.untracked.int32(int(sys.argv[2]))
 )
 
-firstRun = int(argv[2])
-numberEventsInRun = int(argv[3])
-firstLuminosityBlock = int(argv[4])
-numberEventsInLuminosityBlock = int(argv[5])
+firstRun = int(sys.argv[3])
+numberEventsInRun = int(sys.argv[4])
+firstLuminosityBlock = int(sys.argv[5])
+numberEventsInLuminosityBlock = int(sys.argv[6])
 
-if len(argv) > 6:
+if len(sys.argv) > 7:
   #have first run of second file continue the run
   runToLumi = ((2,1),(10,3),(20,5), (30, 7), (40, 9) )
 else:
@@ -50,8 +38,8 @@ numberOfEventsPerLumi = numberEventsInLuminosityBlock
 lumi = 1
 event=0
 oldRun = 2
-numberOfFiles = len(argv[0].split(","))
-numberOfEventsInFile = int(argv[1])/numberOfFiles
+numberOfFiles = len(sys.argv[1].split(","))
+numberOfEventsInFile = int(sys.argv[2])/numberOfFiles
 for i in range(process.maxEvents.input.value()):
    numberOfEventsInLumi +=1
    event += 1
@@ -70,7 +58,7 @@ process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(i
 
 process.source = cms.Source("PoolSource",
     firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
-    fileNames = cms.untracked.vstring(argv[0].split(","))
+    fileNames = cms.untracked.vstring(sys.argv[1].split(","))
 )
 
 process.e = cms.EndPath(process.check)

--- a/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis2_Test_cfg.py
@@ -5,16 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-#ignore script name and anything before it
-argv = []
-foundpy = False
-for a in sys.argv:
-    if foundpy:
-        argv.append(a)
-    if ".py" in a:
-        foundpy = True
-
-
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
@@ -34,7 +24,7 @@ def findRunForLumi( lumi) :
 ids = cms.VEventID()
 numberOfEventsInLumi = 0
 numberOfEventsPerLumi = 5
-lumi = int(argv[1])
+lumi = int(sys.argv[2])
 event= numberOfEventsPerLumi*(lumi-1)
 oldRun = 2
 numberOfFiles = 1
@@ -56,9 +46,9 @@ process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(i
 
 
 process.source = cms.Source("PoolSource",
-                            lumisToProcess = cms.untracked.VLuminosityBlockRange('1:'+str(int(argv[1]))+'-1:'+str(runToLumi[-1][1])),
+                            lumisToProcess = cms.untracked.VLuminosityBlockRange('1:'+str(int(sys.argv[2]))+'-1:'+str(runToLumi[-1][1])),
     firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
-    fileNames = cms.untracked.vstring(argv[0].split(","))
+    fileNames = cms.untracked.vstring(sys.argv[1].split(","))
 )
 
 process.e = cms.EndPath(process.check)

--- a/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py
+++ b/IOPool/Input/test/firstLuminosityBlockForEachRun_skipLumis_Test_cfg.py
@@ -5,18 +5,6 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-import sys
-
-#ignore script name and anything before it
-argv = []
-foundpy = False
-for a in sys.argv:
-    if foundpy:
-        argv.append(a)
-    if ".py" in a:
-        foundpy = True
-
-
 process = cms.Process("TESTRECO")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
@@ -36,7 +24,7 @@ def findRunForLumi( lumi) :
 ids = cms.VEventID()
 numberOfEventsInLumi = 0
 numberOfEventsPerLumi = 5
-lumi = int(argv[1])
+lumi = int(sys.argv[2])
 event= numberOfEventsPerLumi*(lumi-1)
 oldRun = 2
 numberOfFiles = 1
@@ -58,9 +46,9 @@ process.check = cms.EDAnalyzer("EventIDChecker", eventSequence = cms.untracked(i
 
 
 process.source = cms.Source("PoolSource",
-                            firstLuminosityBlock = cms.untracked.uint32(int(argv[1])),
+                            firstLuminosityBlock = cms.untracked.uint32(int(sys.argv[2])),
     firstLuminosityBlockForEachRun = cms.untracked.VLuminosityBlockID(*[cms.LuminosityBlockID(x,y) for x,y in runToLumi]),
-    fileNames = cms.untracked.vstring(argv[0].split(","))
+    fileNames = cms.untracked.vstring(sys.argv[1].split(","))
 )
 
 process.e = cms.EndPath(process.check)

--- a/IOPool/Input/test/testFileOpenErrorExitCode.sh
+++ b/IOPool/Input/test/testFileOpenErrorExitCode.sh
@@ -13,7 +13,7 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/noFallbackFile/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/noFallbackFile/local/storage.json ${SITECONFIG_PATH}/
 F1=${LOCAL_TEST_DIR}/test_fileOpenErrorExitCode_cfg.py
-cmsRun -j NoFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root && die "$F1 should have failed but didn't, exit code was 0" 1
+cmsRun -j NoFallbackFile_jobreport.xml $F1 --input FileThatDoesNotExist.root && die "$F1 should have failed but didn't, exit code was 0" 1
 
 CMSRUN_EXIT_CODE=$(edmFjrDump --exitCode NoFallbackFile_jobreport.xml)
 echo "Exit code after first run of test_fileOpenErrorExitCode_cfg.py is ${CMSRUN_EXIT_CODE}"
@@ -24,7 +24,7 @@ fi
 
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/site-local-config.xml  ${SITECONFIG_PATH}/JobConfig/
 cp ${LOCAL_TEST_DIR}/sitelocalconfig/useFallbackFile/local/storage.json ${SITECONFIG_PATH}/
-cmsRun -j UseFallbackFile_jobreport.xml $F1 -- --input FileThatDoesNotExist.root > UseFallbackFile_output.log 2>&1 && die "$F1 should have failed after file fallback but didn't, exit code was 0" 1
+cmsRun -j UseFallbackFile_jobreport.xml $F1 --input FileThatDoesNotExist.root > UseFallbackFile_output.log 2>&1 && die "$F1 should have failed after file fallback but didn't, exit code was 0" 1
 grep -q "Input file abc/store/FileThatDoesNotExist.root could not be opened, and fallback was attempted" UseFallbackFile_output.log
 RET=$?
 if [ "${RET}" != "0" ]; then

--- a/IOPool/Input/test/test_complex_before_3_8_0_cfg.py
+++ b/IOPool/Input/test/test_complex_before_3_8_0_cfg.py
@@ -19,7 +19,7 @@ process.output = cms.OutputModule("PoolOutputModule",
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[2])
+    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
 )
 
 process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',

--- a/IOPool/Input/test/test_complex_old_formats_cfg.py
+++ b/IOPool/Input/test/test_complex_old_formats_cfg.py
@@ -19,7 +19,7 @@ process.output = cms.OutputModule("PoolOutputModule",
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[2])
+    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
 )
 
 process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',

--- a/IOPool/Input/test/test_empty_old_formats_cfg.py
+++ b/IOPool/Input/test/test_empty_old_formats_cfg.py
@@ -4,4 +4,4 @@ import sys
 process = cms.Process("OLDREAD")
 
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+                            fileNames = cms.untracked.vstring("file:"+sys.argv[1]))

--- a/IOPool/Input/test/test_fileOpenErrorExitCode_cfg.py
+++ b/IOPool/Input/test/test_fileOpenErrorExitCode_cfg.py
@@ -4,11 +4,7 @@ import sys
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test FileOpenErrorExitCode")
 parser.add_argument("--input", type=str, default=[], nargs="*", help="Optional list of input files")
-
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 process = cms.Process("TEST")
 

--- a/IOPool/Input/test/test_merge_two_files.py
+++ b/IOPool/Input/test/test_merge_two_files.py
@@ -4,8 +4,8 @@ import sys
 process = cms.Process("MERGETWOFILES")
 
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring("file:"+sys.argv[2],
-                                                              "file:"+sys.argv[3]),
+                            fileNames = cms.untracked.vstring("file:"+sys.argv[1],
+                                                              "file:"+sys.argv[2]),
                             duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
 

--- a/IOPool/Input/test/test_old_formats_cfg.py
+++ b/IOPool/Input/test/test_old_formats_cfg.py
@@ -4,7 +4,7 @@ import sys
 process = cms.Process("OLDREAD")
 
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+                            fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 
 process.tester = cms.EDAnalyzer("TestFindProduct",
                                 inputTags = cms.untracked.VInputTag(cms.InputTag("i")),

--- a/IOPool/Input/test/test_old_raw_data_step1_cfg.py
+++ b/IOPool/Input/test/test_old_raw_data_step1_cfg.py
@@ -4,7 +4,7 @@ import sys
 process = cms.Process("TEST")
 
 process.source = cms.Source("PoolSource",
-   fileNames = cms.untracked.vstring("file:"+sys.argv[2])
+   fileNames = cms.untracked.vstring("file:"+sys.argv[1])
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_cfg.py
@@ -144,7 +144,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[2]),
+    fileNames = cms.untracked.vstring("file:"+sys.argv[1]),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
 

--- a/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_dup_cfg.py
@@ -82,7 +82,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[2])
+    fileNames = cms.untracked.vstring("file:"+sys.argv[1])
 )
 
 process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',

--- a/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
+++ b/IOPool/Input/test/test_reduced_ProcessHistory_end_cfg.py
@@ -136,7 +136,7 @@ process.testmerge = cms.EDAnalyzer("TestMergeResults",
 )
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring("file:"+sys.argv[2]),
+    fileNames = cms.untracked.vstring("file:"+sys.argv[1]),
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
 

--- a/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
+++ b/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
@@ -7,10 +7,7 @@ parser.add_argument("--guid", type=str, help="GUID that overrides")
 parser.add_argument("--maxSize", type=int, default=None, help="Set maximum file size")
 parser.add_argument("--input", type=str, default=[], nargs="*", help="Optional list of input files")
 
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 process = cms.Process("TESTOUTPUTGUID")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")

--- a/IOPool/Output/test/PoolOutputTest_cfg.py
+++ b/IOPool/Output/test/PoolOutputTest_cfg.py
@@ -5,11 +5,7 @@ import sys
 parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test PoolOutputModule")
 parser.add_argument("--firstLumi", type=int, default=None, help="Set first lumi to process ")
 
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
-
+args = parser.parse_args()
 
 process = cms.Process("TESTOUTPUT")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -40,30 +40,30 @@ cmsRun ${LOCAL_TEST_DIR}/TestProvC_cfg.py || die 'Failure using TestProvC_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduled_cfg.py || die 'Failure using PoolOutputTestUnscheduled_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduledRead_cfg.py || die 'Failure using PoolOutputTestUnscheduledRead_cfg.py' $?
 
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID' $?
 GUID=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
 if [ "x${GUID}" != "xabcdef01-2345-6789-abcd-ef0123456789" ]; then
     echo "GUID in file '${GUID}' did not match 'abcdef01-2345-6789-abcd-ef0123456789'"
     exit 1
 fi
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid ABCDEF01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID (with some capital letteters)' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid ABCDEF01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID (with some capital letteters)' $?
 GUID=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
 if [ "x${GUID}" != "xABCDEF01-2345-6789-abcd-ef0123456789" ]; then
     echo "GUID in file '${GUID}' did not match 'ABCDEF01-2345-6789-abcd-ef0123456789'"
     exit 1
 fi
 
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef01234567890 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 1 did not fail' 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-0abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 2 did not fail' 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid 0abcdef01-2345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 3 did not fail' 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef012-345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 4 did not fail' 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef012345678g && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 5 did not fail' 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd_ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 6 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-abcd-ef01234567890 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 1 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-0abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 2 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid 0abcdef01-2345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 3 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef012-345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 4 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-abcd-ef012345678g && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 5 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-abcd_ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 6 did not fail' 1
 
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py -- --firstLumi 1
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py -- --firstLumi 2
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py --firstLumi 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py --firstLumi 2
 
-cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef0123456789 --input PoolOutputTestLumi1.root PoolOutputTestLumi2.root --maxSize 1 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID and two input files' $?
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py --guid abcdef01-2345-6789-abcd-ef0123456789 --input PoolOutputTestLumi1.root PoolOutputTestLumi2.root --maxSize 1 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID and two input files' $?
 GUID1=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
 GUID2=$(edmFileUtil -u PoolOutputTestOverrideGUID001.root | fgrep uuid | awk '{print $10}')
 if [ "x${GUID1}" != "xabcdef01-2345-6789-abcd-ef0123456789" ]; then

--- a/L1Trigger/L1GctAnalyzer/test/gctLUTGenerator_cfg.py
+++ b/L1Trigger/L1GctAnalyzer/test/gctLUTGenerator_cfg.py
@@ -6,7 +6,7 @@ import os
 
 # arguments
 if (len(sys.argv)>1) :
-    key=str(sys.argv[2])
+    key=str(sys.argv[1])
 else :
     key='Default'
 

--- a/L1Trigger/L1TGlobal/test/SingleElectronPt25_Stage2Test_uGT.py
+++ b/L1Trigger/L1TGlobal/test/SingleElectronPt25_Stage2Test_uGT.py
@@ -20,8 +20,6 @@ dump = False #dump python
 # vvv
 
 
-if len(sys.argv) > 1 and sys.argv[1].endswith('.py'):
-    sys.argv.pop(0)
 if len(sys.argv) == 2 and ':' in sys.argv[1]:
     argv = sys.argv[1].split(':')
 else:

--- a/L1Trigger/L1TGlobal/test/TTBarRelVal_Stage2uGT_TestVectors.py
+++ b/L1Trigger/L1TGlobal/test/TTBarRelVal_Stage2uGT_TestVectors.py
@@ -21,8 +21,6 @@ dump = False #dump python
 # vvv
 
 
-if len(sys.argv) > 1 and sys.argv[1].endswith('.py'):
-    sys.argv.pop(0)
 if len(sys.argv) == 2 and ':' in sys.argv[1]:
     argv = sys.argv[1].split(':')
 else:

--- a/L1Trigger/L1TGlobal/test/raw2l1.py
+++ b/L1Trigger/L1TGlobal/test/raw2l1.py
@@ -31,8 +31,6 @@ reemul = True
 # Argument parsing
 # vvv
 
-if len(sys.argv) > 1 and sys.argv[1].endswith('.py'):
-    sys.argv.pop(0)
 if len(sys.argv) == 2 and ':' in sys.argv[1]:
     argv = sys.argv[1].split(':')
 else:

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -21,8 +21,6 @@ newXML = False #whether running with the new Grammar
 # Argument parsing
 # vvv
 
-if len(sys.argv) > 1 and sys.argv[1].endswith('.py'):
-    sys.argv.pop(0)
 if len(sys.argv) == 2 and ':' in sys.argv[1]:
     argv = sys.argv[1].split(':')
 else:

--- a/L1Trigger/L1TGlobal/test/testVectorCode_data.py
+++ b/L1Trigger/L1TGlobal/test/testVectorCode_data.py
@@ -18,8 +18,6 @@ newXML = False #whether running with the new Grammar
 # ----------------
 # Argument parsing
 # ----------------
-if len(sys.argv) > 1 and sys.argv[1].endswith('.py'):
-    sys.argv.pop(0)
 if len(sys.argv) == 2 and ':' in sys.argv[1]:
     argv = sys.argv[1].split(':')
 else:

--- a/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapDataDump.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapDataDump.py
@@ -70,7 +70,7 @@ path = '/eos/user/a/akalinow/Data/SingleMu/9_3_14_FullEta_v2/' #new sample, but 
 onlyfiles = [f for f in listdir(path) if isfile(join(path, f))]
 #print onlyfiles
 
-filesNameLike = sys.argv[2]
+filesNameLike = sys.argv[1]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_p_10_' in f) or ('_m_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_10_p_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (re.match('.*_._p_10.*', f))]

--- a/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapPatternGenerator.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapPatternGenerator.py
@@ -68,7 +68,7 @@ path = '/eos/user/k/kbunkow/cms_data/SingleMuFullEta/721_FullEta_v4/' #old sampl
 onlyfiles = [f for f in listdir(path) if isfile(join(path, f))]
 #print onlyfiles
 
-filesNameLike = sys.argv[2]
+filesNameLike = sys.argv[1]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_p_10_' in f) or ('_m_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_10_p_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (re.match('.*_._p_10.*', f))]

--- a/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapPatternGeneratorClassProb.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/runMuonOverlapPatternGeneratorClassProb.py
@@ -68,7 +68,7 @@ path = '/eos/user/k/kbunkow/cms_data/SingleMuFullEta/721_FullEta_v4/' #old sampl
 onlyfiles = [f for f in listdir(path) if isfile(join(path, f))]
 #print onlyfiles
 
-filesNameLike = sys.argv[2]
+filesNameLike = sys.argv[1]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_p_10_' in f) or ('_m_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (('_10_p_10_' in f))]
 #chosenFiles = ['file://' + path + f for f in onlyfiles if (re.match('.*_._p_10.*', f))]

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -1,8 +1,8 @@
 import argparse
 import sys
 
-# example: cmsRun L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py -- --patternFilesOFF
-# example: cmsRun L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py -- --dumpFilesOFF --serenity
+# example: cmsRun L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py --patternFilesOFF
+# example: cmsRun L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_patternFiles_cfg.py --dumpFilesOFF --serenity
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Optional parameters')
 
@@ -11,10 +11,7 @@ parser.add_argument("--patternFilesOFF", help="switch on Layer-1 pattern file pr
 parser.add_argument("--serenity", help="use Serenity settigns as default everwhere, i.e. also for barrel", action="store_true", default=False)
 parser.add_argument("--tm18", help="Add TM18 emulators for the endcaps", action="store_true", default=False)
 
-argv = sys.argv[:]
-if '--' in argv:
-    argv.remove("--")
-args, unknown = parser.parse_known_args(argv)
+args = parser.parse_args()
 
 if args.dumpFilesOFF:
     print(f'Switching off dump file creation: dumpFilesOFF is {args.dumpFilesOFF}')

--- a/L1TriggerConfig/GctConfigProducers/test/test-o2o-emulator.py
+++ b/L1TriggerConfig/GctConfigProducers/test/test-o2o-emulator.py
@@ -12,7 +12,7 @@ import os
 from subprocess import *
 
 # arguments
-key=str(sys.argv[2])
+key=str(sys.argv[1])
 
 
 # CMSSW process proper

--- a/L1TriggerConfig/GctConfigProducers/test/test-o2o-print.py
+++ b/L1TriggerConfig/GctConfigProducers/test/test-o2o-print.py
@@ -5,7 +5,7 @@ import os
 
 # arguments
 if (len(sys.argv)>1) :
-    key=str(sys.argv[2])
+    key=str(sys.argv[1])
 else :
     key='Default'
 

--- a/L1TriggerConfig/GctConfigProducers/test/test-o2o-rs.py
+++ b/L1TriggerConfig/GctConfigProducers/test/test-o2o-rs.py
@@ -4,8 +4,8 @@ import sys
 import os
 
 # arguments
-if (len(sys.argv)>2) :
-    key=str(sys.argv[2])
+if (len(sys.argv)>1) :
+    key=str(sys.argv[1])
 else :
     key='Default'
 

--- a/RecoEgamma/ElectronIdentification/test/runElectron_VID.py
+++ b/RecoEgamma/ElectronIdentification/test/runElectron_VID.py
@@ -46,8 +46,8 @@ inputFilesMiniAOD = cms.untracked.vstring(
 # You can list here either AOD or miniAOD files, but not both types mixed
 #
 
-print(sys.argv[2])
-useAOD = bool(int(sys.argv[2]))
+print(sys.argv[1])
+useAOD = bool(int(sys.argv[1]))
 
 if useAOD == True :
     inputFiles = inputFilesAOD
@@ -74,7 +74,7 @@ else :
 switchOnVIDElectronIdProducer(process, dataFormat)
 
 # define which IDs we want to produce
-my_id_modules = [sys.argv[3]]
+my_id_modules = [sys.argv[2]]
 
 #add them to the VID producer
 for idmod in my_id_modules:

--- a/RecoEgamma/PhotonIdentification/test/runPhoton_VID.py
+++ b/RecoEgamma/PhotonIdentification/test/runPhoton_VID.py
@@ -44,8 +44,8 @@ inputFilesMiniAOD = cms.untracked.vstring(
 # You can list here either AOD or miniAOD files, but not both types mixed
 #
 
-print(sys.argv[2])
-useAOD = bool(int(sys.argv[2]))
+print(sys.argv[1])
+useAOD = bool(int(sys.argv[1]))
 
 if useAOD == True :
     inputFiles = inputFilesAOD
@@ -72,7 +72,7 @@ else :
 switchOnVIDPhotonIdProducer(process, dataFormat)
 
 # define which IDs we want to produce
-my_id_modules = [sys.argv[3]]
+my_id_modules = [sys.argv[2]]
 
 #add them to the VID producer
 for idmod in my_id_modules:

--- a/RecoLocalMuon/GEMCSCSegment/test/runGEMCSCCoincidenceRateAnalyzer_cfg.py
+++ b/RecoLocalMuon/GEMCSCSegment/test/runGEMCSCCoincidenceRateAnalyzer_cfg.py
@@ -7,16 +7,6 @@ import FWCore.ParameterSet.Config as cms
 print(f'{sys.argv=}')
 # NTOE when running cmsRun, __file__ is not defined
 
-cfg_idx = -1
-for idx, each in enumerate(sys.argv):
-    if each.endswith('runGEMCSCCoincidenceRateAnalyzer_cfg.py'):
-        cfg_idx = idx
-if cfg_idx < 0:
-    raise RuntimeError(f'cfg not found: {sys.argv=}')
-
-print(f'{sys.argv[:cfg_idx + 1]} are interpreted as arguments for cmsRun.')
-print(f'parsing argumnets from {sys.argv[cfg_idx + 1:]}.')
-
 parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-e', '--era', type=str, default='Phase2C17I13M9', help='era')
@@ -28,7 +18,7 @@ default_data_dir = Path('/eos/cms/store/relval/CMSSW_12_6_0_pre2/RelValSingleMuP
 default_input_files = ['file:' + str(each) for each in default_data_dir.glob('**/*.root')]
 parser.add_argument('-i', '--input-files', type=str, nargs='+', default=default_input_files, help='input files')
 parser.add_argument('-o', '--output-file', type=str, default='output.root', help='output file')
-args = parser.parse_args(sys.argv[cfg_idx + 1:])
+args = parser.parse_args()
 
 for key, value in vars(args).items():
     print(f'{key}={value}')

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-infile_name = sys.argv[2]
-outfile_name = '/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre3_singlegconv/src/RecoParticleFlow/Configuration/test/%s/superClusterDump_%i.root'%(sys.argv[5],int(sys.argv[3]))
-nevents = int(sys.argv[4])
+infile_name = sys.argv[1]
+outfile_name = '/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre3_singlegconv/src/RecoParticleFlow/Configuration/test/%s/superClusterDump_%i.root'%(sys.argv[4],int(sys.argv[2]))
+nevents = int(sys.argv[3])
 
 
 process = cms.Process("REPROD")

--- a/SimTracker/TrackerMaterialAnalysis/test/TrackingMaterialAnalyser_dd4hep.py
+++ b/SimTracker/TrackerMaterialAnalysis/test/TrackingMaterialAnalyser_dd4hep.py
@@ -112,7 +112,7 @@ groupsPh2 = cms.vstring(
     "TrackerRecMaterialPhase2OTForwardDisk5"
 )
 
-optPh = str(sys.argv[2])
+optPh = str(sys.argv[1])
 
 groups = None
 if( optPh.lower() == "phasei"):

--- a/Validation/CaloTowers/test/client_cfg.py
+++ b/Validation/CaloTowers/test/client_cfg.py
@@ -9,7 +9,7 @@ import re
 readFiles = cms.untracked.vstring()
 
 matchRootFile = re.compile("\S*\.root$")
-for argument in sys.argv[2:]:
+for argument in sys.argv[1:]:
    if matchRootFile.search(argument):
       fileToRead = "file:"+argument
       readFiles.append(fileToRead)

--- a/Validation/CaloTowers/test/client_data_cfg.py
+++ b/Validation/CaloTowers/test/client_data_cfg.py
@@ -6,7 +6,7 @@ import sys
 import re
 
 class config: pass
-config.runNumber = int(sys.argv[2])
+config.runNumber = int(sys.argv[1])
 print config.runNumber
 
 for arg in sys.argv: 
@@ -15,7 +15,7 @@ for arg in sys.argv:
 readFiles = cms.untracked.vstring()
 
 matchRootFile = re.compile("\S*\.root$")
-for argument in sys.argv[3:]:
+for argument in sys.argv[2:]:
    if matchRootFile.search(argument):
       fileToRead = "file:"+argument
       readFiles.append(fileToRead)

--- a/Validation/RecoTau/Tools/MergeFilesAndCalculateEfficiencies_cfg.py
+++ b/Validation/RecoTau/Tools/MergeFilesAndCalculateEfficiencies_cfg.py
@@ -19,13 +19,13 @@ import sys
 import FWCore.ParameterSet.Config as cms
 from Validation.RecoTau.ValidationOptions_cff import allowedOptions
 
-if len(sys.argv) < 5:
+if len(sys.argv) < 4:
    print("Error. Expected at least 3 arguments\n\nUsage: MergeFilesAndCalculateEfficiencies.py dataType OutputFile InputFileGlob")
    sys.exit()
 
-dataType   = sys.argv[2]
-OutputFile = sys.argv[3]
-Inputs     = sys.argv[4:]
+dataType   = sys.argv[1]
+OutputFile = sys.argv[2]
+Inputs     = sys.argv[3:]
 
 if not dataType in allowedOptions['eventType']:
    print("Error. The first argument must be the dataType. Types availables are:")


### PR DESCRIPTION
#### PR description:

This PR accounts for two changes from #42650 in non-core packages:
1. When invoking `cmsRun config_file.py ...`, inside the Python config file, the contents of `sys.argv` are `["config_file.py",...]` (consistent with the result of `python3 config_file.py ...`). Previously, when using `cmsRun`, the contents of `sys.argv` would be `["cmsRun","config_file.py",...]`.
2. No need to include the `--` separator when calling `cmsRun config_file.py [args]` to pass `args` to Python.

Among other things, these changes allow removing various kludgey ways of handling the previous non-standard approach to passing arguments to Python. They also mean that index-based access to `sys.argv` shifts by 1.

#### PR validation:

Unit tests that were previously failing (https://github.com/cms-sw/cmssw/pull/42650#issuecomment-1721644905) now pass.

(Non-unit tested scripts are fixed on a best effort basis.)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Unlikely to be backported, see discussion at #42650.