### PR TITLE
Add a Phase2 HLT tracking DQM monitoring (13.1.X)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -643,6 +643,12 @@ approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*'
                               ])
 
+phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
+                        outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                            'keep *_hltPhase2PixelTracks_*_*',
+                            'keep *_hltPhase2PixelVertices_*_*'
+                        ])
+
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 
 (premix_stage2 & phase2_tracker).toModify(FEVTDEBUGHLTEventContent, 

--- a/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2ITMonitorCluster.cc
@@ -102,6 +102,12 @@ void Phase2ITMonitorCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventS
 void Phase2ITMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Getting the clusters
   const auto& itPixelClusterHandle = iEvent.getHandle(itPixelClusterToken_);
+
+  if (!itPixelClusterHandle.isValid()) {
+    edm::LogWarning("Phase2ITMonitorCluster") << "No SiPixelCluster Collection found in the event. Skipping!";
+    return;
+  }
+
   // Number of clusters
   std::map<std::string, unsigned int> nClsmap;
   unsigned int nclusGlobal = 0;

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorCluster.cc
@@ -105,6 +105,12 @@ void Phase2OTMonitorCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventS
 void Phase2OTMonitorCluster::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Getting the clusters
   const auto& clusterHandle = iEvent.getHandle(clustersToken_);
+
+  if (!clusterHandle.isValid()) {
+    edm::LogWarning("Phase2OTMonitorCluster") << "No Phase2TrackerCluster1D Collection found in the event. Skipping!";
+    return;
+  }
+
   // Number of clusters
   std::map<std::string, unsigned int> nClustersCounter_P;  //map of detidkey vs #cls
   std::map<std::string, unsigned int> nClustersCounter_S;  //map of detidkey vs #cls

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -249,7 +249,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                      'DQMNone'],
             }
 
-_phase2_allowed = ['trackingOnlyDQM','outerTracker', 'trackerPhase2', 'muon','hcal','hcal2','egamma','L1TMonPhase2']
+_phase2_allowed = ['trackingOnlyDQM','outerTracker', 'trackerPhase2', 'muon','hcal','hcal2','egamma','L1TMonPhase2','HLTMon']
 autoDQM['phase2'] = ['','','']
 for i in [0,2]:
     autoDQM['phase2'][i] = '+'.join([autoDQM[m][i] for m in _phase2_allowed])

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -204,6 +204,10 @@ offlineHLTSource4HLTMonitorPD = cms.Sequence(
     particleNetMonitoringHLT          # HIG: monitoring of HLT PNET taggers (incl. comparisons to Offline PNET)
 )
 
+# remove Strip HLT monitoring in the phase-2 sequence
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(offlineHLTSource4HLTMonitorPD, offlineHLTSource4HLTMonitorPD.copyAndExclude([ sistripMonitorHLTsequence]))
+
 # sequences run @tier0 on HLTMonitor PD
 OfflineHLTMonitoring = cms.Sequence(
     offlineHLTSource4HLTMonitorPD

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -49,7 +49,6 @@ from DQMOffline.Trigger.TrackingMonitoring_cff import *
 from DQMOffline.Trigger.TrackingMonitoringPA_cff import*
 from DQMOffline.Trigger.TrackToTrackMonitoring_cff import *
 
-
 # hcal
 from DQMOffline.Trigger.HCALMonitoring_cff import *
 
@@ -58,6 +57,9 @@ from DQMOffline.Trigger.SiStrip_OfflineMonitoring_cff import *
 
 # pixel
 from DQMOffline.Trigger.SiPixel_OfflineMonitoring_cff import *
+
+# phase2 tracker
+from DQMOffline.Trigger.SiTrackerPhase2_OfflineMonitoring_cff import *
 
 # B2G
 from DQMOffline.Trigger.B2GMonitoring_cff import *
@@ -204,9 +206,17 @@ offlineHLTSource4HLTMonitorPD = cms.Sequence(
     particleNetMonitoringHLT          # HIG: monitoring of HLT PNET taggers (incl. comparisons to Offline PNET)
 )
 
+_offlineHLTSource4HLTMonitorPDPh2 = cms.Sequence(
+    dqmInfoHLTMon *
+    HLTtrackerphase2DQMSource *           # phase-2 IT and OT clusters
+    trackingMonitorHLT *                  # tracking
+    hltToOfflineTrackValidatorSequence *  # Relative Online to Offline performace
+    vertexingMonitorHLT                   # vertexing
+)
+
 # remove Strip HLT monitoring in the phase-2 sequence
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toReplaceWith(offlineHLTSource4HLTMonitorPD, offlineHLTSource4HLTMonitorPD.copyAndExclude([ sistripMonitorHLTsequence]))
+phase2_tracker.toReplaceWith(offlineHLTSource4HLTMonitorPD,_offlineHLTSource4HLTMonitorPDPh2)
 
 # sequences run @tier0 on HLTMonitor PD
 OfflineHLTMonitoring = cms.Sequence(

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -5,12 +5,22 @@ from DQMOffline.RecoB.PrimaryVertexMonitor_cff import pvMonitor
 hltVerticesMonitoring = pvMonitor.clone(
     beamSpotLabel = "hltOnlineBeamSpot"
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltVerticesMonitoring,
+                        TopFolderName = "HLT/Vertexing/hltFullVertices",
+                        vertexLabel   = cms.InputTag("offlinePrimaryVertices","","HLT"))
+
 hltPixelVerticesMonitoring = hltVerticesMonitoring.clone(
     TopFolderName = "HLT/Vertexing/hltPixelVertices",
     vertexLabel   = "hltPixelVertices",
     ndof          = 1,
     useHPforAlignmentPlots = False
 )
+
+phase2_tracker.toModify(hltPixelVerticesMonitoring,
+                        vertexLabel = "hltPhase2PixelVertices")
+
 hltTrimmedPixelVerticesMonitoring = hltVerticesMonitoring.clone(
     TopFolderName = "HLT/Vertexing/hltTrimmedPixelVertices",
     vertexLabel   = "hltTrimmedPixelVertices",
@@ -34,3 +44,4 @@ vertexingMonitorHLT = cms.Sequence(
 #    + hltVerticesL3PFBjets
 )    
 
+phase2_tracker.toReplaceWith(vertexingMonitorHLT, cms.Sequence(hltPixelVerticesMonitoring + hltVerticesMonitoring))

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -7,13 +7,8 @@ from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toModify(hltSiPixelClusterShapeCache, src = cms.InputTag("siPixelClusters","","HLT"))
-
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
                                                    TTRHBuilder = 'WithTrackAngle') # no templates at HLT
-phase2_tracker.toModify(hltrefittedForPixelDQM, src = cms.InputTag("generalTracks","","HLT"))
-
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -7,8 +7,13 @@ from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltSiPixelClusterShapeCache, src = cms.InputTag("siPixelClusters","","HLT"))
+
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
                                                    TTRHBuilder = 'WithTrackAngle') # no templates at HLT
+phase2_tracker.toModify(hltrefittedForPixelDQM, src = cms.InputTag("generalTracks","","HLT"))
+
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer

--- a/DQMOffline/Trigger/python/SiTrackerPhase2_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiTrackerPhase2_OfflineMonitoring_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+from DQM.SiTrackerPhase2.Phase2ITMonitorCluster_cff import *
+from DQM.SiTrackerPhase2.Phase2OTMonitorCluster_cff import *
+
+HLTclusterMonitorIT = clusterMonitorIT.clone(
+    TopFolderName = cms.string('HLT/TrackerPhase2ITCluster'),
+    InnerPixelClusterSource = cms.InputTag('siPixelClusters','','HLT'),
+)
+HLTclusterMonitorOT = clusterMonitorOT.clone(
+    TopFolderName = cms.string('HLT/TrackerPhase2OTCluster'),
+    clusterSrc = cms.InputTag('siPhase2Clusters','','HLT'),
+)
+
+HLTtrackerphase2DQMSource = cms.Sequence(HLTclusterMonitorIT +
+                                         HLTclusterMonitorOT)
+

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
@@ -22,6 +22,11 @@ hltMerged2highPurity = trackToTrackComparisonHists.clone(
     monitoredPrimaryVertices = "hltVerticesPFSelector"
 )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltMerged2highPurity,
+                        monitoredTrack           = cms.InputTag("generalTracks","","HLT"),
+                        monitoredPrimaryVertices = cms.InputTag("offlinePrimaryVertices","","HLT"))
+
 hltMerged2highPurityPV = trackToTrackComparisonHists.clone(
     dzWRTPvCut               = 0.1,
     monitoredTrack           = "hltMergedTracks",
@@ -32,6 +37,12 @@ hltMerged2highPurityPV = trackToTrackComparisonHists.clone(
     referencePrimaryVertices = "offlinePrimaryVertices",
     monitoredPrimaryVertices = "hltVerticesPFSelector"
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltMerged2highPurityPV,
+                        monitoredTrack           = cms.InputTag("generalTracks","","HLT"),
+                        monitoredPrimaryVertices = cms.InputTag("offlinePrimaryVertices","","HLT"))
+
 hltToOfflineTrackValidatorSequence = cms.Sequence(
     cms.ignore(highPurityTracks)
     + hltMerged2highPurity

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -26,6 +26,12 @@ pixelTracksMonitoringHLT = trackingMonHLT.clone(
     doEffFromHitPatternVsBX   = False,
     doEffFromHitPatternVsLUMI = False
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(pixelTracksMonitoringHLT,
+                        TrackProducer    = 'hltPhase2PixelTracks',
+                        allTrackProducer = 'hltPhase2PixelTracks')
+
 iter0TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter0',
     TrackProducer    = 'hltIter0PFlowCtfWithMaterialTracks',
@@ -94,6 +100,12 @@ iterHLTTracksMonitoringHLT = trackingMonHLT.clone(
     doBSPlots                 = cms.bool(True),
     doSIPPlots                = cms.bool(True)
 )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(iterHLTTracksMonitoringHLT,
+                        TrackProducer    = cms.InputTag("generalTracks","","HLT"),
+                        allTrackProducer = cms.InputTag("generalTracks","","HLT"))
+
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
     TrackProducer    = 'hltIter3Merged',
@@ -213,5 +225,7 @@ trkHLTDQMSourceExtra = cms.Sequence(
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT + doubletRecoveryHPTracksMonitoringHLT )) # + iter0HPTracksMonitoringHLT ))
+phase2_tracker.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+
 run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
 run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))


### PR DESCRIPTION
backport of #42783

#### PR description:

Minimal set of changes needed to the Tracking @ HLT DQM monitoring sequence for the Phase-2 setup.
This relies on the current naming of the tracking collections for the phase-2 HLT:
   * `generalTracks` (somewhat copied from offline)
   * `hltPhase2PixelTracks` (pixel tracks)
   * `hltPhase2PixelVertices` (pixel vertices)

The latter two were introduced in https://github.com/cms-sw/cmssw/pull/42512 but the name change was not percolated to the `FEVTDEBUGHLTEventContent`, so it becomes necessary to include them in the list of collections to be persisted.
Changes for making the Phase-2 HLT Validation are more extensive and will be addressed with another PR at a later time.

#### PR validation:

Run successfully `runTheMatrix.py -l 20834.0 -t 4 -j 8` (and checked that the HLT tracking plots are full).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #42783