### PR TITLE
Get offset to return cell centroid instead of hexagon centre in HGCAL wafers

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -3,7 +3,8 @@
 
 #include <cmath>
 #include <cstdint>
-#include <vector>
+#include <array>
+#include <memory>
 #include "Geometry/HGCalCommonData/interface/HGCalCell.h"
 
 class HGCalCellOffset {

--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -16,7 +16,7 @@ public:
 private:
   const double sqrt3_ = std::sqrt(3.0);
   const double sqrt3By2_ = (0.5 * sqrt3_);
-  std::vector<std::vector<std::vector<double>>> offsetX, offsetY;
+  std::array<std::array<std::array<double, 6>, 3>, 2> offsetX, offsetY;
   int32_t ncell_[2];
   double cellX_[2], cellY_[2], fullArea[2], cellArea[2][3];
   std::unique_ptr<HGCalCell> hgcalcell_;

--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -16,9 +16,9 @@ public:
 private:
   const double sqrt3_ = std::sqrt(3.0);
   const double sqrt3By2_ = (0.5 * sqrt3_);
-  std::array<std::array<std::array<double, 6>, 3>, 2> offsetX, offsetY;
+  std::array<std::array<std::array<double, 6>, 4>, 2> offsetX, offsetY;
   int32_t ncell_[2];
-  double cellX_[2], cellY_[2], fullArea[2], cellArea[2][3];
+  double cellX_[2], cellY_[2], fullArea[2], cellArea[2][4];
   std::unique_ptr<HGCalCell> hgcalcell_;
 };
 

--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -19,7 +19,7 @@ private:
   std::vector<std::vector<std::vector<double>>> offsetX, offsetY;
   int32_t ncell_[2];
   double cellX_[2], cellY_[2], fullArea[2], cellArea[2][3];
-  std::unique_ptr<HGCalCell> hgcalcell;
+  std::unique_ptr<HGCalCell> hgcalcell_;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -11,14 +11,14 @@ public:
   HGCalCellOffset(double waferSize, int32_t nFine, int32_t nCoarse, double guardRingOffset_, double mouseBiteCut_);
 
   std::pair<double, double> cellOffsetUV2XY1(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
-
+  double cellAreaUV(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
 
 private:
   const double sqrt3_ = std::sqrt(3.0);
   const double sqrt3By2_ = (0.5 * sqrt3_);
   std::vector<std::vector<std::vector<double>>> offsetX, offsetY;
   int32_t ncell_[2];
-  double cellX_[2], cellY_[2], cellArea[2][3];
+  double cellX_[2], cellY_[2], fullArea[2], cellArea[2][3];
   std::unique_ptr<HGCalCell> hgcalcell;
 };
 

--- a/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellOffset.h
@@ -1,0 +1,25 @@
+#ifndef Geometry_HGCalCommonData_HGCalCellOffset_h
+#define Geometry_HGCalCommonData_HGCalCellOffset_h
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
+
+class HGCalCellOffset {
+public:
+  HGCalCellOffset(double waferSize, int32_t nFine, int32_t nCoarse, double guardRingOffset_, double mouseBiteCut_);
+
+  std::pair<double, double> cellOffsetUV2XY1(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
+
+
+private:
+  const double sqrt3_ = std::sqrt(3.0);
+  const double sqrt3By2_ = (0.5 * sqrt3_);
+  std::vector<std::vector<std::vector<double>>> offsetX, offsetY;
+  int32_t ncell_[2];
+  double cellX_[2], cellY_[2], cellArea[2][3];
+  std::unique_ptr<HGCalCell> hgcalcell;
+};
+
+#endif

--- a/Geometry/HGCalCommonData/src/HGCalCell.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCell.cc
@@ -349,16 +349,16 @@ std::pair<int32_t, int32_t> HGCalCell::cellType(int32_t u, int32_t v, int32_t nc
       cellx = 7;
       cellt = HGCalCell::truncatedCell;
     } else if ((v - u) == (ncell - 1)) {
-      cellx = 10;
+      cellx = 8;
       cellt = HGCalCell::extendedCell;
     } else if (v == (2 * ncell - 1)) {
-      cellx = 8;
+      cellx = 9;
       cellt = HGCalCell::truncatedCell;
     } else if (u == (2 * ncell - 1)) {
-      cellx = 11;
+      cellx = 10;
       cellt = HGCalCell::extendedCell;
     } else if ((u - v) == ncell) {
-      cellx = 9;
+      cellx = 11;
       cellt = HGCalCell::truncatedCell;
     } else if (v == 0) {
       cellx = 12;
@@ -482,22 +482,22 @@ std::pair<int32_t, int32_t> HGCalCell::cellType(int32_t u, int32_t v, int32_t nc
       cellx = 6;
       cellt = HGCalCell::cornerCell;
     } else if (v == 0) {
-      cellx = 10;
+      cellx = 7;
       cellt = HGCalCell::extendedCell;
     } else if ((u - v) == ncell) {
-      cellx = 7;
-      cellt = HGCalCell::truncatedCell;
-    } else if (u == (2 * ncell - 1)) {
-      cellx = 11;
-      cellt = HGCalCell::extendedCell;
-    } else if (v == (2 * ncell - 1)) {
       cellx = 8;
       cellt = HGCalCell::truncatedCell;
+    } else if (u == (2 * ncell - 1)) {
+      cellx = 9;
+      cellt = HGCalCell::extendedCell;
+    } else if (v == (2 * ncell - 1)) {
+      cellx = 10;
+      cellt = HGCalCell::truncatedCell;
     } else if ((v - u) == (ncell - 1)) {
-      cellx = 12;
+      cellx = 11;
       cellt = HGCalCell::extendedCell;
     } else if (u == 0) {
-      cellx = 9;
+      cellx = 12;
       cellt = HGCalCell::truncatedCell;
     }
     switch (placementIndex) {

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -14,8 +14,8 @@ HGCalCellOffset::HGCalCellOffset(
     cellX_[k] = waferSize / (3 * ncell_[k]);
     cellY_[k] = sqrt3By2_ * cellX_[k];
     fullArea[k] = 3 * sqrt3By2_ * cellY_[k];
-    std::vector<std::vector<double>> tempOffsetX;
-    std::vector<std::vector<double>> tempOffsetY;
+    //std::array<std::array<double, 6>, 3> tempOffsetX;
+    //std::array<std::array<double, 6>, 3> tempOffsetY;
     // For formulas used please refer to https://indico.cern.ch/event/1297259/contributions/5455745/attachments/2667954/4722855/Cell_centroid.pdf
     for (int j = 0; j < 3; ++j) {  // j refers to type of cell : corner, truncated, extended
       if (j == 0) {                // Offset for corner cells
@@ -50,18 +50,22 @@ HGCalCellOffset::HGCalCellOffset(
         // (x, y) coordinates of offset for 6 corners of wafer starting from bottomCorner in clockwise direction
         // offset_x = -1^(i%2)*(Offset_magnitude_X * cos(60*i) - Offset_magnitude_Y * sin(60*i)) i in (0-6)
         // offset_x = (Offset_magnitude_Y * cos(60*i) + Offset_magnitude_X * sin(60*i)) i in (0-6)
-        tempOffsetX.emplace_back(std::vector<double>({xMag,
-                                                      -1.0 * (0.5 * xMag - sqrt3By2_ * yMag),
-                                                      (-0.5 * xMag + sqrt3By2_ * yMag),
-                                                      xMag,
-                                                      (-0.5 * xMag - sqrt3By2_ * yMag),
-                                                      -1.0 * (0.5 * xMag + sqrt3By2_ * yMag)}));
-        tempOffsetY.emplace_back(std::vector<double>({yMag,
-                                                      (0.5 * yMag + sqrt3By2_ * xMag),
-                                                      (-0.5 * yMag - sqrt3By2_ * xMag),
-                                                      -yMag,
-                                                      (-0.5 * yMag + sqrt3By2_ * xMag),
-                                                      (0.5 * yMag - sqrt3By2_ * xMag)}));
+        std::array<double, 6> tempOffsetX = {{xMag,
+                                              -1.0 * (0.5 * xMag - sqrt3By2_ * yMag),
+                                              (-0.5 * xMag + sqrt3By2_ * yMag),
+                                              xMag,
+                                              (-0.5 * xMag - sqrt3By2_ * yMag),
+                                              -1.0 * (0.5 * xMag + sqrt3By2_ * yMag)}};
+        std::array<double, 6> tempOffsetY = {{yMag,
+                                              (0.5 * yMag + sqrt3By2_ * xMag),
+                                              (-0.5 * yMag - sqrt3By2_ * xMag),
+                                              -yMag,
+                                              (-0.5 * yMag + sqrt3By2_ * xMag),
+                                              (0.5 * yMag - sqrt3By2_ * xMag)}};
+        for (int i = 0; i < 6; ++i) {
+          offsetX[k][j][i] = tempOffsetX[i];
+          offsetY[k][j][i] = tempOffsetY[i];
+        }
       } else if (j == 1) {                                                 // Offset for truncated cells
         double totalArea = (5.0 * sqrt3_ / 4.0) * std::pow(cellY_[k], 2);  // Area of cell without any dead zone
         double cutArea =
@@ -72,10 +76,14 @@ HGCalCellOffset::HGCalCellOffset(
         // (x, y) coordinates of offset for 6 sides of wafer starting from bottom left edge in clockwise direction
         // offset_x = -Offset_magnitude * sin(30 + 60*i) i in (0-6)
         // offset_y = -Offset_magnitude * cos(30 + 60*i) i in (0-6)
-        tempOffsetX.emplace_back(
-            std::vector<double>({-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}));
-        tempOffsetY.emplace_back(std::vector<double>(
-            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}));
+        std::array<double, 6> tempOffsetX = {
+            {-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}};
+        std::array<double, 6> tempOffsetY = {
+            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}};
+        for (int i = 0; i < 6; ++i) {
+          offsetX[k][j][i] = tempOffsetX[i];
+          offsetY[k][j][i] = tempOffsetY[i];
+        }
       } else if (j == 2) {                                                 //Offset for truncated cells
         double totalArea = (7.0 * sqrt3_ / 4.0) * std::pow(cellY_[k], 2);  // Area of cell without any dead zone
         double cutArea =
@@ -87,14 +95,16 @@ HGCalCellOffset::HGCalCellOffset(
         // (x, y) coordinates of offset for 6 sides of wafer starting from bottom left edge in clockwise direction
         // offset_x = -Offset_magnitude * sin(30 + 60*i) i in (0-6)
         // offset_y = -Offset_magnitude * cos(30 + 60*i) i in (0-6)
-        tempOffsetX.emplace_back(
-            std::vector<double>({-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}));
-        tempOffsetY.emplace_back(std::vector<double>(
-            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}));
+        std::array<double, 6> tempOffsetX = {
+            {-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}};
+        std::array<double, 6> tempOffsetY = {
+            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}};
+        for (int i = 0; i < 6; ++i) {
+          offsetX[k][j][i] = tempOffsetX[i];
+          offsetY[k][j][i] = tempOffsetY[i];
+        }
       }
     }
-    offsetX.emplace_back(tempOffsetX);
-    offsetY.emplace_back(tempOffsetY);
   }
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "HGCalCellOffset initialized with waferSize " << waferSize << " number of cells "

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -5,84 +5,134 @@
 
 //#define EDM_ML_DEBUG
 
-HGCalCellOffset::HGCalCellOffset(double waferSize, int32_t nFine, int32_t nCoarse, double guardRingOffset_, double mouseBiteCut_) {
+HGCalCellOffset::HGCalCellOffset(
+    double waferSize, int32_t nFine, int32_t nCoarse, double guardRingOffset_, double mouseBiteCut_) {
   ncell_[0] = nFine;
   ncell_[1] = nCoarse;
   hgcalcell = std::make_unique<HGCalCell>(waferSize, nFine, nCoarse);
   for (int k = 0; k < 2; ++k) {
     cellX_[k] = waferSize / (3 * ncell_[k]);
     cellY_[k] = sqrt3By2_ * cellX_[k];
-      std::vector<std::vector<double>> tempOffsetX;
-      std::vector<std::vector<double>> tempOffsetY;
-      for (int j = 0; j < 3; ++j){
-          if(j == 0){
-              double totalArea = (11.0*sqrt3_/8.0)*std::pow(cellY_[k],2);
-              double cutArea1 = (cellY_[k] * sqrt3_ * guardRingOffset_) - (std::pow(guardRingOffset_,2)/(2*sqrt3_));
-              double cutArea2 = (cellY_[k] * sqrt3By2_ * guardRingOffset_) - (std::pow(guardRingOffset_,2)/(2*sqrt3_));
-              double cutArea3 = sqrt3_ * std::pow((mouseBiteCut_ - (guardRingOffset_/sqrt3By2_)), 2);
-              double x1_0 = ((1.5*cellY_[k]) - (cellY_[k] * 0.5 * guardRingOffset_) + (std::pow(guardRingOffset_,2)/18))/((cellY_[k] * sqrt3_) - (guardRingOffset_/(2*sqrt3_)));
-              double y1_0 = ((cellY_[k] * -sqrt3By2_ * guardRingOffset_) + (std::pow(guardRingOffset_,2)/(3*sqrt3_)))/((cellY_[k] * sqrt3_) - (guardRingOffset_/(2*sqrt3_)));
-              double x2_0 = ((0.375*cellY_[k]) - (cellY_[k] * 0.25 * guardRingOffset_) + (std::pow(guardRingOffset_,2)/18))/((cellY_[k] * sqrt3By2_) - (guardRingOffset_/(2*sqrt3_)));
-              double y2_0 = ((cellY_[k] * -0.25 * sqrt3_ * guardRingOffset_) + (std::pow(guardRingOffset_,2)/(3*sqrt3_)))/((cellY_[k] * sqrt3By2_) - (guardRingOffset_/(2*sqrt3_)));
-              double x1 = (sqrt3By2_*x1_0) - (0.5 * y1_0) - cellY_[k];
-              double y1 = (sqrt3By2_*y1_0) + (0.5 * x1_0);
-              double x2 = (-sqrt3By2_*x2_0) - (0.5 * y2_0) + (cellY_[k]*1.25);
-              double y2 = (sqrt3By2_*y2_0) + (0.5 * x2_0) + (cellY_[k]*0.25*sqrt3_);
-              double x3 = 0.5 * cellY_[k];
-              double y3 = (cellY_[k] * sqrt3By2_) - (2*mouseBiteCut_/3) - (guardRingOffset_/(3*sqrt3By2_));
-              cellArea[k][j] = totalArea - cutArea1 - cutArea2 - cutArea3;
-              double xMag = ((35.0 * cellY_[k] / 132.0)*totalArea - (cutArea1*x1) - (cutArea2*x2) - (cutArea3*x3))/(cellArea[k][j]);
-              double yMag = ((5.0 * cellY_[k] / (44.0 * sqrt3_))*totalArea - (cutArea1*y1) - (cutArea2*y2) - (cutArea3*y3))/(cellArea[k][j]);
-              tempOffsetX.emplace_back(std::vector<double>({xMag, -1.0*(0.5*xMag - sqrt3By2_*yMag), (-0.5*xMag + sqrt3By2_*yMag), xMag, (-0.5*xMag - sqrt3By2_*yMag), -1.0*(0.5*xMag + sqrt3By2_*yMag)}));
-              tempOffsetY.emplace_back(std::vector<double>({yMag, (0.5*yMag + sqrt3By2_*xMag), (-0.5*yMag - sqrt3By2_*xMag), -yMag, (-0.5*yMag + sqrt3By2_*xMag), (0.5*yMag - sqrt3By2_*xMag)}));
-          }
-          if(j == 1){
-              double totalArea = (5.0*sqrt3_/4.0)*std::pow(cellY_[k],2);
-              double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
-              cellArea[k][j] = totalArea - cutArea;
-              double offMag = (((-2.0/15.0)*totalArea*cellY_[k]) - ((cellY_[k]-(0.5*guardRingOffset_))*cutArea))/(cellArea[k][j]);
-              tempOffsetX.emplace_back(std::vector<double>({-0.5*offMag, -offMag, -0.5*offMag, 0.5*offMag, offMag, 0.5*offMag}));
-              tempOffsetY.emplace_back(std::vector<double>({-sqrt3By2_*offMag, 0.0, sqrt3By2_*offMag, sqrt3By2_*offMag, 0.0, -sqrt3By2_*offMag}));
-          }
-          if(j == 2){
-              double totalArea = (7.0*sqrt3_/4.0)*std::pow(cellY_[k],2);
-              double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
-              cellArea[k][j] = totalArea - cutArea;
-              double offMag = (((5.0/42.0)*totalArea*cellY_[k]) - ((cellY_[k]-(0.5*guardRingOffset_)))*(cutArea))/(cellArea[k][j]);
-              tempOffsetX.emplace_back(std::vector<double>({-0.5*offMag, -offMag, -0.5*offMag, 0.5*offMag, offMag, 0.5*offMag}));
-              tempOffsetY.emplace_back(std::vector<double>({-sqrt3By2_*offMag, 0.0, sqrt3By2_*offMag, sqrt3By2_*offMag, 0.0, -sqrt3By2_*offMag}));
-          }
+    fullArea[k] = 3 * sqrt3By2_ * cellY_[k];
+    std::vector<std::vector<double>> tempOffsetX;
+    std::vector<std::vector<double>> tempOffsetY;
+    for (int j = 0; j < 3; ++j) {
+      if (j == 0) {
+        double totalArea = (11.0 * sqrt3_ / 8.0) * std::pow(cellY_[k], 2);
+        double cutArea1 = (cellY_[k] * sqrt3_ * guardRingOffset_) - (std::pow(guardRingOffset_, 2) / (2 * sqrt3_));
+        double cutArea2 = (cellY_[k] * sqrt3By2_ * guardRingOffset_) - (std::pow(guardRingOffset_, 2) / (2 * sqrt3_));
+        double cutArea3 = sqrt3_ * std::pow((mouseBiteCut_ - (guardRingOffset_ / sqrt3By2_)), 2);
+        double x1_0 =
+            ((1.5 * cellY_[k]) - (cellY_[k] * 0.5 * guardRingOffset_) + (std::pow(guardRingOffset_, 2) / 18)) /
+            ((cellY_[k] * sqrt3_) - (guardRingOffset_ / (2 * sqrt3_)));
+        double y1_0 = ((cellY_[k] * -sqrt3By2_ * guardRingOffset_) + (std::pow(guardRingOffset_, 2) / (3 * sqrt3_))) /
+                      ((cellY_[k] * sqrt3_) - (guardRingOffset_ / (2 * sqrt3_)));
+        double x2_0 =
+            ((0.375 * cellY_[k]) - (cellY_[k] * 0.25 * guardRingOffset_) + (std::pow(guardRingOffset_, 2) / 18)) /
+            ((cellY_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
+        double y2_0 =
+            ((cellY_[k] * -0.25 * sqrt3_ * guardRingOffset_) + (std::pow(guardRingOffset_, 2) / (3 * sqrt3_))) /
+            ((cellY_[k] * sqrt3By2_) - (guardRingOffset_ / (2 * sqrt3_)));
+        double x1 = (sqrt3By2_ * x1_0) - (0.5 * y1_0) - cellY_[k];
+        double y1 = (sqrt3By2_ * y1_0) + (0.5 * x1_0);
+        double x2 = (-sqrt3By2_ * x2_0) - (0.5 * y2_0) + (cellY_[k] * 1.25);
+        double y2 = (sqrt3By2_ * y2_0) + (0.5 * x2_0) + (cellY_[k] * 0.25 * sqrt3_);
+        double x3 = 0.5 * cellY_[k];
+        double y3 = (cellY_[k] * sqrt3By2_) - (2 * mouseBiteCut_ / 3) - (guardRingOffset_ / (3 * sqrt3By2_));
+        cellArea[k][j] = totalArea - cutArea1 - cutArea2 - cutArea3;
+        double xMag = ((35.0 * cellY_[k] / 132.0) * totalArea - (cutArea1 * x1) - (cutArea2 * x2) - (cutArea3 * x3)) /
+                      (cellArea[k][j]);
+        double yMag =
+            ((5.0 * cellY_[k] / (44.0 * sqrt3_)) * totalArea - (cutArea1 * y1) - (cutArea2 * y2) - (cutArea3 * y3)) /
+            (cellArea[k][j]);
+        tempOffsetX.emplace_back(std::vector<double>({xMag,
+                                                      -1.0 * (0.5 * xMag - sqrt3By2_ * yMag),
+                                                      (-0.5 * xMag + sqrt3By2_ * yMag),
+                                                      xMag,
+                                                      (-0.5 * xMag - sqrt3By2_ * yMag),
+                                                      -1.0 * (0.5 * xMag + sqrt3By2_ * yMag)}));
+        tempOffsetY.emplace_back(std::vector<double>({yMag,
+                                                      (0.5 * yMag + sqrt3By2_ * xMag),
+                                                      (-0.5 * yMag - sqrt3By2_ * xMag),
+                                                      -yMag,
+                                                      (-0.5 * yMag + sqrt3By2_ * xMag),
+                                                      (0.5 * yMag - sqrt3By2_ * xMag)}));
+      } else if (j == 1) {
+        double totalArea = (5.0 * sqrt3_ / 4.0) * std::pow(cellY_[k], 2);
+        double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
+        cellArea[k][j] = totalArea - cutArea;
+        double offMag = (((-2.0 / 15.0) * totalArea * cellY_[k]) - ((cellY_[k] - (0.5 * guardRingOffset_)) * cutArea)) /
+                        (cellArea[k][j]);
+        tempOffsetX.emplace_back(
+            std::vector<double>({-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}));
+        tempOffsetY.emplace_back(std::vector<double>(
+            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}));
+      } else if (j == 2) {
+        double totalArea = (7.0 * sqrt3_ / 4.0) * std::pow(cellY_[k], 2);
+        double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
+        cellArea[k][j] = totalArea - cutArea;
+        double offMag =
+            (((5.0 / 42.0) * totalArea * cellY_[k]) - ((cellY_[k] - (0.5 * guardRingOffset_))) * (cutArea)) /
+            (cellArea[k][j]);
+        tempOffsetX.emplace_back(
+            std::vector<double>({-0.5 * offMag, -offMag, -0.5 * offMag, 0.5 * offMag, offMag, 0.5 * offMag}));
+        tempOffsetY.emplace_back(std::vector<double>(
+            {-sqrt3By2_ * offMag, 0.0, sqrt3By2_ * offMag, sqrt3By2_ * offMag, 0.0, -sqrt3By2_ * offMag}));
       }
-      offsetX.emplace_back(tempOffsetX);
-      offsetY.emplace_back(tempOffsetY);
+    }
+    offsetX.emplace_back(tempOffsetX);
+    offsetY.emplace_back(tempOffsetY);
   }
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "HGCalCell initialized with waferSize " << waferSize << " number of cells " << nFine
-                                << ":" << nCoarse;
+  edm::LogVerbatim("HGCalGeom") << "HGCalCellOffset initialized with waferSize " << waferSize << " number of cells "
+                                << nFine << ":" << nCoarse << " Guardring offset " << guardRingOffset_ << " Mousebite "
+                                << mouseBiteCut_;
 #endif
 }
 
-
 std::pair<double, double> HGCalCellOffset::cellOffsetUV2XY1(int32_t u, int32_t v, int32_t placementIndex, int32_t type) {
-    if (type != 0)
-        type = 1;
-    double x_off(0), y_off(0);
-    std::pair<int, int> cell = hgcalcell->cellType(u, v, ncell_[type] ,placementIndex);
-    int cellPos = cell.first;
-    int cellType = cell.second;
-    std::cout << "size of x_offset " << offsetX.size() << ", " << offsetX[1].size() << "," << offsetX[1][0].size() << std::endl;
-    std::cout << "u = " << u << " v= " << v << " cellType " << cellType << " cellPos " << cellPos << std::endl;
-    if(cellType == HGCalCell::truncatedCell || cellType == HGCalCell::extendedCell){
-        x_off = offsetX[type][cellType-1][cellPos-1];
-        y_off = offsetY[type][cellType-1][cellPos-1];
+  if (type != 0)
+    type = 1;
+  double x_off(0), y_off(0);
+  std::pair<int, int> cell = hgcalcell->cellType(u, v, ncell_[type], placementIndex);
+  int cellPos = cell.first;
+  int cellType = cell.second;
+  if (cellType == HGCalCell::truncatedCell || cellType == HGCalCell::extendedCell) {
+    x_off = offsetX[type][cellType - 1][cellPos - 1];
+    y_off = offsetY[type][cellType - 1][cellPos - 1];
+  } else if (cellType == HGCalCell::cornerCell) {
+    if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 0)) ||
+        ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 1))) {
+      cellPos = 11 + (17 - cellPos) % 6;
     }
-    if(cellType == HGCalCell::cornerCell){
-        if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex%2==0))|| ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex%2==1))) {cellPos = 11 + (17 - cellPos)%6;}
-        x_off = offsetX[type][cellType-1][cellPos-11];
-        y_off = offsetY[type][cellType-1][cellPos-11];
-        if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex%2==0))|| ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex%2==1))) {x_off = -1*x_off;}
-        //std::cout << x_off << "  " << y_off << std::endl;
+    x_off = offsetX[type][cellType - 1][cellPos - 11];
+    y_off = offsetY[type][cellType - 1][cellPos - 11];
+    if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 0)) ||
+        ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex % 2 == 1))) {
+      x_off = -1 * x_off;
     }
-    return std::make_pair(x_off, y_off);
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCellOffset in wafer with placement index " << placementIndex << " type "
+                                << type << " for cell u " << u << " v " << v << " Offset x:y " << x_off << ":" << y_off;
+#endif
+  return std::make_pair(x_off, y_off);
 }
-    
+
+double HGCalCellOffset::cellAreaUV(int32_t u, int32_t v, int32_t placementIndex, int32_t type) {
+  if (type != 0)
+    type = 1;
+  double area(0);
+  std::pair<int, int> cell = hgcalcell->cellType(u, v, ncell_[type], placementIndex);
+  int cellType = cell.second;
+  if (cellType == HGCalCell::fullCell) {
+    area = fullArea[type];
+  } else {
+    area = cellArea[type][cellType - 1];
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCellOffset in wafer with placement index " << placementIndex << " type "
+                                << type << " for cell u " << u << " v " << v << " Area " << area;
+#endif
+  return area;
+}

--- a/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellOffset.cc
@@ -1,0 +1,88 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCellOffset.h"
+#include <vector>
+#include <iostream>
+
+//#define EDM_ML_DEBUG
+
+HGCalCellOffset::HGCalCellOffset(double waferSize, int32_t nFine, int32_t nCoarse, double guardRingOffset_, double mouseBiteCut_) {
+  ncell_[0] = nFine;
+  ncell_[1] = nCoarse;
+  hgcalcell = std::make_unique<HGCalCell>(waferSize, nFine, nCoarse);
+  for (int k = 0; k < 2; ++k) {
+    cellX_[k] = waferSize / (3 * ncell_[k]);
+    cellY_[k] = sqrt3By2_ * cellX_[k];
+      std::vector<std::vector<double>> tempOffsetX;
+      std::vector<std::vector<double>> tempOffsetY;
+      for (int j = 0; j < 3; ++j){
+          if(j == 0){
+              double totalArea = (11.0*sqrt3_/8.0)*std::pow(cellY_[k],2);
+              double cutArea1 = (cellY_[k] * sqrt3_ * guardRingOffset_) - (std::pow(guardRingOffset_,2)/(2*sqrt3_));
+              double cutArea2 = (cellY_[k] * sqrt3By2_ * guardRingOffset_) - (std::pow(guardRingOffset_,2)/(2*sqrt3_));
+              double cutArea3 = sqrt3_ * std::pow((mouseBiteCut_ - (guardRingOffset_/sqrt3By2_)), 2);
+              double x1_0 = ((1.5*cellY_[k]) - (cellY_[k] * 0.5 * guardRingOffset_) + (std::pow(guardRingOffset_,2)/18))/((cellY_[k] * sqrt3_) - (guardRingOffset_/(2*sqrt3_)));
+              double y1_0 = ((cellY_[k] * -sqrt3By2_ * guardRingOffset_) + (std::pow(guardRingOffset_,2)/(3*sqrt3_)))/((cellY_[k] * sqrt3_) - (guardRingOffset_/(2*sqrt3_)));
+              double x2_0 = ((0.375*cellY_[k]) - (cellY_[k] * 0.25 * guardRingOffset_) + (std::pow(guardRingOffset_,2)/18))/((cellY_[k] * sqrt3By2_) - (guardRingOffset_/(2*sqrt3_)));
+              double y2_0 = ((cellY_[k] * -0.25 * sqrt3_ * guardRingOffset_) + (std::pow(guardRingOffset_,2)/(3*sqrt3_)))/((cellY_[k] * sqrt3By2_) - (guardRingOffset_/(2*sqrt3_)));
+              double x1 = (sqrt3By2_*x1_0) - (0.5 * y1_0) - cellY_[k];
+              double y1 = (sqrt3By2_*y1_0) + (0.5 * x1_0);
+              double x2 = (-sqrt3By2_*x2_0) - (0.5 * y2_0) + (cellY_[k]*1.25);
+              double y2 = (sqrt3By2_*y2_0) + (0.5 * x2_0) + (cellY_[k]*0.25*sqrt3_);
+              double x3 = 0.5 * cellY_[k];
+              double y3 = (cellY_[k] * sqrt3By2_) - (2*mouseBiteCut_/3) - (guardRingOffset_/(3*sqrt3By2_));
+              cellArea[k][j] = totalArea - cutArea1 - cutArea2 - cutArea3;
+              double xMag = ((35.0 * cellY_[k] / 132.0)*totalArea - (cutArea1*x1) - (cutArea2*x2) - (cutArea3*x3))/(cellArea[k][j]);
+              double yMag = ((5.0 * cellY_[k] / (44.0 * sqrt3_))*totalArea - (cutArea1*y1) - (cutArea2*y2) - (cutArea3*y3))/(cellArea[k][j]);
+              tempOffsetX.emplace_back(std::vector<double>({xMag, -1.0*(0.5*xMag - sqrt3By2_*yMag), (-0.5*xMag + sqrt3By2_*yMag), xMag, (-0.5*xMag - sqrt3By2_*yMag), -1.0*(0.5*xMag + sqrt3By2_*yMag)}));
+              tempOffsetY.emplace_back(std::vector<double>({yMag, (0.5*yMag + sqrt3By2_*xMag), (-0.5*yMag - sqrt3By2_*xMag), -yMag, (-0.5*yMag + sqrt3By2_*xMag), (0.5*yMag - sqrt3By2_*xMag)}));
+          }
+          if(j == 1){
+              double totalArea = (5.0*sqrt3_/4.0)*std::pow(cellY_[k],2);
+              double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
+              cellArea[k][j] = totalArea - cutArea;
+              double offMag = (((-2.0/15.0)*totalArea*cellY_[k]) - ((cellY_[k]-(0.5*guardRingOffset_))*cutArea))/(cellArea[k][j]);
+              tempOffsetX.emplace_back(std::vector<double>({-0.5*offMag, -offMag, -0.5*offMag, 0.5*offMag, offMag, 0.5*offMag}));
+              tempOffsetY.emplace_back(std::vector<double>({-sqrt3By2_*offMag, 0.0, sqrt3By2_*offMag, sqrt3By2_*offMag, 0.0, -sqrt3By2_*offMag}));
+          }
+          if(j == 2){
+              double totalArea = (7.0*sqrt3_/4.0)*std::pow(cellY_[k],2);
+              double cutArea = cellY_[k] * sqrt3_ * guardRingOffset_;
+              cellArea[k][j] = totalArea - cutArea;
+              double offMag = (((5.0/42.0)*totalArea*cellY_[k]) - ((cellY_[k]-(0.5*guardRingOffset_)))*(cutArea))/(cellArea[k][j]);
+              tempOffsetX.emplace_back(std::vector<double>({-0.5*offMag, -offMag, -0.5*offMag, 0.5*offMag, offMag, 0.5*offMag}));
+              tempOffsetY.emplace_back(std::vector<double>({-sqrt3By2_*offMag, 0.0, sqrt3By2_*offMag, sqrt3By2_*offMag, 0.0, -sqrt3By2_*offMag}));
+          }
+      }
+      offsetX.emplace_back(tempOffsetX);
+      offsetY.emplace_back(tempOffsetY);
+  }
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "HGCalCell initialized with waferSize " << waferSize << " number of cells " << nFine
+                                << ":" << nCoarse;
+#endif
+}
+
+
+std::pair<double, double> HGCalCellOffset::cellOffsetUV2XY1(int32_t u, int32_t v, int32_t placementIndex, int32_t type) {
+    if (type != 0)
+        type = 1;
+    double x_off(0), y_off(0);
+    std::pair<int, int> cell = hgcalcell->cellType(u, v, ncell_[type] ,placementIndex);
+    int cellPos = cell.first;
+    int cellType = cell.second;
+    std::cout << "size of x_offset " << offsetX.size() << ", " << offsetX[1].size() << "," << offsetX[1][0].size() << std::endl;
+    std::cout << "u = " << u << " v= " << v << " cellType " << cellType << " cellPos " << cellPos << std::endl;
+    if(cellType == HGCalCell::truncatedCell || cellType == HGCalCell::extendedCell){
+        x_off = offsetX[type][cellType-1][cellPos-1];
+        y_off = offsetY[type][cellType-1][cellPos-1];
+    }
+    if(cellType == HGCalCell::cornerCell){
+        if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex%2==0))|| ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex%2==1))) {cellPos = 11 + (17 - cellPos)%6;}
+        x_off = offsetX[type][cellType-1][cellPos-11];
+        y_off = offsetY[type][cellType-1][cellPos-11];
+        if (((placementIndex >= HGCalCell::cellPlacementExtra) && (placementIndex%2==0))|| ((placementIndex < HGCalCell::cellPlacementExtra) && (placementIndex%2==1))) {x_off = -1*x_off;}
+        //std::cout << x_off << "  " << y_off << std::endl;
+    }
+    return std::make_pair(x_off, y_off);
+}
+    

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -60,8 +60,8 @@ private:
   const int waferType_;
   const int placeIndex_;
   const int partialType_;
-  const int nTrials_;
-  const int modeUV_;
+  const double mouseBiteCut_;
+  const double guardRingOffset_;
 };
 
 HGCalCellOffsetTester::HGCalCellOffsetTester(const edm::ParameterSet& iC)
@@ -69,11 +69,11 @@ HGCalCellOffsetTester::HGCalCellOffsetTester(const edm::ParameterSet& iC)
       waferType_(iC.getParameter<int>("waferType")),
       placeIndex_(iC.getParameter<int>("cellPlacementIndex")),
       partialType_(iC.getParameter<int>("partialType")),
-      nTrials_(iC.getParameter<int>("numbberOfTrials")),
-      modeUV_(iC.getParameter<int>("modeUV")) {
+      mouseBiteCut_(iC.getParameter<double>("mouseBiteCut")),
+      guardRingOffset_(iC.getParameter<double>("guardRingOffset")) {
   edm::LogVerbatim("HGCalGeom") << "Test positions for wafer of size " << waferSize_ << " Type " << waferType_
-                                << " Partial Type " << partialType_ << " Placement Index " << placeIndex_ << " mode "
-                                << modeUV_ << " with " << nTrials_ << " trials";
+                                << " Placement Index " << placeIndex_ << " GuardRing offset " << guardRingOffset_
+                                << " Mousebite cut " << mouseBiteCut_;
 }
 
 void HGCalCellOffsetTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -82,86 +82,28 @@ void HGCalCellOffsetTester::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<int>("waferType", 0);
   desc.add<int>("cellPlacementIndex", 3);
   desc.add<int>("partialType", 0);
-  desc.add<int>("numbberOfTrials", 1000);
-  desc.add<int>("modeUV", 1);
+  desc.add<double>("mouseBiteCut", 0.0);
+  desc.add<double>("guardRingOffset", 0.0);
   descriptions.add("hgcalCellOffsetTester", desc);
 }
 
 // ------------ method called to produce the data  ------------
 void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
   const int nFine(12), nCoarse(8);
-  double r2 = 0.5 * waferSize_;
-  double R2 = 2 * r2 / sqrt(3);
   int nCells = (waferType_ == 0) ? nFine : nCoarse;
   HGCalCellUV wafer(waferSize_, 0.0, nFine, nCoarse);
   HGCalCell wafer2(waferSize_, nFine, nCoarse);
-  HGCalCellOffset offset(waferSize_, nFine, nCoarse, (waferSize_/(4*std::sqrt(3.0)*nFine)), 0.0);
+  HGCalCellOffset offset(waferSize_, nFine, nCoarse, guardRingOffset_, mouseBiteCut_);
   edm::LogVerbatim("HGCalGeom") << "\nHGCalPartialCellTester:: nCells " << nCells << " and placement index "
                                 << placeIndex_ << "\n\n";
-  auto start_t = std::chrono::high_resolution_clock::now();
-
-  if (modeUV_ <= 0) {
-    for (int i = 0; i < nTrials_; i++) {
-      double xi = (2 * r2 * static_cast<double>(rand()) / RAND_MAX) - r2;
-      double yi = (2 * R2 * static_cast<double>(rand()) / RAND_MAX) - R2;
-      bool goodPoint = true;
-      int ug = 0;
-      int vg = 0;
-      if (partialType_ == 11 || partialType_ == 13 || partialType_ == 15 || partialType_ == 21 || partialType_ == 23 ||
-          partialType_ == 25) {
-        ug = 0;
-        vg = 0;
-      } else if (partialType_ == 12 || partialType_ == 14 || partialType_ == 16 || partialType_ == 22 ||
-                 partialType_ == 24) {
-        ug = nCells + 1;
-        vg = 2 * (nCells - 1);
-      }
-      std::pair<double, double> xyg = wafer2.cellUV2XY2(ug, vg, placeIndex_, waferType_);
-      std::vector<std::pair<double, double> > wxy =
-          HGCalWaferMask::waferXY(partialType_, placeIndex_, waferSize_, 0.0, 0.0, 0.0);
-      for (unsigned int i = 0; i < (wxy.size() - 1); ++i) {
-        double xp1 = wxy[i].first;
-        double yp1 = wxy[i].second;
-        double xp2 = wxy[i + 1].first;
-        double yp2 = wxy[i + 1].second;
-        if ((((xi - xp1) / (xp2 - xp1)) - ((yi - yp1) / (yp2 - yp1))) *
-                (((xyg.first - xp1) / (xp2 - xp1)) - ((xyg.second - yp1) / (yp2 - yp1))) <=
-            0) {
-          goodPoint = false;
-        }
-      }
-      if (goodPoint) {  //Only allowing (x, y) inside a partial wafer 11, placement index 2
-        std::pair<int32_t, int32_t> uv1 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, true, false);
-        std::pair<int32_t, int32_t> uv5 =
-            wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, partialType_, true, false);
-        std::pair<double, double> xy1 = wafer2.cellUV2XY2(uv5.first, uv5.second, placeIndex_, waferType_);
-        std::string cellType = (HGCalWaferMask::goodCell(uv5.first, uv5.second, partialType_)) ? "Goodcell" : "Badcell";
-        std::string pointType = goodPoint ? "GoodPoint" : "BadPoint";
-        std::string comment =
-            ((uv1.first != uv5.first) || (uv1.second != uv5.second) || (xy1.first - xi > 6) || (xy1.second - yi > 6))
-                ? " ***** ERROR *****"
-                : "";
-        edm::LogVerbatim("HGCalGeom") << pointType << " " << cellType << " x = " << xi << ":" << xy1.first
-                                      << " y = " << yi << ":" << xy1.second << " type = " << waferType_
-                                      << " placement index " << placeIndex_ << " u " << uv1.first << ":" << uv5.first
-                                      << ":" << uv5.first << " v " << uv1.second << ":" << uv5.second << ":"
-                                      << uv5.second << ":" << comment;
-      }
-    }
-  } else {
-    std::ofstream outFile1("default.txt");
-    std::ofstream outFile2("offset.txt");
-    //for (int i = 0; i < nTrials_; i++) {
-      //int ui = std::floor(2 * nCells * rand() / RAND_MAX);
-      //int vi = std::floor(2 * nCells * rand() / RAND_MAX);
-    for (int ui = 0; ui < 2 * nCells; ui++){
-    for (int vi = 0; vi < 2 * nCells; vi++){
+  for (int ui = 0; ui < 2 * nCells; ui++) {
+    for (int vi = 0; vi < 2 * nCells; vi++) {
       if ((ui < 2 * nCells) && (vi < 2 * nCells) && ((vi - ui) < nCells) && ((ui - vi) <= nCells)) {
         //Only allowing (U, V) inside a wafer
         std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
         std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
         outFile1 << xy1.first << "    " << xy1.second << std::endl;
-        outFile2 << (xy1.first + xyOffset.first)  << "    " << (xy1.second + xyOffset.second) << std::endl;
+        outFile2 << (xy1.first + xyOffset.first) << "    " << (xy1.second + xyOffset.second) << std::endl;
         std::pair<int32_t, int32_t> uv1 =
             wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, true, false);
         std::pair<int32_t, int32_t> uv5 =
@@ -170,17 +112,12 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
                                   ? " ***** ERROR *****"
                                   : "";
         edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
-                                      << " placement index " << placeIndex_ << " x " << xy1.first << " ,y " << xy1.second << " xoff " << xyOffset.first << " ,yoff " << xyOffset.second 
-                                      << " u " << uv5.first << " v " << uv5.second << comment;
+                                      << " placement index " << placeIndex_ << " u " << uv5.first << " v " << uv5.second
+                                      << " x " << xy1.first << " ,y " << xy1.second << " xoff " << xyOffset.first
+                                      << " ,yoff " << xyOffset.second;
       }
-    }}
-    outFile1.close();
-    outFile2.close();
+    }
   }
-  auto end_t = std::chrono::high_resolution_clock::now();
-  auto diff_t = end_t - start_t;
-  edm::LogVerbatim("HGCalGeom") << "Execution time for " << nTrials_
-                                << " events = " << std::chrono::duration<double, std::milli>(diff_t).count() << " ms";
 }
 
 // define this as a plug-in

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -59,7 +59,6 @@ private:
   const double waferSize_;
   const int waferType_;
   const int placeIndex_;
-  const int partialType_;
   const double mouseBiteCut_;
   const double guardRingOffset_;
 };
@@ -68,7 +67,6 @@ HGCalCellOffsetTester::HGCalCellOffsetTester(const edm::ParameterSet& iC)
     : waferSize_(iC.getParameter<double>("waferSize")),
       waferType_(iC.getParameter<int>("waferType")),
       placeIndex_(iC.getParameter<int>("cellPlacementIndex")),
-      partialType_(iC.getParameter<int>("partialType")),
       mouseBiteCut_(iC.getParameter<double>("mouseBiteCut")),
       guardRingOffset_(iC.getParameter<double>("guardRingOffset")) {
   edm::LogVerbatim("HGCalGeom") << "Test positions for wafer of size " << waferSize_ << " Type " << waferType_
@@ -81,7 +79,6 @@ void HGCalCellOffsetTester::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<double>("waferSize", 166.4408);
   desc.add<int>("waferType", 0);
   desc.add<int>("cellPlacementIndex", 3);
-  desc.add<int>("partialType", 0);
   desc.add<double>("mouseBiteCut", 0.0);
   desc.add<double>("guardRingOffset", 0.0);
   descriptions.add("hgcalCellOffsetTester", desc);
@@ -104,13 +101,10 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
         std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
         std::pair<int32_t, int32_t> uv1 =
             wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, true, false);
-        std::pair<int32_t, int32_t> uv5 =
-            wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, partialType_, true, false);
-        std::string comment = ((uv1.first != ui) || (uv1.second != vi) || (uv5.first != ui) || (uv5.second != vi))
-                                  ? " ***** ERROR (u, v) from the methods dosent match *****"
-                                  : "";
+        std::string comment =
+            ((uv1.first != ui) || (uv1.second != vi)) ? " ***** ERROR (u, v) from the methods dosent match *****" : "";
         edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
-                                      << " placement index " << placeIndex_ << " u " << uv5.first << " v " << uv5.second
+                                      << " placement index " << placeIndex_ << " u " << uv1.first << " v " << uv1.second
                                       << " x " << xy1.first << " ,y " << xy1.second << " xoff " << xyOffset.first
                                       << " ,yoff " << xyOffset.second << comment;
       }

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -102,19 +102,17 @@ void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
         //Only allowing (U, V) inside a wafer
         std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
         std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
-        outFile1 << xy1.first << "    " << xy1.second << std::endl;
-        outFile2 << (xy1.first + xyOffset.first) << "    " << (xy1.second + xyOffset.second) << std::endl;
         std::pair<int32_t, int32_t> uv1 =
             wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, true, false);
         std::pair<int32_t, int32_t> uv5 =
             wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, partialType_, true, false);
         std::string comment = ((uv1.first != ui) || (uv1.second != vi) || (uv5.first != ui) || (uv5.second != vi))
-                                  ? " ***** ERROR *****"
+                                  ? " ***** ERROR (u, v) from the methods dosent match *****"
                                   : "";
         edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
                                       << " placement index " << placeIndex_ << " u " << uv5.first << " v " << uv5.second
                                       << " x " << xy1.first << " ,y " << xy1.second << " xoff " << xyOffset.first
-                                      << " ,yoff " << xyOffset.second;
+                                      << " ,yoff " << xyOffset.second << comment;
       }
     }
   }

--- a/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalCellOffsetTester.cc
@@ -1,0 +1,187 @@
+// -*- C++ -*-
+//
+// Package:    HGCalCellPartialCellTester
+// Class:      HGCalCellPartialCellTester
+//
+/**\class HGCalCellPartialCellTester HGCalCellPartialCellTester.cc
+ test/HGCalCellPartialCellTester.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Sunanda Banerjee, Pruthvi Suryadevara
+//         Created:  Mon 2022/06/10
+//
+//
+
+// system include files
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <stdlib.h>
+#include <cmath>
+//#include <chrono>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
+#include "Geometry/HGCalCommonData/interface/HGCalParameters.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCellUV.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCellOffset.h"
+#include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
+
+class HGCalCellOffsetTester : public edm::one::EDAnalyzer<> {
+public:
+  explicit HGCalCellOffsetTester(const edm::ParameterSet&);
+  ~HGCalCellOffsetTester() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void beginJob() override {}
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endJob() override {}
+
+private:
+  const double waferSize_;
+  const int waferType_;
+  const int placeIndex_;
+  const int partialType_;
+  const int nTrials_;
+  const int modeUV_;
+};
+
+HGCalCellOffsetTester::HGCalCellOffsetTester(const edm::ParameterSet& iC)
+    : waferSize_(iC.getParameter<double>("waferSize")),
+      waferType_(iC.getParameter<int>("waferType")),
+      placeIndex_(iC.getParameter<int>("cellPlacementIndex")),
+      partialType_(iC.getParameter<int>("partialType")),
+      nTrials_(iC.getParameter<int>("numbberOfTrials")),
+      modeUV_(iC.getParameter<int>("modeUV")) {
+  edm::LogVerbatim("HGCalGeom") << "Test positions for wafer of size " << waferSize_ << " Type " << waferType_
+                                << " Partial Type " << partialType_ << " Placement Index " << placeIndex_ << " mode "
+                                << modeUV_ << " with " << nTrials_ << " trials";
+}
+
+void HGCalCellOffsetTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("waferSize", 166.4408);
+  desc.add<int>("waferType", 0);
+  desc.add<int>("cellPlacementIndex", 3);
+  desc.add<int>("partialType", 0);
+  desc.add<int>("numbberOfTrials", 1000);
+  desc.add<int>("modeUV", 1);
+  descriptions.add("hgcalCellOffsetTester", desc);
+}
+
+// ------------ method called to produce the data  ------------
+void HGCalCellOffsetTester::analyze(const edm::Event&, const edm::EventSetup&) {
+  const int nFine(12), nCoarse(8);
+  double r2 = 0.5 * waferSize_;
+  double R2 = 2 * r2 / sqrt(3);
+  int nCells = (waferType_ == 0) ? nFine : nCoarse;
+  HGCalCellUV wafer(waferSize_, 0.0, nFine, nCoarse);
+  HGCalCell wafer2(waferSize_, nFine, nCoarse);
+  HGCalCellOffset offset(waferSize_, nFine, nCoarse, (waferSize_/(4*std::sqrt(3.0)*nFine)), 0.0);
+  edm::LogVerbatim("HGCalGeom") << "\nHGCalPartialCellTester:: nCells " << nCells << " and placement index "
+                                << placeIndex_ << "\n\n";
+  auto start_t = std::chrono::high_resolution_clock::now();
+
+  if (modeUV_ <= 0) {
+    for (int i = 0; i < nTrials_; i++) {
+      double xi = (2 * r2 * static_cast<double>(rand()) / RAND_MAX) - r2;
+      double yi = (2 * R2 * static_cast<double>(rand()) / RAND_MAX) - R2;
+      bool goodPoint = true;
+      int ug = 0;
+      int vg = 0;
+      if (partialType_ == 11 || partialType_ == 13 || partialType_ == 15 || partialType_ == 21 || partialType_ == 23 ||
+          partialType_ == 25) {
+        ug = 0;
+        vg = 0;
+      } else if (partialType_ == 12 || partialType_ == 14 || partialType_ == 16 || partialType_ == 22 ||
+                 partialType_ == 24) {
+        ug = nCells + 1;
+        vg = 2 * (nCells - 1);
+      }
+      std::pair<double, double> xyg = wafer2.cellUV2XY2(ug, vg, placeIndex_, waferType_);
+      std::vector<std::pair<double, double> > wxy =
+          HGCalWaferMask::waferXY(partialType_, placeIndex_, waferSize_, 0.0, 0.0, 0.0);
+      for (unsigned int i = 0; i < (wxy.size() - 1); ++i) {
+        double xp1 = wxy[i].first;
+        double yp1 = wxy[i].second;
+        double xp2 = wxy[i + 1].first;
+        double yp2 = wxy[i + 1].second;
+        if ((((xi - xp1) / (xp2 - xp1)) - ((yi - yp1) / (yp2 - yp1))) *
+                (((xyg.first - xp1) / (xp2 - xp1)) - ((xyg.second - yp1) / (yp2 - yp1))) <=
+            0) {
+          goodPoint = false;
+        }
+      }
+      if (goodPoint) {  //Only allowing (x, y) inside a partial wafer 11, placement index 2
+        std::pair<int32_t, int32_t> uv1 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, true, false);
+        std::pair<int32_t, int32_t> uv5 =
+            wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, partialType_, true, false);
+        std::pair<double, double> xy1 = wafer2.cellUV2XY2(uv5.first, uv5.second, placeIndex_, waferType_);
+        std::string cellType = (HGCalWaferMask::goodCell(uv5.first, uv5.second, partialType_)) ? "Goodcell" : "Badcell";
+        std::string pointType = goodPoint ? "GoodPoint" : "BadPoint";
+        std::string comment =
+            ((uv1.first != uv5.first) || (uv1.second != uv5.second) || (xy1.first - xi > 6) || (xy1.second - yi > 6))
+                ? " ***** ERROR *****"
+                : "";
+        edm::LogVerbatim("HGCalGeom") << pointType << " " << cellType << " x = " << xi << ":" << xy1.first
+                                      << " y = " << yi << ":" << xy1.second << " type = " << waferType_
+                                      << " placement index " << placeIndex_ << " u " << uv1.first << ":" << uv5.first
+                                      << ":" << uv5.first << " v " << uv1.second << ":" << uv5.second << ":"
+                                      << uv5.second << ":" << comment;
+      }
+    }
+  } else {
+    std::ofstream outFile1("default.txt");
+    std::ofstream outFile2("offset.txt");
+    //for (int i = 0; i < nTrials_; i++) {
+      //int ui = std::floor(2 * nCells * rand() / RAND_MAX);
+      //int vi = std::floor(2 * nCells * rand() / RAND_MAX);
+    for (int ui = 0; ui < 2 * nCells; ui++){
+    for (int vi = 0; vi < 2 * nCells; vi++){
+      if ((ui < 2 * nCells) && (vi < 2 * nCells) && ((vi - ui) < nCells) && ((ui - vi) <= nCells)) {
+        //Only allowing (U, V) inside a wafer
+        std::pair<double, double> xy1 = wafer2.cellUV2XY2(ui, vi, placeIndex_, waferType_);
+        std::pair<double, double> xyOffset = offset.cellOffsetUV2XY1(ui, vi, placeIndex_, waferType_);
+        outFile1 << xy1.first << "    " << xy1.second << std::endl;
+        outFile2 << (xy1.first + xyOffset.first)  << "    " << (xy1.second + xyOffset.second) << std::endl;
+        std::pair<int32_t, int32_t> uv1 =
+            wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, true, false);
+        std::pair<int32_t, int32_t> uv5 =
+            wafer.cellUVFromXY1(xy1.first, xy1.second, placeIndex_, waferType_, partialType_, true, false);
+        std::string comment = ((uv1.first != ui) || (uv1.second != vi) || (uv5.first != ui) || (uv5.second != vi))
+                                  ? " ***** ERROR *****"
+                                  : "";
+        edm::LogVerbatim("HGCalGeom") << "u = " << ui << " v = " << vi << " type = " << waferType_
+                                      << " placement index " << placeIndex_ << " x " << xy1.first << " ,y " << xy1.second << " xoff " << xyOffset.first << " ,yoff " << xyOffset.second 
+                                      << " u " << uv5.first << " v " << uv5.second << comment;
+      }
+    }}
+    outFile1.close();
+    outFile2.close();
+  }
+  auto end_t = std::chrono::high_resolution_clock::now();
+  auto diff_t = end_t - start_t;
+  edm::LogVerbatim("HGCalGeom") << "Execution time for " << nTrials_
+                                << " events = " << std::chrono::duration<double, std::milli>(diff_t).count() << " ms";
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HGCalCellOffsetTester);

--- a/Geometry/HGCalCommonData/test/python/testHGCalCellOffsetTester_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalCellOffsetTester_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.HGCalGeom=dict()
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+                                   PGunParameters = cms.PSet(
+                                       PartID = cms.vint32(14),
+                                       MinEta = cms.double(-3.5),
+                                       MaxEta = cms.double(3.5),
+                                       MinPhi = cms.double(-3.14159265359),
+                                       MaxPhi = cms.double(3.14159265359),
+                                       MinE   = cms.double(9.99),
+                                       MaxE   = cms.double(10.01)
+                                   ),
+                                   AddAntiParticle = cms.bool(False),
+                                   Verbosity       = cms.untracked.int32(0),
+                                   firstRun        = cms.untracked.uint32(1)
+                               )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
+                                        ignoreTotal = cms.untracked.int32(1),
+                                        moduleMemorySummary = cms.untracked.bool(True)
+)
+
+process.load("Geometry.HGCalCommonData.hgcalCellOffsetTester_cfi")
+
+ 
+process.p1 = cms.Path(process.generator*process.hgcalCellOffsetTester)


### PR DESCRIPTION
PR description:

Implement script to get the offset from hexagon centre to cell centroid for HGCAL wafers. Also add function to return the area of cells.  

PR validation:

Use runTheMatrix test workflows 'runTheMatrix.py -l limited -i all --ibeos'
Test scripts added in: Geometry/HGCalCommonData/test/
Validation results presented in: https://indico.cern.ch/event/1317673/

if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing