### PR TITLE
minimal fixes to run Phase2 patatrack pixel only workflows without using phase-1 pixel conditions

### DIFF
--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -86,10 +86,9 @@ castorDigis.InputLabel = 'rawDataCollector'
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([castorDigis]))
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-# Remove siPixelDigis until we have phase2 pixel digis
 # No Strips in the Phase-2 tracker
-phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixelDigis,siStripDigis])) # FIXME
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siStripDigis]))
 
 from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
 approxSiStripClusters.toReplaceWith(RawToDigiTask,

--- a/EventFilter/SiPixelRawToDigi/python/siPixelDigis_cff.py
+++ b/EventFilter/SiPixelRawToDigi/python/siPixelDigis_cff.py
@@ -29,7 +29,6 @@ phase1Pixel.toModify(siPixelDigiErrors,
     UsePhase1 = True
 )
 
-
 from Configuration.ProcessModifiers.gpu_cff import gpu
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 (gpu & ~phase2_tracker).toReplaceWith(siPixelDigisTask, cms.Task(
@@ -42,3 +41,6 @@ from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
     # SwitchProducer wrapping the legacy pixel digis producer or an alias combining the pixel digis information converted from SoA
     siPixelDigisTask.copy()
 ))
+
+# Remove siPixelDigis until we have phase2 pixel digis
+phase2_tracker.toReplaceWith(siPixelDigisTask, cms.Task()) #FIXME

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizerPreSplitting_cfi.py
@@ -10,13 +10,19 @@ siPixelClustersPreSplitting = SwitchProducerCUDA(
     cpu = _siPixelClusters.clone()
 )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.ProcessModifiers.gpu_cff import gpu
-# SwitchProducer wrapping the legacy pixel cluster producer or an alias for the pixel clusters information converted from SoA
-gpu.toModify(siPixelClustersPreSplitting,
-    # ensure the same results when running on GPU (which supports only the 'HLT' payload) and CPU
+
+# ensure the same results when running on GPU (which supports only the 'HLT' payload) and CPU
+# but not for phase-2 where we don't calibrate digis in the clusterizer (yet)
+(gpu & ~phase2_tracker).toModify(siPixelClustersPreSplitting,
     cpu = dict(
         payloadType = 'HLT'
-    ),
+    )
+)
+
+# SwitchProducer wrapping the legacy pixel cluster producer or an alias for the pixel clusters information converted from SoA
+gpu.toModify(siPixelClustersPreSplitting,
     cuda = cms.EDAlias(
         siPixelDigisClustersPreSplitting = cms.VPSet(
             cms.PSet(type = cms.string("SiPixelClusteredmNewDetSetVector"))


### PR DESCRIPTION
#### PR description:

Minimal fix for https://github.com/cms-sw/cmssw/pull/42794#issuecomment-1727027260

#### PR validation:

`runTheMatrix.py --what upgrade -l 24834.5,20834.501,20834.502 -t 4 -j 8` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A