### PR TITLE
fixed LHCInfoPer* PopCons not recoginizing ongoing fills in duringFill mode

### DIFF
--- a/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerFillPopConAnalyzer.cc
@@ -98,7 +98,9 @@ namespace theLHCInfoPerFillImpl {
       auto energy = row.get<float>("energy");
       auto creationTime = row.get<boost::posix_time::ptime>("start_time");
       auto stableBeamStartTime = row.get<boost::posix_time::ptime>("start_stable_beam");
-      auto beamDumpTime = row.get<boost::posix_time::ptime>("end_time");
+      std::string endTimeStr = row.get<std::string>("end_time");
+      auto beamDumpTime =
+          (endTimeStr == "null") ? 0 : cond::time::from_boost(row.get<boost::posix_time::ptime>("end_time"));
       auto injectionScheme = row.get<std::string>("injection_scheme");
       targetPayload = std::make_unique<LHCInfoPerFill>();
       targetPayload->setFillNumber(currentFill);
@@ -114,7 +116,7 @@ namespace theLHCInfoPerFillImpl {
       targetPayload->setEnergy(energy);
       targetPayload->setCreationTime(cond::time::from_boost(creationTime));
       targetPayload->setBeginTime(cond::time::from_boost(stableBeamStartTime));
-      targetPayload->setEndTime(cond::time::from_boost(beamDumpTime));
+      targetPayload->setEndTime(beamDumpTime);
       targetPayload->setInjectionScheme(injectionScheme);
       ret = true;
     }

--- a/CondTools/RunInfo/plugins/LHCInfoPerLSPopConAnalyzer.cc
+++ b/CondTools/RunInfo/plugins/LHCInfoPerLSPopConAnalyzer.cc
@@ -217,14 +217,18 @@ public:
         oms.connect(m_omsBaseUrl);
         auto query = oms.query("fills");
         query->addOutputVar("end_time");
+        query->addOutputVar("start_time");
         query->filterEQ("fill_number", m_prevPayload->fillNumber());
         bool foundFill = query->execute();
         if (foundFill) {
           auto result = query->result();
 
           if (!result.empty()) {
-            auto endFillTime = (*result.begin()).get<boost::posix_time::ptime>("end_time");
-            m_prevEndFillTime = cond::time::from_boost(endFillTime);
+            std::string endTimeStr = (*result.begin()).get<std::string>("end_time");
+            m_prevEndFillTime =
+                (endTimeStr == "null")
+                    ? 0
+                    : cond::time::from_boost((*result.begin()).get<boost::posix_time::ptime>("end_time"));
             auto startFillTime = (*result.begin()).get<boost::posix_time::ptime>("start_time");
             m_prevStartFillTime = cond::time::from_boost(startFillTime);
           } else {
@@ -362,7 +366,9 @@ private:
       auto row = *queryResult.begin();
       auto currentFill = row.get<unsigned short>("fill_number");
       m_startFillTime = cond::time::from_boost(row.get<boost::posix_time::ptime>("start_time"));
-      m_endFillTime = cond::time::from_boost(row.get<boost::posix_time::ptime>("end_time"));
+      std::string endTimeStr = row.get<std::string>("end_time");
+      m_endFillTime =
+          (endTimeStr == "null") ? 0 : cond::time::from_boost(row.get<boost::posix_time::ptime>("end_time"));
       m_startStableBeamTime = cond::time::from_boost(row.get<boost::posix_time::ptime>("start_stable_beam"));
       m_endStableBeamTime = cond::time::from_boost(row.get<boost::posix_time::ptime>("end_stable_beam"));
       targetPayload = std::make_unique<LHCInfoPerLS>();
@@ -431,6 +437,7 @@ private:
     }
     return nlumi;
   }
+
   bool getCTPPSData(cond::persistency::Session& session,
                     const boost::posix_time::ptime& beginFillTime,
                     const boost::posix_time::ptime& endFillTime) {

--- a/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
+++ b/CondTools/RunInfo/test/test_lhcInfoNewPopCon.sh
@@ -27,7 +27,7 @@ function assert_found_fills {
 
 rm -f lhcinfo_pop_unit_test.db
 
-echo "testing LHCInfoPerFillPopConAnalyzer in EndFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
+echo "testing LHCInfoPerFillPopConAnalyzer in endFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
 cmsRun ${SCRIPTS_DIR}/LHCInfoPerFillPopConAnalyzer.py mode=endFill \
     destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
     startTime="2022-10-24 01:00:00.000" endTime="2022-10-24 20:00:00.000" \
@@ -50,11 +50,11 @@ cmsRun ${SCRIPTS_DIR}/LHCInfoPerLSPopConAnalyzer.py mode=endFill \
     destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
     startTime="2022-07-11 22:00:00.000" endTime="2022-07-12 18:10:10.000" \
     tag=ls_end_test2 > ls_end_test2.log || die "cmsRun LHCInfoPerLSPopConAnalyzer.py mode=endFill" $?
-assert_equal 69 `cat ls_end_test2.log | grep -E '^Since ' | \
+assert_equal 70 `cat ls_end_test2.log | grep -E '^Since ' | \
     wc -l` "LHCInfoPerLSPopConAnalyzer in endFill mode written wrong number of payloads"
 assert_found_fills ls_end_test2.log "LHCInfoPerLSPopConAnalyzer in endFill mode" 7967
 
-echo "testing LHCInfoPerFillPopConAnalyzer in DuringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
+echo "testing LHCInfoPerFillPopConAnalyzer in duringFill mode for startTime=\"2022-10-24 01:00:00.000\" endTime=\"2022-10-24 20:00:00.000\"" 
 cmsRun ${SCRIPTS_DIR}/LHCInfoPerFillPopConAnalyzer.py mode=duringFill \
     destinationConnection="sqlite_file:lhcinfo_pop_unit_test.db" \
     startTime="2022-10-24 01:00:00.000" endTime="2022-10-24 20:00:00.000" \


### PR DESCRIPTION
#### PR description:

Fixes bugs in `LHCInfoPerFill` and `LHCInfoPerLS` PopCons in `duringFill` mode causing it not to recognize a fill as ongoing. It caused the PopCons not process any fills and not write any data in this mode.

DuringFill mode is supposed to only process ongoing fills and write only one - the newest available payload for each execution during stable beam. It interprets a fill as ongoing if its end_time (taken from OMS) is null which means it didn't end. It is not checking the value for being `null` directly but checking if the `end_time` converted to `cond::Time_t` is equal to 0. It was not working correctly because conversion from `end_time` value taken from OMS as `boost::posix_time::ptime` to `cond::Time_t` converts `null` to `2035-10-29 06:32:22`.

#### PR validation:

It was validated by running the PopCons via `LHCInfoPerFillPopConAnalyzer.py` and `LHCInfoPerLSPopConAnalyzer.py` with `mode=duringFill` during and outside of stable beam of an ongoing fill. It was checked if the payload was written given the right circumstances (ongoing stable beam) and if the written data is correct.

#### Backporting

I think it should be backported to 13_2_X, but it depends on what release the Per* PopCons are going to be deployed.
