### PR TITLE
Remove duplicate entries from `CondTools/RunInfo/plugins/BuildFile.xml`

### DIFF
--- a/CondTools/RunInfo/plugins/BuildFile.xml
+++ b/CondTools/RunInfo/plugins/BuildFile.xml
@@ -74,16 +74,3 @@
 <library file="LHCInfoPerLSWriter.cc" name="LHCInfoPerLSWriter">
   <flags EDM_PLUGIN="1"/>
 </library>
-
-<library file="LHCInfoPerLSAnalyzer.cc" name="LHCInfoPerLSAnalyzer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="LHCInfoPerFillWriter.cc" name="LHCInfoPerFillWriter">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-
-<library file="LHCInfoPerFillAnalyzer.cc" name="LHCInfoPerFillAnalyzer">
-  <flags EDM_PLUGIN="1"/>
-</library>


### PR DESCRIPTION
As far as I can tell, the following lines are duplicated towards the end of [this file](https://github.com/cms-sw/cmssw/blob/master/CondTools/RunInfo/plugins/BuildFile.xml):

```xml
<library file="LHCInfoPerLSAnalyzer.cc" name="LHCInfoPerLSAnalyzer">
  <flags EDM_PLUGIN="1"/>
</library>

<library file="LHCInfoPerFillWriter.cc" name="LHCInfoPerFillWriter">
  <flags EDM_PLUGIN="1"/>
</library>

<library file="LHCInfoPerFillAnalyzer.cc" name="LHCInfoPerFillAnalyzer">
  <flags EDM_PLUGIN="1"/>
</library>
```