### PR TITLE
Make enum to int conversion in `SiStripRawToDigiUnpacker.cc` explicit

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/SiStripRawToDigiUnpacker.cc
@@ -354,7 +354,7 @@ namespace sistrip {
               scope_work_registry_.push_back(regItem);
             }
           } else {  // Unknown readout mode! => assume scope mode
-            warnings_.add(fmt::format("Unknown FED readout mode ({0})! Assuming SCOPE MODE...", mode));
+            warnings_.add(fmt::format("Unknown FED readout mode ({0})! Assuming SCOPE MODE...", int(mode)));
             Registry regItem(key, 0, scope_work_digis_.size(), 0);
             st_ch = fedchannelunpacker::unpackScope(fedChannel, std::back_inserter(scope_work_digis_));
             if (regItem.index != scope_work_digis_.size()) {


### PR DESCRIPTION
This is to avoid a compiler error in my environment (ArchLinux with gcc 13.2.1):

```
/usr/include/fmt/core.h:1577:63: error: ‘fmt::v10::detail::type_is_unformattable_for<const sistrip::FEDReadoutMode, char> _’ has incomplete type
 1577 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
/usr/include/fmt/core.h:1581:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1581 |       formattable,
      |       ^~~~~~~~~~~
/usr/include/fmt/core.h:1581:7: note: ‘formattable’ evaluates to false
```