### PR TITLE
Prepare ECAL multifit reconstruction to use different time calibration records - 132x

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -38,6 +38,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h"
@@ -216,8 +217,10 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   grpsToken_ = c.esConsumes<EcalWeightXtalGroups, EcalWeightXtalGroupsRcd>();
   wgtsToken_ = c.esConsumes<EcalTBWeights, EcalTBWeightsRcd>();
   timeCorrBiasToken_ = c.esConsumes<EcalTimeBiasCorrections, EcalTimeBiasCorrectionsRcd>();
-  itimeToken_ = c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>();
-  offtimeToken_ = c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>();
+  itimeToken_ =
+      c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>(ps.getParameter<edm::ESInputTag>("timeCalibTag"));
+  offtimeToken_ = c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>(
+      ps.getParameter<edm::ESInputTag>("timeOffsetTag"));
 
   // algorithm to be used for timing
   auto const& timeAlgoName = ps.getParameter<std::string>("timealgo");
@@ -768,6 +771,8 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerMultiFit::getAlgoDescription
                                                              true) and
               edm::ParameterDescription<std::vector<double>>("EBamplitudeFitParameters", {1.138, 1.652}, true) and
               edm::ParameterDescription<std::vector<double>>("EEamplitudeFitParameters", {1.890, 1.400}, true) and
+              edm::ParameterDescription<edm::ESInputTag>("timeCalibTag", edm::ESInputTag(), true) and
+              edm::ParameterDescription<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag(), true) and
               edm::ParameterDescription<double>("EBtimeFitLimits_Lower", 0.2, true) and
               edm::ParameterDescription<double>("EBtimeFitLimits_Upper", 1.4, true) and
               edm::ParameterDescription<double>("EEtimeFitLimits_Lower", 0.2, true) and


### PR DESCRIPTION
#### PR description:

Adding two ESInputTag parameters to be able to select the record that the timing calibrations and timing offsets are taken from by the multifit algorithm.
This will be needed to support two records of those conditions within a GT.
Having two records in a GT will be required in some cases (e.g. MC GTs) because two different timing algorithms, using two different sets of conditions, run at the HLT and in offline reconstruction.

This PR just adds the capability to specify the record label but no changes to configuration are made and no changes in existing workflows are expected.

#### PR validation:

Passes limited matrix tests.

Backport of #42817 

This backport is needed because the online DQM runs the CC timing algorithm in reconstruction with the HLT GT, which currently contains the ratio timing calibrations for the ratio timing running at the HLT. In the current situation the onine DQM shows bad ECAL timing distributions due to this.
With an additional EcalTimeCalibConstants record added to the HLT GT both algorithms can be given the correct calibrations with the parameters added in this PR.
