### PR TITLE
fix commented section of `EDAnalyzer::fillDescriptions` skeleton, such that it can actually compile

### DIFF
--- a/FWCore/Skeletons/mkTemplates/EDAnalyzer/EDAnalyzer.cc
+++ b/FWCore/Skeletons/mkTemplates/EDAnalyzer/EDAnalyzer.cc
@@ -135,8 +135,8 @@ void __class__::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
   //Specify that only 'tracks' is allowed
   //To use, remove the default given above and uncomment below
-  //ParameterSetDescription desc;
-  //desc.addUntracked<edm::InputTag>("tracks","ctfWithMaterialTracks");
+  //edm::ParameterSetDescription desc;
+  //desc.addUntracked<edm::InputTag>("tracks", edm::InputTag("ctfWithMaterialTracks"));
   //descriptions.addWithDefaultLabel(desc);
 }
 


### PR DESCRIPTION
#### PR description:

Rather silly, but I hit this enough times to do something about it

#### PR validation:

Checked that after the PR the skeleton comes out as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A