### PR TITLE
Remove noisy missing collection warnings coming from EcalDQMonitorTask

### DIFF
--- a/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
+++ b/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
@@ -46,7 +46,8 @@ private:
 
   edm::EDGetToken collectionTokens_[ecaldqm::nCollections];           // list of EDGetTokens
   std::vector<std::pair<Processor, ecaldqm::Collections>> schedule_;  // schedule of collections to run
-  bool allowMissingCollections_;                                      // when true, skip missing collections silently
+  std::vector<std::string> skipCollections_;  // list of collections to explicitly remove from schedule
+  bool allowMissingCollections_;              // when true, skip missing collections and log as warning
   int processedEvents_;
 
   /* TASK TIME PROFILING */

--- a/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
+++ b/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
@@ -46,8 +46,16 @@ private:
 
   edm::EDGetToken collectionTokens_[ecaldqm::nCollections];           // list of EDGetTokens
   std::vector<std::pair<Processor, ecaldqm::Collections>> schedule_;  // schedule of collections to run
+
   std::vector<std::string> skipCollections_;  // list of collections to explicitly remove from schedule
-  bool allowMissingCollections_;              // when true, skip missing collections and log as warning
+                                              // note: skipping a collection here will result in
+                                              // EcalDQMonitorTask not consuming it, which may lead the
+                                              // module producing the collection to not run at all
+
+  bool allowMissingCollections_;  // when true (default), skip missing collections and log as warning
+                                  // note: collections skipped by the parameter skipCollections will
+                                  // bypass this check and not issue warnings
+
   int processedEvents_;
 
   /* TASK TIME PROFILING */

--- a/DQM/EcalMonitorTasks/interface/GpuTask.h
+++ b/DQM/EcalMonitorTasks/interface/GpuTask.h
@@ -61,46 +61,46 @@ namespace ecaldqm {
       case kEBCpuDigi:
         if (collection_data && runGpuTask_ && enableDigi_)
           runOnCpuDigis(*static_cast<EBDigiCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableDigi_;
         break;
       case kEECpuDigi:
         if (collection_data && runGpuTask_ && enableDigi_)
           runOnCpuDigis(*static_cast<EEDigiCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableDigi_;
         break;
       case kEBGpuDigi:
         if (collection_data && runGpuTask_ && enableDigi_)
           runOnGpuDigis(*static_cast<EBDigiCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableDigi_;
         break;
       case kEEGpuDigi:
         if (collection_data && runGpuTask_ && enableDigi_)
           runOnGpuDigis(*static_cast<EEDigiCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableDigi_;
         break;
       case kEBCpuUncalibRecHit:
       case kEECpuUncalibRecHit:
         if (collection_data && runGpuTask_ && enableUncalib_)
           runOnCpuUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableUncalib_;
         break;
       case kEBGpuUncalibRecHit:
       case kEEGpuUncalibRecHit:
         if (collection_data && runGpuTask_ && enableUncalib_)
           runOnGpuUncalibRecHits(*static_cast<EcalUncalibratedRecHitCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableUncalib_;
         break;
       case kEBCpuRecHit:
       case kEECpuRecHit:
         if (collection_data && runGpuTask_ && enableRecHit_)
           runOnCpuRecHits(*static_cast<EcalRecHitCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableRecHit_;
         break;
       case kEBGpuRecHit:
       case kEEGpuRecHit:
         if (collection_data && runGpuTask_ && enableRecHit_)
           runOnGpuRecHits(*static_cast<EcalRecHitCollection const*>(collection_data), collection);
-        return runGpuTask_;
+        return enableRecHit_;
         break;
       default:
         break;

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -28,6 +28,7 @@ EcalDQMonitorTask::EcalDQMonitorTask(edm::ParameterSet const& _ps)
     : DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::EcalLSCache>>(),
       ecaldqm::EcalDQMonitor(_ps),
       schedule_(),
+      skipCollections_(_ps.getUntrackedParameter<std::vector<std::string>>("skipCollections")),
       allowMissingCollections_(_ps.getUntrackedParameter<bool>("allowMissingCollections")),
       processedEvents_(0),
       lastResetTime_(0),
@@ -92,6 +93,7 @@ void EcalDQMonitorTask::fillDescriptions(edm::ConfigurationDescriptions& _descs)
   collectionTags.addWildcardUntracked<edm::InputTag>("*");
   desc.add("collectionTags", collectionTags);
 
+  desc.addUntracked<std::vector<std::string>>("skipCollections", std::vector<std::string>());
   desc.addUntracked<bool>("allowMissingCollections", true);
   desc.addUntracked<double>("resetInterval", 0.);
 

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cfi.py
@@ -48,6 +48,7 @@ ecalMonitorTask = DQMEDAnalyzer('EcalDQMonitorTask',
     ),
     commonParameters = ecalCommonParams,
     collectionTags = ecalDQMCollectionTags,
+    skipCollections = cms.untracked.vstring(),
     allowMissingCollections = cms.untracked.bool(True),
     verbosity = cms.untracked.int32(0),
     resetInterval = cms.untracked.double(2.)

--- a/DQM/EcalMonitorTasks/python/ecalGpuTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ecalGpuTask_cfi.py
@@ -5,12 +5,13 @@ uncalibOOTAmps_ = [4,6]
 
 ecalGpuTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
+        # ecalGpuTask must be explicitly turned on when using
         runGpuTask = cms.untracked.bool(False),
-
-        # Default plots for each object are 1D CPU distributions and 1D GPU-CPU diff
         enableDigi = cms.untracked.bool(True),
         enableUncalib = cms.untracked.bool(True),
-        enableRecHit = cms.untracked.bool(True),
+
+        # GPU rechits currently unavailable; last edited Sep 2023
+        enableRecHit = cms.untracked.bool(False),
 
         # 1D flags enable distributions of GPU values
         # 2D flags enable 2D comparison maps

--- a/DQM/EcalMonitorTasks/src/GpuTask.cc
+++ b/DQM/EcalMonitorTasks/src/GpuTask.cc
@@ -31,13 +31,17 @@ namespace ecaldqm {
 
   void GpuTask::addDependencies(DependencySet& dependencies) {
     // Ensure we run on CPU objects before GPU objects
-    if (runGpuTask_) {
+    if (enableDigi_) {
       dependencies.push_back(Dependency(kEBGpuDigi, kEBCpuDigi));
       dependencies.push_back(Dependency(kEEGpuDigi, kEECpuDigi));
+    }
 
+    if (enableUncalib_) {
       dependencies.push_back(Dependency(kEBGpuUncalibRecHit, kEBCpuUncalibRecHit));
       dependencies.push_back(Dependency(kEEGpuUncalibRecHit, kEECpuUncalibRecHit));
+    }
 
+    if (enableRecHit_) {
       dependencies.push_back(Dependency(kEBGpuRecHit, kEBCpuRecHit));
       dependencies.push_back(Dependency(kEEGpuRecHit, kEECpuRecHit));
     }

--- a/DQMOffline/Ecal/python/ecal_dqm_source_offline_cff.py
+++ b/DQMOffline/Ecal/python/ecal_dqm_source_offline_cff.py
@@ -31,3 +31,5 @@ ecalOnly_dqm_source_offline = cms.Sequence(
 )
 
 ecalMonitorTask.workerParameters.TrigPrimTask.params.runOnEmul = False
+ecalMonitorTaskEcalOnly.workerParameters.TrigPrimTask.params.runOnEmul = False
+ecalMonitorTaskEcalOnly.workerParameters.RecoSummaryTask.params.fillRecoFlagReduced = False


### PR DESCRIPTION
#### PR description:

Addresses issue https://github.com/cms-sw/cmssw/issues/42720 dealing with multiple missing collection warnings per event coming from the `EcalDQMonitorTask` module using the `ecalMonitorTaskEcalOnly` config in offline relval WFs. The collections fell into one of three groups with each group having a separate reason or set of reasons for the warnings.

---

The `GpuRecHit` collections do not exist (as far as I know this is still the case). RecHit monitoring was switched off for online GPU validation in https://github.com/cms-sw/cmssw/pull/39393, but this was not propagated to offline since RecHits were [enabled by default](https://github.com/cms-sw/cmssw/blob/93e2e3051588c8f931cb559201d76f9edafdb9ec/DQM/EcalMonitorTasks/python/ecalGpuTask_cfi.py#L13) in the ECAL GPU validation module. With this PR, the RecHits will now be switched off by default. The assumed [RecHit input tags](https://github.com/cms-sw/cmssw/blob/93e2e3051588c8f931cb559201d76f9edafdb9ec/DQM/EcalMonitorTasks/python/CollectionTags_cfi.py#L56-L59) are already in place for when the collections are implemented. 

In addition, there was an oversight of mine in https://github.com/cms-sw/cmssw/pull/39371 while implementing these collection-level switches to be used in exactly this kind of context. This is now corrected in this PR, and unused collections for GPU monitoring are no longer consumed. 

---

The `TrigPrimEmulDigi` and `ReducedRecHit` collections are straightforward to explain. They are not being produced in offline DQM `EcalOnly` workflows, and there are already flags in place to switch off running over these collections. The emulated digis were already switched off in the general offline config, but the same was not done for the `EcalOnly` config, as the collection is switched off _after_ cloning the original config. This PR switches these collections off for the offline `EcalOnly` config.

---

`EcalRawData` is the trickiest to switch off on the ECAL DQM side since it's used by several modules. This issue is now resolved in https://github.com/cms-sw/cmssw/pull/42844. 

However, we simultaneously implemented a bandaid solution on the ECAL DQM side. We added a parameter to `EcalDQMonitorTask` called `skipCollections` that takes in the names of collections to be explicitly removed from the list of collections being run by the ECAL DQM module. 

The skipping is done as barebones as possible and we decided to purposefully not remove any dependencies that might cause a problem if a collection is not present. This way we can prevent potentially undefined behavior from slipping through the cracks and leaving little to no trace of something being wrong. 

Skipping a collection will lead to the same behavior as having a missing collection if there is a further issue. The difference is that a skipped collection will not be consumed and the ECAL DQM module will not attempt to access the data. This could be useful in the future and not necessarily in the context of a missing collection.

The other PR is the ideal solution to the current issue so this isn't going to be used right now, but it doesn't hurt to have the extra customizability option in our toolkit. 

---

#### PR validation:

Tested with both workflows brought up in issue https://github.com/cms-sw/cmssw/issues/42720. The workflows ran successfully with no warnings.

```
runTheMatrix.py --what gpu -l 141.008583
runTheMatrix.py --what gpu -l 11634.511
```

Adding `EcalRawData` to the new `skipCollections` parameter works as intended. The warning and exception paths added also run as intended in their relevant scenarios.

---

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport can be made if needed.