### PR TITLE
Fix `PixelCountFilter` and introduce `PixelOccupancyFilter`

### DIFF
--- a/CommonTools/UtilAlgos/interface/CollectionCountEventSelector.h
+++ b/CommonTools/UtilAlgos/interface/CollectionCountEventSelector.h
@@ -1,0 +1,60 @@
+#ifndef CommonTools_UtilAlgos_CollectionCountEventSelector_h
+#define CommonTools_UtilAlgos_CollectionCountEventSelector_h
+
+/** \class CollectionCountEventSelector
+ *
+ * Selects an event if a collection has at least N entries
+ *
+ * \author Luca Lista, INFN
+ *
+ * \version $Revision: 1.2 $
+ *
+ * $Id: CollectionCountEventSelector.h,v 1.2 2010/02/20 20:55:24 wmtan Exp $
+ *
+ */
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/CollectionInCollectionFilterTrait.h"
+#include "CommonTools/UtilAlgos/interface/EventSelectorBase.h"
+
+template <typename C,
+          typename S = AnySelector,
+          typename N = MinNumberSelector,
+          typename CS = typename helper::CollectionInCollectionFilterTrait<C, S, N>::type>
+class CollectionCountEventSelector : public EventSelectorBase {
+public:
+  /// constructor
+  explicit CollectionCountEventSelector(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+      : srcToken_(iC.consumes<C>(cfg.template getParameter<edm::InputTag>("src"))),
+        select_(reco::modules::make<S>(cfg, iC)),
+        sizeSelect_(reco::modules::make<N>(cfg, iC)) {}
+
+  static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    desc.add<edm::InputTag>("src", edm::InputTag());
+    reco::modules::fillPSetDescription<S>(desc);
+    reco::modules::fillPSetDescription<N>(desc);
+  }
+
+  bool operator()(edm::Event& evt, const edm::EventSetup&) const override {
+    edm::Handle<C> source;
+    evt.getByToken(srcToken_, source);
+    return CS::filter(*source, select_, sizeSelect_);
+  }
+
+private:
+  /// source collection label
+  edm::EDGetTokenT<C> srcToken_;
+
+  /// object filter
+  S select_;
+
+  /// minimum number of entries in a collection
+  N sizeSelect_;
+};
+
+#endif

--- a/CommonTools/UtilAlgos/interface/CollectionInCollectionFilter.h
+++ b/CommonTools/UtilAlgos/interface/CollectionInCollectionFilter.h
@@ -1,0 +1,29 @@
+#ifndef CommonTools_UtilAlgos_CollectionInCollectionFilter_h
+#define CommonTools_UtilAlgos_CollectionInCollectionFilter_h
+
+/** \class CollectionInCollectionFilter
+ *
+ * Filters an event if the total sum of the entries of a collection of collections has at least N entries
+ * 
+ * \author Marco Musich
+ *
+ * \version $Revision: 1.1 $
+ *
+ * $Id: CollectionInCollectionFilter.h,v 1.1 2024/09/23 11:00:00  Exp $
+ *
+ */
+
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/CollectionInCollectionFilterTrait.h"
+#include "CommonTools/UtilAlgos/interface/EventSelectorAdapter.h"
+#include "CommonTools/UtilAlgos/interface/CollectionCountEventSelector.h"
+
+template <typename C,
+          typename S = AnySelector,
+          typename N = MinNumberSelector,
+          typename CS = typename helper::CollectionInCollectionFilterTrait<C, S, N>::type>
+struct CollectionInCollectionFilter {
+  typedef EventSelectorAdapter<CollectionCountEventSelector<C, S, N, CS> > type;
+};
+
+#endif

--- a/CommonTools/UtilAlgos/interface/CollectionInCollectionFilterTrait.h
+++ b/CommonTools/UtilAlgos/interface/CollectionInCollectionFilterTrait.h
@@ -1,0 +1,40 @@
+#ifndef UtilAlgos_CollectionInCollectionFilterTrait_h
+#define UtilAlgos_CollectionInCollectionFilterTrait_h
+/* \class CollectionInCollectionFilterTrait<C, S, N>
+ *
+ * \author Marco Musich
+ *
+ */
+#include "CommonTools/UtilAlgos/interface/AnySelector.h"
+#include "CommonTools/UtilAlgos/interface/MinNumberSelector.h"
+
+namespace helper {
+
+  template <typename C, typename N>
+  struct TotalSizeFilter {
+    template <typename S>
+    static bool filter(const C& source, const S&, const N& sizeSelect) {
+      size_t n = 0;
+      // this assumes the input collection is a DetSetVector
+      // loop on the list of DetSet-s
+      for (const auto& i : source) {
+        // loop on the content of the DetSet
+        for (const auto& j : i) {
+          n += j.size();
+        }
+      }
+      if (sizeSelect(n))
+        return true;
+      else
+        return false;
+    }
+  };
+
+  template <typename C, typename S, typename N>
+  struct CollectionInCollectionFilterTrait {
+    typedef TotalSizeFilter<C, N> type;
+  };
+
+}  // namespace helper
+
+#endif

--- a/CommonTools/UtilAlgos/interface/DetSetCounterSelector.h
+++ b/CommonTools/UtilAlgos/interface/DetSetCounterSelector.h
@@ -1,0 +1,27 @@
+#ifndef UtilAlgos_DetSetCounterSelector_h
+#define UtilAlgos_DetSetCounterSelector_h
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/Utils/interface/DetSetCounterSelector.h"
+
+namespace reco {
+  namespace modules {
+
+    template <>
+    struct ParameterAdapter<DetSetCounterSelector> {
+      static DetSetCounterSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return DetSetCounterSelector(cfg.getParameter<unsigned int>("minDetSetCounts"),
+                                     cfg.getParameter<unsigned int>("maxDetSetCounts"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+        desc.add<unsigned int>("minDetSetCounts", 0);
+        desc.add<unsigned int>("maxDetSetCounts", 0);
+      }
+    };
+
+  }  // namespace modules
+}  // namespace reco
+
+#endif

--- a/CommonTools/Utils/interface/DetSetCounterSelector.h
+++ b/CommonTools/Utils/interface/DetSetCounterSelector.h
@@ -1,0 +1,32 @@
+#ifndef RecoAlgos_DetSetCounterSelector_h
+#define RecoAlgos_DetSetCounterSelector_h
+/* \class DetSetCounterSelector
+ *
+ * \author Marco Musich
+ *
+ * $Id: DetSetCounterSelector.h,v 1.6 2023/09/22 16:00:00 musich Exp $
+ */
+
+#include "FWCore/Utilities/interface/TypeDemangler.h"
+
+struct DetSetCounterSelector {
+  DetSetCounterSelector(unsigned int minDetSetCounts, unsigned int maxDetSetCounts)
+      : minDetSetCounts_(minDetSetCounts), maxDetSetCounts_(maxDetSetCounts) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+#ifdef EDM_ML_DEBUG
+    std::string demangledName(edm::typeDemangle(typeid(T).name()));
+    edm::LogVerbatim("DetSetCounterSelector") << "counting counts in: " << demangledName << std::endl;
+#endif
+
+    // count the number of objects in the DetSet
+    unsigned int totalDetSetCounts = t.size();
+    return (totalDetSetCounts >= minDetSetCounts_ && totalDetSetCounts <= maxDetSetCounts_);
+  }
+
+private:
+  unsigned int minDetSetCounts_;
+  unsigned int maxDetSetCounts_;
+};
+
+#endif

--- a/DPGAnalysis/Skims/src/PixelCountFilter.cc
+++ b/DPGAnalysis/Skims/src/PixelCountFilter.cc
@@ -9,7 +9,8 @@
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
+#include "CommonTools/UtilAlgos/interface/DetSetCounterSelector.h"
 
-typedef ObjectCountFilter<SiPixelClusterCollectionNew>::type PixelCountFilter;
+typedef ObjectCountFilter<SiPixelClusterCollectionNew, DetSetCounterSelector>::type PixelCountFilter;
 
 DEFINE_FWK_MODULE(PixelCountFilter);

--- a/DPGAnalysis/Skims/src/PixelCountFilter.cc
+++ b/DPGAnalysis/Skims/src/PixelCountFilter.cc
@@ -8,9 +8,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
-#include "CommonTools/UtilAlgos/interface/DetSetCounterSelector.h"
+#include "CommonTools/UtilAlgos/interface/CollectionInCollectionFilter.h"
 
-typedef ObjectCountFilter<SiPixelClusterCollectionNew, DetSetCounterSelector>::type PixelCountFilter;
+typedef CollectionInCollectionFilter<SiPixelClusterCollectionNew>::type PixelCountFilter;
 
 DEFINE_FWK_MODULE(PixelCountFilter);

--- a/DPGAnalysis/Skims/src/PixelOccupancyFilter.cc
+++ b/DPGAnalysis/Skims/src/PixelOccupancyFilter.cc
@@ -1,0 +1,16 @@
+/* \class PixelOccupancyFilter
+ *
+ * Filters events if at least N pixel modules have M clusters, where A <=  M <= B 
+ *
+ * \author: Marco Musich
+ *
+ */
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
+#include "CommonTools/UtilAlgos/interface/DetSetCounterSelector.h"
+
+typedef ObjectCountFilter<SiPixelClusterCollectionNew, DetSetCounterSelector>::type PixelOccupancyFilter;
+
+DEFINE_FWK_MODULE(PixelOccupancyFilter);


### PR DESCRIPTION
#### PR description:

In [CMSHLT-2928](https://its.cern.ch/jira/browse/CMSHLT-2928), it became clear that the module `PixelCountFilter`  used in the first online 2023 HIon menu (a.k.a `v1.0`), in which there are 4 filters of this type, is "bugged" (it technically works, but it does not produce the intended results), see for more details this [post](https://its.cern.ch/jira/browse/CMSHLT-2928?focusedId=4944093&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4944093). 
The issue is that the `PixelCountFilter` plugin effectively cuts on the number of `DetSet`s (or, detector modules) with pixel clusters, while the intention was to apply a cut on the total number of pixel clusters. One solution (proposed by HIN PAG in [CMSHLT-2922](https://its.cern.ch/jira/browse/CMSHLT-2922)) is to use a different type of plugin ([HLTPixelActivityFilter](https://github.com/cms-sw/cmssw/blob/CMSSW_13_2_4/HLTrigger/special/plugins/HLTPixelActivityFilter.cc)), which is what is going to be implemented for the data-taking.
This PR proposes to fix the module `PixelCountFilter` by introducing the machinery in `CommonTools/Utils{Algos}` in order to count (and cut) on the total number of entries in a `DetSetVector`. This is implemented in c8b39085aad17dcb18d56d51ca29514253be245b.
In parallel a new filter `PixelOccupancyFilter` is introduced, which allows to filter events if at least N pixel modules have M clusters, where A <=  M <= B (N, A and B are configuration parameters). This is implemented in c8b39085aad17dcb18d56d51ca29514253be245b.

#### PR validation:

`cmssw` compiles. Private tests were carried out with this commit https://github.com/mmusich/cmssw/commit/9d74d21abec5d7d4535273345f84ade1fd02ba3b at to test that the newly introduced filters work as expected

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it might be backported to 13.2.X