### PR TITLE
DeepCore model 2.2.1 CMSSW_13_3_0_pre3 (fixed comments)

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -222,7 +222,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
       bool l2off = (splitClustDirSet.empty());
 
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      // DeepCore 2.1.3 Threshold checks:
+      // DeepCore 2.2.1 Threshold checks:
       */
       std::vector<GlobalVector> splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
       bool l2off = (splitClustDirSet.empty()); // no adc BPIX2 

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -95,10 +95,9 @@ public:
   static constexpr int Nover = 3;     //Max number of tracks recorded per pixel
   static constexpr int Npar = 5;      //Number of track parameter
 
-  // DeepCore 2.2.1 thresholds delta 
+  // DeepCore 2.2.1 thresholds delta
   double dth[3] = {0.0, 0.15, 0.3};
   double dthl[3] = {0.1, 0.05, 0};
-
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
@@ -215,24 +214,16 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
     if (jet.pt() > ptMin_) {
       std::set<unsigned long long int> ids;
       const reco::Vertex& jetVertex = vertices[0];
-     // DeepCore 1.0:
-      /*
-      std::vector<GlobalVector> splitClustDirSet =
-                  splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 1, inputPixelClusters_);
-      bool l2off = (splitClustDirSet.empty());
 
-      //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-      // DeepCore 2.2.1 Threshold checks:
-      */
-      std::vector<GlobalVector> splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
-      bool l2off = (splitClustDirSet.empty()); // no adc BPIX2 
+      std::vector<GlobalVector> splitClustDirSet =
+          splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
+      bool l2off = (splitClustDirSet.empty());  // no adc BPIX2
       splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 3, inputPixelClusters_);
-      bool l134off = (splitClustDirSet.empty()); // no adc BPIX1 or BPIX3 or BPIX4
+      bool l134off = (splitClustDirSet.empty());  // no adc BPIX1 or BPIX3 or BPIX4
       splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 4, inputPixelClusters_);
       l134off = (splitClustDirSet.empty() && l134off);
       splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 1, inputPixelClusters_);
       l134off = (splitClustDirSet.empty() && l134off);
-
 
       if (splitClustDirSet.empty()) {  //if layer 1 is broken find direcitons on layer 2
         splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
@@ -316,8 +307,8 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
         for (int i = 0; i < jetDimX; i++) {
           for (int j = 0; j < jetDimY; j++) {
             for (int o = 0; o < Nover; o++) {
-            //  if (seedParamNN.second[i][j][o] > (probThr_ - o * 0.1 - (l2off ? 0.35 : 0))) {  // DeepCore 1.0 Threshold
-                if (seedParamNN.second[i][j][o] > (probThr_ + dth[o] + (l2off ? 0.3 : 0) + (l134off ? dthl[o] : 0))) {  // DeepCore 2.2.1 Threshold
+              if (seedParamNN.second[i][j][o] >
+                  (probThr_ + dth[o] + (l2off ? 0.3 : 0) + (l134off ? dthl[o] : 0))) {  // DeepCore 2.2.1 Threshold
                 std::pair<bool, Basic3DVector<float>> interPair =
                     findIntersection(bigClustDir, (reco::Candidate::Point)jetVertex.position(), globDet);
                 auto localInter = globDet->specificSurface().toLocal((GlobalPoint)interPair.second);
@@ -340,8 +331,6 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
                 double track_theta = 2 * std::atan(std::exp(-track_eta));
                 double track_phi =
                     seedParamNN.first[i][j][o][3] * 0.01 + bigClustDir.phi();  //pay attention to this 0.01
-                // DeepCore 1.0 predicts 1/pt instead of pt, while DeepCore 2.2.1 directly predicts pt
-                // double pt = 1. / seedParamNN.first[i][j][o][4];
                 double pt = seedParamNN.first[i][j][o][4];
                 double normdirR = pt / sin(track_theta);
 
@@ -567,21 +556,17 @@ void DeepCoreSeedGenerator::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("pixelClusters", edm::InputTag("siPixelClustersPreSplitting"));
   desc.add<edm::InputTag>("cores", edm::InputTag("jetsForCoreTracking"));
-  desc.add<double>("ptMin", 100);
-  desc.add<double>("deltaR", 0.25);  // the current training makes use of 0.1
+  desc.add<double>("ptMin", 100);    // the current training uses 500 GeV
+  desc.add<double>("deltaR", 0.25);  // the current training uses 0.1
   desc.add<double>("chargeFractionMin", 18000.0);
   desc.add<double>("centralMIPCharge", 2);
   desc.add<std::string>("pixelCPE", "PixelCPEGeneric");
   desc.add<edm::FileInPath>(
       "weightFile",
-// DeepCore 1.0
-// edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2017.pb"));
-// DeepCore 2.2.1
-    edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2023.pb"));
+      edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2023.pb"));
   desc.add<std::vector<std::string>>("inputTensorName", {"input_1", "input_2", "input_3"});
   desc.add<std::vector<std::string>>("outputTensorName", {"output_node0", "output_node1"});
-//  desc.add<double>("probThr", 0.85); // DeepCore 1.0
-  desc.add<double>("probThr", 0.7); // DeepCore 2.2.1 Threshold
+  desc.add<double>("probThr", 0.7);  // DeepCore 2.2.1 baseline threshold
   descriptions.add("deepCoreSeedGenerator", desc);
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -95,6 +95,11 @@ public:
   static constexpr int Nover = 3;     //Max number of tracks recorded per pixel
   static constexpr int Npar = 5;      //Number of track parameter
 
+  // DeepCore 2.2.1 thresholds delta 
+  double dth[3] = {0.0, 0.15, 0.3};
+  double dthl[3] = {0.1, 0.05, 0};
+
+
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
@@ -210,10 +215,25 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
     if (jet.pt() > ptMin_) {
       std::set<unsigned long long int> ids;
       const reco::Vertex& jetVertex = vertices[0];
-
+     // DeepCore 1.0:
+      /*
       std::vector<GlobalVector> splitClustDirSet =
-          splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 1, inputPixelClusters_);
+                  splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 1, inputPixelClusters_);
       bool l2off = (splitClustDirSet.empty());
+
+      //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+      // DeepCore 2.1.3 Threshold checks:
+      */
+      std::vector<GlobalVector> splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
+      bool l2off = (splitClustDirSet.empty()); // no adc BPIX2 
+      splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 3, inputPixelClusters_);
+      bool l134off = (splitClustDirSet.empty()); // no adc BPIX1 or BPIX3 or BPIX4
+      splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 4, inputPixelClusters_);
+      l134off = (splitClustDirSet.empty() && l134off);
+      splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 1, inputPixelClusters_);
+      l134off = (splitClustDirSet.empty() && l134off);
+
+
       if (splitClustDirSet.empty()) {  //if layer 1 is broken find direcitons on layer 2
         splitClustDirSet = splittedClusterDirections(jet, tTopo, pixelCPE, jetVertex, 2, inputPixelClusters_);
       }
@@ -296,7 +316,8 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
         for (int i = 0; i < jetDimX; i++) {
           for (int j = 0; j < jetDimY; j++) {
             for (int o = 0; o < Nover; o++) {
-              if (seedParamNN.second[i][j][o] > (probThr_ - o * 0.1 - (l2off ? 0.35 : 0))) {
+            //  if (seedParamNN.second[i][j][o] > (probThr_ - o * 0.1 - (l2off ? 0.35 : 0))) {  // DeepCore 1.0 Threshold
+                if (seedParamNN.second[i][j][o] > (probThr_ + dth[o] + (l2off ? 0.3 : 0) + (l134off ? dthl[o] : 0))) {  // DeepCore 2.2.1 Threshold
                 std::pair<bool, Basic3DVector<float>> interPair =
                     findIntersection(bigClustDir, (reco::Candidate::Point)jetVertex.position(), globDet);
                 auto localInter = globDet->specificSurface().toLocal((GlobalPoint)interPair.second);
@@ -319,8 +340,9 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
                 double track_theta = 2 * std::atan(std::exp(-track_eta));
                 double track_phi =
                     seedParamNN.first[i][j][o][3] * 0.01 + bigClustDir.phi();  //pay attention to this 0.01
-
-                double pt = 1. / seedParamNN.first[i][j][o][4];
+                // DeepCore 1.0 predicts 1/pt instead of pt, while DeepCore 2.2.1 directly predicts pt
+                // double pt = 1. / seedParamNN.first[i][j][o][4];
+                double pt = seedParamNN.first[i][j][o][4];
                 double normdirR = pt / sin(track_theta);
 
                 const GlobalVector globSeedDir(
@@ -552,10 +574,14 @@ void DeepCoreSeedGenerator::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<std::string>("pixelCPE", "PixelCPEGeneric");
   desc.add<edm::FileInPath>(
       "weightFile",
-      edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2017.pb"));
+// DeepCore 1.0
+// edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2017.pb"));
+// DeepCore 2.2.1
+    edm::FileInPath("RecoTracker/TkSeedGenerator/data/DeepCore/DeepCoreSeedGenerator_TrainedModel_barrel_2023.pb"));
   desc.add<std::vector<std::string>>("inputTensorName", {"input_1", "input_2", "input_3"});
   desc.add<std::vector<std::string>>("outputTensorName", {"output_node0", "output_node1"});
-  desc.add<double>("probThr", 0.85);
+//  desc.add<double>("probThr", 0.85); // DeepCore 1.0
+  desc.add<double>("probThr", 0.7); // DeepCore 2.2.1 Threshold
   descriptions.add("deepCoreSeedGenerator", desc);
 }
 


### PR DESCRIPTION
#### PR description:

This PR updates the model used when ```--procModifiers seedingDeepCore``` is used in CMSSW workflows. The DeepCoreSeedGenerator.cc file is updated with the new model path as well as new prediction thresholds. This PR depends on [another PR](https://github.com/cms-data/RecoTracker-TkSeedGenerator/pull/3), which will add the DeepCore 2.2.1 model.

Relevant Links:

- [Track POG Update 09/11/2023](https://indico.cern.ch/event/1315747/contributions/5553878/attachments/2712109/4709601/DeepCore_TrackPOG_23_0911.pdf)
- [DeepCore 2 Website](https://hboucham.web.cern.ch) (includes testing workflows and documentation)
- [DeepCore 2 repository](https://github.com/bouchamaouihichem/DeepCore)

#### PR validation:

Workflows 11923.17/0 and 11834.17/0. More details provided in the slides of [Track POG Update 09/11/2023](https://indico.cern.ch/event/1315747/contributions/5553878/attachments/2712109/4709601/DeepCore_TrackPOG_23_0911.pdf) and all the plots are in [DeepCore 2 Website](https://hboucham.web.cern.ch).


