### PR TITLE
ECAL online DQM timing conditions tag override - 132x - do not merge

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -24,6 +24,21 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #process.load("CalibCalorimetry.EcalLaserCorrection.ecalLaserCorrectionService_cfi")
 
+# Temporary override the tag for ECAL timing calibrations and timing offsets so that the online DQM uses the conditions for CC timing.
+# Should be removed once the HLT GTs contain both, the reco and HLT conditions.
+process.GlobalTag.toGet = cms.VPSet(
+    cms.PSet(record = cms.string("EcalTimeCalibConstantsRcd"),
+        tag = cms.string("EcalTimeCalibConstants_v01_prompt"),
+        label = cms.untracked.string(''),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+    ),
+    cms.PSet(record = cms.string("EcalTimeOffsetConstantRcd"),
+        tag = cms.string("EcalTimeOffsetConstant_v01_express"),
+        label = cms.untracked.string(''),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+    )
+)
+
 process.load("FWCore.Modules.preScaler_cfi")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 #process.load("Geometry.CaloEventSetup.CaloGeometry_cfi")


### PR DESCRIPTION
#### PR description:

This PR is intended for the online DQM during the HI run 2023. Do not merge it in official 13_2_X.

The ECAL timing calibration constants and timing offset constants in the GT will be overridden by tags containing conditions for the CC timing. This is needed because the HLT GT used in the online DQM configuration contains the conditions for the ratio timing method running at the HLT.

#### PR validation:

Run the `ecal_dqm_sourceclient-live_cfg.py` configuration.