### PR TITLE
[HGCAL trigger] Technical developments on Stage 1 emulator, validation and floating point compression

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -60,7 +60,7 @@ public:
   virtual unsigned getStage1FpgaFromStage1Link(const unsigned) const = 0;
   virtual unsigned getStage2FpgaFromStage1Link(const unsigned) const = 0;
   virtual geom_set getStage1LinksFromStage1Fpga(const unsigned) const = 0;
-  virtual geom_set getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
+  virtual std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
   virtual unsigned getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getModulesFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getLpgbtsFromModule(const unsigned module_id) const = 0;

--- a/L1Trigger/L1THGCal/interface/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/HGCalVFECompressionImpl.h
@@ -10,8 +10,8 @@ class HGCalVFECompressionImpl {
 public:
   HGCalVFECompressionImpl(const edm::ParameterSet& conf);
 
-  void compress(const std::unordered_map<uint32_t, uint32_t>&, std::unordered_map<uint32_t, std::array<uint32_t, 2> >&);
-  void compressSingle(const uint32_t value, uint32_t& compressedCode, uint32_t& compressedValue) const;
+  void compress(const std::unordered_map<uint32_t, uint32_t>&, std::unordered_map<uint32_t, std::array<uint64_t, 2> >&);
+  void compressSingle(const uint64_t value, uint32_t& compressedCode, uint64_t& compressedValue) const;
 
 private:
   uint32_t exponentBits_;
@@ -19,7 +19,7 @@ private:
   uint32_t truncationBits_;
   bool rounding_;
   uint32_t saturationCode_;
-  uint32_t saturationValue_;
+  uint64_t saturationValue_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
@@ -20,6 +20,10 @@ public:
                const l1thgcfirmware::Stage1TruncationConfig& theConf,
                l1thgcfirmware::HGCalTriggerCellSACollection& tcs_out) const;
 
+  int phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const;
+  double rotatedphi(double x, double y, double z, int sector) const;
+  unsigned rozBin(double roverz, double rozmin, double rozmax, unsigned rozbins) const;
+
 private:
   static constexpr unsigned offset_roz_ = 1;
   static constexpr unsigned mask_roz_ = 0x3f;  // 6 bits, max 64 bins
@@ -34,8 +38,6 @@ private:
 
   uint32_t packBin(unsigned roverzbin, unsigned phibin) const;
   void unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const;
-  int phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const;
-  double rotatedphi(double x, double y, double z, int sector) const;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -42,7 +42,7 @@ public:
   unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
   unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
   geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
-  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned) const final;
   unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
   geom_set getModulesFromLpgbt(const unsigned) const final;
   geom_set getLpgbtsFromModule(const unsigned) const final;
@@ -863,8 +863,8 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1LinksFro
   return stage1link_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
-  geom_set lpgbt_ids;
+std::vector<unsigned> HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
+  std::vector<unsigned> lpgbt_ids;
   return lpgbt_ids;
 }
 

--- a/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
+++ b/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
@@ -7,18 +7,18 @@ HGCalVFECompressionImpl::HGCalVFECompressionImpl(const edm::ParameterSet& conf)
       mantissaBits_(conf.getParameter<uint32_t>("mantissaBits")),
       truncationBits_(conf.getParameter<uint32_t>("truncationBits")),
       rounding_(conf.getParameter<bool>("rounding")) {
-  if (((1 << exponentBits_) + mantissaBits_ - 1) >= 32) {
-    throw cms::Exception("CodespaceCannotFit") << "The code space cannot fit into the unsigned 32-bit space.\n";
+  if (((1 << exponentBits_) + mantissaBits_ - 1) >= 64) {
+    throw cms::Exception("CodespaceCannotFit") << "The code space cannot fit into the unsigned 64-bit space.\n";
   }
   saturationCode_ = (1 << (exponentBits_ + mantissaBits_)) - 1;
   saturationValue_ = (exponentBits_ == 0)
                          ? saturationCode_
-                         : ((1 << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
+                         : ((1ULL << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
 }
 
-void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
+void HGCalVFECompressionImpl::compressSingle(const uint64_t value,
                                              uint32_t& compressedCode,
-                                             uint32_t& compressedValue) const {
+                                             uint64_t& compressedValue) const {
   // check for saturation
   if (value > saturationValue_) {
     compressedCode = saturationCode_;
@@ -28,8 +28,8 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
 
   // count bit length
   uint32_t bitlen;
-  uint32_t shifted_value = value >> truncationBits_;
-  uint32_t valcopy = shifted_value;
+  uint64_t shifted_value = value >> truncationBits_;
+  uint64_t valcopy = shifted_value;
   for (bitlen = 0; valcopy != 0; valcopy >>= 1, bitlen++) {
   }
   if (bitlen <= mantissaBits_) {
@@ -40,7 +40,7 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
 
   // build exponent and mantissa
   const uint32_t exponent = bitlen - mantissaBits_;
-  const uint32_t mantissa = (shifted_value >> (exponent - 1)) & ~(1 << mantissaBits_);
+  const uint64_t mantissa = (shifted_value >> (exponent - 1)) & ~(1ULL << mantissaBits_);
 
   // assemble floating-point
   const uint32_t floatval = (exponent << mantissaBits_) | mantissa;
@@ -48,34 +48,34 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
   // we will never want to round up maximum code here
   if (!rounding_ || floatval == saturationCode_) {
     compressedCode = floatval;
-    compressedValue = ((1 << mantissaBits_) | mantissa) << (exponent - 1);
+    compressedValue = ((1ULL << mantissaBits_) | mantissa) << (exponent - 1);
   } else {
-    const bool roundup = ((shifted_value >> (exponent - 2)) & 1) == 1;
+    const bool roundup = ((shifted_value >> (exponent - 2)) & 1ULL) == 1ULL;
     if (!roundup) {
       compressedCode = floatval;
-      compressedValue = ((1 << mantissaBits_) | mantissa) << (exponent - 1);
+      compressedValue = ((1ULL << mantissaBits_) | mantissa) << (exponent - 1);
     } else {
       compressedCode = floatval + 1;
-      uint32_t rmantissa = mantissa + 1;
+      uint64_t rmantissa = mantissa + 1;
       uint32_t rexponent = exponent;
-      if (rmantissa >= (1U << mantissaBits_)) {
+      if (rmantissa >= (1ULL << mantissaBits_)) {
         rexponent++;
-        rmantissa &= ~(1 << mantissaBits_);
+        rmantissa &= ~(1ULL << mantissaBits_);
       }
-      compressedValue = ((1 << mantissaBits_) | rmantissa) << (rexponent - 1);
+      compressedValue = ((1ULL << mantissaBits_) | rmantissa) << (rexponent - 1);
     }
   }
   compressedValue <<= truncationBits_;
 }
 
 void HGCalVFECompressionImpl::compress(const std::unordered_map<uint32_t, uint32_t>& payload,
-                                       std::unordered_map<uint32_t, std::array<uint32_t, 2> >& compressed_payload) {
+                                       std::unordered_map<uint32_t, std::array<uint64_t, 2> >& compressed_payload) {
   for (const auto& item : payload) {
-    const uint32_t value = item.second;
+    const uint64_t value = static_cast<uint64_t>(item.second);
     uint32_t code(0);
-    uint32_t compressed_value(0);
+    uint64_t compressed_value(0);
     compressSingle(value, code, compressed_value);
-    std::array<uint32_t, 2> compressed_item = {{code, compressed_value}};
+    std::array<uint64_t, 2> compressed_item = {{static_cast<uint64_t>(code), compressed_value}};
     compressed_payload.emplace(item.first, compressed_item);
   }
 }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -23,10 +23,13 @@ void HGCalConcentratorCoarsenerImpl::assignCoarseTriggerCellEnergy(l1t::HGCalTri
                                                                    const CoarseTC& ctc) const {
   //Compress and recalibrate CTC energy
   uint32_t code(0);
-  uint32_t compressed_value(0);
+  uint64_t compressed_value(0);
   vfeCompression_.compressSingle(ctc.sumHwPt, code, compressed_value);
 
-  tc.setHwPt(compressed_value);
+  if (compressed_value > std::numeric_limits<int>::max())
+    edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
+
+  tc.setHwPt(static_cast<int>(compressed_value));
   calibration_.calibrateInGeV(tc);
 }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -31,9 +31,13 @@ HGCalConcentratorSuperTriggerCellImpl::HGCalConcentratorSuperTriggerCellImpl(con
 
 uint32_t HGCalConcentratorSuperTriggerCellImpl::getCompressedSTCEnergy(const SuperTriggerCell& stc) const {
   uint32_t code(0);
-  uint32_t compressed_value(0);
+  uint64_t compressed_value(0);
   vfeCompression_.compressSingle(stc.getSumHwPt(), code, compressed_value);
-  return compressed_value;
+
+  if (compressed_value > std::numeric_limits<uint32_t>::max())
+    edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
+
+  return static_cast<uint32_t>(compressed_value);
 }
 
 void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -2,6 +2,6 @@
 <use name="L1Trigger/L1THGCal"/>
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
-<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc">
+<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc,HGCalBackendStage1ParameterExtractor.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -261,16 +261,16 @@ uint32_t HGCalBackendStage1ParameterExtractor::getTCaddress(int& tc_ueta, int& t
   // transform HGCalHSc TC coordinates to define a TC address in [0,47]
   if (isScintillator) {  // HGCalHSc
     tc_vphi = (tc_vphi - 1) % 4;
-    if (tc_ueta <= 3) {
-      tc_ueta = tc_ueta;
-    } else if (tc_ueta <= 9) {
-      tc_ueta = tc_ueta - 4;
-    } else if (tc_ueta <= 13) {
-      tc_ueta = tc_ueta - 10;
-    } else if (tc_ueta <= 17) {
-      tc_ueta = tc_ueta - 14;
-    } else {
-      tc_ueta = tc_ueta - 18;
+    if (tc_ueta > 3) {
+      if (tc_ueta <= 9) {
+        tc_ueta = tc_ueta - 4;
+      } else if (tc_ueta <= 13) {
+        tc_ueta = tc_ueta - 10;
+      } else if (tc_ueta <= 17) {
+        tc_ueta = tc_ueta - 14;
+      } else {
+        tc_ueta = tc_ueta - 18;
+      }
     }
   }
 

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -1,0 +1,281 @@
+#include <iostream>  // std::cout
+#include <fstream>   // std::ofstream
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+#include "L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h"
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::ordered_json;  // using ordered_json for readability
+
+class HGCalBackendStage1ParameterExtractor : public edm::stream::EDAnalyzer<> {
+public:
+  explicit HGCalBackendStage1ParameterExtractor(const edm::ParameterSet&);
+  ~HGCalBackendStage1ParameterExtractor();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
+  void fillTriggerGeometry(json& json_file);
+  uint32_t getTCaddress(int& tc_ueta, int& tc_vphi, bool isScint);
+  uint32_t getRoZBin(double roverz);
+  uint32_t getPhiBin(uint32_t roverzbin, double phi);
+  double rotatedphi(double phi, int sector);
+
+  HGCalTriggerTools triggerTools_;
+
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+
+  HGCalStage1TruncationImplSA theAlgo_;
+
+  // Metadata
+  std::string detector_version_;
+  int the_fpga_;
+
+  // geometry data
+  std::vector<uint32_t> disconnected_layers_;
+  std::string json_mapping_file_;
+  uint32_t scintillator_trigger_cell_size_;
+  std::string trigger_geom_;
+
+  // truncation parameters
+  double roz_min_;
+  double roz_max_;
+  uint32_t roz_bins_;
+  std::vector<uint32_t> max_tcs_per_bins_;
+  std::vector<double> phi_edges_;
+
+  // TC map parameters:
+  std::map<std::pair<uint32_t, uint32_t>, uint32_t> tc_coord_uv_;
+
+  // output json name:
+  std::string outJSONname_;
+
+  typedef std::unordered_map<uint32_t, std::unordered_set<uint32_t>> trigger_map_set;
+};
+
+HGCalBackendStage1ParameterExtractor::HGCalBackendStage1ParameterExtractor(const edm::ParameterSet& conf)
+    : triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>())
+
+{
+  // get name of output JSON config file
+  outJSONname_ = conf.getParameter<std::string>("outJSONname");
+
+  // get ID of tested FPGA
+  the_fpga_ = conf.getParameter<int>("testedFpga");
+
+  // get meta data
+  const edm::ParameterSet& metaData = conf.getParameterSet("MetaData");
+  detector_version_ = metaData.getParameter<std::string>("geometryVersion");
+
+  // get geometry configuration
+  const edm::ParameterSet& triggerGeom = conf.getParameterSet("TriggerGeometryParam");
+  disconnected_layers_ = triggerGeom.getParameter<std::vector<uint32_t>>("DisconnectedLayers");
+  json_mapping_file_ = triggerGeom.getParameter<edm::FileInPath>("JsonMappingFile").relativePath();
+  scintillator_trigger_cell_size_ = triggerGeom.getParameter<uint32_t>("ScintillatorTriggerCellSize");
+  trigger_geom_ = triggerGeom.getParameter<std::string>("TriggerGeometryName");
+
+  // get TCid -> uv coordinate correspondance
+  const edm::ParameterSet& TCcoord_uv = conf.getParameterSet("TCcoord_UV");
+  std::vector<uint32_t> tc_coord_u = TCcoord_uv.getParameter<std::vector<uint32_t>>("TCu");
+  std::vector<uint32_t> tc_coord_v = TCcoord_uv.getParameter<std::vector<uint32_t>>("TCv");
+  if (tc_coord_u.size() != tc_coord_v.size())
+    throw cms::Exception("BadParameter") << "TCu and TCv vectors should be of same size";
+  for (size_t i = 0; i < tc_coord_u.size(); ++i)
+    tc_coord_uv_.emplace(std::make_pair(tc_coord_u.at(i), tc_coord_v.at(i)), i);
+
+  // Get truncation parameters
+  const edm::ParameterSet& truncationParamConfig = conf.getParameterSet("BackendStage1Params");
+  roz_min_ = truncationParamConfig.getParameter<double>("rozMin");
+  roz_max_ = truncationParamConfig.getParameter<double>("rozMax");
+  roz_bins_ = truncationParamConfig.getParameter<uint32_t>("rozBins");
+
+  max_tcs_per_bins_ = truncationParamConfig.getParameter<std::vector<uint32_t>>("maxTcsPerBin");
+  phi_edges_ = truncationParamConfig.getParameter<std::vector<double>>("phiSectorEdges");
+}
+
+HGCalBackendStage1ParameterExtractor::~HGCalBackendStage1ParameterExtractor() {}
+
+void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
+  triggerGeometry_ = es.getHandle(triggerGeomToken_);
+
+  json outJSON;
+
+  // fill MetaData
+  outJSON["MetaData"]["GeometryVersion"] = detector_version_;
+  outJSON["MetaData"]["fpgaId"] = the_fpga_;
+
+  // fill geometry configuration
+  outJSON["TriggerGeometryConfig"]["TriggerGeometryName"] = trigger_geom_;
+  outJSON["TriggerGeometryConfig"]["DisconnectedLayers"] = disconnected_layers_;
+  outJSON["TriggerGeometryConfig"]["JsonMappingFile"] = json_mapping_file_;
+  outJSON["TriggerGeometryConfig"]["ScintillatorTriggerCellSize"] = scintillator_trigger_cell_size_;
+
+  // fill truncation parameters
+  outJSON["TruncationConfig"]["rozMin"] = roz_min_;
+  outJSON["TruncationConfig"]["rozMax"] = roz_max_;
+  outJSON["TruncationConfig"]["rozBins"] = roz_bins_;
+  outJSON["TruncationConfig"]["maxTcsPerBin"] = max_tcs_per_bins_;
+  outJSON["TruncationConfig"]["phiSectorEdges"] = phi_edges_;
+
+  // fill trigger geometry
+  fillTriggerGeometry(outJSON);
+
+  // write out JSON file
+  std::ofstream outputfile(outJSONname_.c_str());
+  outputfile << std::setw(4) << outJSON << std::endl;
+}
+
+void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file) {
+  std::unordered_set<uint32_t> trigger_cells;
+
+  // retrieve valid trigger cells
+  for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (triggerGeometry_->eeTopology().valid(id))
+      trigger_cells.insert(triggerGeometry_->getTriggerCellFromCell(id));
+  }
+  for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (triggerGeometry_->hsiTopology().valid(id))
+      trigger_cells.insert(triggerGeometry_->getTriggerCellFromCell(id));
+  }
+  for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
+    trigger_cells.insert(triggerGeometry_->getTriggerCellFromCell(id));
+  }
+
+  // loop over trigger cells
+  edm::LogPrint("JSONFilling") << "Filling JSON map";
+
+  //filling tmp json to get TCs per module
+  json tmp_json;
+
+  for (const auto& triggercell : trigger_cells) {
+    DetId id(triggercell);
+    // get module ID and check if relevant module (sector0, zside=1, and connected to FPGA)
+    uint32_t moduleId = triggerGeometry_->getModuleFromTriggerCell(id);
+    if (moduleId == 0 || triggerGeometry_->disconnectedModule(moduleId))
+      continue;
+    HGCalTriggerModuleDetId tc_module(moduleId);
+    if (!(tc_module.isHGCalModuleDetId()) || (tc_module.zside() < 0) || (tc_module.sector() != 0))
+      continue;
+
+    // only retrieve mapping for the tested fpga
+    uint32_t fpgaId = triggerGeometry_->getStage1FpgaFromModule(moduleId);
+    HGCalTriggerBackendDetId tc_fpga(fpgaId);
+    if (!(tc_fpga.isStage1FPGA()) || (tc_fpga.sector() != 0) || (tc_fpga.zside() < 0))
+      continue;
+    if (tc_fpga.label() != the_fpga_)
+      continue;
+
+    // retrieve information to be saved
+    int triggerCellSubdet = 0;
+    int triggerCellLayer = 0;
+    int triggerCellUEta = 0;
+    int triggerCellVPhi = 0;
+
+    bool isScintillatorCell = triggerTools_.isScintillator(id);
+    if (isScintillatorCell) {
+      HGCScintillatorDetId id_sc(triggercell);
+      triggerCellSubdet = id_sc.subdet();
+      triggerCellLayer = id_sc.layer();
+      triggerCellUEta = id_sc.ietaAbs();
+      triggerCellVPhi = id_sc.iphi();
+    } else {
+      HGCalTriggerDetId id_si_trig(triggercell);
+      triggerCellSubdet = id_si_trig.subdet();
+      triggerCellLayer = id_si_trig.layer();
+      triggerCellUEta = id_si_trig.triggerCellU();
+      triggerCellVPhi = id_si_trig.triggerCellV();
+    }
+    GlobalPoint position = triggerGeometry_->getTriggerCellPosition(triggercell);
+    float triggerCellX = position.x();
+    float triggerCellY = position.y();
+    float triggerCellZ = position.z();
+    float triggerCellEta = position.eta();
+    float triggerCellPhi = position.phi();
+    float triggerCellRoverZ = sqrt(triggerCellX * triggerCellX + triggerCellY * triggerCellY) / triggerCellZ;
+
+    uint32_t triggerCellRoZBin = theAlgo_.rozBin(triggerCellRoverZ, roz_min_, roz_max_, roz_bins_);
+    double triggerCellRotatedPhi = theAlgo_.rotatedphi(triggerCellX, triggerCellY, triggerCellZ, tc_fpga.sector());
+    uint32_t triggerCellPhiBin = theAlgo_.phiBin(triggerCellRoZBin, triggerCellRotatedPhi, phi_edges_);
+
+    uint32_t tcAddress = getTCaddress(triggerCellUEta, triggerCellVPhi, isScintillatorCell);
+
+    // save TC info into JSON
+    json theTC;
+    theTC["tcid"] = tcAddress;
+    theTC["subdet"] = triggerCellSubdet;
+    theTC["layer"] = triggerCellLayer;
+    theTC["ueta"] = triggerCellUEta;
+    theTC["vphi"] = triggerCellVPhi;
+    theTC["x"] = triggerCellX;
+    theTC["y"] = triggerCellY;
+    theTC["z"] = triggerCellZ;
+    theTC["roz"] = triggerCellRoverZ;
+    theTC["eta"] = triggerCellEta;
+    theTC["phi"] = triggerCellPhi;
+    theTC["roz_bin"] = triggerCellRoZBin;
+    theTC["phi_bin"] = triggerCellPhiBin;
+
+    std::string strModId = std::to_string(moduleId);
+    tmp_json[strModId].push_back(theTC);
+  }
+
+  // fill output JSON
+  for (auto& module_json : tmp_json.items()) {
+    json j1;
+    j1["hash"] = module_json.key();
+    j1["tcs"] = module_json.value();
+    json_file["TriggerCellMap"]["Module"].push_back(j1);
+  }
+}
+
+uint32_t HGCalBackendStage1ParameterExtractor::getTCaddress(int& tc_ueta, int& tc_vphi, bool isScintillator) {
+  // transform HGCalHSc TC coordinates to define a TC address in [0,47]
+  if (isScintillator) {  // HGCalHSc
+    tc_vphi = (tc_vphi - 1) % 4;
+    if (tc_ueta <= 3) {
+      tc_ueta = tc_ueta;
+    } else if (tc_ueta <= 9) {
+      tc_ueta = tc_ueta - 4;
+    } else if (tc_ueta <= 13) {
+      tc_ueta = tc_ueta - 10;
+    } else if (tc_ueta <= 17) {
+      tc_ueta = tc_ueta - 14;
+    } else {
+      tc_ueta = tc_ueta - 18;
+    }
+  }
+
+  // attribute ID to TC according to subdetector
+  if (isScintillator) {  //HGCalHSc(10)
+    return (tc_ueta << 2) + tc_vphi;
+  } else {  //HGCalHSiTrigger(2) or HGCalEE(1)
+    return tc_coord_uv_.find(std::make_pair(tc_ueta, tc_vphi))->second;
+  }
+}
+
+void HGCalBackendStage1ParameterExtractor::analyze(const edm::Event& e, const edm::EventSetup& es) {}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HGCalBackendStage1ParameterExtractor);

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -713,7 +713,7 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
       HGCalTriggerBackendDetId stage1(stage1_modules.first);
       HGCalTriggerGeometryBase::geom_set modules_geom;
       // Check consistency of modules going to Stage-1 FPGA
-      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
+      std::vector<unsigned> lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
       for (const auto& lpgbt : lpgbts) {
         HGCalTriggerGeometryBase::geom_set modules = triggerGeometry_->getModulesFromLpgbt(lpgbt);
         modules_geom.insert(modules.begin(), modules.end());

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -51,12 +51,25 @@ process = custom_geometry_V11_Imp3(process)
 # Fetch stage 1 truncation parameters
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
 
+
+# setup options
+import FWCore.ParameterSet.VarParsing as VarParsing
+opt = VarParsing.VarParsing('analysis')
+opt.register('outputJSON','geometryConfig_backendStage1.json',
+             VarParsing.VarParsing.multiplicity.singleton,
+             VarParsing.VarParsing.varType.string,
+             'output JSON configuration'
+)
+opt.register('fpgaId',0,
+             VarParsing.VarParsing.multiplicity.singleton,
+             VarParsing.VarParsing.varType.int,
+             'FPGA ID'
+)
+opt.parseArguments()
+
 # ordered u/v coordinated of TCs in a module, for consistent TC index definition
 ordered_tcu = [4, 5, 4, 3, 6, 7, 6, 5, 4, 5, 4, 3, 2, 3, 2, 1, 7, 6, 6, 7, 5, 4, 4, 5, 5, 4, 4, 5, 7, 6, 6, 7, 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3]
 ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7, 6, 6, 5, 5, 4, 4, 5, 5, 4, 4, 3, 2, 3, 4, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6]
-
-# ID of tested FPGA
-fpga_id = 1
 
 # geometry version
 from re import match
@@ -70,8 +83,8 @@ geometry_version = geometry_version[0].split('/')[4]
 
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",
-    outJSONname = cms.string("geometryConfig_backendStage1.json"),
-    testedFpga = cms.int32(fpga_id),
+    outJSONname = cms.string(opt.outputJSON),
+    testedFpga = cms.int32(opt.fpgaId),
     BackendStage1Params = stage1truncation_proc.truncation_parameters,
     TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
     TCcoord_UV = cms.PSet(

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
-process = cms.Process('SIM',Phase2C9)
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process('SIM',Phase2C17I13M9)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -9,8 +9,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
@@ -49,7 +49,7 @@ from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
 process = custom_geometry_V11_Imp3(process)
 
 # Fetch stage 1 truncation parameters
-from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
+from L1Trigger.L1THGCal.l1tHGCalBackEndLayer1Producer_cfi import stage1truncation_proc
 
 
 # setup options
@@ -86,7 +86,7 @@ process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     outJSONname = cms.string(opt.outputJSON),
     testedFpga = cms.int32(opt.fpgaId),
     BackendStage1Params = stage1truncation_proc.truncation_parameters,
-    TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
+    TriggerGeometryParam = process.l1tHGCalTriggerGeometryESProducer.TriggerGeometry,
     TCcoord_UV = cms.PSet(
         TCu = cms.vuint32(ordered_tcu),
         TCv = cms.vuint32(ordered_tcv)

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -1,0 +1,95 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('SIM',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
+
+# Fetch stage 1 truncation parameters
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
+
+# ordered u/v coordinated of TCs in a module, for consistent TC index definition
+ordered_tcu = [4, 5, 4, 3, 6, 7, 6, 5, 4, 5, 4, 3, 2, 3, 2, 1, 7, 6, 6, 7, 5, 4, 4, 5, 5, 4, 4, 5, 7, 6, 6, 7, 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3]
+ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7, 6, 6, 5, 5, 4, 4, 5, 5, 4, 4, 3, 2, 3, 4, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6]
+
+# ID of tested FPGA
+fpga_id = 1
+
+# geometry version
+from re import match
+geomXMLcontent = process.XMLIdealGeometryESSource.geomXMLFiles.value()
+hgcal_xml = 'Geometry/HGCalCommonData/data/hgcal/v.*/hgcal.xml'
+geometry_version = list(filter(lambda v: match(hgcal_xml,v), geomXMLcontent))
+if len(geometry_version) != 1:
+    raise ValueError('Can\'t find geometry version - expected one xml file, but got {}'.format(len(geometry_version)))
+
+geometry_version = geometry_version[0].split('/')[4]
+
+process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
+    "HGCalBackendStage1ParameterExtractor",
+    outJSONname = cms.string("geometryConfig_backendStage1.json"),
+    testedFpga = cms.int32(fpga_id),
+    BackendStage1Params = stage1truncation_proc.truncation_parameters,
+    TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
+    TCcoord_UV = cms.PSet(
+        TCu = cms.vuint32(ordered_tcu),
+        TCv = cms.vuint32(ordered_tcv)
+    ),
+    MetaData = cms.PSet(
+        geometryVersion = cms.string(geometry_version)
+    ),
+)
+
+# Path and EndPath definitions
+process.test_step = cms.Path(process.hgcalbackendstage1parameterextractor)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.test_step,process.endjob_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)

--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -7,8 +7,10 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -97,6 +99,7 @@ public:
   ~HGCalTriggerValidator() override = default;
 
 private:
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &, Histograms &) const override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &, Histograms &) const override;
   void dqmAnalyze(edm::Event const &, edm::EventSetup const &, Histograms const &) const override;
 
@@ -106,7 +109,7 @@ private:
   const edm::EDGetToken clusters_token_;
   const edm::EDGetToken multiclusters_token_;
   const edm::EDGetToken towers_token_;
-  const edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> trigGeom_token_;
+  const edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
 
   std::unique_ptr<HGCalTriggerClusterIdentificationBase> id_;
 
@@ -120,10 +123,19 @@ HGCalTriggerValidator::HGCalTriggerValidator(const edm::ParameterSet &iConfig)
       multiclusters_token_{
           consumes<l1t::HGCalMulticlusterBxCollection>(iConfig.getParameter<edm::InputTag>("Multiclusters"))},
       towers_token_{consumes<l1t::HGCalTowerBxCollection>(iConfig.getParameter<edm::InputTag>("Towers"))},
-      trigGeom_token_(esConsumes()),
+      triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()),
       id_{HGCalTriggerClusterIdentificationFactory::get()->create("HGCalTriggerClusterIdentificationBDT")} {
   id_->initialize(iConfig.getParameter<edm::ParameterSet>("EGIdentification"));
+
   triggerTools_ = std::make_shared<HGCalTriggerTools>();
+}
+
+
+void HGCalTriggerValidator::dqmBeginRun(edm::Run const &iRun,
+                                        edm::EventSetup const &iSetup,
+                                        Histograms &histograms) const {
+  auto const triggerGeometry = iSetup.getHandle(triggerGeomToken_);
+  triggerTools_->setGeometry(triggerGeometry.product());
 }
 
 void HGCalTriggerValidator::bookHistograms(DQMStore::IBooker &iBooker,
@@ -201,8 +213,6 @@ void HGCalTriggerValidator::dqmAnalyze(edm::Event const &iEvent,
   int cl_n = 0;
   int cl3d_n = 0;
   int tower_n = 0;
-
-  triggerTools_->eventSetup(iSetup, trigGeom_token_);
 
   // retrieve trigger cells
   edm::Handle<l1t::HGCalTriggerCellBxCollection> trigger_cells_h;

--- a/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalTriggerValidator.cc
@@ -130,7 +130,6 @@ HGCalTriggerValidator::HGCalTriggerValidator(const edm::ParameterSet &iConfig)
   triggerTools_ = std::make_shared<HGCalTriggerTools>();
 }
 
-
 void HGCalTriggerValidator::dqmBeginRun(edm::Run const &iRun,
                                         edm::EventSetup const &iSetup,
                                         Histograms &histograms) const {

--- a/Validation/HGCalValidation/python/hgcalValidationTPG_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalValidationTPG_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_drnn_cone
+from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_histomax
 
 hgcalTrigPrimValidation = DQMEDAnalyzer(
         "HGCalTriggerValidator",
@@ -8,6 +8,6 @@ hgcalTrigPrimValidation = DQMEDAnalyzer(
         Clusters = cms.InputTag('l1tHGCalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),
         Multiclusters = cms.InputTag('l1tHGCalBackEndLayer2Producer:HGCalBackendLayer2Processor3DClustering'),
         Towers = cms.InputTag('l1tHGCalTowerProducer:HGCalTowerProcessor'),
-        EGIdentification = egamma_identification_drnn_cone.clone()
+        EGIdentification = egamma_identification_histomax.clone()
        )
 

--- a/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
+++ b/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
@@ -6,9 +6,9 @@ import FWCore.ParameterSet.Config as cms
 
 # -*- coding: utf-8 -*-
 
-from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process('USER',Phase2C9)
+process = cms.Process('USER',Phase2C17I13M9)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -16,8 +16,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
@@ -67,7 +67,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DoublePhoton_FlatPt-1To100/FEVT/PU200_111X_mcRun4_realistic_T15_v1_ext1-v2/1210000/F2E5E947-0CB4-D245-A943-17F2F05709D3.root'),
+       fileNames = cms.untracked.vstring('/store/mc/Phase2Fall22DRMiniAOD/DoublePhoton_FlatPt-1To100-gun/GEN-SIM-DIGI-RAW-MINIAOD/PU200_125X_mcRun4_realistic_v2-v1/30000/0075a153-cb64-4ed9-9157-a1b6db9fd431.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -87,11 +87,11 @@ process.source = cms.Source("PoolSource",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
-process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
+process.hgcl1tpg_step = cms.Path(process.L1THGCalTriggerPrimitives)
 
 # load validation
 process.load('Validation.HGCalValidation.hgcalValidationTPG_cff')

--- a/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
+++ b/Validation/HGCalValidation/test/python/testValidationHGCalTrigPrim_RelVal_cfg.py
@@ -16,9 +16,8 @@ process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
-#process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
-#process.load('Configuration.Geometry.GeometryExtended2023D17_cff')
 process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
@@ -68,9 +67,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # Input source
 process.source = cms.Source("PoolSource",
-       #fileNames = cms.untracked.vstring('file:/afs/cern.ch/work/j/jsauvan/public/HGCAL/TestingRelVal/CMSSW_9_3_7/RelValSingleGammaPt35/GEN-SIM-DIGI-RAW/93X_upgrade2023_realistic_v5_2023D17noPU-v2/2661406C-972C-E811-9754-0025905A60DE.root'),
-#       fileNames = cms.untracked.vstring('file:/data_cms_upgrade/sauvan/HGCAL/DIGI/Phase2HLTTDRWinter20DIGI/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3-v2/2D0339A5-751F-3543-BA5B-456EA6E5E294.root'),
-       fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch///eos/cms//store/mc/Phase2HLTTDRWinter20DIGI/QCD_Pt-15to7000_TuneCP5_Flat_14TeV-pythia8/GEN-SIM-DIGI-RAW/FlatPU0To200_castor_110X_mcRun4_realistic_v3_ext1-v1/260000/003F2BA9-0D02-5A43-A53F-4161E513BFA6.root'),
+       fileNames = cms.untracked.vstring('/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DoublePhoton_FlatPt-1To100/FEVT/PU200_111X_mcRun4_realistic_T15_v1_ext1-v2/1210000/F2E5E947-0CB4-D245-A943-17F2F05709D3.root'),
        inputCommands=cms.untracked.vstring(
            'keep *',
            'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
@@ -90,14 +87,11 @@ process.source = cms.Source("PoolSource",
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
 
 # load HGCAL TPG simulation
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
-# Change to V7 trigger geometry for older samples
-#  from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_ZoltanSplit_V7
-#  process = custom_geometry_ZoltanSplit_V7(process)
 
 # load validation
 process.load('Validation.HGCalValidation.hgcalValidationTPG_cff')


### PR DESCRIPTION
#### PR description
Technical developments:
- Stage 1 emulator developments for and following comparison tests with firmware
    - To be noted that the Stage 1 emulator is not run in standard sequences
- Fixes and updates in the validation code
- Floating point compression code now working in 64bits  

Associated internal PRs and reviews:
- hgc-tpg#11
- hgc-tpg#6
- hgc-tpg#17
- hgc-tpg#19
- hgc-tpg#38
- hgc-tpg#40
- hgc-tpg#41
- hgc-tpg#42

#### PR validation
Tested D86, D92, D9 workflows
```
runTheMatrix.py -w upgrade -l 20034.0 --maxSteps=2 & # D86
runTheMatrix.py -w upgrade -l 22434.0 --maxSteps=2 & # D92
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 & # D94
```
