### PR TITLE
Fix bug in defining bin edges of TH2F plots in ECAL DQM

### DIFF
--- a/DQM/EcalCommon/src/MESetEcal.cc
+++ b/DQM/EcalCommon/src/MESetEcal.cc
@@ -173,7 +173,7 @@ namespace ecaldqm {
           } else {
             binning::AxisSpecs *specs[] = {&xaxis, &yaxis};
             for (int iSpec(0); iSpec < 2; iSpec++) {
-              if (!specs[iSpec]->edges.empty()) {
+              if (specs[iSpec]->edges.empty()) {
                 specs[iSpec]->edges = std::vector<float>(specs[iSpec]->nbins + 1);
                 int nbins(specs[iSpec]->nbins);
                 double low(specs[iSpec]->low), high(specs[iSpec]->high);


### PR DESCRIPTION
#### PR description:

This PR fixes a bug that crept in PR https://github.com/cms-sw/cmssw/pull/42188 in here [1] which was giving nonphysical values to the bin edges of certain TH2F plots [2] [3] in the Ecal DQM, due to which they were not being filled correctly ever since central DQM switched to CMSSW_13_2_2 from CMSSW_13_0_10. 

[1] https://github.com/cms-sw/cmssw/pull/42188/files#diff-93b875a059a27e639d23a1e774ccb058f70fabea027504f8dbb22157c6080632L175-R176
[2] https://tinyurl.com/4nrwk9m7
[3] https://tinyurl.com/jkrvbw37

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots are correct on a test DQM GUI.
Also tested with Ecal runTheMatrix workflow 136.874.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the master PR. A backport to 13_2_X, currently used in production is here: https://github.com/cms-sw/cmssw/pull/42858
