### PR TITLE
Add unit test for SiStripApproximateClusterCollection format

### DIFF
--- a/DataFormats/SiStripCluster/README.md
+++ b/DataFormats/SiStripCluster/README.md
@@ -1,0 +1,10 @@
+#  DataFormats/SiStripCluster
+
+## `SiStripApproximateClusterCollection`
+
+The class `SiStripApproximateClusterCollection` is part of the RAW data, and any changes must be backwards compatible. In order to ensure it can be read by all future CMSSW releases, there is a `TestSiStripApproximateClusterCollection` unit test, which makes use of the `TestReadSiStripApproximateClusterCollection` analyzer and the `TestWriteSiStripApproximateClusterCollection` producer. The unit test checks that the object can be read properly from
+
+* a file written by the same release
+* files written by (some) earlier releases
+
+If the persistent format of class `SiStripApproximateClusterCollection` gets changed in the future, please adjust the `TestReadSiStripApproximateClusterCollection` and `TestWriteSiStripApproximateClusterCollection` modules accordingly. It is important that every member container has some content in this test. Please also add a new file to the [https://github.com/cms-data/DataFormats-SiStripCluster/](https://github.com/cms-data/DataFormats-SiStripCluster/) repository, and update the `TestSiStripApproximateClusterCollection` unit test to read the newly created file. The file name should contain the release or pre-release with which it was written.

--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -8,14 +8,18 @@ class SiStripApproximateCluster {
 public:
   SiStripApproximateCluster() {}
 
-  explicit SiStripApproximateCluster(
-      cms_uint16_t barycenter, cms_uint8_t width, cms_uint8_t avgCharge, bool filter, bool isSaturated) {
-    barycenter_ = barycenter;
-    width_ = width;
-    avgCharge_ = avgCharge;
-    filter_ = filter;
-    isSaturated_ = isSaturated;
-  }
+  explicit SiStripApproximateCluster(cms_uint16_t barycenter,
+                                     cms_uint8_t width,
+                                     cms_uint8_t avgCharge,
+                                     bool filter,
+                                     bool isSaturated,
+                                     bool peakFilter = false)
+      : barycenter_(barycenter),
+        width_(width),
+        avgCharge_(avgCharge),
+        filter_(filter),
+        isSaturated_(isSaturated),
+        peakFilter_(peakFilter) {}
 
   explicit SiStripApproximateCluster(const SiStripCluster& cluster,
                                      unsigned int maxNSat,

--- a/DataFormats/SiStripCluster/test/BuildFile.xml
+++ b/DataFormats/SiStripCluster/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="DataFormats/SiStripCluster"/>
+
+<library name="testSiStripApproximateClusterCollection" file="TestReadSiStripApproximateClusterCollection.cc,TestWriteSiStripApproximateClusterCollection.cc">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+</library>
+
+<test name="TestSiStripApproximateClusterCollection" command="TestSiStripApproximateClusterCollection.sh"/>

--- a/DataFormats/SiStripCluster/test/TestReadSiStripApproximateClusterCollection.cc
+++ b/DataFormats/SiStripCluster/test/TestReadSiStripApproximateClusterCollection.cc
@@ -1,0 +1,122 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/SiStripCluster
+// Class:      TestReadSiStripApproximateClusterCollection
+//
+/**\class edmtest::TestReadSiStripApproximateClusterCollection
+  Description: Used as part of tests that ensure the SiStripApproximateClusterCollection
+  data format can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the SiStripApproximateClusterCollection persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  22 September 2023
+
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <vector>
+
+namespace edmtest {
+
+  class TestReadSiStripApproximateClusterCollection : public edm::global::EDAnalyzer<> {
+  public:
+    TestReadSiStripApproximateClusterCollection(edm::ParameterSet const&);
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+    void throwWithMessage(const char*) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    // These expected values are meaningless other than we use them
+    // to check that values read from persistent storage match the values
+    // we know were written.
+    std::vector<unsigned int> expectedIntegralValues_;
+
+    edm::EDGetTokenT<SiStripApproximateClusterCollection> collectionToken_;
+  };
+
+  TestReadSiStripApproximateClusterCollection::TestReadSiStripApproximateClusterCollection(
+      edm::ParameterSet const& iPSet)
+      : expectedIntegralValues_(iPSet.getParameter<std::vector<unsigned int>>("expectedIntegralValues")),
+        collectionToken_(consumes(iPSet.getParameter<edm::InputTag>("collectionTag"))) {
+    if (expectedIntegralValues_.size() != 7) {
+      throw cms::Exception("TestFailure") << "TestReadSiStripApproximateClusterCollection, test configuration error: "
+                                             "expectedIntegralValues should have size 7.";
+    }
+  }
+
+  void TestReadSiStripApproximateClusterCollection::analyze(edm::StreamID,
+                                                            edm::Event const& iEvent,
+                                                            edm::EventSetup const&) const {
+    auto const& siStripApproximateClusterCollection = iEvent.get(collectionToken_);
+
+    unsigned int expectedNumberOfDetIds = (iEvent.id().event() - 1) % 10;
+    unsigned int expectedDetId = expectedIntegralValues_[0] + iEvent.id().event();
+    unsigned int numberOfDetIds = 0;
+    for (const auto& detClusters : siStripApproximateClusterCollection) {
+      ++numberOfDetIds;
+      expectedDetId += iEvent.id().event();
+      if (detClusters.id() != expectedDetId) {
+        throwWithMessage("DetId in detClusters does not have expected value");
+      }
+      unsigned int expectedNumberOfClustersPerDetId = (iEvent.id().event() - 1) % 10;
+      unsigned int j = 0;
+      for (const auto& cluster : detClusters) {
+        unsigned int iOffset = j + iEvent.id().event();
+        if (cluster.barycenter() != expectedIntegralValues_[1] + iOffset) {
+          throwWithMessage("barycenter does not have expected value");
+        }
+        if (cluster.width() != expectedIntegralValues_[2] + iOffset) {
+          throwWithMessage("width does not have expected value");
+        }
+        if (cluster.avgCharge() != expectedIntegralValues_[3] + iOffset) {
+          throwWithMessage("avgCharge does not have expected value");
+        }
+        if (cluster.filter() != (j < (expectedIntegralValues_[4] + iEvent.id().event()) % 10)) {
+          throwWithMessage("filter does not have expected value");
+        }
+        if (cluster.isSaturated() != (j < (expectedIntegralValues_[5] + iEvent.id().event()) % 10)) {
+          throwWithMessage("isSaturated does not have expected value");
+        }
+        if (cluster.peakFilter() != (j < (expectedIntegralValues_[6] + iEvent.id().event()) % 10)) {
+          throwWithMessage("peakFilter does not have expected value");
+        }
+        ++j;
+      }
+      if (j != expectedNumberOfClustersPerDetId) {
+        throwWithMessage("Number of cluster for DetId does not have expected value");
+      }
+    }
+    if (numberOfDetIds != expectedNumberOfDetIds) {
+      throwWithMessage("Number of DetIds does not match expected value");
+    }
+  }
+
+  void TestReadSiStripApproximateClusterCollection::throwWithMessage(const char* msg) const {
+    throw cms::Exception("TestFailure") << "TestReadSiStripApproximateClusterCollection::analyze, " << msg;
+  }
+
+  void TestReadSiStripApproximateClusterCollection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<unsigned int>>("expectedIntegralValues");
+    desc.add<edm::InputTag>("collectionTag");
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestReadSiStripApproximateClusterCollection;
+DEFINE_FWK_MODULE(TestReadSiStripApproximateClusterCollection);

--- a/DataFormats/SiStripCluster/test/TestSiStripApproximateClusterCollection.sh
+++ b/DataFormats/SiStripCluster/test/TestSiStripApproximateClusterCollection.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -ex
+
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+cmsRun ${LOCAL_TEST_DIR}/create_SiStripApproximateClusterCollection_test_file_cfg.py || die 'Failure using create_SiStripApproximateClusterCollection_test_file_cfg.py' $?
+
+file=testSiStripApproximateClusterCollection.root
+
+cmsRun ${LOCAL_TEST_DIR}/test_readSiStripApproximateClusterCollection_cfg.py "$file" || die "Failure using test_readSiStripApproximateClusterCollection_cfg.py $file" $?
+
+oldFiles="testSiStripApproximateClusterCollection_CMSSW_13_2_4.root"
+for file in $oldFiles; do
+  inputfile=$(edmFileInPath DataFormats/SiStripCluster/data/$file) || die "Failure edmFileInPath DataFormats/SiStripCluster/data/$file" $?
+  cmsRun ${LOCAL_TEST_DIR}/test_readSiStripApproximateClusterCollection_cfg.py "$inputfile" || die "Failed to read old file $file" $?
+done
+
+exit 0

--- a/DataFormats/SiStripCluster/test/TestWriteSiStripApproximateClusterCollection.cc
+++ b/DataFormats/SiStripCluster/test/TestWriteSiStripApproximateClusterCollection.cc
@@ -1,0 +1,104 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/SiStripCluster
+// Class:      TestWriteSiStripApproximateClusterCollection
+//
+/**\class edmtest::TestWriteSiStripApproximateClusterCollection
+  Description: Used as part of tests that ensure the SiStripApproximateClusterCollection
+  data format can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the SiStripApproximateClusterCollection persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  20 Sep 2023
+
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripApproximateClusterCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace edmtest {
+
+  class TestWriteSiStripApproximateClusterCollection : public edm::global::EDProducer<> {
+  public:
+    TestWriteSiStripApproximateClusterCollection(edm::ParameterSet const&);
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    std::vector<unsigned int> integralValues_;
+    edm::EDPutTokenT<SiStripApproximateClusterCollection> collectionPutToken_;
+  };
+
+  TestWriteSiStripApproximateClusterCollection::TestWriteSiStripApproximateClusterCollection(
+      edm::ParameterSet const& iPSet)
+      : integralValues_(iPSet.getParameter<std::vector<unsigned int>>("integralValues")),
+        collectionPutToken_(produces()) {
+    if (integralValues_.size() != 7) {
+      throw cms::Exception("TestFailure") << "TestWriteSiStripApproximateClusterCollection, test configuration error: "
+                                             "integralValues should have size 7 and it doesn't";
+    }
+  }
+
+  void TestWriteSiStripApproximateClusterCollection::produce(edm::StreamID,
+                                                             edm::Event& iEvent,
+                                                             edm::EventSetup const&) const {
+    // Fill a SiStripApproximateClusterCollection. Make sure all the containers inside
+    // of it have something in them (not empty). There is a little complexity here
+    // to vary the values written and the sizes of the containers, but the values and
+    // sizes are meaningless other than we want test patterns that aren't all the same
+    // value and same size for a better test.
+    // We will later check that after writing this object to persistent storage
+    // and then reading it in a later process we obtain matching values for
+    // all this content. I imagine if you tried to run reconstruction on these
+    // objects it would crash badly. Here, the only purpose is to test that ROOT
+    // can read the bits properly (maybe years and many ROOT and CSSSW versions
+    // after the files were written).
+
+    auto siStripApproximateClusterCollection = std::make_unique<SiStripApproximateClusterCollection>();
+
+    unsigned int numberDetIds = (iEvent.id().event() - 1) % 10;
+    unsigned int detId = integralValues_[0] + iEvent.id().event();
+    for (unsigned int i = 0; i < numberDetIds; ++i) {
+      detId += iEvent.id().event();
+      auto filler = siStripApproximateClusterCollection->beginDet(detId);
+      unsigned int numberOfClustersPerDetId = (iEvent.id().event() - 1) % 10;
+      for (unsigned int j = 0; j < numberOfClustersPerDetId; ++j) {
+        unsigned int iOffset = j + iEvent.id().event();
+        cms_uint16_t barycenter = integralValues_[1] + iOffset;
+        cms_uint8_t width = integralValues_[2] + iOffset;
+        cms_uint8_t avgCharge = integralValues_[3] + iOffset;
+        bool filter = j < (integralValues_[4] + iEvent.id().event()) % 10;
+        bool isSaturated = j < (integralValues_[5] + iEvent.id().event()) % 10;
+        bool peakFilter = j < (integralValues_[6] + iEvent.id().event()) % 10;
+        SiStripApproximateCluster cluster(barycenter, width, avgCharge, filter, isSaturated, peakFilter);
+        filler.push_back(cluster);
+      }
+    }
+    iEvent.put(collectionPutToken_, std::move(siStripApproximateClusterCollection));
+  }
+
+  void TestWriteSiStripApproximateClusterCollection::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::vector<unsigned int>>("integralValues");
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestWriteSiStripApproximateClusterCollection;
+DEFINE_FWK_MODULE(TestWriteSiStripApproximateClusterCollection);

--- a/DataFormats/SiStripCluster/test/create_SiStripApproximateClusterCollection_test_file_cfg.py
+++ b/DataFormats/SiStripCluster/test/create_SiStripApproximateClusterCollection_test_file_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.collectionProducer = cms.EDProducer("TestWriteSiStripApproximateClusterCollection",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    integralValues = cms.vuint32(11, 21, 31, 41, 51, 62, 73)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSiStripApproximateClusterCollection.root')
+)
+
+process.path = cms.Path(process.collectionProducer)
+process.endPath = cms.EndPath(process.out)

--- a/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
+++ b/DataFormats/SiStripCluster/test/test_readSiStripApproximateClusterCollection_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+
+process.testReadSiStripApproximateClusterCollection = cms.EDAnalyzer("TestReadSiStripApproximateClusterCollection",
+    expectedIntegralValues = cms.vuint32(11, 21, 31, 41, 51, 62, 73),
+    collectionTag = cms.InputTag("collectionProducer", "", "PROD")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSiStripApproximateClusterCollection2.root')
+)
+
+process.path = cms.Path(process.testReadSiStripApproximateClusterCollection)
+
+process.endPath = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

Add a new unit test for the SiStripApproximateClusterCollection data format. This generates a data file containing a SiStripApproximateClusterCollection object with known content. Then it reads it. It verifies that when we read it we obtain values that match the known written values for all the data fields in the object. In particular all containers have content so all contained types are also read.

It also reads the old files in the DataFormats/SiStripCluster data repository which are listed in the shell script. The plan is that each time the data format of SiStripApproximateClusterCollection is modified a file will added.

There is a slight modification to the constructor of SiStripApproximateCluster, but it is only used in the test.

#### PR validation:

This only adds a unit test in DataFormats/SiStripCluster which passes. It shouldn't affect anything else.

