### PR TITLE
Enable ECAL reconstructions to use different time calibration records - 132x

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
@@ -393,6 +393,8 @@ void EcalRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<double>("EELaserMAX", 8.0);
   desc.add<double>("logWarningEtThreshold_EB_FE", 50);
   desc.add<bool>("recoverEEIsolatedChannels", false);
+  desc.add<edm::ESInputTag>("timeCalibTag", edm::ESInputTag());
+  desc.add<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag());
   desc.add<bool>("skipTimeCalib", false);
   descriptions.add("ecalRecHit", desc);
 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitWorkerSimple.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitSimpleAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecProducers/interface/EcalRecHitWorkerBaseClass.h"
@@ -84,8 +85,10 @@ EcalRecHitWorkerSimple::EcalRecHitWorkerSimple(const edm::ParameterSet& ps, edm:
 
   icalToken_ = c.esConsumes<EcalIntercalibConstants, EcalIntercalibConstantsRcd>();
   if (!skipTimeCalib_) {
-    itimeToken_ = c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>();
-    offtimeToken_ = c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>();
+    itimeToken_ = c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>(
+        ps.getParameter<edm::ESInputTag>("timeCalibTag"));
+    offtimeToken_ = c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>(
+        ps.getParameter<edm::ESInputTag>("timeOffsetTag"));
   }
   agcToken_ = c.esConsumes<EcalADCToGeVConstant, EcalADCToGeVConstantRcd>();
   chStatusToken_ = c.esConsumes<EcalChannelStatus, EcalChannelStatusRcd>();

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitProducerGPU.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
@@ -70,6 +71,8 @@ void EcalUncalibRecHitProducerGPU::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<std::string>("recHitsLabelEB", "EcalUncalibRecHitsEB");
   desc.add<std::string>("recHitsLabelEE", "EcalUncalibRecHitsEE");
 
+  desc.add<edm::ESInputTag>("timeCalibTag", edm::ESInputTag());
+  desc.add<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag());
   desc.add<double>("EBtimeFitLimits_Lower", 0.2);
   desc.add<double>("EBtimeFitLimits_Upper", 1.4);
   desc.add<double>("EEtimeFitLimits_Lower", 0.2);
@@ -104,9 +107,11 @@ EcalUncalibRecHitProducerGPU::EcalUncalibRecHitProducerGPU(const edm::ParameterS
       pulseCovariancesToken_{esConsumes<EcalPulseCovariancesGPU, EcalPulseCovariancesRcd>()},
       samplesCorrelationToken_{esConsumes<EcalSamplesCorrelationGPU, EcalSamplesCorrelationRcd>()},
       timeBiasCorrectionsToken_{esConsumes<EcalTimeBiasCorrectionsGPU, EcalTimeBiasCorrectionsRcd>()},
-      timeCalibConstantsToken_{esConsumes<EcalTimeCalibConstantsGPU, EcalTimeCalibConstantsRcd>()},
+      timeCalibConstantsToken_{esConsumes<EcalTimeCalibConstantsGPU, EcalTimeCalibConstantsRcd>(
+          ps.getParameter<edm::ESInputTag>("timeCalibTag"))},
       sampleMaskToken_{esConsumes<EcalSampleMask, EcalSampleMaskRcd>()},
-      timeOffsetConstantToken_{esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>()},
+      timeOffsetConstantToken_{esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>(
+          ps.getParameter<edm::ESInputTag>("timeOffsetTag"))},
       multifitParametersToken_{esConsumes<EcalMultifitParametersGPU, JobConfigurationGPURecord>()} {
   std::pair<double, double> EBtimeFitLimits, EEtimeFitLimits;
   EBtimeFitLimits.first = ps.getParameter<double>("EBtimeFitLimits_Lower");

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -30,6 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h"
@@ -136,8 +137,10 @@ EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::Paramete
       testbeamEBShape(c),
       tokenSampleMask_(c.esConsumes<EcalSampleMask, EcalSampleMaskRcd>()),
       tokenTimeCorrBias_(c.esConsumes<EcalTimeBiasCorrections, EcalTimeBiasCorrectionsRcd>()),
-      tokenItime_(c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>()),
-      tokenOfftime_(c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>()) {
+      tokenItime_(c.esConsumes<EcalTimeCalibConstants, EcalTimeCalibConstantsRcd>(
+          ps.getParameter<edm::ESInputTag>("timeCalibTag"))),
+      tokenOfftime_(c.esConsumes<EcalTimeOffsetConstant, EcalTimeOffsetConstantRcd>(
+          ps.getParameter<edm::ESInputTag>("timeOffsetTag"))) {
   // ratio method parameters
   EBtimeFitParameters_ = ps.getParameter<std::vector<double>>("EBtimeFitParameters");
   EEtimeFitParameters_ = ps.getParameter<std::vector<double>>("EEtimeFitParameters");
@@ -577,6 +580,8 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerGlobal::getAlgoDescription()
       edm::ParameterDescription<double>("EBtimeFitLimits_Lower", 0.2, true) and
       edm::ParameterDescription<bool>("kPoorRecoFlagEE", false, true) and
       edm::ParameterDescription<double>("chi2ThreshEB_", 36.0, true) and
+      edm::ParameterDescription<edm::ESInputTag>("timeCalibTag", edm::ESInputTag(), true) and
+      edm::ParameterDescription<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag(), true) and
       edm::ParameterDescription<std::vector<double>>(
           "EEtimeFitParameters",
           {-2.390548, 3.553628, -17.62341, 67.67538, -133.213, 140.7432, -75.41106, 16.20277},

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -30,6 +30,10 @@ ecalRecHit = cms.EDProducer("EcalRecHitProducer",
     EBLaserMAX = cms.double(3.0),
     EELaserMAX = cms.double(8.0),
 
+    # to select timing conditions record
+    timeCalibTag = cms.ESInputTag('', ''),
+    timeOffsetTag = cms.ESInputTag('', ''),
+
     # useful if time is not calculated, as at HLT                        
     skipTimeCalib = cms.bool(False),                         
 


### PR DESCRIPTION
#### PR description:

Adding two ESInputTag parameters to be able to select the record that the timing calibrations and timing offsets are taken from by the GPU multifit algorithm and other ECAL time reconstructions.
This will be needed to support two records of those conditions within a GT.
Having two records in a GT will be required in some cases (e.g. MC GTs) because two different timing algorithms, using two different sets of conditions, run at the HLT and in offline reconstruction.

This PR just adds the capability to specify the record label but no changes to configuration are made and no changes in existing workflows are expected.

This is a follow up PR to https://github.com/cms-sw/cmssw/pull/42845 , which added this capability already to the CPU multifit algorithm.

#### PR validation:

Passes limited matrix tests.

Backport of #42860 

This backport is mostly needed to enable the same condition selection feature that the CPU multifit algorithm has received with PR #42845 also for the GPU amplitude reconstruction.