### PR TITLE
Adding the scouting event content to MINIAODSIM

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -886,6 +886,7 @@ MINIAODSIMEventContent= cms.PSet(
     compressionLevel=cms.untracked.int32(4)
 )
 MINIAODSIMEventContent.outputCommands.extend(MicroEventContentMC.outputCommands)
+MINIAODSIMEventContent.outputCommands.extend(HLTScouting.outputCommands)
 
 MINIGENEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),


### PR DESCRIPTION
#### PR description:
In the context of the discussion about the plans for scouting in Run 3, the inclusion of the scounting event content within MINIAODSIM data tier was discussed per request of TSG and @dsperka in order to simplify scouting studies and analyses based on scouting data. The request was signed-off by PPD, PC, and O&C.
The plan is to include the change in the master branch to have those collections available from 133X so that it will be part of the campaigns for the TSG 2024 preparation and next year PPD operation.

#### PR validation:
The effect of the change on the event size was tested with a 2023 MinBias, a 2023 ttbar sample, and a 2022 ttHbb sample using a recent 13_3_X release (@kelmorab).
The summary finding is that the average event size (measured with the disksize.pl script from [SWGuidePATEventSize](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePATEventSize )) depends on the process:
- **MinBias**: +5.6 kb from scouting event content -> **12.1%** 
- **ttbar**: +11.7 kb from scouting event content  -> **8.9%**
- **ttHbb**: +8.7 kb from scouting event content  -> **10.4%**

The PR has been prepared starting from CMSSW_13_3_X_2023-09-25-1100:
```
cmsrel CMSSW_13_3_X_2023-09-25-1100
cd CMSSW_13_3_X_2023-09-25-1100/src
cmsenv
git cms-init
git cms-addpkg Configuration/EventContent
scram b && scram b code-checks && scram b code-format && scram b
```

[cc: @missirol @goys @simonepigazzini @jordan-martins]