### PR TITLE
Fix maybe-uninitialized warning in HiTrivialConditionRetriever

### DIFF
--- a/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
@@ -81,9 +81,8 @@ std::unique_ptr<CentralityTable> HiTrivialConditionRetriever::produceTable(const
     }
     CentralityTable::CBin thisBin;
     istringstream ss(line);
-    ss >> thisBin.bin_edge >> thisBin.n_part.mean >> thisBin.n_part.var >>
-        thisBin.n_coll.mean >> thisBin.n_coll.var >> thisBin.n_hard.mean >>
-        thisBin.n_hard.var >> thisBin.b.mean >> thisBin.b.var;
+    ss >> thisBin.bin_edge >> thisBin.n_part.mean >> thisBin.n_part.var >> thisBin.n_coll.mean >> thisBin.n_coll.var >>
+        thisBin.n_hard.mean >> thisBin.n_hard.var >> thisBin.b.mean >> thisBin.b.var;
     CT->m_table.push_back(thisBin);
     i++;
   }

--- a/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
@@ -74,7 +74,6 @@ std::unique_ptr<CentralityTable> HiTrivialConditionRetriever::produceTable(const
   ifstream in(edm::FileInPath(inputFileName_).fullPath().c_str());
   string line;
 
-  int i = 0;
   while (getline(in, line)) {
     if (line.empty() || line[0] == '#') {
       continue;
@@ -84,7 +83,6 @@ std::unique_ptr<CentralityTable> HiTrivialConditionRetriever::produceTable(const
     ss >> thisBin.bin_edge >> thisBin.n_part.mean >> thisBin.n_part.var >> thisBin.n_coll.mean >> thisBin.n_coll.var >>
         thisBin.n_hard.mean >> thisBin.n_hard.var >> thisBin.b.mean >> thisBin.b.var;
     CT->m_table.push_back(thisBin);
-    i++;
   }
 
   return CT;

--- a/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc
@@ -80,11 +80,11 @@ std::unique_ptr<CentralityTable> HiTrivialConditionRetriever::produceTable(const
       continue;
     }
     CentralityTable::CBin thisBin;
-    CT->m_table.push_back(thisBin);
     istringstream ss(line);
-    ss >> CT->m_table[i].bin_edge >> CT->m_table[i].n_part.mean >> CT->m_table[i].n_part.var >>
-        CT->m_table[i].n_coll.mean >> CT->m_table[i].n_coll.var >> CT->m_table[i].n_hard.mean >>
-        CT->m_table[i].n_hard.var >> CT->m_table[i].b.mean >> CT->m_table[i].b.var;
+    ss >> thisBin.bin_edge >> thisBin.n_part.mean >> thisBin.n_part.var >>
+        thisBin.n_coll.mean >> thisBin.n_coll.var >> thisBin.n_hard.mean >>
+        thisBin.n_hard.var >> thisBin.b.mean >> thisBin.b.var;
+    CT->m_table.push_back(thisBin);
     i++;
   }
 


### PR DESCRIPTION
#### PR description:

Fix the "maybe-uninitialized" warning in HiTrivialConditionRetriever::produceTable

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/414f5e450434801acd65888d863b44d9/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-09-25-1100/src/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc: In member function 'produceTable':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/414f5e450434801acd65888d863b44d9/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-09-25-1100/src/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc:83:26: warning: 'thisBin' may be used uninitialized [-Wmaybe-uninitialized]
    83 |     CT->m_table.push_back(thisBin);
      |                          ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1276:7: note: by argument 2 of type 'const struct value_type &' to 'push_back' declared here
 1276 |       push_back(const value_type& __x)
      |       ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/414f5e450434801acd65888d863b44d9/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-09-25-1100/src/RecoHI/HiCentralityAlgos/plugins/HiTrivialConditionRetriever.cc:82:27: note: 'thisBin' declared here
   82 |     CentralityTable::CBin thisBin;
      |                           ^
```

#### PR validation:

Local tests.
