### PR TITLE
Customize HLT for ECAL timing conditions record label HLT

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -237,6 +237,16 @@ def customizeHLTfor42497(process):
     return process
 
 
+def customizeHLTfor42869(process):
+    for prod in producers_by_type(process, 'EcalUncalibRecHitProducer'):
+        if prod.algoPSet.timealgo == "RatioMethod":
+            prod.algoPSet.timeCalibTag = cms.ESInputTag('', 'HLT')
+            prod.algoPSet.timeOffsetTag = cms.ESInputTag('', 'HLT')
+    for prod in producers_by_type(process, 'EcalUncalibRecHitProducerGPU'):
+        prod.timeCalibTag = cms.ESInputTag('', 'HLT')
+        prod.timeOffsetTag = cms.ESInputTag('', 'HLT')
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -247,5 +257,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customizeHLTfor42514(process)
     process = customizeHLTfor42497(process)
+    process = customizeHLTfor42869(process)
 
     return process


### PR DESCRIPTION
#### PR description:

This PR contains a customization for the HLT to consume the ECAL time calibration and time offset records labelled "HLT" instead of the unlabelled ones.
This is needed to be able to use different conditions for the different ECAL timing algorithms at the HLT and in offline reconstruction.

The PR requires PRs #42817 and #42860 , which provide the necessary config parameters.

The GTs need to contain the records `EcalTimeOffsetConstantRcd` and `EcalTimeCalibConstantsRcd` with the label "HLT".
