### PR TITLE
Fixing bug in a photon path in Phase2 HLT

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEG108EtL1SeededFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEG108EtL1SeededFilter_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 hltEG108EtL1SeededFilter = cms.EDFilter("HLTEgammaEtFilter",
     etcutEB = cms.double(108.0),
-    etcutEE = cms.double(108.0),
+    etcutEE = cms.double(9999999.0),
     inputTag = cms.InputTag("hltEgammaCandidatesWrapperL1Seeded"),
     l1EGCand = cms.InputTag("hltEgammaCandidatesL1Seeded"),
     ncandcut = cms.int32(1),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEG108EtUnseededFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEG108EtUnseededFilter_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 hltEG108EtUnseededFilter = cms.EDFilter("HLTEgammaEtFilter",
     etcutEB = cms.double(108.0),
-    etcutEE = cms.double(108.0),
+    etcutEE = cms.double(9999999.0),
     inputTag = cms.InputTag("hltEgammaCandidatesWrapperUnseeded"),
     l1EGCand = cms.InputTag("hltEgammaCandidatesUnseeded"),
     ncandcut = cms.int32(1),


### PR DESCRIPTION
#### PR description:

Fixing a bug in `HLT_Photon108EB_TightID_TightIso_Unseeded` and `HLT_Photon108EB_TightID_TightIso_L1Seeded`. These paths were intended to be barrel-only. That's how they are also for Run3/Run2 (see screenshot of Run3 below). For HLT-TDR, the paths were correctly made to be barrel-only, and the efficiency plots & rates written in TDR correctly reflects that. But the bug was introduced later when the path was put in CMSSW via the initial (giant) PR. It was noticed while reviewing plots coming from a validation study made by @skeshri, where it's clear that this path is also highly efficient in endcaps, which should not be the case. Sumit's plot(middle) and HLT TDR plot(right) are added below, for comparison. 

<img width="250" alt="Screen Shot 2023-09-26 at 16 59 17" src="https://github.com/cms-sw/cmssw/assets/5052706/06692031-1548-460b-9b1d-90fb85133e5a">
<img width="250" alt="eta_hltPhoton108EBTightIDTightIsoHcalIsoL1SeededFilter" src="https://github.com/cms-sw/cmssw/assets/5052706/3f0b8387-ef3d-4c13-9844-d971ae0e61d8">
<img width="250" alt="Screen Shot 2023-09-26 at 17 12 01" src="https://github.com/cms-sw/cmssw/assets/5052706/8dd77299-7f6a-4bb8-a455-8dff4cf9fc6c">



<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Phase2 HLT menu runs fine.