### PR TITLE
Fix for pixel FED error imbalance in DQM plots

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -324,7 +324,8 @@ namespace pixelgpudetails {
       skipROC = (roc < pixelgpudetails::maxROCIndex) ? false : (errorType != 0);
       if (includeErrors and skipROC) {
         uint32_t rID = getErrRawID<debug>(fedId, ww, errorType, cablingMap);
-        err->push_back(SiPixelErrorCompact{rID, ww, errorType, fedId});
+        if (rID != 0xffffffff)  // store errors only for valid DetIds
+          err->push_back(SiPixelErrorCompact{rID, ww, errorType, fedId});
         continue;
       }
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -212,6 +212,7 @@ namespace pixelgpudetails {
         if (!((errorWord >> sipixelconstants::OMIT_ERR_shift) & sipixelconstants::OMIT_ERR_mask)) {
           if constexpr (debug)
             printf("...2nd errorType=29 error, skip\n");
+          break;
         }
         errorFound = true;
         break;


### PR DESCRIPTION
#### PR description:

After recent bug fixes in FED error decoding in the CPU (https://github.com/cms-sw/cmssw/pull/42010) and GPU (https://github.com/cms-sw/cmssw/pull/42618) code, the following imbalance was still present in the `SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU/FEErrorVsFEDIdUnbalance` DQM plot

![FEDErrorVsFEDIdImbalance_ref](https://github.com/cms-sw/cmssw/assets/4885289/c5959cd6-2a34-4fba-bbf1-bc01bec61d8e)

This imbalance is primarily present because the GPU-based pixel unpacker is not dropping spurious errors assigned to invalid DetIds. Specifically for the timeout error (errorType=29), which consists of two error words, the GPU code was not dropping the 2nd word as is done in the CPU code. This PR therefore additionally synchronizes the FED error handling between the GPU and the legacy CPU code. The same DQM plot with this PR included becomes empty (no imbalance present)

![FEDErrorVsFEDIdImbalance_pr](https://github.com/cms-sw/cmssw/assets/4885289/5cdf0d45-a728-41c4-a26e-3f5e17c1f6df)

#### PR validation:

The code was tested and the above DQM plots obtained by running the following workflow

`runTheMatrix.py -w gpu -l 141.008583`

recently introduced in https://github.com/cms-sw/cmssw/pull/42674.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Could be backported to 13_2_X if needed.
