### PR TITLE
Add unit test for std::vector<DetId> raw data format

### DIFF
--- a/DataFormats/DetId/README.md
+++ b/DataFormats/DetId/README.md
@@ -1,0 +1,10 @@
+#  DataFormats/DetId
+
+## `std::vector<DetId>`
+
+The type `std::vector<DetId>` is part of the RAW data, and any changes must be backwards compatible. In order to ensure it can be read by all future CMSSW releases, there is a `TestVectorDetId` unit test, which makes use of the `TestReadVectorDetId` analyzer and the `TestWriteVectorDetId` producer. The unit test checks that the object can be read properly from
+
+* a file written by the same release
+* files written by (some) earlier releases
+
+If the persistent format of class `std::vector<DetId>` gets changed in the future, please adjust the `TestReadVectorDetId` and `TestWriteVectorDetId` modules accordingly. It is important that every member container has some content in this test. Please also add a new file to the [https://github.com/cms-data/DataFormats-DetId/](https://github.com/cms-data/DataFormats-DetId/) repository, and update the `TestVectorDetId` unit test to read the newly created file. The file name should contain the release or pre-release with which it was written.

--- a/DataFormats/DetId/test/BuildFile.xml
+++ b/DataFormats/DetId/test/BuildFile.xml
@@ -1,8 +1,18 @@
+<use name="DataFormats/DetId"/>
+
 <iftool name="cuda-gcc-support">
   <bin name="test_detid" file="test_detid.cu">
     <use name="cuda"/>
-    <use name="DataFormats/DetId"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
 
 </iftool>
+
+<library name="testVectorDetId" file="TestReadVectorDetId.cc,TestWriteVectorDetId.cc">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+</library>
+
+<test name="TestVectorDetId" command="TestVectorDetId.sh"/>

--- a/DataFormats/DetId/test/TestReadVectorDetId.cc
+++ b/DataFormats/DetId/test/TestReadVectorDetId.cc
@@ -1,0 +1,86 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/DetId
+// Class:      TestReadVectorDetId
+//
+/**\class edmtest::TestReadVectorDetId
+  Description: Used as part of tests that ensure the std::vector<DetId>
+  raw data format can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the VectorDetId persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  25 September 2023
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <vector>
+
+namespace edmtest {
+
+  class TestReadVectorDetId : public edm::global::EDAnalyzer<> {
+  public:
+    TestReadVectorDetId(edm::ParameterSet const&);
+    void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+    void throwWithMessage(const char*) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    // This expected value is meaningless other than we use it
+    // to check that values read from persistent storage match the values
+    // we know were written.
+    unsigned int expectedTestValue_;
+
+    edm::EDGetTokenT<std::vector<DetId>> collectionToken_;
+  };
+
+  TestReadVectorDetId::TestReadVectorDetId(edm::ParameterSet const& iPSet)
+      : expectedTestValue_(iPSet.getParameter<unsigned int>("expectedTestValue")),
+        collectionToken_(consumes(iPSet.getParameter<edm::InputTag>("collectionTag"))) {}
+
+  void TestReadVectorDetId::analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+    auto const& vectorDetIds = iEvent.get(collectionToken_);
+
+    unsigned int expectedNumberOfDetIds = (iEvent.id().event() - 1) % 10;
+    unsigned int expectedDetId = expectedTestValue_ + iEvent.id().event();
+    unsigned int numberOfDetIds = 0;
+    for (const auto& detId : vectorDetIds) {
+      ++numberOfDetIds;
+      expectedDetId += iEvent.id().event();
+      if (detId.rawId() != expectedDetId) {
+        throwWithMessage("DetId in vector of DetIds does not have expected value");
+      }
+    }
+    if (numberOfDetIds != expectedNumberOfDetIds) {
+      throwWithMessage("Number of DetIds does not match expected value");
+    }
+  }
+
+  void TestReadVectorDetId::throwWithMessage(const char* msg) const {
+    throw cms::Exception("TestFailure") << "TestReadVectorDetId::analyze, " << msg;
+  }
+
+  void TestReadVectorDetId::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<unsigned int>("expectedTestValue");
+    desc.add<edm::InputTag>("collectionTag");
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestReadVectorDetId;
+DEFINE_FWK_MODULE(TestReadVectorDetId);

--- a/DataFormats/DetId/test/TestVectorDetId.sh
+++ b/DataFormats/DetId/test/TestVectorDetId.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -ex
+
+function die { echo $1: status $2 ;  exit $2; }
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+cmsRun ${LOCAL_TEST_DIR}/create_VectorDetId_test_file_cfg.py || die 'Failure using create_VectorDetId_test_file_cfg.py' $?
+
+file=testVectorDetId.root
+
+cmsRun ${LOCAL_TEST_DIR}/test_readVectorDetId_cfg.py "$file" || die "Failure using test_readVectorDetId_cfg.py $file" $?
+
+oldFiles="testVectorDetId_CMSSW_13_2_4.root"
+for file in $oldFiles; do
+  inputfile=$(edmFileInPath DataFormats/DetId/data/$file) || die "Failure edmFileInPath DataFormats/DetId/data/$file" $?
+  cmsRun ${LOCAL_TEST_DIR}/test_readVectorDetId_cfg.py "$inputfile" || die "Failed to read old file $file" $?
+done
+
+exit 0

--- a/DataFormats/DetId/test/TestWriteVectorDetId.cc
+++ b/DataFormats/DetId/test/TestWriteVectorDetId.cc
@@ -1,0 +1,76 @@
+// -*- C++ -*-
+//
+// Package:    DataFormats/DetId
+// Class:      TestWriteVectorDetId
+//
+/**\class edmtest::TestWriteVectorDetId
+  Description: Used as part of tests that ensure the std::vector<DetId> raw
+  data format type can be persistently written and in a subsequent process
+  read. First, this is done using the current release version for writing
+  and reading. In addition, the output file of the write process should
+  be saved permanently each time the std::vector<DetId> persistent data
+  format changes. In unit tests, we read each of those saved files to verify
+  that the current releases can read older versions of the data format.
+*/
+// Original Author:  W. David Dagenhart
+//         Created:  25 Sep 2023
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace edmtest {
+
+  class TestWriteVectorDetId : public edm::global::EDProducer<> {
+  public:
+    TestWriteVectorDetId(edm::ParameterSet const&);
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    unsigned int testValue_;
+    edm::EDPutTokenT<std::vector<DetId>> putToken_;
+  };
+
+  TestWriteVectorDetId::TestWriteVectorDetId(edm::ParameterSet const& iPSet)
+      : testValue_(iPSet.getParameter<unsigned int>("testValue")), putToken_(produces()) {}
+
+  void TestWriteVectorDetId::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+    // Fill a std::vector<DetId>. Make sure it is not empty.
+    // We will test in a later process that we read the same
+    // value we wrote, but the value is otherwise meaningless.
+    // The only purpose is to test that ROOT can read the bits
+    // properly (maybe years and many ROOT and CSSSW versions
+    // after the files were written).
+
+    auto vectorDetIds = std::make_unique<std::vector<DetId>>();
+
+    unsigned int numberDetIds = (iEvent.id().event() - 1) % 10;
+    unsigned int detId = testValue_ + iEvent.id().event();
+    for (unsigned int i = 0; i < numberDetIds; ++i) {
+      detId += iEvent.id().event();
+      vectorDetIds->emplace_back(detId);
+    }
+    iEvent.put(putToken_, std::move(vectorDetIds));
+  }
+
+  void TestWriteVectorDetId::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<unsigned int>("testValue");
+    descriptions.addDefault(desc);
+  }
+}  // namespace edmtest
+
+using edmtest::TestWriteVectorDetId;
+DEFINE_FWK_MODULE(TestWriteVectorDetId);

--- a/DataFormats/DetId/test/create_VectorDetId_test_file_cfg.py
+++ b/DataFormats/DetId/test/create_VectorDetId_test_file_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 10
+
+process.collectionProducer = cms.EDProducer("TestWriteVectorDetId",
+    # Test values below are meaningless. We just make sure when we read
+    # we get the same values.
+    testValue = cms.uint32(21)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testVectorDetId.root')
+)
+
+process.path = cms.Path(process.collectionProducer)
+process.endPath = cms.EndPath(process.out)

--- a/DataFormats/DetId/test/test_readVectorDetId_cfg.py
+++ b/DataFormats/DetId/test/test_readVectorDetId_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[2]))
+
+process.testReadVectorDetId = cms.EDAnalyzer("TestReadVectorDetId",
+    expectedTestValue = cms.uint32(21),
+    collectionTag = cms.InputTag("collectionProducer", "", "PROD")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testVectorDetId2.root')
+)
+
+process.path = cms.Path(process.testReadVectorDetId)
+
+process.endPath = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

Add a new unit test for the ```std::vector<DetId>``` data format. This generates a data file containing a ```std::vector<DetId>```  object with known content. Then it reads it. It verifies that when we read it we obtain values that match the known written values for all the data fields in the object. In particular all containers have content so all contained types are also read.

It also reads the old files in the DataFormats/DetId data repository which are listed in the shell script. The plan is that each time the data format of ```std::vector<DetId>``` is modified a file will added.

Note that this is the last PR in a series of PRs implementing unit tests for RAW data formats.

#### PR validation:

This only adds a unit test in DataFormats/DetId which passes. It shouldn't affect anything else.
