### PR TITLE
PPS Dump to SQLite only one record (mask or mapping)

### DIFF
--- a/CalibPPS/ESProducers/plugins/WriteTotemDAQMapping.cc
+++ b/CalibPPS/ESProducers/plugins/WriteTotemDAQMapping.cc
@@ -19,40 +19,55 @@
 class WriteTotemDAQMapping : public edm::one::EDAnalyzer<> {
 public:
   WriteTotemDAQMapping(const edm::ParameterSet &ps);
-  ~WriteTotemDAQMapping() override {}
+  ~WriteTotemDAQMapping() override = default;
 
 private:
   /// label of the CTPPS sub-system
   const std::string subSystemName_;
   std::ofstream outStream_;
-  const edm::ESGetToken<TotemDAQMapping, TotemReadoutRcd> mappingToken_;
-  const edm::ESGetToken<TotemAnalysisMask, TotemAnalysisMaskRcd> maskToken_;
+  const bool readMap_;
+  const bool readMask_;
+  edm::ESGetToken<TotemDAQMapping, TotemReadoutRcd> mappingToken_;
+  edm::ESGetToken<TotemAnalysisMask, TotemAnalysisMaskRcd> maskToken_;
   void analyze(const edm::Event &e, const edm::EventSetup &es) override;
 };
 
 WriteTotemDAQMapping::WriteTotemDAQMapping(const edm::ParameterSet &ps)
     : subSystemName_(ps.getUntrackedParameter<std::string>("subSystem")),
       outStream_(ps.getUntrackedParameter<std::string>("fileName"), std::ios_base::app),
-      mappingToken_(esConsumes(edm::ESInputTag("", subSystemName_))),
-      maskToken_(esConsumes(edm::ESInputTag("", subSystemName_))) {}
+      readMap_(ps.getUntrackedParameter<bool>("readMap")),
+      readMask_(ps.getUntrackedParameter<bool>("readMask")) {
+  if (readMap_ == true) {
+    mappingToken_ = esConsumes(edm::ESInputTag("", subSystemName_));
+  }
+  if (readMask_ == true) {
+    maskToken_ = esConsumes(edm::ESInputTag("", subSystemName_));
+  }
+}
 
 //----------------------------------------------------------------------------------------------------
 
 void WriteTotemDAQMapping::analyze(const edm::Event &, edm::EventSetup const &es) {
   // get mapping
-  if (auto mappingHandle = es.getHandle(mappingToken_)) {
-    auto const &mapping = *mappingHandle;
-    mapping.print(outStream_, subSystemName_);
-  } else {
-    edm::LogError("WriteTotemDAQMapping mapping") << "WriteTotemDAQMapping: No mapping found";
+  if (readMap_ == true) {
+    auto mappingHandle = es.getHandle(mappingToken_);
+    if (mappingHandle.isValid() && !mappingHandle.failedToGet()) {
+      auto const &mapping = *mappingHandle;
+      mapping.print(outStream_, subSystemName_);
+    } else {
+      edm::LogError("WriteTotemDAQMapping mapping") << "WriteTotemDAQMapping: No mapping found";
+    }
   }
 
   // get analysis mask to mask channels
-  if (auto analysisMaskHandle = es.getHandle(maskToken_)) {
-    auto const &analysisMask = *analysisMaskHandle;
-    outStream_ << analysisMask;
-  } else {
-    edm::LogError("WriteTotemDAQMapping mask") << "WriteTotemDAQMapping: No analysis mask found";
+  if (readMask_ == true) {
+    auto analysisMaskHandle = es.getHandle(maskToken_);
+    if (analysisMaskHandle.isValid() && !analysisMaskHandle.failedToGet()) {
+      auto const &analysisMask = *analysisMaskHandle;
+      outStream_ << analysisMask;
+    } else {
+      edm::LogError("WriteTotemDAQMapping mask") << "WriteTotemDAQMapping: No analysis mask found";
+    }
   }
 
   outStream_.close();

--- a/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
+++ b/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
@@ -13,10 +13,17 @@ fromDb = True
 if(len(sys.argv)>1 and sys.argv[1].lower()=='false'):
   fromDb = False
   
+  
+# If True Mask and Mapping records will be read and wrote to file; If False only one of them will be processed
+writeBothRecords = False
+if(len(sys.argv)>2 and sys.argv[2].lower()=='true'):
+  writeBothRecords = True
+  
+  
 filesToRead = [totemTiming, timingDiamond, trackingStrip, totemT2] 
-if(len(sys.argv)>2):
-  filesToRead = [filesMap[mapName] for mapName in sys.argv[2:]]
-
+if(len(sys.argv)>3):
+  filesToRead = [filesMap[mapName] for mapName in sys.argv[3:]]
+  
 
 # For each file change the variable values in the config so that they match the selected XML file and then run the config
 for fileContent in filesToRead:
@@ -36,24 +43,43 @@ for fileContent in filesToRead:
             
             # replace name of output file and add adequate suffix to it ('_db' or '_xml')
             fileNameExt = "all_" + fileContent["subSystemName"] + "_db.txt" if fromDb else "all_" + fileContent["subSystemName"] +"_xml.txt"
-            content = re.sub(r'fileName =.*', f'fileName = cms.untracked.string("{fileNameExt}")' , content)
+            content = re.sub(r'fileName =.*', f'fileName = cms.untracked.string("{fileNameExt}"),' , content)
           
             # replace values specific for selected files
             content = re.sub(r'minIov =.*', f'minIov = {fileInfo["validityRange"].start()}', content)
             content = re.sub(r'maxIov =.*', f'maxIov = {fileInfo["validityRange"].end()}', content)
             content = re.sub(r'mappingFileNames =.*', f'mappingFileNames = {fileInfo["mappingFileNames"]},', content)
             content = re.sub(r'maskFileNames =.*', f'maskFileNames = {fileInfo["maskFileNames"]},', content)
+               
+            if fromDb:
+              sourceClass = "PoolDBESSource"  
+              obj = ""           
+            else:    
+              sourceClass = "TotemDAQMappingESSourceXML"     
+              obj =  "totemDAQMappingESSourceXML"
+
+            # replace records which needs to be get from DBSource (one or two of them)
+            dbRecords = ""
+            if writeBothRecords or fileContent == analysisMask:
+              dbRecords += "cms.PSet(\nrecord = cms.string('TotemAnalysisMaskRcd'),\n tag = cms.string('AnalysisMask'),\n label = cms.untracked.string(subSystemName)),\n"
+              replacement = f'process.es_prefer_totemTimingMapping = cms.ESPrefer("{sourceClass}", "{obj}", \
+                {"TotemAnalysisMaskRcd" if fromDb else "TotemReadoutRcd"}=cms.vstring(f"TotemAnalysisMask/{fileContent["subSystemName"]}"))'
+            
+            if writeBothRecords or fileContent != analysisMask:
+              dbRecords += "cms.PSet(\nrecord = cms.string('TotemReadoutRcd'),\n tag = cms.string('DiamondDAQMapping'),\n label = cms.untracked.string(subSystemName))\n"
+              replacement = f'process.es_prefer_totemTimingMapping = cms.ESPrefer("{sourceClass}", "{obj}", \
+                TotemReadoutRcd=cms.vstring(f"TotemDAQMapping/{fileContent["subSystemName"]}"))'
+
+            
+            enters = "\n\n\n\n" if not writeBothRecords else ""
+            
+            content = re.sub(r'readMap = cms.untracked.bool.*', f"readMap = cms.untracked.bool({writeBothRecords or fileContent != analysisMask}),", content)
+            content = re.sub(r'readMask = cms.untracked.bool.*', f"readMask = cms.untracked.bool({writeBothRecords or fileContent == analysisMask}),", content)
+            content = re.sub(r'toGet = cms.VPSet\(\n((?:.*\n){9})', f"toGet = cms.VPSet(\n"+dbRecords+"))\n"+enters, content)       
             
             # replace values in ESPrefer to read data from DB or from XML
-            if fromDb:
-              replacement = f'process.es_prefer_totemTimingMapping = cms.ESPrefer("PoolDBESSource", "", \
-                TotemReadoutRcd=cms.vstring(f"TotemDAQMapping/{fileContent["subSystemName"]}"))'
-            else:          
-              replacement = f'process.es_prefer_totemTimingMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", \
-                "totemDAQMappingESSourceXML", TotemReadoutRcd=cms.vstring("TotemDAQMapping/{fileContent["subSystemName"]}"))'
-                
-            content = re.sub(r'process.es_prefer_totemTimingMapping =.*', replacement, content)            
-          
+            content = re.sub(r'process.es_prefer_totemTimingMapping =.*', replacement, content)  
+            
             f.seek(0)
             f.write(content)
             f.truncate()

--- a/CalibPPS/ESProducers/test/test_printTotemDAQMapping.py
+++ b/CalibPPS/ESProducers/test/test_printTotemDAQMapping.py
@@ -20,7 +20,7 @@ process.source = cms.Source("EmptyIOVSource",
 # load a mapping from XML
 process.load("CalibPPS.ESProducers.totemDAQMappingESSourceXML_cfi")
 process.totemDAQMappingESSourceXML.subSystem = "TimingDiamond"
-process.totemDAQMappingESSourceXML.sampicSubDetId = cms.uint32(6)
+process.totemDAQMappingESSourceXML.sampicSubDetId = 6
 process.totemDAQMappingESSourceXML.configuration = cms.VPSet(
   cms.PSet(
     validityRange = cms.EventRange("340000:min - 362925:max"),

--- a/CalibPPS/ESProducers/test/test_writeTotemDAQMapping.py
+++ b/CalibPPS/ESProducers/test/test_writeTotemDAQMapping.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-minIov = 368023
+minIov = 1
 maxIov = 999999999
-subSystemName = "TotemT2"
+subSystemName = ""
 
 process = cms.Process('test')
 
@@ -25,41 +25,43 @@ process.source = cms.Source("EmptyIOVSource",
 process.load("CalibPPS.ESProducers.totemDAQMappingESSourceXML_cfi")
 process.totemDAQMappingESSourceXML.subSystem = subSystemName
 process.totemDAQMappingESSourceXML.sampicSubDetId = cms.uint32(7)
-process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = True
+process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = False
 process.totemDAQMappingESSourceXML.configuration = cms.VPSet(
   cms.PSet(
     validityRange = cms.EventRange(f"{minIov}:min - {maxIov}:max"),
-    mappingFileNames = cms.vstring('CondFormats/PPSObjects/xml/mapping_totem_nt2_2023_final.xml'),
+    mappingFileNames = cms.vstring(),
     maskFileNames = cms.vstring(),
   )
 )
 
 # load a mapping from DB
 process.load('CondCore.CondDB.CondDB_cfi')
-process.CondDB.connect = "sqlite_file:CTPPSTotemT2_DAQMapping.db"
+process.CondDB.connect = "sqlite_file:CTPPS_AnalysisMask.db"
 process.PoolDBESSource = cms.ESSource('PoolDBESSource',
     process.CondDB,
     toGet = cms.VPSet(
-        cms.PSet(
-            record = cms.string('TotemReadoutRcd'),
-            tag = cms.string('DiamondDAQMapping'),
-            label = cms.untracked.string(subSystemName)
-        ),
-        cms.PSet(
-            record = cms.string('TotemAnalysisMaskRcd'),
-            tag = cms.string('AnalysisMask'),
-            label = cms.untracked.string(subSystemName)
-        )
-    )
-)
+      cms.PSet(
+      record = cms.string('TotemAnalysisMaskRcd'),
+      tag = cms.string('AnalysisMask'),
+      label = cms.untracked.string(subSystemName)),
+    ))
+
+
+
+
+
+
+
 
 # prefer to read mapping from DB than from XML or otherwise
-process.es_prefer_totemTimingMapping = cms.ESPrefer("TotemDAQMappingESSourceXML",                 "totemDAQMappingESSourceXML", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TotemT2"))
+process.es_prefer_totemTimingMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML",                 TotemReadoutRcd=cms.vstring(f"TotemAnalysisMask/"))
 
 # print the mapping
 process.writeTotemDAQMapping = cms.EDAnalyzer("WriteTotemDAQMapping",
   subSystem = cms.untracked.string(subSystemName),
-  fileName = cms.untracked.string("all_TotemT2_xml.txt")
+  fileName = cms.untracked.string("all__xml.txt"),
+  readMap = cms.untracked.bool(False),
+  readMask = cms.untracked.bool(True),
 )
 
 process.path = cms.Path(

--- a/CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc
+++ b/CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc
@@ -30,7 +30,7 @@
 class WriteCTPPSTotemDAQMappingMask : public edm::one::EDAnalyzer<> {
 public:
   WriteCTPPSTotemDAQMappingMask(const edm::ParameterSet &ps);
-  ~WriteCTPPSTotemDAQMappingMask() override {}
+  ~WriteCTPPSTotemDAQMappingMask() override = default;
 
 private:
   const cond::Time_t daqMappingIov_;
@@ -59,7 +59,8 @@ WriteCTPPSTotemDAQMappingMask::WriteCTPPSTotemDAQMappingMask(const edm::Paramete
 void WriteCTPPSTotemDAQMappingMask::analyze(const edm::Event &, edm::EventSetup const &es) {
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
 
-  if (auto mappingHandle = es.getHandle(tokenMapping_)) {
+  auto mappingHandle = es.getHandle(tokenMapping_);
+  if (!recordMap_.empty() && mappingHandle.isValid() && !mappingHandle.failedToGet()) {
     const auto &mapping = es.getData(tokenMapping_);
     std::stringstream output;
     mapping.print(output, label_);
@@ -73,10 +74,11 @@ void WriteCTPPSTotemDAQMappingMask::analyze(const edm::Event &, edm::EventSetup 
     }
 
   } else {
-    edm::LogError("WriteCTPPSTotemDAQMappingMask mapping") << "WriteCTPPSTotemDAQMappingMask: No mapping found";
+    edm::LogWarning("WriteCTPPSTotemDAQMappingMask mapping") << "WriteCTPPSTotemDAQMappingMask: No mapping found";
   }
 
-  if (auto maskHandle = es.getHandle(tokenAnalysisMask_)) {
+  auto maskHandle = es.getHandle(tokenAnalysisMask_);
+  if (!recordMask_.empty() && maskHandle.isValid() && !maskHandle.failedToGet()) {
     const auto &analysisMask = es.getData(tokenAnalysisMask_);
     edm::LogInfo("WriteCTPPSTotemDAQMappingMask mask") << analysisMask;
 
@@ -87,7 +89,7 @@ void WriteCTPPSTotemDAQMappingMask::analyze(const edm::Event &, edm::EventSetup 
           << "WriteCTPPSTotemDAQMappingMask: PoolDBService not availible. Data not written.";
     }
   } else {
-    edm::LogError("WriteCTPPSTotemDAQMappingMask mask") << "WriteCTPPSTotemDAQMappingMask: No analysis mask found";
+    edm::LogWarning("WriteCTPPSTotemDAQMappingMask mask") << "WriteCTPPSTotemDAQMappingMask: No analysis mask found";
   }
 }
 

--- a/CondTools/CTPPS/python/mappings_PPSObjects_XML_cfi.py
+++ b/CondTools/CTPPS/python/mappings_PPSObjects_XML_cfi.py
@@ -149,10 +149,25 @@ totemT2 = {
   ]
 }
 
+analysisMask = {
+  "dbConnect": "sqlite_file:CTPPS_AnalysisMask.db",
+  "subSystemName": "",
+  "multipleChannelsPerPayload": False,
+  "configuration": [
+    {
+      "sampicSubDetId": cms.uint32(7),
+      "validityRange" : cms.EventRange("1:min - 999999999:max"),
+      "mappingFileNames": cms.vstring(),
+      "maskFileNames" : cms.vstring()
+    }
+  ]
+}
+
 filesMap = {
   "TotemTiming": totemTiming,
   "TimingDiamond":timingDiamond,
   "TrackingStrip": trackingStrip, 
-  "TotemT2":totemT2
+  "TotemT2":totemT2,
+  "AnalysisMask": analysisMask
 }
 

--- a/CondTools/CTPPS/test/script-ctpps-write-many-XML-to-SQLite.py
+++ b/CondTools/CTPPS/test/script-ctpps-write-many-XML-to-SQLite.py
@@ -7,10 +7,14 @@ import sys
 # Script which reads data from XML and drops objects to SQLite
 # Run with python3
 
-filesToWrite = [totemTiming, timingDiamond, trackingStrip, totemT2] 
+filesToWrite = [totemTiming, timingDiamond, trackingStrip, totemT2, analysisMask] 
+writeBothRecords = False
 
-if(len(sys.argv)>1):
-  filesToWrite = [filesMap[mapName] for mapName in sys.argv[1:]]
+if(len(sys.argv)>1 and sys.argv[1].lower()=='true'):
+  writeBothRecords = True
+
+if(len(sys.argv)>2):
+  filesToWrite = [filesMap[mapName] for mapName in sys.argv[2:]]
 
 
 # For each file change the variable values in the config so that they match the selected XML file and then run the config
@@ -34,6 +38,19 @@ for fileContent in filesToWrite:
           content = re.sub(r'mappingFileNames =.*', f'mappingFileNames = {fileInfo["mappingFileNames"]},', content)
           content = re.sub(r'maskFileNames =.*', f'maskFileNames = {fileInfo["maskFileNames"]},', content)
           
+          
+          mapRcd = ''
+          maskRcd = ''
+          if writeBothRecords or fileContent != analysisMask:
+            mapRcd = 'TotemReadoutRcd'
+          if writeBothRecords or fileContent == analysisMask:
+            maskRcd = 'TotemAnalysisMaskRcd'
+            
+            
+          content = re.sub(r'recordMap = cms.string.*', f"recordMap = cms.string('{mapRcd}'),", content)
+          content = re.sub(r'recordMask = cms.string.*', f"recordMask = cms.string('{maskRcd}'),", content)
+            
+            
           f.seek(0)
           f.write(content)
           f.truncate()

--- a/CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh
+++ b/CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh
@@ -3,17 +3,21 @@
 function die { echo $1: status $2 ; exit $2; }
 
 DET_TO_CHECK=("TotemTiming" "TimingDiamond" "TrackingStrip" "TotemT2")
+MASK_DATA="AnalysisMask"
 TEST_DIR=$CMSSW_BASE/src/CondTools/CTPPS/test
 PRINTER_SCRIPT=$CMSSW_BASE/src/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
 
 # ---------------
-python3 ${TEST_DIR}/script-ctpps-write-many-XML-to-SQLite.py "${DET_TO_CHECK[@]}" || die 'Failed in script-ctpps-write-many-XML-to-SQLite.py' $?
+python3 ${TEST_DIR}/script-ctpps-write-many-XML-to-SQLite.py False "${DET_TO_CHECK[@]}" || die 'Failed in script-ctpps-write-many-XML-to-SQLite.py' $?
+python3 ${TEST_DIR}/script-ctpps-write-many-XML-to-SQLite.py False "${MASK_DATA}" || die 'Failed in script-ctpps-write-many-XML-to-SQLite.py' $?
 echo "Generated SQLite files"
 
-python3 ${PRINTER_SCRIPT} True "${DET_TO_CHECK[@]}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
+python3 ${PRINTER_SCRIPT} True False "${DET_TO_CHECK[@]}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
+python3 ${PRINTER_SCRIPT} True False "${MASK_DATA}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
 echo "Generated text files with SQLite content"
 
-python3 ${PRINTER_SCRIPT} False "${DET_TO_CHECK[@]}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
+python3 ${PRINTER_SCRIPT} False False "${DET_TO_CHECK[@]}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
+python3 ${PRINTER_SCRIPT} False False "${MASK_DATA}" || die 'Failed in script_test_many_writeTotemDAQMapping.py' $?
 echo "Generated text files with XML content"
 
 # ---------------
@@ -21,6 +25,7 @@ for det in "${DET_TO_CHECK[@]}"
 do
     diff all_${det}_db.txt all_${det}_xml.txt > /dev/null || die "Failed in XML and SQLite files comparison for det ${det}" $?
 done
+diff all__db.txt all__xml.txt > /dev/null || die "Failed in XML and SQLite files comparison for det ${MASK_DATA}" $?
 echo "Checked whether SQLite and XML content is the same"
 
 
@@ -30,4 +35,7 @@ do
     rm all_${det}_db.txt all_${det}_xml.txt
     rm CTPPS${det}_DAQMapping.db
 done
+rm all__db.txt all__xml.txt
+rm CTPPS_AnalysisMask.db
+
 echo "Cleaned after tests"


### PR DESCRIPTION
#### PR description:

This PR is makes a small addition to work started in PR  #42471 concerning migration of all PPS detectors' mappings from XML to CondDB.

In this PR are updates of: 

- plugin which creates SQLite files based on XML files ([CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:mapping-dump-update?expand=1#diff-140c17cd5e469a3e3692f7f3e397d10512b8b9e95d1038ac986f3737902f8475))
- plugin which reads SQLite/XML file and dumps data to text file ([CalibPPS/ESProducers/plugins/WriteTotemDAQMapping.cc](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:mapping-dump-update?expand=1#diff-276299009e7ad4e9336945c66d7cfcb5b6ec85d7835707bcd3096bcfb382c7dc))
- configs/scripts used for tests


Previously both AnalysisMask and DAQMapping were read from XML files.
Based on that TotemReadoutRcd and AnalysisMaskRcd records were created and dumped to one SQLite file.

**This PR makes possible to dump only one record to SQLite file (using WriteCTPPSTotemDAQMappingMask plugin).**
Also  adds option to read and dump only one record from SQLite/XML files (using WriteTotemDAQMapping plugin).


#### PR validation:

To validate this PR I used a test I made for PR  #42471 ([CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:mapping-dump-update?expand=1#diff-1dba015306a25198f8fc530bec2f491c24af99f0b3fafb31d66dba92e8df90cd)).

In the test firstly SQLite files are created based on XML files. In each SQLite file is only one type of record (TotemReadoutRcd or AnalysisMaskRcd).
Then data is read from SQLite files and dumped to text files.
Then data is read from XML files and dumped to text files.
Then corresponding text files are compared.

The results show that the data is the same in XML and SQLite, so the migration from XML to SQLite was successful.

---
@grzanka for your attention