### PR TITLE
Don't run testAllocMonitorPreloadX tests for ASAN IBs

### DIFF
--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -3,21 +3,23 @@
   <use name="catch2"/>
 </bin>
 
-<bin file="test_proxies.cc" name="testAllocMonitorPreload">
-  <use name="PerfTools/AllocMonitor"/>
-  <use name="PerfTools/AllocMonitorPreload"/>
-  <flags CXXFLAGS="-O0"/>
-</bin>
+<ifrelease name="!_ASAN_">
+  <bin file="test_proxies.cc" name="testAllocMonitorPreload">
+    <use name="PerfTools/AllocMonitor"/>
+    <use name="PerfTools/AllocMonitorPreload"/>
+    <flags CXXFLAGS="-O0"/>
+  </bin>
 
-<bin file="test_proxies.cc" name="testAllocMonitorPreloadTC">
-  <use name="PerfTools/AllocMonitor"/>
-  <use name="PerfTools/AllocMonitorPreload"/>
-  <use name="tcmalloc_minimal"/>
-  <flags CXXFLAGS="-O0"/>
-</bin>
-<bin file="test_proxies.cc" name="testAllocMonitorPreloadJE">
-  <use name="PerfTools/AllocMonitor"/>
-  <use name="PerfTools/AllocMonitorPreload"/>
-  <use name="jemalloc"/>
-  <flags CXXFLAGS="-O0"/>
-</bin>
+  <bin file="test_proxies.cc" name="testAllocMonitorPreloadTC">
+    <use name="PerfTools/AllocMonitor"/>
+    <use name="PerfTools/AllocMonitorPreload"/>
+    <use name="tcmalloc_minimal"/>
+    <flags CXXFLAGS="-O0"/>
+  </bin>
+  <bin file="test_proxies.cc" name="testAllocMonitorPreloadJE">
+    <use name="PerfTools/AllocMonitor"/>
+    <use name="PerfTools/AllocMonitorPreload"/>
+    <use name="jemalloc"/>
+    <flags CXXFLAGS="-O0"/>
+  </bin>
+</ifrelease>


### PR DESCRIPTION
Fixes #42758 

#### PR description:

Don't run testAllocMonitorPreloadX tests for ASAN IBs

#### PR validation:

Bot tests