### PR TITLE
[Phase2HLT] Change hltAK4PFPuppiJets correctors tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -88,7 +88,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '132X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '132X_mcRun4_realistic_v1'
+    'phase2_realistic'             : '132X_mcRun4_realistic_v2'
 }
 
 aliases = {

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL1_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL1_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 hltAK4PFPuppiJetCorrectorL1 = cms.EDProducer("L1FastjetCorrectorProducer",
-    #algorithm = cms.string('AK4PFPuppiHLT'),
-    algorithm = cms.string('AK4PFPuppi'),
+    algorithm = cms.string('AK4PFPuppiHLT'),
+    #algorithm = cms.string('AK4PFPuppi'),
     level = cms.string('L1FastJet'),
     srcRho = cms.InputTag("fixedGridRhoFastjetAllTmp")
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL2_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL2_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hltAK4PFPuppiJetCorrectorL2 = cms.EDProducer("LXXXCorrectorProducer",
-    #algorithm = cms.string('AK4PFPuppiHLT'),
-    algorithm = cms.string('AK4PFPuppi'),
+    algorithm = cms.string('AK4PFPuppiHLT'),
+    #algorithm = cms.string('AK4PFPuppi'),
     level = cms.string('L2Relative')
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL3_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltAK4PFPuppiJetCorrectorL3_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hltAK4PFPuppiJetCorrectorL3 = cms.EDProducer("LXXXCorrectorProducer",
-    #algorithm = cms.string('AK4PFPuppiHLT'),
-    algorithm = cms.string('AK4PFPuppi'),
+    algorithm = cms.string('AK4PFPuppiHLT'),
+    #algorithm = cms.string('AK4PFPuppi'),
     level = cms.string('L3Absolute')
 )


### PR DESCRIPTION
#### PR description:

The PR updates the labels used for AK4PFPuppi jets in HLT Phase2 menu. This is to use the latest updated corrections used for HLT jets/MET studies, [uploaded recently in the GT](https://cms-talk.web.cern.ch/t/mc-phase2hlt-new-jet-energy-corrections-for-ak4puppi-jets/29741)

#### PR validation:

Running the standard Phase2 workflow produces no error
`runTheMatrix.py -l 24834.0`
