### PR TITLE
T0 scenario for repacked pp

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-_ppEra_Run3_2023_
+_ppEra_Run3_2023_repacked_
 
 Scenario supporting proton collisions for 2023 with updated HCAL Barrel thresholds
 

--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2023_
+
+Scenario supporting proton collisions for 2023 with updated HCAL Barrel thresholds
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2023_repacked(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.isRepacked=True
+        self.eras=Run3_2023
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
+    """
+    _ppEra_Run3_2023_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2023
+
+    """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -57,7 +57,7 @@ do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
-declare -a arr=("ppEra_Run3" "ppEra_Run3_repacked")
+declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -57,7 +57,7 @@ do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
-declare -a arr=("ppEra_Run3")
+declare -a arr=("ppEra_Run3" "ppEra_Run3_repacked")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
New T0 scenario for pp reco, but with the RAW data format that is repacked at the HLT.
https://cms-talk.web.cern.ch/t/possible-issue-with-t0-config-for-hi-prompt-reco

A backport to 13_2_X will be made.

Tested with the help of German. 
