### PR TITLE
Add missing include to FitWithRooFit.h

### DIFF
--- a/Alignment/OfflineValidation/interface/FitWithRooFit.h
+++ b/Alignment/OfflineValidation/interface/FitWithRooFit.h
@@ -17,6 +17,7 @@
 #include "RooDataHist.h"
 #include "RooAddPdf.h"
 #include "RooChebychev.h"
+#include "RooFitResult.h"
 #include "RooGenericPdf.h"
 #include "RooGaussModel.h"
 #include "RooAddModel.h"

--- a/DQMOffline/Trigger/plugins/GenericTnPFitter.h
+++ b/DQMOffline/Trigger/plugins/GenericTnPFitter.h
@@ -9,6 +9,7 @@
 #include "RooGlobalFunc.h"
 #include "RooCategory.h"
 #include "RooSimultaneous.h"
+#include "RooFitResult.h"
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH2F.h"


### PR DESCRIPTION
#### PR description:

All RooFit functions now return an owning pointer (`std::unique_ptr`) instead of a raw pointer. A destructor of `std::unique_ptr` calls wrapped class' destructor, so that class needs to be fully defined, or the compilation will fail with 
```
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/bits/unique_ptr.h:83:23: error: invalid application of 'sizeof' to incomplete type 'RooFitResult'
   83 |         static_assert(sizeof(_Tp)>0,
      |                       ^~~~~~~~~~~
gmake: *** [tmp/el8_amd64_gcc11/src/DQMOffline/Alignment/src/DQMOfflineAlignment/DiMuonMassBiasClient.cc.o] Error 1
```

#### PR validation:

Tested in https://github.com/cms-sw/cmsdist/pull/8734

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
