### PR TITLE
Update `FitWithRooFit` in Alignment/OfflineValidation to fix memory leaks

### DIFF
--- a/Alignment/OfflineValidation/interface/FitWithRooFit.h
+++ b/Alignment/OfflineValidation/interface/FitWithRooFit.h
@@ -1,9 +1,7 @@
 #ifndef Alignment_OfflineValidation_FitWithRooFit_h
 #define Alignment_OfflineValidation_FitWithRooFit_h
 
-#ifndef __CINT__
 #include "RooGlobalFunc.h"
-#endif
 #include "TCanvas.h"
 #include "TTree.h"
 #include "TH1D.h"
@@ -44,264 +42,129 @@
  * The methods names after the variables return the fit result.
  */
 
-namespace {
-  typedef std::pair<RooRealVar, RooDataHist*> rooPair;
-}
-
 class FitWithRooFit {
 public:
-  FitWithRooFit()
-      : useChi2_(false),
-        mean_(nullptr),
-        mean2_(nullptr),
-        mean3_(nullptr),
-        sigma_(nullptr),
-        sigma2_(nullptr),
-        sigma3_(nullptr),
-        gamma_(nullptr),
-        gaussFrac_(nullptr),
-        gaussFrac2_(nullptr),
-        expCoeffa0_(nullptr),
-        expCoeffa1_(nullptr),
-        expCoeffa2_(nullptr),
-        fsig_(nullptr),
-        a0_(nullptr),
-        a1_(nullptr),
-        a2_(nullptr),
-        a3_(nullptr),
-        a4_(nullptr),
-        a5_(nullptr),
-        a6_(nullptr),
-        alpha_(nullptr),
-        n_(nullptr),
-        fGCB_(nullptr) {}
-
-  rooPair importTH1(TH1* histo, const double& inputXmin, const double& inputXmax);
+  std::unique_ptr<RooDataHist> importTH1(TH1* histo, double xMin, double xMax);
 
   void fit(TH1* histo,
            const TString signalType,
            const TString backgroundType,
-           const double& xMin = 0.,
-           const double& xMax = 0.,
+           double xMin = 0.,
+           double xMax = 0.,
            bool sumW2Error = false);
 
-  void initMean(const double& value,
-                const double& min,
-                const double& max,
-                const TString& name = "mean",
-                const TString& title = "mean");
+  void initMean(double value, double min, double max, const TString& name = "mean", const TString& title = "mean");
+  void initMean2(double value, double min, double max, const TString& name = "mean2", const TString& title = "mean2");
+  void initMean3(double value, double min, double max, const TString& name = "mean3", const TString& title = "mean3");
+  void initSigma(double value, double min, double max, const TString& name = "sigma", const TString& title = "sigma");
+  void initSigma2(double value, double min, double max, const TString& name = "sigma2", const TString& title = "sigma2");
+  void initSigma3(double value, double min, double max, const TString& name = "sigma3", const TString& title = "sigma3");
+  void initGamma(double value, double min, double max, const TString& name = "gamma", const TString& title = "gamma");
+  void initGaussFrac(
+      double value, double min, double max, const TString& name = "GaussFrac", const TString& title = "GaussFrac");
+  void initGaussFrac2(
+      double value, double min, double max, const TString& name = "GaussFrac2", const TString& title = "GaussFrac2");
+  void initExpCoeffA0(
+      double value, double min, double max, const TString& name = "expCoeffa0", const TString& title = "expCoeffa0");
+  void initExpCoeffA1(
+      double value, double min, double max, const TString& name = "expCoeffa1", const TString& title = "expCoeffa1");
+  void initExpCoeffA2(
+      double value, double min, double max, const TString& name = "expCoeffa2", const TString& title = "expCoeffa2");
+  void initFsig(
+      double value, double min, double max, const TString& name = "fsig", const TString& title = "signal fraction");
+  void initA0(double value, double min, double max, const TString& name = "a0", const TString& title = "a0");
+  void initA1(double value, double min, double max, const TString& name = "a1", const TString& title = "a1");
+  void initA2(double value, double min, double max, const TString& name = "a2", const TString& title = "a2");
+  void initA3(double value, double min, double max, const TString& name = "a3", const TString& title = "a3");
+  void initA4(double value, double min, double max, const TString& name = "a4", const TString& title = "a4");
+  void initA5(double value, double min, double max, const TString& name = "a5", const TString& title = "a5");
+  void initA6(double value, double min, double max, const TString& name = "a6", const TString& title = "a6");
+  void initAlpha(double value, double min, double max, const TString& name = "alpha", const TString& title = "alpha");
+  void initN(double value, double min, double max, const TString& name = "n", const TString& title = "n");
+  void initFGCB(double value, double min, double max, const TString& name = "fGCB", const TString& title = "fGCB");
 
-  void initMean2(const double& value,
-                 const double& min,
-                 const double& max,
-                 const TString& name = "mean2",
-                 const TString& title = "mean2");
-
-  void initMean3(const double& value,
-                 const double& min,
-                 const double& max,
-                 const TString& name = "mean3",
-                 const TString& title = "mean3");
-
-  void initSigma(const double& value,
-                 const double& min,
-                 const double& max,
-                 const TString& name = "sigma",
-                 const TString& title = "sigma");
-
-  void initSigma2(const double& value,
-                  const double& min,
-                  const double& max,
-                  const TString& name = "sigma2",
-                  const TString& title = "sigma2");
-
-  void initSigma3(const double& value,
-                  const double& min,
-                  const double& max,
-                  const TString& name = "sigma3",
-                  const TString& title = "sigma3");
-
-  void initGamma(const double& value,
-                 const double& min,
-                 const double& max,
-                 const TString& name = "gamma",
-                 const TString& title = "gamma");
-
-  void initGaussFrac(const double& value,
-                     const double& min,
-                     const double& max,
-                     const TString& name = "GaussFrac",
-                     const TString& title = "GaussFrac");
-
-  void initGaussFrac2(const double& value,
-                      const double& min,
-                      const double& max,
-                      const TString& name = "GaussFrac2",
-                      const TString& title = "GaussFrac2");
-
-  void initExpCoeffA0(const double& value,
-                      const double& min,
-                      const double& max,
-                      const TString& name = "expCoeffa0",
-                      const TString& title = "expCoeffa0");
-
-  void initExpCoeffA1(const double& value,
-                      const double& min,
-                      const double& max,
-                      const TString& name = "expCoeffa1",
-                      const TString& title = "expCoeffa1");
-
-  void initExpCoeffA2(const double& value,
-                      const double& min,
-                      const double& max,
-                      const TString& name = "expCoeffa2",
-                      const TString& title = "expCoeffa2");
-
-  void initFsig(const double& value,
-                const double& min,
-                const double& max,
-                const TString& name = "fsig",
-                const TString& title = "signal fraction");
-
-  void initA0(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a0",
-              const TString& title = "a0");
-
-  void initA1(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a1",
-              const TString& title = "a1");
-
-  void initA2(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a2",
-              const TString& title = "a2");
-
-  void initA3(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a3",
-              const TString& title = "a3");
-
-  void initA4(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a4",
-              const TString& title = "a4");
-
-  void initA5(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a5",
-              const TString& title = "a5");
-
-  void initA6(const double& value,
-              const double& min,
-              const double& max,
-              const TString& name = "a6",
-              const TString& title = "a6");
-
-  void initAlpha(const double& value,
-                 const double& min,
-                 const double& max,
-                 const TString& name = "alpha",
-                 const TString& title = "alpha");
-
-  void initN(
-      const double& value, const double& min, const double& max, const TString& name = "n", const TString& title = "n");
-
-  void initFGCB(const double& value,
-                const double& min,
-                const double& max,
-                const TString& name = "fGCB",
-                const TString& title = "fGCB");
-
-  inline RooRealVar* mean() { return mean_; }
-  inline RooRealVar* mean2() { return mean2_; }
-  inline RooRealVar* mean3() { return mean3_; }
-  inline RooRealVar* sigma() { return sigma_; }
-  inline RooRealVar* sigma2() { return sigma2_; }
-  inline RooRealVar* sigma3() { return sigma3_; }
-  inline RooRealVar* gamma() { return gamma_; }
-  inline RooRealVar* gaussFrac() { return gaussFrac_; }
-  inline RooRealVar* gaussFrac2() { return gaussFrac2_; }
-  inline RooRealVar* expCoeffa0() { return expCoeffa0_; }
-  inline RooRealVar* expCoeffa1() { return expCoeffa1_; }
-  inline RooRealVar* expCoeffa2() { return expCoeffa2_; }
-  inline RooRealVar* fsig() { return fsig_; }
-  inline RooRealVar* a0() { return a0_; }
-  inline RooRealVar* a1() { return a1_; }
-  inline RooRealVar* a2() { return a2_; }
-  inline RooRealVar* a3() { return a3_; }
-  inline RooRealVar* a4() { return a4_; }
-  inline RooRealVar* a5() { return a5_; }
-  inline RooRealVar* a6() { return a6_; }
-  inline RooRealVar* alpha() { return alpha_; }
-  inline RooRealVar* n() { return n_; }
-  inline RooRealVar* fGCB() { return fGCB_; }
+  inline RooRealVar* mean() { return mean_.get(); }
+  inline RooRealVar* mean2() { return mean2_.get(); }
+  inline RooRealVar* mean3() { return mean3_.get(); }
+  inline RooRealVar* sigma() { return sigma_.get(); }
+  inline RooRealVar* sigma2() { return sigma2_.get(); }
+  inline RooRealVar* sigma3() { return sigma3_.get(); }
+  inline RooRealVar* gamma() { return gamma_.get(); }
+  inline RooRealVar* gaussFrac() { return gaussFrac_.get(); }
+  inline RooRealVar* gaussFrac2() { return gaussFrac2_.get(); }
+  inline RooRealVar* expCoeffa0() { return expCoeffa0_.get(); }
+  inline RooRealVar* expCoeffa1() { return expCoeffa1_.get(); }
+  inline RooRealVar* expCoeffa2() { return expCoeffa2_.get(); }
+  inline RooRealVar* fsig() { return fsig_.get(); }
+  inline RooRealVar* a0() { return a0_.get(); }
+  inline RooRealVar* a1() { return a1_.get(); }
+  inline RooRealVar* a2() { return a2_.get(); }
+  inline RooRealVar* a3() { return a3_.get(); }
+  inline RooRealVar* a4() { return a4_.get(); }
+  inline RooRealVar* a5() { return a5_.get(); }
+  inline RooRealVar* a6() { return a6_.get(); }
+  inline RooRealVar* alpha() { return alpha_.get(); }
+  inline RooRealVar* n() { return n_.get(); }
+  inline RooRealVar* fGCB() { return fGCB_.get(); }
 
   void reinitializeParameters();
 
-  RooAbsPdf* buildSignalModel(RooRealVar* x, const TString& signalType);
-  RooAbsPdf* buildBackgroundModel(RooRealVar* x, const TString& backgroundType);
-  RooAbsPdf* buildModel(RooRealVar* x, const TString& signalType, const TString& backgroundType);
+  std::unique_ptr<RooAbsPdf> buildSignalModel(RooRealVar* x, const TString& signalType);
+  std::unique_ptr<RooAbsPdf> buildBackgroundModel(RooRealVar* x, const TString& backgroundType);
+  std::unique_ptr<RooAbsPdf> buildModel(RooRealVar* x, const TString& signalType, const TString& backgroundType);
 
-  bool useChi2_;
+  bool useChi2_ = false;
 
 protected:
   // Declare all variables
-  RooRealVar* mean_;
-  RooRealVar* mean2_;
-  RooRealVar* mean3_;
-  RooRealVar* sigma_;
-  RooRealVar* sigma2_;
-  RooRealVar* sigma3_;
-  RooRealVar* gamma_;
-  RooRealVar* gaussFrac_;
-  RooRealVar* gaussFrac2_;
-  RooRealVar* expCoeffa0_;
-  RooRealVar* expCoeffa1_;
-  RooRealVar* expCoeffa2_;
-  RooRealVar* fsig_;
-  RooRealVar* a0_;
-  RooRealVar* a1_;
-  RooRealVar* a2_;
-  RooRealVar* a3_;
-  RooRealVar* a4_;
-  RooRealVar* a5_;
-  RooRealVar* a6_;
-  RooRealVar* alpha_;
-  RooRealVar* n_;
-  RooRealVar* fGCB_;
+  std::unique_ptr<RooRealVar> mean_;
+  std::unique_ptr<RooRealVar> mean2_;
+  std::unique_ptr<RooRealVar> mean3_;
+  std::unique_ptr<RooRealVar> sigma_;
+  std::unique_ptr<RooRealVar> sigma2_;
+  std::unique_ptr<RooRealVar> sigma3_;
+  std::unique_ptr<RooRealVar> gamma_;
+  std::unique_ptr<RooRealVar> gaussFrac_;
+  std::unique_ptr<RooRealVar> gaussFrac2_;
+  std::unique_ptr<RooRealVar> expCoeffa0_;
+  std::unique_ptr<RooRealVar> expCoeffa1_;
+  std::unique_ptr<RooRealVar> expCoeffa2_;
+  std::unique_ptr<RooRealVar> fsig_;
+  std::unique_ptr<RooRealVar> a0_;
+  std::unique_ptr<RooRealVar> a1_;
+  std::unique_ptr<RooRealVar> a2_;
+  std::unique_ptr<RooRealVar> a3_;
+  std::unique_ptr<RooRealVar> a4_;
+  std::unique_ptr<RooRealVar> a5_;
+  std::unique_ptr<RooRealVar> a6_;
+  std::unique_ptr<RooRealVar> alpha_;
+  std::unique_ptr<RooRealVar> n_;
+  std::unique_ptr<RooRealVar> fGCB_;
 
   // Initial values
-  double initVal_mean;
-  double initVal_mean2;
-  double initVal_mean3;
-  double initVal_sigma;
-  double initVal_sigma2;
-  double initVal_sigma3;
-  double initVal_gamma;
-  double initVal_gaussFrac;
-  double initVal_gaussFrac2;
-  double initVal_expCoeffa0;
-  double initVal_expCoeffa1;
-  double initVal_expCoeffa2;
-  double initVal_fsig;
-  double initVal_a0;
-  double initVal_a1;
-  double initVal_a2;
-  double initVal_a3;
-  double initVal_a4;
-  double initVal_a5;
-  double initVal_a6;
-  double initVal_alpha;
-  double initVal_n;
-  double initVal_fGCB;
+  double initVal_mean = 0.0;
+  double initVal_mean2 = 0.0;
+  double initVal_mean3 = 0.0;
+  double initVal_sigma = 0.0;
+  double initVal_sigma2 = 0.0;
+  double initVal_sigma3 = 0.0;
+  double initVal_gamma = 0.0;
+  double initVal_gaussFrac = 0.0;
+  double initVal_gaussFrac2 = 0.0;
+  double initVal_expCoeffa0 = 0.0;
+  double initVal_expCoeffa1 = 0.0;
+  double initVal_expCoeffa2 = 0.0;
+  double initVal_fsig = 0.0;
+  double initVal_a0 = 0.0;
+  double initVal_a1 = 0.0;
+  double initVal_a2 = 0.0;
+  double initVal_a3 = 0.0;
+  double initVal_a4 = 0.0;
+  double initVal_a5 = 0.0;
+  double initVal_a6 = 0.0;
+  double initVal_alpha = 0.0;
+  double initVal_n = 0.0;
+  double initVal_fGCB = 0.0;
 };
 
 #endif

--- a/Alignment/OfflineValidation/src/FitWithRooFit.cc
+++ b/Alignment/OfflineValidation/src/FitWithRooFit.cc
@@ -1,10 +1,9 @@
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Alignment/OfflineValidation/interface/FitWithRooFit.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 // Import TH1 histogram into a RooDataHist
-rooPair FitWithRooFit::importTH1(TH1* histo, const double& inputXmin, const double& inputXmax) {
-  double xMin = inputXmin;
-  double xMax = inputXmax;
+std::unique_ptr<RooDataHist> FitWithRooFit::importTH1(TH1* histo, double xMin, double xMax) {
   if ((xMin == xMax) && xMin == 0) {
     xMin = histo->GetXaxis()->GetXmin();
     xMax = histo->GetXaxis()->GetXmax();
@@ -12,21 +11,16 @@ rooPair FitWithRooFit::importTH1(TH1* histo, const double& inputXmin, const doub
   // Declare observable x
   RooRealVar x("InvMass", "di-muon mass M(#mu^{+}#mu^{-}) [GeV]", xMin, xMax);
   // Create a binned dataset that imports contents of TH1 and associates its contents to observable 'x'
-  return (std::make_pair(x, new RooDataHist("dh", "dh", x, RooFit::Import(*histo))));
+  return std::make_unique<RooDataHist>("dh", "dh", x, RooFit::Import(*histo));
 }
 
 // Plot and fit a RooDataHist fitting signal and background
-void FitWithRooFit::fit(TH1* histo,
-                        const TString signalType,
-                        const TString backgroundType,
-                        const double& xMin,
-                        const double& xMax,
-                        bool sumW2Error) {
+void FitWithRooFit::fit(
+    TH1* histo, const TString signalType, const TString backgroundType, double xMin, double xMax, bool sumW2Error) {
   reinitializeParameters();
 
-  rooPair imported = importTH1(histo, xMin, xMax);
-  RooRealVar x(imported.first);
-  RooDataHist* dh = imported.second;
+  std::unique_ptr<RooDataHist> dh = importTH1(histo, xMin, xMax);
+  RooRealVar x(*static_cast<RooRealVar*>(dh->get()->find("x")));
 
   // Make plot of binned dataset showing Poisson error bars (RooFit default)
   RooPlot* frame = x.frame(RooFit::Title("di-muon mass M(#mu^{+}#mu^{-}) [GeV]"));
@@ -34,7 +28,7 @@ void FitWithRooFit::fit(TH1* histo,
   dh->plotOn(frame);
 
   // Build the composite model
-  RooAbsPdf* model = buildModel(&x, signalType, backgroundType);
+  std::unique_ptr<RooAbsPdf> model = buildModel(&x, signalType, backgroundType);
 
   std::unique_ptr<RooAbsReal> chi2{model->createChi2(*dh, RooFit::DataError(RooAbsData::SumW2))};
 
@@ -42,10 +36,7 @@ void FitWithRooFit::fit(TH1* histo,
   // -----------------------
   // Fit with likelihood
   if (!useChi2_) {
-    if (sumW2Error)
-      model->fitTo(*dh, RooFit::Save(), RooFit::SumW2Error(kTRUE));
-    else
-      model->fitTo(*dh);
+    model->fitTo(*dh, RooFit::SumW2Error(sumW2Error));
   }
   // Fit with chi^2
   else {
@@ -102,242 +93,154 @@ void FitWithRooFit::fit(TH1* histo,
 }
 
 // Initialization methods for all the parameters
-void FitWithRooFit::initMean(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (mean_ != nullptr)
-    delete mean_;
-  mean_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initMean(double value, double min, double max, const TString& name, const TString& title) {
+  mean_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_mean = value;
 }
 
-void FitWithRooFit::initMean2(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (mean2_ != nullptr)
-    delete mean2_;
-  mean2_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initMean2(double value, double min, double max, const TString& name, const TString& title) {
+  mean2_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_mean2 = value;
 }
 
-void FitWithRooFit::initMean3(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (mean3_ != nullptr)
-    delete mean3_;
-  mean3_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initMean3(double value, double min, double max, const TString& name, const TString& title) {
+  mean3_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_mean3 = value;
 }
 
-void FitWithRooFit::initSigma(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (sigma_ != nullptr)
-    delete sigma_;
-  sigma_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initSigma(double value, double min, double max, const TString& name, const TString& title) {
+  sigma_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_sigma = value;
 }
 
-void FitWithRooFit::initSigma2(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (sigma2_ != nullptr)
-    delete sigma2_;
-  sigma2_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initSigma2(double value, double min, double max, const TString& name, const TString& title) {
+  sigma2_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_sigma2 = value;
 }
 
-void FitWithRooFit::initSigma3(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (sigma3_ != nullptr)
-    delete sigma3_;
-  sigma3_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initSigma3(double value, double min, double max, const TString& name, const TString& title) {
+  sigma3_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_sigma3 = value;
 }
 
-void FitWithRooFit::initGamma(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (gamma_ != nullptr)
-    delete gamma_;
-  gamma_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initGamma(double value, double min, double max, const TString& name, const TString& title) {
+  gamma_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_gamma = value;
 }
 
-void FitWithRooFit::initGaussFrac(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (gaussFrac_ != nullptr)
-    delete gaussFrac_;
-  gaussFrac_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initGaussFrac(double value, double min, double max, const TString& name, const TString& title) {
+  gaussFrac_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_gaussFrac = value;
 }
 
-void FitWithRooFit::initGaussFrac2(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (gaussFrac2_ != nullptr)
-    delete gaussFrac2_;
-  gaussFrac2_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initGaussFrac2(double value, double min, double max, const TString& name, const TString& title) {
+  gaussFrac2_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_gaussFrac2 = value;
 }
 
-void FitWithRooFit::initExpCoeffA0(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (expCoeffa0_ != nullptr)
-    delete expCoeffa0_;
-  expCoeffa0_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initExpCoeffA0(double value, double min, double max, const TString& name, const TString& title) {
+  expCoeffa0_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_expCoeffa0 = value;
 }
 
-void FitWithRooFit::initExpCoeffA1(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (expCoeffa1_ != nullptr)
-    delete expCoeffa1_;
-  expCoeffa1_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initExpCoeffA1(double value, double min, double max, const TString& name, const TString& title) {
+  expCoeffa1_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_expCoeffa1 = value;
 }
 
-void FitWithRooFit::initExpCoeffA2(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (expCoeffa2_ != nullptr)
-    delete expCoeffa2_;
-  expCoeffa2_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initExpCoeffA2(double value, double min, double max, const TString& name, const TString& title) {
+  expCoeffa2_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_expCoeffa2 = value;
 }
 
-void FitWithRooFit::initFsig(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (fsig_ != nullptr)
-    delete fsig_;
-  fsig_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initFsig(double value, double min, double max, const TString& name, const TString& title) {
+  fsig_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_fsig = value;
 }
 
-void FitWithRooFit::initA0(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a0_ != nullptr)
-    delete a0_;
-  a0_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA0(double value, double min, double max, const TString& name, const TString& title) {
+  a0_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a0 = value;
 }
 
-void FitWithRooFit::initA1(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a1_ != nullptr)
-    delete a1_;
-  a1_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA1(double value, double min, double max, const TString& name, const TString& title) {
+  a1_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a1 = value;
 }
 
-void FitWithRooFit::initA2(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a2_ != nullptr)
-    delete a2_;
-  a2_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA2(double value, double min, double max, const TString& name, const TString& title) {
+  a2_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a2 = value;
 }
 
-void FitWithRooFit::initA3(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a3_ != nullptr)
-    delete a3_;
-  a3_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA3(double value, double min, double max, const TString& name, const TString& title) {
+  a3_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a3 = value;
 }
 
-void FitWithRooFit::initA4(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a4_ != nullptr)
-    delete a4_;
-  a4_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA4(double value, double min, double max, const TString& name, const TString& title) {
+  a4_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a4 = value;
 }
 
-void FitWithRooFit::initA5(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a5_ != nullptr)
-    delete a5_;
-  a5_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA5(double value, double min, double max, const TString& name, const TString& title) {
+  a5_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a5 = value;
 }
 
-void FitWithRooFit::initA6(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (a6_ != nullptr)
-    delete a6_;
-  a6_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initA6(double value, double min, double max, const TString& name, const TString& title) {
+  a6_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_a6 = value;
 }
 
-void FitWithRooFit::initAlpha(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (alpha_ != nullptr)
-    delete alpha_;
-  alpha_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initAlpha(double value, double min, double max, const TString& name, const TString& title) {
+  alpha_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_alpha = value;
 }
 
-void FitWithRooFit::initN(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (n_ != nullptr)
-    delete n_;
-  n_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initN(double value, double min, double max, const TString& name, const TString& title) {
+  n_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_n = value;
 }
 
-void FitWithRooFit::initFGCB(
-    const double& value, const double& min, const double& max, const TString& name, const TString& title) {
-  if (fGCB_ != nullptr)
-    delete fGCB_;
-  fGCB_ = new RooRealVar(name, title, value, min, max);
+void FitWithRooFit::initFGCB(double value, double min, double max, const TString& name, const TString& title) {
+  fGCB_ = std::make_unique<RooRealVar>(name, title, value, min, max);
   initVal_fGCB = value;
 }
 
 void FitWithRooFit::reinitializeParameters() {
-  if (mean_ != nullptr)
-    mean_->setVal(initVal_mean);
-  if (mean2_ != nullptr)
-    mean2_->setVal(initVal_mean2);
-  if (mean3_ != nullptr)
-    mean3_->setVal(initVal_mean3);
-  if (sigma_ != nullptr)
-    sigma_->setVal(initVal_sigma);
-  if (sigma2_ != nullptr)
-    sigma2_->setVal(initVal_sigma2);
-  if (sigma3_ != nullptr)
-    sigma3_->setVal(initVal_sigma3);
-  if (gamma_ != nullptr)
-    gamma_->setVal(initVal_gamma);
-  if (gaussFrac_ != nullptr)
-    gaussFrac_->setVal(initVal_gaussFrac);
-  if (gaussFrac2_ != nullptr)
-    gaussFrac2_->setVal(initVal_gaussFrac2);
-  if (expCoeffa0_ != nullptr)
-    expCoeffa0_->setVal(initVal_expCoeffa0);
-  if (expCoeffa1_ != nullptr)
-    expCoeffa1_->setVal(initVal_expCoeffa1);
-  if (expCoeffa2_ != nullptr)
-    expCoeffa2_->setVal(initVal_expCoeffa2);
-  if (fsig_ != nullptr)
-    fsig_->setVal(initVal_fsig);
-  if (a0_ != nullptr)
-    a0_->setVal(initVal_a0);
-  if (a1_ != nullptr)
-    a1_->setVal(initVal_a1);
-  if (a2_ != nullptr)
-    a2_->setVal(initVal_a2);
-  if (a3_ != nullptr)
-    a3_->setVal(initVal_a3);
-  if (a4_ != nullptr)
-    a4_->setVal(initVal_a4);
-  if (a5_ != nullptr)
-    a5_->setVal(initVal_a5);
-  if (a6_ != nullptr)
-    a6_->setVal(initVal_a6);
-  if (alpha_ != nullptr)
-    alpha_->setVal(initVal_alpha);
-  if (n_ != nullptr)
-    n_->setVal(initVal_n);
-  if (fGCB_ != nullptr)
-    fGCB_->setVal(initVal_fGCB);
+  auto initParam = [](std::unique_ptr<RooRealVar>& var, double val) {
+    if (var)
+      var->setVal(val);
+  };
+
+  initParam(mean_, initVal_mean);
+  initParam(mean2_, initVal_mean2);
+  initParam(mean3_, initVal_mean3);
+  initParam(sigma_, initVal_sigma);
+  initParam(sigma2_, initVal_sigma2);
+  initParam(sigma3_, initVal_sigma3);
+  initParam(gamma_, initVal_gamma);
+  initParam(gaussFrac_, initVal_gaussFrac);
+  initParam(gaussFrac2_, initVal_gaussFrac2);
+  initParam(expCoeffa0_, initVal_expCoeffa0);
+  initParam(expCoeffa1_, initVal_expCoeffa1);
+  initParam(expCoeffa2_, initVal_expCoeffa2);
+  initParam(fsig_, initVal_fsig);
+  initParam(a0_, initVal_a0);
+  initParam(a1_, initVal_a1);
+  initParam(a2_, initVal_a2);
+  initParam(a3_, initVal_a3);
+  initParam(a4_, initVal_a4);
+  initParam(a5_, initVal_a5);
+  initParam(a6_, initVal_a6);
+  initParam(alpha_, initVal_alpha);
+  initParam(n_, initVal_n);
+  initParam(fGCB_, initVal_fGCB);
 }
 
 /// Build the model for the specified signal type
-RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalType) {
-  RooAbsPdf* signal = nullptr;
+std::unique_ptr<RooAbsPdf> FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalType) {
   if (signalType == "gaussian") {
     // Fit a Gaussian p.d.f to the data
     if ((mean_ == nullptr) || (sigma_ == nullptr)) {
@@ -345,7 +248,7 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
           << "Error: one or more parameters are not initialized. Please be sure to initialize mean and sigma";
       exit(1);
     }
-    signal = new RooGaussian("gauss", "gauss", *x, *mean_, *sigma_);
+    return std::make_unique<RooGaussian>("gauss", "gauss", *x, *mean_, *sigma_);
   } else if (signalType == "doubleGaussian") {
     // Fit with double gaussian
     if ((mean_ == nullptr) || (sigma_ == nullptr) || (sigma2_ == nullptr)) {
@@ -355,7 +258,10 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     }
     RooGaussModel* gaussModel = new RooGaussModel("gaussModel", "gaussModel", *x, *mean_, *sigma_);
     RooGaussModel* gaussModel2 = new RooGaussModel("gaussModel2", "gaussModel2", *x, *mean_, *sigma2_);
-    signal = new RooAddModel("doubleGaussian", "double gaussian", RooArgList(*gaussModel, *gaussModel2), *gaussFrac_);
+    RooArgList components{*gaussModel, *gaussModel2};
+    auto out = std::make_unique<RooAddModel>("doubleGaussian", "double gaussian", components, *gaussFrac_);
+    out->addOwnedComponents(components);
+    return out;
   } else if (signalType == "tripleGaussian") {
     // Fit with triple gaussian
     if ((mean_ == nullptr) || (mean2_ == nullptr) || (mean3_ == nullptr) || (sigma_ == nullptr) ||
@@ -368,10 +274,11 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     RooGaussModel* gaussModel = new RooGaussModel("gaussModel", "gaussModel", *x, *mean_, *sigma_);
     RooGaussModel* gaussModel2 = new RooGaussModel("gaussModel2", "gaussModel2", *x, *mean2_, *sigma2_);
     RooGaussModel* gaussModel3 = new RooGaussModel("gaussModel3", "gaussModel3", *x, *mean3_, *sigma3_);
-    signal = new RooAddModel("tripleGaussian",
-                             "triple gaussian",
-                             RooArgList(*gaussModel, *gaussModel2, *gaussModel3),
-                             RooArgList(*gaussFrac_, *gaussFrac2_));
+    RooArgList components{*gaussModel, *gaussModel2, *gaussModel3};
+    auto out = std::make_unique<RooAddModel>(
+        "tripleGaussian", "triple gaussian", components, RooArgList{*gaussFrac_, *gaussFrac2_});
+    out->addOwnedComponents(components);
+    return out;
   } else if (signalType == "breitWigner") {
     // Fit a Breit-Wigner
     if ((mean_ == nullptr) || (gamma_ == nullptr)) {
@@ -379,7 +286,7 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
           << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma";
       exit(1);
     }
-    signal = new RooBreitWigner("breiWign", "breitWign", *x, *mean_, *gamma_);
+    return std::make_unique<RooBreitWigner>("breiWign", "breitWign", *x, *mean_, *gamma_);
   } else if (signalType == "relBreitWigner") {
     // Fit a relativistic Breit-Wigner
     if ((mean_ == nullptr) || (gamma_ == nullptr)) {
@@ -387,10 +294,10 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
           << "Error: one or more parameters are not initialized. Please be sure to initialize mean and gamma";
       exit(1);
     }
-    signal = new RooGenericPdf("Relativistic Breit-Wigner",
-                               "RBW",
-                               "@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",
-                               RooArgList(*x, *mean_, *gamma_));
+    return std::make_unique<RooGenericPdf>("Relativistic Breit-Wigner",
+                                           "RBW",
+                                           "@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",
+                                           RooArgList{*x, *mean_, *gamma_});
   } else if (signalType == "voigtian") {
     // Fit a Voigtian
     if ((mean_ == nullptr) || (sigma_ == nullptr) || (gamma_ == nullptr)) {
@@ -398,7 +305,7 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
           << "Error: one or more parameters are not initialized. Please be sure to initialize mean, sigma and gamma";
       exit(1);
     }
-    signal = new RooVoigtian("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
+    return std::make_unique<RooVoigtian>("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
   } else if (signalType == "crystalBall") {
     // Fit a CrystalBall
     if ((mean_ == nullptr) || (sigma_ == nullptr) || (alpha_ == nullptr) || (n_ == nullptr)) {
@@ -407,7 +314,7 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
              "alpha and n";
       exit(1);
     }
-    signal = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
+    return std::make_unique<RooCBShape>("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
   } else if (signalType == "breitWignerTimesCB") {
     // Fit a Breit Wigner convoluted with a CrystalBall
     if ((mean_ == nullptr) || (mean2_ == nullptr) || (sigma_ == nullptr) || (gamma_ == nullptr) ||
@@ -419,7 +326,9 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     }
     RooAbsPdf* bw = new RooBreitWigner("breiWigner", "breitWigner", *x, *mean_, *gamma_);
     RooAbsPdf* cb = new RooCBShape("crystalBall", "crystalBall", *x, *mean2_, *sigma_, *alpha_, *n_);
-    signal = new RooFFTConvPdf("breitWignerTimesCB", "breitWignerTimesCB", *x, *bw, *cb);
+    auto out = std::make_unique<RooFFTConvPdf>("breitWignerTimesCB", "breitWignerTimesCB", *x, *bw, *cb);
+    out->addOwnedComponents({*bw, *cb});
+    return out;
   } else if (signalType == "relBreitWignerTimesCB") {
     // Fit a relativistic Breit Wigner convoluted with a CrystalBall
     if ((mean_ == nullptr) || (mean2_ == nullptr) || (sigma_ == nullptr) || (gamma_ == nullptr) ||
@@ -432,9 +341,11 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     RooGenericPdf* bw = new RooGenericPdf("Relativistic Breit-Wigner",
                                           "RBW",
                                           "@0/(pow(@0*@0 - @1*@1,2) + @2*@2*@0*@0*@0*@0/(@1*@1))",
-                                          RooArgList(*x, *mean_, *gamma_));
+                                          {*x, *mean_, *gamma_});
     RooAbsPdf* cb = new RooCBShape("crystalBall", "crystalBall", *x, *mean2_, *sigma_, *alpha_, *n_);
-    signal = new RooFFTConvPdf("relBreitWignerTimesCB", "relBreitWignerTimesCB", *x, *bw, *cb);
+    auto out = std::make_unique<RooFFTConvPdf>("relBreitWignerTimesCB", "relBreitWignerTimesCB", *x, *bw, *cb);
+    out->addOwnedComponents({*bw, *cb});
+    return out;
   } else if (signalType == "gaussianPlusCrystalBall") {
     // Fit a Gaussian + CrystalBall with the same mean
     if ((mean_ == nullptr) || (sigma_ == nullptr) || (alpha_ == nullptr) || (n_ == nullptr) || (sigma2_ == nullptr) ||
@@ -446,9 +357,11 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     }
     RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma_, *alpha_, *n_);
     RooAbsPdf* tempGaussian = new RooGaussian("gauss", "gauss", *x, *mean_, *sigma2_);
+    RooArgList components{*tempCB, *tempGaussian};
 
-    signal =
-        new RooAddPdf("gaussianPlusCrystalBall", "gaussianPlusCrystalBall", RooArgList(*tempCB, *tempGaussian), *fGCB_);
+    auto out = std::make_unique<RooAddPdf>("gaussianPlusCrystalBall", "gaussianPlusCrystalBall", components, *fGCB_);
+    out->addOwnedComponents(components);
+    return out;
   } else if (signalType == "voigtianPlusCrystalBall") {
     // Fit a Voigtian + CrystalBall with the same mean
     if ((mean_ == nullptr) || (sigma_ == nullptr) || (gamma_ == nullptr) || (alpha_ == nullptr) || (n_ == nullptr) ||
@@ -460,9 +373,11 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     }
     RooAbsPdf* tempVoigt = new RooVoigtian("voigt", "voigt", *x, *mean_, *gamma_, *sigma_);
     RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
+    RooArgList components{*tempVoigt, *tempCB};
 
-    signal =
-        new RooAddPdf("voigtianPlusCrystalBall", "voigtianPlusCrystalBall", RooArgList(*tempCB, *tempVoigt), *fGCB_);
+    auto out = std::make_unique<RooAddPdf>("voigtianPlusCrystalBall", "voigtianPlusCrystalBall", components, *fGCB_);
+    out->addOwnedComponents(components);
+    return out;
   } else if (signalType == "breitWignerPlusCrystalBall") {
     // Fit a Breit-Wigner + CrystalBall with the same mean
     if ((mean_ == nullptr) || (gamma_ == nullptr) || (alpha_ == nullptr) || (n_ == nullptr) || (sigma2_ == nullptr) ||
@@ -474,20 +389,22 @@ RooAbsPdf* FitWithRooFit::buildSignalModel(RooRealVar* x, const TString& signalT
     }
     RooAbsPdf* tempBW = new RooBreitWigner("breitWign", "breitWign", *x, *mean_, *gamma_);
     RooAbsPdf* tempCB = new RooCBShape("crystalBall", "crystalBall", *x, *mean_, *sigma2_, *alpha_, *n_);
+    RooArgList components{*tempCB, *tempBW};
 
-    signal =
-        new RooAddPdf("breitWignerPlusCrystalBall", "breitWignerPlusCrystalBall", RooArgList(*tempCB, *tempBW), *fGCB_);
+    auto out =
+        std::make_unique<RooAddPdf>("breitWignerPlusCrystalBall", "breitWignerPlusCrystalBall", components, *fGCB_);
+    out->addOwnedComponents(components);
+    return out;
   }
 
   else if (signalType != "") {
     edm::LogError("FitWithRooFit") << "Unknown signal function: " << signalType << ". Signal will not be in the model";
   }
-  return signal;
+  return nullptr;
 }
 
 /// Build the model for the specified background type
-RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& backgroundType) {
-  RooAbsPdf* background = nullptr;
+std::unique_ptr<RooAbsPdf> FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& backgroundType) {
   if (backgroundType == "exponential") {
     // Add an exponential for the background
     if ((expCoeffa1_ == nullptr) || (fsig_ == nullptr)) {
@@ -495,7 +412,7 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
           << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeffa1 and fsig";
       exit(1);
     }
-    background = new RooExponential("exponential", "exponential", *x, *expCoeffa1_);
+    return std::make_unique<RooExponential>("exponential", "exponential", *x, *expCoeffa1_);
   }
 
   if (backgroundType == "exponentialpol") {
@@ -505,10 +422,10 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
           << "Error: one or more parameters are not initialized. Please be sure to initialize expCoeff and fsig";
       exit(1);
     }
-    background = new RooGenericPdf("exponential",
-                                   "exponential",
-                                   "TMath::Exp(@1+@2*@0+@3*@0*@0)",
-                                   RooArgList(*x, *expCoeffa0_, *expCoeffa1_, *expCoeffa2_));
+    return std::make_unique<RooGenericPdf>("exponential",
+                                           "exponential",
+                                           "TMath::Exp(@1+@2*@0+@3*@0*@0)",
+                                           RooArgList{*x, *expCoeffa0_, *expCoeffa1_, *expCoeffa2_});
   }
 
   else if (backgroundType == "chebychev0") {
@@ -518,7 +435,7 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
           << "Error: one or more parameters are not initialized. Please be sure to initialize a0";
       exit(1);
     }
-    background = new RooChebychev("chebychev0", "chebychev0", *x, *a0_);
+    return std::make_unique<RooChebychev>("chebychev0", "chebychev0", *x, *a0_);
   } else if (backgroundType == "chebychev1") {
     // Add a 2nd order chebychev polynomial background
     if ((a0_ == nullptr) || (a1_ == nullptr)) {
@@ -526,7 +443,7 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
           << "Error: one or more parameters are not initialized. Please be sure to initialize a0 and a1";
       exit(1);
     }
-    background = new RooChebychev("chebychev1", "chebychev1", *x, RooArgList(*a0_, *a1_));
+    return std::make_unique<RooChebychev>("chebychev1", "chebychev1", *x, RooArgList{*a0_, *a1_});
   } else if (backgroundType == "chebychev3") {
     // Add a 3rd order chebychev polynomial background
     if ((a0_ == nullptr) || (a1_ == nullptr) || (a2_ == nullptr) || (a3_ == nullptr)) {
@@ -534,7 +451,7 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
           << "Error: one or more parameters are not initialized. Please be sure to initialize a0, a1, a2 and a3";
       exit(1);
     }
-    background = new RooChebychev("3rdOrderPol", "3rdOrderPol", *x, RooArgList(*a0_, *a1_, *a2_, *a3_));
+    return std::make_unique<RooChebychev>("3rdOrderPol", "3rdOrderPol", *x, RooArgList{*a0_, *a1_, *a2_, *a3_});
   }
 
   else if (backgroundType == "chebychev6") {
@@ -546,30 +463,33 @@ RooAbsPdf* FitWithRooFit::buildBackgroundModel(RooRealVar* x, const TString& bac
              "a4, a5 and a6";
       exit(1);
     }
-    background =
-        new RooChebychev("6thOrderPol", "6thOrderPol", *x, RooArgList(*a0_, *a1_, *a2_, *a3_, *a4_, *a5_, *a6_));
+    return std::make_unique<RooChebychev>(
+        "6thOrderPol", "6thOrderPol", *x, RooArgList{*a0_, *a1_, *a2_, *a3_, *a4_, *a5_, *a6_});
   }
-
-  return background;
+  return nullptr;
 }
 
 /// Build the model to fit
-RooAbsPdf* FitWithRooFit::buildModel(RooRealVar* x, const TString& signalType, const TString& backgroundType) {
-  RooAbsPdf* model = nullptr;
+std::unique_ptr<RooAbsPdf> FitWithRooFit::buildModel(RooRealVar* x,
+                                                     const TString& signalType,
+                                                     const TString& backgroundType) {
+  std::unique_ptr<RooAbsPdf> model;
 
-  RooAbsPdf* signal = buildSignalModel(x, signalType);
-  RooAbsPdf* background = buildBackgroundModel(x, backgroundType);
+  std::unique_ptr<RooAbsPdf> signal = buildSignalModel(x, signalType);
+  std::unique_ptr<RooAbsPdf> background = buildBackgroundModel(x, backgroundType);
 
   if ((signal != nullptr) && (background != nullptr)) {
     // Combine signal and background pdfs
     edm::LogPrint("FitWithRooFit") << "Building model with signal and backgound";
-    model = new RooAddPdf("model", "model", RooArgList(*signal, *background), *fsig_);
+    RooArgList components{*signal.release(), *background.release()};
+    model = std::make_unique<RooAddPdf>("model", "model", components, *fsig_);
+    model->addOwnedComponents(components);
   } else if (signal != nullptr) {
     edm::LogPrint("FitWithRooFit") << "Building model with signal";
-    model = signal;
+    model = std::move(signal);
   } else if (background != nullptr) {
     edm::LogPrint("FitWithRooFit") << "Building model with backgound";
-    model = background;
+    model = std::move(background);
   } else {
     edm::LogWarning("FitWithRooFit") << "Nothing to fit";
     exit(0);


### PR DESCRIPTION
#### PR description:

  * Avoid memory leak of RooDataHist by wrapping it in `unique_ptr`

  * Avoid memory leaks of RooRealVars also by wrapping in `unique_ptr`

  * Avoid leaking RooAbsPdf models also with `unique_ptr`

  * Avoid memory leak of model components by passing ownership to the top-level pdf via `RooAbsArg::addOwnedComponents()`

  * Use `double` instead of `const double&` for function parameters

  * Avoid a leaking fit result because of the `Save()` command argument to `fitTo()` (if one uses `Save()`, the fitting routine returns a `RooFitResult *` that needs to be deleted)

#### PR validation:

I could do no validation of this refactoring and memory leak fixing work. It should not change any code behavior, but it would be nice if an alignment expert could validate it.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport intended.