### PR TITLE
 (DAQ) increase monitoring limit on number of streams (13_2_X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -13,7 +13,7 @@
 
 namespace evf {
 
-  constexpr int nReservedModules = 64;
+  constexpr int nReservedModules = 128;
   constexpr int nSpecialModules = 10;
   constexpr int nReservedPaths = 1;
 


### PR DESCRIPTION
#### PR description:

Increases the number of placeholders in the monitoring data reserved mostly for output modules (therefore HLT streams).
With more streams planning to be used in heavy-ion, 64 is no longer sufficient.

#### PR validation:

Tested in a DAQ test setup with full chain HLT and monitoring.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42901