### PR TITLE
SiStrip Lorentz Angle PCL: minor fixes

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLHarvester.cc
@@ -226,6 +226,8 @@ void SiStripLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   for (const auto& ME : iHists_.h2_) {
     if (!ME.second)
       continue;
+    // draw colored 2D plots
+    ME.second->setOption("colz");
     TProfile* hp = (TProfile*)ME.second->getTH2F()->ProfileX();
     iBooker.setCurrentFolder(folderToHarvest + "/" + getStem(ME.first, /* isFolder = */ true));
     iHists_.p_[hp->GetName()] = iBooker.bookProfile(hp->GetName(), hp);

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLMonitor.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLMonitor.cc
@@ -425,22 +425,22 @@ void SiStripLorentzAnglePCLMonitor::bookHistograms(DQMStore::IBooker& ibook,
 	titles = Form("Cluster variance (w=3) in %s;cluster variance (w=3);n. clusters", locType.c_str());
         iHists_.h1_[Form("%s_variance_w3", locType.c_str())] = ibook.book1D(Form("%s_variance_w3", locType.c_str()), titles, 100, 0, 1);
 
-	titles = Form("tan(#theta_{trk})cos(#phi_{trk}) vs n. strips in %s;n. strips;tan(#theta_{trk})cos(#phi_{trk});n. clusters", locType.c_str());
+	titles = Form("n. strips in %s vs tan(#theta_{trk})cos(#phi_{trk});tan(#theta_{trk})cos(#phi_{trk});n. strips;n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_tanthcosphtrk_nstrip", locType.c_str())] = ibook.book2D(Form("%s_tanthcosphtrk_nstrip", locType.c_str()), titles, 360, -0.9, 0.9, 20, 0, 20);
 
-	titles = Form("#theta_{trk} vs n. strips in %s;n. strips;#theta_{trk} [rad];n. clusters", locType.c_str());
+	titles = Form("n. strips in %s vs #theta_{trk};#theta_{trk} [rad];n. strips;n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_thetatrk_nstrip", locType.c_str())] = ibook.book2D(Form("%s_thetatrk_nstrip", locType.c_str()), titles, 360, -0.9, 0.9, 20, 0, 20);
 
-	titles = Form("tan(#theta_{trk})cos(#phi_{trk}) vs cluster variance (w=2) in %s;cluster variance (w=2);tan(#theta_{trk})cos(#phi_{trk});n. clusters", locType.c_str());
+	titles = Form("cluster variance (w=2) in %s vs tan(#theta_{trk})cos(#phi_{trk});tan(#theta_{trk})cos(#phi_{trk});cluster variance (w=2);n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_tanthcosphtrk_var2", locType.c_str())] = ibook.book2D(Form("%s_tanthcosphtrk_var2", locType.c_str()), titles, 360, -0.9, 0.9, 50, 0, 1);
 
-	titles =  Form("tan(#theta_{trk})cos(#phi_{trk}) vs cluster variance (w=3) in %s;cluster variance (w=3);tan(#theta_{trk})cos(#phi_{trk});n. clusters", locType.c_str());
+	titles =  Form("cluster variance (w=3) in %s vs tan(#theta_{trk})cos(#phi_{trk});tan(#theta_{trk})cos(#phi_{trk});cluster variance (w=3);n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_tanthcosphtrk_var3", locType.c_str())] = ibook.book2D(Form("%s_tanthcosphtrk_var3", locType.c_str()), titles, 360, -0.9, 0.9, 50, 0, 1);
 
-	titles =  Form("#theta_{trk}cos(#phi_{trk}) vs cluster variance (w=2) in %s;cluster variance (w=2);#theta_{trk}cos(#phi_{trk});n. clusters", locType.c_str());
+	titles =  Form("cluster variance (w=2) in %s vs #theta_{trk}cos(#phi_{trk});#theta_{trk}cos(#phi_{trk});cluster variance (w=2);n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_thcosphtrk_var2", locType.c_str())] = ibook.book2D(Form("%s_thcosphtrk_var2", locType.c_str()), titles, 360, -0.9, 0.9, 50, 0, 1);
 
-	titles = Form("#theta_{trk}cos(#phi_{trk}) vs cluster variance (w=3) in %s;cluster variance (w=3);#theta_{trk}cos(#phi_{trk});n. clusters", locType.c_str());
+	titles = Form("cluster variance (w=3) in %s vs #theta_{trk}cos(#phi_{trk});#theta_{trk}cos(#phi_{trk});cluster variance (w=3);n. clusters", locType.c_str());
         iHists_.h2_[Form("%s_thcosphtrk_var3", locType.c_str())] = ibook.book2D(Form("%s_thcosphtrk_var3", locType.c_str()), titles, 360, -0.9, 0.9, 50, 0, 1);
         // clang-format on
       }


### PR DESCRIPTION
#### PR description:

Submitting a couple of minor fixes to the SiStrip Lorenzt Angle PCL modules introduced in https://github.com/cms-sw/cmssw/pull/42574, that were spotted during this [presentation](https://indico.cern.ch/event/1271480/contributions/5558331/attachments/2717052/4719540/mm_SiStrip_LorentzAngle_in_PCL_19.09.2023.pdf).
   * fix swapped axes labels 
   * make 2D histograms plotted in color scale by default

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
