### PR TITLE
Herwig lhe matching fix 10_6

### DIFF
--- a/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
@@ -6,7 +6,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,

--- a/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,
@@ -40,7 +40,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
 )
 
 

--- a/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -7,5 +7,5 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
   args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/UL/13TeV/madgraph/V5_2.6.5/dyellell01234j_5f_LO_MLM_v2/DYJets_HT-incl_slc6_amd64_gcc630_CMSSW_9_3_16_tarball.tar.xz','false','slc6_amd64_gcc630','CMSSW_9_3_16'),
   nEvents = cms.untracked.uint32(10),
   generateConcurrently = cms.untracked.bool(True),
-  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7LHECommonSettingsBlock = cms.PSet(
 
         # set the weight option (e.g. for MC@NLO)
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
 
         'set /Herwig/Generators/EventGenerator:EventHandler /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7MGMergingSettingsBlock = cms.PSet(
         'set LesHouchesHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',
         'set LesHouchesHandler:DecayHandler /Herwig/Decays/DecayHandler',
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
         'set /Herwig/Generators/EventGenerator:EventHandler  /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',
         'cd /Herwig/EventHandlers',

--- a/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
+++ b/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
@@ -7,7 +7,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7LHECommonSettings_cfi import
 from Configuration.Generator.Herwig7Settings.Herwig7LHEPowhegSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7LHECommonSettingsBlock,

--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -7,7 +7,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )
 
 #Link to datacards:

--- a/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
+++ b/GeneratorInterface/Herwig7Interface/plugins/Herwig7Hadronizer.cc
@@ -65,6 +65,7 @@ class Herwig7Hadronizer : public Herwig7Interface, public gen::BaseHadronizer {
 	unsigned int			eventsToPrint;
 
 	ThePEG::EventPtr		thepegEvent;
+    bool haveEvt = false;
 	
 	std::shared_ptr<lhef::LHEProxy> proxy_;
 	const std::string		handlerDirectory_;
@@ -110,8 +111,20 @@ bool Herwig7Hadronizer::initializeForInternalPartons()
 
 bool Herwig7Hadronizer::initializeForExternalPartons()
 {
-	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-	return false;
+	if (currentLumiBlock==firstLumiBlock)
+	{
+		std::ifstream runFile(runFileName+".run");
+		if (runFile.fail()) //required for showering of LHE files
+		{
+			initRepository(paramSettings);
+		}
+		if (!initGenerator())
+		{
+			edm::LogInfo("Generator|Herwig7Hadronizer") << "No run step for Herwig chosen. Program will be aborted.";
+			exit(0);
+		}
+	}
+	return true;
 }
 
 bool Herwig7Hadronizer::declareStableParticles(const std::vector<int> &pdgIds)
@@ -155,9 +168,38 @@ bool Herwig7Hadronizer::generatePartonsAndHadronize()
 
 bool Herwig7Hadronizer::hadronize()
 {
+    if (!haveEvt) {
+        try {
+                thepegEvent = eg_->shoot();
+                haveEvt = true;
+        } catch (std::exception& exc) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "EGPtr::shoot() thrown an exception, event skipped: " << exc.what();
+                return false;
+        }
+    }
+    int evtnum = lheEvent()->evtnum();
+    if (evtnum == -1) {
+        edm::LogError("Generator|Herwig7Hadronizer") << "Event number not set in lhe file, needed for correctly aligning Herwig and LHE events!";
+        return false;
+    } else if (thepegEvent->number() == evtnum) {
+        edm::LogError("Herwig7 interface") << "Herwig does not seem to be generating events in order, did you set /Herwig/EventHandlers/FxFxLHReader:AllowedToReOpen Yes?";
+        return false;
+    } else if (thepegEvent->number() == evtnum) {
+        haveEvt = false;
+        if (!thepegEvent) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "thepegEvent not initialized";
+                return false;
+        }
 
-	edm::LogError("Herwig7 interface") << "Read in of LHE files is not supported in this way. You can read them manually if necessary.";
-	return false;
+        event() = convert(thepegEvent);
+        if (!event().get()) {
+                edm::LogWarning("Generator|Herwig7Hadronizer") << "genEvent not initialized";
+                return false;
+        }
+        return true;
+    }
+    edm::LogWarning("Generator|Herwig7Hadronizer") << "Event "  << evtnum << " not generated (likely skipped in merging)";
+    return false;
 }
 
 std::unique_ptr<GenLumiInfoHeader> Herwig7Hadronizer::getGenLumiInfoHeader() const {

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -55,9 +55,11 @@ class LHEEvent {
 	
 	int npLO() const { return npLO_; }
 	int npNLO() const { return npNLO_; }
+	int evtnum() const { return evtnum_; }
 	
 	void setNpLO(int n) { npLO_ = n; }
 	void setNpNLO(int n) { npNLO_ = n; }
+	void setEvtNum(int n) { evtnum_ = n; }
 	
 	void addComment(const std::string &line) { comments.push_back(line); }
 
@@ -95,6 +97,7 @@ class LHEEvent {
         std::vector<float>                      scales_; //scale value used to exclude EWK-produced partons from matching
         int 					npLO_; //number of partons for LO process (used to steer matching/merging)
         int 					npNLO_; //number of partons for NLO process (used to steer matching/merging)
+        int                     evtnum_; //The number of the event (needed to ensure the correct LHE events are saved for MG +Herwig)
 };
 
 } // namespace lhef

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -188,7 +188,7 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (!partonLevel_) {
     throw edm::Exception(edm::errors::EventGenerationFailure) << "No lhe event found in ExternalLHEProducer::produce().  "
     << "The likely cause is that the lhe file contains fewer events than were requested, which is possible "
-    << "in case of phase space integration or uneweighting efficiency problems.";
+    << "in case of phase space integration or unweighting efficiency problems.";
   }
 
   std::unique_ptr<LHEEventProduct> product(
@@ -203,6 +203,7 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                 boost::bind(&LHEEventProduct::addWeight,
                             product.get(), _1));
   product->setScales(partonLevel_->scales());
+  product->setEvtNum(partonLevel_->evtnum());
   if (nPartonMapping_.empty()) {
     product->setNpLO(partonLevel_->npLO());
     product->setNpNLO(partonLevel_->npNLO());

--- a/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
+++ b/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
@@ -8,34 +8,40 @@ import os
 import re
 
 
+def number_events(input_file, output_file=None, offset=0):
+    if output_file is None:
+        output_file = input_file
+    if not os.path.exists(os.path.dirname(os.path.realpath(output_file))):
+        os.makedirs(os.path.dirname(os.path.realpath(output_file)))
+
+    nevent = offset
+    with open('tmp.txt', 'w') as fw:
+        with open(input_file, 'r') as ftmp:
+            for line in ftmp:
+                if re.search('\s*</event>', line):
+                    nevent += 1
+                    fw.write('<event_num num="' + str(nevent) +  '"> ' + str(nevent) + '</event_num>\n')
+                fw.write(line)
+    if output_file is not None:
+        os.rename("tmp.txt", output_file)
+    else:
+        os.rename("tmp.txt", input_file)
+    return nevent
+
+
 if __name__=="__main__":
 
     parser = argparse.ArgumentParser(
         description="Add numbers to lhe")
     parser.add_argument("input_file", type=str,
-                        help="Input LHE file paths separated by commas. Shell-type wildcards are supported.")
-    parser.add_argument("-o", "--output-file", default='output.lhe', type=str,
-                        help="Output LHE file path.")
-    parser.add_argument("--debug", action='store_true',
-                        help="Use the debug mode.")
+                        help="Input LHE file path.")
+    parser.add_argument("-o", "--output-file", default=None, type=str,
+                        help="Output LHE file path. If not specified, output to input file")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        format='[%(levelname)s] %(message)s',
-        level=logging.INFO if not args.debug else DEBUG)
-    logging.info('>>> launch mergeLHE.py in %s' % os.path.abspath(os.getcwd()))
+    logging.info('>>> launch addLHEnumbers.py in %s' % os.path.abspath(os.getcwd()))
 
     logging.info('>>> Input file: [%s]' % args.input_file)
     logging.info('>>> Write to output: %s ' % args.output_file)
 
-    if not os.path.exists(os.path.dirname(os.path.realpath(args.output_file))):
-        os.makedirs(os.path.dirname(os.path.realpath(args.output_file)))
-
-    nevent = 0
-    with open(args.output_file, 'w') as fw:
-        with open(args.input_file, 'r') as ftmp:
-            for line in ftmp:
-                if re.search('\s*</event>', line):
-                    nevent += 1
-                    fw.write("<event num> " + str(nevent) +  "</event num>\n")
-                fw.write(line)
+    number_events(args.input_file, args.output_file)

--- a/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
+++ b/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import logging
+import argparse
+import sys
+import os
+import re
+
+
+if __name__=="__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Add numbers to lhe")
+    parser.add_argument("input_file", type=str,
+                        help="Input LHE file paths separated by commas. Shell-type wildcards are supported.")
+    parser.add_argument("-o", "--output-file", default='output.lhe', type=str,
+                        help="Output LHE file path.")
+    parser.add_argument("--debug", action='store_true',
+                        help="Use the debug mode.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format='[%(levelname)s] %(message)s',
+        level=logging.INFO if not args.debug else DEBUG)
+    logging.info('>>> launch mergeLHE.py in %s' % os.path.abspath(os.getcwd()))
+
+    logging.info('>>> Input file: [%s]' % args.input_file)
+    logging.info('>>> Write to output: %s ' % args.output_file)
+
+    if not os.path.exists(os.path.dirname(os.path.realpath(args.output_file))):
+        os.makedirs(os.path.dirname(os.path.realpath(args.output_file)))
+
+    nevent = 0
+    with open(args.output_file, 'w') as fw:
+        with open(args.input_file, 'r') as ftmp:
+            for line in ftmp:
+                if re.search('\s*</event>', line):
+                    nevent += 1
+                    fw.write("<event num> " + str(nevent) +  "</event num>\n")
+                fw.write(line)

--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -28,6 +28,7 @@ class DefaultLHEMerger(BaseLHEMerger):
         super(DefaultLHEMerger, self).__init__(input_files, output_file)
 
         self.bypass_check = kwargs.get('bypass_check', False)
+        self.number_events = kwargs.get('number_events', False)
         # line-by-line iterator for each input file
         self._f = [self.file_iterator(name) for name in self.input_files]
         self._header_str = []
@@ -222,6 +223,8 @@ class DefaultLHEMerger(BaseLHEMerger):
                         line = next(self._f[i])
                         if re.search('\s*</event>', line):
                             nevent += 1
+                            if self.number_events:
+                                _fwtmp.write("<event num> " + str(sum(self._nevent) + nevent) +  "</event num>\n")
                         if re.search('\s*</LesHouchesEvents>', line):
                             break
                         _fwtmp.write(line)
@@ -366,6 +369,8 @@ def main(argv = None):
                         help=("Bypass the compatibility check for the headers. If true, the header and init block "
                              "will be just a duplicate from the first input file, and events are concatenated without "
                              "modification."))
+    parser.add_argument("-n", "--number-events", action='store_true',
+                        help=("Add a tag to number each lhe event. Needed for Herwig to find correct lhe events"))
     parser.add_argument("--debug", action='store_true',
                         help="Use the debug mode.")
     args = parser.parse_args(argv)
@@ -408,7 +413,8 @@ def main(argv = None):
     elif args.force_cpp_merger:
         lhe_merger = ExternalCppLHEMerger(input_files, args.output_file)
     else:
-        lhe_merger = DefaultLHEMerger(input_files, args.output_file, bypass_check=args.bypass_check)
+        lhe_merger = DefaultLHEMerger(
+            input_files, args.output_file, bypass_check=args.bypass_check, number_events=args.number_events)
 
     # Do merging
     lhe_merger.merge()

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -36,7 +36,7 @@ namespace lhef {
 LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    std::istream &in) :
   runInfo(runInfo), weights_(0), counted(false), 
-  readAttemptCounter(0), npLO_(-99), npNLO_(-99)
+  readAttemptCounter(0), npLO_(-99), npNLO_(-99), evtnum_(-1)
   
 {
 	hepeup.NUP = 0;
@@ -116,7 +116,7 @@ LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    const HEPEUP &hepeup) :
 	runInfo(runInfo), hepeup(hepeup), counted(false), readAttemptCounter(0),
-        npLO_(-99), npNLO_(-99)
+        npLO_(-99), npNLO_(-99), evtnum_(-1)
 {
 }
 
@@ -126,7 +126,7 @@ LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                    const std::vector<std::string> &comments) :
 	runInfo(runInfo), hepeup(hepeup), pdf(pdf ? new PDF(*pdf) : nullptr),
 	comments(comments), counted(false), readAttemptCounter(0),
-	npLO_(-99), npNLO_(-99)
+	npLO_(-99), npNLO_(-99), evtnum_(-1)
 {
 }
 
@@ -138,7 +138,7 @@ LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
 	comments(product.comments_begin(), product.comments_end()),
 	counted(false), readAttemptCounter(0),
 	originalXWGTUP_(product.originalXWGTUP()), scales_(product.scales()),
-	npLO_(product.npLO()), npNLO_(product.npNLO())
+	npLO_(product.npLO()), npNLO_(product.npNLO()), evtnum_(product.evtnum())
 {
 }
 

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -153,6 +153,7 @@ class LHEReader::XMLHandler : public XMLDocument::Handler {
         int                             npLO;
         int                             npNLO;
         std::vector<float>              scales;
+        int                             evtnum=-1;
 };
 
 static void attributesToDom(DOMElement *dom, const Attributes &attributes)
@@ -234,7 +235,11 @@ void LHEReader::XMLHandler::startElement(const XMLCh *const uri,
         
         scales.push_back(scaleval);
       }
+    } else if( name == "event_num" ) {
+      const char *evtnumstr = XMLSimpleStr(attributes.getValue(XMLString::transcode("num")));
+      sscanf(evtnumstr,"%d",&evtnum);
     }
+    
     xmlEventNodes.push_back(elem);
     return;
   } else if (mode == kInit) {
@@ -576,12 +581,14 @@ LHEReader::~LHEReader()
 	  lheevent->addWeight(gen::WeightsInfo(info[i].first,num));
 	}
 	lheevent->setNpLO(handler->npLO);
-        lheevent->setNpNLO(handler->npNLO);
-        //fill scales
-        if (!handler->scales.empty()) {
-          lheevent->setScales(handler->scales);
-        }
-        return lheevent;
+    lheevent->setNpNLO(handler->npNLO);
+    lheevent->setEvtNum(handler->evtnum);
+    handler->evtnum = -1;
+    //fill scales
+    if (!handler->scales.empty()) {
+      lheevent->setScales(handler->scales);
+    }
+    return lheevent;
 	}
       }
     }

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -33,6 +33,7 @@ class LHEEventProduct {
 	  scales_ = std::move(other.scales_);
 	  npLO_ = std::move(other.npLO_);
 	  npNLO_ = std::move(other.npNLO_);
+	  evtnum_ = std::move(other.evtnum_);
 	}
 	LHEEventProduct& operator=(LHEEventProduct&& other) {
 	  hepeup_ = std::move(other.hepeup_);
@@ -43,6 +44,7 @@ class LHEEventProduct {
 	  scales_ = std::move(other.scales_);
 	  npLO_ = std::move(other.npLO_);
 	  npNLO_ = std::move(other.npNLO_);
+	  evtnum_ = std::move(other.evtnum_);
 	  return *this;
 	}
 	~LHEEventProduct() {}
@@ -61,9 +63,11 @@ class LHEEventProduct {
 	
         int npLO() const { return npLO_; }
         int npNLO() const { return npNLO_; }
+        int evtnum() const { return evtnum_; }
         
         void setNpLO(int n) { npLO_ = n; }
-        void setNpNLO(int n) { npNLO_ = n; }	
+        void setNpNLO(int n) { npNLO_ = n; }
+        void setEvtNum(int n) { evtnum_ = n; }	
 	
 	const lhef::HEPEUP &hepeup() const { return hepeup_; }
 	const PDF *pdf() const { return pdf_.get(); }
@@ -125,6 +129,7 @@ class LHEEventProduct {
         std::vector<float>              scales_; //scale value used to exclude EWK-produced partons from matching
         int                             npLO_; //number of partons for LO process (used to steer matching/merging)
         int                             npNLO_; //number of partons for NLO process (used to steer matching/merging)
+        int                             evtnum_; //The number of the event (needed to ensure the correct LHE events are saved for MG +Herwig)
 };
 
 #endif // GeneratorEvent_LHEInterface_LHEEventProduct_h

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -206,11 +206,12 @@
 	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="13">
+	<class name="LHEEventProduct" ClassVersion="14">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
   <version ClassVersion="12" checksum="259352862"/>
   <version ClassVersion="13" checksum="3927731647"/>
+  <version ClassVersion="14" checksum="395176982"/>
  </class>
  <ioread sourceClass = "LHEEventProduct" version="[-12]" targetClass="LHEEventProduct" source = "" target="npLO_">
     <![CDATA[npLO_ = -99;]]>


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/42673 for use in Run 2 UL gen production. These add a new Herwig7HadronizerFilter, designed to resolve the issue of the wrong lhe events being saved with Herwig.

Should be tested with https://github.com/cms-sw/cmsdist/pull/8728