### PR TITLE
Update BeamSpot scripts for FTVs

### DIFF
--- a/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineFromOfflineConverter_cfg.py
@@ -10,15 +10,25 @@ options.register('unitTest',
                  VarParsing.VarParsing.varType.bool, # string, int, or float
                  "are we running the unit test?")
 options.register('inputTag',
-                 "myTagName", # default value
+                 "myInputTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input tag name")
+options.register('inputFile',
+                 "", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "input sqlite (.db) file")
+options.register('outputTag',
+                 "myOutputTagName", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
                  "output tag name")
-options.register('inputRecord',
+options.register('outputRecord',
                  "BeamSpotOnlineLegacyObjectsRcd", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
-                 "type of record")
+                 "type of output record")
 options.register('startRun',
                  1, # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -34,7 +44,7 @@ options.parseArguments()
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 100000 # do not clog output with IO
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(999))
 
 ####################################################################
 # Empty source 
@@ -43,52 +53,54 @@ process.source = cms.Source("EmptySource",
                             firstRun = cms.untracked.uint32(options.startRun),                  
                             firstLuminosityBlock = cms.untracked.uint32(options.startLumi),     
                             numberEventsInLuminosityBlock = cms.untracked.uint32(1),            
-                            numberEventsInRun = cms.untracked.uint32(1))
+                            numberEventsInRun = cms.untracked.uint32(999))
 
 ####################################################################
 # Connect to conditions DB
 ####################################################################
+if options.inputFile != "":
+    from CondCore.CondDB.CondDB_cfi import *
+    # Load from a local db file
+    CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:'+options.inputFile))
+    #To connect directly to a database replace the above line with:
+    #CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
 
-# either from Global Tag
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag,"auto:phase2_realistic")
-
-# ...or specify database connection and tag:  
-#from CondCore.CondDB.CondDB_cfi import *
-#CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
-#process.dbInput = cms.ESSource("PoolDBESSource",
-#                               CondDBBeamSpotObjects,
-#                               toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotOnlineLegacyObjectsRcd'), # BeamSpotOnlineLegacy record
-#                                                          tag = cms.string('BSLegacy_tag')                       # choose your favourite tag
-#                                                          )
-#                                                 )
-#                               )
-# ...or from a local db file
-# input database (in this case the local sqlite file)
+    # Specifying the tag name:
+    process.dbInput = cms.ESSource("PoolDBESSource",
+                                   CondDBBeamSpotObjects,
+                                   toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotObjectsRcd'),
+                                                              tag = cms.string(options.inputTag) # choose your input tag
+                                                             )
+                                                    )
+                                  )
+else:
+    # Load from Global Tag
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag = GlobalTag(process.GlobalTag,"auto:run2_data")
 
 ####################################################################
 # Load and configure outputservice
 ####################################################################
 if options.unitTest :
-    if options.inputRecord ==  "BeamSpotOnlineLegacyObjectsRcd" : 
+    if options.outputRecord ==  "BeamSpotOnlineLegacyObjectsRcd" :
         tag_name = 'BSLegacy_tag'
     else:
         tag_name = 'BSHLT_tag'
 else:
-    tag_name = options.inputTag
+    tag_name = options.outputTag
 
 from CondCore.CondDB.CondDB_cfi import *
 CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % tag_name)) # choose an output name
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           CondDBBeamSpotObjects,
                                           timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string(options.inputRecord), # BeamSpotOnline record
-                                                                     tag = cms.string(tag_name))),             # choose your favourite tag
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string(options.outputRecord), # BeamSpotOnline record
+                                                                     tag = cms.string(tag_name))),              # choose your favourite tag
                                           loadBlobStreamer = cms.untracked.bool(False)
                                           )
 
-isForHLT = (options.inputRecord == "BeamSpotOnlineHLTObjectsRcd")
+isForHLT = (options.outputRecord == "BeamSpotOnlineHLTObjectsRcd")
 print("isForHLT: ",isForHLT)
 
 ####################################################################
@@ -96,6 +108,8 @@ print("isForHLT: ",isForHLT)
 ####################################################################
 from CondTools.BeamSpot.beamSpotOnlineFromOfflineConverter_cfi import beamSpotOnlineFromOfflineConverter
 process.BeamSpotOnlineFromOfflineConverter = beamSpotOnlineFromOfflineConverter.clone(isHLT = isForHLT)
+process.BeamSpotOnlineFromOfflineConverter.IOVStartRun  = options.startRun
+process.BeamSpotOnlineFromOfflineConverter.IOVStartLumi = options.startLumi
 
 # Put module in path:
 process.p = cms.Path(process.BeamSpotOnlineFromOfflineConverter)

--- a/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
@@ -41,7 +41,8 @@ printf "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?
 
 printf "TESTING converting BeamSpotOnlineObjects from BeamSpotObjects ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True || die "Failure running BeamSpotRcdPrinter" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True startRun=325172 startLumi=458 || die "Failure running single-IOV BeamSpotOnlineFromOfflineConverter" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True startRun=325172 startLumi=398 || die "Failure running multi-IOV BeamSpotOnlineFromOfflineConverter" $?
 
 printf "TESTING Reading SimBeamSpotObjectsRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamProfile2DBReader_cfg.py unitTest=True || die "Failure reading payload for SimBeamSpotObjectsRcd" $?

--- a/RecoVertex/BeamSpotProducer/scripts/createPayload.py
+++ b/RecoVertex/BeamSpotProducer/scripts/createPayload.py
@@ -216,14 +216,22 @@ if __name__ == '__main__':
         if len(listoffiles)==1 and option.merged:
             mergedfile = open(beam_file)
             alllines = mergedfile.readlines()
-            npayloads = len(alllines)/23
+            npayloads = int(len(alllines)/23)
             for i in range(0,npayloads):
                 block = alllines[i * 23: (i+1)*23]
-                #line = block[2]
-                #atime = time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z")
-                line = block[0]
-                atime = line.split()[1]
-                sortedlist[atime] = block
+                arun  = ''
+                atime = ''
+                alumi = ''
+                for line in block:
+                    if line.find('Runnumber') != -1:
+                        arun = line.split()[1]
+                    if line.find("EndTimeOfFit") != -1:
+                        atime = time.strptime(line.split()[1] +  " " + line.split()[2] + " " + line.split()[3],"%Y.%m.%d %H:%M:%S %Z")
+                    if line.find("LumiRange") != -1:
+                        alumi = line.split()[3]
+                    if line.find('Type') != -1 and line.split()[1] != '2':
+                        continue
+                sortedlist[int(pack(int(arun), int(alumi)))] = block
             break
 
         tmpfile = open(beam_file)
@@ -291,7 +299,7 @@ if __name__ == '__main__':
         beam_file = sortedlist[key]
         tmp_datafilename = workflowdirTmp+"tmp_datafile.txt"
         if option.merged:
-            tmpfile = file(tmp_datafilename,'w')
+            tmpfile = open(tmp_datafilename,'w')
             tmpfile.writelines(sortedlist[key])
             tmpfile.close()
             beam_file = tmp_datafilename


### PR DESCRIPTION
#### PR description:
In order to ease the BeamSpot workflow usage by the TkAl experts for the Full Track Validations (in order not to rely only on the BeamSpot experts), this PR updates two scripts:
- `RecoVertex/BeamSpotProducer/scripts/createPayload.py`
   - The `option.merged` is used to handle the cases in which the input txt file contains multiple BeamSpot fits. This option was never really used so far (AFAIK) and it contained a few bugs, which are now fixed.
- The `BeamSpotOnlineFromOfflineConverter.cc` plugin (and its python config) has been updated to be able to also handle multi-IOV input tags via the `ESWatcher` mechanism (thanks @mmusich for the tip!)

**Important Note:**
Both these scripts are **NOT** used in production, but only ran manually by experts.

#### PR validation:
Few tests run:
 - code compiles
 - ran `scram b runtests` successfully
 - tested privately with:
   -  ```
      python3 createPayload.py -I lumibase -t [MY_TAG] -d [INPUT_TXT_FILE] -O [OUTPUT_DIR] --merged
      ```
   -  ```
      cmsRun BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True
      ```
   - ```
      cmsRun BeamSpotOnlineFromOfflineConverter_cfg.py \
        inputTag=[INPUT_TAG] \
        inputFile=[INPUT_DB_FILE] \
        outputTag=[OUTPUT_TAG] \
        startRun=373710 \
        startLumi=179
      ```

#### Backport:
Not a backport, no backport needed

------
FYI @lguzzi @dzuolo @mmusich @TomasKello @henriettepetersen 
