### PR TITLE
Replace reference to ParameterSet with a struct of parameter values in (Global)EvFOutputModule

### DIFF
--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -46,7 +46,7 @@ namespace evf {
 
   class EvFOutputJSONWriter {
   public:
-    EvFOutputJSONWriter(edm::ParameterSet const& ps,
+    EvFOutputJSONWriter(edm::StreamerOutputModuleCommon::Parameters const& commonParameters,
                         edm::SelectedProducts const* selections,
                         std::string const& streamLabel,
                         std::string const& moduleLabel);
@@ -92,7 +92,7 @@ namespace evf {
 
     Trig getTriggerResults(edm::EDGetTokenT<edm::TriggerResults> const& token, edm::EventForOutput const& e) const;
 
-    edm::ParameterSet const& ps_;
+    edm::StreamerOutputModuleCommon::Parameters commonParameters_;
     std::string streamLabel_;
     edm::EDGetTokenT<edm::TriggerResults> trToken_;
     edm::EDGetTokenT<edm::SendJobHeader::ParameterSetMap> psetToken_;

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -24,11 +24,11 @@
 
 namespace evf {
 
-  EvFOutputJSONWriter::EvFOutputJSONWriter(edm::ParameterSet const& ps,
+  EvFOutputJSONWriter::EvFOutputJSONWriter(edm::StreamerOutputModuleCommon::Parameters const& commonParameters,
                                            edm::SelectedProducts const* selections,
                                            std::string const& streamLabel,
                                            std::string const& moduleLabel)
-      : streamerCommon_(ps, selections, moduleLabel),
+      : streamerCommon_(commonParameters, selections, moduleLabel),
         processed_(0),
         accepted_(0),
         errorEvents_(0),
@@ -109,7 +109,7 @@ namespace evf {
   EvFOutputModule::EvFOutputModule(edm::ParameterSet const& ps)
       : edm::one::OutputModuleBase(ps),
         EvFOutputModuleType(ps),
-        ps_(ps),
+        commonParameters_(edm::StreamerOutputModuleCommon::parameters(ps)),
         streamLabel_(ps.getParameter<std::string>("@module_label")),
         trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
         psetToken_(consumes<edm::SendJobHeader::ParameterSetMap, edm::InRun>(
@@ -150,7 +150,7 @@ namespace evf {
   void EvFOutputModule::beginRun(edm::RunForOutput const& run) {
     //create run Cache holding JSON file writer and variables
     jsonWriter_ = std::make_unique<EvFOutputJSONWriter>(
-        ps_, &keptProducts()[edm::InEvent], streamLabel_, description().moduleLabel());
+        commonParameters_, &keptProducts()[edm::InEvent], streamLabel_, description().moduleLabel());
 
     //output INI file (non-const). This doesn't require globalBeginRun to be finished
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -20,9 +20,25 @@ namespace edm {
 
   class StreamerOutputModuleCommon {
   public:
-    explicit StreamerOutputModuleCommon(ParameterSet const& ps,
+    struct Parameters {
+      Strings hltTriggerSelections;
+      std::string compressionAlgoStr;
+      int compressionLevel;
+      int lumiSectionInterval;
+      bool useCompression;
+    };
+
+    static Parameters parameters(ParameterSet const& ps);
+
+    explicit StreamerOutputModuleCommon(Parameters const& p,
                                         SelectedProducts const* selections,
                                         std::string const& moduleLabel);
+
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps,
+                                        SelectedProducts const* selections,
+                                        std::string const& moduleLabel)
+        : StreamerOutputModuleCommon(parameters(ps), selections, moduleLabel) {}
+
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription& desc);
 

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -23,16 +23,26 @@
 #include <zlib.h>
 
 namespace edm {
-  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps,
+  StreamerOutputModuleCommon::Parameters StreamerOutputModuleCommon::parameters(ParameterSet const& ps) {
+    Parameters ret;
+    ret.hltTriggerSelections = EventSelector::getEventSelectionVString(ps);
+    ret.compressionAlgoStr = ps.getUntrackedParameter<std::string>("compression_algorithm");
+    ret.compressionLevel = ps.getUntrackedParameter<int>("compression_level");
+    ret.lumiSectionInterval = ps.getUntrackedParameter<int>("lumiSection_interval");
+    ret.useCompression = ps.getUntrackedParameter<bool>("use_compression");
+    return ret;
+  }
+
+  StreamerOutputModuleCommon::StreamerOutputModuleCommon(Parameters const& p,
                                                          SelectedProducts const* selections,
                                                          std::string const& moduleLabel)
       :
 
         serializer_(selections),
-        useCompression_(ps.getUntrackedParameter<bool>("use_compression")),
-        compressionAlgoStr_(ps.getUntrackedParameter<std::string>("compression_algorithm")),
-        compressionLevel_(ps.getUntrackedParameter<int>("compression_level")),
-        lumiSectionInterval_(ps.getUntrackedParameter<int>("lumiSection_interval")),
+        useCompression_(p.useCompression),
+        compressionAlgoStr_(p.compressionAlgoStr),
+        compressionLevel_(p.compressionLevel),
+        lumiSectionInterval_(p.lumiSectionInterval),
         hltsize_(0),
         host_name_(),
         hltTriggerSelections_(),
@@ -85,7 +95,7 @@ namespace edm {
 
     // 25-Jan-2008, KAB - pull out the trigger selection request
     // which we need for the INIT message
-    hltTriggerSelections_ = EventSelector::getEventSelectionVString(ps);
+    hltTriggerSelections_ = p.hltTriggerSelections;
 
     Strings const& hltTriggerNames = edm::getAllTriggerNames();
     hltsize_ = hltTriggerNames.size();


### PR DESCRIPTION
#### PR description:

This PR replaces the references to `ParameterSet` with a struct of parameter values in GlobalEvFOutputModule and EvFOutputModule.

Fixes https://github.com/cms-sw/cmssw/issues/42910
Resolves https://github.com/makortel/framework/issues/684

#### PR validation:
 
Unit tests pass