### PR TITLE
Replace reference to ParameterSet with vector<int> in HcalMahiPulseOffsetsGPUESProducer

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalMahiPulseOffsetsGPU.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalMahiPulseOffsetsGPU.h
@@ -1,8 +1,6 @@
 #ifndef RecoLocalCalo_HcalRecAlgos_interface_HcalMahiPulseOffsetsGPU_h
 #define RecoLocalCalo_HcalRecAlgos_interface_HcalMahiPulseOffsetsGPU_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #ifndef __CUDACC__
 #include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"
 #include "HeterogeneousCore/CUDACore/interface/ESProduct.h"
@@ -17,7 +15,7 @@ public:
 
 #ifndef __CUDACC__
   // rearrange reco params
-  HcalMahiPulseOffsetsGPU(edm::ParameterSet const&);
+  HcalMahiPulseOffsetsGPU(std::vector<int> const& values);
 
   // will trigger deallocation of Product thru ~Product
   ~HcalMahiPulseOffsetsGPU() = default;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalMahiPulseOffsetsGPU.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalMahiPulseOffsetsGPU.cc
@@ -4,8 +4,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 // FIXME: add proper getters to conditions
-HcalMahiPulseOffsetsGPU::HcalMahiPulseOffsetsGPU(edm::ParameterSet const& ps) {
-  auto const& values = ps.getParameter<std::vector<int>>("pulseOffsets");
+HcalMahiPulseOffsetsGPU::HcalMahiPulseOffsetsGPU(std::vector<int> const& values) {
   values_.resize(values.size());
   std::copy(values.begin(), values.end(), values_.begin());
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalMahiPulseOffsetsGPUESProducer.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalMahiPulseOffsetsGPUESProducer.cc
@@ -31,10 +31,11 @@ protected:
                       edm::ValidityInterval&) override;
 
 private:
-  edm::ParameterSet const& pset_;
+  std::vector<int> pulseOffsets_;
 };
 
-HcalMahiPulseOffsetsGPUESProducer::HcalMahiPulseOffsetsGPUESProducer(edm::ParameterSet const& pset) : pset_{pset} {
+HcalMahiPulseOffsetsGPUESProducer::HcalMahiPulseOffsetsGPUESProducer(edm::ParameterSet const& pset)
+    : pulseOffsets_(pset.getParameter<std::vector<int>>("pulseOffsets")) {
   setWhatProduced(this);
   findingRecord<JobConfigurationGPURecord>();
 }
@@ -52,7 +53,7 @@ void HcalMahiPulseOffsetsGPUESProducer::fillDescriptions(edm::ConfigurationDescr
 }
 
 std::unique_ptr<HcalMahiPulseOffsetsGPU> HcalMahiPulseOffsetsGPUESProducer::produce(JobConfigurationGPURecord const&) {
-  return std::make_unique<HcalMahiPulseOffsetsGPU>(pset_);
+  return std::make_unique<HcalMahiPulseOffsetsGPU>(pulseOffsets_);
 }
 
 DEFINE_FWK_EVENTSETUP_SOURCE(HcalMahiPulseOffsetsGPUESProducer);


### PR DESCRIPTION
#### PR description:

This PR replaces reference to ParameterSet with the parsed parameter (`vector<int>`) in `HcalMahiPulseOffsetsGPUESProducer`.

Fixes https://github.com/cms-sw/cmssw/issues/42913
Resolves https://github.com/makortel/framework/issues/685

#### PR validation:

Code compiles.