### PR TITLE
[RFC] Replace RangeMap used in Muon hit storage

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -49,7 +49,7 @@
 
    <class name="susybsm::MuonSegment" ClassVersion="11">
     <version ClassVersion="10" checksum="3541168201"/>
-    <version ClassVersion="11" checksum="312144579"/>
+    <version ClassVersion="11" checksum="841063529"/>
    </class>
    <class name="susybsm::MuonSegmentCollection"/>
    <class name="susybsm::MuonSegmentRef"/>

--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -47,8 +47,9 @@
    <class name="edm::Wrapper<susybsm::HSCPDeDxInfoCollection>"/>
    <class name="edm::Wrapper<susybsm::HSCPDeDxInfoValueMap>"/>
 
-   <class name="susybsm::MuonSegment" ClassVersion="10">
+   <class name="susybsm::MuonSegment" ClassVersion="11">
     <version ClassVersion="10" checksum="3541168201"/>
+    <version ClassVersion="11" checksum="312144579"/>
    </class>
    <class name="susybsm::MuonSegmentCollection"/>
    <class name="susybsm::MuonSegmentRef"/>

--- a/CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h
+++ b/CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h
@@ -1,0 +1,74 @@
+#ifndef CommonTools_RecoAlgos_RangeMapOwnVectorToVectorConverter_h
+#define CommonTools_RecoAlgos_RangeMapOwnVectorToVectorConverter_h
+// -*- C++ -*-
+//
+// Package:     CommonTools/RecoAlgos
+// Class  :     RangeMapOwnVectorToVectorConverter
+//
+/**\class RangeMapOwnVectorToVectorConverter RangeMapOwnVectorToVectorConverter.h "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 25 Sep 2023 14:10:44 GMT
+//
+
+// system include files
+#include <vector>
+
+// user include files
+#include "DataFormats/Common/interface/RangeMap.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+
+// forward declarations
+
+namespace reco {
+  template <typename ID, typename T>
+  class RangeMapOwnVectorToVectorConverter : public edm::global::EDProducer<> {
+  public:
+    RangeMapOwnVectorToVectorConverter(edm::ParameterSet const& iPSet)
+        : get_(consumes(iPSet.getParameter<edm::InputTag>("get"))), put_(produces()) {}
+
+    RangeMapOwnVectorToVectorConverter(const RangeMapOwnVectorToVectorConverter&) = delete;  // stop default
+    const RangeMapOwnVectorToVectorConverter& operator=(const RangeMapOwnVectorToVectorConverter&) =
+        delete;  // stop default
+
+    // ---------- const member functions ---------------------
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const final {
+      auto ownRange = iEvent.get(get_);
+
+      edm::RangeMap<ID, std::vector<T>> vecRange;
+      for (auto ids = ownRange.id_begin(); ids != ownRange.id_end(); ++ids) {
+        auto range = ownRange.get(*ids);
+        vecRange.put(*ids, range.first, range.second);
+      }
+      iEvent.emplace(put_, std::move(vecRange));
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& iConfig) {
+      edm::ParameterSetDescription pset;
+      pset.add<edm::InputTag>("get");
+
+      iConfig.addDefault(pset);
+    }
+
+  private:
+    // ---------- member data --------------------------------
+    edm::EDGetTokenT<edm::RangeMap<ID, edm::OwnVector<T>>> get_;
+    edm::EDPutTokenT<edm::RangeMap<ID, std::vector<T>>> put_;
+  };
+}  // namespace reco
+#endif

--- a/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
@@ -6,13 +6,15 @@
  * The collection of CSCRecHit2D's. See \ref CSCRecHit2DCollection.h for details.
  *
  */
-#include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
+#include <vector>
 
-#include <DataFormats/Common/interface/RangeMap.h>
-#include <DataFormats/Common/interface/ClonePolicy.h>
-#include <DataFormats/Common/interface/OwnVector.h>
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
 
-typedef edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D> > CSCRecHit2DCollection;
+#include "DataFormats/Common/interface/RangeMap.h"
+#include "DataFormats/Common/interface/ClonePolicy.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+
+using CSCRecHit2DCollection = edm::RangeMap<CSCDetId, std::vector<CSCRecHit2D> >;
 
 #endif

--- a/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h
@@ -11,10 +11,8 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
 
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-using CSCRecHit2DCollection = edm::RangeMap<CSCDetId, std::vector<CSCRecHit2D> >;
+using CSCRecHit2DCollection = edm::IdToHitRange<CSCDetId, CSCRecHit2D>;
 
 #endif

--- a/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
@@ -8,17 +8,16 @@
  *  \author Matteo Sani
  */
 
-#include <DataFormats/MuonDetId/interface/CSCDetId.h>
-#include <DataFormats/CSCRecHit/interface/CSCSegment.h>
+#include <vector>
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
 
-#include <DataFormats/Common/interface/RangeMap.h>
-#include <DataFormats/Common/interface/ClonePolicy.h>
-#include <DataFormats/Common/interface/OwnVector.h>
+#include "DataFormats/Common/interface/RangeMap.h"
 
-typedef edm::RangeMap<CSCDetId, edm::OwnVector<CSCSegment> > CSCSegmentCollection;
+using CSCSegmentCollection = edm::RangeMap<CSCDetId, std::vector<CSCSegment> >;
 
-#include <DataFormats/Common/interface/Ref.h>
-typedef edm::Ref<CSCSegmentCollection> CSCSegmentRef;
+#include "DataFormats/Common/interface/Ref.h"
+using CSCSegmentRef = edm::Ref<CSCSegmentCollection>;
 
 //typedef std::vector<CSCSegment> CSCSegmentCollection;
 

--- a/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
+++ b/DataFormats/CSCRecHit/interface/CSCSegmentCollection.h
@@ -8,13 +8,12 @@
  *  \author Matteo Sani
  */
 
-#include <vector>
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegment.h"
 
-#include "DataFormats/Common/interface/RangeMap.h"
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-using CSCSegmentCollection = edm::RangeMap<CSCDetId, std::vector<CSCSegment> >;
+using CSCSegmentCollection = edm::IdToHitRange<CSCDetId, CSCSegment>;
 
 #include "DataFormats/Common/interface/Ref.h"
 using CSCSegmentRef = edm::Ref<CSCSegmentCollection>;

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -17,6 +17,8 @@
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
+  <class name="edm::RangeMap<CSCDetId,std::vector<CSCRecHit2D>,edm::CopyPolicy<CSCRecHit2D> >"/>
+  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,std::vector<CSCRecHit2D>,edm::CopyPolicy<CSCRecHit2D> > >"/>
 
   <class name="std::vector<CSCSegment>"/>
   <class name="std::vector<CSCSegment*>"/>
@@ -26,8 +28,10 @@
   </class>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
+  <class name="edm::RangeMap<CSCDetId,std::vector<CSCSegment>,edm::CopyPolicy<CSCSegment> >"/>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
+  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,std::vector<CSCSegment>,edm::CopyPolicy<CSCSegment> > >"/>
   <class name="CSCSegmentRef"/>
 </selection>
 

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -17,8 +17,8 @@
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
-  <class name="edm::RangeMap<CSCDetId,std::vector<CSCRecHit2D>,edm::CopyPolicy<CSCRecHit2D> >"/>
-  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,std::vector<CSCRecHit2D>,edm::CopyPolicy<CSCRecHit2D> > >"/>
+  <class name="edm::IdToHitRange<CSCDetId,CSCRecHit2D>"/>
+  <class name="edm::Wrapper<edm::IdToHitRange<CSCDetId,CSCRecHit2D>>"/>
 
   <class name="std::vector<CSCSegment>"/>
   <class name="std::vector<CSCSegment*>"/>
@@ -28,10 +28,10 @@
   </class>
   <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
-  <class name="edm::RangeMap<CSCDetId,std::vector<CSCSegment>,edm::CopyPolicy<CSCSegment> >"/>
+  <class name="edm::IdToHitRange<CSCDetId,CSCSegment>"/>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>
-  <class name="edm::Wrapper<edm::RangeMap<CSCDetId,std::vector<CSCSegment>,edm::CopyPolicy<CSCSegment> > >"/>
+  <class name="edm::Wrapper<edm::IdToHitRange<CSCDetId,CSCSegment>>"/>
   <class name="CSCSegmentRef"/>
 </selection>
 

--- a/DataFormats/Common/interface/IdToHitRange.h
+++ b/DataFormats/Common/interface/IdToHitRange.h
@@ -1,0 +1,220 @@
+#ifndef DataFormats_Common_IdToHitRange_h
+#define DataFormats_Common_IdToHitRange_h
+// -*- C++ -*-
+//
+// Package:     DataFormats/Common
+// Class  :     IdToHitRange
+//
+/**\class IdToHitRange IdToHitRange.h "DataFormats/Common/interface/IdToHitRange.h"
+
+ Description: Used to associate an ID to a range of hits
+
+ Usage:
+    Allows quick lookup of a range of hits via the ID
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 26 Sep 2023 20:41:14 GMT
+//
+
+// system include files
+#include <vector>
+#include <algorithm>
+
+// user include files
+#include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+// forward declarations
+
+namespace edm {
+  template <typename ID, typename HIT>
+  class IdToHitRange {
+  public:
+    using container = std::vector<HIT>;
+    /// contained object type
+    using value_type = typename container::value_type;
+    /// collection size type
+    using size_type = typename container::size_type;
+    /// reference type
+    using reference = typename container::reference;
+    /// pointer type
+    using pointer = typename container::pointer;
+    /// constant access iterator type
+    using const_iterator = typename container::const_iterator;
+    /// iterator range
+    using range = std::pair<const_iterator, const_iterator>;
+
+    using id_iterator = typename std::vector<ID>::const_iterator;
+
+  public:
+    IdToHitRange() {}
+
+    // ---------- const member functions ---------------------
+    /// get a range of objects with specified identifier
+    range get(ID id) const {
+      auto i = find(id);
+      if (i == ids_.end()) {
+        return {collection_.end(), collection_.end()};
+      }
+      auto offsetInOffsets = i - ids_.begin();
+      if (ids_.size() != offsets_.size()) {
+        offsetInOffsets = offsets_[offsetInOffsets] + ids_.size();
+      }
+      auto startIndex = offsets_[offsetInOffsets];
+      if (static_cast<std::size_t>(offsetInOffsets + 1) == offsets_.size()) {
+        return {collection_.begin() + startIndex, collection_.end()};
+      }
+      auto endIndex = offsets_[offsetInOffsets + 1];
+      return {collection_.begin() + startIndex, collection_.begin() + endIndex};
+    }
+
+    /// get range of objects matching a specified identifier with a specified comparator.
+    /// <b>WARNING</b>: the comparator has to be written
+    /// in such a way that the std::equal_range
+    /// function returns a meaningful range.
+    /// Not properly written comparators may return
+    /// an unpredictable range. It is recommended
+    /// to use only comparators provided with CMSSW release.
+    template <typename CMP>
+    range get(ID id, CMP comparator) const {
+      if (ids_.size() != offsets_.size()) {
+        throw edm::Exception(edm::errors::LogicError, "calling get with comparitor before sorting.");
+      }
+      auto r = std::equal_range(ids_.begin(), ids_.end(), id, comparator);
+      const_iterator begin, end;
+      if ((r.first) == ids_.end()) {
+        begin = end = collection_.end();
+        return std::make_pair(begin, end);
+      } else {
+        begin = collection_.begin() + offsets_[r.first - ids_.begin()];
+      }
+      if ((r.second) == ids_.end()) {
+        end = collection_.end();
+      } else {
+        end = collection_.begin() + offsets_[r.second - ids_.begin()];
+      }
+      return std::make_pair(begin, end);
+    }
+    /// get range of objects matching a specified identifier with a specified comparator.
+    template <typename CMP>
+    range get(std::pair<ID, CMP> p) const {
+      return get(p.first, p.second);
+    }
+
+    /// return number of contained object
+    size_t size() const { return collection_.size(); }
+    /// first collection iterator
+    /// hits in collection are not guaranteed to be in ID order
+    const_iterator begin() const { return collection_.begin(); }
+    /// last collection iterator
+    const_iterator end() const { return collection_.end(); }
+
+    // ---------- member functions ---------------------------
+    /// insert an object range with specified identifier
+    template <typename CI>
+    void put(ID id, CI begin, CI end) {
+      auto i = std::lower_bound(ids_.begin(), ids_.end(), id);
+      if (i == ids_.end()) {
+        bool isAlreadySorted = (offsets_.size() == ids_.size());
+        ids_.emplace_back(std::move(id));
+        offsets_.push_back(collection_.size());
+        collection_.insert(collection_.end(), begin, end);
+        if (not isAlreadySorted) {
+          //need to update the indirection table used to find the ranges
+          offsets_.insert(offsets_.begin() + ids_.size() - 1, offsets_.size() - ids_.size());
+        }
+        return;
+      } else if (*i == id) {
+        throw edm::Exception(edm::errors::LogicError, "trying to insert duplicate entry");
+      }
+      if (offsets_.size() == ids_.size()) {
+        //was sorted, but now it will not be so need to reformat offsets_
+        std::vector<unsigned int> newOffsets;
+        newOffsets.reserve(ids_.size() * 2 + 2);
+        for (std::size_t index = 0; index < ids_.size(); ++index) {
+          newOffsets.push_back(index);
+        }
+        for (std::size_t index = 0; index < ids_.size(); ++index) {
+          newOffsets.push_back(offsets_[index]);
+        }
+        offsets_ = std::move(newOffsets);
+      }
+      auto offsetInIds = i - ids_.begin();
+      ids_.insert(i, id);
+      offsets_.push_back(collection_.size());
+      collection_.insert(collection_.end(), begin, end);
+      offsets_.insert(offsets_.begin() + offsetInIds, offsets_.size() - ids_.size());
+    }
+
+    /// perfor post insert action
+    void post_insert() {
+      if (ids_.size() == offsets_.size()) {
+        //already sorted
+        return;
+      }
+
+      std::vector<HIT> sortedCollection;
+      sortedCollection.reserve(collection_.size());
+
+      std::vector<unsigned int> offsets;
+      offsets.reserve(ids_.size());
+
+      for (auto id : ids_) {
+        offsets.push_back(sortedCollection.size());
+        auto range = get(id);
+        sortedCollection.insert(sortedCollection.end(), range.first, range.second);
+      }
+      offsets_ = std::move(offsets);
+      collection_ = std::move(sortedCollection);
+    }
+
+    /// first identifier iterator
+    id_iterator id_begin() const { return ids_.begin(); }
+    /// last identifier iterator
+    id_iterator id_end() const { return ids_.end(); }
+    /// number of contained identifiers
+    size_t id_size() const { return ids_.size(); }
+    /// indentifier vector
+    std::vector<ID> ids() const { return ids_; }
+    /// direct access to an object in the collection
+    reference operator[](size_type i) { return collection_[i]; }
+
+    /// swap member function
+    void swap(IdToHitRange<ID, HIT>& other);
+
+    //Used by ROOT storage
+    CMS_CLASS_VERSION(3)
+
+  private:
+    typename std::vector<ID>::const_iterator find(ID id) const {
+      auto i = std::lower_bound(ids_.begin(), ids_.end(), id);
+      if (i == ids_.end() or *i != id) {
+        return ids_.end();
+      }
+      return i;
+    }
+
+    // ---------- member data --------------------------------
+    std::vector<ID> ids_;
+    std::vector<unsigned int> offsets_;
+    container collection_;
+  };
+
+  template <typename ID, typename HIT>
+  inline void IdToHitRange<ID, HIT>::swap(IdToHitRange<ID, HIT>& other) {
+    ids_.swap(other.ids_);
+    offsets_.swap(other.offsets_);
+    collection_.swap(other.collection_);
+  }
+
+  // free swap function
+  template <typename ID, typename HIT>
+  inline void swap(IdToHitRange<ID, HIT>& a, IdToHitRange<ID, HIT>& b) {
+    a.swap(b);
+  }
+
+}  // namespace edm
+
+#endif

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -35,7 +35,7 @@
 <bin file="Ref_t.cpp">
 </bin>
 
-<bin file="ThinnedRefSet_t.cpp">
+<bin name ="DataFormatsCommonCatch2Tests" file="ThinnedRefSet_t.cpp,IdToHitRange_t.cpp">
   <use name="catch2"/>
 </bin>
 

--- a/DataFormats/Common/test/IdToHitRange_t.cpp
+++ b/DataFormats/Common/test/IdToHitRange_t.cpp
@@ -1,0 +1,440 @@
+#include "catch.hpp"
+#include "DataFormats/Common/interface/IdToHitRange.h"
+
+namespace {
+  struct Hit {
+    Hit(int iValue) : value_(iValue) {}
+    int value_ = -1;
+  };
+}  // namespace
+
+TEST_CASE("test IdToHitRange", "[IdToHitRange]") {
+  SECTION("empty") {
+    edm::IdToHitRange<int, Hit> hr{};
+
+    REQUIRE(0 == hr.size());
+    REQUIRE(hr.begin() == hr.end());
+    REQUIRE(hr.id_size() == 0);
+    REQUIRE(hr.id_begin() == hr.id_end());
+    REQUIRE(hr.ids().empty());
+    REQUIRE(hr.get(0) == std::make_pair(hr.end(), hr.end()));
+  }
+
+  SECTION("one entry") {
+    SECTION("with one hit") {
+      edm::IdToHitRange<int, Hit> hr{};
+      std::array<Hit, 1> a = {{0}};
+      hr.put(0, a.begin(), a.end());
+
+      REQUIRE(1 == hr.size());
+      REQUIRE(hr.begin() != hr.end());
+      REQUIRE(hr.end() - hr.begin() == 1);
+      REQUIRE(hr.get(0) == std::make_pair(hr.begin(), hr.end()));
+      REQUIRE(hr.get(0).first->value_ == 0);
+      REQUIRE(hr.get(1) == std::make_pair(hr.end(), hr.end()));
+      REQUIRE(hr.id_size() == 1);
+      REQUIRE(hr.id_begin() != hr.id_end());
+      REQUIRE(hr.id_end() - hr.id_begin() == 1);
+      REQUIRE(*hr.id_begin() == 0);
+      REQUIRE(hr.ids().size() == 1);
+    }
+
+    SECTION("with two hit") {
+      edm::IdToHitRange<int, Hit> hr{};
+      std::array<Hit, 2> a = {{{0}, {0}}};
+      hr.put(0, a.begin(), a.end());
+
+      REQUIRE(2 == hr.size());
+      REQUIRE(hr.begin() != hr.end());
+      REQUIRE(hr.end() - hr.begin() == 2);
+      REQUIRE(hr.get(0) == std::make_pair(hr.begin(), hr.end()));
+      REQUIRE(hr.get(0).first->value_ == 0);
+      REQUIRE(hr.get(1) == std::make_pair(hr.end(), hr.end()));
+      REQUIRE(hr.id_size() == 1);
+      REQUIRE(hr.id_begin() != hr.id_end());
+      REQUIRE(hr.id_end() - hr.id_begin() == 1);
+      REQUIRE(*hr.id_begin() == 0);
+      REQUIRE(hr.ids().size() == 1);
+    }
+  }
+
+  SECTION("two entries") {
+    SECTION("consecutive IDs") {
+      SECTION("added in order") {
+        edm::IdToHitRange<int, Hit> hr{};
+        std::array<Hit, 1> a = {{0}};
+        hr.put(0, a.begin(), a.end());
+        std::array<Hit, 2> b = {{{1}, {1}}};
+        hr.put(1, b.begin(), b.end());
+
+        REQUIRE(3 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 3);
+        REQUIRE(hr.get(0) == std::make_pair(hr.begin(), hr.begin() + 1));
+        REQUIRE(hr.get(0).first->value_ == 0);
+        auto get_1 = hr.get(1);
+        REQUIRE(get_1 == std::make_pair(hr.begin() + 1, hr.end()));
+        REQUIRE(get_1.second - get_1.first == 2);
+        REQUIRE(get_1.first->value_ == 1);
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(2) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.id_size() == 2);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 2);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 1);
+        REQUIRE(hr.ids().size() == 2);
+      }
+
+      SECTION("added out of order") {
+        edm::IdToHitRange<int, Hit> hr{};
+        std::array<Hit, 2> b = {{{1}, {1}}};
+        hr.put(1, b.begin(), b.end());
+        std::array<Hit, 1> a = {{0}};
+        hr.put(0, a.begin(), a.end());
+
+        REQUIRE(hr.id_size() == 2);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 2);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 1);
+        REQUIRE(hr.ids().size() == 2);
+
+        REQUIRE(3 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 3);
+        auto get_0 = hr.get(0);
+        REQUIRE(get_0.first != hr.end());
+        REQUIRE(get_0.first->value_ == 0);
+        REQUIRE(get_0.second - get_0.first == 1);
+        REQUIRE(hr.get(0) == std::make_pair(hr.begin() + 2, hr.end()));
+        REQUIRE(hr.get(0).first->value_ == 0);
+        auto get_1 = hr.get(1);
+        REQUIRE(get_1 == std::make_pair(hr.begin(), hr.begin() + 2));
+        REQUIRE(get_1.second - get_1.first == 2);
+        REQUIRE(get_1.first->value_ == 1);
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(2) == std::make_pair(hr.end(), hr.end()));
+
+        SECTION("post_insert") {
+          hr.post_insert();
+
+          REQUIRE(3 == hr.size());
+          REQUIRE(hr.begin() != hr.end());
+          REQUIRE(hr.end() - hr.begin() == 3);
+          REQUIRE(hr.get(0) == std::make_pair(hr.begin(), hr.begin() + 1));
+          REQUIRE(hr.get(0).first->value_ == 0);
+          auto get_1 = hr.get(1);
+          REQUIRE(get_1 == std::make_pair(hr.begin() + 1, hr.end()));
+          REQUIRE(get_1.second - get_1.first == 2);
+          REQUIRE(get_1.first->value_ == 1);
+          REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+          REQUIRE(hr.get(2) == std::make_pair(hr.end(), hr.end()));
+          REQUIRE(hr.id_size() == 2);
+          REQUIRE(hr.id_begin() != hr.id_end());
+          REQUIRE(hr.id_end() - hr.id_begin() == 2);
+          REQUIRE(*hr.id_begin() == 0);
+          REQUIRE(*(hr.id_begin() + 1) == 1);
+          REQUIRE(hr.ids().size() == 2);
+        }
+      }
+    }
+
+    SECTION("non-consecutive IDs") {
+      SECTION("added in order") {
+        edm::IdToHitRange<int, Hit> hr{};
+        std::array<Hit, 1> a = {{0}};
+        hr.put(0, a.begin(), a.end());
+        std::array<Hit, 2> b = {{{2}, {2}}};
+        hr.put(2, b.begin(), b.end());
+
+        REQUIRE(3 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 3);
+        REQUIRE(hr.get(0) == std::make_pair(hr.begin(), hr.begin() + 1));
+        REQUIRE(hr.get(0).first->value_ == 0);
+        auto get_2 = hr.get(2);
+        REQUIRE(get_2 == std::make_pair(hr.begin() + 1, hr.end()));
+        REQUIRE(get_2.second - get_2.first == 2);
+        REQUIRE(get_2.first->value_ == 2);
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.id_size() == 2);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 2);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 2);
+        REQUIRE(hr.ids().size() == 2);
+      }
+
+      SECTION("added out of order") {
+        edm::IdToHitRange<int, Hit> hr{};
+        std::array<Hit, 2> b = {{{2}, {2}}};
+        hr.put(2, b.begin(), b.end());
+        std::array<Hit, 1> a = {{0}};
+        hr.put(0, a.begin(), a.end());
+
+        REQUIRE(hr.id_size() == 2);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 2);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 2);
+        REQUIRE(hr.ids().size() == 2);
+
+        REQUIRE(3 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 3);
+        auto get_0 = hr.get(0);
+        REQUIRE(get_0.first != hr.end());
+        REQUIRE(get_0.first->value_ == 0);
+        REQUIRE(get_0.second - get_0.first == 1);
+        REQUIRE(hr.get(0) == std::make_pair(hr.begin() + 2, hr.end()));
+        REQUIRE(hr.get(0).first->value_ == 0);
+        auto get_2 = hr.get(2);
+        REQUIRE(get_2 == std::make_pair(hr.begin(), hr.begin() + 2));
+        REQUIRE(get_2.second - get_2.first == 2);
+        REQUIRE(get_2.first->value_ == 2);
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+      }
+    }
+  }
+  SECTION("three entries") {
+    SECTION("first two in order, third out") {
+      SECTION("last added ID at beginning") {
+        edm::IdToHitRange<int, Hit> hr{};
+        {
+          std::array<Hit, 2> b = {{{1}, {1}}};
+          hr.put(1, b.begin(), b.end());
+        }
+        {
+          std::array<Hit, 3> c = {{{2}, {2}, {2}}};
+          hr.put(2, c.begin(), c.end());
+        }
+        {
+          std::array<Hit, 1> a = {{0}};
+          hr.put(0, a.begin(), a.end());
+        }
+        REQUIRE(hr.id_size() == 3);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 3);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 1);
+        REQUIRE(*(hr.id_begin() + 2) == 2);
+        REQUIRE(hr.ids().size() == 3);
+
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+
+        REQUIRE(6 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 6);
+        {
+          auto get_0 = hr.get(0);
+          REQUIRE(get_0.first != hr.end());
+          REQUIRE(get_0.first->value_ == 0);
+          REQUIRE(get_0.second - get_0.first == 1);
+          REQUIRE(get_0 == std::make_pair(hr.begin() + 5, hr.end()));
+        }
+        {
+          auto get_1 = hr.get(1);
+          REQUIRE(get_1.first != hr.end());
+          REQUIRE(get_1.first->value_ == 1);
+          REQUIRE(get_1.second - get_1.first == 2);
+          REQUIRE(get_1 == std::make_pair(hr.begin(), hr.begin() + 2));
+        }
+        {
+          auto get_2 = hr.get(2);
+          REQUIRE(get_2.first != hr.end());
+          REQUIRE(get_2.first->value_ == 2);
+          REQUIRE(get_2.second - get_2.first == 3);
+          REQUIRE(get_2 == std::make_pair(hr.begin() + 2, hr.begin() + 5));
+        }
+
+        SECTION("post_insert") {
+          hr.post_insert();
+
+          REQUIRE(hr.id_size() == 3);
+          REQUIRE(hr.id_begin() != hr.id_end());
+          REQUIRE(hr.id_end() - hr.id_begin() == 3);
+          REQUIRE(*hr.id_begin() == 0);
+          REQUIRE(*(hr.id_begin() + 1) == 1);
+          REQUIRE(*(hr.id_begin() + 2) == 2);
+          REQUIRE(hr.ids().size() == 3);
+
+          REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+          REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+
+          REQUIRE(6 == hr.size());
+          REQUIRE(hr.begin() != hr.end());
+          REQUIRE(hr.end() - hr.begin() == 6);
+          {
+            auto get_0 = hr.get(0);
+            REQUIRE(get_0.first != hr.end());
+            REQUIRE(get_0.first->value_ == 0);
+            REQUIRE(get_0.second - get_0.first == 1);
+            REQUIRE(get_0 == std::make_pair(hr.begin(), hr.begin() + 1));
+          }
+          {
+            auto get_1 = hr.get(1);
+            REQUIRE(get_1.first != hr.end());
+            REQUIRE(get_1.first->value_ == 1);
+            REQUIRE(get_1.second - get_1.first == 2);
+            REQUIRE(get_1 == std::make_pair(hr.begin() + 1, hr.begin() + 3));
+          }
+          {
+            auto get_2 = hr.get(2);
+            REQUIRE(get_2.first != hr.end());
+            REQUIRE(get_2.first->value_ == 2);
+            REQUIRE(get_2.second - get_2.first == 3);
+            REQUIRE(get_2 == std::make_pair(hr.begin() + 3, hr.end()));
+          }
+        }
+      }
+      SECTION("last added ID in middle") {
+        edm::IdToHitRange<int, Hit> hr{};
+        {
+          std::array<Hit, 1> a = {{0}};
+          hr.put(0, a.begin(), a.end());
+        }
+        {
+          std::array<Hit, 3> c = {{{2}, {2}, {2}}};
+          hr.put(2, c.begin(), c.end());
+        }
+        {
+          std::array<Hit, 2> b = {{{1}, {1}}};
+          hr.put(1, b.begin(), b.end());
+        }
+        REQUIRE(hr.id_size() == 3);
+        REQUIRE(hr.id_begin() != hr.id_end());
+        REQUIRE(hr.id_end() - hr.id_begin() == 3);
+        REQUIRE(*hr.id_begin() == 0);
+        REQUIRE(*(hr.id_begin() + 1) == 1);
+        REQUIRE(*(hr.id_begin() + 2) == 2);
+        REQUIRE(hr.ids().size() == 3);
+
+        REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+        REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+
+        REQUIRE(6 == hr.size());
+        REQUIRE(hr.begin() != hr.end());
+        REQUIRE(hr.end() - hr.begin() == 6);
+        {
+          auto get_0 = hr.get(0);
+          REQUIRE(get_0.first != hr.end());
+          REQUIRE(get_0.first->value_ == 0);
+          REQUIRE(get_0.second - get_0.first == 1);
+          REQUIRE(get_0 == std::make_pair(hr.begin(), hr.begin() + 1));
+        }
+        {
+          auto get_1 = hr.get(1);
+          REQUIRE(get_1.first != hr.end());
+          REQUIRE(get_1.first->value_ == 1);
+          REQUIRE(get_1.second - get_1.first == 2);
+          REQUIRE(get_1 == std::make_pair(hr.begin() + 4, hr.end()));
+        }
+        {
+          auto get_2 = hr.get(2);
+          REQUIRE(get_2.first != hr.end());
+          REQUIRE(get_2.first->value_ == 2);
+          REQUIRE(get_2.second - get_2.first == 3);
+          REQUIRE(get_2 == std::make_pair(hr.begin() + 1, hr.begin() + 4));
+        }
+
+        SECTION("post_insert") {
+          hr.post_insert();
+
+          REQUIRE(hr.id_size() == 3);
+          REQUIRE(hr.id_begin() != hr.id_end());
+          REQUIRE(hr.id_end() - hr.id_begin() == 3);
+          REQUIRE(*hr.id_begin() == 0);
+          REQUIRE(*(hr.id_begin() + 1) == 1);
+          REQUIRE(*(hr.id_begin() + 2) == 2);
+          REQUIRE(hr.ids().size() == 3);
+
+          REQUIRE(hr.get(-1) == std::make_pair(hr.end(), hr.end()));
+          REQUIRE(hr.get(3) == std::make_pair(hr.end(), hr.end()));
+
+          REQUIRE(6 == hr.size());
+          REQUIRE(hr.begin() != hr.end());
+          REQUIRE(hr.end() - hr.begin() == 6);
+          {
+            auto get_0 = hr.get(0);
+            REQUIRE(get_0.first != hr.end());
+            REQUIRE(get_0.first->value_ == 0);
+            REQUIRE(get_0.second - get_0.first == 1);
+            REQUIRE(get_0 == std::make_pair(hr.begin(), hr.begin() + 1));
+          }
+          {
+            auto get_1 = hr.get(1);
+            REQUIRE(get_1.first != hr.end());
+            REQUIRE(get_1.first->value_ == 1);
+            REQUIRE(get_1.second - get_1.first == 2);
+            REQUIRE(get_1 == std::make_pair(hr.begin() + 1, hr.begin() + 3));
+          }
+          {
+            auto get_2 = hr.get(2);
+            REQUIRE(get_2.first != hr.end());
+            REQUIRE(get_2.first->value_ == 2);
+            REQUIRE(get_2.second - get_2.first == 3);
+            REQUIRE(get_2 == std::make_pair(hr.begin() + 3, hr.end()));
+          }
+        }
+      }
+    }
+  }
+  SECTION("get with comparator") {
+    edm::IdToHitRange<int, Hit> hr{};
+    {
+      std::array<Hit, 1> a = {{0}};
+      hr.put(0, a.begin(), a.end());
+    }
+    {
+      std::array<Hit, 2> b = {{{1}, {1}}};
+      hr.put(1, b.begin(), b.end());
+    }
+    {
+      std::array<Hit, 3> c = {{{2}, {2}, {2}}};
+      hr.put(2, c.begin(), c.end());
+    }
+
+    SECTION("none before") {
+      auto range = hr.get(-2, [](auto i, auto j) { return i / 2 < j / 2; });
+      REQUIRE(range.second == range.first);
+    }
+
+    SECTION("none after") {
+      auto range = hr.get(4, [](auto i, auto j) { return i / 2 < j / 2; });
+      REQUIRE(range.second == range.first);
+    }
+
+    SECTION("matches") {
+      SECTION("match to 0") {
+        auto range = hr.get(0, [](auto i, auto j) { return i / 2 < j / 2; });
+        REQUIRE(range.second != range.first);
+        REQUIRE(range.second - range.first == 3);
+        REQUIRE(range.first->value_ == 0);
+      }
+      SECTION("match to 1") {
+        auto range = hr.get(0, [](auto i, auto j) { return i / 2 < j / 2; });
+        REQUIRE(range.second != range.first);
+        REQUIRE(range.second - range.first == 3);
+        REQUIRE(range.first->value_ == 0);
+      }
+      SECTION("match to 2") {
+        auto range = hr.get(2, [](auto i, auto j) { return i / 2 < j / 2; });
+        REQUIRE(range.second != range.first);
+        REQUIRE(range.second - range.first == 3);
+        REQUIRE(range.first->value_ == 2);
+      }
+      SECTION("match to 3") {
+        auto range = hr.get(3, [](auto i, auto j) { return i / 2 < j / 2; });
+        REQUIRE(range.second != range.first);
+        REQUIRE(range.second - range.first == 3);
+        REQUIRE(range.first->value_ == 2);
+      }
+    }
+  }
+}

--- a/DataFormats/DTRecHit/interface/DTRecHitCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecHitCollection.h
@@ -9,11 +9,8 @@
 
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/DTRecHit/interface/DTRecHit1DPair.h"
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
-#include <functional>
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-typedef edm::RangeMap<DTLayerId, edm::OwnVector<DTRecHit1DPair> > DTRecHitCollection;
+typedef edm::IdToHitRange<DTLayerId, DTRecHit1DPair> DTRecHitCollection;
 
 #endif

--- a/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
@@ -10,17 +10,17 @@
 
 /* Base Class Headers */
 #include <functional>
+#include <vector>
 
 /* Collaborating Class Declarations */
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 
-typedef edm::RangeMap<DTChamberId, edm::OwnVector<DTRecSegment4D> > DTRecSegment4DCollection;
+using DTRecSegment4DCollection = edm::RangeMap<DTChamberId, std::vector<DTRecSegment4D>>;
 
 #include "DataFormats/Common/interface/Ref.h"
-typedef edm::Ref<DTRecSegment4DCollection> DTRecSegment4DRef;
+using DTRecSegment4DRef = edm::Ref<DTRecSegment4DCollection>;
 
 #endif

--- a/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
+++ b/DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h
@@ -13,12 +13,11 @@
 #include <vector>
 
 /* Collaborating Class Declarations */
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
+#include "DataFormats/Common/interface/IdToHitRange.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4D.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 
-using DTRecSegment4DCollection = edm::RangeMap<DTChamberId, std::vector<DTRecSegment4D>>;
+using DTRecSegment4DCollection = edm::IdToHitRange<DTChamberId, DTRecSegment4D>;
 
 #include "DataFormats/Common/interface/Ref.h"
 using DTRecSegment4DRef = edm::Ref<DTRecSegment4DCollection>;

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -18,6 +18,8 @@
   <class name="edm::ClonePolicy<DTRecHit1DPair>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTLayerId,edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> >"/> 
   <class name="edm::Wrapper<edm::RangeMap <DTLayerId, edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> > >"/>
+  <class name="edm::IdToHitRange <DTLayerId,DTRecHit1DPair>"/> 
+  <class name="edm::Wrapper<edm::IdToHitRange <DTLayerId, DTRecHit1DPair> >"/>
   <class name="std::vector<DTRecHit1D>"/>
   <class name="std::vector<DTRecHit1DPair>"/>
   <class name="DTSLRecCluster" ClassVersion="11">
@@ -61,8 +63,8 @@
   <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>
-  <class name="edm::RangeMap <DTChamberId, std::vector<DTRecSegment4D>,edm::CopyPolicy<DTRecSegment4D> >"/>
-  <class name="edm::Wrapper<edm::RangeMap <DTChamberId, std::vector<DTRecSegment4D>,edm::CopyPolicy<DTRecSegment4D> > >"/>
+  <class name="edm::IdToHitRange <DTChamberId, DTRecSegment4D>"/>
+  <class name="edm::Wrapper<edm::IdToHitRange <DTChamberId, DTRecSegment4D> >"/>
   <class name="DTRecSegment4DRef"/>
 </selection>
 <exclusion>

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -51,6 +51,7 @@
    <version ClassVersion="11" checksum="3765797874"/>
    <version ClassVersion="10" checksum="2324947244"/>
   </class>
+  <class name="std::vector<DTRecSegment4D>"/>
   <class name="std::vector<DTRecSegment4D*>"/>
   <class name="std::map<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::pair<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
@@ -60,6 +61,8 @@
   <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>
+  <class name="edm::RangeMap <DTChamberId, std::vector<DTRecSegment4D>,edm::CopyPolicy<DTRecSegment4D> >"/>
+  <class name="edm::Wrapper<edm::RangeMap <DTChamberId, std::vector<DTRecSegment4D>,edm::CopyPolicy<DTRecSegment4D> > >"/>
   <class name="DTRecSegment4DRef"/>
 </selection>
 <exclusion>

--- a/DataFormats/DTRecHit/test/BuildFile.xml
+++ b/DataFormats/DTRecHit/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="test_catch2_*.cc" name="testDataFormatsDTRecHitCatch2">
+  <use name="DataFormats/DTRecHit"/>
+  <use name="catch2"/>
+</bin>

--- a/DataFormats/DTRecHit/test/test_catch2_DTRangeMapAccessor.cc
+++ b/DataFormats/DTRecHit/test/test_catch2_DTRangeMapAccessor.cc
@@ -1,0 +1,86 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/DTRecHit/interface/DTRangeMapAccessor.h"
+
+namespace {
+
+  template <typename F>
+  void loop_all_superlayers(F&& iF) {
+    for (int wheel = DTChamberId::minWheelId; wheel <= DTChamberId::maxWheelId; ++wheel) {
+      for (int station = DTChamberId::minStationId; station <= DTChamberId::maxStationId; ++station) {
+        for (int sector = DTChamberId::minSectorId; sector <= DTChamberId::maxSectorId; ++sector) {
+          for (int superlayer = DTChamberId::minSuperLayerId; superlayer <= DTChamberId::maxSuperLayerId;
+               ++superlayer) {
+            iF(DTSuperLayerId(wheel, station, sector, superlayer));
+          }
+        }
+      }
+    }
+  }
+
+  template <typename F>
+  void loop_all_layers(F&& iF) {
+    loop_all_superlayers([&iF](auto superLayer) {
+      for (int layer = DTChamberId::minLayerId; layer <= DTChamberId::maxLayerId; ++layer) {
+        iF(DTLayerId(superLayer, layer));
+      }
+    });
+  }
+
+}  // namespace
+
+TEST_CASE("Test DTRangeMapAccessor", "[DTRangeMapAccessor]") {
+  SECTION("DTSuperLayerIdComparator") {
+    SECTION("compare DTSuperLayerIds") {
+      loop_all_superlayers([](auto iLayer1) {
+        loop_all_superlayers([iLayer1](auto iLayer2) {
+          DTSuperLayerIdComparator cmp;
+          if (iLayer1 < iLayer2) {
+            REQUIRE(cmp(iLayer1, iLayer2));
+            REQUIRE(not cmp(iLayer2, iLayer1));
+          } else if (iLayer2 < iLayer1) {
+            REQUIRE(not cmp(iLayer1, iLayer2));
+            REQUIRE(cmp(iLayer2, iLayer1));
+          } else {
+            REQUIRE(not cmp(iLayer1, iLayer2));
+          }
+        });
+      });
+    }
+    SECTION("compare DTSuperLayerId to DTLayerId") {
+      //NOTE: the DTSuperLayerIdComparator only works for this case
+      // because the comparitor takes its arguments by value, which
+      // means a new DTSuperLayerId must be created from the DTLayerId via
+      // the call to DTSuperLayerId(DTSuperLayerId const&) and that constructor
+      // explicitly masks out all the extra values coming from DTLayerId.
+
+      loop_all_layers([](auto iLayer1) {
+        loop_all_superlayers([iLayer1](auto iLayer2) {
+          //                    std::cout <<"1 "<<iLayer1<<" 2 "<<iLayer2<<std::endl;
+          DTSuperLayerIdComparator cmp;
+          if (iLayer1 < iLayer2) {
+            REQUIRE(cmp(iLayer1, iLayer2));
+            REQUIRE(not cmp(iLayer2, iLayer1));
+          } else if (iLayer2 < iLayer1) {
+            REQUIRE(not cmp(iLayer1, iLayer2));
+            //REQUIRE(cmp(iLayer2, iLayer1)); //cmp may think they are equal
+          } else {
+            REQUIRE(not cmp(iLayer1, iLayer2));
+          }
+        });
+      });
+    }
+    SECTION("find all DTLayerId with same DTSuperLayerId") {
+      std::vector<DTLayerId> ids;
+      loop_all_layers([&ids](auto iID) { ids.emplace_back(iID); });
+      std::sort(ids.begin(), ids.end());
+
+      loop_all_superlayers([&ids](auto iSuper) {
+        DTSuperLayerIdComparator cmp;
+        auto range = std::equal_range(ids.begin(), ids.end(), iSuper, cmp);
+        REQUIRE(range.second - range.first == DTChamberId::maxLayerId - DTChamberId::minLayerId + 1);
+      });
+    }
+  }
+}

--- a/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
@@ -7,14 +7,11 @@
  *  \author M. Maggi - INFN Bari
  */
 
-#include <vector>
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
-#include <functional>
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-using GEMRecHitCollection = edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit>>;
+using GEMRecHitCollection = edm::IdToHitRange<GEMDetId, GEMRecHit>;
 ;
 
 #endif

--- a/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMRecHitCollection.h
@@ -7,14 +7,14 @@
  *  \author M. Maggi - INFN Bari
  */
 
+#include <vector>
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHit.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
 
-typedef edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >
-    GEMRecHitCollection;
+using GEMRecHitCollection = edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit>>;
+;
 
 #endif

--- a/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
@@ -7,17 +7,16 @@
  *
  *  \author Piet Verwilligen
  */
-
+#include <vector>
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GEMRecHit/interface/GEMSegment.h"
 
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 
-typedef edm::RangeMap<GEMDetId, edm::OwnVector<GEMSegment> > GEMSegmentCollection;
+using GEMSegmentCollection = edm::RangeMap<GEMDetId, std::vector<GEMSegment>>;
 
 #include "DataFormats/Common/interface/Ref.h"
-typedef edm::Ref<GEMSegmentCollection> GEMSegmentRef;
+using GEMSegmentRef = edm::Ref<GEMSegmentCollection>;
 
 #endif

--- a/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
+++ b/DataFormats/GEMRecHit/interface/GEMSegmentCollection.h
@@ -7,14 +7,12 @@
  *
  *  \author Piet Verwilligen
  */
-#include <vector>
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/GEMRecHit/interface/GEMSegment.h"
 
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-using GEMSegmentCollection = edm::RangeMap<GEMDetId, std::vector<GEMSegment>>;
+using GEMSegmentCollection = edm::IdToHitRange<GEMDetId, GEMSegment>;
 
 #include "DataFormats/Common/interface/Ref.h"
 using GEMSegmentRef = edm::Ref<GEMSegmentCollection>;

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -12,6 +12,8 @@
   <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> > >" splitLevel="0"/>
+  <class name="edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit> > >" splitLevel="0"/>
 
   <class name="ME0RecHit" splitLevel="0" ClassVersion="11">
   <version ClassVersion="11" checksum="3948270793"/>
@@ -44,9 +46,12 @@
   </ioread>
   </class>
   <class name="std::vector<GEMSegment*>" splitLevel="0"/>
+  <class name="std::vector<GEMSegment>"/>
   <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
+  <class name="edm::RangeMap<GEMDetId,std::vector<GEMSegment>,edm::CopyPolicy<GEMSegment> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<GEMDetId,std::vector<GEMSegment>,edm::CopyPolicy<GEMSegment> > >" splitLevel="0"/>
   <class name="GEMSegmentRef" splitLevel="0"/>
 
   <class name="ME0Segment" ClassVersion="13">

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -12,8 +12,8 @@
   <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> > >" splitLevel="0"/>
-  <class name="edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<GEMDetId, std::vector<GEMRecHit>, edm::CopyPolicy<GEMRecHit> > >" splitLevel="0"/>
+  <class name="edm::IdToHitRange<GEMDetId, GEMRecHit>" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::IdToHitRange<GEMDetId, GEMRecHit>>" splitLevel="0"/>
 
   <class name="ME0RecHit" splitLevel="0" ClassVersion="11">
   <version ClassVersion="11" checksum="3948270793"/>
@@ -50,8 +50,8 @@
   <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
-  <class name="edm::RangeMap<GEMDetId,std::vector<GEMSegment>,edm::CopyPolicy<GEMSegment> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<GEMDetId,std::vector<GEMSegment>,edm::CopyPolicy<GEMSegment> > >" splitLevel="0"/>
+  <class name="edm::IdToHitRange<GEMDetId,GEMSegment>" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::IdToHitRange<GEMDetId,GEMSegment>>" splitLevel="0"/>
   <class name="GEMSegmentRef" splitLevel="0"/>
 
   <class name="ME0Segment" ClassVersion="13">

--- a/DataFormats/MuonDetId/src/classes.h
+++ b/DataFormats/MuonDetId/src/classes.h
@@ -11,3 +11,4 @@
 #include "DataFormats/MuonDetId/interface/DTSectCollId.h"
 #include "DataFormats/MuonDetId/interface/GEMDetId.h"
 #include "DataFormats/MuonDetId/interface/ME0DetId.h"
+#include <vector>

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -3,6 +3,7 @@
    <version ClassVersion="11" checksum="1427930561"/>
    <version ClassVersion="10" checksum="1566132205"/>
   </class>
+  <class name="std::vector<DTChamberId>"/>
   <class name="DTSuperLayerId" ClassVersion="12">
    <version ClassVersion="12" checksum="4252195609"/>
    <version ClassVersion="11" checksum="95429957"/>
@@ -13,6 +14,7 @@
    <version ClassVersion="11" checksum="2590490736"/>
    <version ClassVersion="10" checksum="3694998457"/>
   </class>
+  <class name="std::vector<DTLayerId>"/>
   <class name="DTWireId" ClassVersion="12">
    <version ClassVersion="12" checksum="3971842612"/>
    <version ClassVersion="11" checksum="4110044256"/>
@@ -22,10 +24,12 @@
    <version ClassVersion="11" checksum="1194325071"/>
    <version ClassVersion="10" checksum="56607943"/>
   </class>
+  <class name="std::vector<CSCDetId>"/>
   <class name="RPCDetId" ClassVersion="11">
    <version ClassVersion="11" checksum="2362875019"/>
    <version ClassVersion="10" checksum="3608243239"/>
   </class>
+  <class name="std::vector<RPCDetId>"/>
   <class name="RPCCompDetId" ClassVersion="10">
    <version ClassVersion="10" checksum="2407084845"/>
   </class>
@@ -49,6 +53,7 @@
     ]]>
    </ioread>
   </class>
+  <class name="std::vector<GEMDetId>"/>
   <class name="ME0DetId" ClassVersion="11">
    <version ClassVersion="11" checksum="1292662416"/>
    <version ClassVersion="10" checksum="388194174"/>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -65,7 +65,8 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="11" checksum="541727491"/>
    <version ClassVersion="10" checksum="4050071853"/>
   </class>
-  <class name="reco::MuonSegmentMatch" ClassVersion="11">
+  <class name="reco::MuonSegmentMatch" ClassVersion="12">
+    <version ClassVersion="12" checksum="4225674270"/>
     <version ClassVersion="11" checksum="2861296960"/>
     <version ClassVersion="10" checksum="754193003"/>    
   </class>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -66,7 +66,7 @@ initial version number of a class which has never been stored before.
    <version ClassVersion="10" checksum="4050071853"/>
   </class>
   <class name="reco::MuonSegmentMatch" ClassVersion="12">
-    <version ClassVersion="12" checksum="4225674270"/>
+    <version ClassVersion="12" checksum="3329152288"/>
     <version ClassVersion="11" checksum="2861296960"/>
     <version ClassVersion="10" checksum="754193003"/>    
   </class>

--- a/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
@@ -6,14 +6,11 @@
  *
  *  \author M. Maggi - INFN Bari
  */
-#include <vector>
 
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
-#include <functional>
+#include "DataFormats/Common/interface/IdToHitRange.h"
 
-using RPCRecHitCollection = edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit>>;
+using RPCRecHitCollection = edm::IdToHitRange<RPCDetId, RPCRecHit>;
 
 #endif

--- a/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
+++ b/DataFormats/RPCRecHit/interface/RPCRecHitCollection.h
@@ -6,15 +6,14 @@
  *
  *  \author M. Maggi - INFN Bari
  */
+#include <vector>
 
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include <functional>
 
-typedef edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >
-    RPCRecHitCollection;
+using RPCRecHitCollection = edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit>>;
 
 #endif

--- a/DataFormats/RPCRecHit/src/classes.h
+++ b/DataFormats/RPCRecHit/src/classes.h
@@ -1,3 +1,5 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/RPCRecHit/src/classes_def.xml
+++ b/DataFormats/RPCRecHit/src/classes_def.xml
@@ -15,8 +15,8 @@
   <class name="edm::ClonePolicy<RPCRecHit>" /> <!-- Root6 -->
   <class name="edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> > >" splitLevel="0"/>
-  <class name="edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit> >" splitLevel="0"/>
-  <class name="edm::Wrapper<edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit> > >" splitLevel="0"/>
+  <class name="edm::IdToHitRange<RPCDetId, RPCRecHit>" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::IdToHitRange<RPCDetId, RPCRecHit>>" splitLevel="0"/>
 </selection>
 <exclusion>
   <class name="edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >">

--- a/DataFormats/RPCRecHit/src/classes_def.xml
+++ b/DataFormats/RPCRecHit/src/classes_def.xml
@@ -15,6 +15,8 @@
   <class name="edm::ClonePolicy<RPCRecHit>" /> <!-- Root6 -->
   <class name="edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> > >" splitLevel="0"/>
+  <class name="edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit> >" splitLevel="0"/>
+  <class name="edm::Wrapper<edm::RangeMap<RPCDetId, std::vector<RPCRecHit>, edm::CopyPolicy<RPCRecHit> > >" splitLevel="0"/>
 </selection>
 <exclusion>
   <class name="edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >">

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -83,7 +83,7 @@ namespace edm {
         "edm::AssociationMap<edm::OneToManyWithQuality<(.*?), *(.*?), *(.*?), *u[a-z]*> >");
     static std::regex const reToVector("edm::AssociationVector<(.*), *(.*), *edm::Ref.*,.*>");
     //NOTE: if the item within a clone policy is a template, this substitution will probably fail
-    static std::regex const reToRangeMap("edm::RangeMap< *(.*), *(.*), *edm::ClonePolicy<([^>]*)> >");
+    static std::regex const reToRangeMap("edm::RangeMap< *(.*), *(.*), *edm::(Clone|Copy)Policy<([^>]*)> >");
     //NOTE: If container is a template with one argument which is its 'type' then can simplify name
     static std::regex const reToRefs1(
         "edm::RefVector< *(.*)< *(.*) *>, *\\2 *, *edm::refhelper::FindUsingAdvance< *\\1< *\\2 *> *, *\\2 *> *>");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -184,6 +184,10 @@ void testfriendlyName::test() {
              ">,edm::ClonePolicy<SiPixelRecHit> > >",
              "DetIdSiPixelRecHitsOwnedRangeMaps"));
   classToFriendly.insert(
+      Values("edm::RangeMap<CSCDetId,std::vector<CSCSegment>"
+             ",edm::CopyPolicy<CSCSegment> >",
+             "CSCDetIdCSCSegmentsRangeMap"));
+  classToFriendly.insert(
       Values("edm::RefVector< edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >,reco::Candidate, "
              "edm::refhelper::FindUsingAdvance<edm::OwnVector<reco::Candidate,edm::ClonePolicy<reco::Candidate> >, "
              "reco::Candidate> >",

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHit2DOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHit2DOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<CSCDetId, CSCRecHit2D>;
+
+using CSCRecHit2DOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<CSCDetId, CSCRecHit2D>;
+DEFINE_FWK_MODULE(CSCRecHit2DOwnVectorRangeMapConverter);

--- a/RecoLocalMuon/CSCRecHitD/test/BuildFile.xml
+++ b/RecoLocalMuon/CSCRecHitD/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<bin file="test_catch2_*.cc" name="testRecoLocalMuonCSCRecHitD">
+  <use name="FWCore/TestProcessor"/>
+  <use name="DataFormats/CSCRecHit"/>
+  <use name="catch2"/>
+</bin>

--- a/RecoLocalMuon/CSCRecHitD/test/test_catch2_CSCRecHit2DOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/CSCRecHitD/test/test_catch2_CSCRecHit2DOwnVectorRangeMapConverter.cc
@@ -1,0 +1,79 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/Common/interface/RangeMap.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "catch.hpp"
+
+static constexpr auto s_tag = "[CSCRecHit2DOwnVectorRangeMapConverter]";
+
+TEST_CASE("Standard checks of CSCRecHit2DOwnVectorRangeMapConverter", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.toTest = cms.EDProducer("CSCRecHit2DOwnVectorRangeMapConverter",
+get = cms.InputTag("src")
+ )
+process.moduleToTest(process.toTest)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  using OldRange = edm::RangeMap<CSCDetId, edm::OwnVector<CSCRecHit2D>>;
+  auto token = config.produces<OldRange>("src");
+
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_THROWS_AS(tester.test(), cms::Exception);
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+  SECTION("Transform old data") {
+    edm::test::TestProcessor tester(config);
+
+    auto oldRange = std::make_unique<OldRange>();
+    std::vector<CSCRecHit2D> v(3);
+    CSCDetId id1(1, 0, 0, 0);
+    CSCDetId id2(1, 1, 0, 0);
+    CSCDetId id3(2, 0, 0, 0);
+    std::vector<CSCDetId> ordered;
+    ordered.reserve(3);
+    ordered.push_back(id1);
+    ordered.push_back(id2);
+    ordered.push_back(id3);
+    std::sort(ordered.begin(), ordered.end(), std::less<CSCDetId>());
+
+    oldRange->put(id1, v.begin(), v.begin() + 1);
+    oldRange->put(id2, v.begin(), v.begin() + 2);
+    oldRange->put(id3, v.begin(), v.end());
+    oldRange->post_insert();
+    REQUIRE(oldRange->size() == 6);
+    REQUIRE(oldRange->id_size() == 3);
+    REQUIRE(oldRange->ids() == ordered);
+
+    auto event = tester.test(std::make_pair(token, std::move(oldRange)));
+
+    auto newRange = event.get<CSCRecHit2DCollection>();
+    REQUIRE(newRange->size() == 6);
+    REQUIRE(newRange->id_size() == 3);
+    REQUIRE(newRange->ids() == ordered);
+  }
+}

--- a/RecoLocalMuon/CSCRecHitD/test/test_catch2_main.cc
+++ b/RecoLocalMuon/CSCRecHitD/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<CSCDetId, CSCSegment>;
+
+using CSCSegmentOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<CSCDetId, CSCSegment>;
+DEFINE_FWK_MODULE(CSCSegmentOwnVectorRangeMapConverter);

--- a/RecoLocalMuon/DTSegment/src/DTRecSegment4DOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/DTSegment/src/DTRecSegment4DOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<DTChamberId, DTRecSegment4D>;
+
+using DTRecSegment4DOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<DTChamberId, DTRecSegment4D>;
+DEFINE_FWK_MODULE(DTRecSegment4DOwnVectorRangeMapConverter);

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<GEMDetId, GEMRecHit>;
+
+using GEMRecHitOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<GEMDetId, GEMRecHit>;
+DEFINE_FWK_MODULE(GEMRecHitOwnVectorRangeMapConverter);

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/GEMRecHit/interface/GEMSegmentCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<GEMDetId, GEMSegment>;
+
+using GEMSegmentOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<GEMDetId, GEMSegment>;
+DEFINE_FWK_MODULE(GEMSegmentOwnVectorRangeMapConverter);

--- a/RecoLocalMuon/RPCRecHit/plugins/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/DTSegtoRPC.cc
@@ -56,7 +56,7 @@ std::unique_ptr<RPCRecHitCollection> DTSegtoRPC::thePoints(const DTRecSegment4DC
                                                            bool debug,
                                                            double eyr) {
   auto _ThePoints = std::make_unique<RPCRecHitCollection>();
-  edm::OwnVector<RPCRecHit> RPCPointVector;
+  std::vector<RPCRecHit> RPCPointVector;
   std::vector<uint32_t> extrapolatedRolls;
 
   if (all4DSegments->size() > 8) {

--- a/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitOwnVectorRangeMapConverter.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/RPCRecHitOwnVectorRangeMapConverter.cc
@@ -1,0 +1,8 @@
+#include "CommonTools/RecoAlgos/interface/RangeMapOwnVectorToVectorConverter.h"
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+template class reco::RangeMapOwnVectorToVectorConverter<RPCDetId, RPCRecHit>;
+
+using RPCRecHitOwnVectorRangeMapConverter = reco::RangeMapOwnVectorToVectorConverter<RPCDetId, RPCRecHit>;
+DEFINE_FWK_MODULE(RPCRecHitOwnVectorRangeMapConverter);


### PR DESCRIPTION
#### PR description:

Changed the use of `edm::RangeMap<ID, edm::OwnVector<HIT>>` in muon code to `edm::IdToHitRange<ID, HIT>`. This is a part of the migration away from the use of `edm::OwnVector` (see #42734 ). The classes modified are those which are stored to either RECO, AOD, or MiniAOD files and the `HIT` class does not have any inheriting classes so the use of an `edm::OwnVector` was never needed. The `edm::IdToHitRange` should take up less memory as well as be easier/faster/smaller to store (measurements need to be done to confirm this).

As part of the change, new EDProducers were introduced to be able to convert `edm::RangeMap` into the equivalent `edm::IdToHitRange`. Thes EDProducers can be used to allow reading of old files containing `edm::RangeMap` and then covert to the new type as needed.

The `edm::IdToHitRange` is designed to be a drop-in replacement to `edm::RangeMap` so shares the same API. One of the functions in `edm::RangMap` allows one to pass in a different comparison function in order to find a range of hits. This is a very dangerous item as it requires the new comparison to be degenerate with respect to the standard comparator used to sort in `edm::RangeMap`. I added a new unit test for one of the two comparators to prove that it meets that standard (and to guarantee if it is ever change to keep meeting that standard).

#### PR validation:

Code compiles and new unit tests pass. I ran workflow 12434.0 using the new code.