### PR TITLE
Hcal DQM: Fix the ZDC illegal cast in HCAL offline DQM

### DIFF
--- a/DQM/HcalTasks/src/DigiRunSummary.cc
+++ b/DQM/HcalTasks/src/DigiRunSummary.cc
@@ -151,6 +151,15 @@ namespace hcaldqm {
     vtmpflags[fLED] = flag::Flag("LEDMisfire");
     for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
       HcalElectronicsId eid(*it);
+
+      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring flags settings.
+      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+        for (std::vector<flag::Flag>::iterator ft = vtmpflags.begin(); ft != vtmpflags.end(); ++ft)
+          ft->reset();
+        lssum._vflags.push_back(vtmpflags);
+        continue;
+      }
+
       HcalDetId did = HcalDetId(_emap->lookup(eid));
 
       //	reset all the tmp flags to fNA
@@ -335,6 +344,13 @@ namespace hcaldqm {
       flag::Flag ffDead("Dead");
       flag::Flag ffUniSlotHF("UniSlotHF");
       HcalElectronicsId eid(it_crate);
+
+      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring flags settings.
+      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+        sumflags.push_back(fSumRun);
+        continue;
+      }
+
       HcalDetId did = HcalDetId(_emap->lookup(eid));
 
       //	ITERATE OVER EACH LS

--- a/DQM/HcalTasks/src/RecoRunSummary.cc
+++ b/DQM/HcalTasks/src/RecoRunSummary.cc
@@ -138,6 +138,13 @@ namespace hcaldqm {
     for (std::vector<uint32_t>::const_iterator it = _vhashCrates.begin(); it != _vhashCrates.end(); ++it) {
       flag::Flag fSum("RECO");
       HcalElectronicsId eid(*it);
+
+      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring settings.
+      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+        sumflags.push_back(fSum);
+        continue;
+      }
+
       HcalDetId did = HcalDetId(_emap->lookup(eid));
 
       //	registered @cDAQ

--- a/DQM/HcalTasks/src/TPRunSummary.cc
+++ b/DQM/HcalTasks/src/TPRunSummary.cc
@@ -138,6 +138,13 @@ namespace hcaldqm {
     for (auto& it_hashcrate : _vhashCrates) {
       flag::Flag fSum("TP");
       HcalElectronicsId eid(it_hashcrate);
+
+      // skip monitoring for ZDC crate for now (Oct. 1 2023), the Hcal DQM group need to discuss with the ZDC group on the monitoring settings.
+      if (HcalGenericDetId(_emap->lookup(eid)).isHcalZDCDetId()) {
+        sumflags.push_back(fSum);
+        continue;
+      }
+
       HcalDetId did = HcalDetId(_emap->lookup(eid));
 
       if (did.subdet() == HcalBarrel || did.subdet() == HcalEndcap || did.subdet() == HcalForward) {


### PR DESCRIPTION
#### PR description:

Fix the issue raised [here](https://cms-talk.web.cern.ch/t/fast-track-validation-hlt-express-new-hcal-electronicsmap-condition/29957/6) due to PR #42895  

In the [HCAL offline DQM monitoring](https://tinyurl.com/yklptro9) we have a special set of plots that monitors per crate information. The monitoring elements can be different for HB/HE/HO/HF, thus for each crate we try to determine its HcalDetId component from [here](https://github.com/cms-sw/cmssw/blob/master/DQM/HcalTasks/src/DigiRunSummary.cc#L153-L154). This leads to issue without HcalDetId protection when including ZDC crates from the new emap. 

For now the ZDC crate is protected against. The future developers could add its monitoring (will take way to much time for this fix).

#### PR validation:

runTheMatrix.py didn't reveal this problem before. And the previous DQM validations only involve online DQM clients. I manually tested the bug and the fix running over the problem revealing file: "root://eoscms.cern.ch//eos/cms/tier0/store/express/HIRun2023A/StreamExpressCosmics/DQMIO/Express-v1/000/374/579/00000/1BAA5049-8AA5-49AF-AEC6-2BFED4B05269.root"

Offline DQM validation tests should be done to test this PR.

```c++
from Configuration.AlCa.GlobalTag import GlobalTag
process.GlobalTag.globaltag = '132X_dataRun3_Express_RecoverHcalEmap_v1'

process.GlobalTag.toGet = cms.VPSet(
  cms.PSet(record = cms.string("HcalElectronicsMapRcd"),
           tag = cms.string("HcalElectronicsMap_2023_v1.0_data"),
           connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
          )
)

# Path and EndPath definitions
process.dqmsave_step = cms.Path(process.DQMSaver)

# Schedule definition
process.schedule = cms.Schedule(process.dqmHarvesting,process.dqmsave_step)
``` 
