### PR TITLE
Use ECAL ratio timing algorithm for Run 1 and Run 2, and CC timing algorithm for Run 3 and beyond

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -14,7 +14,8 @@ from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
 
 Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018, run2_HLTconditions_2018]),
-                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC)
+                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal)
 

--- a/Configuration/Eras/python/Modifier_run3_ecal_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_ecal_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_ecal = cms.Modifier()
+

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -740,7 +740,7 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerMultiFit::getAlgoDescription
               edm::ParameterDescription<double>("addPedestalUncertaintyEB", 0., true) and
               edm::ParameterDescription<double>("addPedestalUncertaintyEE", 0., true) and
               edm::ParameterDescription<bool>("simplifiedNoiseModelForGainSwitch", true, true) and
-              edm::ParameterDescription<std::string>("timealgo", "crossCorrelationMethod", true) and
+              edm::ParameterDescription<std::string>("timealgo", "RatioMethod", true) and
               edm::ParameterDescription<std::vector<double>>("EBtimeFitParameters",
                                                              {-2.015452e+00,
                                                               3.130702e+00,
@@ -773,10 +773,10 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerMultiFit::getAlgoDescription
               edm::ParameterDescription<double>("EEtimeConstantTerm", 1.0, true) and
               edm::ParameterDescription<double>("EBtimeNconst", 28.5, true) and
               edm::ParameterDescription<double>("EEtimeNconst", 31.8, true) and
-              edm::ParameterDescription<double>("outOfTimeThresholdGain12pEB", 2.5, true) and
-              edm::ParameterDescription<double>("outOfTimeThresholdGain12mEB", 2.5, true) and
-              edm::ParameterDescription<double>("outOfTimeThresholdGain61pEB", 2.5, true) and
-              edm::ParameterDescription<double>("outOfTimeThresholdGain61mEB", 2.5, true) and
+              edm::ParameterDescription<double>("outOfTimeThresholdGain12pEB", 5., true) and
+              edm::ParameterDescription<double>("outOfTimeThresholdGain12mEB", 5., true) and
+              edm::ParameterDescription<double>("outOfTimeThresholdGain61pEB", 5., true) and
+              edm::ParameterDescription<double>("outOfTimeThresholdGain61mEB", 5., true) and
               edm::ParameterDescription<double>("outOfTimeThresholdGain12pEE", 1000, true) and
               edm::ParameterDescription<double>("outOfTimeThresholdGain12mEE", 1000, true) and
               edm::ParameterDescription<double>("outOfTimeThresholdGain61pEE", 1000, true) and

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -12,8 +12,8 @@ run3_ecal.toModify(ecalMultiFitUncalibRecHit,
         outOfTimeThresholdGain12mEB = 2.5,
         outOfTimeThresholdGain61pEB = 2.5,
         outOfTimeThresholdGain61mEB = 2.5,
-        timeCalibTag = cms.ESInputTag('', 'CC'),
-        timeOffsetTag = cms.ESInputTag('', 'CC')
+        timeCalibTag = ':CC',
+        timeOffsetTag = ':CC'
     )
 )
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -3,3 +3,17 @@ import  RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHitProducer_cfi as 
 # producer of rechits starting from digis
 ecalMultiFitUncalibRecHit = _mod.ecalMultiFitUncalibRecHitProducer.clone()
 
+# use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+run3_ecal.toModify(ecalMultiFitUncalibRecHit,
+    algoPSet = dict(timealgo = 'crossCorrelationMethod',
+        outOfTimeThresholdGain12pEB = 2.5,
+        outOfTimeThresholdGain12mEB = 2.5,
+        outOfTimeThresholdGain61pEB = 2.5,
+        outOfTimeThresholdGain61mEB = 2.5,
+        timeCalibTag = cms.ESInputTag('', 'CC'),
+        timeOffsetTag = cms.ESInputTag('', 'CC')
+    )
+)
+


### PR DESCRIPTION
#### PR description:

This PR sets the default ECAL timing algorithm to the ratio method. This is the default timing algorithm for Run 1 and Run 2.
For Run 3 and Phase 2 a new modifier `run3_ecal` is used to change the timing algorithm to CC timing and use different records with the label 'CC' for the timing calibrations and timing offset constants.

Note that this behaviour is different than what was discussed in the [meeting](https://indico.cern.ch/event/1329876/) on the 27th Sept. when the plan was made to make the CC timing the default and use eras to modify Run 1 and Run 2 configurations to use the ratio method. Since Run 1 configurations could not be modified using eras we decided to reverse the behaviour as in the description above.

#### PR validation:

The PR passes Run 1 and Run2 WFs in the limited matrix tests but currently fails all Run 3 and Phase 2 WFs because the consumed records with the 'CC' label are not yet in the GTs.