### PR TITLE
Add ECAL portable data formats, collections and conditions for alpaka

### DIFF
--- a/CondFormats/DataRecord/interface/EcalMultifitConditionsRcd.h
+++ b/CondFormats/DataRecord/interface/EcalMultifitConditionsRcd.h
@@ -1,0 +1,27 @@
+#ifndef CondFormats_DataRecord_EcalMultifitConditionsRcd_h
+#define CondFormats_DataRecord_EcalMultifitConditionsRcd_h
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPulseCovariancesRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPulseShapesRcd.h"
+#include "CondFormats/DataRecord/interface/EcalSampleMaskRcd.h"
+#include "CondFormats/DataRecord/interface/EcalSamplesCorrelationRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeBiasCorrectionsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeCalibConstantsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTimeOffsetConstantRcd.h"
+
+class EcalMultifitConditionsRcd
+    : public edm::eventsetup::DependentRecordImplementation<EcalMultifitConditionsRcd,
+                                                            edm::mpl::Vector<EcalGainRatiosRcd,
+                                                                             EcalPedestalsRcd,
+                                                                             EcalPulseCovariancesRcd,
+                                                                             EcalPulseShapesRcd,
+                                                                             EcalSampleMaskRcd,
+                                                                             EcalSamplesCorrelationRcd,
+                                                                             EcalTimeBiasCorrectionsRcd,
+                                                                             EcalTimeCalibConstantsRcd,
+                                                                             EcalTimeOffsetConstantRcd>> {};
+#endif

--- a/CondFormats/DataRecord/interface/EcalMultifitParametersRcd.h
+++ b/CondFormats/DataRecord/interface/EcalMultifitParametersRcd.h
@@ -1,0 +1,8 @@
+#ifndef CondFormats_DataRecord_EcalMultifitParametersRcd_h
+#define CondFormats_DataRecord_EcalMultifitParametersRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class EcalMultifitParametersRcd : public edm::eventsetup::EventSetupRecordImplementation<EcalMultifitParametersRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/EcalMultifitConditionsRcd.cc
+++ b/CondFormats/DataRecord/src/EcalMultifitConditionsRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/EcalMultifitConditionsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalMultifitConditionsRcd);

--- a/CondFormats/DataRecord/src/EcalMultifitParametersRcd.cc
+++ b/CondFormats/DataRecord/src/EcalMultifitParametersRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/EcalMultifitParametersRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(EcalMultifitParametersRcd);

--- a/CondFormats/EcalObjects/BuildFile.xml
+++ b/CondFormats/EcalObjects/BuildFile.xml
@@ -3,6 +3,8 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/EcalDigi"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="boost"/>
@@ -10,6 +12,8 @@
 <use name="rootmath"/>
 <use name="clhep"/>
 <use name="cuda"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CondFormats/EcalObjects/interface/EcalElectronicsMappingHost.h
+++ b/CondFormats/EcalObjects/interface/EcalElectronicsMappingHost.h
@@ -1,0 +1,11 @@
+#ifndef CondFormats_EcalObjects_interface_EcalElectronicsMappingHost_h
+#define CondFormats_EcalObjects_interface_EcalElectronicsMappingHost_h
+
+#include "CondFormats/EcalObjects/interface/EcalElectronicsMappingSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+using EcalElectronicsMappingHost = PortableHostCollection<EcalElectronicsMappingSoA>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalElectronicsMappingSoA.h
+++ b/CondFormats/EcalObjects/interface/EcalElectronicsMappingSoA.h
@@ -1,0 +1,12 @@
+#ifndef CondFormats_EcalObjects_EcalElectronicsMappingSoA_h
+#define CondFormats_EcalObjects_EcalElectronicsMappingSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+GENERATE_SOA_LAYOUT(EcalElectronicsMappingSoALayout, SOA_COLUMN(uint32_t, rawid))
+
+using EcalElectronicsMappingSoA = EcalElectronicsMappingSoALayout<>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalMultifitConditionsHost.h
+++ b/CondFormats/EcalObjects/interface/EcalMultifitConditionsHost.h
@@ -1,0 +1,11 @@
+#ifndef CondFormats_EcalObjects_interface_EcalMultifitConditionsHost_h
+#define CondFormats_EcalObjects_interface_EcalMultifitConditionsHost_h
+
+#include "CondFormats/EcalObjects/interface/EcalMultifitConditionsSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+using EcalMultifitConditionsHost = PortableHostCollection<EcalMultifitConditionsSoA>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalMultifitConditionsSoA.h
+++ b/CondFormats/EcalObjects/interface/EcalMultifitConditionsSoA.h
@@ -1,0 +1,60 @@
+#ifndef CondFormats_EcalObjects_EcalMultifitConditionsSoA_h
+#define CondFormats_EcalObjects_EcalMultifitConditionsSoA_h
+
+#include <array>
+#include <Eigen/Dense>
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
+#include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
+
+using PulseShapeArray = std::array<float, EcalPulseShape::TEMPLATESAMPLES>;
+using SampleCorrelationArray = std::array<double, ecalPh1::sampleSize>;
+
+using CovarianceMatrix = Eigen::Matrix<float, EcalPulseShape::TEMPLATESAMPLES, EcalPulseShape::TEMPLATESAMPLES>;
+
+constexpr size_t kMaxTimeBiasCorrectionBinsEB = 71;
+constexpr size_t kMaxTimeBiasCorrectionBinsEE = 58;
+using TimeBiasCorrArrayEB = std::array<float, kMaxTimeBiasCorrectionBinsEB>;
+using TimeBiasCorrArrayEE = std::array<float, kMaxTimeBiasCorrectionBinsEE>;
+
+GENERATE_SOA_LAYOUT(EcalMultifitConditionsSoALayout,
+                    SOA_COLUMN(uint32_t, rawid),
+                    SOA_COLUMN(float, pedestals_mean_x12),
+                    SOA_COLUMN(float, pedestals_mean_x6),
+                    SOA_COLUMN(float, pedestals_mean_x1),
+                    SOA_COLUMN(float, pedestals_rms_x12),
+                    SOA_COLUMN(float, pedestals_rms_x6),
+                    SOA_COLUMN(float, pedestals_rms_x1),
+                    SOA_COLUMN(PulseShapeArray, pulseShapes),
+                    // NxN  N=templatesamples  for each xtal
+                    SOA_EIGEN_COLUMN(CovarianceMatrix, pulseCovariance),
+                    SOA_COLUMN(float, gain12Over6),
+                    SOA_COLUMN(float, gain6Over1),
+                    SOA_COLUMN(float, timeCalibConstants),
+                    // timeBiasCorrections (fixed since 2011)
+                    SOA_SCALAR(TimeBiasCorrArrayEB, timeBiasCorrections_amplitude_EB),
+                    SOA_SCALAR(TimeBiasCorrArrayEB, timeBiasCorrections_shift_EB),
+                    SOA_SCALAR(TimeBiasCorrArrayEE, timeBiasCorrections_amplitude_EE),
+                    SOA_SCALAR(TimeBiasCorrArrayEE, timeBiasCorrections_shift_EE),
+                    SOA_SCALAR(size_t, timeBiasCorrectionSizeEB),
+                    SOA_SCALAR(size_t, timeBiasCorrectionSizeEE),
+                    // Sample correlation scalar: array of 10 values for each gain in EB and EE
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EB_G12),
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EB_G6),
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EB_G1),
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EE_G12),
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EE_G6),
+                    SOA_SCALAR(SampleCorrelationArray, sampleCorrelation_EE_G1),
+                    // Samples Masks
+                    SOA_SCALAR(unsigned int, sampleMask_EB),
+                    SOA_SCALAR(unsigned int, sampleMask_EE),
+                    SOA_SCALAR(float, timeOffset_EB),
+                    SOA_SCALAR(float, timeOffset_EE),
+                    // offset for hashed ID access to EE items of columns
+                    SOA_SCALAR(uint32_t, offsetEE))
+
+using EcalMultifitConditionsSoA = EcalMultifitConditionsSoALayout<>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalMultifitParametersHost.h
+++ b/CondFormats/EcalObjects/interface/EcalMultifitParametersHost.h
@@ -1,0 +1,11 @@
+#ifndef CondFormats_EcalObjects_interface_EcalMultifitParametersHost_h
+#define CondFormats_EcalObjects_interface_EcalMultifitParametersHost_h
+
+#include "CondFormats/EcalObjects/interface/EcalMultifitParametersSoA.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+using EcalMultifitParametersHost = PortableHostCollection<EcalMultifitParametersSoA>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/EcalMultifitParametersSoA.h
+++ b/CondFormats/EcalObjects/interface/EcalMultifitParametersSoA.h
@@ -1,0 +1,22 @@
+#ifndef CondFormats_EcalObjects_EcalMultifitParametersSoA_h
+#define CondFormats_EcalObjects_EcalMultifitParametersSoA_h
+
+#include <array>
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+constexpr size_t kNTimeFitParams = 8;
+constexpr size_t kNAmplitudeFitParams = 2;
+using TimeFitParamsArray = std::array<float, kNTimeFitParams>;
+using AmplitudeFitParamsArray = std::array<float, kNAmplitudeFitParams>;
+
+GENERATE_SOA_LAYOUT(EcalMultifitParametersSoALayout,
+                    SOA_SCALAR(TimeFitParamsArray, timeFitParamsEB),
+                    SOA_SCALAR(TimeFitParamsArray, timeFitParamsEE),
+                    SOA_SCALAR(AmplitudeFitParamsArray, amplitudeFitParamsEB),
+                    SOA_SCALAR(AmplitudeFitParamsArray, amplitudeFitParamsEE))
+
+using EcalMultifitParametersSoA = EcalMultifitParametersSoALayout<>;
+
+#endif

--- a/CondFormats/EcalObjects/interface/alpaka/EcalElectronicsMappingDevice.h
+++ b/CondFormats/EcalObjects/interface/alpaka/EcalElectronicsMappingDevice.h
@@ -1,0 +1,17 @@
+#ifndef CondFormats_EcalObjects_interface_alpaka_EcalElectronicsMappingDevice_h
+#define CondFormats_EcalObjects_interface_alpaka_EcalElectronicsMappingDevice_h
+
+#include "CondFormats/EcalObjects/interface/EcalElectronicsMappingHost.h"
+#include "CondFormats/EcalObjects/interface/EcalElectronicsMappingSoA.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using ::EcalElectronicsMappingHost;
+  using EcalElectronicsMappingDevice = PortableCollection<EcalElectronicsMappingSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/CondFormats/EcalObjects/interface/alpaka/EcalMultifitConditionsDevice.h
+++ b/CondFormats/EcalObjects/interface/alpaka/EcalMultifitConditionsDevice.h
@@ -1,0 +1,17 @@
+#ifndef CondFormats_EcalObjects_interface_alpaka_EcalMultifitConditionsDevice_h
+#define CondFormats_EcalObjects_interface_alpaka_EcalMultifitConditionsDevice_h
+
+#include "CondFormats/EcalObjects/interface/EcalMultifitConditionsHost.h"
+#include "CondFormats/EcalObjects/interface/EcalMultifitConditionsSoA.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using ::EcalMultifitConditionsHost;
+  using EcalMultifitConditionsDevice = PortableCollection<EcalMultifitConditionsSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/CondFormats/EcalObjects/interface/alpaka/EcalMultifitParametersDevice.h
+++ b/CondFormats/EcalObjects/interface/alpaka/EcalMultifitParametersDevice.h
@@ -1,0 +1,17 @@
+#ifndef CondFormats_EcalObjects_interface_alpaka_EcalMultifitParametersDevice_h
+#define CondFormats_EcalObjects_interface_alpaka_EcalMultifitParametersDevice_h
+
+#include "CondFormats/EcalObjects/interface/EcalMultifitParametersHost.h"
+#include "CondFormats/EcalObjects/interface/EcalMultifitParametersSoA.h"
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  using ::EcalMultifitParametersHost;
+  using EcalMultifitParametersDevice = PortableCollection<EcalMultifitParametersSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/CondFormats/EcalObjects/src/ES_EcalElectronicsMappingHost.cc
+++ b/CondFormats/EcalObjects/src/ES_EcalElectronicsMappingHost.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/EcalObjects/interface/EcalElectronicsMappingHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(EcalElectronicsMappingHost);

--- a/CondFormats/EcalObjects/src/ES_EcalMultifitConditionsHost.cc
+++ b/CondFormats/EcalObjects/src/ES_EcalMultifitConditionsHost.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/EcalObjects/interface/EcalMultifitConditionsHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(EcalMultifitConditionsHost);

--- a/CondFormats/EcalObjects/src/ES_EcalMultifitParametersHost.cc
+++ b/CondFormats/EcalObjects/src/ES_EcalMultifitParametersHost.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/EcalObjects/interface/EcalMultifitParametersHost.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(EcalMultifitParametersHost);

--- a/CondFormats/EcalObjects/src/alpaka/ES_EcalElectronicsMappingDevice.cc
+++ b/CondFormats/EcalObjects/src/alpaka/ES_EcalElectronicsMappingDevice.cc
@@ -1,0 +1,4 @@
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+#include "CondFormats/EcalObjects/interface/alpaka/EcalElectronicsMappingDevice.h"
+TYPELOOKUP_ALPAKA_DATA_REG(EcalElectronicsMappingDevice);

--- a/CondFormats/EcalObjects/src/alpaka/ES_EcalMultifitConditionsDevice.cc
+++ b/CondFormats/EcalObjects/src/alpaka/ES_EcalMultifitConditionsDevice.cc
@@ -1,0 +1,4 @@
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+#include "CondFormats/EcalObjects/interface/alpaka/EcalMultifitConditionsDevice.h"
+TYPELOOKUP_ALPAKA_DATA_REG(EcalMultifitConditionsDevice);

--- a/CondFormats/EcalObjects/src/alpaka/ES_EcalMultifitParametersDevice.cc
+++ b/CondFormats/EcalObjects/src/alpaka/ES_EcalMultifitParametersDevice.cc
@@ -1,0 +1,4 @@
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+
+#include "CondFormats/EcalObjects/interface/alpaka/EcalMultifitParametersDevice.h"
+TYPELOOKUP_ALPAKA_DATA_REG(EcalMultifitParametersDevice);

--- a/DataFormats/EcalDigi/BuildFile.xml
+++ b/DataFormats/EcalDigi/BuildFile.xml
@@ -1,8 +1,12 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/EcalDetId"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/EcalDigi/interface/EcalConstants.h
+++ b/DataFormats/EcalDigi/interface/EcalConstants.h
@@ -30,7 +30,7 @@ class ecalPh2 {
 public:
   static constexpr double Samp_Period = 6.25;               // ADC sampling period in ns
   static constexpr unsigned int NGAINS = ecalph2::NGAINS;   // Number of CATIA gains
-  static constexpr const float *gains = ecalph2::gains;     // CATIA gain values
+  static constexpr const float* gains = ecalph2::gains;     // CATIA gain values
   static constexpr unsigned int gainId1 = 1;                // Position of gain 1 in gains array
   static constexpr unsigned int gainId10 = 0;               // Position of gain 10 in gains array
   static constexpr unsigned int sampleSize = 16;            // Number of samples per event
@@ -49,7 +49,7 @@ class ecalPh1 {
 public:
   static constexpr double Samp_Period = 25.;               // ADC sampling period in ns
   static constexpr unsigned int NGAINS = ecalph1::NGAINS;  // Number of MGPA gains including a zero gain
-  static constexpr const float *gains = ecalph1::gains;    // MGPA gain values including a zero gain
+  static constexpr const float* gains = ecalph1::gains;    // MGPA gain values including a zero gain
   static constexpr unsigned int sampleSize = 10;           // Number of samples per event
   static constexpr unsigned int NBITS = 12;                // Number of available bits
   static constexpr unsigned int kNOffsets = 2000;          // Number of time offsets generated for APD pulse shape

--- a/DataFormats/EcalDigi/interface/EcalDigiHostCollection.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiHostCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_EcalDigi_EcalDigiHostCollection_h
+#define DataFormats_EcalDigi_EcalDigiHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiSoA.h"
+
+// EcalDigiSoA in host memory
+using EcalDigiHostCollection = PortableHostCollection<EcalDigiSoA>;
+
+#endif

--- a/DataFormats/EcalDigi/interface/EcalDigiPhase2HostCollection.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiPhase2HostCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_EcalDigi_EcalDigiPhase2HostCollection_h
+#define DataFormats_EcalDigi_EcalDigiPhase2HostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h"
+
+// EcalDigiPhase2SoA in host memory
+using EcalDigiPhase2HostCollection = PortableHostCollection<EcalDigiPhase2SoA>;
+
+#endif

--- a/DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_EcalDigi_EcalDigiPhase2SoA_h
+#define DataFormats_EcalDigi_EcalDigiPhase2SoA_h
+
+#include "DataFormats/Common/interface/StdArray.h"
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+// due to a ROOT limitation the std::array needs to be wrapped
+// https://github.com/root-project/root/issues/12007
+using EcalDataArrayPhase2 = edm::StdArray<uint16_t, ecalPh2::sampleSize>;
+
+GENERATE_SOA_LAYOUT(EcalDigiPhase2SoALayout,
+                    SOA_COLUMN(uint32_t, id),
+                    SOA_COLUMN(EcalDataArrayPhase2, data),
+                    SOA_SCALAR(uint32_t, size))
+
+using EcalDigiPhase2SoA = EcalDigiPhase2SoALayout<>;
+
+#endif

--- a/DataFormats/EcalDigi/interface/EcalDigiSoA.h
+++ b/DataFormats/EcalDigi/interface/EcalDigiSoA.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_EcalDigi_EcalDigiSoA_h
+#define DataFormats_EcalDigi_EcalDigiSoA_h
+
+#include "DataFormats/Common/interface/StdArray.h"
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+// due to a ROOT limitation the std::array needs to be wrapped
+// https://github.com/root-project/root/issues/12007
+using EcalDataArray = edm::StdArray<uint16_t, ecalPh1::sampleSize>;
+
+GENERATE_SOA_LAYOUT(EcalDigiSoALayout,
+                    SOA_COLUMN(uint32_t, id),
+                    SOA_COLUMN(EcalDataArray, data),
+                    SOA_SCALAR(uint32_t, size))
+
+using EcalDigiSoA = EcalDigiSoALayout<>;
+
+#endif

--- a/DataFormats/EcalDigi/interface/alpaka/EcalDigiDeviceCollection.h
+++ b/DataFormats/EcalDigi/interface/alpaka/EcalDigiDeviceCollection.h
@@ -1,0 +1,15 @@
+#ifndef DataFormats_EcalDigi_interface_alpaka_EcalDigiDeviceCollection_h
+#define DataFormats_EcalDigi_interface_alpaka_EcalDigiDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  // EcalDigiSoA in device global memory
+  using EcalDigiDeviceCollection = PortableCollection<EcalDigiSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/DataFormats/EcalDigi/interface/alpaka/EcalDigiPhase2DeviceCollection.h
+++ b/DataFormats/EcalDigi/interface/alpaka/EcalDigiPhase2DeviceCollection.h
@@ -1,0 +1,15 @@
+#ifndef DataFormats_EcalDigi_interface_alpaka_EcalDigiPhase2DeviceCollection_h
+#define DataFormats_EcalDigi_interface_alpaka_EcalDigiPhase2DeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  // EcalDigiPhase2SoA in device global memory
+  using EcalDigiPhase2DeviceCollection = PortableCollection<EcalDigiPhase2SoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/DataFormats/EcalDigi/src/alpaka/classes_cuda.h
+++ b/DataFormats/EcalDigi/src/alpaka/classes_cuda.h
@@ -1,0 +1,6 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiSoA.h"
+#include "DataFormats/EcalDigi/interface/alpaka/EcalDigiDeviceCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h"
+#include "DataFormats/EcalDigi/interface/alpaka/EcalDigiPhase2DeviceCollection.h"

--- a/DataFormats/EcalDigi/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/EcalDigi/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,9 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::EcalDigiDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::EcalDigiPhase2DeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::EcalDigiPhase2DeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::EcalDigiPhase2DeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/EcalDigi/src/alpaka/classes_rocm.h
+++ b/DataFormats/EcalDigi/src/alpaka/classes_rocm.h
@@ -1,0 +1,6 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiSoA.h"
+#include "DataFormats/EcalDigi/interface/alpaka/EcalDigiDeviceCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h"
+#include "DataFormats/EcalDigi/interface/alpaka/EcalDigiPhase2DeviceCollection.h"

--- a/DataFormats/EcalDigi/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/EcalDigi/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,9 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::EcalDigiDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::EcalDigiDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::EcalDigiDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_rocm_async::EcalDigiPhase2DeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::EcalDigiPhase2DeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::EcalDigiPhase2DeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/EcalDigi/src/classes.h
+++ b/DataFormats/EcalDigi/src/classes.h
@@ -1,2 +1,6 @@
-#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiHostCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiSoA.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2HostCollection.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiPhase2SoA.h"

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -132,4 +132,40 @@
    <class name="edm::Wrapper<edm::SortedCollection<EESrFlag,edm::StrictWeakOrdering<EESrFlag> > >" splitLevel="0" id="CE18D35E-E4F5-4685-8D9A-213D9ACB0606"/>
    <class name="edm::Wrapper<edm::SortedCollection<EcalPnDiodeDigi,edm::StrictWeakOrdering<EcalPnDiodeDigi> > >" id="8104DEE4-28BC-284A-8397-7EF8F5DBA1B1"/>
    <class name="edm::Wrapper<edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> > >" id="09B54EAE-7A1A-B892-117A-EFE5E32AF982"/>
+
+   <class name="EcalDataArray"/>
+   <class name="EcalDigiSoA"/>
+   <class name="EcalDigiSoA::View"/>
+
+   <class name="EcalDigiHostCollection"/>
+   <read
+     sourceClass="EcalDigiHostCollection"
+     targetClass="EcalDigiHostCollection"
+     version="[1-]"
+     source="EcalDigiSoA layout_;"
+     target="buffer_,layout_,view_"
+     embed="false">
+   <![CDATA[
+     EcalDigiHostCollection::ROOTReadStreamer(newObj, onfile.layout_);
+   ]]>
+   </read>
+   <class name="edm::Wrapper<EcalDigiHostCollection>" splitLevel="0"/>
+
+   <class name="EcalDataArrayPhase2"/>
+   <class name="EcalDigiPhase2SoA"/>
+   <class name="EcalDigiPhase2SoA::View"/>
+
+   <class name="EcalDigiPhase2HostCollection"/>
+   <read
+     sourceClass="EcalDigiPhase2HostCollection"
+     targetClass="EcalDigiPhase2HostCollection"
+     version="[1-]"
+     source="EcalDigiPhase2SoA layout_;"
+     target="buffer_,layout_,view_"
+     embed="false">
+   <![CDATA[
+     EcalDigiPhase2HostCollection::ROOTReadStreamer(newObj, onfile.layout_);
+   ]]>
+   </read>
+   <class name="edm::Wrapper<EcalDigiPhase2HostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/EcalRecHit/BuildFile.xml
+++ b/DataFormats/EcalRecHit/BuildFile.xml
@@ -3,7 +3,11 @@
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/EcalDigi"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="FWCore/MessageLogger"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitHostCollection.h
+++ b/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitHostCollection.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_EcalRecHit_EcalUncalibratedRecHitHostCollection_h
+#define DataFormats_EcalRecHit_EcalUncalibratedRecHitHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h"
+
+// EcalUncalibratedRecHitSoA in host memory
+using EcalUncalibratedRecHitHostCollection = PortableHostCollection<EcalUncalibratedRecHitSoA>;
+
+#endif

--- a/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h
+++ b/DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h
@@ -1,0 +1,29 @@
+#ifndef DataFormats_EcalRecHit_EcalUncalibratedRecHitSoA_h
+#define DataFormats_EcalRecHit_EcalUncalibratedRecHitSoA_h
+
+#include "DataFormats/Common/interface/StdArray.h"
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+// due to a ROOT limitation the std::array needs to be wrapped
+// https://github.com/root-project/root/issues/12007
+using EcalOotAmpArray =
+    edm::StdArray<float, ecalPh1::sampleSize>;  //number of OOT amplitudes currently=number of samples, to be revised
+
+GENERATE_SOA_LAYOUT(EcalUncalibratedRecHitSoALayout,
+                    SOA_COLUMN(uint32_t, id),
+                    SOA_SCALAR(uint32_t, size),
+                    SOA_COLUMN(float, amplitude),
+                    SOA_COLUMN(float, amplitudeError),
+                    SOA_COLUMN(float, pedestal),
+                    SOA_COLUMN(float, jitter),
+                    SOA_COLUMN(float, jitterError),
+                    SOA_COLUMN(float, chi2),
+                    SOA_COLUMN(float, OOTchi2),
+                    SOA_COLUMN(uint32_t, flags),
+                    SOA_COLUMN(uint32_t, aux),
+                    SOA_COLUMN(EcalOotAmpArray, outOfTimeAmplitudes))
+
+using EcalUncalibratedRecHitSoA = EcalUncalibratedRecHitSoALayout<>;
+
+#endif

--- a/DataFormats/EcalRecHit/interface/alpaka/EcalUncalibratedRecHitDeviceCollection.h
+++ b/DataFormats/EcalRecHit/interface/alpaka/EcalUncalibratedRecHitDeviceCollection.h
@@ -1,0 +1,15 @@
+#ifndef DataFormats_EcalRecHit_alpaka_EcalUncalibratedRecHitDeviceCollection_h
+#define DataFormats_EcalRecHit_alpaka_EcalUncalibratedRecHitDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  // EcalUncalibratedRecHitSoA in device global memory
+  using EcalUncalibratedRecHitDeviceCollection = PortableCollection<EcalUncalibratedRecHitSoA>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/DataFormats/EcalRecHit/src/alpaka/classes_cuda.h
+++ b/DataFormats/EcalRecHit/src/alpaka/classes_cuda.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h"
+#include "DataFormats/EcalRecHit/interface/alpaka/EcalUncalibratedRecHitDeviceCollection.h"

--- a/DataFormats/EcalRecHit/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/EcalRecHit/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/EcalRecHit/src/alpaka/classes_rocm.h
+++ b/DataFormats/EcalRecHit/src/alpaka/classes_rocm.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h"
+#include "DataFormats/EcalRecHit/interface/alpaka/EcalUncalibratedRecHitDeviceCollection.h"

--- a/DataFormats/EcalRecHit/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/EcalRecHit/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::EcalUncalibratedRecHitDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::EcalUncalibratedRecHitDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::EcalUncalibratedRecHitDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/EcalRecHit/src/classes.h
+++ b/DataFormats/EcalRecHit/src/classes.h
@@ -13,3 +13,6 @@
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitComparison.h"
+
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitHostCollection.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHitSoA.h"

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -39,4 +39,22 @@
   <class name="edm::Wrapper<edm::DetSetVector<EcalRecHit> >"/>
   <class name="edm::Wrapper<std::vector<std::vector<edm::DetSet<EcalRecHit> > > >"/>
 
+  <class name="EcalOotAmpArray"/>
+  <class name="EcalUncalibratedRecHitSoA"/>
+  <class name="EcalUncalibratedRecHitSoA::View"/>
+
+  <class name="EcalUncalibratedRecHitHostCollection"/>
+  <read
+    sourceClass="EcalUncalibratedRecHitHostCollection"
+    targetClass="EcalUncalibratedRecHitHostCollection"
+    version="[1-]"
+    source="EcalUncalibratedRecHitSoA layout_;"
+    target="buffer_,layout_,view_"
+    embed="false">
+  <![CDATA[
+    EcalUncalibratedRecHitHostCollection::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="edm::Wrapper<EcalUncalibratedRecHitHostCollection>" splitLevel="0"/>
+
 </lcgdict>


### PR DESCRIPTION
#### PR description:

This PR is the first in a planned series of three to migrate the ECAL local reconstruction for Run 3 and Phase 2 to alpaka.
It adds the conditions formats and portable collections as well as the data formats and portable collections.

Conditions:
- Multifit conditions
- Electronics mapping

SoA data formats:
- Digis
- Digis Phase 2
- Uncalibrated RecHits

All developments of @valsdav , @Jakub-Gajownik , and @thomreis have been squashed into one commit for clarity.

Since this PR just adds collections for future use in the coming commits no changes are expected from this PR.

PRs 2 and 3 will be made to add the Phase 2 local reconstruction code and multifit algorithm migrations, respectively.

#### PR validation:

Passes GPU WFs 12434.512 and 24834.612