### PR TITLE
Add FastTimer and Throughput Services to HLT Phase2 timing menu.

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/services/ThroughputService_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/services/ThroughputService_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+ThroughputService = cms.Service('ThroughputService',
+  eventRange = cms.untracked.uint32(10000),
+  eventResolution = cms.untracked.uint32(1),
+  printEventSummary = cms.untracked.bool(False),
+  enableDQM = cms.untracked.bool(True),
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_timing_cff.py
@@ -221,6 +221,24 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/psets/TrajectoryFilterForElectr
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLTriggerFinalPath_cff")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLTAnalyzerEndpath_cff")
 
+# Load and configure the FastTimerService
+fragment.load("HLTrigger/Configuration/HLT_75e33/services/FastTimerService_cfi")
+fragment.FastTimerService.enableDQM = False
+fragment.FastTimerService.enableDQMbyModule = False
+fragment.FastTimerService.enableDQMbyPath = False
+fragment.FastTimerService.jsonFileName = 'Phase2Timing_resources.json'
+
+# Load and configure the ThroughputService
+fragment.load("HLTrigger/Configuration/HLT_75e33/services/ThroughputService_cfi")
+fragment.ThroughputService.eventRange = 1000
+fragment.ThroughputService.eventResolution = 50
+fragment.ThroughputService.printEventSummary = True
+fragment.ThroughputService.enableDQM = False
+
+# Cusotmize the output as well
+if fragment.HLTriggerFinalPath.contains(fragment.hltTriggerSummaryAOD):
+    fragment.HLTriggerFinalPath.remove(fragment.hltTriggerSummaryAOD)
+
 fragment.schedule = cms.Schedule(*[
 
     fragment.L1T_SinglePFPuppiJet230off,


### PR DESCRIPTION
#### PR description:

* Add FastTimerService and ThroughputService to the HLT Phase2 timing menu.
* Also, remove for the moment the `triggerSummaryAOD` module that is causing weird behaviour.
* For timing measurements, also the output module should be disabled. But this is easily achieved by using the `--output={}` option of `cmsDriver.py`.

#### PR validation:

Tested locally using workflow `24834.75`, rerunning step4 using the `HLT:75e33_timing` menu.
