### PR TITLE
Fix logic error in `FinalPath` checks

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1285,9 +1285,9 @@ class Process(object):
               iFinalPath.resolve(self.__dict__)
               finalpathValidator.setLabel(finalpathname)
               iFinalPath.visit(finalpathValidator)
-              filtersOrProducers = finalpathValidator.filtersOnFinalpaths + finalpathValidator.producersOnFinalpaths
-              if filtersOrProducers:
-                  raise RuntimeError("FinalPath %s has non OutputModules %s" % (finalpathname, ",".join(filtersOrProducers)))
+              invalidModules = finalpathValidator.invalidModulesOnFinalpaths
+              if invalidModules:
+                  raise RuntimeError("FinalPath %s has non OutputModules %s" % (finalpathname, ",".join(invalidModules)))
               modulesOnFinalPath.extend(iFinalPath.moduleNames())
           for m in modulesOnFinalPath:
             mod = getattr(self, m)
@@ -3351,7 +3351,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.anal = EDAnalyzer("MyAnalyzer")
             p.t = FinalPath(p.anal)
             pset = TestMakePSet()
-            p.fillProcessDesc(pset)
+            self.assertRaises(RuntimeError, p.fillProcessDesc, pset)
 
             p.prod = EDProducer("MyProducer")
             p.t = FinalPath(p.prod)

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -3325,7 +3325,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             path = FinalPath(p.a*(p.b+p.c))
             self.assertEqual(str(path),'a+b+c')
             p.es = ESProducer("AnESProducer")
-            self.assertRaises(TypeError,FinalPath,p.es)
+            self.assertRaises(TypeError,FinalPath, p.es)
 
             t = FinalPath()
             self.assertEqual(t.dumpPython(PrintOptions()), 'cms.FinalPath()\n')
@@ -3347,7 +3347,27 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.t = FinalPath(p.a)
             p.a = OutputModule("ReplacedOutputModule")
             self.assertEqual(p.t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
-            
+
+            p.anal = EDAnalyzer("MyAnalyzer")
+            p.t = FinalPath(p.anal)
+            pset = TestMakePSet()
+            p.fillProcessDesc(pset)
+
+            p.prod = EDProducer("MyProducer")
+            p.t = FinalPath(p.prod)
+            pset = TestMakePSet()
+            self.assertRaises(RuntimeError, p.fillProcessDesc, pset)
+
+            p.filt = EDFilter("MyFilter")
+            p.t = FinalPath(p.filt)
+            pset = TestMakePSet()
+            self.assertRaises(RuntimeError, p.fillProcessDesc, pset)
+
+            p.outp = OutputModule("MyOutputModule")
+            p.t = FinalPath(p.outp)
+            pset = TestMakePSet()
+            p.fillProcessDesc(pset)
+
         def testCloneSequence(self):
             p = Process("test")
             a = EDAnalyzer("MyAnalyzer")

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1285,10 +1285,9 @@ class Process(object):
               iFinalPath.resolve(self.__dict__)
               finalpathValidator.setLabel(finalpathname)
               iFinalPath.visit(finalpathValidator)
-              if finalpathValidator.filtersOnFinalpaths or finalpathValidator.producersOnFinalpaths:
-                  names = [p.label_ for p in finalpathValidator.filtersOnFinalpaths]
-                  names.extend( [p.label_ for p in finalpathValidator.producersOnFinalpaths])
-                  raise RuntimeError("FinalPath %s has non OutputModules %s" % (finalpathname, ",".join(names)))
+              filtersOrProducers = finalpathValidator.filtersOnFinalpaths + finalpathValidator.producersOnFinalpaths
+              if filtersOrProducers:
+                  raise RuntimeError("FinalPath %s has non OutputModules %s" % (finalpathname, ",".join(filtersOrProducers)))
               modulesOnFinalPath.extend(iFinalPath.moduleNames())
           for m in modulesOnFinalPath:
             mod = getattr(self, m)

--- a/FWCore/ParameterSet/python/SequenceVisitors.py
+++ b/FWCore/ParameterSet/python/SequenceVisitors.py
@@ -72,8 +72,7 @@ class FinalPathValidator(object):
     def __init__(self):
         self.__label = ''
         self._levelInTasks = 0
-        self.filtersOnFinalpaths = []
-        self.producersOnFinalpaths = []
+        self.invalidModulesOnFinalpaths = []
     def setLabel(self,label):
         self.__label = "'"+label+"' "
     def enter(self,visitee):
@@ -88,10 +87,8 @@ class FinalPathValidator(object):
             self._levelInTasks += 1
         if self._levelInTasks > 0:
             return
-        if isinstance(visitee,EDFilter):
-            self.filtersOnFinalpaths.append(visitee.type_())
-        if isinstance(visitee,EDProducer):
-            self.producersOnFinalpaths.append(visitee.type_())
+        if isinstance(visitee,(EDAnalyzer,EDProducer,EDFilter)):
+            self.invalidModulesOnFinalpaths.append(visitee.type_())
     def leave(self,visitee):
         if self._levelInTasks > 0:
             if isinstance(visitee, Task):


### PR DESCRIPTION
#### PR description:

If an `EDProducer` or `EDFilter` is inserted in a `FinalPath`, the job fails with a cryptic error:
```
----- Begin Fatal Exception 03-Oct-2023 15:42:41 CEST-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named dump.py
Exception Message:
 unknown python problem occurred.
AttributeError: 'str' object has no attribute 'label_'

At:
  /data/user/fwyzard/CMSSW_13_3_X_2023-10-02-2300/src/FWCore/ParameterSet/python/Config.py(1292): <listcomp>
  /data/user/fwyzard/CMSSW_13_3_X_2023-10-02-2300/src/FWCore/ParameterSet/python/Config.py(1292): _insertPaths
  /data/user/fwyzard/CMSSW_13_3_X_2023-10-02-2300/src/FWCore/ParameterSet/python/Config.py(1490): fillProcessDesc
  <string>(2): <module>

----- End Fatal Exception -------------------------------------------------
```

With these changes, the error is more meaningful:
```
----- Begin Fatal Exception 03-Oct-2023 15:46:00 CEST-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named dump.py
Exception Message:
 unknown python problem occurred.
RuntimeError: FinalPath HLTriggerFinalPath has non OutputModules HLTBool,TriggerSummaryProducerRAW

At:
  /data/user/fwyzard/CMSSW_13_3_X_2023-10-02-2300/src/FWCore/ParameterSet/python/Config.py(1290): _insertPaths
  /data/user/fwyzard/CMSSW_13_3_X_2023-10-02-2300/src/FWCore/ParameterSet/python/Config.py(1487): fillProcessDesc
  <string>(2): <module>

----- End Fatal Exception -------------------------------------------------
```

Implement the python checks to notify that also `EDAnalyzer`s are not supported on `FinalPath`s.

The unit tests are extended to catch the error.

#### PR validation:

The extended unit tests pass.
