### PR TITLE
Adding DeepFlavour Jet tags to BTV DQM

### DIFF
--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -72,11 +72,11 @@ hltBTVmonitoring = topMonitoring.clone(
         phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416],
     ),
     met       = "pfMet", # pfMet  
-    jets      = "ak4PFJetsCHS", # ak4PFJets, ak4PFJetsCHS, ak4PFJets
+    jets      = "ak4PFJetsPuppi", #ak4PFJetsCHS,  ak4PFJets, ak4PFJetsCHS, ak4PFJets
     electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
     muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !     
     
-    btagAlgos = ['pfDeepCSVJetTags:probb', 'pfDeepCSVJetTags:probbb'], 
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     workingpoint = -1., #no cut applied
     
     HTdefinition = 'pt>30 & abs(eta)<2.5',

--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -66,6 +66,7 @@ pfBTaggingTask = cms.Task(
     pfGhostTrackVertexTagInfos,
     pfGhostTrackBJetTags,
     pfDeepCSVTask,
+    pfDeepFlavourTask,
 
     # soft lepton tag infos and algos
     softPFMuonsTagInfos,
@@ -94,7 +95,7 @@ btagging = cms.Sequence(btaggingTask)
 ## modifying b-tagging task in Run3 adding ParticleNet inferece
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 _pfBTaggingTask_run3 = cms.Task(
-    # Keep all the infos and DeepCSV
+    # Keep all the infos and DeepCSV and DeepFlavour
     pfImpactParameterTagInfos,
     pfTrackCountingHighEffBJetTags,
     pfJetProbabilityBJetTags,
@@ -105,6 +106,7 @@ _pfBTaggingTask_run3 = cms.Task(
     pfInclusiveSecondaryVertexFinderTagInfos,
     pfGhostTrackVertexTagInfos,
     pfDeepCSVTask,
+    pfDeepFlavourTask,
 
     softPFMuonsTagInfos,
     softPFElectronsTagInfos,


### PR DESCRIPTION
This PR aims to replace the outdated DeepCSV jet tags in Trigger DQM with the DeepFlavour algorithm, updating [#42808](https://github.com/cms-sw/cmssw/pull/42808).

Lastly, since we are trying to select events offline, we also added the DeepFlavour task to the RecoBTag sequence.

The expected changes are new btagging input plots in BTV HLT DQM.

This passes the basic tests suggested in [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).  
12434.0 workflow runs without error and histograms are filled.

edit: further changes may be added, tbc