### PR TITLE
Update of Phase2 Tracker Digitizer to fix an issue in Premixing

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -997,7 +997,7 @@ int Phase2TrackerDigitizerAlgorithm::convertSignalToAdc(uint32_t detID, float si
     signal_in_adc = theAdcFullScale_;
   } else {
     if (thePhase2ReadoutMode_ == -1) {
-      temp_signal = std::min(static_cast<int>(signal_in_elec / theElectronPerADC_), theAdcFullScale_);
+      temp_signal = std::min(static_cast<int>(std::round(signal_in_elec / theElectronPerADC_)), theAdcFullScale_);
     } else {
       // calculate the kink point and the slope
       int dualslope_param = std::min(std::abs(thePhase2ReadoutMode_), max_limit);
@@ -1005,7 +1005,8 @@ int Phase2TrackerDigitizerAlgorithm::convertSignalToAdc(uint32_t detID, float si
       // C-ROC: first valid ToT code above threshold is 0b0000
       temp_signal = std::floor((signal_in_elec - threshold) / theElectronPerADC_);
       if (temp_signal > kink_point)
-        temp_signal = std::floor((temp_signal - kink_point) / (pow(2, dualslope_param - 1))) + kink_point;
+        temp_signal =
+            static_cast<int>(std::floor((temp_signal - kink_point) / (pow(2, dualslope_param - 1)))) + kink_point;
     }
     signal_in_adc = std::min(temp_signal, theAdcFullScale_);
     LogTrace("Phase2TrackerDigitizerAlgorithm")

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -233,11 +233,17 @@ _premixStage1ModifyDict = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        Phase2ReadoutMode = -1,
+        AdcFullScale = 255,
+        AddXTalk = False,
     ),
     Pixel3DDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        Phase2ReadoutMode = -1,
+        AdcFullScale = 255,
+        AddXTalk = False,
     ),
     PSPDigitizerAlgorithm = dict(
         AddNoisyPixels = False,

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -221,10 +221,15 @@ phase2TrackerDigitizer = cms.PSet(
 # - do not add noisy pixels (to be done in stage2)
 # - do not apply inefficiency (to be done in stage2)
 # - disable threshold smearing
+# - disable x-talk simulatiom
 #
-# For outer tracker
-# - force analog readout to get the ADCs
-#
+# For both Inner and Outer tracker
+# - force analog readout to get Full Charge  ADCs 
+# - for Inner Tracker Dual Slope signal scaling NOT used here to avoid any singal loss.
+#   At step 2 Dual Slope signal scaling is used as default. To keep the full precision
+#   ADCFull scaling is also changed to 255 for Inner Tracker
+# 
+# - 
 # NOTE: It is currently assumed that all sub-digitizers have the same ElectronPerAdc.
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 _premixStage1ModifyDict = dict(
@@ -233,33 +238,38 @@ _premixStage1ModifyDict = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        AddXTalk = False,
         Phase2ReadoutMode = -1,
         AdcFullScale = 255,
-        AddXTalk = False,
     ),
     Pixel3DDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        AddXTalk = False,
         Phase2ReadoutMode = -1,
         AdcFullScale = 255,
-        AddXTalk = False,
     ),
     PSPDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        AddXTalk = False,
+        Phase2ReadoutMode = -1,
     ),
     PSSDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        AddXTalk = False,
         Phase2ReadoutMode = -1,
     ),
     SSDigitizerAlgorithm = dict(
         AddNoisyPixels = False,
         AddInefficiency = False,
         AddThresholdSmearing = False,
+        AddXTalk = False,
+        Phase2ReadoutMode = -1,
     ),
 )
 


### PR DESCRIPTION
#### PR description:
Updating Phase2TrackerDigitizerAlgorithm to fix the issue observed during Premixing of PU events at the Digitization. It was observed that the Digitized signal gets lowered and correspondingly #  Digis are lower than expected in inner Pixel layers . It was found that this is due to the fact that the Dual-Slope signal scaling is used. It is now fixed using simple liner scaling of charge during the first step  of Pre-Mixing.  

  - Changes are NOT expected! As shown in the validation plots, the PreMixing and noPreMixing show similar behaviour as expected.  
  - NO other PRs or externals it depends upon it
  - The details of the code change and the validation results are reported to Tk Phase2 Simulation group [Link](https://indico.cern.ch/event/1321219/contributions/5602295/attachments/2726551/4738571/Phase2TrackerDigi_PreMixing_Validation_29092023.pdf)
  
@emiglior 
