### PR TITLE
era to store ZDC digis for pp reco

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2023_repacked.py
@@ -11,7 +11,7 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
+from Configuration.Eras.Era_Run3_2023_ZDC_cff import Run3_2023_ZDC
 
 from Configuration.DataProcessing.Impl.pp import pp
 
@@ -21,14 +21,14 @@ class ppEra_Run3_2023_repacked(pp):
         self.recoSeq=''
         self.cbSc='pp'
         self.isRepacked=True
-        self.eras=Run3_2023
+        self.eras=Run3_2023_ZDC
         self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
         self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
         self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2023' ]
     """
     _ppEra_Run3_2023_
 
-    Implement configuration building for data processing for proton
-    collision data taking for Run3_2023
+    Implement configuration building for data processing for PbPb collisions with pp reco
+    collision data taking for Run3_2023_ZDC
 
     """

--- a/Configuration/Eras/python/Era_Run3_2023_ZDC_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2023_ZDC_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+from Configuration.ProcessModifiers.storeZDCDigis_cff import storeZDCDigis
+
+Run3_2023_ZDC = cms.ModifierChain(Run3, run3_egamma_2023, storeZDCDigis)

--- a/Configuration/ProcessModifiers/python/storeZDCDigis_cff.py
+++ b/Configuration/ProcessModifiers/python/storeZDCDigis_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+storeZDCDigis =  cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -44,6 +44,7 @@ class Eras (object):
                  'Run3_DDD',
                  'Run3_FastSim',
                  'Run3_2023_FastSim',
+                 'Run3_2023_ZDC',
                  'Phase2',
                  'Phase2C9',
                  'Phase2C10',

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -160,6 +160,10 @@ _pp_on_AA_extraCommands = [
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
 
+_zdc_extraCommands = ['keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*']
+from Configuration.ProcessModifiers.storeZDCDigis_cff import storeZDCDigis
+storeZDCDigis.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _zdc_extraCommands)
+
 MicroEventContentMC = cms.PSet(
     outputCommands = cms.untracked.vstring(MicroEventContent.outputCommands)
 )

--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_EventContent_cff.py
@@ -19,6 +19,7 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.storeZDCDigis_cff import storeZDCDigis
 # don't modify AOD for HGCal yet, need "reduced" rechits collection first (i.e. requires reconstruction)
 phase2_hgcal.toModify( RecoLocalCaloAOD, 
     outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_HGCalRecHit_*_*',
@@ -35,6 +36,8 @@ phase2_hfnose.toModify( RecoLocalCaloAOD,
                                                            'keep ZDCDataFramesSorted_castorDigis_*_*',
                                                            'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*'])
         )
+storeZDCDigis.toModify( RecoLocalCaloAOD,
+                        outputCommands = RecoLocalCaloAOD.outputCommands + ['keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*'])
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toModify( RecoLocalCaloAOD, 
     outputCommands = RecoLocalCaloAOD.outputCommands + ['keep *_towerMaker_*_*',


### PR DESCRIPTION
#### PR description:

Add an variant of the ongoing pp era `Run_2023`, which stores the ZDC digis `Run_2023_ZDC`.
This information is already stored in the heavy-ion eras. 
I also updated the T0 processing era `ppEra_Run3_2023_repacked` to use this option. 
The idea is to test whether the `HIForward` datasets can now be reconstructed with standard pp settings, now that the HLT V1.1 has been deployed, which removes the (heavy) hadronic interactions.   


#### PR validation:

Tested at driver level, by modifying 140.6 by hand. 
Will need to be tested in a T0 replay. 

Backport to 13_2_X will be made.  
