### PR TITLE
Use ECAL ratio timing algorithm for Run 1 and Run 2, and CC timing algorithm for Run 3 and beyond - 131X

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -14,7 +14,8 @@ from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
 
 Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018, run2_HLTconditions_2018]),
-                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC)
+                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal)
 

--- a/Configuration/Eras/python/Modifier_run3_ecal_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_ecal_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_ecal = cms.Modifier()
+

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -32,8 +32,10 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       addPedestalUncertaintyEE = cms.double(0.),
 
       # decide which algorithm to be use to calculate the jitter
-      timealgo = cms.string("crossCorrelationMethod"),
+      timealgo = cms.string("RatioMethod"),
 
+      timeCalibTag = cms.ESInputTag(),
+      timeOffsetTag = cms.ESInputTag(),
       # for ratio method
       EBtimeFitParameters = cms.vdouble(-2.015452e+00, 3.130702e+00, -1.234730e+01, 4.188921e+01, -8.283944e+01, 9.101147e+01, -5.035761e+01, 1.105621e+01),
       EEtimeFitParameters = cms.vdouble(-2.390548e+00, 3.553628e+00, -1.762341e+01, 6.767538e+01, -1.332130e+02, 1.407432e+02, -7.541106e+01, 1.620277e+01),
@@ -50,10 +52,10 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       # for kOutOfTime flag
       EBtimeNconst      = cms.double(28.5),
       EEtimeNconst      = cms.double(31.8),
-      outOfTimeThresholdGain12pEB    = cms.double(2.5),      # times estimated precision
-      outOfTimeThresholdGain12mEB    = cms.double(2.5),      # times estimated precision
-      outOfTimeThresholdGain61pEB    = cms.double(2.5),      # times estimated precision
-      outOfTimeThresholdGain61mEB    = cms.double(2.5),      # times estimated precision
+      outOfTimeThresholdGain12pEB    = cms.double(5),      # times estimated precision
+      outOfTimeThresholdGain12mEB    = cms.double(5),      # times estimated precision
+      outOfTimeThresholdGain61pEB    = cms.double(5),      # times estimated precision
+      outOfTimeThresholdGain61mEB    = cms.double(5),      # times estimated precision
       outOfTimeThresholdGain12pEE    = cms.double(1000),   # times estimated precision
       outOfTimeThresholdGain12mEE    = cms.double(1000),   # times estimated precision
       outOfTimeThresholdGain61pEE    = cms.double(1000),   # times estimated precision
@@ -71,3 +73,17 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
       crossCorrelationMinTimeToBeLateMax = cms.double(5)
    )
 )
+
+# use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+run3_ecal.toModify(ecalMultiFitUncalibRecHit,
+    algoPSet = dict(timealgo = 'crossCorrelationMethod',
+        outOfTimeThresholdGain12pEB = 2.5,
+        outOfTimeThresholdGain12mEB = 2.5,
+        outOfTimeThresholdGain61pEB = 2.5,
+        outOfTimeThresholdGain61mEB = 2.5,
+        timeCalibTag = cms.ESInputTag('', 'CC'),
+        timeOffsetTag = cms.ESInputTag('', 'CC')
+    )
+)
+


### PR DESCRIPTION
#### PR description:

This PR sets the default ECAL timing algorithm to the ratio method. This is the default timing algorithm for Run 1 and Run 2.
For Run 3 and Phase 2 a new modifier `run3_ecal` is used to change the timing algorithm to CC timing and use different records with the label 'CC' for the timing calibrations and timing offset constants.

Note that this behaviour is different than what was discussed in the [meeting](https://indico.cern.ch/event/1329876/) on the 27th Sept. when the plan was made to make the CC timing the default and use eras to modify Run 1 and Run 2 configurations to use the ratio method. Since Run 1 configurations could not be modified using eras we decided to reverse the behaviour as in the description above.

Backport of #42928 

#### PR validation:

The PR passes Run 1 and Run2 WFs in the limited matrix tests but currently fails all Run 3 and Phase 2 WFs because the consumed records with the 'CC' label are not yet in the GTs.