### PR TITLE
Miscellaneous improvements for `DQM/Integration` unit tests

### DIFF
--- a/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
@@ -13,7 +13,8 @@ process.MessageLogger = cms.Service("MessageLogger",
                                     debugModules = cms.untracked.vstring('siStripDigis',
                                                                          'siStripClusters',
                                                                          'siStripZeroSuppression',
-                                                                         'SiStripClusterizer'),
+                                                                         'SiStripClusterizer',
+                                                                         'siStripApproximateClusterComparator'),
                                     cout = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')),
                                     destinations = cms.untracked.vstring('cout')
                                     )
@@ -35,15 +36,15 @@ offlineTesting=not live
 #-----------------------------
 # for live online DQM in P5
 if (unitTest):
-    process.load("DQM.Integration.config.unittestinputsource_cfi")
-    from DQM.Integration.config.unittestinputsource_cfi import options
+  process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+  from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 elif (live):
-    process.load("DQM.Integration.config.inputsource_cfi")
-    from DQM.Integration.config.inputsource_cfi import options
+  process.load("DQM.Integration.config.inputsource_cfi")
+  from DQM.Integration.config.inputsource_cfi import options
 # for testing in lxplus
 elif(offlineTesting):
-    process.load("DQM.Integration.config.fileinputsource_cfi")
-    from DQM.Integration.config.fileinputsource_cfi import options
+  process.load("DQM.Integration.config.fileinputsource_cfi")
+  from DQM.Integration.config.fileinputsource_cfi import options
 
 #----------------------------
 # DQM Live Environment
@@ -86,7 +87,10 @@ elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
     #you may need to set manually the GT in the line below
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_hlt', '')
+
+
+print("Will process with GlobalTag %s",process.GlobalTag.globaltag.value())
 
 #--------------------------------------------
 # Patch to avoid using Run Info information in reconstruction
@@ -177,7 +181,7 @@ else :
 
 process.DQMCommon = cms.Sequence(process.dqmEnv*process.dqmEnvTr*process.dqmSaver*process.dqmSaverPB)
 
-print("Running with run type = ", process.runType.getRunType())
+print("Running with run type = ", process.runType.getRunTypeName())
 
 ### HEAVY ION SETTING
 if process.runType.getRunType() == process.runType.hi_run:

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -22,10 +22,11 @@
 <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 369956"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 369956"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 369956"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 373710"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 373710"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 373710"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->

--- a/DQM/Integration/test/runtest.sh
+++ b/DQM/Integration/test/runtest.sh
@@ -19,7 +19,10 @@ mkdir -p $LOCAL_TEST_DIR/upload
 
 if [[ $# -eq 1 ]]; then
     cmsRun $CLIENTS_DIR/$1 unitTest=True
-else
+elif [[ $# -eq 2 ]]; then
     echo "Will use streamers files for run $2"
     cmsRun $CLIENTS_DIR/$1 unitTest=True runNumber=$2
+else
+    echo "Will use streamers files for run $2 and runkey $3"
+    cmsRun $CLIENTS_DIR/$1 unitTest=True runNumber=$2 runkey=$3
 fi

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -224,7 +224,7 @@ void SiPixelPhase1RawDataErrorComparator::analyze(const edm::Event& iEvent, cons
     }
   }
 
-  edm::LogPrint(kName) << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU;
+  LogDebug(kName) << " on gpu found: " << errorsOnGPU << " on cpu found: " << errorsOnCPU;
 
   h_totFEDErrors_->Fill(errorsOnCPU, errorsOnGPU);
 
@@ -274,14 +274,14 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
   h_totFEDErrors_ = make2DIfLog(iBook,
                                 true,
                                 true,
-                                "nTotalFEDError",
-                                "n. of total Pixel FEDError per event; CPU; GPU",
-                                500,
+                                "nTotalFEDErrors",
+                                "n. of total Pixel FEDErrors per event; CPU; GPU",
+                                200,
                                 log10(0.5),
-                                log10(5000.5),
-                                500,
+                                log10(1000.),
+                                200,
                                 log10(0.5),
-                                log10(5000.5));
+                                log10(1000.));
 
   for (const auto& element : errorCodeToStringMap) {
     h_nFEDErrors_[element.first] = iBook.book2I(fmt::sprintf("nFED%i_Errors", element.first),

--- a/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
+++ b/DQM/SiStripMonitorApproximateCluster/plugins/SiStripMonitorApproximateCluster.cc
@@ -221,12 +221,22 @@ void SiStripMonitorApproximateCluster::analyze(const edm::Event& iEvent, const e
 
     // starts here comaparison with regular clusters
     if (compareClusters_) {
+      if (stripClusterCollection_->empty()) {
+        edm::LogWarning("SiStripMonitorApproximateCluster")
+            << "Input SiStrip Cluster collecction was empty, skipping event! " << std::endl;
+        return;
+      }
+
       edmNew::DetSetVector<SiStripCluster>::const_iterator isearch =
           stripClusterCollection_->find(detid);  // search clusters of same detid
 
       // protect against a missing match
-      if (isearch != stripClusterCollection_->end())
+      if (isearch != stripClusterCollection_->end()) {
         strip_clusters_detset = (*isearch);
+      } else {
+        edm::LogWarning("SiStripMonitorApproximateCluster")
+            << "No edmNew::DetSet<SiStripCluster> was found for detid " << detid << std::endl;
+      }
     }
 
     for (const auto& cluster : detClusters) {


### PR DESCRIPTION
#### PR description:

This PR proposes 4 updates:
   * improved logging for the `SiStripMonitorApproximateCluster` (commit https://github.com/cms-sw/cmssw/commit/06dd05e0c315d606f992378edb921bbeee652939)
   * added support for running the unit test for the `sistrip_approx_dqm_sourceclient` introduced in PR https://github.com/cms-sw/cmssw/pull/42881 (commit 093de3f4fab2e7448bc7ca6a2fdff351d3882a3e)
   * added unit test for `sistrip_approx_dqm_sourceclient` and refresh runs used for the GPUvsCPU clients (this last point is necessary since (as pointed out in https://github.com/cms-sw/cmssw/pull/42542 the old streamers lack the proper pixel collections `SiPixelRawDataErroredmDetSetVector_hltSiPixelDigisFromSoA_*_*` and `SiPixelRawDataErroredmDetSetVector_hltSiPixelDigisLegacy_*_*`) (commit https://github.com/cms-sw/cmssw/commit/13fa0840061a85858aae7d8041c1c5fa8dcafaca)
   * in `SiPixelPhase1RawDataErrorComparator`: demote `LogPrint` to `LogDebug` and redefine binning of `h_totFEDErrors_` (commit 9cb0dd8e92edb6462f6d29200c492a2b532a50b3)
   
   
**Note to reviewers: to pass tests this PR needs to be tested with https://github.com/cms-data/DQM-Integration/pull/5**   
   
#### PR validation:

Run successfully the unit tests of this package:
```console
scram b runtests_TestDQMOnlineClient-sistrip_approx_dqm_sourceclient
scram b runtests_pixelgpu_dqm_sourceclient
scram b runtests_ecalgpu_dqm_sourceclient
scram b runtests_hcalgpu_dqm_sourceclient
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
