### PR TITLE
temporarily remove `HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1` from phase-2 HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -290,7 +290,8 @@ fragment.schedule = cms.Schedule(*[
     fragment.HLT_Diphoton30_23_IsoCaloId_L1Seeded,
 
     fragment.HLT_DoubleMediumChargedIsoPFTauHPS40_eta2p1,
-    fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
+    ### Removed temporarily until solution of https://github.com/cms-sw/cmssw/issues/42862
+    #fragment.HLT_DoubleMediumDeepTauPFTauHPS35_eta2p1,
 
     ### Removed temporarily until final decision on L1T tau Phase-2
     #fragment.L1T_DoubleNNTau52,


### PR DESCRIPTION
#### PR description:

See https://github.com/cms-sw/cmssw/issues/42862, temporary measure to avoid relval failures.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A