### PR TITLE
Fix condition to add anti-particle to G4ParticleTable

### DIFF
--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -302,7 +302,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
       }
       if (sign == -1 && pdgId != 25 && pdgId != 35 && pdgId != 36 && pdgId != 37 && pdgId != 1000039) {
         tmp = "anti_" + name;
-        if (nullptr != theParticleTable->FindParticle(-pdgId)) {
+        if (theParticleTable->FindParticle(-pdgId) == nullptr) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " << -pdgId << ", mass "
               << mass << " GeV, name " << tmp;


### PR DESCRIPTION
#### PR description:

This PR is to fix the behaviour of the CustomParticleFactory class in order to correctly include the corresponding anti-particle each time a new particle is added to the list.
The correct behaviour was somehow broken with [this commit](https://github.com/cms-sw/cmssw/commit/c3d2a3218041b3de169093b1c1df2d337fe1d74d#diff-3356a0227a88656afdbec257541eeac667962e40e2514de565256487d2ca9b32) which reverted the condition necessary to call the addCustomParticle() function (which should add the anti-particle to the particle table).
So in the current releases the function will be called only if the anti-particle is already there.
As an example, in my case I needed to add the stau and anti-stau particles, but only the stau was added, while the anti-stau was not, with a series of consequences in the following steps (e.g., charge was set to 0, anti-stau track non added to the SIM track collection, etc...)

FYI @civanch 

#### PR validation:

Testing locally. For example, I was previously getting this printout when checking particle info [here](https://github.com/cms-sw/cmssw/blob/CMSSW_12_4_11_patch3/SimG4Core/Generators/src/Generator.cc#L399)

```
==== PDGcode -1000015  Particle name  is not defined in G4.
 Assigned charge : 0
     Momentum ( -208.984[GeV/c], 278.581[GeV/c], -974.195[GeV/c] )
     kinetic Energy : 1.03457e+06 [GeV]
     Mass is not assigned
     Weight : 1
```
and with the fix I get the expected behaviour

```
==== PDGcode -1000015  Particle name anti_~tau_1
 Assigned charge : 1
     Momentum ( -208.984[GeV/c], 278.58[GeV/c], -974.194[GeV/c] )
     kinetic Energy : 939392 [GeV]
     Mass : 100 [GeV]
     Weight : 1
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

I think we need to backport this change also to other release cycles, for sure to 12_4_X used for Run3Summer22(EE) MC production.
The behaviour is correct in the 10_6_X cycle used for UL MC production (see [here](https://github.com/cms-sw/cmssw/blob/CMSSW_10_6_X/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc#L307)).

