### PR TITLE
Fill Photon PF ID DNN score properly

### DIFF
--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -24,6 +24,7 @@ Photon::Photon(const Photon& rhs)
       eCorrections_(rhs.eCorrections_),
       mipVariableBlock_(rhs.mipVariableBlock_),
       pfIsolation_(rhs.pfIsolation_),
+      pfID_(rhs.pfID_),
       haloTaggerMVAVal_(rhs.haloTaggerMVAVal_) {}
 
 Photon::~Photon() {}


### PR DESCRIPTION
#### PR description:

Solves https://github.com/cms-sw/cmssw/issues/42949. 

#### PR validation:
`12434.7` and `12434.0` runs fine. 
photon's pfDNN() now shows meaningful results. 