### PR TITLE
Use `TriggerResultsFilterFromDB`-based selection for Heavy AlCaRecos in `pp_on_AA`

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_cff.py
@@ -49,13 +49,24 @@ seqALCARECOTkAlMinBias = cms.Sequence(ALCARECOTkAlMinBiasHLT*~ALCARECOTkAlMinBia
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-(pp_on_XeXe_2017 | pp_on_AA).toModify(ALCARECOTkAlMinBiasHLT,
-                                      eventSetupPathsKey='TkAlMinBiasHI'
-)
-
 (pp_on_XeXe_2017 | pp_on_AA).toModify(ALCARECOTkAlMinBias,
                                     trackQualities = cms.vstring("highPurity")
 )
+
+pp_on_XeXe_2017.toModify(ALCARECOTkAlMinBiasHLT,
+                         eventSetupPathsKey='TkAlMinBiasHI')
+
+import HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi
+ALCARECOTkAlMinBiasTriggerResultsHI = HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi.triggerResultsFilterFromDB.clone(
+    eventSetupPathsKey = 'TkAlMinBiasHI',
+    usePathStatus = False,
+    hltResults = 'TriggerResults::HLT',
+    l1tResults = '', # leaving empty (not interested in L1T results)
+    throw = False # tolerate triggers stated above, but not available
+)
+
+seqALCARECOTkAlMinBiasHI = cms.Sequence(ALCARECOTkAlMinBiasTriggerResultsHI*~ALCARECOTkAlMinBiasNOTHLT+ALCARECOTkAlMinBiasDCSFilter+ALCARECOTkAlMinBias)
+pp_on_AA.toReplaceWith(seqALCARECOTkAlMinBias,seqALCARECOTkAlMinBiasHI)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ALCARECOTkAlMinBias, etaMin = -4, etaMax = 4)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_cff.py
@@ -42,7 +42,18 @@ seqALCARECOSiStripCalMinBias = cms.Sequence(ALCARECOSiStripCalMinBiasHLT*DCSStat
 
 ## customizations for the pp_on_AA eras
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+pp_on_XeXe_2017.toModify(ALCARECOSiStripCalMinBiasHLT,
+                         eventSetupPathsKey='SiStripCalMinBiasHI')
+
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-(pp_on_XeXe_2017 | pp_on_AA).toModify(ALCARECOSiStripCalMinBiasHLT,
-                                    eventSetupPathsKey='SiStripCalMinBiasHI'
+import HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi
+ALCARECOSiStripCalMinBiasTriggerResultsHI = HLTrigger.HLTfilters.triggerResultsFilterFromDB_cfi.triggerResultsFilterFromDB.clone(
+    eventSetupPathsKey = 'SiStripCalMinBiasHI',
+    usePathStatus = False,
+    hltResults = 'TriggerResults::HLT',
+    l1tResults = '', # leaving empty (not interested in L1T results)
+    throw = False # tolerate triggers stated above, but not available
 )
+
+seqALCARECOSiStripCalMinBiasHI = cms.Sequence(ALCARECOSiStripCalMinBiasTriggerResultsHI*DCSStatusForSiStripCalMinBias*ALCARECOSiStripCalMinBias)
+pp_on_AA.toReplaceWith(seqALCARECOSiStripCalMinBias,seqALCARECOSiStripCalMinBiasHI)

--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilterFromDB.cc
@@ -40,6 +40,9 @@ TriggerResultsFilterFromDB::~TriggerResultsFilterFromDB() { delete m_expression;
 
 void TriggerResultsFilterFromDB::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  // # use HLTPathStatus results
+  desc.add<bool>("usePathStatus", false)
+      ->setComment("Read the HLT results from the TriggerResults (false) or from the current job's PathStatus (true).");
   // # HLT results   - set to empty to ignore HLT
   desc.add<edm::InputTag>("hltResults", edm::InputTag("TriggerResults"));
   // # L1 uGT results - set to empty to ignore L1T


### PR DESCRIPTION
#### PR description:

In this [cmsTalk post](https://cms-talk.web.cern.ch/t/cut-down-alca-producers-for-pds-with-index-0/30327) it was proposed to cut down the number of PDs in which the `TkAlMinBias` and `SiStripCalMinBias` producers are run to avoid producing too large datasets during the 2023 HIon run. 
An alternative (or complementary) approach consists in prescaling the number of events accepted for each of the trigger paths firing (and accepted by the AlCaReco).
This can be done using the `TriggerResultsFilterFromDB` module and appropriate usage of the `eventSetupPathsKey`-associated HLT patterns, e.g.: 
   * `HLT_HIPhysics_v*/10;HLT_HIPuAK4*/10;HLT_HICsAK4*/10;HLT_HIZeroBias_v*/10;HLT_HIMinimumBiasHF*/10` 

This is implemented in commit 70d8a19d6940d22cd8f7b6142c0c2fa59d06a087
The other commit of this PR (47bfc8424b81d15b7cdf2543988c60e3539b94f3) is purely technical an implements a leftover parameter in `TriggerResultsFilterFromDB::fillDescriptions`, necessary to be able to validate the configuration.

#### PR validation:

Run:

```bash
cmsDriver.py stepTest --conditions 132X_dataRun3_Prompt_v4 \
    --custom_conditions="AlCaRecoTriggerBits_testPrescales_HIMinBias_v0,AlCaRecoTriggerBitsRcd,frontier://FrontierPrep/CMS_CONDITIONS" \
    --data \
    --datatier ALCARECO \
    --era Run3 \
    --eventcontent ALCARECO \
    --filein /store/hidata/HIRun2023A/HIPhysicsRawPrime0/RAW/v1/000/374/646/00000/40fbbb7f-a214-40fe-a02b-04212c90e0d0.root \
    --fileout file:step2.root \
    --nStreams 4 \
    --nThreads 8 \
    --number 100 \
    --process reRECO \
    --repacked \
    --python_filename step_2_cfg.py \
    --scenario pp \
    --step RAW2DIGI,L1Reco,RECO,ALCA:SiStripCalMinBias+TkAlMinBias \
    --era Run3_pp_on_PbPb_approxSiStripClusters_2023 \
    --no_exec
```

and obtained the desired reduction in the event output.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but to be backported to CMSSW_13_2_X (eventually for 2023 HIon data-taking).
