### PR TITLE
Tracer can output a compact tracing log file

### DIFF
--- a/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
+++ b/FWCore/Concurrency/scripts/edmStreamStallGrapher.py
@@ -79,7 +79,7 @@ def processingStepsFromStallMonitorOutput(f,moduleNames, esModuleNames):
         payload=payload.split()
 
         # Ignore these
-        if step == 'E' or step == 'e':
+        if step == 'E' or step == 'e' or step == 'F' or step == 'f':
             continue
 
         # Payload format is:
@@ -156,6 +156,7 @@ class StallMonitorParser(object):
         numStreamsFromSource = 0
         moduleNames = {}
         esModuleNames = {}
+        frameworkTransitions = False
         for rawl in f:
             l = rawl.strip()
             if l and l[0] == 'M':
@@ -176,6 +177,8 @@ class StallMonitorParser(object):
                 (id,name)=tuple(l[2:].split())
                 esModuleNames[id] = name
                 continue
+            if len(l) > 40 and l[0:24] == "# preFrameworkTransition":
+                frameworkTransitions = True
 
         self._f = f
         if numStreams == 0:
@@ -189,6 +192,8 @@ class StallMonitorParser(object):
         for n in esModuleNames.items():
             self.maxNameSize = max(self.maxNameSize,len(n))
         self.maxNameSize = max(self.maxNameSize,len(kSourceDelayedRead))
+        if frameworkTransitions:
+            self.maxNameSize = max(self.maxNameSize, len('streamBeginLumi'))
 
     def processingSteps(self):
         """Create a generator which can step through the file and return each processing step.

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -1137,6 +1137,7 @@ namespace edm {
                 }
               }
             });
+        moduleCallingContext_.setContext(ModuleCallingContext::State::kPrefetching, parentContext, nullptr);
         esPrefetchAsync(
             WaitingTaskHolder(*group, afterPrefetch), transitionInfo.eventSetupImpl(), T::transition_, serviceToken);
       } else {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -695,8 +695,6 @@ namespace edm {
       schedule_->initializeEarlyDelete(branchesToDeleteEarly, referencesToBranches, modulesToSkip, *preg_);
     }
 
-    actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
-
     if (preallocations_.numberOfLuminosityBlocks() > 1) {
       throwAboutModulesRequiringLuminosityBlockSynchronization();
     }
@@ -719,13 +717,16 @@ namespace edm {
     //if(looper_) {
     //   looper_->beginOfJob(es);
     //}
+    espController_->finishConfiguration();
+    actReg_->eventSetupConfigurationSignal_(esp_->recordsToResolverIndices(), processContext_);
+    actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
     try {
       convertException::wrap([&]() { input_->doBeginJob(); });
     } catch (cms::Exception& ex) {
       ex.addContext("Calling beginJob for the source");
       throw;
     }
-    espController_->finishConfiguration();
+
     schedule_->beginJob(*preg_, esp_->recordsToResolverIndices(), *processBlockHelper_);
     if (looper_) {
       constexpr bool mustPrefetchMayGet = true;

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -106,6 +106,7 @@ namespace edm {
     struct ComponentDescription;
     class DataKey;
     class EventSetupRecordKey;
+    class ESRecordsToProductResolverIndices;
   }  // namespace eventsetup
   namespace service {
     class SystemBounds;
@@ -144,6 +145,15 @@ namespace edm {
     Preallocate preallocateSignal_;
     void watchPreallocate(Preallocate::slot_type const& iSlot) { preallocateSignal_.connect(iSlot); }
     AR_WATCH_USING_METHOD_1(watchPreallocate)
+
+    typedef signalslot::Signal<void(eventsetup::ESRecordsToProductResolverIndices const&, ProcessContext const&)>
+        EventSetupConfiguration;
+    ///signal is emitted before beginJob
+    EventSetupConfiguration eventSetupConfigurationSignal_;
+    void watchEventSetupConfiguration(EventSetupConfiguration::slot_type const& iSlot) {
+      eventSetupConfigurationSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchEventSetupConfiguration)
 
     typedef signalslot::Signal<void(PathsAndConsumesOfModulesBase const&, ProcessContext const&)> PreBeginJob;
     ///signal is emitted before all modules have gotten their beginJob called

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -90,6 +90,7 @@ namespace edm {
 
   void ActivityRegistry::connectGlobals(ActivityRegistry& iOther) {
     preallocateSignal_.connect(std::cref(iOther.preallocateSignal_));
+    eventSetupConfigurationSignal_.connect(std::cref(iOther.eventSetupConfigurationSignal_));
     beginProcessingSignal_.connect(std::cref(iOther.beginProcessingSignal_));
     endProcessingSignal_.connect(std::cref(iOther.endProcessingSignal_));
     postBeginJobSignal_.connect(std::cref(iOther.postBeginJobSignal_));
@@ -329,6 +330,7 @@ namespace edm {
 
   void ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
     copySlotsToFrom(preallocateSignal_, iOther.preallocateSignal_);
+    copySlotsToFrom(eventSetupConfigurationSignal_, iOther.eventSetupConfigurationSignal_);
     copySlotsToFrom(beginProcessingSignal_, iOther.beginProcessingSignal_);
     copySlotsToFrom(endProcessingSignal_, iOther.endProcessingSignal_);
     copySlotsToFrom(preBeginJobSignal_, iOther.preBeginJobSignal_);

--- a/FWCore/Services/bin/edmTracerCompactLogViewer.py
+++ b/FWCore/Services/bin/edmTracerCompactLogViewer.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+from __future__ import print_function
+from builtins import range
+from itertools import groupby
+from operator import attrgetter,itemgetter
+import sys
+from collections import defaultdict
+#----------------------------------------------
+def printHelp():
+    s = '''
+To Use: Add the Tracer Service to the cmsRun job use something like this
+  in the configuration:
+
+  process.add_(cms.Service("Tracer", fileName = cms.untracked.string("tracer.log")))
+
+  After running the job, execute this script and pass the name of the
+  Tracer log file to the script.
+
+  This script will output a more human readable form of the data in the Tracer log file.'''
+    return s
+
+#these values come from tracer_setupFile.cc
+#enum class Step : char {
+#  preSourceTransition = 'S',
+#  postSourceTransition = 's',
+#  preModulePrefetching = 'P',
+#  postModulePrefetching = 'p',
+#  preModuleEventAcquire = 'A',
+#  postModuleEventAcquire = 'a',
+#  preModuleTransition = 'M',
+#  preEventReadFromSource = 'R',
+#  postEventReadFromSource = 'r',
+#  preModuleEventDelayedGet = 'D',
+#  postModuleEventDelayedGet = 'd',
+#  postModuleTransition = 'm',
+#  preESModulePrefetching = 'Q',
+#  postESModulePrefetching = 'q',
+#  preESModule = 'N',
+#  postESModule = 'n',
+#  preESModuleAcquire = 'B',
+#  postESModuleAcquire = 'b',
+#  preFrameworkTransition = 'F',
+#  postFrameworkTransition = 'f'
+#};
+
+
+#Special names
+kSourceFindEvent = "sourceFindEvent"
+kSourceDelayedRead ="sourceDelayedRead"
+
+#these values must match the enum class Phase in tracer_setupFile.cc
+class Phase (object):
+  destruction = -14
+  endJob = -11
+  endStream = -10
+  writeProcessBlock = -9
+  endProcessBlock = -8
+  globalWriteRun = -6
+  globalEndRun = -5
+  streamEndRun = -4
+  globalWriteLumi = -3
+  globalEndLumi = -2
+  streamEndLumi = -1
+  Event = 0
+  streamBeginLumi = 1
+  globalBeginLumi = 2
+  streamBeginRun = 4
+  globalBeginRun = 5
+  accessInputProcessBlock = 7
+  beginProcessBlock = 8
+  beginStream = 10
+  beginJob  = 11
+  esSync = 12
+  esSyncEnqueue = 13
+  construction = 14
+  startTracing = 15
+
+
+def transitionName(transition):
+    if transition == Phase.startTracing:
+        return 'start tracing'
+    if transition == Phase.construction:
+        return 'construction'
+    if transition == Phase.destruction:
+        return 'destruction'
+    if transition == Phase.beginJob:
+        return 'begin job'
+    if transition == Phase.endJob:
+        return 'end job'
+    if transition == Phase.beginStream:
+        return 'begin stream'
+    if transition == Phase.endStream:
+        return 'end stream'
+    if transition == Phase.beginProcessBlock:
+        return 'begin process block'
+    if transition == Phase.endProcessBlock:
+        return 'end process block'
+    if transition == Phase.accessInputProcessBlock:
+        return 'access input process block'
+    if transition == Phase.writeProcessBlock:
+        return 'write process block'
+    if transition == Phase.globalBeginRun:
+        return 'global begin run'
+    if transition == Phase.globalEndRun:
+        return 'global end run'
+    if transition == Phase.globalWriteRun:
+        return 'global write run'
+    if transition == Phase.streamBeginRun:
+        return 'stream begin run'
+    if transition == Phase.streamEndRun:
+        return 'stream end run'
+    if transition == Phase.globalBeginLumi:
+        return 'global begin lumi'
+    if transition == Phase.globalEndLumi:
+        return 'global end lumi'
+    if transition == Phase.globalWriteLumi:
+        return 'global write lumi'
+    if transition == Phase.streamBeginLumi:
+        return 'stream begin lumi'
+    if transition == Phase.streamEndLumi:
+        return 'stream end lumi'
+    if transition == Phase.esSyncEnqueue:
+        return 'EventSetup synchronization'
+    if transition == Phase.esSync:
+        return 'EventSetup synchronization'
+    if transition == Phase.Event:
+        return 'event'
+
+def transitionIndentLevel(transition):
+    if transition == Phase.startTracing:
+        return 0
+    if transition == Phase.construction or transition == Phase.destruction:
+        return 0
+    if transition == Phase.endJob or transition == Phase.beginJob:
+        return 0
+    if transition == Phase.beginStream or transition == Phase.endStream:
+        return 0
+    if transition == Phase.beginProcessBlock or transition == Phase.endProcessBlock:
+        return 1
+    if transition == Phase.accessInputProcessBlock:
+        return 1
+    if transition == Phase.writeProcessBlock:
+        return 1
+    if transition == Phase.globalBeginRun or Phase.globalEndRun == transition:
+        return 1
+    if transition == Phase.globalWriteRun:
+        return 1
+    if transition == Phase.streamBeginRun or Phase.streamEndRun == transition:
+        return 1
+    if transition == Phase.globalBeginLumi or Phase.globalEndLumi == transition:
+        return 2
+    if transition == Phase.globalWriteLumi:
+        return 2
+    if transition == Phase.streamBeginLumi or Phase.streamEndLumi == transition:
+        return 2
+    if transition == Phase.Event:
+        return 3
+    if transition == Phase.esSyncEnqueue or transition == Phase.esSync:
+        return 1
+    return None
+
+def textPrefix_(time, indentLevel):
+    #using 11 spaces for time should accomodate a job that runs 24 hrs
+    return f'{time:>11} '+"++"*indentLevel
+
+class FrameworkTransitionParser (object):
+    def __init__(self, payload):
+        self.transition = int(payload[0])
+        self.index = int(payload[1])
+        self.sync = (int(payload[2]), int(payload[3]), int(payload[4]))
+        self.time = int(payload[5])
+    def indentLevel(self):
+        return transitionIndentLevel(self.transition)
+    def textPrefix(self):
+        return textPrefix_(self.time, self.indentLevel())
+    def syncText(self):
+        if self.transition == Phase.globalBeginRun or Phase.globalEndRun == self.transition:
+            return f'run={self.sync[0]}'
+        if self.transition == Phase.globalWriteRun:
+            return f'run={self.sync[0]}'
+        if self.transition == Phase.streamBeginRun or Phase.streamEndRun == self.transition:
+            return f'run={self.sync[0]}'
+        if self.transition == Phase.globalBeginLumi or Phase.globalEndLumi == self.transition:
+            return f'run={self.sync[0]} lumi={self.sync[1]}'
+        if self.transition == Phase.globalWriteLumi:
+            return f'run={self.sync[0]} lumi={self.sync[1]}'
+        if self.transition == Phase.streamBeginLumi or Phase.streamEndLumi == self.transition:
+            return f'run={self.sync[0]} lumi={self.sync[1]}'
+        if self.transition == Phase.Event:
+            return f'run={self.sync[0]} lumi={self.sync[1]} event={self.sync[2]}'
+        if self.transition == Phase.esSyncEnqueue or self.transition == Phase.esSync:
+            return f'run={self.sync[0]} lumi={self.sync[1]}'
+        if self.transition == Phase.beginJob:
+            return ''
+        if self.transition == Phase.beginProcessBlock or self.transition == Phase.endProcessBlock or self.transition == Phase.writeProcessBlock or self.transition == Phase.accessInputProcessBlock:
+            return ''
+        if self.transition == Phase.startTracing:
+            return ''
+        if self.transition == Phase.construction or self.transition == Phase.destruction:
+            return ''
+    def textPostfix(self):
+        return f'{transitionName(self.transition)} : id={self.index} {self.syncText()}'
+    def text(self, context):
+        return f'{self.textPrefix()} {self.textSpecial()}: {self.textPostfix()}'
+
+class PreFrameworkTransitionParser (FrameworkTransitionParser):
+    def __init__(self, payload):
+        super().__init__(payload)
+    def textSpecial(self):
+        return "starting"
+        
+
+class PostFrameworkTransitionParser (FrameworkTransitionParser):
+    def __init__(self, payload):
+        super().__init__(payload)
+    def textSpecial(self):
+        return "finished"
+
+class QueuingFrameworkTransitionParser (FrameworkTransitionParser):
+    def __init__(self, payload):
+        super().__init__(payload)
+    def textSpecial(self):
+        return "queuing"
+
+class SourceTransitionParser(object):
+    def __init__(self, payload):
+        self.transition = int(payload[0])
+        self.index = int(payload[1])
+        self.time = int(payload[2])
+    def indentLevel(self):
+        if self.transition == Phase.globalBeginRun:
+            return 1
+        if self.transition == Phase.globalBeginLumi:
+            return 2
+        if self.transition == Phase.Event:
+            return 3
+        if self.transition == Phase.construction:
+            return 1
+        return None
+    def textPrefix(self):
+        return textPrefix_(self.time, self.indentLevel())
+    def textPostfix(self):
+        return f'source during {transitionName(self.transition)} : id={self.index}'
+    def text(self, context):
+        return f'{self.textPrefix()} {self.textSpecial()}: {self.textPostfix()}'
+
+class PreSourceTransitionParser(SourceTransitionParser):
+    def __init__(self, payload):
+        super().__init__(payload)
+    def textSpecial(self):
+        return "starting"
+
+class PostSourceTransitionParser(SourceTransitionParser):
+    def __init__(self, payload):
+        super().__init__(payload)
+    def textSpecial(self):
+        return "finished"
+
+class EDModuleTransitionParser(object):
+    def __init__(self, payload, moduleNames):
+        self.transition = int(payload[0])
+        self.index = int(payload[1])
+        self.moduleID = int(payload[2])
+        self.moduleName = moduleNames[self.moduleID]
+        self.requestingModuleID = int(payload[3])
+        self.requestingModuleName = None
+        if self.requestingModuleID != 0:
+            self.requestingModuleName = moduleNames[self.requestingModuleID]
+        self.time = int(payload[4])
+    def baseIndentLevel(self):
+        return transitionIndentLevel(self.transition)
+    def textPrefix(self, context):
+        indent = 0
+        if self.requestingModuleID != 0:
+            indent = context[(self.transition, self.index, self.requestingModuleID)]
+        context[(self.transition, self.index, self.moduleID)] = indent+1
+        return textPrefix_(self.time, indent+1+self.baseIndentLevel())
+    def textPostfix(self):
+        return f'{self.moduleName} during {transitionName(self.transition)} : id={self.index}'
+    def text(self, context):
+        return f'{self.textPrefix(context)} {self.textSpecial()}: {self.textPostfix()}'
+
+class PreEDModuleTransitionParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "starting action"
+
+class PostEDModuleTransitionParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "finished action"
+
+class PreEDModulePrefetchingParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "starting prefetch"
+
+class PostEDModulePrefetchingParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "finished prefetch"
+
+class PreEDModuleAcquireParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "starting acquire"
+
+class PostEDModuleAcquireParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "finished acquire"
+
+class PreEDModuleEventDelayedGetParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "starting delayed get"
+
+class PostEDModuleEventDelayedGetParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "finished delayed get"
+
+class PreEventReadFromSourceParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "starting read from source"
+
+class PostEventReadFromSourceParser(EDModuleTransitionParser):
+    def __init__(self, payload, names):
+        super().__init__(payload, names)
+    def textSpecial(self):
+        return "finished read from source"
+
+class ESModuleTransitionParser(object):
+    def __init__(self, payload, moduleNames, esModuleNames, recordNames):
+        self.transition = int(payload[0])
+        self.index = int(payload[1])
+        self.moduleID = int(payload[2])
+        self.moduleName = esModuleNames[self.moduleID]
+        self.recordID = int(payload[3])
+        self.recordName = recordNames[self.recordID]
+        self.requestingModuleID = int(payload[4])
+        self.requestingModuleName = None
+        if self.requestingModuleID < 0 :
+            self.requestingModuleName = esModuleNames[-1*self.requestingModuleID]
+        else:
+            self.requestingModuleName = moduleNames[self.requestingModuleID]
+        self.time = int(payload[5])
+    def baseIndentLevel(self):
+        return transitionIndentLevel(self.transition)
+    def textPrefix(self, context):
+        indent = 0
+        indent = context[(self.transition, self.index, self.requestingModuleID)]
+        context[(self.transition, self.index, -1*self.moduleID)] = indent+1
+        return textPrefix_(self.time, indent+1+self.baseIndentLevel())
+    def textPostfix(self):
+        return f'esmodule {self.moduleName} in record {self.recordName} during {transitionName(self.transition)} : id={self.index}'
+    def text(self, context):
+        return f'{self.textPrefix(context)} {self.textSpecial()}: {self.textPostfix()}'
+
+class PreESModuleTransitionParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, esNames, recordNames):
+        super().__init__(payload, names, esNames, recordNames)
+    def textSpecial(self):
+        return "starting action"
+
+class PostESModuleTransitionParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, esNames, recordNames):
+        super().__init__(payload, names, esNames, recordNames)
+    def textSpecial(self):
+        return "finished action"
+
+class PreESModulePrefetchingParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, esNames, recordNames):
+        super().__init__(payload, names, esNames, recordNames)
+    def textSpecial(self):
+        return "starting prefetch"
+
+class PostESModulePrefetchingParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, esNames, recordNames):
+        super().__init__(payload, names, esNames, recordNames)
+    def textSpecial(self):
+        return "finished prefetch"
+
+class PreESModuleAcquireParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, recordNames):
+        super().__init__(payload, names, recordNames)
+    def textSpecial(self):
+        return "starting acquire"
+
+class PostESModuleAcquireParser(ESModuleTransitionParser):
+    def __init__(self, payload, names, esNames, recordNames):
+        super().__init__(payload, names, esNames, recordNames)
+    def textSpecial(self):
+        return "finished acquire"
+
+
+def lineParserFactory (step, payload, moduleNames, esModuleNames, recordNames, frameworkOnly):
+    if step == 'F':
+        parser = PreFrameworkTransitionParser(payload)
+        if parser.transition == Phase.esSyncEnqueue:
+            return QueuingFrameworkTransitionParser(payload)
+        return parser
+    if step == 'f':
+        return PostFrameworkTransitionParser(payload)
+    if step == 'S':
+        return PreSourceTransitionParser(payload)
+    if step == 's':
+        return PostSourceTransitionParser(payload)
+    if frameworkOnly:
+        return None
+    if step == 'M':
+        return PreEDModuleTransitionParser(payload, moduleNames)
+    if step == 'm':
+        return PostEDModuleTransitionParser(payload, moduleNames)
+    if step == 'P':
+        return PreEDModulePrefetchingParser(payload, moduleNames)
+    if step == 'p':
+        return PostEDModulePrefetchingParser(payload, moduleNames)
+    if step == 'A':
+        return PreEDModuleAcquireParser(payload, moduleNames)
+    if step == 'a':
+        return PostEDModuleAcquireParser(payload, moduleNames)
+    if step == 'D':
+        return PreEDModuleEventDelayedGetParser(payload, moduleNames)
+    if step == 'd':
+        return PostEDModuleEventDelayedGetParser(payload, moduleNames)
+    if step == 'R':
+        return PreEventReadFromSourceParser(payload, moduleNames)
+    if step == 'r':
+        return PostEventReadFromSourceParser(payload, moduleNames)
+    if step == 'N':
+        return PreESModuleTransitionParser(payload, moduleNames, esModuleNames, recordNames)
+    if step == 'n':
+        return PostESModuleTransitionParser(payload, moduleNames, esModuleNames, recordNames)
+    if step == 'Q':
+        return PreESModulePrefetchingParser(payload, moduleNames, esModuleNames, recordNames)
+    if step == 'q':
+        return PostESModulePrefetchingParser(payload, moduleNames, esModuleNames, recordNames)
+    if step == 'B':
+        return PreESModuleAcquireParser(payload, moduleNames, esModuleNames, recordNames)
+    if step == 'b':
+        return PostESModuleAcquireParser(payload, moduleNames, esModuleNames, recordNames)
+
+    
+#----------------------------------------------
+def processingStepsFromFile(f,moduleNames, esModuleNames, recordNames, frameworkOnly):
+    for rawl in f:
+        l = rawl.strip()
+        if not l or l[0] == '#':
+            continue
+        (step,payload) = tuple(l.split(None,1))
+        payload=payload.split()
+
+        parser = lineParserFactory(step, payload, moduleNames, esModuleNames, recordNames, frameworkOnly)
+        if parser:
+            yield parser
+    return
+
+class TracerCompactFileParser(object):
+    def __init__(self,f, frameworkOnly):
+        streamBeginRun = str(Phase.streamBeginRun)
+        numStreams = 0
+        numStreamsFromSource = 0
+        moduleNames = {}
+        esModuleNames = {}
+        recordNames = {}
+        for rawl in f:
+            l = rawl.strip()
+            if l and l[0] == 'M':
+                i = l.split(' ')
+                if i[3] == streamBeginRun:
+                    #found global begin run
+                    numStreams = int(i[1])+1
+                    break
+            if numStreams == 0 and l and l[0] == 'S':
+                s = int(l.split(' ')[1])
+                if s > numStreamsFromSource:
+                  numStreamsFromSource = s
+            if len(l) > 5 and l[0:2] == "#M":
+                (id,name)=tuple(l[2:].split())
+                moduleNames[int(id)] = name
+                continue
+            if len(l) > 5 and l[0:2] == "#N":
+                (id,name)=tuple(l[2:].split())
+                esModuleNames[int(id)] = name
+                continue
+            if len(l) > 5 and l[0:2] == "#R":
+                (id,name)=tuple(l[2:].split())
+                recordNames[int(id)] = name
+                continue
+
+        self._f = f
+        self._frameworkOnly = frameworkOnly
+        if numStreams == 0:
+          numStreams = numStreamsFromSource +2
+        self.numStreams =numStreams
+        self._moduleNames = moduleNames
+        self._esModuleNames = esModuleNames
+        self._recordNames = recordNames
+        self.maxNameSize =0
+        for n in moduleNames.items():
+            self.maxNameSize = max(self.maxNameSize,len(n))
+        for n in esModuleNames.items():
+            self.maxNameSize = max(self.maxNameSize,len(n))
+        self.maxNameSize = max(self.maxNameSize,len(kSourceDelayedRead))
+        self.maxNameSize = max(self.maxNameSize, len('streamBeginLumi'))
+
+    def processingSteps(self):
+        """Create a generator which can step through the file and return each processing step.
+        Using a generator reduces the memory overhead when parsing a large file.
+            """
+        self._f.seek(0)
+        return processingStepsFromFile(self._f,self._moduleNames, self._esModuleNames, self._recordNames, self._frameworkOnly)
+
+def textOutput( parser ):
+    context = {}
+    for p in parser.processingSteps():
+        print(p.text(context))
+    
+#=======================================
+if __name__=="__main__":
+    import argparse
+    import re
+    import sys
+
+    # Program options
+    parser = argparse.ArgumentParser(description='Convert a compact tracer file into human readable output.',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog=printHelp())
+    parser.add_argument('filename',
+                        type=argparse.FileType('r'), # open file
+                        help='file to process')
+    parser.add_argument('-f', '--frameworkOnly',
+                        action='store_true',
+                        help='''Output only the framework transitions, excluding the individual module transitions.''')
+    args = parser.parse_args()
+
+    parser = TracerCompactFileParser(args.filename, args.frameworkOnly)
+    textOutput(parser)

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -45,25 +45,15 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
 
+#include "tracer_setupFile.h"
+
 #include <iostream>
 #include <vector>
-
 #include <string>
 #include <set>
+#include <optional>
 
 namespace edm {
-  class ConfigurationDescriptions;
-  class GlobalContext;
-  class HLTPathStatus;
-  class LuminosityBlock;
-  class ModuleCallingContext;
-  class ModuleDescription;
-  class PathContext;
-  class PathsAndConsumesOfModulesBase;
-  class ProcessContext;
-  class Run;
-  class StreamContext;
-
   namespace service {
     class Tracer {
     public:
@@ -262,6 +252,8 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
       dumpPathsAndConsumes_(iPS.getUntrackedParameter<bool>("dumpPathsAndConsumes")),
       printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps")),
       dumpEventSetupInfo_(iPS.getUntrackedParameter<bool>("dumpEventSetupInfo")) {
+  tracer::setupFile(iPS.getUntrackedParameter<std::string>("fileName"), iRegistry);
+
   for (std::string& label : iPS.getUntrackedParameter<std::vector<std::string>>("dumpContextForLabels"))
     dumpContextForLabels_.insert(std::move(label));
 
@@ -488,6 +480,8 @@ void Tracer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       ->setComment(
           "Prints info 3 times when an event setup cache is filled, before the lock, after the lock, and after "
           "filling");
+  desc.addUntracked<std::string>("fileName", "")
+      ->setComment("If fileName is given, write a compact representation of tracer info to the file.");
   descriptions.add("Tracer", desc);
   descriptions.setComment(
       "This service prints each phase the framework is processing, e.g. constructing a module,running a module, etc.");

--- a/FWCore/Services/plugins/monitor_file_utilities.cc
+++ b/FWCore/Services/plugins/monitor_file_utilities.cc
@@ -1,0 +1,32 @@
+#include "monitor_file_utilities.h"
+#include "FWCore/Utilities/interface/OStreamColumn.h"
+
+#include <vector>
+
+namespace {
+  std::string const space{"  "};
+}
+
+namespace edm::service::monitor_file_utilities {
+  void moduleIdToLabel(std::ostream& oStream,
+                       std::vector<std::string> const& iModuleLabels,
+                       char moduleIdSymbol,
+                       std::string const& iIDHeader,
+                       std::string const& iLabelHeader) {
+    std::size_t const width{std::to_string(iModuleLabels.size()).size()};
+    OStreamColumn col0{iIDHeader, width};
+    std::string const& lastCol = iLabelHeader;
+
+    oStream << "\n#  " << col0 << space << lastCol << '\n';
+    oStream << "#  " << std::string(col0.width() + space.size() + lastCol.size(), '-') << '\n';
+
+    for (std::size_t i{}; i < iModuleLabels.size(); ++i) {
+      auto const& label = iModuleLabels[i];
+      if (not label.empty()) {
+        oStream << '#' << moduleIdSymbol << ' ' << std::setw(width) << std::left << col0(i) << space << std::left
+                << label << '\n';
+      }
+    }
+    oStream << '\n';
+  }
+}  // namespace edm::service::monitor_file_utilities

--- a/FWCore/Services/plugins/monitor_file_utilities.h
+++ b/FWCore/Services/plugins/monitor_file_utilities.h
@@ -1,0 +1,39 @@
+#ifndef FWCore_Services_monitor_file_utilities_h
+#define FWCore_Services_monitor_file_utilities_h
+
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Framework/interface/ComponentDescription.h"
+
+namespace edm::service::monitor_file_utilities {
+
+  inline auto stream_id(edm::StreamContext const& cs) { return cs.streamID().value(); }
+
+  inline auto module_id(edm::ModuleCallingContext const& mcc) { return mcc.moduleDescription()->id(); }
+
+  inline auto module_id(edm::ESModuleCallingContext const& mcc) { return mcc.componentDescription()->id_; }
+
+  template <typename T>
+  std::enable_if_t<std::is_integral<T>::value> concatenate(std::ostream& os, T const t) {
+    os << ' ' << t;
+  }
+
+  template <typename H, typename... T>
+  std::enable_if_t<std::is_integral<H>::value> concatenate(std::ostream& os, H const h, T const... t) {
+    os << ' ' << h;
+    concatenate(os, t...);
+  }
+
+  void moduleIdToLabel(std::ostream&,
+                       std::vector<std::string> const& iModules,
+                       char moduleIdSymbol,
+                       std::string const& iIDHeader,
+                       std::string const& iLabelHeader);
+}  // namespace edm::service::monitor_file_utilities
+#endif

--- a/FWCore/Services/plugins/tracer_setupFile.cc
+++ b/FWCore/Services/plugins/tracer_setupFile.cc
@@ -1,0 +1,814 @@
+#include "tracer_setupFile.h"
+#include "monitor_file_utilities.h"
+
+#include <chrono>
+
+#include <sstream>
+#include <type_traits>
+#include <cassert>
+#include <typeindex>
+
+#include "FWCore/Concurrency/interface/ThreadSafeOutputFileStream.h"
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/Provenance/interface/RunID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ESModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/ESRecordsToProductResolverIndices.h"
+
+#include "FWCore/Utilities/interface/TimingServiceBase.h"
+
+using namespace edm::service::monitor_file_utilities;
+
+namespace {
+  using duration_t = std::chrono::microseconds;
+  using clock_t = std::chrono::steady_clock;
+  auto const now = clock_t::now;
+
+  enum class Step : char {
+    preSourceTransition = 'S',
+    postSourceTransition = 's',
+    preModulePrefetching = 'P',
+    postModulePrefetching = 'p',
+    preModuleEventAcquire = 'A',
+    postModuleEventAcquire = 'a',
+    preModuleTransition = 'M',
+    preEventReadFromSource = 'R',
+    postEventReadFromSource = 'r',
+    preModuleEventDelayedGet = 'D',
+    postModuleEventDelayedGet = 'd',
+    postModuleTransition = 'm',
+    preESModulePrefetching = 'Q',
+    postESModulePrefetching = 'q',
+    preESModule = 'N',
+    postESModule = 'n',
+    preESModuleAcquire = 'B',
+    postESModuleAcquire = 'b',
+    preFrameworkTransition = 'F',
+    postFrameworkTransition = 'f'
+  };
+
+  enum class Phase : short {
+    destruction = -14,
+    endJob = -11,
+    endStream = -10,
+    writeProcessBlock = -9,
+    endProcessBlock = -8,
+    globalWriteRun = -6,
+    globalEndRun = -5,
+    streamEndRun = -4,
+    globalWriteLumi = -3,
+    globalEndLumi = -2,
+    streamEndLumi = -1,
+    Event = 0,
+    streamBeginLumi = 1,
+    globalBeginLumi = 2,
+    streamBeginRun = 4,
+    globalBeginRun = 5,
+    accessInputProcessBlock = 7,
+    beginProcessBlock = 8,
+    beginStream = 10,
+    beginJob = 11,
+    esSync = 12,
+    esSyncEnqueue = 13,
+    construction = 14,
+    startTracing = 15
+  };
+
+  std::ostream& operator<<(std::ostream& os, Step const s) {
+    os << static_cast<std::underlying_type_t<Step>>(s);
+    return os;
+  }
+
+  std::ostream& operator<<(std::ostream& os, Phase const s) {
+    os << static_cast<std::underlying_type_t<Phase>>(s);
+    return os;
+  }
+
+  template <Step S, typename... ARGS>
+  std::string assembleMessage(ARGS const... args) {
+    std::ostringstream oss;
+    oss << S;
+    concatenate(oss, args...);
+    oss << '\n';
+    return oss.str();
+  }
+
+  Phase toTransitionImpl(edm::StreamContext const& iContext) {
+    using namespace edm;
+    switch (iContext.transition()) {
+      case StreamContext::Transition::kBeginStream:
+        return Phase::beginStream;
+      case StreamContext::Transition::kBeginRun:
+        return Phase::streamBeginRun;
+      case StreamContext::Transition::kBeginLuminosityBlock:
+        return Phase::streamBeginLumi;
+      case StreamContext::Transition::kEvent:
+        return Phase::Event;
+      case StreamContext::Transition::kEndLuminosityBlock:
+        return Phase::streamEndLumi;
+      case StreamContext::Transition::kEndRun:
+        return Phase::streamEndRun;
+      case StreamContext::Transition::kEndStream:
+        return Phase::endStream;
+      default:
+        break;
+    }
+    assert(false);
+    return Phase::Event;
+  }
+
+  auto toTransition(edm::StreamContext const& iContext) -> std::underlying_type_t<Phase> {
+    return static_cast<std::underlying_type_t<Phase>>(toTransitionImpl(iContext));
+  }
+
+  Phase toTransitionImpl(edm::GlobalContext const& iContext) {
+    using namespace edm;
+    switch (iContext.transition()) {
+      case GlobalContext::Transition::kBeginProcessBlock:
+        return Phase::beginProcessBlock;
+      case GlobalContext::Transition::kAccessInputProcessBlock:
+        return Phase::accessInputProcessBlock;
+      case GlobalContext::Transition::kBeginRun:
+        return Phase::globalBeginRun;
+      case GlobalContext::Transition::kBeginLuminosityBlock:
+        return Phase::globalBeginLumi;
+      case GlobalContext::Transition::kEndLuminosityBlock:
+        return Phase::globalEndLumi;
+      case GlobalContext::Transition::kWriteLuminosityBlock:
+        return Phase::globalWriteLumi;
+      case GlobalContext::Transition::kEndRun:
+        return Phase::globalEndRun;
+      case GlobalContext::Transition::kWriteRun:
+        return Phase::globalWriteRun;
+      case GlobalContext::Transition::kEndProcessBlock:
+        return Phase::endProcessBlock;
+      case GlobalContext::Transition::kWriteProcessBlock:
+        return Phase::writeProcessBlock;
+      default:
+        break;
+    }
+    assert(false);
+    return Phase::Event;
+  }
+  auto toTransition(edm::GlobalContext const& iContext) -> std::underlying_type_t<Phase> {
+    return static_cast<std::underlying_type_t<Phase>>(toTransitionImpl(iContext));
+  }
+
+  unsigned int toTransitionIndex(edm::GlobalContext const& iContext) {
+    if (iContext.transition() == edm::GlobalContext::Transition::kBeginProcessBlock or
+        iContext.transition() == edm::GlobalContext::Transition::kEndProcessBlock or
+        iContext.transition() == edm::GlobalContext::Transition::kWriteProcessBlock or
+        iContext.transition() == edm::GlobalContext::Transition::kAccessInputProcessBlock) {
+      return 0;
+    }
+    if (iContext.transition() == edm::GlobalContext::Transition::kBeginRun or
+        iContext.transition() == edm::GlobalContext::Transition::kEndRun or
+        iContext.transition() == edm::GlobalContext::Transition::kWriteRun) {
+      return iContext.runIndex();
+    }
+    return iContext.luminosityBlockIndex();
+  }
+
+  template <Step S>
+  struct ESModuleState {
+    ESModuleState(std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile,
+                  decltype(now()) beginTime,
+                  std::shared_ptr<std::vector<std::type_index>> recordIndices)
+        : logFile_{logFile}, recordIndices_{recordIndices}, beginTime_{beginTime} {}
+
+    void operator()(edm::eventsetup::EventSetupRecordKey const& iKey,
+                    edm::ESModuleCallingContext const& iContext) const {
+      using namespace edm;
+      auto const t = std::chrono::duration_cast<duration_t>(now() - beginTime_).count();
+      auto top = iContext.getTopModuleCallingContext();
+      short int phase = 0;
+      unsigned long phaseID = 0xFFFFFFFF;
+      if (top->type() == ParentContext::Type::kGlobal) {
+        auto global = top->globalContext();
+        phase = toTransition(*global);
+        phaseID = toTransitionIndex(*global);
+      } else if (top->type() == ParentContext::Type::kStream) {
+        auto stream = top->getStreamContext();
+        phase = toTransition(*stream);
+        phaseID = stream_id(*stream);
+      } else if (top->type() == ParentContext::Type::kPlaceInPath) {
+        auto stream = top->getStreamContext();
+        phase = toTransition(*stream);
+        phaseID = stream_id(*stream);
+      }
+      auto recordIndex = findRecordIndices(iKey);
+      long long requestingModuleID;
+      if (iContext.type() == ESParentContext::Type::kModule) {
+        requestingModuleID = iContext.moduleCallingContext()->moduleDescription()->id();
+      } else {
+        requestingModuleID =
+            -1 * static_cast<long long>(iContext.esmoduleCallingContext()->componentDescription()->id_ + 1);
+      }
+      auto msg = assembleMessage<S>(
+          phase, phaseID, iContext.componentDescription()->id_ + 1, recordIndex, requestingModuleID, t);
+      logFile_->write(std::move(msg));
+    }
+
+  private:
+    int findRecordIndices(edm::eventsetup::EventSetupRecordKey const& iKey) const {
+      auto index = std::type_index(iKey.type().value());
+      auto itFind = std::find(recordIndices_->begin(), recordIndices_->end(), index);
+      return itFind - recordIndices_->begin();
+    }
+
+    std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile_;
+    std::shared_ptr<std::vector<std::type_index>> recordIndices_;
+    decltype(now()) beginTime_;
+  };
+
+  template <Step S>
+  struct GlobalEDModuleState {
+    GlobalEDModuleState(std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile, decltype(now()) beginTime)
+        : logFile_{logFile}, beginTime_{beginTime} {}
+
+    void operator()(edm::GlobalContext const& gc, edm::ModuleCallingContext const& mcc) {
+      using namespace edm;
+      auto const t = std::chrono::duration_cast<duration_t>(now() - beginTime_).count();
+      long requestingModuleID = 0;
+      if (mcc.type() == ParentContext::Type::kModule) {
+        requestingModuleID = module_id(*mcc.parent().moduleCallingContext());
+      }
+      auto msg = assembleMessage<S>(toTransition(gc), toTransitionIndex(gc), module_id(mcc), requestingModuleID, t);
+      logFile_->write(std::move(msg));
+    }
+
+  private:
+    std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile_;
+    decltype(now()) beginTime_;
+  };
+
+  template <Step S>
+  struct StreamEDModuleState {
+    StreamEDModuleState(std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile, decltype(now()) beginTime)
+        : logFile_{logFile}, beginTime_{beginTime} {}
+
+    void operator()(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
+      using namespace edm;
+      auto const t = std::chrono::duration_cast<duration_t>(now() - beginTime_).count();
+      long requestingModuleID = 0;
+      if (mcc.type() == ParentContext::Type::kModule) {
+        requestingModuleID = module_id(*mcc.parent().moduleCallingContext());
+      }
+      auto msg = assembleMessage<S>(toTransition(sc), stream_id(sc), module_id(mcc), requestingModuleID, t);
+      logFile_->write(std::move(msg));
+    }
+
+  private:
+    std::shared_ptr<edm::ThreadSafeOutputFileStream> logFile_;
+    decltype(now()) beginTime_;
+  };
+
+  struct ModuleCtrDtr {
+    long long beginConstruction = 0;
+    long long endConstruction = 0;
+    long long beginDestruction = 0;
+    long long endDestruction = 0;
+  };
+}  // namespace
+
+namespace edm::service::tracer {
+  void setupFile(std::string const& iFileName, edm::ActivityRegistry& iRegistry) {
+    auto beginTracer = now();
+    using namespace std::chrono;
+
+    if (iFileName.empty()) {
+      return;
+    }
+
+    auto logFile = std::make_shared<edm::ThreadSafeOutputFileStream>(iFileName);
+
+    auto beginTime = TimingServiceBase::jobStartTime();
+
+    auto esModuleLabelsPtr = std::make_shared<std::vector<std::string>>();
+    auto& esModuleLabels = *esModuleLabelsPtr;
+    //acquire names for all the ED and ES modules
+    iRegistry.watchPostESModuleRegistration([&esModuleLabels](auto const& iDescription) {
+      if (esModuleLabels.size() <= iDescription.id_ + 1) {
+        esModuleLabels.resize(iDescription.id_ + 2);
+      }
+      //NOTE: we want the id to start at 1 not 0
+      if (not iDescription.label_.empty()) {
+        esModuleLabels[iDescription.id_ + 1] = iDescription.label_;
+      } else {
+        esModuleLabels[iDescription.id_ + 1] = iDescription.type_;
+      }
+    });
+    auto moduleCtrDtrPtr = std::make_shared<std::vector<ModuleCtrDtr>>();
+    auto& moduleCtrDtr = *moduleCtrDtrPtr;
+    auto moduleLabelsPtr = std::make_shared<std::vector<std::string>>();
+    auto& moduleLabels = *moduleLabelsPtr;
+    iRegistry.watchPreModuleConstruction([&moduleLabels, &moduleCtrDtr, beginTime](ModuleDescription const& md) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+
+      auto const mid = md.id();
+      if (mid < moduleLabels.size()) {
+        moduleLabels[mid] = md.moduleLabel();
+        moduleCtrDtr[mid].beginConstruction = t;
+      } else {
+        moduleLabels.resize(mid + 1);
+        moduleLabels.back() = md.moduleLabel();
+        moduleCtrDtr.resize(mid + 1);
+        moduleCtrDtr.back().beginConstruction = t;
+      }
+    });
+    iRegistry.watchPostModuleConstruction([&moduleCtrDtr, beginTime](auto const& md) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      moduleCtrDtr[md.id()].endConstruction = t;
+    });
+
+    iRegistry.watchPreModuleDestruction([&moduleCtrDtr, beginTime](auto const& md) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      moduleCtrDtr[md.id()].beginDestruction = t;
+    });
+    iRegistry.watchPostModuleDestruction([&moduleCtrDtr, beginTime](auto const& md) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      moduleCtrDtr[md.id()].endDestruction = t;
+    });
+
+    auto sourceCtrPtr = std::make_shared<ModuleCtrDtr>();
+    auto& sourceCtr = *sourceCtrPtr;
+    iRegistry.watchPreSourceConstruction([&sourceCtr, beginTime](auto const&) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      sourceCtr.beginConstruction = t;
+    });
+    iRegistry.watchPostSourceConstruction([&sourceCtr, beginTime](auto const&) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      sourceCtr.endConstruction = t;
+    });
+    //iRegistry.watchPreModuleDestruction([&moduleLabels](auto& md) { moduleLabels[md.id()] = ""; });
+
+    auto recordIndices = std::make_shared<std::vector<std::type_index>>();
+    iRegistry.watchEventSetupConfiguration(
+        [logFile, recordIndices](auto const& recordsToResolvers, auto const&) mutable {
+          std::ostringstream oss;
+
+          auto recordKeys = recordsToResolvers.recordKeys();
+          std::sort(recordKeys.begin(), recordKeys.end());
+          std::vector<std::string> recordNames;
+          //want id to start at 1 not 0
+          recordNames.reserve(recordKeys.size() + 1);
+          recordNames.emplace_back("");
+          recordIndices->reserve(recordKeys.size() + 1);
+          recordIndices->push_back(std::type_index(typeid(void)));
+          for (auto const& r : recordKeys) {
+            recordNames.push_back(r.name());
+            recordIndices->push_back(std::type_index(r.type().value()));
+          }
+
+          moduleIdToLabel(oss, recordNames, 'R', "Record ID", "Record name");
+          logFile->write(oss.str());
+        });
+
+    iRegistry.watchPreBeginJob(
+        [logFile, moduleLabelsPtr, esModuleLabelsPtr, moduleCtrDtrPtr, sourceCtrPtr, beginTime, beginTracer](
+            auto&, auto&) mutable {
+          {
+            std::ostringstream oss;
+            moduleIdToLabel(oss, *moduleLabelsPtr, 'M', "EDModule ID", "Module label");
+            logFile->write(oss.str());
+            moduleLabelsPtr.reset();
+          }
+          {
+            std::ostringstream oss;
+            moduleIdToLabel(oss, *esModuleLabelsPtr, 'N', "ESModule ID", "ESModule label");
+            logFile->write(oss.str());
+            esModuleLabelsPtr.reset();
+          }
+          {
+            auto const tracerStart = duration_cast<duration_t>(beginTracer - beginTime).count();
+            auto msg = assembleMessage<Step::preFrameworkTransition>(
+                static_cast<std::underlying_type_t<Phase>>(Phase::startTracing), 0, 0, 0, 0, tracerStart);
+            logFile->write(std::move(msg));
+          }
+          //NOTE: the source construction can run concurently with module construction so we need to properly
+          // interleave its timing in with the modules
+          auto srcBeginConstruction = sourceCtrPtr->beginConstruction;
+          auto srcEndConstruction = sourceCtrPtr->endConstruction;
+          sourceCtrPtr.reset();
+          auto handleSource = [&srcBeginConstruction, &srcEndConstruction, &logFile](long long iTime) mutable {
+            if (srcBeginConstruction != 0 and srcBeginConstruction < iTime) {
+              auto bmsg = assembleMessage<Step::preSourceTransition>(
+                  static_cast<std::underlying_type_t<Phase>>(Phase::construction), 0, srcBeginConstruction);
+              logFile->write(std::move(bmsg));
+              srcBeginConstruction = 0;
+            }
+            if (srcEndConstruction != 0 and srcEndConstruction < iTime) {
+              auto bmsg = assembleMessage<Step::postSourceTransition>(
+                  static_cast<std::underlying_type_t<Phase>>(Phase::construction), 0, srcEndConstruction);
+              logFile->write(std::move(bmsg));
+              srcEndConstruction = 0;
+            }
+          };
+          {
+            int id = 0;
+            for (auto const& ctr : *moduleCtrDtrPtr) {
+              if (ctr.beginConstruction != 0) {
+                handleSource(ctr.beginConstruction);
+                auto bmsg = assembleMessage<Step::preModuleTransition>(
+                    static_cast<std::underlying_type_t<Phase>>(Phase::construction), 0, id, 0, ctr.beginConstruction);
+                logFile->write(std::move(bmsg));
+                handleSource(ctr.endConstruction);
+                auto emsg = assembleMessage<Step::postModuleTransition>(
+                    static_cast<std::underlying_type_t<Phase>>(Phase::construction), 0, id, 0, ctr.endConstruction);
+                logFile->write(std::move(emsg));
+              }
+              ++id;
+            }
+            id = 0;
+            for (auto const& dtr : *moduleCtrDtrPtr) {
+              if (dtr.beginDestruction != 0) {
+                handleSource(dtr.beginDestruction);
+                auto bmsg = assembleMessage<Step::preModuleTransition>(
+                    static_cast<std::underlying_type_t<Phase>>(Phase::destruction), 0, id, 0, dtr.beginDestruction);
+                logFile->write(std::move(bmsg));
+                handleSource(dtr.endDestruction);
+                auto emsg = assembleMessage<Step::postModuleTransition>(
+                    static_cast<std::underlying_type_t<Phase>>(Phase::destruction), 0, id, 0, dtr.endDestruction);
+                logFile->write(std::move(emsg));
+              }
+              ++id;
+            }
+            moduleCtrDtrPtr.reset();
+          }
+          auto const t = duration_cast<duration_t>(now() - beginTime).count();
+          handleSource(t);
+          auto msg = assembleMessage<Step::preFrameworkTransition>(
+              static_cast<std::underlying_type_t<Phase>>(Phase::beginJob), 0, 0, 0, 0, t);
+          logFile->write(std::move(msg));
+        });
+    iRegistry.watchPostBeginJob([logFile, beginTime]() {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      auto msg = assembleMessage<Step::postFrameworkTransition>(
+          static_cast<std::underlying_type_t<Phase>>(Phase::beginJob), 0, 0, 0, 0, t);
+      logFile->write(std::move(msg));
+    });
+
+    iRegistry.watchPreEndJob([logFile, beginTime]() {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      auto msg = assembleMessage<Step::preFrameworkTransition>(
+          static_cast<std::underlying_type_t<Phase>>(Phase::endJob), 0, 0, 0, 0, t);
+      logFile->write(std::move(msg));
+    });
+    iRegistry.watchPostEndJob([logFile, beginTime]() {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      auto msg = assembleMessage<Step::postFrameworkTransition>(
+          static_cast<std::underlying_type_t<Phase>>(Phase::endJob), 0, 0, 0, 0, t);
+      logFile->write(std::move(msg));
+    });
+
+    iRegistry.watchPreEvent([logFile, beginTime](auto const& sc) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      auto msg = assembleMessage<Step::preFrameworkTransition>(static_cast<std::underlying_type_t<Phase>>(Phase::Event),
+                                                               stream_id(sc),
+                                                               sc.eventID().run(),
+                                                               sc.eventID().luminosityBlock(),
+                                                               sc.eventID().event(),
+                                                               t);
+      logFile->write(std::move(msg));
+    });
+    iRegistry.watchPostEvent([logFile, beginTime](auto const& sc) {
+      auto const t = duration_cast<duration_t>(now() - beginTime).count();
+      auto msg =
+          assembleMessage<Step::postFrameworkTransition>(static_cast<std::underlying_type_t<Phase>>(Phase::Event),
+                                                         stream_id(sc),
+                                                         sc.eventID().run(),
+                                                         sc.eventID().luminosityBlock(),
+                                                         sc.eventID().event(),
+                                                         t);
+      logFile->write(std::move(msg));
+    });
+    {
+      auto preGlobal = [logFile, beginTime](GlobalContext const& gc) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preFrameworkTransition>(toTransition(gc),
+                                                                 toTransitionIndex(gc),
+                                                                 gc.luminosityBlockID().run(),
+                                                                 gc.luminosityBlockID().luminosityBlock(),
+                                                                 0,
+                                                                 t);
+        logFile->write(std::move(msg));
+      };
+      iRegistry.watchPreBeginProcessBlock(preGlobal);
+      iRegistry.watchPreEndProcessBlock(preGlobal);
+      iRegistry.watchPreWriteProcessBlock(preGlobal);
+      iRegistry.watchPreAccessInputProcessBlock(preGlobal);
+      iRegistry.watchPreGlobalBeginRun(preGlobal);
+      iRegistry.watchPreGlobalBeginLumi(preGlobal);
+      iRegistry.watchPreGlobalEndLumi(preGlobal);
+      iRegistry.watchPreGlobalWriteLumi(preGlobal);
+      iRegistry.watchPreGlobalEndRun(preGlobal);
+      iRegistry.watchPreGlobalWriteRun(preGlobal);
+    }
+    {
+      auto postGlobal = [logFile, beginTime](GlobalContext const& gc) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postFrameworkTransition>(toTransition(gc),
+                                                                  toTransitionIndex(gc),
+                                                                  gc.luminosityBlockID().run(),
+                                                                  gc.luminosityBlockID().luminosityBlock(),
+                                                                  0,
+                                                                  t);
+        logFile->write(std::move(msg));
+      };
+      iRegistry.watchPostBeginProcessBlock(postGlobal);
+      iRegistry.watchPostEndProcessBlock(postGlobal);
+      iRegistry.watchPostWriteProcessBlock(postGlobal);
+      iRegistry.watchPostAccessInputProcessBlock(postGlobal);
+      iRegistry.watchPostGlobalBeginRun(postGlobal);
+      iRegistry.watchPostGlobalBeginLumi(postGlobal);
+      iRegistry.watchPostGlobalEndLumi(postGlobal);
+      iRegistry.watchPostGlobalWriteLumi(postGlobal);
+      iRegistry.watchPostGlobalEndRun(postGlobal);
+      iRegistry.watchPostGlobalWriteRun(postGlobal);
+    }
+    {
+      auto preStream = [logFile, beginTime](StreamContext const& sc) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preFrameworkTransition>(
+            toTransition(sc), stream_id(sc), sc.eventID().run(), sc.eventID().luminosityBlock(), 0, t);
+        logFile->write(std::move(msg));
+      };
+      iRegistry.watchPreStreamBeginRun(preStream);
+      iRegistry.watchPreStreamBeginLumi(preStream);
+      iRegistry.watchPreStreamEndLumi(preStream);
+      iRegistry.watchPreStreamEndRun(preStream);
+    }
+    {
+      auto postStream = [logFile, beginTime](StreamContext const& sc) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postFrameworkTransition>(
+            toTransition(sc), stream_id(sc), sc.eventID().run(), sc.eventID().luminosityBlock(), 0, t);
+        logFile->write(std::move(msg));
+      };
+      iRegistry.watchPostStreamBeginRun(postStream);
+      iRegistry.watchPostStreamBeginLumi(postStream);
+      iRegistry.watchPostStreamEndLumi(postStream);
+      iRegistry.watchPostStreamEndRun(postStream);
+    }
+    {
+      iRegistry.watchESSyncIOVQueuing([logFile, beginTime](IOVSyncValue const& sv) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preFrameworkTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::esSyncEnqueue),
+            -1,
+            sv.eventID().run(),
+            sv.eventID().luminosityBlock(),
+            0,
+            t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPreESSyncIOV([logFile, beginTime](IOVSyncValue const& sv) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg =
+            assembleMessage<Step::preFrameworkTransition>(static_cast<std::underlying_type_t<Phase>>(Phase::esSync),
+                                                          -1,
+                                                          sv.eventID().run(),
+                                                          sv.eventID().luminosityBlock(),
+                                                          0,
+                                                          t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostESSyncIOV([logFile, beginTime](IOVSyncValue const& sv) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg =
+            assembleMessage<Step::postFrameworkTransition>(static_cast<std::underlying_type_t<Phase>>(Phase::esSync),
+                                                           -1,
+                                                           sv.eventID().run(),
+                                                           sv.eventID().luminosityBlock(),
+                                                           0,
+                                                           t);
+        logFile->write(std::move(msg));
+      });
+    }
+    {
+      iRegistry.watchPreSourceEvent([logFile, beginTime](StreamID id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::Event), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostSourceEvent([logFile, beginTime](StreamID id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::Event), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+
+      iRegistry.watchPreSourceRun([logFile, beginTime](RunIndex id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::globalBeginRun), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostSourceRun([logFile, beginTime](RunIndex id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::globalBeginRun), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+
+      iRegistry.watchPreSourceLumi([logFile, beginTime](auto id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::globalBeginLumi), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostSourceLumi([logFile, beginTime](auto id) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postSourceTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::globalBeginLumi), id.value(), t);
+        logFile->write(std::move(msg));
+      });
+
+      //ED Modules
+      iRegistry.watchPreModuleBeginJob([logFile, beginTime](auto const& md) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preModuleTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::beginJob), 0, md.id(), 0, t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostModuleBeginJob([logFile, beginTime](auto const& md) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postModuleTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::beginJob), 0, md.id(), 0, t);
+        logFile->write(std::move(msg));
+      });
+
+      iRegistry.watchPreModuleBeginStream(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleBeginStream(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleEndStream(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleEndStream(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleEndJob([logFile, beginTime](auto const& md) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::preModuleTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::endJob), 0, md.id(), 0, t);
+        logFile->write(std::move(msg));
+      });
+      iRegistry.watchPostModuleEndJob([logFile, beginTime](auto const& md) {
+        auto const t = duration_cast<duration_t>(now() - beginTime).count();
+        auto msg = assembleMessage<Step::postModuleTransition>(
+            static_cast<std::underlying_type_t<Phase>>(Phase::endJob), 0, md.id(), 0, t);
+        logFile->write(std::move(msg));
+      });
+
+      iRegistry.watchPreModuleEventPrefetching(StreamEDModuleState<Step::preModulePrefetching>(logFile, beginTime));
+      iRegistry.watchPostModuleEventPrefetching(StreamEDModuleState<Step::postModulePrefetching>(logFile, beginTime));
+
+      iRegistry.watchPreModuleEvent(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleEvent(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleEventAcquire(StreamEDModuleState<Step::preModuleEventAcquire>(logFile, beginTime));
+      iRegistry.watchPostModuleEventAcquire(StreamEDModuleState<Step::postModuleEventAcquire>(logFile, beginTime));
+      iRegistry.watchPreModuleEventDelayedGet(StreamEDModuleState<Step::preModuleEventDelayedGet>(logFile, beginTime));
+      iRegistry.watchPostModuleEventDelayedGet(
+          StreamEDModuleState<Step::postModuleEventDelayedGet>(logFile, beginTime));
+      iRegistry.watchPreEventReadFromSource(StreamEDModuleState<Step::preEventReadFromSource>(logFile, beginTime));
+      iRegistry.watchPostEventReadFromSource(StreamEDModuleState<Step::postEventReadFromSource>(logFile, beginTime));
+
+      iRegistry.watchPreModuleStreamPrefetching(StreamEDModuleState<Step::preModulePrefetching>(logFile, beginTime));
+      iRegistry.watchPostModuleStreamPrefetching(StreamEDModuleState<Step::postModulePrefetching>(logFile, beginTime));
+
+      iRegistry.watchPreModuleStreamBeginRun(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleStreamBeginRun(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleStreamEndRun(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleStreamEndRun(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleStreamBeginLumi(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleStreamBeginLumi(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleStreamEndLumi(StreamEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleStreamEndLumi(StreamEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleBeginProcessBlock(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleBeginProcessBlock(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleAccessInputProcessBlock(
+          GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleAccessInputProcessBlock(
+          GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleEndProcessBlock(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleEndProcessBlock(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleGlobalPrefetching(GlobalEDModuleState<Step::preModulePrefetching>(logFile, beginTime));
+      iRegistry.watchPostModuleGlobalPrefetching(GlobalEDModuleState<Step::postModulePrefetching>(logFile, beginTime));
+
+      iRegistry.watchPreModuleGlobalBeginRun(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleGlobalBeginRun(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleGlobalEndRun(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleGlobalEndRun(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleGlobalBeginLumi(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleGlobalBeginLumi(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+      iRegistry.watchPreModuleGlobalEndLumi(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleGlobalEndLumi(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleWriteProcessBlock(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleWriteProcessBlock(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleWriteRun(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleWriteRun(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      iRegistry.watchPreModuleWriteLumi(GlobalEDModuleState<Step::preModuleTransition>(logFile, beginTime));
+      iRegistry.watchPostModuleWriteLumi(GlobalEDModuleState<Step::postModuleTransition>(logFile, beginTime));
+
+      //ES Modules
+      iRegistry.watchPreESModulePrefetching(
+          ESModuleState<Step::preESModulePrefetching>(logFile, beginTime, recordIndices));
+      iRegistry.watchPostESModulePrefetching(
+          ESModuleState<Step::postESModulePrefetching>(logFile, beginTime, recordIndices));
+      iRegistry.watchPreESModule(ESModuleState<Step::preESModule>(logFile, beginTime, recordIndices));
+      iRegistry.watchPostESModule(ESModuleState<Step::postESModule>(logFile, beginTime, recordIndices));
+      iRegistry.watchPreESModuleAcquire(ESModuleState<Step::preESModuleAcquire>(logFile, beginTime, recordIndices));
+      iRegistry.watchPostESModuleAcquire(ESModuleState<Step::postESModuleAcquire>(logFile, beginTime, recordIndices));
+    }
+
+    std::ostringstream oss;
+    oss << "# Transition              Symbol\n";
+    oss << "#------------------------ ------\n";
+    oss << "# construction            " << Phase::construction << " \n"
+        << "# esSyncEnqueue           " << Phase::esSyncEnqueue << "\n"
+        << "# esSync                  " << Phase::esSync << "\n"
+        << "# beginJob                " << Phase::beginJob << "\n"
+        << "# beginStream             " << Phase::beginStream << "\n"
+        << "# beginProcessBlock       " << Phase::beginProcessBlock << "\n"
+        << "# accessInputProcessBlock " << Phase::accessInputProcessBlock << "\n"
+        << "# globalBeginRun          " << Phase::globalBeginRun << "\n"
+        << "# streamBeginRun          " << Phase::streamBeginRun << "\n"
+        << "# globalBeginLumi         " << Phase::globalBeginLumi << "\n"
+        << "# streamBeginLumi         " << Phase::streamBeginLumi << "\n"
+        << "# Event                   " << Phase::Event << "\n"
+        << "# streamEndLumi           " << Phase::streamEndLumi << "\n"
+        << "# globalEndLumi           " << Phase::globalEndLumi << "\n"
+        << "# globalWriteLumi         " << Phase::globalWriteLumi << "\n"
+        << "# streamEndRun            " << Phase::streamEndRun << "\n"
+        << "# globalEndRun            " << Phase::globalEndRun << "\n"
+        << "# globalWriteRun          " << Phase::globalWriteRun << "\n"
+        << "# endProcessBlock         " << Phase::endProcessBlock << "\n"
+        << "# writeProcessBlock       " << Phase::writeProcessBlock << "\n"
+        << "# endStream               " << Phase::endStream << "\n"
+        << "# endJob                  " << Phase::endJob << "\n\n";
+    oss << "# Step                       Symbol Entries\n"
+        << "# -------------------------- ------ ------------------------------------------\n"
+        << "# preSourceTransition           " << Step::preSourceTransition
+        << "   <Transition type> <Transition ID> <Time since beginJob (us)>\n"
+        << "# postSourceTransition          " << Step::postSourceTransition
+        << "   <Transition type> <Transition ID> <Time since beginJob (us)>\n"
+        << "# preModulePrefetching          " << Step::preModulePrefetching
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# postModulePrefetching         " << Step::postModulePrefetching
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# preModuleEventAcquire         " << Step::preModuleEventAcquire
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# postModuleEventAcquire        " << Step::postModuleEventAcquire
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# preModuleTransition           " << Step::preModuleTransition
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# preEventReadFromSource        " << Step::preEventReadFromSource
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# postEventReadFromSource       " << Step::postEventReadFromSource
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID or 0> <Time since beginJob "
+           "(us)>\n"
+        << "# postModuleTransition          " << Step::postModuleTransition
+        << "   <Transition type> <Transition ID> <EDModule ID> <Requesting EDModule ID> <Time since beginJob (us)>\n"
+        << "# preESModulePrefetching        " << Step::preESModulePrefetching
+        << "   <Transition type> <Transition ID> <ESModule ID> <Record ID> <Requesting module ID (+ED, -ES)> <Time "
+           "since beginJob (us)>\n"
+        << "# postESModulePrefetching       " << Step::postESModulePrefetching
+        << "   <Transition type> <Transition ID> <ESModule ID> <Record ID> <Requesting module ID (+ED, -ES)> <Time "
+           "since beginJob (us)>\n"
+        << "# preESModuleTransition         " << Step::preESModule
+        << "   <TransitionType> <Transition ID> <ESModule ID> <Record ID> <Requesting module ID (+ED, -ES)> <Time "
+           "since beginJob (us)>\n"
+        << "# postESModuleTransition        " << Step::postESModule
+        << "   <TransitionType> <Transition ID> <ESModule ID> <Record ID> <Requesting module ID (+ED, -ES)> <Time "
+           "since beginJob (us)>\n"
+        << "# preFrameworkTransition        " << Step::preFrameworkTransition
+        << "   <Transition type> <Transition ID> <Run#> <LumiBlock#> <Event #> <Time since beginJob (ms)>\n"
+        << "# postFrameworkTransition       " << Step::postFrameworkTransition
+        << "   <Transition type> <Transition ID> <Run#> <LumiBlock#> <Event #> <Time since beginJob (ms)>\n";
+    logFile->write(oss.str());
+    return;
+  }
+}  // namespace edm::service::tracer

--- a/FWCore/Services/plugins/tracer_setupFile.h
+++ b/FWCore/Services/plugins/tracer_setupFile.h
@@ -1,0 +1,13 @@
+#ifndef FWCore_Services_tracer_setupFile_h
+#define FWCore_Services_tracer_setupFile_h
+
+#include <string>
+
+namespace edm {
+  class ActivityRegistry;
+  namespace service::tracer {
+    void setupFile(std::string const& iFileName, edm::ActivityRegistry&);
+  }
+}  // namespace edm
+
+#endif

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -413,11 +413,11 @@ namespace edm {
       // Since the test os also allowed to do so, it can lead to problems.
       //pathsAndConsumesOfModules.initialize(schedule_.get(), preg_);
 
+      espController_->finishConfiguration();
+      actReg_->eventSetupConfigurationSignal_(esp_->recordsToResolverIndices(), processContext_);
       //NOTE: this may throw
       //checkForModuleDependencyCorrectness(pathsAndConsumesOfModules, false);
       actReg_->preBeginJobSignal_(pathsAndConsumesOfModules, processContext_);
-
-      espController_->finishConfiguration();
 
       schedule_->beginJob(*preg_, esp_->recordsToResolverIndices(), *processBlockHelper_);
       actReg_->postBeginJobSignal_();


### PR DESCRIPTION
#### PR description:

Added an option to the Tracer service to output a compact log file of the transitions seen in the framework job. 
Included a python program to convert the file into more humanly readable output.

#### PR validation:

Code compiles. Visual inspection of a file generated from a simple configuration shows the expected values.