### PR TITLE
[TkAl] Realign DQM and Offline analysis of μμ + vertex events

### DIFF
--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -96,6 +96,17 @@ elif options.era=='2017':
 elif options.era=='2018':
     print("===> running era 2018")
     process = cms.Process('Analysis',eras.Run2_2018)
+elif options.era=='2022':
+    print("===> running era 2022")
+    process = cms.Process('Analysis',eras.Run3)
+elif options.era=='2023':
+    print("===> running era 2023")
+    process = cms.Process('Analysis',eras.Run3_2023)
+
+###################################################################
+# Set the process to run multi-threaded
+###################################################################
+process.options.numberOfThreads = 8
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
+++ b/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
@@ -142,6 +142,14 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
     myTracks.emplace_back(&muonTrk);
   }
 
+#ifdef EDM_ML_DEBUG
+  for (const auto& track : myTracks) {
+    edm::LogVerbatim("DiMuonVertexMonitor") << __PRETTY_FUNCTION__ << " pT: " << track->pt() << " GeV"
+                                            << " , pT error: " << track->ptError() << " GeV"
+                                            << " , eta: " << track->eta() << " , phi: " << track->phi() << std::endl;
+  }
+#endif
+
   const TransientTrackBuilder* theB = &iSetup.getData(ttbESToken_);
   TransientVertex mumuTransientVtx;
   std::vector<reco::TransientTrack> tks;
@@ -160,6 +168,17 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   TLorentzVector p4_tplus(tplus->px(), tplus->py(), tplus->pz(), sqrt((tplus->p() * tplus->p()) + mumass2));
   TLorentzVector p4_tminus(tminus->px(), tminus->py(), tminus->pz(), sqrt((tminus->p() * tminus->p()) + mumass2));
+
+#ifdef EDM_ML_DEBUG
+  // Define a lambda function to convert TLorentzVector to a string
+  auto tLorentzVectorToString = [](const TLorentzVector& vector) {
+    return std::to_string(vector.Px()) + " " + std::to_string(vector.Py()) + " " + std::to_string(vector.Pz()) + " " +
+           std::to_string(vector.E());
+  };
+
+  edm::LogVerbatim("DiMuonVertexMonitor") << "mu+" << tLorentzVectorToString(p4_tplus) << std::endl;
+  edm::LogVerbatim("DiMuonVertexMonitor") << "mu-" << tLorentzVectorToString(p4_tminus) << std::endl;
+#endif
 
   const auto& Zp4 = p4_tplus + p4_tminus;
   float track_invMass = Zp4.M();
@@ -211,6 +230,14 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
       mumuTransientVtx.position().x(), mumuTransientVtx.position().y(), mumuTransientVtx.position().z());
   const math::XYZPoint deltaVtx(
       theMainVtxPos.x() - myVertex.x(), theMainVtxPos.y() - myVertex.y(), theMainVtxPos.z() - myVertex.z());
+
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("DiMuonVertexMonitor") << "mm vertex position:" << aTransientVertex.position().x() << ","
+                                          << aTransientVertex.position().y() << "," << aTransientVertex.position().z();
+
+  edm::LogVerbatim("DiMuonVertexMonitor") << "main vertex position:" << TheMainVertex.position().x() << ","
+                                          << TheMainVertex.position().y() << "," << TheMainVertex.position().z();
+#endif
 
   if (theMainVtx.isValid()) {
     // fill the impact parameter plots
@@ -288,6 +315,11 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
       // inverted
       hCosPhiInv_->Fill(-cosphi);
       hCosPhiInv3D_->Fill(-cosphi3D);
+
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("DiMuonVertexMonitor")
+          << "distance " << distance * cmToum << " cosphi3D:" << cosphi3D << std::endl;
+#endif
 
       // unbalance
       hCosPhiUnbalance_->Fill(cosphi, 1.);


### PR DESCRIPTION
#### PR description:

Title says it all. After offline investigation (mainly from @vbotta) some discrepancy was found when comparing the results from the `DiMuonVertexValidation` module (in the package `Alignment/OfflineValidation`) and `DiMuonVertexMonitor` (in the package `DQMOffline/Alignment`).
These were traced back to the fact that the DQM module (by default) selects the primary vertex closest to the di-muon vertex, while the one in `Alignment/OfflineValidation` selects the first one (presumably the hardest in the event, but not guaranteed because there is no re-sorting post-refit). This is addressed in 2e70c3b9b0a1004584c02be33e7debd107a7aa62 by offering the user the possibility to use the closest (to X→μμ decay vertex) or the first primary vertex.
The other two commits:
   * 79451cfaeb1501f149aee6d3e530a98f91acee40 updates slightly the unit test configuration for `DiMuonVertexValidation`,
   *  4839b20b27939a69ac9661f4c04be251daae280d adds some debug statement in `DiMuonVertexMonitor`, that were useful during the debugging process.

#### PR validation:

Run successfully:
   * `scram b runtests_DiMuonVertex use-ibeos`
   * `scram b runtests_testDiMuonVertexMonitor use-ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
