### PR TITLE
disable unit test of `hltPrintMenuVersions` in non-`x86-64` builds

### DIFF
--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -1,8 +1,13 @@
 <!-- test access to EDM files used in HLT-AddOnTests and HLT-Validation tests -->
 <test name="testAccessToEDMInputsOfHLTTests" command="testAccessToEDMInputsOfHLTTests.sh"/>
 
-<!-- test script hltPrintMenuVersions -->
-<test name="test_hltPrintMenuVersions" command="test_hltPrintMenuVersions.sh"/>
+<!-- test script hltPrintMenuVersions
+     enabled only for the x86-64 architecture, because the python module cx_Oracle
+     does not fully work in CMSSW builds with non-x86-64 architectures
+-->
+<ifarch value="x86_64">
+  <test name="test_hltPrintMenuVersions" command="test_hltPrintMenuVersions.sh"/>
+</ifarch>
 
 <!-- test script hltMenuContentToCSVs -->
 <test name="test_hltMenuContentToCSVs" command="test_hltMenuContentToCSVs.sh"/>


### PR DESCRIPTION
resolves #42975

(Well, "resolves" is a strong word in this case.)

#### PR description:

This PR restricts the execution of the unit test of `hltPrintMenuVersions` (added in #42967) to the `x86-64` architecture, given that the python module `cx_Oracle` is not fully working in CMSSW builds with non-`x86-64` architecture (e.g. Aarch64 and PowerPC).

The implementation is tentatively copied from other unit tests in CMSSW.

#### PR validation:

Tested that the unit test is ignored in a recent Aarch64 IB.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

Will be included in #42969, i.e. the backport of #42967.
