### PR TITLE
Additional fix for pixel FED error imbalance in DQM plots

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -191,13 +191,11 @@ namespace pixelgpudetails {
       case (26): {
         if constexpr (debug)
           printf("Gap word found (errorType = 26)\n");
-        errorFound = true;
         break;
       }
       case (27): {
         if constexpr (debug)
           printf("Dummy word found (errorType = 27)\n");
-        errorFound = true;
         break;
       }
       case (28): {
@@ -227,6 +225,7 @@ namespace pixelgpudetails {
         if (stateMatch != 1 && stateMatch != 8) {
           if constexpr (debug)
             printf("FED error 30 with unexpected State Bits (errorType = 30)\n");
+          break;
         }
         if (stateMatch == 1)
           errorType = 40;  // 1=Overflow -> 40, 8=number of ROCs -> 30


### PR DESCRIPTION
#### PR description:

After a recent fix for pixel FED error imbalance in DQM plots (https://github.com/cms-sw/cmssw/pull/42872), some imbalance still remained as can be see in the [online DQM plots for run 374731](https://cmsweb.cern.ch/dqm/online/start?runnr=374731;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=SiPixelHeterogeneous/Layouts;focus=SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU/FEErrorVsFEDIdUnbalance;zoom=yes;). This was later confirmed in local tests with 2k events from wf 141.008583 as can be seen in the `SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU/FEErrorVsFEDIdUnbalance` plot
![FEDErrorImbalance_ref](https://github.com/cms-sw/cmssw/assets/4885289/0745d2fb-463d-40a8-96d2-961f1f565d72)
The remaining imbalance concerns errorType=30 (TBM error trailer) and originates from the relevant GPU and CPU codes not being fully in sync. With this PR added the imbalance plot become empty
![FEDErrorImbalance_pr](https://github.com/cms-sw/cmssw/assets/4885289/7f8ab111-0be0-4869-b58b-e3642c0ff625)
I also took this opportunity to fully synchronize the code for errorTypes 26 and 27.

#### PR validation:

The code was tested and the above DQM plots obtained by running the following workflow

`runTheMatrix.py -w gpu -l 141.008583`

over 2k events (by default the wf runs over 100 events).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 13_2_X planned.
