### PR TITLE
Phase2-hgx346X Add new collection names and information of Calibration Cells to the HGCal SD Class

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -40,6 +40,14 @@ public:
   std::pair<int, int> assignCell(float x, float y, int lay, int subSec, bool reco) const;
   std::array<int, 5> assignCellHex(float x, float y, int zside, int lay, bool reco, bool extend, bool debug) const;
   std::array<int, 3> assignCellTrap(float x, float y, float z, int lay, bool reco) const;
+  std::vector<int> calibCells(bool hd, bool full) const {
+    if (hd) {
+      return (full ? hgpar_->calibCellFullHD_ : hgpar_->calibCellPartHD_);
+    } else {
+      return (full ? hgpar_->calibCellFullLD_ : hgpar_->calibCellPartLD_);
+    }
+  }
+  double calibCellRad(bool hd) const { return (hd ? hgpar_->calibCellRHD_ : hgpar_->calibCellRLD_); }
   bool cassetteMode() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
             (mode_ == HGCalGeometryMode::Hexagon8CalibCell));

--- a/SimG4CMS/Calo/interface/HGCalSD.h
+++ b/SimG4CMS/Calo/interface/HGCalSD.h
@@ -54,7 +54,10 @@ private:
   bool storeAllG4Hits_;
   bool fiducialCut_, rejectMB_, waferRot_, checkID_;
   int useSimWt_, verbose_;
-  bool dd4hep_;
+  bool dd4hep_, calibCells_;
+  double calibCellRHD_, calibCellRLD_;
+  std::vector<int> calibCellFullHD_, calibCellPartHD_;
+  std::vector<int> calibCellFullLD_, calibCellPartLD_;
   const double tan30deg_, cos30deg_;
   std::vector<double> angles_;
   std::string missingFile_;

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -386,10 +386,10 @@ void CaloSD::EndOfEvent(G4HCofThisEvent*) {
   cleanHitCollection();
 
 #ifdef EDM_ML_DEBUG
-  if (theHC == nullptr)
+  if (theHC[0] == nullptr)
     edm::LogVerbatim("CaloSim") << "CaloSD: EndofEvent entered with no entries";
   else
-    edm::LogVerbatim("CaloSim") << "CaloSD: EndofEvent entered with " << theHC->entries() << " entries";
+    edm::LogVerbatim("CaloSim") << "CaloSD: EndofEvent entered with " << theHC[0]->entries() << " entries";
 #endif
 }
 

--- a/SimG4CMS/Calo/test/python/runHGC1_cfg.py
+++ b/SimG4CMS/Calo/test/python/runHGC1_cfg.py
@@ -1,13 +1,41 @@
+###############################################################################
+# Way to use this:
+#   cmsRun ttbar.py geometry=V18
+#   Options for geometry V17Shift, V18
+# 
+###############################################################################
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+import os, sys, imp, re
+import FWCore.ParameterSet.VarParsing as VarParsing
 
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "V18",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "geometry of operations: V17Shift, V18")
+
+### get and parse the command line arguments
+ 
+options.parseArguments()
+print(options)
+
+####################################################################
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
 process = cms.Process("PROD",Phase2C11)
+
+geomFile = "Geometry.HGCalCommonData.testHGCal" + options.geometry + "Reco_cff"
+print("Geometry file: ", geomFile)
+
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load('Configuration.StandardSequences.Generator_cff')
 process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
 process.load('GeneratorInterface.Core.genFilterSummary_cff')
 process.load('Configuration.StandardSequences.SimIdeal_cff')
-process.load("Configuration.Geometry.GeometryExtended2026D49Reco_cff")
+process.load(geomFile)
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -159,6 +159,9 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
   produces<edm::PCaloHitContainer>("HGCHitsEE");
   produces<edm::PCaloHitContainer>("HGCHitsHEfront");
   produces<edm::PCaloHitContainer>("HGCHitsHEback");
+  produces<edm::PCaloHitContainer>("CalibrationHGCHitsEE");
+  produces<edm::PCaloHitContainer>("CalibrationHGCHitsHEfront");
+  produces<edm::PCaloHitContainer>("CalibrationHGCHitsHEback");
 
   produces<edm::PSimHitContainer>("MuonDTHits");
   produces<edm::PSimHitContainer>("MuonCSCHits");


### PR DESCRIPTION
#### PR description:

Add new collection names and information of Calibration Cells to the HGCal SD Class. This is to replace #42961 which was messed up

#### PR validation:

Tested using the cfg file in SimG4CMS/Calo/test/python

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special