### PR TITLE
[13.2.X] Increase number of sequences to be analyzed in `DQMOffline/Configuration` unit tests

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,290,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,300,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="cmsswSequenceInfo.py --runTheMatrix --steps DQM,VALIDATION --infile file://${LOCALTOP}/tmp/${INFILE_NAME} --limit 50 --offset 300 --threads 1 | grep 'Analyzing 0 seqs'">
+<test name="TestDQMOfflineConfigurationGotAll" command="cmsswSequenceInfo.py --runTheMatrix --steps DQM,VALIDATION --infile file://${LOCALTOP}/tmp/${INFILE_NAME} --limit 50 --offset 310 --threads 1 | grep 'Analyzing 0 seqs'">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/42831

#### PR description:

As reported in https://github.com/cms-sw/cmssw/issues/42831#issuecomment-1757023443, it seems that https://github.com/cms-sw/cmssw/pull/42714 (more specifically just commit https://github.com/cms-sw/cmssw/commit/5e21e71cce8757cf20c043efc223689fa687824e) causes the total number of distinct sequences to grow above the current limit (300) as analyzed by the unit tests of this package.
I merely follow the indications in the commented section of the `BuildFile.xml`:

https://github.com/cms-sw/cmssw/blob/d9d4aec32230b7d62e51c4622dfd654e8cea106a/DQMOffline/Configuration/test/BuildFile.xml#L11-L12

**N.B. a forward port of this seems not necessary, the total number of sequences appears to be release-dependent**

#### PR validation:

` scram b runtests_TestDQMOfflineConfigurationGotAll use-ibeos` runs fine.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
