### PR TITLE
Remove unnecessary using namespace directive in WriteCTPPSTotemDAQMappingMask

### DIFF
--- a/CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc
+++ b/CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc
@@ -43,16 +43,13 @@ private:
   void analyze(const edm::Event &e, const edm::EventSetup &es) override;
 };
 
-using namespace std;
-using namespace edm;
-
 //----------------------------------------------------------------------------------------------------
 
 WriteCTPPSTotemDAQMappingMask::WriteCTPPSTotemDAQMappingMask(const edm::ParameterSet &ps)
     : daqMappingIov_(ps.getParameter<unsigned long long>("daqMappingIov")),
-      recordMap_(ps.getParameter<string>("recordMap")),
-      recordMask_(ps.getParameter<string>("recordMask")),
-      label_(ps.getParameter<string>("label")),
+      recordMap_(ps.getParameter<std::string>("recordMap")),
+      recordMask_(ps.getParameter<std::string>("recordMask")),
+      label_(ps.getParameter<std::string>("label")),
       tokenMapping_(esConsumes<TotemDAQMapping, TotemReadoutRcd>(edm::ESInputTag("", label_))),
       tokenAnalysisMask_(esConsumes<TotemAnalysisMask, TotemReadoutRcd>(edm::ESInputTag("", label_))) {}
 


### PR DESCRIPTION
#### PR description:

This is a simple PR to remove `using namespace` directives and explicitly use the std:: declaration where needed in [CondTools/CTPPS/plugins/WriteCTPPSTotemDAQMappingMask.cc](https://github.com/cms-sw/cmssw/compare/master...rsreds:cmssw:fix-using-namespace?expand=1#diff-140c17cd5e469a3e3692f7f3e397d10512b8b9e95d1038ac986f3737902f8475)

This is in response to https://github.com/cms-sw/cmssw/pull/42879#issuecomment-1746288968

#### PR validation:

The PR has been tested by running the same test described in the previous PR #42879  ([CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:mapping-dump-update?expand=1#diff-1dba015306a25198f8fc530bec2f491c24af99f0b3fafb31d66dba92e8df90cd))
as well as the basic test procedures.
