### PR TITLE
Latest updates in DQM/TrackingMonitorSource for data/MC comparisons for the Tracking POG

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/BuildFile.xml
+++ b/DQM/TrackingMonitorSource/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>
+<use name="RecoVertex/KalmanVertexFit"/>
 <use name="TrackingTools/TransientTrack"/>
 <use name="TrackingTools/Records"/>
 <use name="TrackingTools/IPTools"/>

--- a/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZEEDetails.cc
@@ -115,8 +115,8 @@ void ZEEDetails::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.addUntracked<uint32_t>("minStripHits", 8);
   desc.addUntracked<double>("maxIso", 0.3);
   desc.addUntracked<double>("minPtHighest", 24);
-  desc.addUntracked<double>("minInvMass", 60);
-  desc.addUntracked<double>("maxInvMass", 120);
+  desc.addUntracked<double>("minInvMass", 75);
+  desc.addUntracked<double>("maxInvMass", 105);
   desc.addUntracked<std::string>("trackQuality", "highPurity");
   desc.addUntracked<bool>("isMC", false);
   desc.addUntracked<bool>("doPUCorrection", false);
@@ -152,8 +152,8 @@ ZEEDetails::ZEEDetails(const edm::ParameterSet& ps)
       minStripHits_(ps.getUntrackedParameter<uint32_t>("minStripHits", 8)),
       maxIso_(ps.getUntrackedParameter<double>("maxIso", 0.3)),
       minPtHighest_(ps.getUntrackedParameter<double>("minPtHighest", 24)),
-      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 60)),
-      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 120)),
+      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 75)),
+      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 105)),
       trackQuality_(ps.getUntrackedParameter<std::string>("trackQuality", "highPurity")),
       isMC_(ps.getUntrackedParameter<bool>("isMC", false)),
       doPUCorrection_(ps.getUntrackedParameter<bool>("doPUCorrection", false)),

--- a/DQM/TrackingMonitorSource/plugins/ZtoEEElectronTrackProducer.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZtoEEElectronTrackProducer.cc
@@ -84,8 +84,8 @@ void ZtoEEElectronTrackProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.addUntracked<unsigned int>("minStripHits", 8);
   desc.addUntracked<double>("maxIso", 0.3);
   desc.addUntracked<double>("minPtHighest", 24);
-  desc.addUntracked<double>("minInvMass", 60);
-  desc.addUntracked<double>("maxInvMass", 120);
+  desc.addUntracked<double>("minInvMass", 75);
+  desc.addUntracked<double>("maxInvMass", 105);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -111,8 +111,8 @@ ZtoEEElectronTrackProducer::ZtoEEElectronTrackProducer(const edm::ParameterSet& 
       minStripHits_(ps.getUntrackedParameter<uint32_t>("minStripHits", 8)),
       maxIso_(ps.getUntrackedParameter<double>("maxIso", 0.3)),
       minPtHighest_(ps.getUntrackedParameter<double>("minPtHighest", 24)),
-      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 60)),
-      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 120)) {
+      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 75)),
+      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 105)) {
   produces<reco::TrackCollection>("");
 }
 

--- a/DQM/TrackingMonitorSource/plugins/ZtoEEEventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZtoEEEventSelector.cc
@@ -79,8 +79,8 @@ void ZtoEEEventSelector::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<uint32_t>("minStripHits", 8);
   desc.addUntracked<double>("maxIso", 0.3);
   desc.addUntracked<double>("minPtHighest", 24);
-  desc.addUntracked<double>("minInvMass", 60);
-  desc.addUntracked<double>("maxInvMass", 120);
+  desc.addUntracked<double>("minInvMass", 75);
+  desc.addUntracked<double>("maxInvMass", 105);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -106,8 +106,8 @@ ZtoEEEventSelector::ZtoEEEventSelector(const edm::ParameterSet& ps)
       minStripHits_(ps.getUntrackedParameter<uint32_t>("minStripHits", 8)),
       maxIso_(ps.getUntrackedParameter<double>("maxIso", 0.3)),
       minPtHighest_(ps.getUntrackedParameter<double>("minPtHighest", 24)),
-      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 60)),
-      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 120)) {}
+      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 75)),
+      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 105)) {}
 
 bool ZtoEEEventSelector::filter(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // Read Electron Collection

--- a/DQM/TrackingMonitorSource/plugins/ZtoMMEventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZtoMMEventSelector.cc
@@ -66,8 +66,8 @@ void ZtoMMEventSelector::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<double>("minMatchedStations", 2);
   desc.addUntracked<double>("maxIso", 0.3);
   desc.addUntracked<double>("minPtHighest", 24);
-  desc.addUntracked<double>("minInvMass", 60);
-  desc.addUntracked<double>("maxInvMass", 120);
+  desc.addUntracked<double>("minInvMass", 75);
+  desc.addUntracked<double>("maxInvMass", 105);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -89,8 +89,8 @@ ZtoMMEventSelector::ZtoMMEventSelector(const edm::ParameterSet& ps)
       minMatchedStations_(ps.getUntrackedParameter<double>("minMatchedStations", 2)),
       maxIso_(ps.getUntrackedParameter<double>("maxIso", 0.3)),
       minPtHighest_(ps.getUntrackedParameter<double>("minPtHighest", 24)),
-      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 60)),
-      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 120)) {}
+      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 75)),
+      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 105)) {}
 
 bool ZtoMMEventSelector::filter(edm::Event& iEvent, edm::EventSetup const& iSetup) {
   // Read Muon Collection

--- a/DQM/TrackingMonitorSource/plugins/ZtoMMMuonTrackProducer.cc
+++ b/DQM/TrackingMonitorSource/plugins/ZtoMMMuonTrackProducer.cc
@@ -74,8 +74,8 @@ void ZtoMMMuonTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.addUntracked<double>("minMatchedStations", 2);
   desc.addUntracked<double>("maxIso", 0.3);
   desc.addUntracked<double>("minPtHighest", 24);
-  desc.addUntracked<double>("minInvMass", 60);
-  desc.addUntracked<double>("maxInvMass", 120);
+  desc.addUntracked<double>("minInvMass", 75);
+  desc.addUntracked<double>("maxInvMass", 105);
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -96,8 +96,8 @@ ZtoMMMuonTrackProducer::ZtoMMMuonTrackProducer(const edm::ParameterSet& ps)
       minMatchedStations_(ps.getUntrackedParameter<double>("minMatchedStations", 2)),
       maxIso_(ps.getUntrackedParameter<double>("maxIso", 0.3)),
       minPtHighest_(ps.getUntrackedParameter<double>("minPtHighest", 24)),
-      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 60)),
-      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 120)) {
+      minInvMass_(ps.getUntrackedParameter<double>("minInvMass", 75)),
+      maxInvMass_(ps.getUntrackedParameter<double>("maxInvMass", 105)) {
   produces<reco::TrackCollection>("");
 }
 

--- a/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
@@ -5,6 +5,7 @@ from DQM.TrackingMonitorSource.standaloneTrackMonitorDefault_cfi import standalo
 standaloneTrackMonitor = standaloneTrackMonitorDefault.clone(
     moduleName        = "StandaloneTrackMonitor",
     folderName        = "highPurityTracks",
+    isRECO            = False,
     vertexTag         = "selectedPrimaryVertices", # "offlinePrimaryVertices",
     puTag             = "addPileupInfo",
     clusterTag        = "siStripClusters",


### PR DESCRIPTION
This pull request contains the implementation of the latest distributions and plugins which are used by the Tracking POG for their data/MC comparisons. The main changes are to the StandaloneTrackMonitor plugin: a bug regarding the Z invariant mass and pt distribution has been fixed (they didn't have an impact on the results anyway), the histograms about the error on the IP are now in log scale, for dilepton events the cosphi3d distribution described here: https://indico.cern.ch/event/1312617/contributions/5521545/attachments/2694079/4675527/2023.08.01.misAlignmentPPD.pdf is evaluated. 
