### PR TITLE
[13.2.X] remove `edmCheckMultithreading` from `hltIntegrationTests`

### DIFF
--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -392,9 +392,6 @@ fi
 # check the prescale modules
 hltCheckPrescaleModules -w hlt.py
 
-# check for multi-threading
-edmCheckMultithreading hlt.py | grep legacy
-
 log "Preparing single-trigger configurations"
 for TRIGGER in $TRIGGERS; do
   cat > "${TRIGGER}".py << @EOF


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42993

#### PR description:

As pointed out in https://github.com/cms-sw/cmssw/issues/42988#issuecomment-1758041971 this is no longer needed, as the Framework doesn't support Legacy module types as of `CMSSW_13_0_0_pre3`.
This should alleviate the pressure on CERN HTCondor batch nodes in which HLT IBs tests are run, for a more thorough description see https://github.com/cms-sw/cmssw/issues/42988#issue-1937749471.

#### PR validation:

Run an integration test from a recent HLT integration ticket [CMSHLT-2957](https://its.cern.ch/jira/browse/CMSHLT-2957)
```
 hltIntegrationTests /users/ddesouza/HI2023/Add_ZDC_Assym/HLT/V1 -n 800 --mc -d output_hltIntegTestPbPb_upc -x "--globaltag auto:phase1_2023_realistic_hi" -x "--eras Run3 --l1-emulator uGT" -x "--l1 L1Menu_CollisionsHeavyIons2023_v1_1_4_xml" -i file:/eos/cms/store/group/phys_heavyions/anstahll/CERN/Run3/2023/MC/STARLIGHT/CohJPsi_STARLIGHT_5p36TeV_2023Run3_RAW_20230812/CohJPsi_STARLIGHT_5p36TeV_2023Run3/CohJPsi_STARLIGHT_5p36TeV_2023Run3_RAW_20230812/230812_063634/0000/step2_STARlight_Digi_10.root -x "--no-output --open --paths HLT_HIUPC*nAsymXOR*" >& test.txt &
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/42993 to 13.2.X
