### PR TITLE
fix mistake in `EDM_ML_DEBUG` protected section of `DiMuonVertexMonitor`

### DIFF
--- a/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
+++ b/DQMOffline/Alignment/src/DiMuonVertexMonitor.cc
@@ -232,11 +232,11 @@ void DiMuonVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetu
       theMainVtxPos.x() - myVertex.x(), theMainVtxPos.y() - myVertex.y(), theMainVtxPos.z() - myVertex.z());
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("DiMuonVertexMonitor") << "mm vertex position:" << aTransientVertex.position().x() << ","
-                                          << aTransientVertex.position().y() << "," << aTransientVertex.position().z();
+  edm::LogVerbatim("DiMuonVertexMonitor") << "mm vertex position:" << mumuTransientVtx.position().x() << ","
+                                          << mumuTransientVtx.position().y() << "," << mumuTransientVtx.position().z();
 
-  edm::LogVerbatim("DiMuonVertexMonitor") << "main vertex position:" << TheMainVertex.position().x() << ","
-                                          << TheMainVertex.position().y() << "," << TheMainVertex.position().z();
+  edm::LogVerbatim("DiMuonVertexMonitor") << "main vertex position:" << theMainVtx.position().x() << ","
+                                          << theMainVtx.position().y() << "," << theMainVtx.position().z();
 #endif
 
   if (theMainVtx.isValid()) {


### PR DESCRIPTION
#### PR description:

Fixes a trivial mistake in the `EDM_ML_DEBUG`-protected section of `DiMuonVertexMonitor`, slipped in https://github.com/cms-sw/cmssw/pull/42971.
Noticed in the [static analyzer checks](https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-c4b5c5/35112/llvm-analysis/runStaticChecks.log) of PR https://github.com/cms-sw/cmssw/pull/42971

#### PR validation:

Compiled  defining `EDM_ML_DEBUG` as pre-processor directive.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but it will be backported to CMSSW_13.2.X at https://github.com/cms-sw/cmssw/pull/42973