### PR TITLE
add 'beam' (`AlCaBeamMonitor`) sequence for Phase-2

### DIFF
--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -249,7 +249,7 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
                      'DQMNone'],
             }
 
-_phase2_allowed = ['trackingOnlyDQM','outerTracker', 'trackerPhase2', 'muon','hcal','hcal2','egamma','L1TMonPhase2','HLTMon']
+_phase2_allowed = ['beam','trackingOnlyDQM','outerTracker', 'trackerPhase2', 'muon','hcal','hcal2','egamma','L1TMonPhase2','HLTMon']
 autoDQM['phase2'] = ['','','']
 for i in [0,2]:
     autoDQM['phase2'][i] = '+'.join([autoDQM[m][i] for m in _phase2_allowed])


### PR DESCRIPTION
#### PR description:

I noticed that in Phase-2 relvals the `AlCaBeamMonitor` fit is not run and I think it would be interesting to start exercising it. 
It has been suggested that the length (in terms of amount of events processed) of a lumisection in phase-2 simulation (due to job splitting) might imply a large amount of fits. If this poses a problem it could be mitigated in a follow-up using ad-hoc LS-merging.
Also in real data applications https://github.com/cms-sw/cmssw/issues/42995 might play a role.
Opening as a draft for comments for now.

#### PR validation:

`runTheMatrix.py -l limited -i all --ibeos` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A