### PR TITLE
Do not forward-declare G4VTouchable

### DIFF
--- a/SimG4CMS/Tracker/interface/TrackerG4SimHitNumberingScheme.h
+++ b/SimG4CMS/Tracker/interface/TrackerG4SimHitNumberingScheme.h
@@ -4,8 +4,8 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <G4VTouchable.hh>
 
-class G4VTouchable;
 class G4VPhysicalVolume;
 class GeometricDet;
 

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <G4VTouchable.hh>
 
 #include "SimG4Core/Watcher/interface/SimProducer.h"
 #include "SimG4Core/Notification/interface/Observer.h"
@@ -22,7 +23,6 @@ class EndOfTrack;
 class G4Step;
 
 class G4StepPoint;
-class G4VTouchable;
 class G4VPhysicalVolume;
 class G4LogicalVolume;
 class G4TouchableHistory;

--- a/Validation/Geometry/interface/MaterialBudgetAction.h
+++ b/Validation/Geometry/interface/MaterialBudgetAction.h
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <CLHEP/Vector/LorentzVector.h>
+#include <G4VTouchable.hh>
 
 class BeginOfTrack;
 class BeginOfRun;
@@ -28,7 +29,6 @@ class G4Step;
 class EndOfTrack;
 class EndOfRun;
 class G4StepPoint;
-class G4VTouchable;
 
 class MaterialBudgetAction : public SimWatcher,
                              public Observer<const BeginOfRun*>,


### PR DESCRIPTION
#### PR description:

Definition of `G4VTouchable` was changed in recent Geant4 update (from class to alias), thus making it not forward-declarable.

#### PR validation:

Tested in https://github.com/cms-sw/cmsdist/pull/8741
