### PR TITLE
Remove deprecated std::iterator from CondCore/CondDB

### DIFF
--- a/CondCore/CondDB/interface/GTProxy.h
+++ b/CondCore/CondDB/interface/GTProxy.h
@@ -35,8 +35,15 @@ namespace cond {
 
     public:
       // more or less compliant with typical iterator semantics...
-      class Iterator : public std::iterator<std::input_iterator_tag, cond::GTEntry_t> {
+      class Iterator {
       public:
+        // C++17 compliant iterator definition
+        using iterator_category = std::input_iterator_tag;
+        using value_type = cond::GTEntry_t;
+        using difference_type = void;  // Not used
+        using pointer = void;          // Not used
+        using reference = void;        // Not used
+
         //
         Iterator();
         explicit Iterator(GTContainer::const_iterator current);

--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -34,8 +34,15 @@ namespace cond {
 
     public:
       // more or less compliant with typical iterator semantics...
-      class Iterator : public std::iterator<std::input_iterator_tag, cond::Iov_t> {
+      class Iterator {
       public:
+        // C++17 compliant iterator definition
+        using iterator_category = std::input_iterator_tag;
+        using value_type = cond::Iov_t;
+        using difference_type = void;  // Not used
+        using pointer = void;          // Not used
+        using reference = void;        // Not used
+
         //
         Iterator();
         Iterator(IOVContainer::const_iterator current, const IOVArray* parent);

--- a/CondCore/CondDB/interface/RunInfoProxy.h
+++ b/CondCore/CondDB/interface/RunInfoProxy.h
@@ -29,8 +29,15 @@ namespace cond {
 
     public:
       // more or less compliant with typical iterator semantics...
-      class Iterator : public std::iterator<std::input_iterator_tag, cond::RunInfo_t> {
+      class Iterator {
       public:
+        // C++17 compliant iterator definition
+        using iterator_category = std::input_iterator_tag;
+        using value_type = cond::RunInfo_t;
+        using difference_type = void;  // Not used
+        using pointer = void;          // Not used
+        using reference = void;        // Not used
+
         //
         Iterator();
         explicit Iterator(RunInfoData::const_iterator current);

--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -404,8 +404,15 @@ namespace cond {
     class Query;
 
     template <typename... Types>
-    class QueryIterator : public std::iterator<std::input_iterator_tag, std::tuple<Types...> > {
+    class QueryIterator {
     public:
+      // C++17 compliant iterator definition
+      using iterator_category = std::input_iterator_tag;
+      using value_type = std::tuple<Types...>;
+      using difference_type = void;  // Not used
+      using pointer = void;          // Not used
+      using reference = void;        // Not used
+
       QueryIterator() {}
 
       QueryIterator(const QueryIterator& rhs) : m_query(rhs.m_query), m_currentRow(rhs.m_currentRow) {}


### PR DESCRIPTION
#### PR description:
Addressing issue #43009 

This PR removes the C++17 deprecated `std::iterator` in `CondCore/CondDB` in favor of the explicit declaration of the five iterator traits, as suggested by the link posted in the original issue.

@makortel I would appreciate your feedback on whether this is the correct approach/solution to the issue.

#### PR validation:
Code compiles.
Completed successfully the tests from `scram b runtests`

#### Backport:
Not a backport, no backport needed