### PR TITLE
[13_2_X]  HCAL unpacker: adding more protection against corrupted data

### DIFF
--- a/EventFilter/HcalRawToDigi/interface/AMC13Header.h
+++ b/EventFilter/HcalRawToDigi/interface/AMC13Header.h
@@ -39,8 +39,8 @@ namespace hcal {
     inline bool AMCMore(int i) const { return ((modulesHeaders[i] >> 61) & 0x1) != 0; }
     /** Segmented data? */
     inline bool AMCSegmented(int i) const { return ((modulesHeaders[i] >> 60) & 0x1) != 0; }
-    /** Was the length as expected? */
-    inline bool AMCLengthOk(int i) const { return ((modulesHeaders[i] >> 62) & 0x1) != 0; }
+    /** Was the length as expected? (logic appears inverted in firmware) */
+    inline bool AMCLengthOk(int i) const { return ((modulesHeaders[i] >> 62) & 0x1) == 0; }
     /** Was the CRC correct as received by the AMC13? */
     inline bool AMCCRCOk(int i) const { return ((modulesHeaders[i] >> 56) & 0x1) != 0; }
     /** Is there data for this AMC? */

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -99,7 +99,8 @@ public:
   inline uint32_t slot() const { return uint32_t(m_raw64[1] >> 8) & 0xF; }
   /** \brief Get the presamples */
   inline uint32_t presamples() const { return uint32_t(m_raw64[1] >> 12) & 0xF; }
-
+  /** \brief Get the length from the uHTR header */
+  inline uint32_t length64_uhtr() const { return uint32_t(m_raw64[0]) & 0xFFFFF; }
   /** \brief Was this channel passed as part of Mark&Pass ZS?*/
   bool wasMarkAndPassZS(int fiber, int fiberchan) const;
   /** \brief Was this channel passed as part of Mark&Pass ZS?*/

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -8,7 +8,7 @@
 #include "DataFormats/HcalDigi/interface/HcalQIESample.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalTTPUnpacker.h"
-
+#include <iomanip>
 //#define DebugLog
 
 namespace HcalUnpacker_impl {
@@ -708,6 +708,14 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw,
     if (amc13->AMCSegmented(iamc)) {
       if (!silent)
         edm::LogWarning("Invalid Data") << "Unpacker cannot handle segmented data observed on iamc " << iamc
+                                        << " of AMC13 with source id " << amc13->sourceId();
+      report.countSpigotFormatError();
+      continue;
+    }
+
+    if (!amc13->AMCLengthOk(iamc)) {
+      if (!silent)
+        edm::LogWarning("Invalid Data") << "Length mismatch between uHTR and AMC13 observed on iamc " << iamc
                                         << " of AMC13 with source id " << amc13->sourceId();
       report.countSpigotFormatError();
       continue;


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/43011

#### PR validation:

(1) Allows for the job to run without segfault in the setup conditions described in #42960

(2) runTheMatrix.py -l limited --ibeos --useInput all

