### PR TITLE
Adding d0 cut to TrackletCalculatorDisplaced.cc

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -586,7 +586,6 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
       edm::LogVerbatim("Tracklet") << "Failed tracklet approx d0 cut " << d0approx;
     success = false;
   }
-
   if (std::abs(d0) > settings_.maxd0()) {
     if (settings_.debugTracklet())
       edm::LogVerbatim("Tracklet") << "Failed tracklet exact d0 cut " << d0;
@@ -1005,7 +1004,12 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
   }
   if (std::abs(d0approx) > settings_.maxd0()) {
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      edm::LogVerbatim("Tracklet") << "Failed tracklet approx d0 cut " << d0approx;
+    success = false;
+  }
+  if (std::abs(d0) > settings_.maxd0()) {
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "Failed tracklet exact d0 cut " << d0;
     success = false;
   }
 
@@ -1401,7 +1405,12 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
   }
   if (std::abs(d0approx) > settings_.maxd0()) {
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      edm::LogVerbatim("Tracklet") << "Failed tracklet approx d0 cut " << d0approx;
+    success = false;
+  }
+  if (std::abs(d0) > settings_.maxd0()) {
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "Failed tracklet exact d0 cut " << d0;
     success = false;
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -583,7 +583,13 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
   }
   if (std::abs(d0approx) > settings_.maxd0()) {
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      edm::LogVerbatim("Tracklet") << "Failed tracklet approx d0 cut " << d0approx;
+    success = false;
+  }
+
+  if (std::abs(d0) > settings_.maxd0()) {
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "Failed tracklet exact d0 cut " << d0;
     success = false;
   }
 


### PR DESCRIPTION
#### PR description:

This PR is opened to address Issue #41357. A cut on d0 exact is added to TrackletCalculatorDisplaced.cc. This fixes the problem that was reported in #41357.

#### PR validation:

I tested this PR with [instruction](https://github.com/cms-sw/cmssw/issues/41357#issuecomment-1731175261) specified in #41357 by @srimanob.
