### PR TITLE
[13_1_X] Include ECAL Timing CC labelled tags in Run3 data and MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,93 +2,93 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  : '131X_mcRun1_design_v2',
+    'run1_design'                     : '131X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      : '131X_mcRun1_realistic_v2',
+    'run1_mc'                         : '131X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   : '131X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'                      : '131X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 : '131X_mcRun2_startup_v2',
+    'run2_mc_50ns'                    : '131X_mcRun2_startup_v2',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             : '131X_mcRun2_asymptotic_l1stage1_v2',
+    'run2_mc_l1stage1'                : '131X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  : '131X_mcRun2_design_v2',
+    'run2_design'                     : '131X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              : '131X_mcRun2_asymptotic_preVFP_v2',
+    'run2_mc_pre_vfp'                 : '131X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      : '131X_mcRun2_asymptotic_v2',
+    'run2_mc'                         : '131X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              : '131X_mcRun2cosmics_asymptotic_deco_v2',
+    'run2_mc_cosmics'                 : '131X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   : '131X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'                      : '131X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   : '131X_mcRun2_pA_v2',
+    'run2_mc_pa'                      : '131X_mcRun2_pA_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '124X_dataRun2_v2',
+    'run2_data'                       : '124X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '124X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'                : '124X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'         : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_hlt'                     : '130X_dataRun3_HLT_frozen_v4',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_express'            : '130X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with snapshot at 2023-07-25 12:00:00 (UTC)
-    'run3_data_prompt'             : '130X_dataRun3_Prompt_frozen_v4',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-05-09 15:38:20 (UTC)
-    'run3_data'                    : '130X_dataRun3_v2',
+    'run2_hlt_relval'                 : '123X_dataRun2_HLT_relval_v3',
+    # GlobalTag for Run3 HLT: identical to the online GT (130X_dataRun3_HLT_v2) but with snapshot at 2023-10-10 05:19:41 (UTC)
+    'run3_hlt'                        : '131X_dataRun3_HLT_frozen_v2',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 130X_dataRun3_Express_v3 but with Ecal timing CC label tags and snapshot at 2023-10-10 04:40:53 (UTC)
+    'run3_data_express'               : '131X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 130X_dataRun3_Prompt_v4 but with Ecal timing CC label tags and snapshot at 2023-10-10 04:40:53 (UTC)
+    'run3_data_prompt'                : '131X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-13 12:00:00 (UTC)
+    'run3_data'                       : '131X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           : '131X_mc2017_design_v2',
+    'phase1_2017_design'              : '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        : '131X_mc2017_realistic_v2',
+    'phase1_2017_realistic'           : '131X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          : '131X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'             : '131X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     : '131X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak'        : '131X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           : '131X_upgrade2018_design_v2',
+    'phase1_2018_design'              : '131X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        : '131X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'           : '131X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     : '131X_upgrade2018_realistic_RD_v2',
+    'phase1_2018_realistic_rd'        : '131X_upgrade2018_realistic_RD_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     : '131X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi'        : '131X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' : '131X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail'    : '131X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          : '131X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'             : '131X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     : '131X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak'        : '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '131X_mcRun3_2022_design_v4',
+    'phase1_2022_design'              : '131X_mcRun3_2022_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '131X_mcRun3_2022_realistic_v7',
+    'phase1_2022_realistic'           : '131X_mcRun3_2022_realistic_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' : '131X_mcRun3_2022_realistic_postEE_v7',
+    'phase1_2022_realistic_postEE'    : '131X_mcRun3_2022_realistic_postEE_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '131X_mcRun3_2022cosmics_realistic_deco_v7',
+    'phase1_2022_cosmics'             : '131X_mcRun3_2022cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '131X_mcRun3_2022cosmics_design_deco_v4',
+    'phase1_2022_cosmics_design'      : '131X_mcRun3_2022cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '131X_mcRun3_2022_realistic_HI_v8',
+    'phase1_2022_realistic_hi'        : '131X_mcRun3_2022_realistic_HI_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           : '131X_mcRun3_2023_design_v8',
+    'phase1_2023_design'              : '131X_mcRun3_2023_design_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '131X_mcRun3_2023_realistic_v12',
+    'phase1_2023_realistic'           : '131X_mcRun3_2023_realistic_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '131X_mcRun3_2023_realistic_postBPix_v3',
+    'phase1_2023_realistic_postBPix'  : '131X_mcRun3_2023_realistic_postBPix_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          : '131X_mcRun3_2023cosmics_realistic_deco_v11',
+    'phase1_2023_cosmics'             : '131X_mcRun3_2023cosmics_realistic_deco_v12',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   : '131X_mcRun3_2023cosmics_design_deco_v8',
+    'phase1_2023_cosmics_design'      : '131X_mcRun3_2023cosmics_design_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     : '131X_mcRun3_2023_realistic_HI_v12',
+    'phase1_2023_realistic_hi'        : '131X_mcRun3_2023_realistic_HI_v15',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '131X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'           : '131X_mcRun3_2024_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '131X_mcRun4_realistic_v7'
+    'phase2_realistic'                : '131X_mcRun4_realistic_v9'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

See master PR for details https://github.com/cms-sw/cmssw/pull/42958. The PR is a companion to https://github.com/cms-sw/cmssw/pull/42947. 

An additional change with respect to the master PR
- 2023 HI MC GT updated to bring it upto date with 2023 postBPIx MC conditions (except the HI specific) ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v14/131X_mcRun3_2023_realistic_HI_v13)) See CMS Talk post [1]. For the master, a separate PR will be opened to update the above change

[1] https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455

**GT Differences**
- **Run3 data HLT** : No change, just updated snapshot time
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_HLT_frozen_v4/131X_dataRun3_HLT_frozen_v2
  - Diff from last 130X HLT GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_dataRun3_HLT_frozen_v2/130X_dataRun3_HLT_v2

- **Run3 data Express** : Includes Ecal Timing CC labelled tags, with new snapshot time 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_dataRun3_Express_frozen_v1/130X_dataRun3_Express_frozen_v4
  - Diff from last 130X Express GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_dataRun3_Express_frozen_v1/130X_dataRun3_Express_v3

- **Run3 data Prompt** : Includes Ecal Timing CC labelled tags, with new snapshot time 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_dataRun3_Prompt_frozen_v1/130X_dataRun3_Prompt_frozen_v4
  - Diff from last 130X Prompt GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_dataRun3_Prompt_frozen_v1/130X_dataRun3_Prompt_v4 

- **Run3 data Offline** : Includes Ecal Timing CC labelled tags and updates the ES Channel status tag to ESChannelStatus_V05_offline to fix the wrong IOV upload 375472 instead of 374572
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/130X_dataRun3_v2/131X_dataRun3_v2

- **Phase1 2022 design** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_design_v5/131X_mcRun3_2022_design_v4

- **Phase1 2022 realistic** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_v8/131X_mcRun3_2022_realistic_v7

- **Phase1 2022 realistic postEE** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_postEE_v8/131X_mcRun3_2022_realistic_postEE_v7

- **Phase1 2022 cosmics** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_realistic_deco_v8/131X_mcRun3_2022cosmics_realistic_deco_v7

- **Phase1 2022 cosmics design** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022cosmics_design_deco_v5/131X_mcRun3_2022cosmics_design_deco_v4

- **Phase1 2022 realistic hi** : Includes Ecal Timing CC labelled tags and updates SiPixelDynamic inefficiency tag
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2022_realistic_HI_v10/131X_mcRun3_2022_realistic_HI_v8

- **Phase1 2023 design** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_design_v9/131X_mcRun3_2023_design_v8

- **Phase1 2023 realistic** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_v13/131X_mcRun3_2023_realistic_v12

- **Phase1 2023 realistic postBPix** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_postBPix_v4/131X_mcRun3_2023_realistic_postBPix_v3
	
- **Phase1 2023 cosmics reaslistic** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_realistic_deco_v12/131X_mcRun3_2023cosmics_realistic_deco_v11

- **Phase1 2023 cosmics design** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023cosmics_design_deco_v9/131X_mcRun3_2023cosmics_design_deco_v8

- **Phase1 2023 realistic hi** : Includes Ecal Timing CC labelled tags and updates the HI MC GT 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2023_realistic_HI_v15/131X_mcRun3_2023_realistic_HI_v12

- **Phase1 2024 realistic** : Includes Ecal Timing CC labelled tags and updates SiPixelDynamic inefficiency tag
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun3_2024_realistic_v7/131X_mcRun3_2024_realistic_v4

- **Phase2** : Includes Ecal Timing CC labelled tags
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/131X_mcRun4_realistic_v9/131X_mcRun4_realistic_v7


#### PR validation:

Tested successfully with https://github.com/cms-sw/cmssw/pull/42947 via
- `runTheMatrix.py -l 138.2,138.4,138.5,139.001,141.002,141.003,159.1,160.1,312.0,12034.0,12434.0,12834.0,11601.0,23234.0 -j10 --ibeos` 
- `runTheMatrix.py -l 12430.0,12440.0 --what upgrade -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/42958