### PR TITLE
SiPixel Payload Inspector: introduce utility to display probability-weighted `SiPixelFEDChannelContainer` contents

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc
@@ -28,6 +28,7 @@
 
 // the data format of the condition to be inspected
 #include "CondFormats/SiPixelObjects/interface/SiPixelFEDChannelContainer.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQualityProbabilities.h"  // to display aggregate probability
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -449,6 +450,218 @@ namespace {
   using SiPixelFPixFEDChannelContainerMap = SiPixelFEDChannelContainerMapSimple<SiPixelPI::t_forward>;
   using SiPixelFullFEDChannelContainerMap = SiPixelFEDChannelContainerMapSimple<SiPixelPI::t_all>;
 
+  /*
+    Produces an aggregate map of the masked components for all scenarios,
+    weighted on the probability per PU unit from SiPixelQualityProbabilities
+    assuming a flat PU profile in the range encoded in  SiPixelQualityProbabilities
+    The SiPixelQualityProbabilities tag comes from user input
+  */
+  template <SiPixelPI::DetType myType>
+  class SiPixelFEDChannelContainerMapWeigthed : public PlotImage<SiPixelFEDChannelContainer, SINGLE_IOV> {
+  public:
+    SiPixelFEDChannelContainerMapWeigthed()
+        : PlotImage<SiPixelFEDChannelContainer, SINGLE_IOV>(
+              "SiPixelFEDChannelContainer Pixel Track Map of one (or more scenarios)") {
+      // for inputs
+      PlotBase::addInputParam("SiPixelQualityProbabilitiesTag");
+
+      // hardcoded connection to the SiPixelQualityProbability tag, though luck
+      m_condSiPixelProb = "frontier://FrontierProd/CMS_CONDITIONS";
+      m_connectionPool.setParameters(m_connectionPset);
+      m_connectionPool.configure();
+    }
+
+    bool fill() override {
+      auto paramValues = PlotBase::inputParamValues();
+      auto ip = paramValues.find("SiPixelQualityProbabilitiesTag");
+      if (ip != paramValues.end()) {
+        m_SiPixelProbTagName = ip->second;
+      } else {
+        edm::LogWarning(k_ClassName) << "\n WARNING!!!! \n The needed parameter SiPixelQualityProbabilitiesTag was not "
+                                        "inputed from the user \n Display will be aborted \n\n";
+        return false;
+      }
+
+      Phase1PixelROCMaps theROCMap("", "Masking Probability [%]");
+
+      auto tag = PlotBase::getTag<0>();
+      auto tagname = tag.name;
+      auto iov = tag.iovs.front();
+
+      // open db session for the cabling map
+      edm::LogPrint(k_ClassName) << "[SiPixelFEDChannelContainerTest::" << __func__ << "] "
+                                 << "Query the condition database " << m_condSiPixelProb;
+
+      cond::persistency::Session condDbSession = m_connectionPool.createSession(m_condSiPixelProb);
+      condDbSession.transaction().start(true);
+
+      // query the database
+      edm::LogPrint(k_ClassName) << "[SiPixelFEDChannelContainerTest::" << __func__ << "] "
+                                 << "Reading IOVs from tag " << m_SiPixelProbTagName;
+
+      const auto MIN_VAL = cond::timeTypeSpecs[cond::runnumber].beginValue;
+      const auto MAX_VAL = cond::timeTypeSpecs[cond::runnumber].endValue;
+
+      // get the list of payloads for the Cabling Map
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> m_pixelProb_iovs;
+      condDbSession.readIov(m_SiPixelProbTagName).selectRange(MIN_VAL, MAX_VAL, m_pixelProb_iovs);
+
+      // in MC there should be only 1 IOV, oh well...
+      edm::LogPrint(k_ClassName) << " using the SiPixelQualityProbabilities with hash: "
+                                 << std::get<1>(m_pixelProb_iovs.front()) << std::endl;
+
+      auto probabilitiesPayload =
+          condDbSession.fetchPayload<SiPixelQualityProbabilities>(std::get<1>(m_pixelProb_iovs.front()));
+
+      const auto& PUbins = probabilitiesPayload->getPileUpBins();
+
+      SiPixelQualityProbabilities::probabilityMap m_probabilities = probabilitiesPayload->getProbability_Map();
+
+      // find the PU-averaged (assuming flat PU in the range) probabilities for each scenario
+      std::map<std::string, float> puAvgedProbabilities;
+      for (const auto& [PUbin, ProbMap] : m_probabilities) {
+        float totProbInPUbin = 0.f;
+        for (const auto& [scenName, prob] : ProbMap) {
+          totProbInPUbin += prob;
+          if (puAvgedProbabilities.find(scenName) == puAvgedProbabilities.end()) {
+            puAvgedProbabilities[scenName] += prob;
+          } else {
+            puAvgedProbabilities.insert({scenName, prob});
+          }
+        }
+        LogDebug(k_ClassName) << "PU bin: " << PUbin << " tot probability " << totProbInPUbin << std::endl;
+      }
+
+      std::shared_ptr<SiPixelFEDChannelContainer> payload = fetchPayload(std::get<1>(iov));
+      const auto& scenarioMap = payload->getScenarioMap();
+
+      float totProb{0.f};
+      for (const auto& [scenName, prob] : puAvgedProbabilities) {
+        // only sum up the scenarios that are in the SiPixelFEDChannelContainer payload!
+        if (scenarioMap.find(scenName) != scenarioMap.end()) {
+          LogDebug(k_ClassName) << scenName << " : " << prob << std::endl;
+          totProb += prob;
+        }
+      }
+
+      LogDebug(k_ClassName) << "Total probability to normalize to: " << totProb << std::endl;
+
+      //normalize the probabilities per scenario to the toal probability
+      for (auto& pair : puAvgedProbabilities) {
+        pair.second /= totProb;
+      }
+
+      for (const auto& scenario : scenarioMap) {
+        std::string scenName = scenario.first;
+        LogDebug(k_ClassName) << "\t Found Scenario: " << scenName << " ==> dumping it";
+
+        // calculate the weight
+        float w_frac = 0.f;
+        if (puAvgedProbabilities.find(scenName) != puAvgedProbabilities.end()) {
+          w_frac = puAvgedProbabilities[scenName];
+        }
+
+        // if scenario is not in the probability payload, continue
+        if (w_frac == 0.f)
+          continue;
+
+        LogDebug(k_ClassName) << "scen: " << scenName << " weight: " << w_frac << " log(weight):" << log10(w_frac)
+                              << std::endl;
+
+        const auto& theDetSetBadPixelFedChannels = payload->getDetSetBadPixelFedChannels(scenName);
+        for (const auto& disabledChannels : *theDetSetBadPixelFedChannels) {
+          const auto t_detid = disabledChannels.detId();
+          int subid = DetId(t_detid).subdetId();
+          LogDebug(k_ClassName) << fmt::sprintf("DetId : %i \n", t_detid) << std::endl;
+
+          std::bitset<16> badRocsFromFEDChannels;
+
+          for (const auto& ch : disabledChannels) {
+            std::string toOut_ = fmt::sprintf("fed : %i | link : %2i | roc_first : %2i | roc_last: %2i \n",
+                                              ch.fed,
+                                              ch.link,
+                                              ch.roc_first,
+                                              ch.roc_last);
+
+            LogDebug(k_ClassName) << toOut_ << std::endl;
+            for (unsigned int i_roc = ch.roc_first; i_roc <= ch.roc_last; ++i_roc) {
+              badRocsFromFEDChannels.set(i_roc);
+            }
+          }
+
+          LogDebug(k_ClassName) << badRocsFromFEDChannels << std::endl;
+
+          const auto& myDetId = DetId(t_detid);
+
+          if (subid == PixelSubdetector::PixelBarrel) {
+            theROCMap.fillSelectedRocs(myDetId, badRocsFromFEDChannels, w_frac * 100);
+          }  // if it's barrel
+          else if (subid == PixelSubdetector::PixelEndcap) {
+            theROCMap.fillSelectedRocs(myDetId, badRocsFromFEDChannels, w_frac * 100);
+          }  // if it's endcap
+          else {
+            throw cms::Exception("LogicError") << "Unknown Pixel SubDet ID " << std::endl;
+          }  // else nonsense
+        }    // loop on the channels
+      }      // loop on the scenarios
+
+      gStyle->SetOptStat(0);
+      //=========================
+      TCanvas canvas("Summary", "Summary", 1200, k_height[myType]);
+      canvas.cd();
+
+      auto unpacked = SiPixelPI::unpack(std::get<0>(iov));
+
+      std::string IOVstring = (unpacked.first == 0)
+                                  ? std::to_string(unpacked.second)
+                                  : (std::to_string(unpacked.first) + "," + std::to_string(unpacked.second));
+
+      const auto headerText =
+          fmt::sprintf("#bf{#scale[0.6]{#color[2]{%s}, #color[4]{%s}}}", tagname, m_SiPixelProbTagName);
+
+      switch (myType) {
+        case SiPixelPI::t_barrel:
+          theROCMap.drawBarrelMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_forward:
+          theROCMap.drawForwardMaps(canvas, headerText);
+          break;
+        case SiPixelPI::t_all:
+          theROCMap.drawMaps(canvas, headerText);
+          break;
+        default:
+          throw cms::Exception("LogicError") << "\nERROR: unrecognized Pixel Detector part " << std::endl;
+      }
+
+      // add list of scenarios watermark
+      canvas.cd();
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      //ltx.SetTextColor(kMagenta);
+      ltx.SetTextSize(0.023);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin() - 0.09, gPad->GetBottomMargin() - 0.09, "");
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+      return true;
+    }
+
+  private:
+    // graphics
+    static constexpr std::array<int, 3> k_height = {{1200, 600, 1600}};
+    static constexpr const char* k_ClassName = "SiPixelFEDChannelContainerMapWeigthed";
+
+    // parameters for auxilliary DB connection
+    edm::ParameterSet m_connectionPset;
+    cond::persistency::ConnectionPool m_connectionPool;
+    std::string m_SiPixelProbTagName;
+    std::string m_condSiPixelProb;
+  };
+
+  using SiPixelBPixFEDChannelContainerWeightedMap = SiPixelFEDChannelContainerMapWeigthed<SiPixelPI::t_barrel>;
+  using SiPixelFPixFEDChannelContainerWeightedMap = SiPixelFEDChannelContainerMapWeigthed<SiPixelPI::t_forward>;
+  using SiPixelFullFEDChannelContainerWeightedMap = SiPixelFEDChannelContainerMapWeigthed<SiPixelPI::t_all>;
+
   /************************************************
   1d histogram of number of SiPixelFEDChannelContainer scenarios
   *************************************************/
@@ -547,5 +760,8 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelFEDChannelContainer) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelBPixFEDChannelContainerMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFPixFEDChannelContainerMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFullFEDChannelContainerMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelBPixFEDChannelContainerWeightedMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFPixFEDChannelContainerWeightedMap);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelFullFEDChannelContainerWeightedMap);
   PAYLOAD_INSPECTOR_CLASS(SiPixelFEDChannelContainerScenarios);
 }

--- a/CondCore/SiPixelPlugins/test/testSiPixelFEDChannelContainer.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelFEDChannelContainer.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+if [ -d $W_DIR/plots_FEDChannelContainer ]; then
+    rm -fr $W_DIR/plots_FEDChannelContainer
+fi
+
+mkdir $W_DIR/plots_FEDChannelContainer
+
+getPayloadData.py \
+    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+    --plot plot_SiPixelBPixFEDChannelContainerMap \
+    --tag SiPixelStatusScenarios_StuckTBM_2023_v1_mc \
+    --input_params '{"Scenarios": "370097_302"}' \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_FEDChannelContainer/SiPixelBPixFEDChannelContainerMap.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+    --plot plot_SiPixelBPixFEDChannelContainerWeightedMap \
+    --tag SiPixelStatusScenarios_StuckTBMandOther_2023_v2_mc \
+    --input_params '{"SiPixelQualityProbabilitiesTag": "SiPixelQualityProbabilities_2023_v2_mc"}' \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_FEDChannelContainer/SiPixelFEDChannelContainerMapWeigthed.png
+
+getPayloadData.py \
+    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
+    --plot plot_SiPixelBPixFEDChannelContainerWeightedMap \
+    --tag SiPixelStatusScenarios_StuckTBM_2023_v1_mc \
+    --input_params '{"SiPixelQualityProbabilitiesTag": "SiPixelQualityProbabilities_2023_for_eGamma_v1_mc"}' \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_FEDChannelContainer/SiPixelFEDChannelContainerMapWeigthed_v2.png

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -9,6 +9,7 @@
 #include "CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelQualityProbabilities_PayloadInspector.cc"
 #include "CondCore/SiPixelPlugins/plugins/SiPixelDynamicInefficiency_PayloadInspector.cc"
+#include "CondCore/SiPixelPlugins/plugins/SiPixelFEDChannelContainer_PayloadInspector.cc"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -240,6 +241,26 @@ int main(int argc, char** argv) {
   SiPixelDynamicInefficiencyPUParamComparisonTwoTags histo30;
   histo30.process(connectionString, PI::mk_input(tag, start, end, tag2, start2, start2));
   edm::LogPrint("testSiPixelPayloadInspector") << histo30.data() << std::endl;
+
+  // SiPixelFEDChannelContainer
+  tag = "SiPixelStatusScenarios_StuckTBMandOther_2023_v2_mc";
+  tag2 = "SiPixelQualityProbabilities_2023_v2_mc";
+  start = static_cast<unsigned long long>(1);
+  end = static_cast<unsigned long long>(1);
+
+  edm::LogPrint("testSiPixelPayloadInspector") << "## Exercising SiPixelFEDChannelContainer plots " << std::endl;
+
+  inputs["SiPixelQualityProbabilitiesTag"] = tag2;  // Quality Probabilities tag to use
+  SiPixelBPixFEDChannelContainerWeightedMap histo31;
+  histo31.setInputParamValues(inputs);
+  histo31.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo31.data() << std::endl;
+
+  inputs["Scenarios"] = "370097_302";
+  SiPixelBPixFEDChannelContainerMap histo32;
+  histo32.setInputParamValues(inputs);
+  histo32.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testSiPixelPayloadInspector") << histo32.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to add the class `SiPixelFEDChannelContainerMapWeigthed` to `SiPixelFEDChannelContainer` Payload Inspector plugin (this is done in commit  b03913c32ada263af5d113c8d2dd7c4babb2b6b1).
This class displays an aggregate map of the masked components for all scenarios included in the examined payload, weighted on the probability per PU unit from a `SiPixelQualityProbabilities` payload (assuming a flat PU profile in the range encoded in  `SiPixelQualityProbabilities`).
The `SiPixelQualityProbabilities` tag comes from user input and is retrieved via a local `cond::persistency::Session` opened in the production database.
This is useful, because without combining the information from both `SiPixelStatusScenariosRcd` and `SiPixelStatusScenarioProbabilityRcd` it is not possible *a priori* to determine the fraction of events in which a given ROC will be masked when the [bad FED channel simulation](https://indico.cern.ch/event/823473/contributions/3444523/attachments/1851561/3039790/trackerDPG_27052019.pdf) is used (as it will be in the 2022 and 2023 physics MC).
Additionally I add a standalone testing script (in commit db7d86ed502b1a2189ee66819b3381eabd646944) and add this class to the pre-existing unit test script of this package (in commit f06968ca5a81f4f6c43075a8fc0e17a3dd1751a9).
A possible extension to supply provision for a user-input list of PU weights (to make it even more adherent to actual full simulation process) is envisaged, but let for a follow-up PR.

#### PR validation:

This PR passes unit tests of the involved package: `scram b runtests`
Additionally I tested the code with this command:

```bash
getPayloadData.py \
    --plugin pluginSiPixelFEDChannelContainer_PayloadInspector \
    --plot plot_SiPixelBPixFEDChannelContainerWeightedMap \
    --tag SiPixelStatusScenarios_StuckTBMandOther_2023_v2_mc \
    --input_params '{"SiPixelQualityProbabilitiesTag": "SiPixelQualityProbabilities_2023_v2_mc"}' \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test ;
```

and obtained the following plot:

![image](https://github.com/cms-sw/cmssw/assets/5082376/6cd536af-29c1-43f0-834f-61a0e8644e72)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @tsusa 