### PR TITLE
Phase 2 MET cosLUT fixes to match firmware

### DIFF
--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -41,9 +41,9 @@ namespace l1t::demo::codecs {
       math::XYZTLorentzVector v(0, 0, 0, 0);
       l1t::EtSum s(v,
                    l1t::EtSum::EtSumType::kMissingEt,
-                   l1tmetemu::METWord_t(x(1 + l1tmetemu::kMETSize, 1)),
+                   l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
                    0,
-                   l1tmetemu::METWordphi_t(x(1 + l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 17)).to_int(),
+                   l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
                    0);
       etSums.push_back(s);
     }

--- a/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_etsums.cc
@@ -39,12 +39,13 @@ namespace l1t::demo::codecs {
         break;
 
       math::XYZTLorentzVector v(0, 0, 0, 0);
-      l1t::EtSum s(v,
-                   l1t::EtSum::EtSumType::kMissingEt,
-                   l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
-                   0,
-                   l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
-                   0);
+      l1t::EtSum s(
+          v,
+          l1t::EtSum::EtSumType::kMissingEt,
+          l1tmetemu::METWord_t(x(l1tmetemu::kMETSize, 1)),
+          0,
+          l1tmetemu::METWordphi_t(x(l1tmetemu::kMETSize + l1tmetemu::kMETPhiSize, 1 + l1tmetemu::kMETSize)).to_int(),
+          0);
       etSums.push_back(s);
     }
 

--- a/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkEtMissEmuAlgo.cc
@@ -12,7 +12,6 @@ namespace l1tmetemu {
       phi += stepPhi;
       //std::cout << LUT_idx << "," << (cos_lut_fixed_t)(cos(phi)) << std::endl;
     }
-    cosLUT[1023] = (cos_lut_fixed_t)(0);  //Match F/W for Integration Tests
     return cosLUT;
   }
 


### PR DESCRIPTION
#### PR description:

This PR forward-ports two extra changes to the TrackMET, one of them removing a bug previously retained to match firmware behavior (explicitly wrong setting of a LUT value in the cos function), and the other removing an off-by-one bug in the encoding of the MET word for the APx and EMP test vectors.

This is a folow-up to:
https://github.com/cms-sw/cmssw/pull/42553

This is a partial forward-port of the following PR (which back-ported the above PR to the cms-l1t-offline phase2 integration branch, then added the 3 commits being forward-ported here):
https://github.com/cms-l1t-offline/cmssw/pull/1160

The new changes correspond to the following bug fix in GTT's LibHLS repo:
https://gitlab.cern.ch/GTT/LibHLS/-/merge_requests/31
(GTT members: see the Issue related to the above merge request for more details on why this change was necessary and deferred)

This PR slightly changes the Px and Py lookups for tracks going into the TrackMET calculation, for about 0.1% of tracks, thus the differences will be small (and now physically correct)

#### PR validation:
This PR passes
scram b
scram b code-checks
scram b code-format

and it is used to successfully generate GTT test vectors (the only place the codecs_etsums play a part).