### PR TITLE
add explicit values to `l1t::GlobalObject` enum

### DIFF
--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -1,62 +1,65 @@
 #ifndef DataFormats_L1TGlobal_GlobalObject_h
 #define DataFormats_L1TGlobal_GlobalObject_h
 
-// system include files
 #include <string>
 
 namespace l1t {
 
-  // user include files
-  //   base class
+  /* Enum of L1T GlobalObjects
 
-  // forward declarations
-
-  /// L1 GT objects
-  ///    ObjNull catch all errors
+     IMPORTANT
+       The values of the l1t::GlobalObject enum used in the data format GlobalObjectMapRecord,
+       which is produced by the L1TGlobalProducer plugin (emulator of the Stage-2 Level-1 Global Trigger).
+       One instance of this product is created online by the HLT, and is written to disk as part of the RAW data tier.
+       In order not to change the meaning of existing data when adding entries to the enum below,
+       it is necessary to add such new entries with an explicit integer value which has not been used before in the enum.
+       For further information on the subject, please see
+        https://github.com/cms-sw/cmssw/pull/42634#discussion_r1302636113
+        https://github.com/cms-sw/cmssw/issues/42719
+  */
   enum GlobalObject {
-    gtMu,
-    gtMuShower,
-    gtEG,
-    gtJet,
-    gtTau,
-    gtETM,
-    gtETT,
-    gtHTT,
-    gtHTM,
-    gtETMHF,
-    gtTowerCount,
-    gtMinBiasHFP0,
-    gtMinBiasHFM0,
-    gtMinBiasHFP1,
-    gtMinBiasHFM1,
-    gtETTem,
-    gtAsymmetryEt,
-    gtAsymmetryHt,
-    gtAsymmetryEtHF,
-    gtAsymmetryHtHF,
-    gtCentrality0,
-    gtCentrality1,
-    gtCentrality2,
-    gtCentrality3,
-    gtCentrality4,
-    gtCentrality5,
-    gtCentrality6,
-    gtCentrality7,
-    gtExternal,
-    gtZDCP,
-    gtZDCM,
-    ObjNull
+    gtMu = 0,
+    gtMuShower = 1,
+    gtEG = 2,
+    gtJet = 3,
+    gtTau = 4,
+    gtETM = 5,
+    gtETT = 6,
+    gtHTT = 7,
+    gtHTM = 8,
+    gtETMHF = 9,
+    gtTowerCount = 10,
+    gtMinBiasHFP0 = 11,
+    gtMinBiasHFM0 = 12,
+    gtMinBiasHFP1 = 13,
+    gtMinBiasHFM1 = 14,
+    gtETTem = 15,
+    gtAsymmetryEt = 16,
+    gtAsymmetryHt = 17,
+    gtAsymmetryEtHF = 18,
+    gtAsymmetryHtHF = 19,
+    gtCentrality0 = 20,
+    gtCentrality1 = 21,
+    gtCentrality2 = 22,
+    gtCentrality3 = 23,
+    gtCentrality4 = 24,
+    gtCentrality5 = 25,
+    gtCentrality6 = 26,
+    gtCentrality7 = 27,
+    gtExternal = 28,
+    gtZDCP = 29,
+    gtZDCM = 30,
+    ObjNull = 31
   };
 
-  /// the string to enum and enum to string conversions for GlobalObject
+  // utility functions to convert GlobalObject enum to std::string and viceversa
+  l1t::GlobalObject l1TGtObjectStringToEnum(const std::string&);
+  std::string l1TGtObjectEnumToString(const GlobalObject&);
 
   struct L1TGtObjectStringToEnum {
     const char* label;
     GlobalObject value;
   };
-
-  l1t::GlobalObject l1TGtObjectStringToEnum(const std::string&);
-  std::string l1TGtObjectEnumToString(const GlobalObject&);
 
 }  // namespace l1t
 

--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -2,17 +2,27 @@
 #define DataFormats_L1TGlobal_GlobalObject_h
 
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace l1t {
 
   /* Enum of L1T GlobalObjects
 
      IMPORTANT
-       The values of the l1t::GlobalObject enum used in the data format GlobalObjectMapRecord,
-       which is produced by the L1TGlobalProducer plugin (emulator of the Stage-2 Level-1 Global Trigger).
-       One instance of this product is created online by the HLT, and is written to disk as part of the RAW data tier.
-       In order not to change the meaning of existing data when adding entries to the enum below,
+       The elements of the enum l1t::GlobalObject are used in the data format GlobalObjectMapRecord.
+       One instance of GlobalObjectMapRecord is produced online by the HLT,
+       and it is written to disk as part of the RAW data tier.
+       Said instance of GlobalObjectMapRecord is produced at HLT by the plugin L1TGlobalProducer,
+       which implements the emulator of the Stage-2 Level-1 Global Trigger.
+
+       In order not to change the meaning of existing data when adding entries to the enum l1t::GlobalObject,
        it is necessary to add such new entries with an explicit integer value which has not been used before in the enum.
+
+       When adding new elements to the enum l1t::GlobalObject, make sure to also update accordingly
+       (a) the vector l1t::kGlobalObjectEnumStringPairs in this file, and
+       (b) the unit test implemented in test/test_catch2_l1tGlobalObject.cc in this package.
+
        For further information on the subject, please see
         https://github.com/cms-sw/cmssw/pull/42634#discussion_r1302636113
         https://github.com/cms-sw/cmssw/issues/42719
@@ -49,17 +59,47 @@ namespace l1t {
     gtExternal = 28,
     gtZDCP = 29,
     gtZDCM = 30,
-    ObjNull = 31
+    ObjNull = 31,
+  };
+
+  const std::vector<std::pair<GlobalObject, std::string>> kGlobalObjectEnumStringPairs = {
+      {gtMu, "Mu"},                    //  0
+      {gtMuShower, "MuShower"},        //  1
+      {gtEG, "EG"},                    //  2
+      {gtJet, "Jet"},                  //  3
+      {gtTau, "Tau"},                  //  4
+      {gtETM, "ETM"},                  //  5
+      {gtETT, "ETT"},                  //  6
+      {gtHTT, "HTT"},                  //  7
+      {gtHTM, "HTM"},                  //  8
+      {gtETMHF, "ETMHF"},              //  9
+      {gtTowerCount, "TowerCount"},    // 10
+      {gtMinBiasHFP0, "MinBiasHFP0"},  // 11
+      {gtMinBiasHFM0, "MinBiasHFM0"},  // 12
+      {gtMinBiasHFP1, "MinBiasHFP1"},  // 13
+      {gtMinBiasHFM1, "MinBiasHFM1"},  // 14
+      {gtETTem, "ETTem"},              // 15
+      {gtAsymmetryEt, "AsymEt"},       // 16
+      {gtAsymmetryHt, "AsymHt"},       // 17
+      {gtAsymmetryEtHF, "AsymEtHF"},   // 18
+      {gtAsymmetryHtHF, "AsymHtHF"},   // 19
+      {gtCentrality0, "CENT0"},        // 20
+      {gtCentrality1, "CENT1"},        // 21
+      {gtCentrality2, "CENT2"},        // 22
+      {gtCentrality3, "CENT3"},        // 23
+      {gtCentrality4, "CENT4"},        // 24
+      {gtCentrality5, "CENT5"},        // 25
+      {gtCentrality6, "CENT6"},        // 26
+      {gtCentrality7, "CENT7"},        // 27
+      {gtExternal, "External"},        // 28
+      {gtZDCP, "ZDCP"},                // 29
+      {gtZDCM, "ZDCM"},                // 30
+      {ObjNull, "ObjNull"},            // 31
   };
 
   // utility functions to convert GlobalObject enum to std::string and viceversa
-  l1t::GlobalObject l1TGtObjectStringToEnum(const std::string&);
-  std::string l1TGtObjectEnumToString(const GlobalObject&);
-
-  struct L1TGtObjectStringToEnum {
-    const char* label;
-    GlobalObject value;
-  };
+  l1t::GlobalObject GlobalObjectStringToEnum(const std::string&);
+  std::string GlobalObjectEnumToString(const GlobalObject&);
 
 }  // namespace l1t
 

--- a/DataFormats/L1TGlobal/src/GlobalObject.cc
+++ b/DataFormats/L1TGlobal/src/GlobalObject.cc
@@ -12,217 +12,54 @@
  *
  */
 
-// this class header
 #include "DataFormats/L1TGlobal/interface/GlobalObject.h"
-
-// system include files
-#include <cstring>
-
-// user include files
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace l1t;
+l1t::GlobalObject l1t::GlobalObjectStringToEnum(const std::string& label) {
+  l1t::GlobalObject ret = l1t::ObjNull;
+  unsigned int nMatches = 0;
 
-l1t::GlobalObject l1TGtObjectStringToEnum(const std::string& label) {
-  static const l1t::L1TGtObjectStringToEnum l1TGtObjectStringToEnumMap[] = {{"Mu", gtMu},
-                                                                            {"MuShower", gtMuShower},
-                                                                            {"EG", gtEG},
-                                                                            {"Tau", gtTau},
-                                                                            {"Jet", gtJet},
-                                                                            {"ETM", gtETM},
-                                                                            {"ETT", gtETT},
-                                                                            {"HTT", gtHTT},
-                                                                            {"HTM", gtHTM},
-                                                                            {"ETMHF", gtETMHF},
-                                                                            {"TowerCount", gtTowerCount},
-                                                                            {"MinBiasHFP0", gtMinBiasHFP0},
-                                                                            {"MinBiasHFM0", gtMinBiasHFM0},
-                                                                            {"MinBiasHFP1", gtMinBiasHFP1},
-                                                                            {"MinBiasHFM1", gtMinBiasHFM1},
-                                                                            {"ETTem", gtETTem},
-                                                                            {"AsymEt", gtAsymmetryEt},
-                                                                            {"AsymHt", gtAsymmetryHt},
-                                                                            {"AsymEtHF", gtAsymmetryEtHF},
-                                                                            {"AsymEtHF", gtAsymmetryHtHF},
-                                                                            {"CENT0", gtCentrality0},
-                                                                            {"CENT1", gtCentrality1},
-                                                                            {"CENT2", gtCentrality2},
-                                                                            {"CENT3", gtCentrality3},
-                                                                            {"CENT4", gtCentrality4},
-                                                                            {"CENT5", gtCentrality5},
-                                                                            {"CENT6", gtCentrality6},
-                                                                            {"CENT7", gtCentrality7},
-                                                                            {"External", gtExternal},
-                                                                            {"ZDCP", gtZDCP},
-                                                                            {"ZDCM", gtZDCM},
-                                                                            {"ObjNull", ObjNull},
-                                                                            {nullptr, (GlobalObject)-1}};
-
-  l1t::GlobalObject value = (GlobalObject)-1;
-
-  bool found = false;
-  for (int i = 0; l1TGtObjectStringToEnumMap[i].label && (!found); ++i)
-    if (!std::strcmp(label.c_str(), l1TGtObjectStringToEnumMap[i].label)) {
-      found = true;
-      value = l1TGtObjectStringToEnumMap[i].value;
+  for (auto const& [value, name] : l1t::kGlobalObjectEnumStringPairs) {
+    if (name == label) {
+      ++nMatches;
+      ret = value;
     }
-
-  // in case of unrecognized GlobalObject, returns Mu
-  // and write a warning (to not throw an exception)
-  if (!found) {
-    edm::LogInfo("L1TGlobal") << "\n  '" << label << "' is not a recognized GlobalObject. \n  Return ObjNull.";
-
-    value = ObjNull;
   }
 
-  if (value == ObjNull) {
-    edm::LogInfo("L1TGlobal") << "\n  ObjNull means no valid GlobalObject defined!";
+  if (nMatches == 0) {
+    edm::LogWarning("l1tGlobalObjectStringToEnum")
+        << "Failed to find l1t::GlobalObject corresponding to \"" << label << "\"."
+        << " Will return l1t::ObjNull (" << ret << ").";
+  } else if (nMatches > 1) {
+    edm::LogError("l1tGlobalObjectStringToEnum")
+        << "Multiple matches (" << nMatches << ") found for label \"" << label << "\"."
+        << " Will return last valid match (" << ret << ")."
+        << " Please remove duplicates from l1t::kGlobalObjectEnumStringPairs !!";
   }
 
-  return value;
+  return ret;
 }
 
-std::string l1t::l1TGtObjectEnumToString(const GlobalObject& gtObject) {
-  std::string gtObjectString;
+std::string l1t::GlobalObjectEnumToString(const l1t::GlobalObject& gtObject) {
+  std::string ret = "ObjNull";
+  unsigned int nMatches = 0;
 
-  switch (gtObject) {
-    case gtMu: {
-      gtObjectString = "Mu";
-    } break;
-
-    case gtMuShower: {
-      gtObjectString = "MuShower";
-    } break;
-
-    case gtEG: {
-      gtObjectString = "EG";
-    } break;
-
-    case gtTau: {
-      gtObjectString = "Tau";
-    } break;
-
-    case gtJet: {
-      gtObjectString = "Jet";
-    } break;
-
-    case gtETM: {
-      gtObjectString = "ETM";
-    } break;
-
-    case gtETT: {
-      gtObjectString = "ETT";
-    } break;
-
-    case gtHTT: {
-      gtObjectString = "HTT";
-    } break;
-
-    case gtHTM: {
-      gtObjectString = "HTM";
-    } break;
-
-    case gtETMHF: {
-      gtObjectString = "ETMHF";
-    } break;
-
-    case gtTowerCount: {
-      gtObjectString = "TowerCount";
-    } break;
-
-    case gtMinBiasHFP0: {
-      gtObjectString = "MinBiasHFP0";
-    } break;
-
-    case gtMinBiasHFM0: {
-      gtObjectString = "MinBiasHFM0";
-    } break;
-
-    case gtMinBiasHFP1: {
-      gtObjectString = "MinBiasHFP1";
-    } break;
-
-    case gtMinBiasHFM1: {
-      gtObjectString = "MinBiasHFM1";
-    } break;
-
-    case gtETTem: {
-      gtObjectString = "ETTem";
-    } break;
-
-    case gtAsymmetryEt: {
-      gtObjectString = "AsymEt";
-    } break;
-
-    case gtAsymmetryHt: {
-      gtObjectString = "AsymHt";
-    } break;
-
-    case gtAsymmetryEtHF: {
-      gtObjectString = "AsymEtHF";
-    } break;
-
-    case gtAsymmetryHtHF: {
-      gtObjectString = "AsymHtHF";
-    } break;
-
-    case gtCentrality0: {
-      gtObjectString = "CENT0";
-    } break;
-
-    case gtCentrality1: {
-      gtObjectString = "CENT1";
-    } break;
-
-    case gtCentrality2: {
-      gtObjectString = "CENT2";
-    } break;
-
-    case gtCentrality3: {
-      gtObjectString = "CENT3";
-    } break;
-
-    case gtCentrality4: {
-      gtObjectString = "CENT4";
-    } break;
-
-    case gtCentrality5: {
-      gtObjectString = "CENT5";
-    } break;
-
-    case gtCentrality6: {
-      gtObjectString = "CENT6";
-    } break;
-
-    case gtCentrality7: {
-      gtObjectString = "CENT7";
-    } break;
-
-    case gtExternal: {
-      gtObjectString = "External";
-    } break;
-
-    case gtZDCP: {
-      gtObjectString = "ZDCP";
-    } break;
-
-    case gtZDCM: {
-      gtObjectString = "ZDCM";
-    } break;
-
-    case ObjNull: {
-      gtObjectString = "ObjNull";
-      edm::LogInfo("L1TGlobal") << "\n  ObjNull means no valid GlobalObject defined!";
-    } break;
-
-    default: {
-      edm::LogInfo("L1TGlobal") << "\n  '" << gtObject << "' is not a recognized GlobalObject. "
-                                << "\n  Return ObjNull, which means no valid GlobalObject defined!";
-
-      gtObjectString = "ObjNull";
-
-    } break;
+  for (auto const& [value, name] : l1t::kGlobalObjectEnumStringPairs) {
+    if (value == gtObject) {
+      ++nMatches;
+      ret = name;
+    }
   }
 
-  return gtObjectString;
+  if (nMatches == 0) {
+    edm::LogWarning("l1TGtObjectEnumToString") << "Failed to find l1t::GlobalObject with a value of " << gtObject << "."
+                                               << " Will return \"" << ret << "\".";
+  } else if (nMatches > 1) {
+    edm::LogError("l1TGtObjectEnumToString")
+        << "Multiple matches (" << nMatches << ") found for l1t::GlobalObject value of " << gtObject
+        << ". Will return last valid match (\"" << ret << "\")."
+        << " Please remove duplicates from l1t::kGlobalObjectEnumStringPairs !!";
+  }
+
+  return ret;
 }

--- a/DataFormats/L1TGlobal/test/BuildFile.xml
+++ b/DataFormats/L1TGlobal/test/BuildFile.xml
@@ -8,3 +8,8 @@
 </library>
 
 <test name="TestGlobalObjectMapRecordFormat" command="TestGlobalObjectMapRecordFormat.sh"/>
+
+<bin file="test_catch2_l1tGlobalObject.cc" name="test_l1tGlobalObjectCatch2">
+  <use name="FWCore/MessageLogger"/>
+  <use name="catch2"/>
+</bin>

--- a/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
+++ b/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
@@ -1,0 +1,104 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <algorithm>
+#include <string>
+
+#include "DataFormats/L1TGlobal/interface/GlobalObject.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace {
+
+  bool hasNoDuplicateEnums() {
+    std::vector<l1t::GlobalObject> vec;
+    vec.reserve(l1t::kGlobalObjectEnumStringPairs.size());
+    for (auto const& [value, name] : l1t::kGlobalObjectEnumStringPairs) {
+      vec.emplace_back(value);
+    }
+    std::sort(vec.begin(), vec.end());
+    auto const it = std::unique(vec.begin(), vec.end());
+    return (it == vec.end());
+  }
+
+  bool hasNoDuplicateStrings() {
+    std::vector<std::string> vec;
+    vec.reserve(l1t::kGlobalObjectEnumStringPairs.size());
+    for (auto const& [value, name] : l1t::kGlobalObjectEnumStringPairs) {
+      vec.emplace_back(name);
+    }
+    std::sort(vec.begin(), vec.end());
+    auto const it = std::unique(vec.begin(), vec.end());
+    return (it == vec.end());
+  }
+
+  bool isValidGlobalObject(unsigned int const idx, l1t::GlobalObject const& obj, std::string const& label) {
+    if (idx != obj) {
+      edm::LogError("testL1TGlobalObjectCatch2")
+          << "Index (" << idx << ") and Enum (" << obj << ") do not match (Label = \"" << label << "\")";
+      return false;
+    }
+
+    auto const enumToString = l1t::GlobalObjectEnumToString(obj);
+    if (enumToString != label) {
+      edm::LogError("testL1TGlobalObjectCatch2")
+          << "EnumToString (\"" << enumToString << "\") and Label (\"" << label << "\") do not match"
+          << " (Index = " << idx << ", Enum = " << obj << ") !!";
+      return false;
+    }
+
+    auto const stringToEnum = l1t::GlobalObjectStringToEnum(label);
+    if (stringToEnum != obj) {
+      edm::LogError("testL1TGlobalObjectCatch2")
+          << "StringToEnum (\"" << stringToEnum << "\") and Enum (" << obj << ") do not match"
+          << " (Index = " << idx << ", Label = \"" << label << "\") !!";
+      return false;
+    }
+
+    return true;
+  }
+
+}  // namespace
+
+TEST_CASE("Test l1t::GlobalObject", "[l1tGlobalObject]") {
+  // verify that the enums in l1t::kGlobalObjectEnumStringPairs are all unique
+  SECTION("NoDuplicateEnums") { REQUIRE(hasNoDuplicateEnums()); }
+
+  // verify that the strings in l1t::kGlobalObjectEnumStringPairs are all unique
+  SECTION("NoDuplicateStrings") { REQUIRE(hasNoDuplicateStrings()); }
+
+  // verify correctness of index, enum and string of every GlobalObject
+  SECTION("TestGlobalObjects") {
+    REQUIRE(isValidGlobalObject(0, l1t::gtMu, "Mu"));                     //  0
+    REQUIRE(isValidGlobalObject(1, l1t::gtMuShower, "MuShower"));         //  1
+    REQUIRE(isValidGlobalObject(2, l1t::gtEG, "EG"));                     //  2
+    REQUIRE(isValidGlobalObject(3, l1t::gtJet, "Jet"));                   //  3
+    REQUIRE(isValidGlobalObject(4, l1t::gtTau, "Tau"));                   //  4
+    REQUIRE(isValidGlobalObject(5, l1t::gtETM, "ETM"));                   //  5
+    REQUIRE(isValidGlobalObject(6, l1t::gtETT, "ETT"));                   //  6
+    REQUIRE(isValidGlobalObject(7, l1t::gtHTT, "HTT"));                   //  7
+    REQUIRE(isValidGlobalObject(8, l1t::gtHTM, "HTM"));                   //  8
+    REQUIRE(isValidGlobalObject(9, l1t::gtETMHF, "ETMHF"));               //  9
+    REQUIRE(isValidGlobalObject(10, l1t::gtTowerCount, "TowerCount"));    // 10
+    REQUIRE(isValidGlobalObject(11, l1t::gtMinBiasHFP0, "MinBiasHFP0"));  // 11
+    REQUIRE(isValidGlobalObject(12, l1t::gtMinBiasHFM0, "MinBiasHFM0"));  // 12
+    REQUIRE(isValidGlobalObject(13, l1t::gtMinBiasHFP1, "MinBiasHFP1"));  // 13
+    REQUIRE(isValidGlobalObject(14, l1t::gtMinBiasHFM1, "MinBiasHFM1"));  // 14
+    REQUIRE(isValidGlobalObject(15, l1t::gtETTem, "ETTem"));              // 15
+    REQUIRE(isValidGlobalObject(16, l1t::gtAsymmetryEt, "AsymEt"));       // 16
+    REQUIRE(isValidGlobalObject(17, l1t::gtAsymmetryHt, "AsymHt"));       // 17
+    REQUIRE(isValidGlobalObject(18, l1t::gtAsymmetryEtHF, "AsymEtHF"));   // 18
+    REQUIRE(isValidGlobalObject(19, l1t::gtAsymmetryHtHF, "AsymHtHF"));   // 19
+    REQUIRE(isValidGlobalObject(20, l1t::gtCentrality0, "CENT0"));        // 20
+    REQUIRE(isValidGlobalObject(21, l1t::gtCentrality1, "CENT1"));        // 21
+    REQUIRE(isValidGlobalObject(22, l1t::gtCentrality2, "CENT2"));        // 22
+    REQUIRE(isValidGlobalObject(23, l1t::gtCentrality3, "CENT3"));        // 23
+    REQUIRE(isValidGlobalObject(24, l1t::gtCentrality4, "CENT4"));        // 24
+    REQUIRE(isValidGlobalObject(25, l1t::gtCentrality5, "CENT5"));        // 25
+    REQUIRE(isValidGlobalObject(26, l1t::gtCentrality6, "CENT6"));        // 26
+    REQUIRE(isValidGlobalObject(27, l1t::gtCentrality7, "CENT7"));        // 27
+    REQUIRE(isValidGlobalObject(28, l1t::gtExternal, "External"));        // 28
+    REQUIRE(isValidGlobalObject(29, l1t::gtZDCP, "ZDCP"));                // 29
+    REQUIRE(isValidGlobalObject(30, l1t::gtZDCM, "ZDCM"));                // 30
+    REQUIRE(isValidGlobalObject(31, l1t::ObjNull, "ObjNull"));            // 31
+  }
+}

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -945,15 +945,14 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
       }  //end switch on second leg
 
       if (m_verbosity) {
-        LogDebug("L1TGlobal") << "    Correlation pair [" << l1TGtObjectEnumToString(cndObjTypeVec[0]) << ", "
-                              << l1TGtObjectEnumToString(cndObjTypeVec[1]) << "] with collection indices [" << obj0Index
-                              << ", " << obj1Index << "] "
+        LogDebug("L1TGlobal") << "    Correlation pair [" << l1t::GlobalObjectEnumToString(cndObjTypeVec[0]) << ", "
+                              << l1t::GlobalObjectEnumToString(cndObjTypeVec[1]) << "] with collection indices ["
+                              << obj0Index << ", " << obj1Index << "] "
                               << " has: \n"
                               << "     Et  value   = [" << etIndex0 << ", " << etIndex1 << "]\n"
                               << "     phi indices = [" << phiIndex0 << ", " << phiIndex1 << "]\n"
                               << "     eta indices = [" << etaIndex0 << ", " << etaIndex1 << "]\n"
-                              << "     chrg        = [" << chrg0 << ", " << chrg1 << "]\n"
-                              << std::endl;
+                              << "     chrg        = [" << chrg0 << ", " << chrg1 << "]\n";
       }
 
       // Now perform the desired correlation on these two objects. Assume true until we find a contradition

--- a/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrThreeBodyCondition.cc
@@ -454,9 +454,9 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
         if (m_verbosity) {
           LogDebug("L1TGlobal") << "\n >>>>>> THREE-MUON EVENT!" << std::endl;
           LogDebug("L1TGlobal") << ">>>>>> Object involved in the three-body correlation condition are ["
-                                << l1TGtObjectEnumToString(cndObjTypeVec[0]) << ", "
-                                << l1TGtObjectEnumToString(cndObjTypeVec[1]) << ", "
-                                << l1TGtObjectEnumToString(cndObjTypeVec[2]) << "] with collection indices ["
+                                << l1t::GlobalObjectEnumToString(cndObjTypeVec[0]) << ", "
+                                << l1t::GlobalObjectEnumToString(cndObjTypeVec[1]) << ", "
+                                << l1t::GlobalObjectEnumToString(cndObjTypeVec[2]) << "] with collection indices ["
                                 << obj0Index << ", " << obj1Index << obj2Index << "] "
                                 << " having: \n"
                                 << "     Et  values  = [" << etIndex0 << ", " << etIndex1 << ", " << etIndex2 << "]\n"
@@ -464,8 +464,7 @@ const bool l1t::CorrThreeBodyCondition::evaluateCondition(const int bxEval) cons
                                 << "]\n"
                                 << "     eta indices = [" << etaIndex0 << ", " << etaIndex1 << ", " << etaIndex2
                                 << "]\n"
-                                << "     charge values = [" << chrg0 << ", " << chrg1 << ", " << chrg2 << "]\n"
-                                << std::endl;
+                                << "     charge values = [" << chrg0 << ", " << chrg1 << ", " << chrg2 << "]\n";
         }
 
         // Now perform the desired correlation on these three objects:

--- a/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrWithOverlapRemovalCondition.cc
@@ -1084,15 +1084,14 @@ const bool l1t::CorrWithOverlapRemovalCondition::evaluateCondition(const int bxE
       }  //end switch on second leg
 
       if (m_verbosity) {
-        LogDebug("L1TGlobal") << "    Correlation pair [" << l1TGtObjectEnumToString(cndObjTypeVec[0]) << ", "
-                              << l1TGtObjectEnumToString(cndObjTypeVec[1]) << "] with collection indices [" << obj0Index
-                              << ", " << obj1Index << "] "
+        LogDebug("L1TGlobal") << "    Correlation pair [" << l1t::GlobalObjectEnumToString(cndObjTypeVec[0]) << ", "
+                              << l1t::GlobalObjectEnumToString(cndObjTypeVec[1]) << "] with collection indices ["
+                              << obj0Index << ", " << obj1Index << "] "
                               << " has: \n"
                               << "     Et  value   = [" << etIndex0 << ", " << etIndex1 << "]\n"
                               << "     phi indices = [" << phiIndex0 << ", " << phiIndex1 << "]\n"
                               << "     eta indices = [" << etaIndex0 << ", " << etaIndex1 << "]\n"
-                              << "     chrg        = [" << chrg0 << ", " << chrg1 << "]\n"
-                              << std::endl;
+                              << "     chrg        = [" << chrg0 << ", " << chrg1 << "]\n";
       }
 
       // Now perform the desired correlation on these two objects. Assume true until we find a contradition


### PR DESCRIPTION
#### PR description:

This PR implements one of the suggestions discussed in #42719 (adding explicit values to enum entries), in order to avoid introducing non-backward-compatible changes to the RAW data tier when modifying the enum `l1t::GlobalObject` (see https://github.com/cms-sw/cmssw/pull/42634#discussion_r1302636113 and replies).

While editing `GlobalObject.cc`, I noticed a mismatch between [this](https://github.com/cms-sw/cmssw/blob/9fb1e71911837a0407457aa95098a9618bc5b008/DataFormats/L1TGlobal/src/GlobalObject.cc#L46) and [this](https://github.com/cms-sw/cmssw/blob/9fb1e71911837a0407457aa95098a9618bc5b008/DataFormats/L1TGlobal/src/GlobalObject.cc#L166). I tried to re-implement the corresponding utilities to avoid such mistakes in the future (these utilities seem to be used in CMSSW only for `LogDebug` statements, so they are fairly unconsequential).

A related unit test is also added.

Merely technical. No changes expected.

#### PR validation:

The new unit test passes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
