### PR TITLE
Use the ratio timing method for ECAL online DQM - 131X

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -52,6 +52,13 @@ process.load("DQM.EcalMonitorClient.EcalMonitorClient_cfi")
 
 ### Individual module setups ###
 
+# Use the ratio timing method for the online DQM
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timealgo = cms.string("RatioMethod")
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12pEB = cms.double(5.)
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12mEB = cms.double(5.)
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61pEB = cms.double(5.)
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61mEB = cms.double(5.)
+
 process.ecalPhysicsFilter = cms.EDFilter("EcalMonitorPrescaler",
     cosmics = cms.untracked.uint32(1),
     physics = cms.untracked.uint32(1),

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -53,11 +53,13 @@ process.load("DQM.EcalMonitorClient.EcalMonitorClient_cfi")
 ### Individual module setups ###
 
 # Use the ratio timing method for the online DQM
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timealgo = cms.string("RatioMethod")
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12pEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12mEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61pEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61mEB = cms.double(5.)
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timealgo = "RatioMethod"
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12pEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12mEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61pEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61mEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timeCalibTag = cms.ESInputTag()
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timeOffsetTag = cms.ESInputTag()
 
 process.ecalPhysicsFilter = cms.EDFilter("EcalMonitorPrescaler",
     cosmics = cms.untracked.uint32(1),


### PR DESCRIPTION
#### PR description:

This PR sets the ECAL timing algorithm used in the online DQM reconstruction to the ratio method. Like this the online DQM monitors the algorithm that is used at the HLT and can also directly use the calibrations and offsets from the HLT GT.

This PR should replace https://github.com/cms-sw/cmssw/pull/42855 on the online DQM.

#### PR validation:

Ran ecal_dqm_sourceclient-live_cfg.py configuration locally.

Backport of https://github.com/cms-sw/cmssw/pull/42932