### PR TITLE
Use the ratio timing method for ECAL online DQM- 132X part 2

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -53,11 +53,13 @@ process.load("DQM.EcalMonitorClient.EcalMonitorClient_cfi")
 ### Individual module setups ###
 
 # Use the ratio timing method for the online DQM
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timealgo = cms.string("RatioMethod")
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12pEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12mEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61pEB = cms.double(5.)
-process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61mEB = cms.double(5.)
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timealgo = "RatioMethod"
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12pEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain12mEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61pEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.outOfTimeThresholdGain61mEB = 5.
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timeCalibTag = cms.ESInputTag()
+process.ecalMultiFitUncalibRecHit.cpu.algoPSet.timeOffsetTag = cms.ESInputTag()
 
 process.ecalPhysicsFilter = cms.EDFilter("EcalMonitorPrescaler",
     cosmics = cms.untracked.uint32(1),


### PR DESCRIPTION
#### PR description:

This PR extends the backport PR #42933 and explicitly sets the time algorithm conditions tag such that is also works together with PR #42946 .

Together with PR #42933 this matches the behaviour of the master PR #42932.

#### PR validation:

Ran ecal_dqm_sourceclient-live_cfg.py configuration locally.

Backport of #42932 