### PR TITLE
fixed dimuon invariant mass plots range

### DIFF
--- a/DQMOffline/Muon/interface/DiMuonHistograms.h
+++ b/DQMOffline/Muon/interface/DiMuonHistograms.h
@@ -64,10 +64,10 @@ private:
   double etaECMax;
 
   //Defining the relevant invariant mass regions
-  double LowMassMin;
-  double LowMassMax;
-  double HighMassMin;
-  double HighMassMax;
+  double lowMassMin;
+  double lowMassMax;
+  double highMassMin;
+  double highMassMax;
 
   std::vector<MonitorElement*> GlbGlbMuon_LM;
   std::vector<MonitorElement*> GlbGlbMuon_HM;

--- a/DQMOffline/Muon/python/diMuonHistograms_cfi.py
+++ b/DQMOffline/Muon/python/diMuonHistograms_cfi.py
@@ -17,10 +17,10 @@ diMuonHistos = DQMEDAnalyzer('DiMuonHistograms',
                               etaECMin = cms.double(0.9),
                               etaECMax = cms.double(2.4),
                               
-                              LowMassMin = cms.double(2.0),
-                              LowMassMax = cms.double(12.0),
-                              HighMassMin = cms.double(70.0),
-                              HighMassMax = cms.double(110.0),
+                              lowMassMin = cms.double(2.0),
+                              lowMassMax = cms.double(12.0),
+                              highMassMin = cms.double(70.0),
+                              highMassMax = cms.double(110.0),
                               folder = cms.string("Muons/diMuonHistograms")
                               )
 diMuonHistos_miniAOD = DQMEDAnalyzer('DiMuonHistograms',
@@ -37,10 +37,10 @@ diMuonHistos_miniAOD = DQMEDAnalyzer('DiMuonHistograms',
                                       etaECMin = cms.double(0.9),
                                       etaECMax = cms.double(2.4),
                                       
-                                      LowMassMin = cms.double(2.0),
-                                      LowMassMax = cms.double(12.0),
-                                      HighMassMin = cms.double(70.0),
-                                      HighMassMax = cms.double(110.0),
+                                      lowMassMin = cms.double(2.0),
+                                      lowMassMax = cms.double(12.0),
+                                      highMassMin = cms.double(70.0),
+                                      highMassMax = cms.double(110.0),
                                       folder = cms.string("Muons_miniAOD/diMuonHistograms")
                                       )
 
@@ -50,8 +50,8 @@ pA_2016.toModify(diMuonHistos,
     etaBBin = 350, 
     etaEBin = 350, 
 
-    LowMassMin = 2.0, 
-    LowMassMax = 51.0, 
-    HighMassMin = 55.0, 
-    HighMassMax = 125.0
+    lowMassMin = 2.0, 
+    lowMassMax = 51.0, 
+    highMassMin = 55.0, 
+    highMassMax = 125.0
     )

--- a/DQMOffline/Muon/src/DiMuonHistograms.cc
+++ b/DQMOffline/Muon/src/DiMuonHistograms.cc
@@ -111,18 +111,18 @@ void DiMuonHistograms::bookHistograms(DQMStore::IBooker& ibooker,
     TightTightMuon.push_back(ibooker.book1D("TightTightMuon" + EtaName[iEtaRegion],
                                             "InvMass_{Tight,Tight}" + EtaName[iEtaRegion],
                                             nBin[iEtaRegion],
-                                            LowMassMin,
-                                            LowMassMax));
+                                            HighMassMin,
+                                            HighMassMax));
     MediumMediumMuon.push_back(ibooker.book1D("MediumMediumMuon" + EtaName[iEtaRegion],
                                               "InvMass_{Medium,Medium}" + EtaName[iEtaRegion],
                                               nBin[iEtaRegion],
-                                              LowMassMin,
-                                              LowMassMax));
+                                              HighMassMin,
+                                              HighMassMax));
     LooseLooseMuon.push_back(ibooker.book1D("LooseLooseMuon" + EtaName[iEtaRegion],
                                             "InvMass_{Loose,Loose}" + EtaName[iEtaRegion],
                                             nBin[iEtaRegion],
-                                            LowMassMin,
-                                            LowMassMax));
+                                            HighMassMin,
+                                            HighMassMax));
     //Fraction of bad hits in the tracker track to the total
     TightTightMuonBadFrac.push_back(ibooker.book1D(
         "TightTightMuonBadFrac" + EtaName[iEtaRegion], "BadFrac_{Tight,Tight}" + EtaName[iEtaRegion], 10, 0, 0.4));

--- a/DQMOffline/Muon/src/DiMuonHistograms.cc
+++ b/DQMOffline/Muon/src/DiMuonHistograms.cc
@@ -53,10 +53,10 @@ DiMuonHistograms::DiMuonHistograms(const edm::ParameterSet& pSet) {
   etaECMin = parameters.getParameter<double>("etaECMin");
   etaECMax = parameters.getParameter<double>("etaECMax");
 
-  LowMassMin = parameters.getParameter<double>("LowMassMin");
-  LowMassMax = parameters.getParameter<double>("LowMassMax");
-  HighMassMin = parameters.getParameter<double>("HighMassMin");
-  HighMassMax = parameters.getParameter<double>("HighMassMax");
+  lowMassMin = parameters.getParameter<double>("lowMassMin");
+  lowMassMax = parameters.getParameter<double>("lowMassMax");
+  highMassMin = parameters.getParameter<double>("highMassMin");
+  highMassMax = parameters.getParameter<double>("highMassMax");
 
   theFolder = parameters.getParameter<string>("folder");
 }
@@ -78,51 +78,51 @@ void DiMuonHistograms::bookHistograms(DQMStore::IBooker& ibooker,
     GlbGlbMuon_LM.push_back(ibooker.book1D("GlbGlbMuon_LM" + EtaName[iEtaRegion],
                                            "InvMass_{GLB,GLB}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           LowMassMin,
-                                           LowMassMax));
+                                           lowMassMin,
+                                           lowMassMax));
     TrkTrkMuon_LM.push_back(ibooker.book1D("TrkTrkMuon_LM" + EtaName[iEtaRegion],
                                            "InvMass_{TRK,TRK}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           LowMassMin,
-                                           LowMassMax));
+                                           lowMassMin,
+                                           lowMassMax));
     StaTrkMuon_LM.push_back(ibooker.book1D("StaTrkMuon_LM" + EtaName[iEtaRegion],
                                            "InvMass_{STA,TRK}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           LowMassMin,
-                                           LowMassMax));
+                                           lowMassMin,
+                                           lowMassMax));
 
     GlbGlbMuon_HM.push_back(ibooker.book1D("GlbGlbMuon_HM" + EtaName[iEtaRegion],
                                            "InvMass_{GLB,GLB}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           HighMassMin,
-                                           HighMassMax));
+                                           highMassMin,
+                                           highMassMax));
     TrkTrkMuon_HM.push_back(ibooker.book1D("TrkTrkMuon_HM" + EtaName[iEtaRegion],
                                            "InvMass_{TRK,TRK}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           HighMassMin,
-                                           HighMassMax));
+                                           highMassMin,
+                                           highMassMax));
     StaTrkMuon_HM.push_back(ibooker.book1D("StaTrkMuon_HM" + EtaName[iEtaRegion],
                                            "InvMass_{STA,TRK}" + EtaName[iEtaRegion],
                                            nBin[iEtaRegion],
-                                           HighMassMin,
-                                           HighMassMax));
+                                           highMassMin,
+                                           highMassMax));
 
     // arround the Z peak
     TightTightMuon.push_back(ibooker.book1D("TightTightMuon" + EtaName[iEtaRegion],
                                             "InvMass_{Tight,Tight}" + EtaName[iEtaRegion],
                                             nBin[iEtaRegion],
-                                            HighMassMin,
-                                            HighMassMax));
+                                            highMassMin,
+                                            highMassMax));
     MediumMediumMuon.push_back(ibooker.book1D("MediumMediumMuon" + EtaName[iEtaRegion],
                                               "InvMass_{Medium,Medium}" + EtaName[iEtaRegion],
                                               nBin[iEtaRegion],
-                                              HighMassMin,
-                                              HighMassMax));
+                                              highMassMin,
+                                              highMassMax));
     LooseLooseMuon.push_back(ibooker.book1D("LooseLooseMuon" + EtaName[iEtaRegion],
                                             "InvMass_{Loose,Loose}" + EtaName[iEtaRegion],
                                             nBin[iEtaRegion],
-                                            HighMassMin,
-                                            HighMassMax));
+                                            highMassMin,
+                                            highMassMax));
     //Fraction of bad hits in the tracker track to the total
     TightTightMuonBadFrac.push_back(ibooker.book1D(
         "TightTightMuonBadFrac" + EtaName[iEtaRegion], "BadFrac_{Tight,Tight}" + EtaName[iEtaRegion], 10, 0, 0.4));
@@ -222,9 +222,9 @@ void DiMuonHistograms::analyze(const edm::Event& iEvent, const edm::EventSetup& 
                 fabs(recoCombinedGlbTrack1->eta()) < EtaCutMax[iEtaRegion] &&
                 fabs(recoCombinedGlbTrack2->eta()) > EtaCutMin[iEtaRegion] &&
                 fabs(recoCombinedGlbTrack2->eta()) < EtaCutMax[iEtaRegion]) {
-              if (InvMass < LowMassMax)
+              if (InvMass < lowMassMax)
                 GlbGlbMuon_LM[iEtaRegion]->Fill(InvMass);
-              if (InvMass > HighMassMin)
+              if (InvMass > highMassMin)
                 GlbGlbMuon_HM[iEtaRegion]->Fill(InvMass);
             }
           }
@@ -300,9 +300,9 @@ void DiMuonHistograms::analyze(const edm::Event& iEvent, const edm::EventSetup& 
             if (fabs(recoStaTrack->eta()) > EtaCutMin[iEtaRegion] &&
                 fabs(recoStaTrack->eta()) < EtaCutMax[iEtaRegion] && fabs(recoTrack->eta()) > EtaCutMin[iEtaRegion] &&
                 fabs(recoTrack->eta()) < EtaCutMax[iEtaRegion]) {
-              if (InvMass < LowMassMax)
+              if (InvMass < lowMassMax)
                 StaTrkMuon_LM[iEtaRegion]->Fill(InvMass);
-              if (InvMass > HighMassMin)
+              if (InvMass > highMassMin)
                 StaTrkMuon_HM[iEtaRegion]->Fill(InvMass);
             }
           }
@@ -322,9 +322,9 @@ void DiMuonHistograms::analyze(const edm::Event& iEvent, const edm::EventSetup& 
             if (fabs(recoStaTrack->eta()) > EtaCutMin[iEtaRegion] &&
                 fabs(recoStaTrack->eta()) < EtaCutMax[iEtaRegion] && fabs(recoTrack->eta()) > EtaCutMin[iEtaRegion] &&
                 fabs(recoTrack->eta()) < EtaCutMax[iEtaRegion]) {
-              if (InvMass < LowMassMax)
+              if (InvMass < lowMassMax)
                 StaTrkMuon_LM[iEtaRegion]->Fill(InvMass);
-              if (InvMass > HighMassMin)
+              if (InvMass > highMassMin)
                 StaTrkMuon_HM[iEtaRegion]->Fill(InvMass);
             }
           }
@@ -345,9 +345,9 @@ void DiMuonHistograms::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           for (unsigned int iEtaRegion = 0; iEtaRegion < 3; iEtaRegion++) {
             if (fabs(recoTrack1->eta()) > EtaCutMin[iEtaRegion] && fabs(recoTrack1->eta()) < EtaCutMax[iEtaRegion] &&
                 fabs(recoTrack2->eta()) > EtaCutMin[iEtaRegion] && fabs(recoTrack2->eta()) < EtaCutMax[iEtaRegion]) {
-              if (InvMass < LowMassMax)
+              if (InvMass < lowMassMax)
                 TrkTrkMuon_LM[iEtaRegion]->Fill(InvMass);
-              if (InvMass > HighMassMin)
+              if (InvMass > highMassMin)
                 TrkTrkMuon_HM[iEtaRegion]->Fill(InvMass);
             }
           }


### PR DESCRIPTION
#### PR description:

This PR fixes the range of the following histograms under the Muons/diMuonHistograms area of the Offline DQM:
- LooseLooseMuon
- LooseLooseMuon_Barrel
- LooseLooseMuon_EndCap
- MediumMediumMuon 
- MediumMediumMuon_Barrel
- MediumMediumMuon_EndCap 
- TightTightMuon 
- TightTightMuon_Barrel
- TightTightMuon_EndCap 

The ranges of all the above plots were not centered on the Z peak, so they were showing no entries (e.g. https://tinyurl.com/ytbrrk9w). To fix this I've just put the correct mass range around the Z peak (namely from `HighMassMin` to `HighMassMax` defined [here](https://github.com/cms-sw/cmssw/blob/master/DQMOffline/Muon/python/diMuonHistograms_cfi.py#L22-L23)).

#### PR validation:
I have checked that the above plots are filled as intended by running the `10842.0` Z->MuMu workflow on CMSSW_13_2_6. The Z peak was visible as expected.

FYI @caruta 

P.S. This PR was opened by mistake in the main branch: [https://github.com/cms-sw/cmssw/pull/43026](https://github.com/cms-sw/cmssw/pull/43026)
