### PR TITLE
Removed std::iterator use from DataFormats/Common

### DIFF
--- a/DataFormats/Common/interface/BaseVectorHolder.h
+++ b/DataFormats/Common/interface/BaseVectorHolder.h
@@ -14,9 +14,10 @@ namespace edm {
     template <typename T>
     class BaseVectorHolder {
     public:
-      typedef size_t size_type;
-      typedef T element_type;
-      typedef RefToBase<T> base_ref_type;
+      using size_type = size_t;
+      using element_type = T;
+      using base_ref_type = RefToBase<T>;
+
       BaseVectorHolder() {}
       virtual ~BaseVectorHolder() {}
       virtual BaseVectorHolder* clone() const = 0;
@@ -36,7 +37,7 @@ namespace edm {
       // to allow dictionary to compile
       //    protected:
       struct const_iterator_imp {
-        typedef ptrdiff_t difference_type;
+        using difference_type = ptrdiff_t;
         const_iterator_imp() {}
         virtual ~const_iterator_imp() {}
         virtual const_iterator_imp* clone() const = 0;
@@ -51,10 +52,12 @@ namespace edm {
         virtual difference_type difference(const_iterator_imp const*) const = 0;
       };
 
-      struct const_iterator : public std::iterator<std::random_access_iterator_tag, RefToBase<T> > {
-        typedef base_ref_type value_type;
-        typedef std::unique_ptr<value_type> pointer;
-        typedef std::ptrdiff_t difference_type;
+      struct const_iterator {
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = base_ref_type;
+        using pointer = std::unique_ptr<value_type>;
+        using difference_type = std::ptrdiff_t;
+        using reference = base_ref_type&;
 
         const_iterator() : i(nullptr) {}
         const_iterator(const_iterator_imp* it) : i(it) {}

--- a/DataFormats/Common/interface/PtrVector.h
+++ b/DataFormats/Common/interface/PtrVector.h
@@ -48,12 +48,15 @@ namespace edm {
   };
 
   template <typename T>
-  class PtrVectorItr : public std::iterator<std::random_access_iterator_tag, Ptr<T> > {
+  class PtrVectorItr {
   public:
-    typedef Ptr<T> const reference;  // otherwise boost::range does not work
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = Ptr<T>;
+    using pointer = Ptr<T>*;
+    using reference = Ptr<T> const;  // otherwise boost::range does not work
                                      // const, because this is a const_iterator
-    typedef PtrVectorItr<T> iterator;
-    typedef typename std::iterator<std::random_access_iterator_tag, Ptr<T> >::difference_type difference_type;
+    using iterator = PtrVectorItr<T>;
+    using difference_type = std::ptrdiff_t;
 
     PtrVectorItr(std::vector<void const*>::const_iterator const& iItr, PtrVector<T> const* iBase)
         : iter_(iItr), base_(iBase) {}
@@ -121,11 +124,11 @@ namespace edm {
   template <typename T>
   class PtrVector : public PtrVectorBase {
   public:
-    typedef PtrVectorItr<T> const_iterator;
-    typedef PtrVectorItr<T> iterator;  // make boost::sub_range happy (std allows this)
-    typedef Ptr<T> value_type;
-    typedef T member_type;
-    typedef void collection_type;
+    using const_iterator = PtrVectorItr<T>;
+    using iterator = PtrVectorItr<T>;  // make boost::sub_range happy (std allows this)
+    using value_type = Ptr<T>;
+    using member_type = T;
+    using collection_type = void;
 
     friend class PtrVectorItr<T>;
     PtrVector() : PtrVectorBase() {}

--- a/DataFormats/Common/interface/RefVectorHolderBase.h
+++ b/DataFormats/Common/interface/RefVectorHolderBase.h
@@ -13,8 +13,8 @@ namespace edm {
     class RefVectorHolderBase {
     public:
       virtual ~RefVectorHolderBase() {}
-      typedef size_t size_type;
-      typedef RefHolderBase value_type;
+      using size_type = size_t;
+      using value_type = RefHolderBase;
       void swap(RefVectorHolderBase&) {}  // nothing to swap
       virtual bool empty() const = 0;
       virtual size_type size() const = 0;
@@ -29,7 +29,7 @@ namespace edm {
       // to allow dictionary to compile
       //    protected:
       struct const_iterator_imp {
-        typedef ptrdiff_t difference_type;
+        using difference_type = ptrdiff_t;
         const_iterator_imp() {}
         virtual ~const_iterator_imp() {}
         virtual const_iterator_imp* clone() const = 0;
@@ -44,9 +44,12 @@ namespace edm {
         virtual difference_type difference(const_iterator_imp const*) const = 0;
       };
 
-      struct const_iterator : public std::iterator<std::random_access_iterator_tag, void*> {
-        typedef std::shared_ptr<RefHolderBase> value_type;
-        typedef std::ptrdiff_t difference_type;
+      struct const_iterator {
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = std::shared_ptr<RefHolderBase>;
+        using pointer = void**;
+        using reference = void*&;
+        using difference_type = std::ptrdiff_t;
         const_iterator() : i(nullptr) {}
         const_iterator(const_iterator_imp* it) : i(it) {}
         const_iterator(const_iterator const& it) : i(it.isValid() ? it.i->clone() : nullptr) {}

--- a/DataFormats/Common/interface/RefVectorIterator.h
+++ b/DataFormats/Common/interface/RefVectorIterator.h
@@ -17,18 +17,21 @@ Note: this is actually a *const_iterator*
 namespace edm {
 
   template <typename C, typename T = typename Ref<C>::value_type, typename F = typename Ref<C>::finder_type>
-  class RefVectorIterator : public std::iterator<std::random_access_iterator_tag, Ref<C, T, F> > {
+  class RefVectorIterator {
   public:
-    typedef Ref<C, T, F> value_type;
-    typedef Ref<C, T, F> const const_reference;  // Otherwise boost::iterator_reference assumes '*it' returns 'Ref &'
-    typedef const_reference reference;  // This to prevent compilation of code that tries to modify the RefVector
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = Ref<C, T, F>;
+    using const_reference = Ref<C, T, F> const;  // Otherwise boost::iterator_reference assumes '*it' returns 'Ref &'
+    using reference = const_reference;  // This to prevent compilation of code that tries to modify the RefVector
                                         // through this iterator
-    typedef typename value_type::key_type key_type;
+    using pointer = Ref<C, T, F> const*;
+    using key_type = typename value_type::key_type;
 
-    typedef RefVectorIterator<C, T, F> iterator;
-    typedef std::ptrdiff_t difference;
-    typedef typename std::vector<key_type>::const_iterator keyIter;
-    typedef typename std::vector<void const*>::const_iterator MemberIter;
+    using iterator = RefVectorIterator<C, T, F>;
+    using difference = std::ptrdiff_t;
+    using difference_type = difference;
+    using keyIter = typename std::vector<key_type>::const_iterator;
+    using MemberIter = typename std::vector<void const*>::const_iterator;
 
     RefVectorIterator() : refVector_(nullptr), nestedRefVector_(nullptr), iter_(0) {}
 

--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -14,7 +14,6 @@
       <class name="edm::RefProd<std::vector<L2MuonTrajectorySeed> >"/>
       <class name="edm::RefVector<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> >"/>
       <class name="edm::RefVectorIterator<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> >"/>
-      <class pattern="std::iterator<*edm::Ref*L2MuonTrajectorySeed*>"/>
     
       <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> > >"/>
       <class name="edm::reftobase::Holder<L2MuonTrajectorySeed,edm::Ref<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> > >"/>
@@ -44,7 +43,6 @@
       <class name="edm::RefProd<std::vector<L3MuonTrajectorySeed> >"/>
       <class name="edm::RefVector<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed> >"/>
       <class name="edm::RefVectorIterator<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed> >"/>
-      <class pattern="std::iterator<*edm::Ref*L3MuonTrajectorySeed*>"/>
     
       <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed> > >"/>
       <class name="edm::reftobase::Holder<L3MuonTrajectorySeed,edm::Ref<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L3MuonTrajectorySeed>,L3MuonTrajectorySeed> > >"/>


### PR DESCRIPTION

#### PR description:

- C++17 deprecated std::iterator. Changed to new way of specifying iterator meta data.
- Changed typedef to using.

#### PR validation:

Code compiles.