### PR TITLE
Fix build errors when compiled with -O0

### DIFF
--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/RunInfo"/>
 <use name="CondFormats/SiPixelObjects"/>
+<use name="CondCore/SiPixelPlugins"/>
 <use name="CalibTracker/SiStripCommon"/>
 <use name="DQM/TrackerRemapper"/>
 <use name="DQM/SiPixelPhase1Common"/>

--- a/Calibration/IsolatedParticles/src/FindDistCone.cc
+++ b/Calibration/IsolatedParticles/src/FindDistCone.cc
@@ -78,10 +78,10 @@ namespace spr {
       dR = fabs(Rec * ce1 * sqrt(1. / z / z - 1.));
     else
       dR = 999999.;
-    return dR;
     if (debug)
       edm::LogVerbatim("IsoTrack") << "getDistInCMatHcal: between (" << eta1 << ", " << phi1 << ") and (" << eta2
                                    << ", " << phi2 << " is " << dR;
+    return dR;
   }
 
   void getEtaPhi(HBHERecHitCollection::const_iterator hit,

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -3360,7 +3360,6 @@ int TrackerMap::module(int fedId, int fedCh) {
     return (apvpair->mod->idex);
   }
   return (0);
-  std::cout << "*** error in FedTrackerMap module method ***";
 }
 void TrackerMap::fill_fed_channel(int fedId, int fedCh, float qty) {
   int key = fedId * 1000 + fedCh;

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -223,7 +223,6 @@ namespace {
 
     std::pair<bool, float> getFromPayload(RunInfo& payload) override {
       bool isRealRun = ((payload.m_run) != -1);
-      float fieldIntensity = RunInfoPI::theBField(payload.m_avg_current);
 
       switch (param) {
         case RunInfoPI::m_start_current:
@@ -237,12 +236,12 @@ namespace {
         case RunInfoPI::m_min_current:
           return std::make_pair(isRealRun, payload.m_min_current);
         case RunInfoPI::m_BField:
-          return std::make_pair(isRealRun, fieldIntensity);
+          return std::make_pair(isRealRun, RunInfoPI::theBField(payload.m_avg_current));
         default:
           edm::LogWarning("LogicError") << "Unknown parameter: " << param;
           break;
       }
-
+      return std::make_pair(isRealRun, -1.0);
     }  // payload
 
     /************************************************/

--- a/CondFormats/DQMObjects/src/HDQMSummary.cc
+++ b/CondFormats/DQMObjects/src/HDQMSummary.cc
@@ -53,10 +53,10 @@ bool HDQMSummary::put(const uint32_t& DetId, InputVector& input, std::vector<std
 const HDQMSummary::Range HDQMSummary::getRange(const uint32_t& DetId) const {
   RegistryIterator p = std::lower_bound(indexes_.begin(), indexes_.end(), DetId, HDQMSummary::StrictWeakOrdering());
   if (p == indexes_.end() || p->detid != DetId) {
+    edm::LogWarning("HDQMSummary") << "not in range";
     return HDQMSummary::Range(v_sum_.end(), v_sum_.end());
-    std::cout << "not in range " << std::endl;
-  } else
-    return HDQMSummary::Range(v_sum_.begin() + p->ibegin, v_sum_.begin() + p->ibegin + userDBContent_.size());
+  }
+  return HDQMSummary::Range(v_sum_.begin() + p->ibegin, v_sum_.begin() + p->ibegin + userDBContent_.size());
 }
 
 std::vector<uint32_t> HDQMSummary::getDetIds() const {

--- a/CondFormats/SiStripObjects/src/SiStripSummary.cc
+++ b/CondFormats/SiStripObjects/src/SiStripSummary.cc
@@ -61,10 +61,10 @@ bool SiStripSummary::put(sistripsummary::TrackerRegion region,
 const SiStripSummary::Range SiStripSummary::getRange(const uint32_t& DetId) const {
   RegistryIterator p = std::lower_bound(indexes_.begin(), indexes_.end(), DetId, SiStripSummary::StrictWeakOrdering());
   if (p == indexes_.end() || p->detid != DetId) {
+    edm::LogWarning("SiStripSummary") << "not in range";
     return SiStripSummary::Range(v_sum_.end(), v_sum_.end());
-    std::cout << "not in range " << std::endl;
-  } else
-    return SiStripSummary::Range(v_sum_.begin() + p->ibegin, v_sum_.begin() + p->ibegin + userDBContent_.size());
+  }
+  return SiStripSummary::Range(v_sum_.begin() + p->ibegin, v_sum_.begin() + p->ibegin + userDBContent_.size());
 }
 
 std::vector<uint32_t> SiStripSummary::getDetIds() const {

--- a/DQM/HcalCommon/src/ElectronicsQuantity.cc
+++ b/DQM/HcalCommon/src/ElectronicsQuantity.cc
@@ -283,7 +283,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FED() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[12];
       for (int i = 0; i < FED_TOTAL_NUM; i++) {
         HcalElectronicsId eid = getEid_FED(i);
         sprintf(name, "%d", eid.isVMEid() ? eid.dccid() + 700 : utilities::crate2fed(eid.crateId(), eid.slot()));
@@ -294,7 +294,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FEDuTCA() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[12];
       for (int i = 0; i < FED_uTCA_NUM; i++) {
         HcalElectronicsId eid = getEid_FEDuTCA(i);
         sprintf(name, "%d", utilities::crate2fed(eid.crateId(), eid.slot()));
@@ -305,7 +305,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FEDVME() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[12];
       for (int i = 0; i < FED_VME_NUM; i++) {
         sprintf(name, "%d", getEid_FEDVME(i).dccid() + 700);
         labels.push_back(std::string(name));
@@ -423,7 +423,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FEDVMESpigot() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < FED_VME_NUM; i++)
         for (int j = 0; j < SPIGOT_NUM; j++) {
           if (j > 0) {
@@ -440,7 +440,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FiberuTCAFiberCh() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < FIBER_uTCA_NUM; i++)
         for (int j = 0; j < FIBERCH_NUM; j++) {
           if (j > 0) {
@@ -457,7 +457,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FiberVMEFiberCh() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < FIBER_VME_NUM; i++)
         for (int j = 0; j < FIBERCH_NUM; j++) {
           if (j > 0) {
@@ -473,7 +473,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_SLB() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < SLB_NUM; i++) {
         HcalElectronicsId eid = getEid_SLB(i);
         sprintf(name, "%d", eid.slbSiteNumber());
@@ -485,7 +485,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_SLBCh() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < SLBCH_NUM; i++) {
         HcalElectronicsId eid = getEid_SLBCh(i);
         sprintf(name, "%d", eid.slbChannelIndex());
@@ -497,7 +497,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_SLBSLBCh() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < SLB_NUM; i++)
         for (int j = 0; j < SLBCH_NUM; j++) {
           HcalElectronicsId eid = getEid_SLBSLBCh(i * SLBCH_NUM + j);
@@ -510,7 +510,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FiberuTCATP() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < TPFIBER_NUM; i++) {
         HcalElectronicsId eid = getEid_FiberuTCATP(i);
         sprintf(name, "%d", eid.fiberIndex());
@@ -522,7 +522,7 @@ namespace hcaldqm {
 
     std::vector<std::string> getLabels_FiberChuTCATP() {
       std::vector<std::string> labels;
-      char name[10];
+      char name[23];
       for (int i = 0; i < TPFIBERCH_NUM; i++) {
         HcalElectronicsId eid = getEid_FiberChuTCATP(i);
         sprintf(name, "%d", eid.fiberChanId());

--- a/DQM/HcalCommon/src/HashFunctions.cc
+++ b/DQM/HcalCommon/src/HashFunctions.cc
@@ -333,7 +333,7 @@ namespace hcaldqm {
     }
 
     std::string name_FED(HcalElectronicsId const &eid) {
-      char name[10];
+      char name[15];
       sprintf(name, "FED%d", eid.isVMEid() ? eid.dccid() + 700 : utilities::crate2fed(eid.crateId(), eid.slot()));
       return std::string(name);
     }

--- a/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/OnlineBeamSpotESProducer.cc
@@ -177,11 +177,10 @@ std::shared_ptr<const BeamSpotObjects> OnlineBeamSpotESProducer::produce(const B
   }
   if (best) {
     return std::shared_ptr<const BeamSpotObjects>(best, edm::do_nothing_deleter());
-  } else {
-    return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
-    edm::LogWarning("OnlineBeamSpotESProducer")
-        << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one(fallback to PCL).";
   }
-};
+  edm::LogWarning("OnlineBeamSpotESProducer")
+      << "None of the Online BeamSpots in the ES is suitable, \n returning a fake one(fallback to PCL).";
+  return std::shared_ptr<const BeamSpotObjects>(&fakeBS_, edm::do_nothing_deleter());
+}
 
 DEFINE_FWK_EVENTSETUP_MODULE(OnlineBeamSpotESProducer);


### PR DESCRIPTION
Building cmsw with `-O0` instead of `O2` failed with many error like 
```
error: control reaches end of non-void function
error: '%d' directive writing between 1 and 11 bytes into a region of size 7 [-Werror=format-overflow=]
```

This PR fixes those errors. 

[a] https://github.com/cms-sw/cmsdist/pull/8761
- https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-78c587/35209/build-logs/Calibration/IsolatedParticles/log.html

```
Calibration/IsolatedParticles/src/FindDistCone.cc: In function 'double spr::getDistInCMatHcal(double, double, double, double, bool)':
  Calibration/IsolatedParticles/src/FindDistCone.cc:85:3: error: control reaches end of non-void function [-Werror=return-type]
    85 |   }
```
 - https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-78c587/35209/build-logs/DQM/HcalCommon/log.html
```
  DQM/HcalCommon/src/HashFunctions.cc:337:25: error: '%d' directive writing between 1 and 11 bytes into a region of size 7 [-Werror=format-overflow=]
   337 |       sprintf(name, "FED%d", eid.isVMEid() ? eid.dccid() + 700 : utilities::crate2fed(eid.crateId(), eid.slot()));

 DQM/HcalCommon/src/ElectronicsQuantity.cc:435:18: note: 'sprintf' output between 4 and 24 bytes into a destination of size 10
  435 |           sprintf(name, "%d-%d", eid.dccid() + FED_VME_MIN, eid.spigot());
```