### PR TITLE
Fix may be used uninitialized warning in `RecoTracker/MeasurementDet` (el8_aarch64_gcc12)

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -15,7 +15,7 @@ namespace {
 }  // namespace
 
 TkPixelMeasurementDet::TkPixelMeasurementDet(const GeomDet* gdet, PxMeasurementConditionSet& conditions)
-    : MeasurementDet(gdet), theDetConditions(&conditions) {
+    : MeasurementDet(gdet), index_(0), theDetConditions(&conditions) {
   if (dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
     throw MeasurementDetException("TkPixelMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
   }

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -85,7 +85,6 @@ public:
   void setIndex(int i) { index_ = i; }
 
 private:
-  unsigned int id_;
   std::vector<LocalPoint> badRocPositions_;
 
   int index_;


### PR DESCRIPTION
Hello,

I followed @makortel suggestion on https://github.com/cms-sw/cmssw/issues/42625#issuecomment-1688340530 to fix the following warning in `el8_aarch64_gcc12` IBs (I think the same reasoning applies here):

```
  /data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h:17:18: warning: 'MEM[(const struct TkPixelMeasurementDet &)&D.27209].id_' may be used uninitialized [-Wmaybe-uninitialized]
    17 | class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {
      |                  ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc: In member function 'addDets':
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc:276:72: note: '<anonymous>' declared here
  276 |     thePixelDets.push_back(TkPixelMeasurementDet(gd, thePxDetConditions));
      |                                                                        ^
In member function '__ct ',
    inlined from 'construct' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/new_allocator.h:175:4,
    inlined from 'construct' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/alloc_traits.h:516:17,
    inlined from '_M_realloc_insert' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:462:28,
    inlined from 'emplace_back' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:123:21,
    inlined from 'push_back' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/el8_aarch64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1294:21,
    inlined from 'addPixelDet' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc:276:27,
    inlined from 'addDets' at /data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc:232:22:
  /data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h:17:18: warning: 'MEM[(const struct TkPixelMeasurementDet &)&D.27209].index_' may be used uninitialized [-Wmaybe-uninitialized]
    17 | class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {
      |                  ^
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc: In member function 'addDets':
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/dcf6cec92d4b7e97e1c4b72c2e293d08/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-15-2300/src/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc:276:72: note: '<anonymous>' declared here
  276 |     thePixelDets.push_back(TkPixelMeasurementDet(gd, thePxDetConditions));
      |                                                                        ^
Leaving library rule at src/RecoTracker/MeasurementDet/plugins
```


See full log at [CMSSW_13_3_X_2023-10-16-2300](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_aarch64_gcc12/CMSSW_13_3_X_2023-10-16-2300/RecoTracker/MeasurementDet).

Tested with a local build.