### PR TITLE
Add more tests for cmsRun argument parsing

### DIFF
--- a/FWCore/Framework/test/test_catch2_CmsRunParser.cc
+++ b/FWCore/Framework/test/test_catch2_CmsRunParser.cc
@@ -37,7 +37,16 @@ TEST_CASE("test cmsRun command line parsing", "[commandline]") {
     REQUIRE(edm::CmsRunParser::getExit(output) == 0);
   }
 
-  SECTION("wrong") {
+  SECTION("wrong (short)") {
+    constexpr int kSize = 2;
+    const char* args[kSize] = {"cmsRun", "-w"};
+    const auto& output = parser.parse(kSize, args);
+
+    REQUIRE(not edm::CmsRunParser::hasVM(output));
+    REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
+  }
+
+  SECTION("wrong (long)") {
     constexpr int kSize = 2;
     const char* args[kSize] = {"cmsRun", "--wrong"};
     const auto& output = parser.parse(kSize, args);
@@ -46,26 +55,307 @@ TEST_CASE("test cmsRun command line parsing", "[commandline]") {
     REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
   }
 
-  SECTION("Config file only") {
-    constexpr int kSize = 2;
-    const std::string arg("config.py");
-    const char* args[kSize] = {"cmsRun", arg.c_str()};
-    const auto& output = parser.parse(kSize, args);
+  SECTION("Config file") {
+    const std::string arg = "config.py";
 
-    REQUIRE(edm::CmsRunParser::hasVM(output));
-    auto vm = edm::CmsRunParser::getVM(output);
+    SECTION("Config file only") {
+      constexpr int kSize = 2;
+      const char* args[kSize] = {"cmsRun", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
 
-    REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
-    REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
-    REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
-    REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("With --") {
+      constexpr int kSize = 3;
+      const char* args[kSize] = {"cmsRun", "--", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("cmsRun argument") {
+      constexpr int kSize = 4;
+      const std::string jobreport = "report.xml";
+      const char* args[kSize] = {"cmsRun", "-j", jobreport.c_str(), arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(vm[edm::CmsRunParser::kJobreportOpt].as<std::string>() == jobreport);
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("Wrong cmsRun argument (short)") {
+      constexpr int kSize = 3;
+      const char* args[kSize] = {"cmsRun", "-w", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(not edm::CmsRunParser::hasVM(output));
+      REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
+    }
+
+    SECTION("Wrong cmsRun argument (long)") {
+      constexpr int kSize = 3;
+      const char* args[kSize] = {"cmsRun", "--wrong", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(not edm::CmsRunParser::hasVM(output));
+      REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
+    }
+
+    SECTION("python argument") {
+      constexpr int kSize = 3;
+      const std::string parg = "--test";
+      const char* args[kSize] = {"cmsRun", arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kPythonOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("cmsRun and python argument") {
+      constexpr int kSize = 5;
+      const std::string jobreport = "report.xml";
+      const std::string parg = "--test";
+      const char* args[kSize] = {"cmsRun", "-j", jobreport.c_str(), arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(vm[edm::CmsRunParser::kJobreportOpt].as<std::string>() == jobreport);
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("Same cmsRun and python argument") {
+      constexpr int kSize = 4;
+      const std::string parg = "--strict";
+      const char* args[kSize] = {"cmsRun", parg.c_str(), arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+  }
+
+  SECTION("Config file with -") {
+    const std::string arg = "-config.py";
+
+    SECTION("Config file only") {
+      constexpr int kSize = 3;
+      const char* args[kSize] = {"cmsRun", "--", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("cmsRun argument") {
+      constexpr int kSize = 5;
+      const std::string jobreport = "report.xml";
+      const char* args[kSize] = {"cmsRun", "-j", jobreport.c_str(), "--", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(vm[edm::CmsRunParser::kJobreportOpt].as<std::string>() == jobreport);
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kPythonOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("Wrong cmsRun argument (short)") {
+      constexpr int kSize = 4;
+      const char* args[kSize] = {"cmsRun", "-w", "--", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(not edm::CmsRunParser::hasVM(output));
+      REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
+    }
+
+    SECTION("Wrong cmsRun argument (long)") {
+      constexpr int kSize = 4;
+      const char* args[kSize] = {"cmsRun", "--wrong", "--", arg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(not edm::CmsRunParser::hasVM(output));
+      REQUIRE(edm::CmsRunParser::getExit(output) == edm::errors::CommandLineProcessing);
+    }
+
+    SECTION("python argument") {
+      constexpr int kSize = 4;
+      const std::string parg = "--test";
+      const char* args[kSize] = {"cmsRun", "--", arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kPythonOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("cmsRun and python arguments") {
+      constexpr int kSize = 6;
+      const std::string jobreport = "report.xml";
+      const std::string parg = "--test";
+      const char* args[kSize] = {"cmsRun", "-j", jobreport.c_str(), "--", arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(vm[edm::CmsRunParser::kJobreportOpt].as<std::string>() == jobreport);
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
+
+    SECTION("same cmsRun and python arguments") {
+      constexpr int kSize = 5;
+      const std::string parg = "--strict";
+      const char* args[kSize] = {"cmsRun", parg.c_str(), "--", arg.c_str(), parg.c_str()};
+      const auto& output = parser.parse(kSize, args);
+
+      REQUIRE(edm::CmsRunParser::hasVM(output));
+      auto vm = edm::CmsRunParser::getVM(output);
+
+      REQUIRE(vm.count(edm::CmsRunParser::kParameterSetOpt));
+      REQUIRE(vm[edm::CmsRunParser::kParameterSetOpt].as<std::string>() == arg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kHelpOpt));
+      REQUIRE(vm.count(edm::CmsRunParser::kStrictOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kEnableJobreportOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kNumberOfThreadsOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kSizeOfStackForThreadOpt));
+      REQUIRE(not vm.count(edm::CmsRunParser::kJobModeOpt));
+      auto pythonOptValues = vm[edm::CmsRunParser::kPythonOpt].as<std::vector<std::string>>();
+      REQUIRE(pythonOptValues.size() == 1);
+      REQUIRE(pythonOptValues[0] == parg);
+      REQUIRE(not vm.count(edm::CmsRunParser::kCmdOpt));
+    }
   }
 
   SECTION("Command line input only") {


### PR DESCRIPTION
#### PR description:

This PR extends the cmsRun argument parsing tests with what I commented in https://github.com/cms-sw/cmssw/pull/42650#issuecomment-1747471112 .

Resolves https://github.com/makortel/framework/issues/695

#### PR validation:

Unit tests run.