### PR TITLE
Increasing max number of pixel clusters threshold in BeamMonitor client

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -370,12 +370,13 @@ process.dqmBeamMonitor.jetTrigger  = [
          "HLT_PixelClusters"]
 
 # for HI only: select events based on the pixel cluster multiplicity
+# This is done to limit the combinatorics that must be resolved during track reconstruction
 if (process.runType.getRunType() == process.runType.hi_run):
     import HLTrigger.special.hltPixelActivityFilter_cfi
     process.multFilter = HLTrigger.special.hltPixelActivityFilter_cfi.hltPixelActivityFilter.clone(
         inputTag  = 'siPixelClustersPreSplitting',
         minClusters = 150,
-        maxClusters = 50000 # was 10000
+        maxClusters = 70000 # was 50000
     )
        
     process.filter_step = cms.Sequence( process.siPixelDigis


### PR DESCRIPTION
#### PR description:

We observed in recent runs (e.g. 375259) that the BeamMonitor DQM client uses much less PVs for the BeamSpot fit than the BeamMonitorHLT client (~100 vs ~2000, see attached images).

![nPVs_BeamMonitor_Run375259](https://github.com/cms-sw/cmssw/assets/46677792/aa8dd2c7-43dc-4cbc-9084-541fa05ab7fc)
![nPVs_BeamMonitorHLT_Run375259](https://github.com/cms-sw/cmssw/assets/46677792/21d341e9-1f43-4bc1-8f09-8f8861e56ee6)

After some investigations we found out that this is caused by this filter

https://github.com/cms-sw/cmssw/blob/master/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py#L372-L379

which is also applied in the SiStrip client with the same threshold.

https://github.com/cms-sw/cmssw/blob/master/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py#L634-L639

After some studies on streamDQM files from Run 374307 currently used in DQM playback we want to raise threshold to 70k clusters.

Some validation plots can be found in the images (50k cluster (black), 70k cluster (red), 80k cluster (blue)) and more details will be presented in the next TkDPG/POG meeting.

![nPVs_50_70_80](https://github.com/cms-sw/cmssw/assets/46677792/45f3e08d-6603-4935-a5bc-4771cbe71288)
![sigmaX_50_70_80](https://github.com/cms-sw/cmssw/assets/46677792/cff0437e-9c13-4b91-9a16-150439d76758)
![xPos_50_70_80](https://github.com/cms-sw/cmssw/assets/46677792/da5d1a35-fcd4-47f7-af10-d3638adf8510)

#### PR validation:

Validation offline using streamDQM files.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and a backport is not needed.

FYI: @francescobrivio @lguzzi @gennai @mmusich @sroychow @slava77 

We kindly request to add this PR to the playback system to check that everything is ok