### PR TITLE
Use script_test_many_writeTotemDAQMapping.py from release if missing locally

### DIFF
--- a/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
+++ b/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
@@ -26,9 +26,10 @@ if(len(sys.argv)>3):
   
 
 # For each file change the variable values in the config so that they match the selected XML file and then run the config
+test_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'test_writeTotemDAQMapping.py')
 for fileContent in filesToRead:
     for fileInfo in fileContent["configuration"]:
-        with open(f'{os.environ["CMSSW_BASE"]}/src/CalibPPS/ESProducers/test/test_writeTotemDAQMapping.py', 'r+') as f:        
+        with open(test_script, 'r+') as f:
             content = f.read()
             # replace values specific for selected detector
             content = re.sub(r'subSystemName =.*', f'subSystemName = "{fileContent["subSystemName"]}"', content)

--- a/CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh
+++ b/CondTools/CTPPS/test/test_XML_to_SQLite_mapping.sh
@@ -6,6 +6,7 @@ DET_TO_CHECK=("TotemTiming" "TimingDiamond" "TrackingStrip" "TotemT2")
 MASK_DATA="AnalysisMask"
 TEST_DIR=$CMSSW_BASE/src/CondTools/CTPPS/test
 PRINTER_SCRIPT=$CMSSW_BASE/src/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
+[ -e ${PRINTER_SCRIPT} ] || PRINTER_SCRIPT=$CMSSW_RELEASE_BASE/src/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
 
 # ---------------
 python3 ${TEST_DIR}/script-ctpps-write-many-XML-to-SQLite.py False "${DET_TO_CHECK[@]}" || die 'Failed in script-ctpps-write-many-XML-to-SQLite.py' $?


### PR DESCRIPTION
This PR allows to use `CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py` from release area if missing locally. Note that during PR tests it is not guaranteed that package `CalibPPS/ESProducer` will be checkout e.g. for PR https://github.com/cms-sw/cmsdist/pull/8764 , unit test `test_XMLToSQLiteMapping` failed due to missing `CalibPPS/ESProducer` 

https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-ee81ff/35212/unitTests/src/CondTools/CTPPS/test/test_XMLToSQLiteMapping/testing.log
```
===== Test "test_XMLToSQLiteMapping" ====
Generated SQLite files
python3: can't open file '/pool/condor/dir_7825/jenkins/workspace/ib-run-pr-tests/CMSSW_13_3_X_2023-10-16-1100/src/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py': [Errno 2] No such file or directory
Failed in script_test_many_writeTotemDAQMapping.py: status 2

---> test test_XMLToSQLiteMapping had ERRORS
TestTime:72
^^^^ End Test test_XMLToSQLiteMapping ^^^^

```