### PR TITLE
Fixing warning on `hgtopo[i]` uninitialized (`SimGeneral/Debugging`) in SKYLAKEAVX512 IBs

### DIFF
--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -309,6 +309,8 @@ void CaloParticleDebugger::fillSimHits(std::map<int, float>& detIdToTotalSimEner
   hgtopo[1] = &(fhgeom->topology());
   if (bhgeomnew)
     hgtopo[2] = &(bhgeomnew->topology());
+  else
+    hgtopo[2] = nullptr;
 
   for (unsigned i = 0; i < 3; ++i) {
     if (hgtopo[i])


### PR DESCRIPTION
Hello,

Conditionally initializing `hgtopo[2]` (https://github.com/cms-sw/cmssw/blob/master/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc#L310-L311) leads to a warning in `SKYLAKEAVX512` IBs (module `SimGeneral/Debugging`):
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc: In member function 'fillSimHits':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc:314:17: warning: 'hgtopo' may be used uninitialized [-Wmaybe-uninitialized]
   314 |     if (hgtopo[i])
      |                 ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc:291:24: note: 'hgtopo' declared here
  291 |   const HGCalTopology* hgtopo[3];
      |                        ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc: In member function 'fillSimHits':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc:314:17: warning: 'hgtopo' may be used uninitialized [-Wmaybe-uninitialized]
   314 |     if (hgtopo[i])
      |                 ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f7e55b54829c1b9a76c39d00d5ff27d3/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_SKYLAKEAVX512_X_2023-10-15-2300/src/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc:291:24: note: 'hgtopo' declared here
  291 |   const HGCalTopology* hgtopo[3];
      |                        ^
```

I suggest initialize it to `nullptr` when no needed. Feel free to suggest any other option since I am not fully familiar with the module implementation.

Many thanks,
Andrea

