### PR TITLE
Add the ASSERT_DEVICE_MATCHES_HOST_COLLECTION macro

### DIFF
--- a/DataFormats/Portable/interface/alpaka/PortableCollection.h
+++ b/DataFormats/Portable/interface/alpaka/PortableCollection.h
@@ -12,6 +12,10 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
 
+// This header is not used by PortableCollection, but is included here to automatically
+// provide its content to users of ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection.
+#include "HeterogeneousCore/AlpakaInterface/interface/AssertDeviceMatchesHostCollection.h"
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
@@ -21,19 +25,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <typename T>
   using PortableCollection = ::PortableHostCollection<T>;
 
-  // check that the portable device collection for the host device is the same as the portable host collection
-#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)       \
-  static_assert(std::is_same_v<alpaka_serial_sync::DEVICE_COLLECTION, HOST_COLLECTION>, \
-                "The device collection for the host device and the host collection must be the same type!");
-
 #else
 
   // generic SoA-based product in device memory
   template <typename T>
   using PortableCollection = ::PortableDeviceCollection<T, Device>;
-
-  // the portable device collections for the non-host devices do not require any checks
-#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)
 
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 

--- a/DataFormats/Portable/interface/alpaka/PortableCollection.h
+++ b/DataFormats/Portable/interface/alpaka/PortableCollection.h
@@ -21,11 +21,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <typename T>
   using PortableCollection = ::PortableHostCollection<T>;
 
+  // check that the portable device collection for the host device is the same as the portable host collection
+#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)       \
+  static_assert(std::is_same_v<alpaka_serial_sync::DEVICE_COLLECTION, HOST_COLLECTION>, \
+                "The device collection for the host device and the host collection must be the same type!");
+
 #else
 
   // generic SoA-based product in device memory
   template <typename T>
   using PortableCollection = ::PortableDeviceCollection<T, Device>;
+
+  // the portable device collections for the non-host devices do not require any checks
+#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)
 
 #endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 

--- a/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
+++ b/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
@@ -2,6 +2,7 @@
 #define DataFormats_PortableTestObjects_interface_alpaka_TestDeviceCollection_h
 
 #include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
@@ -13,11 +14,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // inside the ALPAKA_ACCELERATOR_NAMESPACE::portabletest namespace
     using namespace ::portabletest;
 
+    // SoA with x, y, z, id fields in host memory
+    using ::portabletest::TestHostCollection;
+
     // SoA with x, y, z, id fields in device global memory
     using TestDeviceCollection = PortableCollection<TestSoA>;
 
   }  // namespace portabletest
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+// check that the portable device collection for the host device is the same as the portable host collection
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(portabletest::TestDeviceCollection, portabletest::TestHostCollection);
 
 #endif  // DataFormats_PortableTestObjects_interface_alpaka_TestDeviceCollection_h

--- a/HeterogeneousCore/AlpakaInterface/interface/AssertDeviceMatchesHostCollection.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AssertDeviceMatchesHostCollection.h
@@ -1,0 +1,22 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_AssertDeviceMatchesHostCollection_h
+#define HeterogeneousCore_AlpakaInterface_interface_AssertDeviceMatchesHostCollection_h
+
+#include <type_traits>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+// check that the portable device collection for the host device is the same as the portable host collection
+#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)       \
+  static_assert(std::is_same_v<alpaka_serial_sync::DEVICE_COLLECTION, HOST_COLLECTION>, \
+                "The device collection for the host device and the host collection must be the same type!");
+
+#else
+
+// the portable device collections for the non-host devices do not require any checks
+#define ASSERT_DEVICE_MATCHES_HOST_COLLECTION(DEVICE_COLLECTION, HOST_COLLECTION)
+
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_AssertDeviceMatchesHostCollection_h

--- a/HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h
+++ b/HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h
@@ -19,4 +19,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using AlpakaESTestDataDDevice = PortableCollection<cms::alpakatest::AlpakaESTestSoAD>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#endif
+// check that the portable device collections for the host device are the same as the portable host collections
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataADevice, cms::alpakatest::AlpakaESTestDataAHost);
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataCDevice, cms::alpakatest::AlpakaESTestDataCHost);
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(AlpakaESTestDataDDevice, cms::alpakatest::AlpakaESTestDataDHost);
+
+#endif  // HeterogeneousCore_AlpakaTest_interface_alpaka_AlpakaESTestData_h


### PR DESCRIPTION
#### PR description:

Add a macro to check that the portable device collection for the host device is the same as the portable host collection.

Add tests from the event data and event setup portable collections.

#### PR validation:

The code compiles correctly, including the new static assertions.