### PR TITLE
Add storing of invalid ROC number error (errorType=36) in pixel GPU code

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -330,12 +330,13 @@ namespace pixelgpudetails {
 
       // check for spurious channels
       if (roc > MAX_ROC or link > MAX_LINK) {
+        uint32_t rawId = getRawId(cablingMap, fedId, link, 1).rawId;
         if constexpr (debug) {
-          printf("spurious roc %d found on link %d, detector %d (index %d)\n",
-                 roc,
-                 link,
-                 getRawId(cablingMap, fedId, link, 1).rawId,
-                 gIndex);
+          printf("spurious roc %d found on link %d, detector %d (index %d)\n", roc, link, rawId, gIndex);
+        }
+        if (roc > MAX_ROC and roc < 25) {
+          uint8_t error = conversionError<debug>(fedId, 2);
+          err->push_back(SiPixelErrorCompact{rawId, ww, error, fedId});
         }
         continue;
       }


### PR DESCRIPTION
#### PR description:

This is the latest in the series of PRs addressing imbalance in pixel FED errors in the GPU and CPU codes. After https://github.com/cms-sw/cmssw/pull/42977 or, to be more precise, its 13_2_X backport https://github.com/cms-sw/cmssw/pull/42978 was deployed in HI data taking, a remaining tiny mismatch concerning `errorType=36` (invalid ROC number) was observed in [online DQM for run 375202](https://cmsweb.cern.ch/dqm/online/start?runnr=375202;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU;focus=SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU/FEErrorVsFEDIdUnbalance;zoom=yes;). The origin of this mismatch was traced to the [this CPU code block](https://github.com/cms-sw/cmssw/blob/CMSSW_13_2_6/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc#L145-L151) handling `errorType=36` that does not have its equivalent in the GPU code. This missing piece in the GPU is added in this PR.

#### PR validation:

To test the PR a single event where an error of type 36 occurs was picked from `/HIExpressPhysics/HIRun2023A-Express-v2/FEVT` (`Run 375202, Event 158786571, LumiSection 177`) and a modified version of wf 141.008583 was run on it. Before this PR the DQM plot the `SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU/FEErrorVsFEDIdUnbalance` shows a mismatch
![FEDErrorVsFEDIdImbalance_ref3](https://github.com/cms-sw/cmssw/assets/4885289/32ad99dc-4969-4d00-a708-4eb0d6d67614)
and with the PR applied the mismatch is gone
![FEDErrorVsFEDIdImbalance_pr3](https://github.com/cms-sw/cmssw/assets/4885289/887b0363-f8b0-475a-a574-eca9f798ccfc)
This errors is fairly rare and it required processing close to 250k events from run 375202 in `/HIExpressPhysics/HIRun2023A-Express-v2/FEVT` to find the first occurrence of this error.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 13_2_X planned.
