### PR TITLE
Clean up deprecated edm::RefToBase list 1 for RNTuple

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -302,7 +302,6 @@
   <class name="std::vector<Measurement1D>"/>
 
   <!-- RefToBase stuff -->
-  <class name="edm::RefToBase<reco::BaseTagInfo>" />
   <class name="edm::reftobase::BaseHolder<reco::BaseTagInfo>" />
   <class name="edm::reftobase::IndirectHolder<reco::BaseTagInfo>" />
   <class name="edm::reftobase::Holder<reco::BaseTagInfo, reco::BaseTagInfoRef>" />

--- a/DataFormats/Candidate/interface/CompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/CompositeCandidateFwd.h
@@ -21,12 +21,12 @@ namespace reco {
   typedef edm::View<CompositeCandidate> CompositeCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<CompositeCandidateCollection> CompositeCandidateRef;
-  /// persistent reference to an object in a collection of Candidate objects
-  typedef edm::RefToBase<CompositeCandidate> CompositeCandidateBaseRef;
+  //  /// persistent reference to an object in a collection of Candidate objects
+  //  typedef edm::RefToBase<CompositeCandidate> CompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<CompositeCandidateCollection> CompositeCandidateRefVector;
-  /// vector of references to objects in the same collection of Candidate objects via base type
-  typedef edm::RefToBaseVector<CompositeCandidate> CompositeCandidateBaseRefVector;
+  //  /// vector of references to objects in the same collection of Candidate objects via base type
+  //  typedef edm::RefToBaseVector<CompositeCandidate> CompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<CompositeCandidateCollection> CompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/CompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/CompositeCandidateFwd.h
@@ -21,12 +21,8 @@ namespace reco {
   typedef edm::View<CompositeCandidate> CompositeCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<CompositeCandidateCollection> CompositeCandidateRef;
-  //  /// persistent reference to an object in a collection of Candidate objects
-  //  typedef edm::RefToBase<CompositeCandidate> CompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<CompositeCandidateCollection> CompositeCandidateRefVector;
-  //  /// vector of references to objects in the same collection of Candidate objects via base type
-  //  typedef edm::RefToBaseVector<CompositeCandidate> CompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<CompositeCandidateCollection> CompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
@@ -25,8 +25,8 @@ namespace reco {
   typedef edm::RefToBase<NamedCompositeCandidate> NamedCompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<NamedCompositeCandidateCollection> NamedCompositeCandidateRefVector;
-  /// vector of references to objects in the same collection of Candidate objects via base type
-  typedef edm::RefToBaseVector<NamedCompositeCandidate> NamedCompositeCandidateBaseRefVector;
+  //  /// vector of references to objects in the same collection of Candidate objects via base type
+  //  typedef edm::RefToBaseVector<NamedCompositeCandidate> NamedCompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<NamedCompositeCandidateCollection> NamedCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/NamedCompositeCandidateFwd.h
@@ -25,8 +25,6 @@ namespace reco {
   typedef edm::RefToBase<NamedCompositeCandidate> NamedCompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<NamedCompositeCandidateCollection> NamedCompositeCandidateRefVector;
-  //  /// vector of references to objects in the same collection of Candidate objects via base type
-  //  typedef edm::RefToBaseVector<NamedCompositeCandidate> NamedCompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<NamedCompositeCandidateCollection> NamedCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
@@ -21,12 +21,8 @@ namespace reco {
   typedef edm::View<VertexCompositeCandidate> VertexCompositeCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<VertexCompositeCandidateCollection> VertexCompositeCandidateRef;
-  //  /// persistent reference to an object in a collection of Candidate objects
-  //  typedef edm::RefToBase<VertexCompositeCandidate> VertexCompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<VertexCompositeCandidateCollection> VertexCompositeCandidateRefVector;
-  //  /// vector of references to objects in the same collection of Candidate objects via base type
-  //  typedef edm::RefToBaseVector<VertexCompositeCandidate> VertexCompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<VertexCompositeCandidateCollection> VertexCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h
@@ -21,12 +21,12 @@ namespace reco {
   typedef edm::View<VertexCompositeCandidate> VertexCompositeCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<VertexCompositeCandidateCollection> VertexCompositeCandidateRef;
-  /// persistent reference to an object in a collection of Candidate objects
-  typedef edm::RefToBase<VertexCompositeCandidate> VertexCompositeCandidateBaseRef;
+  //  /// persistent reference to an object in a collection of Candidate objects
+  //  typedef edm::RefToBase<VertexCompositeCandidate> VertexCompositeCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<VertexCompositeCandidateCollection> VertexCompositeCandidateRefVector;
-  /// vector of references to objects in the same collection of Candidate objects via base type
-  typedef edm::RefToBaseVector<VertexCompositeCandidate> VertexCompositeCandidateBaseRefVector;
+  //  /// vector of references to objects in the same collection of Candidate objects via base type
+  //  typedef edm::RefToBaseVector<VertexCompositeCandidate> VertexCompositeCandidateBaseRefVector;
   /// reference to a collection of Candidate objects
   typedef edm::RefProd<VertexCompositeCandidateCollection> VertexCompositeCandidateRefProd;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
@@ -21,8 +21,6 @@ namespace reco {
   typedef edm::View<VertexCompositePtrCandidate> VertexCompositePtrCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<VertexCompositePtrCandidateCollection> VertexCompositePtrCandidateRef;
-  //  /// persistent reference to an object in a collection of Candidate objects
-  //  typedef edm::RefToBase<VertexCompositePtrCandidate> VertexCompositePtrCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<VertexCompositePtrCandidateCollection> VertexCompositePtrCandidateRefVector;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
+++ b/DataFormats/Candidate/interface/VertexCompositePtrCandidateFwd.h
@@ -21,8 +21,8 @@ namespace reco {
   typedef edm::View<VertexCompositePtrCandidate> VertexCompositePtrCandidateView;
   /// persistent reference to an object in a collection of Candidate objects
   typedef edm::Ref<VertexCompositePtrCandidateCollection> VertexCompositePtrCandidateRef;
-  /// persistent reference to an object in a collection of Candidate objects
-  typedef edm::RefToBase<VertexCompositePtrCandidate> VertexCompositePtrCandidateBaseRef;
+  //  /// persistent reference to an object in a collection of Candidate objects
+  //  typedef edm::RefToBase<VertexCompositePtrCandidate> VertexCompositePtrCandidateBaseRef;
   /// vector of references to objects in the same  collection of Candidate objects
   typedef edm::RefVector<VertexCompositePtrCandidateCollection> VertexCompositePtrCandidateRefVector;
   /// vector of references to objects in the same collection of Candidate objects via base type

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -81,11 +81,8 @@
   
   <class name="std::vector<reco::PhotonCore>"/>
   <class name="edm::reftobase::BaseHolder<reco::PhotonCore>"/>
-  <class name="edm::RefToBase<reco::PhotonCore>"/>
   <class name="edm::reftobase::IndirectHolder<reco::PhotonCore>" />
   <class name="edm::RefToBaseProd<reco::PhotonCore>" />
-  <class name="edm::RefToBaseVector<reco::PhotonCore>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::PhotonCore> >" />
   <class name="edm::reftobase::BaseVectorHolder<reco::PhotonCore>" />
   <class name="edm::Wrapper<std::vector<reco::PhotonCore> >"/>
   <class name="edm::Ref<std::vector<reco::PhotonCore>,reco::PhotonCore,edm::refhelper::FindUsingAdvance<std::vector<reco::PhotonCore>,reco::PhotonCore> >"/>
@@ -144,11 +141,8 @@
 
   <class name="std::vector<reco::GsfElectronCore>"/>
   <class name="edm::reftobase::BaseHolder<reco::GsfElectronCore>"/>
-  <class name="edm::RefToBase<reco::GsfElectronCore>"/>
   <class name="edm::reftobase::IndirectHolder<reco::GsfElectronCore>" />
   <class name="edm::RefToBaseProd<reco::GsfElectronCore>" />
-  <class name="edm::RefToBaseVector<reco::GsfElectronCore>" />
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::GsfElectronCore> >" />
   <class name="edm::reftobase::BaseVectorHolder<reco::GsfElectronCore>" />
   <class name="edm::Wrapper<std::vector<reco::GsfElectronCore> >"/>
   <class name="edm::Ref<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfElectronCore>,reco::GsfElectronCore> >"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -107,7 +107,6 @@
   <class name="edm::Wrapper<std::vector<reco::ElectronSeed> >"/>
   <class name="edm::RefVector<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
-  <class name="edm::RefToBase<reco::ElectronSeed>"/>
   <class name="edm::reftobase::BaseHolder<reco::ElectronSeed>" />
   <class name="edm::reftobase::IndirectHolder<reco::ElectronSeed>" />
   <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>

--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -4,7 +4,6 @@
        <version ClassVersion="11" checksum="541533207"/>
        <version ClassVersion="10" checksum="2502730614"/>
       </class>
-      <class name="edm::RefToBase<L2MuonTrajectorySeed>"/>
       <class name="edm::reftobase::BaseHolder<L2MuonTrajectorySeed>" />
       <class name="edm::reftobase::IndirectHolder<L2MuonTrajectorySeed>" />
     
@@ -34,7 +33,6 @@
        <version ClassVersion="11" checksum="981061883"/>
        <version ClassVersion="10" checksum="2200485484"/>
       </class>
-      <class name="edm::RefToBase<L3MuonTrajectorySeed>"/>
       <class name="edm::reftobase::BaseHolder<L3MuonTrajectorySeed>" />
       <class name="edm::reftobase::IndirectHolder<L3MuonTrajectorySeed>" />
     

--- a/DataFormats/ParticleFlowReco/src/classes_def_1.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_1.xml
@@ -53,7 +53,6 @@
   <class name="edm::Wrapper<std::vector<reco::ConvBremSeed> >"/>
   <class name="edm::RefVector<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> > >"/>
-  <class name="edm::RefToBase<reco::ConvBremSeed>"/>
   <class name="edm::reftobase::BaseHolder<reco::ConvBremSeed>" />
   <class name="edm::reftobase::RefHolder<edm::Ref<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> > >"/>
   <class name="edm::reftobase::Holder<reco::ConvBremSeed,edm::Ref<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> > >"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -41,12 +41,8 @@
   <class name="edm::RefToBaseProd<reco::PFTau>" >
      <!-- <field name="view_" transient="true" /> -->
   </class>
-  <class name="edm::RefToBase<reco::PFTau>" />
   <class name="edm::reftobase::BaseHolder<reco::PFTau>" />
   <class name="edm::reftobase::IndirectHolder<reco::PFTau>" />
-    <!---<class name="edm::reftobase::Holder<reco::PFTau,edm::RefToBase<reco::PFTau> > "/>-->
-  <class name="edm::RefToBaseVector<reco::PFTau>"/>
-  <class name="edm::Wrapper<edm::RefToBaseVector<reco::PFTau> >"/>
   <class name="edm::reftobase::BaseVectorHolder<reco::PFTau>"/>
   <class name="edm::reftobase::Holder<reco::PFTau, reco::PFTauRef>" />
   <class name="edm::reftobase::RefHolder<reco::PFTauRef>" />

--- a/SimDataFormats/TrackingHit/interface/PSimHitContainer.h
+++ b/SimDataFormats/TrackingHit/interface/PSimHitContainer.h
@@ -14,9 +14,6 @@ namespace edm {
 typedef edm::Ref<edm::PSimHitContainer> TrackPSimHitRef;
 typedef edm::RefProd<edm::PSimHitContainer> TrackPSimHitRefProd;
 
-typedef std::vector<edm::RefToBase<PSimHit> > TrackPSimHitRefToBaseVector;
-typedef edm::RefToBase<PSimHit> TrackPSimHitRefToBase;
-typedef std::vector<edm::RefToBase<PSimHit> > TrackPSimHitRefToBaseVector;
 typedef edm::reftobase::Holder<PSimHit, TrackPSimHitRef> TrackPSimHitRefToBaseHolder;
 
 #endif

--- a/SimDataFormats/TrackingHit/src/classes_def.xml
+++ b/SimDataFormats/TrackingHit/src/classes_def.xml
@@ -9,8 +9,6 @@
   <class name="edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> >"/>
 
   <class name="edm::reftobase::BaseHolder<PSimHit>"/>
-  <class name="edm::RefToBase<PSimHit>"/>
-  <class name="std::vector<edm::RefToBase<PSimHit> >"/>
   <class name="edm::reftobase::Holder<PSimHit,edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> > >"/>
 
 </lcgdict>


### PR DESCRIPTION
#### PR description:
This pull request is the first update to address the opened issue #42737 :

 ROOT is eventually deprecating the current TTree data storage in favor of their new `RNTuple`. The `RNTuple` is not planned to support dynamic polymorphism. One such use case in our data formats is `edm::RefToBase<T>` that internally uses dynamic-polymorphism based type erasure. The straightforward migration path is towards [`edm::Ptr<T>`](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMRef), but there are also many cases where the use of `edm::RefToBase<T>` could be cleaned up.

This PR covers the first case on the list in the issue #42737.
It contains the set of deprecated `edm::RefToBase` that only dictionary declaration and/or type aliases and/or commented-out code, otherwise unused case. 
All of these can be easily removed without any impact.

#### PR validation:
Tested in CMSSW_13_3_0_pre3, the basic test passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
