### PR TITLE
Skip EcalRawData collection in ECAL DQM in GPU WFs

### DIFF
--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
@@ -9,3 +9,8 @@ from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask
 gpuValidationEcal.toModify(ecalGpuTask.params, runGpuTask = True)
 gpuValidationEcal.toModify(ecalMonitorTask.workers, func = lambda workers: workers.append("GpuTask"))
 gpuValidationEcal.toModify(ecalMonitorTask, workerParameters = dict(GpuTask = ecalGpuTask))
+
+# Skip consuming and running over the EcalRawData collection for all GPU WFs
+# This is to be used as long as the GPU unpacker unpacks a dummy EcalRawData collection
+from Configuration.ProcessModifiers.gpu_cff import gpu
+gpu.toModify(ecalMonitorTask.skipCollections, func = lambda skipCollections: skipCollections.append("EcalRawData"))


### PR DESCRIPTION
#### PR description:

ECAL DQM plots were showing up empty in GPU WFs in the most recent CMSSW IB releases. This was due to the introduction of a dummy `EcalRawData` collection in PR https://github.com/cms-sw/cmssw/pull/42844, which was done in order to get rid of the error messages in issue https://github.com/cms-sw/cmssw/issues/42720.

The problem is that most ECAL DQM tasks implement a `filterRunType()` function that uses `EcalRawData` to determine whether or not the task should run. It appears that for MC the run type is set to -1 (at least on GPUs), which is not a defined run type. This means that all tasks with a `filterRunType()` function are not scheduled to run.

The solution implemented is to skip `EcalRawData` using the new `skipCollections` parameter introduced in https://github.com/cms-sw/cmssw/pull/42848. This is done using the `gpu` modifier to skip the collection for all GPU WFs, not just those used for ECAL GPU validation.

This is only to be used as long as the GPU unpacker unpacks a dummy `EcalRawData` collection.

It would be great if this could be integrated before 13_3_0_pre4 gets cut.

#### PR validation:

Validated on WF `12434.513`. Plots are now filled as expected.

```
runTheMatrix.py --what gpu -l 12434.513
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A