### PR TITLE
[NanoAOD] Add pthatmax variable

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -97,7 +97,7 @@ public:
     out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
     out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
     if (savePtHatMax_) {
-      out.addColumnValue<float>("pthatmax", pthatmax, "Maximum pt-hat");
+      out.addColumnValue<float>("pthatmax", pthatmax, "Maximum pt-hat", 10);
     }
   }
 

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.globalVariablesTableProducer_cfi import globalVariablesTableProducer
 from PhysicsTools.NanoAOD.simpleBeamspotFlatTableProducer_cfi import simpleBeamspotFlatTableProducer
 from PhysicsTools.NanoAOD.simpleGenEventFlatTableProducer_cfi import simpleGenEventFlatTableProducer
@@ -34,7 +35,10 @@ puTable = cms.EDProducer("NPUTablesProducer",
         src = cms.InputTag("slimmedAddPileupInfo"),
         pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
         zbins = cms.vdouble( [0.0,1.7,2.6,3.0,3.5,4.2,5.2,6.0,7.5,9.0,12.0] ),
-        savePtHatMax = cms.bool(False),
+        savePtHatMax = cms.bool(True),
+)
+(run2_nanoAOD_ANY | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+    puTable, savePtHatMax=False
 )
 
 genTable  = simpleGenEventFlatTableProducer.clone(

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -145,6 +145,17 @@ run2_nanoAOD_ANY.toModify(
     plots = _SubJet_EarlyRun3_plots
 )
 
+
+_Pileup_pre13X_plots = cms.VPSet()
+for plot in nanoDQM.vplots.Pileup.plots:
+    if 'pthatmax' not in plot.name.value():
+        _Pileup_pre13X_plots.append(plot)
+
+(run2_nanoAOD_ANY | run3_nanoAOD_122 | run3_nanoAOD_124).toModify(
+    nanoDQM.vplots.Pileup,
+    plots = _Pileup_pre13X_plots
+)
+
 ## MC
 nanoDQMMC = nanoDQM.clone()
 nanoDQMMC.vplots.Electron.sels.Prompt = cms.string("genPartFlav == 1")

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -709,6 +709,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('pudensity', 'pudensity', 5, -0.5, 4.5, 'PU vertices / mm'),
                 Plot1D('sumEOOT', 'sumEOOT', 20, 0, 800, 'number of early out of time pileup'),
                 Plot1D('sumLOOT', 'sumLOOT', 20, 0, 300, 'number of late out of time pileup'),
+                Plot1D('pthatmax','pthatmax',20, 0, 400, 'Maximum pt-hat'),
             )
         ),
         PuppiMET = cms.PSet(


### PR DESCRIPTION
#### PR description:

This PR switches on the flag to save the `pthatmax` variable in the `Pileup` table for central NanoAOD, beginning from `v13`. The event size increase is negligible (0.002 kb /event).

#### PR validation:

- passes the standard runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
- passes the following NanoAOD workflows: `runTheMatrix.py -i all --ibeos -l 2500.0,2500.001,2500.002,2500.01,2500.011,2500.012,2500.1,2500.2,2500.21,2500.3,2500.31,2500.4`
