### PR TITLE
Fixes/impovements towards the first production version of the custom muon DPG NANO

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -139,12 +139,32 @@ steps['NANO_mc13.0']=merge([{'--era':'Run3',
 steps['MuonEG2023MINIAOD13.0'] = { 'INPUT':InputInfo(location='STD',ls=run3_lumis,
                                                      dataSet='/MuonEG/Run2023C-PromptReco-v4/MINIAOD')}
 
+steps['ZMuSkim2023DRAWRECO13.0'] = { 'INPUT':InputInfo(location='STD',ls={ 370775: [[1, 168]]},
+                                                     dataSet='/Muon0/Run2023D-ZMu-PromptReco-v2/RAW-RECO')}
+
+steps['ZeroBias2023DRAW13.0']={'INPUT':InputInfo(location='STD', ls={369978: [[1, 800]]},
+                                             dataSet='/ZeroBias/Run2023D-v1/RAW')}
+
 steps['NANO_data13.0']=merge([{'--era':'Run3',
                                '--conditions':'auto:run3_data'},
                               _NANO_data])
 
 steps['NANO_data13.0_prompt']=merge([{'--customise' : 'PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize', '-n' : '1000'},
                                      steps['NANO_data13.0']])
+
+steps['muDPGANO_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:DPGAnalysis/MuonTools/muNtupleProducer_cff.muNtupleProducer',
+                                   '--conditions':'auto:run3_data',
+                                   '-n' : '100',
+                                   '--era' : 'Run3',
+                                   '--datatier':'NANOAOD',
+                                   '--eventcontent':'NANOAOD'}])
+
+steps['muDPGANOBkg_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muNtupleProducerBkg',
+                                   '--conditions':'auto:run3_data',
+                                   '-n' : '100',
+                                   '--era' : 'Run3',
+                                   '--datatier':'NANOAOD',
+                                   '--eventcontent':'NANOAOD'}])
 
 ###current release cycle workflows : 13.2
 steps['TTBarMINIAOD13.2'] = {'INPUT':InputInfo(location='STD',
@@ -208,6 +228,8 @@ workflows[_wfn()] = ['NANOmc130X', ['TTBarMINIAOD13.0', 'NANO_mc13.0', 'HRV_NANO
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0', 'HRV_NANO_data']]
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0_prompt', 'HRV_NANO_data']]
+workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGANO_data13.0']]
+workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGANOBkg_data13.0']]
 
 _wfn.next()
 ################

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -152,14 +152,14 @@ steps['NANO_data13.0']=merge([{'--era':'Run3',
 steps['NANO_data13.0_prompt']=merge([{'--customise' : 'PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize', '-n' : '1000'},
                                      steps['NANO_data13.0']])
 
-steps['muDPGANO_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:DPGAnalysis/MuonTools/muNtupleProducer_cff.muNtupleProducer',
+steps['muDPGNANO_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:@MUDPG',
                                    '--conditions':'auto:run3_data',
                                    '-n' : '100',
                                    '--era' : 'Run3',
                                    '--datatier':'NANOAOD',
                                    '--eventcontent':'NANOAOD'}])
 
-steps['muDPGANOBkg_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muNtupleProducerBkg',
+steps['muDPGNANOBkg_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:@MUDPGBKG',
                                    '--conditions':'auto:run3_data',
                                    '-n' : '100',
                                    '--era' : 'Run3',
@@ -228,8 +228,8 @@ workflows[_wfn()] = ['NANOmc130X', ['TTBarMINIAOD13.0', 'NANO_mc13.0', 'HRV_NANO
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0', 'HRV_NANO_data']]
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0_prompt', 'HRV_NANO_data']]
-workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGANO_data13.0']]
-workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGANOBkg_data13.0']]
+workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGNANO_data13.0']]
+workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGNANOBkg_data13.0']]
 
 _wfn.next()
 ################

--- a/DPGAnalysis/MuonTools/plugins/MuCSCTnPFlatTableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuCSCTnPFlatTableProducer.cc
@@ -56,8 +56,6 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
-#include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 
 class MuonServiceProxy;
 
@@ -383,9 +381,13 @@ void MuCSCTnPFlatTableProducer::fillTable(edm::Event& ev) {
         m_chamberEndcap.push_back(endcapCSC * 1);
 
         Int_t iiStationFail = 0;
+        Int_t iiStation0Pass = 0;
         for (int iiStationZ = 0; iiStationZ < 6; iiStationZ++) {
           UChar_t stationCSC = iiStationZ > 2 ? iiStationZ - 2 : 0;
           UChar_t ringCSC = 0;
+          // Could monitor this problem here if necessary;
+          if (stationCSC == 0 && iiStation0Pass > 0)
+            continue;
           TrajectoryStateOnSurface tsos = surfExtrapTrkSam(track, ec ? MEZ[iiStationZ] : -MEZ[iiStationZ]);
 
           if (tsos.isValid()) {
@@ -407,6 +409,8 @@ void MuCSCTnPFlatTableProducer::fillTable(edm::Event& ev) {
               tsos = surfExtrapTrkSam(track, Layer3Surface.position().z());
 
               if (tsos.isValid()) {
+                if (stationCSC == 0)
+                  iiStation0Pass++;
                 // Fill track intersection denominator information
                 LocalPoint localTTIntPoint = Layer3Surface.toLocal(tsos.freeState()->position());
                 const CSCLayerGeometry* layerGeoma = m_cscGeometry->chamber(Layer0Id)->layer(3)->geometry();

--- a/DPGAnalysis/MuonTools/plugins/MuDTMuonExtTableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuDTMuonExtTableProducer.cc
@@ -329,7 +329,16 @@ void MuDTMuonExtTableProducer::fillTable(edm::Event& ev) {
     tabMatches->setDoc("RECO muon matches_* vectors");
 
     addColumn(tabMatches, "x", matches_x, "x position of the extrapolated track on the matched DT chamber");
-    addColumn(tabMatches, "y", matches_y, "x position of the extrapolated track on the matched DT chamber");
+    addColumn(tabMatches, "y", matches_y, "y position of the extrapolated track on the matched DT chamber");
+
+    addColumn(tabMatches,
+              "edgeX",
+              matches_edgeX,
+              "distance in x of the extrapolated track to the matched DT chamber border (<0 == inside the chamber)");
+    addColumn(tabMatches,
+              "edgeY",
+              matches_edgeY,
+              "distance in y of the extrapolated track to the matched DT chamber border (<0 == inside the chamber)");
 
     addColumn(tabMatches, "wheel", matches_wheel, "matched DT chamber wheel");
     addColumn(tabMatches, "sector", matches_sector, "matched DT chamber sector");

--- a/DPGAnalysis/MuonTools/plugins/MuGEMMuonExtTableProducer.cc
+++ b/DPGAnalysis/MuonTools/plugins/MuGEMMuonExtTableProducer.cc
@@ -213,9 +213,8 @@ void MuGEMMuonExtTableProducer::fillTable(edm::Event& ev) {
           continue;
         }
 
-        const auto&& start_state =
-            is_insideout ? transient_track.outermostMeasurementState() : transient_track.innermostMeasurementState();
-        auto& propagator = is_incoming ? propagator_along : propagator_opposite;
+        const auto&& start_state = transient_track.innermostMeasurementState();
+        auto& propagator = propagator_any;
 
         auto recHitMu = outerTrackRef->recHitsBegin();
         auto recHitMuEnd = outerTrackRef->recHitsEnd();

--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -2,9 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.common_cff import *
 
+from DPGAnalysis.MuonTools.nano_mu_global_cff import *
 from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
 
-muNtupleProducerBkg = cms.Sequence(muDigiProducersBkg)
+muNtupleProducerBkg = cms.Sequence(lhcInfoTableProducer
+                                   + lumiTableProducer
+                                   + muDigiProducersBkg)
 
 def nanoAOD_customizeCommon(process) :
 

--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -5,11 +5,11 @@ from PhysicsTools.NanoAOD.common_cff import *
 from DPGAnalysis.MuonTools.nano_mu_global_cff import *
 from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
 
-muNtupleProducerBkg = cms.Sequence(lhcInfoTableProducer
+muDPGNanoProducerBkg = cms.Sequence(lhcInfoTableProducer
                                    + lumiTableProducer
                                    + muDigiProducersBkg)
 
-def nanoAOD_customizeCommon(process) :
+def muDPGNanoBkgCustomize(process) :
 
      if hasattr(process, "NANOAODoutput"):
           process.NANOAODoutput.outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -2,12 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.common_cff import *
 
+from DPGAnalysis.MuonTools.nano_mu_global_cff import *
 from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
 from DPGAnalysis.MuonTools.nano_mu_local_reco_cff import *
 from DPGAnalysis.MuonTools.nano_mu_reco_cff import *
 from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
+from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
 
-muNtupleProducer = cms.Sequence(muDigiProducers 
+muNtupleProducer = cms.Sequence(lhcInfoTableProducer
+                                + lumiTableProducer
+                                + muDigiProducers 
                                 + muLocalRecoProducers 
                                 + muRecoProducers
                                 + muL1TriggerProducers
@@ -15,6 +19,15 @@ muNtupleProducer = cms.Sequence(muDigiProducers
                                
 def nanoAOD_customizeCommon(process) :
      
+     if hasattr(process, "dtrpcPointFlatTableProducer") and \
+        hasattr(process, "cscrpcPointFlatTableProducer") and \
+        hasattr(process, "RawToDigiTask"):
+          process.load("RecoLocalMuon.RPCRecHit.rpcPointProducer_cff")
+          process.rpcPointProducer.dt4DSegments =  'dt4DSegments'
+          process.rpcPointProducer.cscSegments =  'cscSegments'
+          process.rpcPointProducer.ExtrapolatedRegion = 0.6
+          process.RawToDigiTask.add(process.rpcPointProducer)
+          
      if hasattr(process, "muGEMMuonExtTableProducer") or hasattr(process, "muCSCTnPFlatTableProducer"):
           process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -9,7 +9,7 @@ from DPGAnalysis.MuonTools.nano_mu_reco_cff import *
 from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
 from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
 
-muNtupleProducer = cms.Sequence(lhcInfoTableProducer
+muDPGNanoProducer = cms.Sequence(lhcInfoTableProducer
                                 + lumiTableProducer
                                 + muDigiProducers 
                                 + muLocalRecoProducers 
@@ -17,7 +17,7 @@ muNtupleProducer = cms.Sequence(lhcInfoTableProducer
                                 + muL1TriggerProducers
                                )
                                
-def nanoAOD_customizeCommon(process) :
+def muDPGNanoCustomize(process) :
      
      if hasattr(process, "dtrpcPointFlatTableProducer") and \
         hasattr(process, "cscrpcPointFlatTableProducer") and \

--- a/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.NanoAOD.common_cff import *
+
+lumiTableProducer = cms.EDProducer("SimpleOnlineLuminosityFlatTableProducer",
+    src = cms.InputTag("onlineMetaDataDigis"),
+    name = cms.string("lumi"),
+    doc  = cms.string("Online luminosity information"),
+    variables = cms.PSet(
+        instLumi = Var( "instLumi()", "double", doc = "Instantaneous luminosity"),
+        avgPileUp = Var( "avgPileUp()", "double", doc = "Average PU")
+    )
+)
+
+lhcInfoTableProducer = cms.EDProducer("LHCInfoProducer")

--- a/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
@@ -82,6 +82,85 @@ rpcRecHitFlatTableProducer.detIdVariables = cms.PSet(
         rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
 )
 
+dtrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'dtrpcPointProducer', src = cms.InputTag('rpcPointProducer','RPCDTExtrapolatedPoints'), doc = "DT extrapolated point on RPC")
+
+dtrpcPointFlatTableProducer.variables = cms.PSet(
+        coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
+        coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
+        coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
+)
+
+dtrpcPointFlatTableProducer.detIdVariables = cms.PSet(
+        region = DetIdVar("region()", "int8", doc = "0: barrel, +-1: endcap"),
+        ring = DetIdVar("ring()", "int8", doc = "ring id:"
+                                        "<br />wheel number in barrel (from -2 to +2)"
+                                        "<br />ring number in endcap (from 1 to 3)"),
+        station = DetIdVar("station()", "int8", doc = "chambers at same R in barrel, chambers at same Z ion endcap"),
+        layer = DetIdVar("layer()", "int8", doc = "layer id:"
+                                          "<br />in station 1 and 2 for barrel, we have two layers of chambers:"
+                                          "<br />layer 1 is the inner chamber and layer 2 is the outer chamber"),
+        sector = DetIdVar("sector()", "int8", doc = "group of chambers at same phi"),
+        subsector = DetIdVar("subsector()", "int8", doc = "Some sectors are divided along the phi direction in subsectors "
+                                                  "(from 1 to 4 in Barrel, from 1 to 6 in Endcap)"),
+        roll = DetIdVar("roll()", "int8", doc = "roll id (also known as eta partition):"
+                                        "<br />each chamber is divided along the strip direction"),
+        rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+)
+cscrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'cscToRpc',
+                                                                src = cms.InputTag('rpcPointProducer','RPCCSCExtrapolatedPoints'),
+                                                                doc = "CSC segment extrapolated on RPC")
+
+cscrpcPointFlatTableProducer.variables = cms.PSet(
+        coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
+        coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
+        coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
+)
+
+cscrpcPointFlatTableProducer.detIdVariables = cms.PSet(
+        region = DetIdVar("region()", "int8", doc = "0: barrel, +-1: endcap"),
+        ring = DetIdVar("ring()", "int8", doc = "ring id:"
+                                        "<br />wheel number in barrel (from -2 to +2)"
+                                        "<br />ring number in endcap (from 1 to 3)"),
+        station = DetIdVar("station()", "int8", doc = "chambers at same R in barrel, chambers at same Z ion endcap"),
+        layer = DetIdVar("layer()", "int8", doc = "layer id:"
+                                          "<br />in station 1 and 2 for barrel, we have two layers of chambers:"
+                                          "<br />layer 1 is the inner chamber and layer 2 is the outer chamber"),
+        sector = DetIdVar("sector()", "int8", doc = "group of chambers at same phi"),
+        subsector = DetIdVar("subsector()", "int8", doc = "Some sectors are divided along the phi direction in subsectors "
+                                                  "(from 1 to 4 in Barrel, from 1 to 6 in Endcap)"),
+        roll = DetIdVar("roll()", "int8", doc = "roll id (also known as eta partition):"
+                                        "<br />each chamber is divided along the strip direction"),
+        rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+)
+
+dtrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'dtToRpc',
+                                                               src = cms.InputTag('rpcPointProducer','RPCDTExtrapolatedPoints'),
+                                                               doc = "DT segment extrapolated on RPC")
+
+dtrpcPointFlatTableProducer.variables = cms.PSet(
+        coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
+        coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
+        coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
+)
+
+dtrpcPointFlatTableProducer.detIdVariables = cms.PSet(
+        region = DetIdVar("region()", "int8", doc = "0: barrel, +-1: endcap"),
+        ring = DetIdVar("ring()", "int8", doc = "ring id:"
+                                        "<br />wheel number in barrel (from -2 to +2)"
+                                        "<br />ring number in endcap (from 1 to 3)"),
+        station = DetIdVar("station()", "int8", doc = "chambers at same R in barrel, chambers at same Z ion endcap"),
+        layer = DetIdVar("layer()", "int8", doc = "layer id:"
+                                          "<br />in station 1 and 2 for barrel, we have two layers of chambers:"
+                                          "<br />layer 1 is the inner chamber and layer 2 is the outer chamber"),
+        sector = DetIdVar("sector()", "int8", doc = "group of chambers at same phi"),
+        subsector = DetIdVar("subsector()", "int8", doc = "Some sectors are divided along the phi direction in subsectors "
+                                                  "(from 1 to 4 in Barrel, from 1 to 6 in Endcap)"),
+        roll = DetIdVar("roll()", "int8", doc = "roll id (also known as eta partition):"
+                                        "<br />each chamber is divided along the strip direction"),
+        rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+)
+
+
 from DPGAnalysis.MuonTools.gemRecHitFlatTableProducer_cfi import gemRecHitFlatTableProducer
 
 gemRecHitFlatTableProducer.name = "gemRecHit"
@@ -156,6 +235,8 @@ gemSegmentFlatTableProducer.globalDirVariables = cms.PSet(
 )
 
 muLocalRecoProducers = cms.Sequence(rpcRecHitFlatTableProducer
+                                    + dtrpcPointFlatTableProducer
+                                    + cscrpcPointFlatTableProducer
                                     + gemRecHitFlatTableProducer
                                     + dtSegmentFlatTableProducer
                                     + muDTSegmentExtTableProducer

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/L1TGlobal"/>
 <use name="DataFormats/NanoAOD"/>
+<use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/ProtonReco"/>
 <use name="FWCore/Framework"/>

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -21,6 +21,9 @@ typedef SimpleFlatTableProducer<CTPPSLocalTrackLite> SimpleLocalTrackFlatTablePr
 #include "DataFormats/Math/interface/Point3D.h"
 typedef EventSingletonSimpleFlatTableProducer<math::XYZPointF> SimpleXYZPointFlatTableProducer;
 
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
+typedef EventSingletonSimpleFlatTableProducer<OnlineLuminosityRecord> SimpleOnlineLuminosityFlatTableProducer;
+
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 typedef EventSingletonSimpleFlatTableProducer<reco::BeamSpot> SimpleBeamspotFlatTableProducer;
 
@@ -62,6 +65,7 @@ DEFINE_FWK_MODULE(SimpleHTXSFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleProtonTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleLocalTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleXYZPointFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleOnlineLuminosityFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleBeamspotFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -28,6 +28,11 @@ autoNANO = {
     # L1 flavours: add tables through customize, supposed to be combined with PHYS
     'L1' : {'customize': 'nanoL1TrigObjCustomize'},
     'L1FULL' : {'customize': 'nanoL1TrigObjCustomizeFull'},
+    # MUDPG flavours: use their own sequence 
+    'MUDPG' : {'sequence': 'muDPGNanoProducer',
+               'customize': 'muDPGNanoCustomize'},
+    'MUDPGBKG' : {'sequence': 'muDPGNanoProducerBkg',
+                  'customize': 'muDPGNanoBkgCustomize'},
     # PromptReco config: PHYS+L1
     'Prompt' : {'sequence': '@PHYS', 
                 'customize': '@PHYS+@L1'}

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -283,3 +283,8 @@ def nanoL1TrigObjCustomize(process):
 def nanoL1TrigObjCustomizeFull(process):
     process.nanoTableTaskCommon.add(process.l1TablesTask)
     return process
+
+### muon DPG NANO flavour sequences and customize functions
+from DPGAnalysis.MuonTools.muNtupleProducer_cff import *
+from DPGAnalysis.MuonTools.muNtupleProducerBkg_cff import *
+


### PR DESCRIPTION
#### PR description:

Update of common muon ntuple content + fixes based on feedback from analysers/users:

- fix bug generating broken flat table in CSC TnP producer
- add missing information to allow DT TnP analysis
- add CSC/DT segment extrapolation to nearby RPC chambers
- fix propagation issue in GEMMuonExtTable producer
- add producer writing online luminosity information

Last [report at xPOG workshop](https://indico.cern.ch/event/1263032/timetable/#12-experience-and-plans-muondp)

#### PR validation:

Compilation and use in private production (ran using 13_0_X and covering Run2023_v1) for now. Though `cmsDriver.py` customisations are available, ntuple production is not included, at present, in any central workflow.

