### PR TITLE
Phase2L1CaloPFClusterEmulator: fix warnings in getEt

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h
@@ -119,7 +119,7 @@ namespace gctpf {
   }
 
   inline float getEt(float temp[nTowerEtaSLR][nTowerPhiSLR], int eta, int phi) {
-    float et_sumEta[3];
+    float et_sumEta[3] = {0., 0., 0.};
 
     for (int i = 0; i < (nTowerEtaSLR - 2); i++) {
       for (int j = 0; j < (nTowerPhiSLR - 2); j++) {


### PR DESCRIPTION
#### PR description:

The followings warnings are emitted during [compilation](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_DBG_X_2023-10-19-2300/L1Trigger/L1CaloTrigger):
```
In function 'getEt',
    inlined from 'recoPfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:162:31,
    inlined from 'pfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:181:35,
    inlined from 'produce' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc:149:38:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:134:11: warning: 'et_sumEta[2]' may be used uninitialized [-Wmaybe-uninitialized]
   134 |     float pfcluster_et = et_sumEta[0] + et_sumEta[1] + et_sumEta[2];
      |           ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h: In member function 'produce':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:122:11: note: 'et_sumEta[2]' was declared here
  122 |     float et_sumEta[3];
      |           ^
In function 'getEt',
    inlined from 'recoPfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:162:31,
    inlined from 'pfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:181:35,
    inlined from 'produce' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc:149:38:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:134:39: warning: 'et_sumEta[1]' may be used uninitialized [-Wmaybe-uninitialized]
   134 |     float pfcluster_et = et_sumEta[0] + et_sumEta[1] + et_sumEta[2];
      |                                       ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h: In member function 'produce':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:122:11: note: 'et_sumEta[1]' was declared here
  122 |     float et_sumEta[3];
      |           ^
In function 'getEt',
    inlined from 'recoPfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:162:31,
    inlined from 'pfcluster' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:181:35,
    inlined from 'produce' at /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloPFClusterEmulator.cc:149:38:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:134:39: warning: 'et_sumEta[0]' may be used uninitialized [-Wmaybe-uninitialized]
   134 |     float pfcluster_et = et_sumEta[0] + et_sumEta[1] + et_sumEta[2];
      |                                       ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h: In member function 'produce':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a3801c18577931e4a34d824c3c3171/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_DBG_X_2023-10-19-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloPFClusterEmulator.h:122:11: note: 'et_sumEta[0]' was declared here
  122 |     float et_sumEta[3];
      |           ^
```

#### PR validation:

Bot tests

