### PR TITLE
Fix mismatch error in CTPPSRPAlignmentInfoAnalyzer

### DIFF
--- a/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
+++ b/CondTools/CTPPS/src/CTPPSRPAlignmentInfoAnalyzer.cc
@@ -76,13 +76,13 @@ void CTPPSRPAlignmentInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::
                            &eS = iSetup,
                            &tAI = tokenAlignmentIdeal_,
                            &tAR = tokenAlignmentReal_,
-                           &tAM = tokenAlignmentMisaligned_]() -> const CTPPSRPAlignmentCorrectionsData* {
+                           &tAM = tokenAlignmentMisaligned_]() -> const CTPPSRPAlignmentCorrectionsData {
     if (r == "CTPPSRPAlignmentCorrectionsDataRcd") {
-      return &eS.getData(tAI);
+      return eS.getData(tAI);
     } else if (r == "RPRealAlignmentRecord") {
-      return &eS.getData(tAR);
+      return eS.getData(tAR);
     } else {
-      return &eS.getData(tAM);
+      return eS.getData(tAM);
     }
   }();
 


### PR DESCRIPTION
#### PR description:

Fix provided by @wpcarvalho, for CTPPSRPAlignmentInfoAnalyzer.cc to hold an object of type `CTPPSRPAlignmentCorrectionsData`, not a pointer to it, for a successful creation of DB files using the [CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py](https://github.com/cms-sw/cmssw/blob/master/CondTools/CTPPS/test/write-ctpps-rprealalignment_cfg.py)

#### PR validation:

Tested locally with `CMSSW_13_3_0_pre4`
```shell
cmsRun $CMSSW_BASE/src/CondTools/CTPPS/test/retrieve-sqlite-rpalignment_cfg.py /eos/cms/store/group/phys_pps/alignment/2023/results/CTPPSRPAlignment_2023_preTS1_366403_367840.db 367840 CTPPSRPAlignment_real
```

Informing @fabferro,  @grzanka. @wpcarvalho

