### PR TITLE
Fix maybe-uninitialized warning in TkPixelMeasurementDet

### DIFF
--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -85,10 +85,10 @@ public:
   void setIndex(int i) { index_ = i; }
 
 private:
-  unsigned int id_;
+  unsigned int id_ {};
   std::vector<LocalPoint> badRocPositions_;
 
-  int index_;
+  int index_ {};
   PxMeasurementConditionSet* theDetConditions;
   PxMeasurementConditionSet& conditionSet() { return *theDetConditions; }
   const PxMeasurementConditionSet& conditionSet() const { return *theDetConditions; }

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -85,10 +85,10 @@ public:
   void setIndex(int i) { index_ = i; }
 
 private:
-  unsigned int id_ {};
+  unsigned int id_{};
   std::vector<LocalPoint> badRocPositions_;
 
-  int index_ {};
+  int index_{};
   PxMeasurementConditionSet* theDetConditions;
   PxMeasurementConditionSet& conditionSet() { return *theDetConditions; }
   const PxMeasurementConditionSet& conditionSet() const { return *theDetConditions; }


### PR DESCRIPTION
#### PR description:

Fix the following two warnings:

``` 
/data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/8625618ee98163e15f7bff6dc65787d2/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h:17:18: warning: 'MEM[(const struct TkPixelMeasurementDet &)&D.27209].id_' may be used uninitialized [-Wmaybe-uninitialized]
    17 | class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {
      |                  ^
<...>
  /data/cmsbld/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/8625618ee98163e15f7bff6dc65787d2/opt/cmssw/el8_aarch64_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h:17:18: warning: 'MEM[(const struct TkPixelMeasurementDet &)&D.27209].index_' may be used uninitialized [-Wmaybe-uninitialized]
    17 | class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {
      |                  ^
```

#### PR validation:

Bot tests.