### PR TITLE
Remove build warning in TrackerMap

### DIFF
--- a/CommonTools/TrackerMap/interface/TrackerMap.h
+++ b/CommonTools/TrackerMap/interface/TrackerMap.h
@@ -611,8 +611,9 @@ public:
       return lay + 33;
     if (det == 3 && part == 2)
       return lay + 37;
-    std::cout << "Error in TrackerMap: this can never happen as det and part are comprised between 1 and 3, while they are " 
-              << det << " and " << part << " respectively" << std::endl;
+    std::cout
+        << "Error in TrackerMap: this can never happen as det and part are comprised between 1 and 3, while they are "
+        << det << " and " << part << " respectively" << std::endl;
     return lay;
   }
 

--- a/CommonTools/TrackerMap/interface/TrackerMap.h
+++ b/CommonTools/TrackerMap/interface/TrackerMap.h
@@ -611,7 +611,9 @@ public:
       return lay + 33;
     if (det == 3 && part == 2)
       return lay + 37;
-    return -1;  // This can never happen: det and part are comprised between 1 and 3
+    std::cout << "Error in TrackerMap: this can never happen as det and part are comprised between 1 and 3, while they are " 
+              << det << " and " << part << " respectively" << std::endl;
+    return lay;
   }
 
   std::string layername(int layer) {


### PR DESCRIPTION
#### PR description:

Fix warning in TrackerMap:

```
>> Compiling  /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc
CMSSW_CPU_TYPE= /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DCMSSW_GIT_HASH='CMSSW_13_3_X_2023-10-22-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_3_X_2023-10-22-2300' -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -isystem/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/boost/1.80.0-25dc4c664004df9af6a87cc561ac9af1/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -isystem/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/clhep/2.4.7.1-5bfe601b6d65215d210a10fe9d6d7478/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/cuda/12.2.1-bdf3fff69eaec65abe18a7569592cab6/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/gsl/2.6-f316a321a173f181b66df52be79d894b/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -isystem/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/lcg/root/6.26.11-cd568a953108f53546aa1c922b721a13/include -isystem/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/tbb/v2021.9.0-b095b6d0e5df24a3b5f9bdd21e523ee3/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-8ad1a182dbaa9ab375b9d1d584a1b40f/include/eigen3 -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/fmt/8.0.1-54e94b39f5cf29341bb9c4765764e1ca/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/OpenBLAS/0.3.15-15504a5c800a9ecbbc2befbb991bead5/include -I/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/el8_ppc64le_gcc12/external/tinyxml2/6.2.0-d17873b4d6a42a43226cf689f82ec1ef/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -fsigned-char -fsigned-bitfields -mcpu=power8 -mtune=power8 --param=l1-cache-size=64 --param=l1-cache-line-size=128 --param=l2-cache-size=512 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS  -fPIC  -MMD -MF tmp/el8_ppc64le_gcc12/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TrackerMap.cc.d /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc -o tmp/el8_ppc64le_gcc12/src/CommonTools/TrackerMap/src/CommonToolsTrackerMap/TrackerMap.cc.o
/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc: In member function 'void TrackerMap::init()':
  /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:498:29: warning: array subscript -2 is below array bounds of 'int [43]' [-Warray-bounds]
   498 |         ntotRing[layer_g - 1] = nrings;
      |         ~~~~~~~~~~~~~~~~~~~~^
In file included from /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:1:
/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/interface/TrackerMap.h:643:7: note: while referencing 'TrackerMap::ntotRing'
  643 |   int ntotRing[43];
      |       ^~~~~~~~
  /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:499:30: warning: array subscript -2 is below array bounds of 'int [43]' [-Warray-bounds]
   499 |         firstRing[layer_g - 1] = 1;
      |         ~~~~~~~~~~~~~~~~~~~~~^
/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/interface/TrackerMap.h:644:7: note: while referencing 'TrackerMap::firstRing'
  644 |   int firstRing[43];
      |       ^~~~~~~~~
  /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:498:29: warning: array subscript -2 is below array bounds of 'int [43]' [-Warray-bounds]
   498 |         ntotRing[layer_g - 1] = nrings;
      |         ~~~~~~~~~~~~~~~~~~~~^
/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/interface/TrackerMap.h:643:7: note: while referencing 'TrackerMap::ntotRing'
  643 |   int ntotRing[43];
      |       ^~~~~~~~
  /scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/src/TrackerMap.cc:499:30: warning: array subscript -2 is below array bounds of 'int [43]' [-Warray-bounds]
   499 |         firstRing[layer_g - 1] = 1;
      |         ~~~~~~~~~~~~~~~~~~~~~^
/scratch/cmsbuild/jenkins_b/workspace/build-any-ib/w/tmp/BUILDROOT/b7795e3ac29b716738cd04366bdc996a/opt/cmssw/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/CommonTools/TrackerMap/interface/TrackerMap.h:644:7: note: while referencing 'TrackerMap::firstRing'
  644 |   int firstRing[43];
      |       ^~~~~~~~~
```

as suggested by @perrotta in https://github.com/cms-sw/cmssw/pull/42373#issuecomment-1774628461

#### PR validation:

Bot tests
