### PR TITLE
Fix Wdeprecated-copy warnings in DataFormats/Common

### DIFF
--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -121,10 +121,6 @@ namespace edm {
     /// to modify the DSV, but you should not count on them)
     explicit DetSetVector(std::vector<DetSet<T> >& input, bool alreadySorted = false);
 
-    void swap(DetSetVector& other);
-
-    DetSetVector& operator=(DetSetVector const& other);
-
     ///  Insert the given DetSet.
     // What should happen if there is already a DetSet with this
     // DetId? Right now, it is up to the user *not* to do this. If you
@@ -199,21 +195,6 @@ namespace edm {
     _sets.swap(input);
     if (!alreadySorted)
       _sort();
-  }
-
-  template <class T>
-  inline void DetSetVector<T>::swap(DetSetVector<T>& other) {
-    _sets.swap(other._sets);
-    bool tmp = _alreadySorted;
-    _alreadySorted = other._alreadySorted;
-    other._alreadySorted = tmp;
-  }
-
-  template <class T>
-  inline DetSetVector<T>& DetSetVector<T>::operator=(DetSetVector<T> const& other) {
-    DetSetVector<T> temp(other);
-    swap(temp);
-    return *this;
   }
 
   template <class T>
@@ -381,12 +362,6 @@ namespace edm {
   struct has_fillView<edm::DetSetVector<T> > {
     static bool const value = true;
   };
-
-  // Free swap function
-  template <class T>
-  inline void swap(DetSetVector<T>& a, DetSetVector<T>& b) {
-    a.swap(b);
-  }
 
 }  // namespace edm
 

--- a/DataFormats/Common/interface/OrphanHandleBase.h
+++ b/DataFormats/Common/interface/OrphanHandleBase.h
@@ -31,23 +31,9 @@ namespace edm {
 
     OrphanHandleBase(void const* iProd, ProductID const& iId) : product_(iProd), id_(iId) { assert(iProd); }
 
-    ~OrphanHandleBase() {}
-
     void clear() {
       product_ = nullptr;
       id_ = ProductID();
-    }
-
-    void swap(OrphanHandleBase& other) {
-      using std::swap;
-      swap(product_, other.product_);
-      std::swap(id_, other.id_);
-    }
-
-    OrphanHandleBase& operator=(OrphanHandleBase const& rhs) {
-      OrphanHandleBase temp(rhs);
-      this->swap(temp);
-      return *this;
     }
 
     bool isValid() const { return product_ && id_ != ProductID(); }
@@ -62,8 +48,6 @@ namespace edm {
     ProductID id_;
   };
 
-  // Free swap function
-  inline void swap(OrphanHandleBase& a, OrphanHandleBase& b) { a.swap(b); }
 }  // namespace edm
 
 #endif

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -305,13 +305,13 @@ void work() {
   assert(c.size() == 3);
 
   coll_type another;
-  c.swap(another);
+  std::swap(c, another);
   assert(c.empty());
   assert(another.size() == 3);
   sanity_check(c);
   sanity_check(another);
 
-  c.swap(another);
+  std::swap(c, another);
   assert(c.size() == 3);
 
   {

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -229,7 +229,7 @@ namespace Phase2Tracker {
         }
 
         edm::DetSetVector<Phase2TrackerDigi> proc_raw_dsv(sorted_and_merged, true);
-        pr->swap(proc_raw_dsv);
+        std::swap(pr, proc_raw_dsv);
         event.put(std::unique_ptr<edm::DetSetVector<Phase2TrackerDigi>>(pr), "ProcessedRaw");
         delete buffer;
       }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/Phase2TrackerDigiProducer.cc
@@ -229,7 +229,7 @@ namespace Phase2Tracker {
         }
 
         edm::DetSetVector<Phase2TrackerDigi> proc_raw_dsv(sorted_and_merged, true);
-        std::swap(pr, proc_raw_dsv);
+        std::swap(*pr, proc_raw_dsv);
         event.put(std::unique_ptr<edm::DetSetVector<Phase2TrackerDigi>>(pr), "ProcessedRaw");
         delete buffer;
       }


### PR DESCRIPTION
#### PR description:

Implicit copy-constructors are deprecated, and not necessary in most cases. This PR removes unnnecessary copy-assignment operators (and `swap` methods) in favor of auto-generated ones.

#### PR validation:

Bot tests
