### PR TITLE
Fix deprecated-copy warnings in CondFormats/OptAlignObjects

### DIFF
--- a/CondFormats/OptAlignObjects/interface/OpticalAlignInfo.h
+++ b/CondFormats/OptAlignObjects/interface/OpticalAlignInfo.h
@@ -34,7 +34,6 @@ std::ostream &operator<<(std::ostream &, const OpticalAlignParam &);
 class OpticalAlignParam {
 public:
   OpticalAlignParam();
-  OpticalAlignParam(const OpticalAlignParam &rhs);
 
   std::string name() const { return name_; }
   double value() const { return value_; }

--- a/CondFormats/OptAlignObjects/src/OpticalAlignInfo.cc
+++ b/CondFormats/OptAlignObjects/src/OpticalAlignInfo.cc
@@ -54,14 +54,6 @@ std::ostream& operator<<(std::ostream& os, const OpticalAlignParam& r) {
   return os;
 }
 
-OpticalAlignParam::OpticalAlignParam(const OpticalAlignParam& rhs) {
-  value_ = rhs.value_;
-  error_ = rhs.error_;
-  quality_ = rhs.quality_;
-  name_ = rhs.name_;
-  dim_type_ = rhs.dim_type_;
-}
-
 OpticalAlignParam* OpticalAlignInfo::findExtraEntry(std::string& name) {
   OpticalAlignParam* param = nullptr;
   std::vector<OpticalAlignParam>::iterator ite;


### PR DESCRIPTION
#### PR description:

Implicit copy-constructors are deprecated, and not necessary in most cases. This PR removes unnnecessary copy-assignment operators (and swap methods) in favor of auto-generated ones.

#### PR validation:

Bot tests