### PR TITLE
TestGeneratorInterfacePythia8ConcurrentGeneratorFilter: follow redirects

### DIFF
--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
+curl -L -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
 touch GIP8/__init__.py
 export PYTHONPATH="${PWD}${PYTHONPATH:+:$PYTHONPATH}"
 


### PR DESCRIPTION
#### PR description:

Test TestGeneratorInterfacePythia8ConcurrentGeneratorFilter is failing with the following error:

```
===== Test "TestGeneratorInterfacePythia8ConcurrentGeneratorFilter" ====
+ cmsDriver.py GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py --python_filename test_BTV-RunIISummer20UL17GEN-00002_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:test_BTV-RunIISummer20UL17GEN-00002.root --conditions auto:run2_mc --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands 'process.source.numberEventsInLuminosityBlock=cms.untracked.uint32(10)' --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 50 --nThreads 4 --nConcurrentLumis 0
GEN,ENDJOB
with DB:
Step: GEN Spec: 
Loading generator fragment from GIP8.BTV-RunIISummer20UL17GEN-00002-fragment
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/sw/ppc64le/week0/el8_ppc64le_gcc12/cms/cmssw/CMSSW_13_3_X_2023-10-22-2300/src/Configuration/Applications/python/ConfigBuilder.py", line 1430, in prepare_GEN
    __import__(loadFragment)
  File "/scratch/cmsbuild/jenkins_b/workspace/ib-run-qa/CMSSW_13_3_X_2023-10-22-2300/unit_tests/TestGeneratorInterfacePythia8ConcurrentGeneratorFilter/GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py", line 1
    <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
    ^
SyntaxError: invalid syntax
```

This is due to original URL now returning a redirect message. This PR adds `-L` flag to cURL invocation to let it follow redirects.

#### PR validation:

Bot tests
