### PR TITLE
Make empty std::optionals to work as ESProducer return value

### DIFF
--- a/FWCore/Framework/interface/produce_helpers.h
+++ b/FWCore/Framework/interface/produce_helpers.h
@@ -34,15 +34,6 @@ namespace edm::eventsetup {
     iTo = std::move(iFrom);
   }
 
-  template <typename FromT, typename ToT>
-  void moveFromTo(std::unique_ptr<FromT>& iFrom, ToT& iTo) {
-    iTo = std::move(iFrom);
-  }
-  template <typename FromT, typename ToT>
-  void moveFromTo(std::optional<FromT>& iFrom, ToT& iTo) {
-    iTo = std::move(iFrom.value());
-  }
-
   namespace produce {
     struct Null {};
     template <typename T>

--- a/FWCore/Framework/src/exceptionContext.cc
+++ b/FWCore/Framework/src/exceptionContext.cc
@@ -25,6 +25,8 @@ namespace edm {
       }
       imcc = imcc->esmoduleCallingContext();
     }
-    edm::exceptionContext(ex, *imcc->moduleCallingContext());
+    if (imcc->type() == ESParentContext::Type::kModule) {
+      edm::exceptionContext(ex, *imcc->moduleCallingContext());
+    }
   }
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

The `std:optional` as an `ESProducer::produce()` return type has been supported for a long time already. However, the `ESProducer::produce()` returning an empty std::optional lead to an exception being thrown (about de-referencing an empty std::optional). The fix is use the the default form of the `moveFromTo()` function also for `std::optional`.

I removed the overload for `std::unique_ptr` as well since it provided no functionality over the default implementation of the function.

In order to make the unit tests to not hang in case an exception is thrown by the `moveFromTo()` I added a protection in `exceptionContext()` function.

Resolves https://github.com/makortel/framework/issues/700

#### PR validation:

The `FWCore/Framework` unit tests run.