### PR TITLE
Correct url of the GEN fragment in a Pythia8Interface test and of the RelMon main page, after SSO migration

### DIFF
--- a/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
+++ b/GeneratorInterface/Pythia8Interface/test/test_Pythia8ConcurrentGeneratorFilter_WZ_TuneCP5_13TeV-pythia8.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-curl -L -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
+curl -L -s -k https://cms-pdmv-prod.web.cern.ch/mcm/public/restapi/requests/get_fragment/BTV-RunIISummer20UL17GEN-00002 --retry 3 --create-dirs -o GIP8/BTV-RunIISummer20UL17GEN-00002-fragment.py
 touch GIP8/__init__.py
 export PYTHONPATH="${PWD}${PYTHONPATH:+:$PYTHONPATH}"
 

--- a/Utilities/RelMon/python/definitions.py
+++ b/Utilities/RelMon/python/definitions.py
@@ -23,7 +23,7 @@ test_codes={"EMPTY":-101,
             "NO_HIST":-105,
             "FEW_BINS":-105}
 #-------------------------------------------------------------------------------  
-relmon_mainpage="https://cms-pdmv.cern.ch/relmon"
+relmon_mainpage="https://cms-pdmv-prod.web.cern.ch/relmon"
 
 #-------------------------------------------------------------------------------  
 


### PR DESCRIPTION
#### PR description:

Unit test "TestGeneratorInterfacePythia8ConcurrentGeneratorFilter" was failing in the IBs because of a modified address in the pdmv repository of the GEN fragment needed for the test:
From: cms-pdmv.cern.ch
To: cms-pdmv-prod.web.cern.ch

The change in the url of pdmv scripts, to access McM, get in with recent SSO migration

Since I found another such case in Utilities/RelMon/python/definitions.py, I decided to fix also the url listed there in this PR (title and description modified from the original PR)

#### PR validation:

`scram b runtests` works without errors


#### Backports

The unit test is currently failing in all releases: if we want to fix it, this simple fix should be backported in all them