### PR TITLE
Introduce tracking and vertexing HLT validation (w.r.t TPs) for Phase 2

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -41,9 +41,7 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
 # Temporary Phase-2 config
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([hltMultiTrackValidation,
-                                                                           hltMultiPVValidation,
-                                                                           egammaSelectors,
+phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([egammaSelectors,
                                                                            ExoticaValidationProdSeq,
                                                                            hltMultiTrackValidationGsfTracks,
                                                                            hltMultiTrackValidationMuonTracks])

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -30,3 +30,9 @@ def _modifyForRun3(trackvalidator):
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)
+
+def _modifyForPhase2(trackvalidator):
+    trackvalidator.label = ["generalTracks::HLT","hltPhase2PixelTracks"]
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)

--- a/Validation/RecoTrack/python/associators_cff.py
+++ b/Validation/RecoTrack/python/associators_cff.py
@@ -13,6 +13,13 @@ hltTPClusterProducer = _tpClusterProducer.clone(
     stripClusterSrc = "hltSiStripRawToClustersFacility",
 )
 
+def _modifyForPhase2(tpClusterProducer):
+    tpClusterProducer.pixelClusterSrc = "siPixelClusters::HLT"
+    tpClusterProducer.phase2OTClusterSrc = "siPhase2Clusters::HLT"
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltTPClusterProducer, _modifyForPhase2)
+
 hltTrackAssociatorByHits = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone()
 hltTrackAssociatorByHits.cluster2TPSrc            = cms.InputTag("hltTPClusterProducer")
 hltTrackAssociatorByHits.UseGrouped               = cms.bool( False )
@@ -24,7 +31,6 @@ hltTrackAssociatorByDeltaR.method             = cms.string('momdr')
 hltTrackAssociatorByDeltaR.QCut               = cms.double(0.5)
 hltTrackAssociatorByDeltaR.ConsiderAllSimHits = cms.bool(True)
 
-
 # Note: the TrackAssociatorEDProducers defined below, and
 # tpToHLTtracksAssociationSequence sequence, are not currently needed
 # to run MTV for HLT, as it is configured to produce the
@@ -35,6 +41,8 @@ tpToHLTpixelTrackAssociation = _trackingParticleRecoTrackAsssociation.clone(
     associator = cms.InputTag('hltTrackAssociatorByHits'),
     ignoremissingtrackcollection = cms.untracked.bool(True)
 )
+
+phase2_tracker.toModify(tpToHLTpixelTrackAssociation, label_tr = "hltPhase2PixelTracks")
 
 tpToHLTiter0tracksAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = cms.InputTag("hltIter0PFlowCtfWithMaterialTracks"),

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -22,7 +22,6 @@ vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPos
     trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
 )
 
-
 hltPixelPVanalysis = hltMultiPVanalysis.clone(
     do_generic_sim_plots  = True,
     trackAssociatorMap    = "tpToHLTpixelTrackAssociation",
@@ -33,6 +32,11 @@ hltPixelPVanalysis = hltMultiPVanalysis.clone(
     )
 )
 
+def _modifyPixelPVanalysisForPhase2(pvanalysis):
+    pvanalysis.vertexRecoCollections = ["hltPhase2PixelVertices"]
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltPixelPVanalysis, _modifyPixelPVanalysisForPhase2)
 
 hltPVanalysis = hltMultiPVanalysis.clone(
     trackAssociatorMap = "tpToHLTpfMuonMergingTrackAssociation",
@@ -42,12 +46,29 @@ hltPVanalysis = hltMultiPVanalysis.clone(
     #"hltFastPVPixelVertices"
     )
 )
+
+tpToHLTphase2TrackAssociation = tpToHLTpixelTrackAssociation.clone(
+    label_tr = "generalTracks::HLT"
+)
+vertexAssociatorByPositionAndTracks4phase2HLTTracks = _VertexAssociatorByPositionAndTracks.clone(
+    trackAssociation = "tpToHLTphase2TrackAssociation"
+)
+
+def _modifyFullPVanalysisForPhase2(pvanalysis):
+    pvanalysis.vertexRecoCollections = ["offlinePrimaryVertices::HLT"]
+    pvanalysis.trackAssociatorMap = "tpToHLTphase2TrackAssociation"
+    pvanalysis.vertexAssociator   = "vertexAssociatorByPositionAndTracks4phase2HLTTracks"
+
+phase2_tracker.toModify(hltPVanalysis, _modifyFullPVanalysisForPhase2)
+
 hltMultiPVAssociations = cms.Task(
     hltTrackAssociatorByHits,
     tpToHLTpixelTrackAssociation,
     vertexAssociatorByPositionAndTracks4pixelTracks,
     tpToHLTpfMuonMergingTrackAssociation,
-    vertexAssociatorByPositionAndTracks4pfMuonMergingTracks
+    vertexAssociatorByPositionAndTracks4pfMuonMergingTracks,
+    tpToHLTphase2TrackAssociation,
+    vertexAssociatorByPositionAndTracks4phase2HLTTracks
 )
 
 hltMultiPVValidation = cms.Sequence( 


### PR DESCRIPTION
#### PR description:

This PR is a companion of https://github.com/cms-sw/cmssw/pull/42783.
Changes needed to the Tracking and Vertexing Validation (w.r.t. Simulation) @ HLT  sequence for the Phase-2 setup.
This relies on the current naming of the tracking collections for the phase-2 HLT:
   * `generalTracks::HLT` (somewhat copied from offline)
   * `offlinePrimaryVertices::HLT` (as above)
   * `hltPhase2PixelTracks` (pixel tracks)
   * `hltPhase2PixelVertices` (pixel vertices)

#### PR validation:

Run successfully `runTheMatrix.py -l 24834.0 -t 4 -j 8 --ibeos` and checked that HLT tracking and vertexing validation plots are filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but might be backported to 13.1.X if there is interest from the Upgrade community.