### PR TITLE
Include HcalPFCuts Rcd in Run2,3 offline data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '124X_dataRun2_v2',
+    'run2_data'                    :    '133X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             :    '124X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'             :    '133X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      :    '124X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'      :    '133X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              :    '123X_dataRun2_HLT_relval_v3',
+    'run2_hlt_relval'              :    '133X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 HLT: identical to the online GT (132X_dataRun3_HLT_v2) but with snapshot at 2023-10-04 21:27:37 (UTC)
     'run3_hlt'                     :    '133X_dataRun3_HLT_frozen_v1',
     # GlobalTag for Run3 data relvals (express GT) - 132X_dataRun3_Express_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
     'run3_data_express'            :    '133X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - 132X_dataRun3_Prompt_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
     'run3_data_prompt'             :    '133X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-06 09:32:44 (UTC)
-    'run3_data'                    :    '133X_dataRun3_v2',
-    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-06 10:12:57 (UTC)
-    'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-19 12:00:00 (UTC)
+    'run3_data'                    :    '133X_dataRun3_v3',
+    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-19 12:00:00 (UTC)
+    'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
The PR updates the Run-2 and Run-3 data GTs to include the missing Hcal PF Cuts Record recognized in [1] with the following tags:
- `HcalPFCuts_v1.0_hlt` for all HLT/Express/Prompt like GTs
- `HcalPFCuts_v1.0_offline` for all offline GTs

from the request/suggestion in [2]. Detailed CMS Talk posts for this are [3] [4]. 

[1] https://github.com/cms-sw/cmssw/pull/43025
[2] https://github.com/cms-sw/cmssw/pull/43025#issuecomment-1770449909
[3] https://cms-talk.web.cern.ch/t/mc-newly-created-hcalpfcuts-mc-tags-submitted-to-13-1-x-mc-queues/22585/3
[4] https://cms-talk.web.cern.ch/t/queue-132x-data-queues-for-pp-ref-and-hi-data-taking/28067

**GT Differences**
- **Run2 data offline** :  Added Rcd with tag `HcalPFCuts_v1.0_offline`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_v2/133X_dataRun2_v1

- **Run2 data HEfail** : Added Rcd with tag `HcalPFCuts_v1.0_offline`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_HEfail_v2/133X_dataRun2_HEfail_v1

- **Run2 data PromptLikeHI** : Added Rcd with tag `HcalPFCuts_v1.0_hlt`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_PromptLike_HI_v1/133X_dataRun2_PromptLike_HI_v1

- **Run2 data HLT RelVal** : Added Rcd with tag `HcalPFCuts_v1.0_hlt`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun2_HLT_relval_v3/133X_dataRun2_HLT_relval_v1

- **Run3 data offline** : Added Rcd with tag `HcalPFCuts_v1.0_offline`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_v2/133X_dataRun3_v3

- **Run3 data PromptAnalysis** : Added Rcd with tag `HcalPFCuts_v1.0_hlt`
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_PromptAnalysis_v1/133X_dataRun3_PromptAnalysis_v2

#### PR validation:

Tested successfully with 
- `runTheMatrix.py -l 136.731,136.793136.874,140.53,4.53,139.001,1000.0,1000.1 -j 8 --ibeos` 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 
