### PR TITLE
Control maximum number of process to run for generating validation plots

### DIFF
--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -43,7 +43,7 @@ def main(opts):
     filenames = [(f, f.replace(".root", "")) for f in opts.files]
     sample = SimpleSample(opts.subdirprefix[0], opts.html_sample, filenames)
   
-    val = SimpleValidation([sample], opts.outputDir[0])
+    val = SimpleValidation([sample], opts.outputDir[0], nProc=opts.jobs)
     if opts.separate:
         val = SeparateValidation([sample], opts.outputDir[0])
     htmlReport = val.createHtmlReport(validationName=opts.html_validation_name[0])   
@@ -144,6 +144,8 @@ if __name__ == "__main__":
                         help="Choose output plots collections among possible choices")    
     parser.add_argument("--extended", action="store_true", default = False,
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
+    parser.add_argument("--jobs", default=0, type=int,
+                        help="Number of jobs to run in parallel for generating plots. Default is 0 i.e. run number of cpu cores jobs.")
     parser.add_argument("--verbose", action="store_true", default = False,
                         help="Be verbose")
 

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -36,7 +36,7 @@ def main(opts):
     if opts.verbose:
         plotting.verbose = True
 
-    val = SimpleValidation([sample], opts.outputDir)
+    val = SimpleValidation([sample], opts.outputDir, nProc=opts.jobs)
     htmlReport = val.createHtmlReport(validationName=opts.html_validation_name)
 
     limitProcessing = LimitTrackAlgo(opts.limit_tracking_algo, includePtCut=opts.ptcut)
@@ -110,6 +110,8 @@ if __name__ == "__main__":
                         help="Sample name for HTML page generation (default 'Sample')")
     parser.add_argument("--html-validation-name", default="",
                         help="Validation name for HTML page generation (enters to <title> element) (default '')")
+    parser.add_argument("--jobs", default=0, type=int,
+                        help="Number of jobs to run in parallel for generating plots. Default is 0 i.e. run number of cpu cores jobs.")
     parser.add_argument("--verbose", action="store_true",
                         help="Be verbose")
 

--- a/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
+++ b/Validation/RecoTrack/test/test_makeTrackValidationPlots.sh
@@ -8,7 +8,7 @@ echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
     echo "Using file ${DQMFILE}. Running in ${LOCAL_TEST_DIR}."
     xrdcp root://cms-xrd-global.cern.ch/${REMOTE}${DQMFILE} .
-    (makeTrackValidationPlots.py ./${DQMFILE}) || die 'failed running makeTrackValidationPlots.py $DQMFILE' $?
+    (makeTrackValidationPlots.py --jobs 4 ./${DQMFILE}) || die 'failed running makeTrackValidationPlots.py $DQMFILE' $?
     rm -fr ./${DQMFILE}
 else 
   die "SKIPPING test, file ${DQMFILE} not found" 0

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -111,7 +111,7 @@ if plotterDrawArgs["separate"]:
     plotGroup.getPlot("GenAllV_Z").setProperties(xtitle="Simulated vertex z (cm)", legendDy=-0.1, legendDx=-0.45, ratioYmax=2.5, **common)
 
 
-val = SimpleValidation(samples, outputDir)
+val = SimpleValidation(samples, outputDir, nProc=2)
 report = val.createHtmlReport(validationName=description)
 val.doPlots([
     trackingPlots.plotter,     # standard tracking plots


### PR DESCRIPTION
As noticed in https://github.com/cms-sw/cmssw/issues/43077 , unit test `Validation/RecoTrack/test/testMakeTrackValidationPlots` does not have any control over how many paralell jobs should be running for generating validation plots. This PR added the option to control the parallel running jobs. Default is to run # of CPUs jobs.

The unit tests `testMakeTrackValidationPlots` is change to run max of `4` jobs.