### PR TITLE
Fix GlobalTag for dumping Fireworks Geometry

### DIFF
--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -79,7 +79,7 @@ def recoGeoLoad(score):
        versionCheck(options.version)
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['run2_mc']
+       process.GlobalTag.globaltag = autoCond['phase2_realistic']
        process.load('Configuration.Geometry.GeometryExtended2026'+options.version+'Reco_cff')
        
     elif score == "MaPSA":


### PR DESCRIPTION
This PR is meant to fix the global tag in `dumpRecoGeometry_cfg.py` for the 2026 scenario. 
It was set to `run2_mc`, and now has been changed to `phase2_realistic`

Issue:
https://github.com/cms-sw/cmssw/issues/43097

Test:
private tests

Tested on CloseByParticleGun (in HGCAL), everything seems to work properly
![image](https://github.com/cms-sw/cmssw/assets/39335169/a38b5a49-3d3e-48ef-b2d2-148be903e8c0)



