### PR TITLE
Fix Wdeprecated-copy warnings in DataFormats/Common (2nd attempt)

### DIFF
--- a/DataFormats/Common/interface/Association.h
+++ b/DataFormats/Common/interface/Association.h
@@ -69,11 +69,6 @@ namespace edm {
       this->ValueMap<int>::swap(other);
       ref_.swap(other.ref_);
     }
-    Association& operator=(Association const& rhs) {
-      Association temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
 
     class Filler : public helper::Filler<Association<C> > {
       typedef helper::Filler<Association<C> > base;

--- a/DataFormats/Common/interface/DataFrameContainer.h
+++ b/DataFormats/Common/interface/DataFrameContainer.h
@@ -72,12 +72,6 @@ namespace edm {
       m_data.swap(rh.m_data);
     }
 
-    DataFrameContainer& operator=(DataFrameContainer const& rhs) {
-      DataFrameContainer temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
-
     void swap(IdContainer& iic, DataContainer& idc) {
       m_ids.swap(iic);
       m_data.swap(idc);
@@ -200,15 +194,5 @@ namespace edm {
   inline void swap(DataFrameContainer& lhs, DataFrameContainer& rhs) { lhs.swap(rhs); }
 
 }  // namespace edm
-
-// The standard allows us to specialize std::swap for non-templates.
-// This ensures that DataFrameContainer::swap() will be used in algorithms.
-
-namespace std {
-  template <>
-  inline void swap(edm::DataFrameContainer& lhs, edm::DataFrameContainer& rhs) {
-    lhs.swap(rhs);
-  }
-}  // namespace std
 
 #endif  // DataFormats_Common_DataFrameContainer_h

--- a/DataFormats/Common/interface/DetSetVector.h
+++ b/DataFormats/Common/interface/DetSetVector.h
@@ -123,8 +123,6 @@ namespace edm {
 
     void swap(DetSetVector& other);
 
-    DetSetVector& operator=(DetSetVector const& other);
-
     ///  Insert the given DetSet.
     // What should happen if there is already a DetSet with this
     // DetId? Right now, it is up to the user *not* to do this. If you
@@ -207,13 +205,6 @@ namespace edm {
     bool tmp = _alreadySorted;
     _alreadySorted = other._alreadySorted;
     other._alreadySorted = tmp;
-  }
-
-  template <class T>
-  inline DetSetVector<T>& DetSetVector<T>::operator=(DetSetVector<T> const& other) {
-    DetSetVector<T> temp(other);
-    swap(temp);
-    return *this;
   }
 
   template <class T>

--- a/DataFormats/Common/interface/HLTGlobalStatus.h
+++ b/DataFormats/Common/interface/HLTGlobalStatus.h
@@ -74,12 +74,6 @@ namespace edm {
     void reset(const unsigned int i) { at(i).reset(); }
     /// swap function
     void swap(HLTGlobalStatus& other) { paths_.swap(other.paths_); }
-    /// copy assignment implemented with swap()
-    HLTGlobalStatus& operator=(HLTGlobalStatus const& rhs) {
-      HLTGlobalStatus temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
 
   private:
     /// Global state variable calculated on the fly
@@ -118,15 +112,5 @@ namespace edm {
   }
 
 }  // namespace edm
-
-// The standard allows us to specialize std::swap for non-templates.
-// This ensures that HLTGlobalStatus::swap() will be used in algorithms.
-
-namespace std {
-  template <>
-  inline void swap(edm::HLTGlobalStatus& lhs, edm::HLTGlobalStatus& rhs) {
-    lhs.swap(rhs);
-  }
-}  // namespace std
 
 #endif  // DataFormats_Common_HLTGlobalStatus_h

--- a/DataFormats/Common/interface/OrphanHandleBase.h
+++ b/DataFormats/Common/interface/OrphanHandleBase.h
@@ -31,8 +31,6 @@ namespace edm {
 
     OrphanHandleBase(void const* iProd, ProductID const& iId) : product_(iProd), id_(iId) { assert(iProd); }
 
-    ~OrphanHandleBase() {}
-
     void clear() {
       product_ = nullptr;
       id_ = ProductID();
@@ -42,12 +40,6 @@ namespace edm {
       using std::swap;
       swap(product_, other.product_);
       std::swap(id_, other.id_);
-    }
-
-    OrphanHandleBase& operator=(OrphanHandleBase const& rhs) {
-      OrphanHandleBase temp(rhs);
-      this->swap(temp);
-      return *this;
     }
 
     bool isValid() const { return product_ && id_ != ProductID(); }

--- a/DataFormats/Common/interface/RangeMap.h
+++ b/DataFormats/Common/interface/RangeMap.h
@@ -194,9 +194,6 @@ namespace edm {
     /// swap member function
     void swap(RangeMap<ID, C, P>& other);
 
-    /// copy assignment
-    RangeMap& operator=(RangeMap const& rhs);
-
     //Used by ROOT storage
     CMS_CLASS_VERSION(10)
 
@@ -211,13 +208,6 @@ namespace edm {
   inline void RangeMap<ID, C, P>::swap(RangeMap<ID, C, P>& other) {
     collection_.swap(other.collection_);
     map_.swap(other.map_);
-  }
-
-  template <typename ID, typename C, typename P>
-  inline RangeMap<ID, C, P>& RangeMap<ID, C, P>::operator=(RangeMap<ID, C, P> const& rhs) {
-    RangeMap<ID, C, P> temp(rhs);
-    this->swap(temp);
-    return *this;
   }
 
   // free swap function

--- a/DataFormats/Common/interface/RefVectorHolder.h
+++ b/DataFormats/Common/interface/RefVectorHolder.h
@@ -18,9 +18,7 @@ namespace edm {
       RefVectorHolder() : RefVectorHolderBase() {}
       RefVectorHolder(REFV const& refs) : RefVectorHolderBase(), refs_(refs) {}
       explicit RefVectorHolder(ProductID const& iId) : RefVectorHolderBase(), refs_(iId) {}
-      ~RefVectorHolder() override {}
       void swap(RefVectorHolder& other);
-      RefVectorHolder& operator=(RefVectorHolder const& rhs);
       bool empty() const override;
       size_type size() const override;
       void clear() override;
@@ -93,13 +91,6 @@ namespace edm {
     inline void RefVectorHolder<REFV>::swap(RefVectorHolder<REFV>& other) {
       this->RefVectorHolderBase::swap(other);
       refs_.swap(other.refs_);
-    }
-
-    template <typename REFV>
-    inline RefVectorHolder<REFV>& RefVectorHolder<REFV>::operator=(RefVectorHolder<REFV> const& rhs) {
-      RefVectorHolder<REFV> temp(rhs);
-      this->swap(temp);
-      return *this;
     }
 
     template <typename REFV>

--- a/DataFormats/Common/interface/TriggerResults.h
+++ b/DataFormats/Common/interface/TriggerResults.h
@@ -64,13 +64,6 @@ namespace edm {
       names_.swap(other.names_);
     }
 
-    /// Copy assignment using swap.
-    TriggerResults& operator=(TriggerResults const& rhs) {
-      TriggerResults temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
-
     // The next three functions are OBSOLETE and should only be used for backward
     // compatibility to older data.  The names_ vector is always empty in new data.
 

--- a/DataFormats/Common/interface/ValueMap.h
+++ b/DataFormats/Common/interface/ValueMap.h
@@ -120,12 +120,6 @@ namespace edm {
       ids_.swap(other.ids_);
     }
 
-    ValueMap& operator=(ValueMap const& rhs) {
-      ValueMap temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
-
     template <typename RefKey>
     const_reference_type operator[](const RefKey& r) const {
       return get(r.id(), r.key());


### PR DESCRIPTION
#### PR description:

Implicit copy-constructors are deprecated, and not necessary in most cases. This PR removes unnnecessary copy-assignment operators and destructors in favor of auto-generated ones.

#### PR validation:

Bot tests
