### PR TITLE
[13_0_X] Fix condition to add anti-particle to G4ParticleTable

### DIFF
--- a/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
+++ b/SimG4Core/CustomPhysics/src/CustomParticleFactory.cc
@@ -302,7 +302,7 @@ void CustomParticleFactory::getMassTable(std::ifstream *configFile) {
       }
       if (sign == -1 && pdgId != 25 && pdgId != 35 && pdgId != 36 && pdgId != 37 && pdgId != 1000039) {
         tmp = "anti_" + name;
-        if (nullptr != theParticleTable->FindParticle(-pdgId)) {
+        if (theParticleTable->FindParticle(-pdgId) == nullptr) {
           edm::LogVerbatim("SimG4CoreCustomPhysics")
               << "CustomParticleFactory: Calling addCustomParticle for antiparticle with pdgId: " << -pdgId << ", mass "
               << mass << " GeV, name " << tmp;


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/42957

**PR description:**
This PR is to fix the behaviour of the CustomParticleFactory class in order to correctly include the corresponding anti-particle each time a new particle is added to the list.
The correct behaviour was somehow broken with [this commit](https://github.com/cms-sw/cmssw/commit/c3d2a3218041b3de169093b1c1df2d337fe1d74d#diff-3356a0227a88656afdbec257541eeac667962e40e2514de565256487d2ca9b32) which reverted the condition necessary to call the addCustomParticle() function (which should add the anti-particle to the particle table).
So in the current releases the function will be called only if the anti-particle is already there.
As an example, in my case I needed to add the stau and anti-stau particles, but only the stau was added, while the anti-stau was not, with a series of consequences in the following steps (e.g., charge was set to 0, anti-stau track non added to the SIM track collection, etc...)

**PR validation:**
see original PR

**If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:**  
Verbatim backport of https://github.com/cms-sw/cmssw/pull/42957 to 13_0_X to be used for Summer23 MC production