### PR TITLE
Use likelihood fit instead of chi-square fit in DQMServices slice fits

### DIFF
--- a/DQMServices/Components/plugins/DQMGenericClient.cc
+++ b/DQMServices/Components/plugins/DQMGenericClient.cc
@@ -158,7 +158,7 @@ public:
     // ... create your hists
     TH2F* h = me->getTH2F();
     TF1 fgaus("fgaus", "gaus", h->GetYaxis()->GetXmin(), h->GetYaxis()->GetXmax(), TF1::EAddToList::kNo);
-    h->FitSlicesY(&fgaus, 0, -1, 0, "QNR SERIAL");
+    h->FitSlicesY(&fgaus, 0, -1, 0, "QNRL SERIAL");
     string name(h->GetName());
     h0 = (TH1*)gDirectory->Get((name + "_0").c_str());
     h1 = (TH1*)gDirectory->Get((name + "_1").c_str());


### PR DESCRIPTION
The DQM plots use the `TH2::FitSlicesY()` function to fit some Gaussians. However, some of the fits are failing. This was not resulting in errors so far, but with the switch to Minuit2 by default in ROOT 6.30 it will.

The problem is that it uses chi-square fits to fit slices with many empty bins, which is not appropriate. Doing a likelihood fit with the `"l"` option is one way to fix the problem, because it can better deal with empty bins.

Thanks to @lmoneta for this suggestion!
See https://github.com/root-project/root/issues/13852

Closes #42979.

@smuzaffar, needs to be tested with ROOT master or 6.30 if possible.