### PR TITLE
Update beamhlt client unitTests

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" />
+<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient-legacy" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" />  <!-- To be removed once https://github.com/cms-sw/cmssw/issues/43108 is solved -->
+<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py 370580"/>
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py"/>


### PR DESCRIPTION
#### PR description:

This PR updates the DQM `beamhlt` client unitTest to use the streamer files of a 2023 pp collisions run (370580),
which have the correct event content (see https://github.com/cms-data/DQM-Integration/issues/3 for details)
 - The new files are being added in `cms-data` in https://github.com/cms-data/DQM-Integration/pull/6

Additionally, in light of the issue reported in https://github.com/cms-sw/cmssw/issues/43108, the old unitTest configuration (i.e. using the streamer files from an older run) is kept active under the name: `TestDQMOnlineClient-beamhlt_dqm_sourceclient-legacy`

#### PR validation:
Successfully ran the `beamhlt` unittest on the new run.

#### Backport:
Not a backport, no backport needed