### PR TITLE
[13_2_X] Use ZDC digis in uGT DQM

### DIFF
--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -135,6 +135,7 @@ valGtStage2Digis = simGtStage2Digis.clone(
     TauInputTag = "gtStage2Digis:Tau",
     JetInputTag = "gtStage2Digis:Jet",
     EtSumInputTag = "gtStage2Digis:EtSum",
+    EtSumZdcInputTag = "gtStage2Digis:EtSumZDC",
     AlgorithmTriggersUnmasked = False,
     AlgorithmTriggersUnprescaled = False,
     EmulateBxInEvent = cms.int32(5),


### PR DESCRIPTION
#### PR description:

Add unpacked ZDC digis to uGT DQM. This was overlooked when the ZDC unpacker was added to CMSSW.

Backport of https://github.com/cms-sw/cmssw/pull/43043
