### PR TITLE
Addition of CaloSummary (CICADA) to L1 Emulation Sequences and Ntuples

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -160,7 +160,7 @@ L1TCaloSummary<INPUT, OUTPUT>::L1TCaloSummary(const edm::ParameterSet& iConfig)
 
   //anomaly trigger loading
   model = loader.load_model();
-  produces<float>("anomalyScore");
+  produces<float>("CICADAScore");
 }
 
 //
@@ -174,7 +174,7 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
 
   std::unique_ptr<L1JetParticleCollection> bJetCands(new L1JetParticleCollection);
 
-  std::unique_ptr<float> anomalyScore = std::make_unique<float>();
+  std::unique_ptr<float> CICADAScore = std::make_unique<float>();
 
   UCTGeometry g;
 
@@ -222,7 +222,7 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
   model->predict();
   model->read_result(modelResult);
 
-  *anomalyScore = modelResult[0].to_float();
+  *CICADAScore = modelResult[0].to_float();
 
   summaryCard.setRegionData(inputRegions);
 
@@ -288,7 +288,7 @@ void L1TCaloSummary<INPUT, OUTPUT>::produce(edm::Event& iEvent, const edm::Event
 
   iEvent.put(std::move(bJetCands), "Boosted");
   //Write out anomaly score
-  iEvent.put(std::move(anomalyScore), "anomalyScore");
+  iEvent.put(std::move(CICADAScore), "CICADAScore");
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/simDigis_cff.py
@@ -41,6 +41,7 @@ from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 #from L1Trigger.L1TCalorimeter.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
 # - layer1 from L1Trigger/L1TCaloLayer1 package
 from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Digis_cfi import simCaloStage2Layer1Digis
+from L1Trigger.L1TCaloLayer1.simCaloStage2Layer1Summary_cfi import simCaloStage2Layer1Summary
 from L1Trigger.L1TCalorimeter.simCaloStage2Digis_cfi import simCaloStage2Digis
-stage2L1Trigger.toReplaceWith(SimL1TCalorimeterTask, cms.Task( simCaloStage2Layer1Digis, simCaloStage2Digis ))
+stage2L1Trigger.toReplaceWith(SimL1TCalorimeterTask, cms.Task( simCaloStage2Layer1Digis, simCaloStage2Layer1Summary, simCaloStage2Digis ))
 

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h
@@ -2,21 +2,21 @@
 #define L1Trigger_L1TNtuples_L1AnalysisCaloSummaryDataFormat_h
 
 namespace L1Analysis {
-    struct L1AnalysisCaloSummaryDataFormat {
-        L1AnalysisCaloSummaryDataFormat() { Reset(); }
-        ~L1AnalysisCaloSummaryDataFormat() {};
+  struct L1AnalysisCaloSummaryDataFormat {
+    L1AnalysisCaloSummaryDataFormat() { Reset(); }
+    ~L1AnalysisCaloSummaryDataFormat(){};
 
-        void Reset() {
-            CICADAScore = 0;
-            for (short iPhi = 0; iPhi < 18; ++iPhi)
-                for (short iEta = 0; iEta < 14; ++iEta)
-                    modelInput[iPhi][iEta] = 0;
-        }
-        void Init() {}
+    void Reset() {
+      CICADAScore = 0;
+      for (short iPhi = 0; iPhi < 18; ++iPhi)
+        for (short iEta = 0; iEta < 14; ++iEta)
+          modelInput[iPhi][iEta] = 0;
+    }
+    void Init() {}
 
-        float CICADAScore;
-        unsigned short int modelInput[18][14]; //Stored in indices of [iPhi][iEta]
-    };
-}
+    float CICADAScore;
+    unsigned short int modelInput[18][14];  //Stored in indices of [iPhi][iEta]
+  };
+}  // namespace L1Analysis
 
 #endif

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h
@@ -1,0 +1,22 @@
+#ifndef L1Trigger_L1TNtuples_L1AnalysisCaloSummaryDataFormat_h
+#define L1Trigger_L1TNtuples_L1AnalysisCaloSummaryDataFormat_h
+
+namespace L1Analysis {
+    struct L1AnalysisCaloSummaryDataFormat {
+        L1AnalysisCaloSummaryDataFormat() { Reset(); }
+        ~L1AnalysisCaloSummaryDataFormat() {};
+
+        void Reset() {
+            CICADAScore = 0;
+            for (short iPhi = 0; iPhi < 18; ++iPhi)
+                for (short iEta = 0; iEta < 14; ++iEta)
+                    modelInput[iPhi][iEta] = 0;
+        }
+        void Init() {}
+
+        float CICADAScore;
+        unsigned short int modelInput[18][14]; //Stored in indices of [iPhi][iEta]
+    };
+}
+
+#endif

--- a/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
@@ -1,0 +1,83 @@
+// Producer for the CaloSummary cards emulator
+// Author: Andrew Loeliger
+// Presumably the L1TNtuple Format is going to last very long with the advent of L1NanoAOD, 
+// But as of now, this is the only way to get CICADA into official menu studying tools
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TTree.h"
+
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h"
+
+#include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
+#include "DataFormats/L1CaloTrigger/interface/L1CaloRegion.h"
+
+
+class L1CaloSummaryTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+    public:
+        explicit L1CaloSummaryTreeProducer (const edm::ParameterSet&);
+        ~L1CaloSummaryTreeProducer() override;
+
+    private:
+        void beginJob() override {};
+        void analyze(const edm::Event&, const edm::EventSetup&) override;
+        void endJob() override {};
+    
+    public:
+        L1Analysis::L1AnalysisCaloSummaryDataFormat* caloSummaryData_;
+    
+    private:
+        const edm::EDGetTokenT<float> scoreToken_;
+        const edm::EDGetTokenT<L1CaloRegionCollection> regionToken_;
+        edm::Service<TFileService> fs_;
+        TTree* tree_;
+};
+
+L1CaloSummaryTreeProducer::L1CaloSummaryTreeProducer(const edm::ParameterSet& iConfig):
+    scoreToken_(consumes<float>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
+    regionToken_(consumes<L1CaloRegionCollection>(iConfig.getUntrackedParameter<edm::InputTag>("regionToken"))) {
+        usesResource(TFileService::kSharedResource);
+        tree_ = fs_->make<TTree>("L1CaloSummaryTree", "L1CaloSummaryTree");
+        tree_->Branch("CaloSummary","L1Analysis::L1AnalysisCaloSummaryDataFormat", &caloSummaryData_, 32000, 3);
+
+        caloSummaryData_ = new L1Analysis::L1AnalysisCaloSummaryDataFormat();       
+}
+
+void L1CaloSummaryTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    caloSummaryData_->Reset();
+
+    edm::Handle<L1CaloRegionCollection> regions;
+    iEvent.getByToken(regionToken_, regions);
+
+    if(regions.isValid()) {
+        for (auto itr: *regions) {
+            caloSummaryData_->modelInput[itr.gctPhi()][itr.gctEta()-4] = itr.et(); //4 is subtracted off of the Eta to account for the 4+4 forward/backward HF regions that are not used in CICADA. These take offset the iEta by 4
+        }
+    }
+    else {
+        edm::LogWarning("L1Ntuple") << "Could not find region regions. CICADA model input will not be filled";
+    }
+
+    edm::Handle<float> score;
+    iEvent.getByToken(scoreToken_, score);
+    if (score.isValid()) caloSummaryData_->CICADAScore = *score;
+    else edm::LogWarning("L1Ntuple") << "Could not find a proper CICADA score. CICADA score will not be filled.";
+
+    tree_->Fill();
+}
+
+L1CaloSummaryTreeProducer::~L1CaloSummaryTreeProducer() {
+    delete caloSummaryData_;
+}
+
+DEFINE_FWK_MODULE(L1CaloSummaryTreeProducer);

--- a/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
@@ -1,6 +1,6 @@
 // Producer for the CaloSummary cards emulator
 // Author: Andrew Loeliger
-// Presumably the L1TNtuple Format is going to last very long with the advent of L1NanoAOD, 
+// Presumably the L1TNtuple Format is going to last very long with the advent of L1NanoAOD,
 // But as of now, this is the only way to get CICADA into official menu studying tools
 
 #include <memory>
@@ -22,62 +22,61 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegion.h"
 
-
 class L1CaloSummaryTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
-    public:
-        explicit L1CaloSummaryTreeProducer (const edm::ParameterSet&);
-        ~L1CaloSummaryTreeProducer() override;
+public:
+  explicit L1CaloSummaryTreeProducer(const edm::ParameterSet&);
+  ~L1CaloSummaryTreeProducer() override;
 
-    private:
-        void beginJob() override {};
-        void analyze(const edm::Event&, const edm::EventSetup&) override;
-        void endJob() override {};
-    
-    public:
-        L1Analysis::L1AnalysisCaloSummaryDataFormat* caloSummaryData_;
-    
-    private:
-        const edm::EDGetTokenT<float> scoreToken_;
-        const edm::EDGetTokenT<L1CaloRegionCollection> regionToken_;
-        edm::Service<TFileService> fs_;
-        TTree* tree_;
+private:
+  void beginJob() override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override{};
+
+public:
+  L1Analysis::L1AnalysisCaloSummaryDataFormat* caloSummaryData_;
+
+private:
+  const edm::EDGetTokenT<float> scoreToken_;
+  const edm::EDGetTokenT<L1CaloRegionCollection> regionToken_;
+  edm::Service<TFileService> fs_;
+  TTree* tree_;
 };
 
-L1CaloSummaryTreeProducer::L1CaloSummaryTreeProducer(const edm::ParameterSet& iConfig):
-    scoreToken_(consumes<float>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
-    regionToken_(consumes<L1CaloRegionCollection>(iConfig.getUntrackedParameter<edm::InputTag>("regionToken"))) {
-        usesResource(TFileService::kSharedResource);
-        tree_ = fs_->make<TTree>("L1CaloSummaryTree", "L1CaloSummaryTree");
-        tree_->Branch("CaloSummary","L1Analysis::L1AnalysisCaloSummaryDataFormat", &caloSummaryData_, 32000, 3);
+L1CaloSummaryTreeProducer::L1CaloSummaryTreeProducer(const edm::ParameterSet& iConfig)
+    : scoreToken_(consumes<float>(iConfig.getUntrackedParameter<edm::InputTag>("scoreToken"))),
+      regionToken_(consumes<L1CaloRegionCollection>(iConfig.getUntrackedParameter<edm::InputTag>("regionToken"))) {
+  usesResource(TFileService::kSharedResource);
+  tree_ = fs_->make<TTree>("L1CaloSummaryTree", "L1CaloSummaryTree");
+  tree_->Branch("CaloSummary", "L1Analysis::L1AnalysisCaloSummaryDataFormat", &caloSummaryData_, 32000, 3);
 
-        caloSummaryData_ = new L1Analysis::L1AnalysisCaloSummaryDataFormat();       
+  caloSummaryData_ = new L1Analysis::L1AnalysisCaloSummaryDataFormat();
 }
 
 void L1CaloSummaryTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    caloSummaryData_->Reset();
+  caloSummaryData_->Reset();
 
-    edm::Handle<L1CaloRegionCollection> regions;
-    iEvent.getByToken(regionToken_, regions);
+  edm::Handle<L1CaloRegionCollection> regions;
+  iEvent.getByToken(regionToken_, regions);
 
-    if(regions.isValid()) {
-        for (auto itr: *regions) {
-            caloSummaryData_->modelInput[itr.gctPhi()][itr.gctEta()-4] = itr.et(); //4 is subtracted off of the Eta to account for the 4+4 forward/backward HF regions that are not used in CICADA. These take offset the iEta by 4
-        }
+  if (regions.isValid()) {
+    for (auto itr : *regions) {
+      caloSummaryData_->modelInput[itr.gctPhi()][itr.gctEta() - 4] =
+          itr.et();  //4 is subtracted off of the Eta to account for the 4+4 forward/backward HF regions that are not used in CICADA. These take offset the iEta by 4
     }
-    else {
-        edm::LogWarning("L1Ntuple") << "Could not find region regions. CICADA model input will not be filled";
-    }
+  } else {
+    edm::LogWarning("L1Ntuple") << "Could not find region regions. CICADA model input will not be filled";
+  }
 
-    edm::Handle<float> score;
-    iEvent.getByToken(scoreToken_, score);
-    if (score.isValid()) caloSummaryData_->CICADAScore = *score;
-    else edm::LogWarning("L1Ntuple") << "Could not find a proper CICADA score. CICADA score will not be filled.";
+  edm::Handle<float> score;
+  iEvent.getByToken(scoreToken_, score);
+  if (score.isValid())
+    caloSummaryData_->CICADAScore = *score;
+  else
+    edm::LogWarning("L1Ntuple") << "Could not find a proper CICADA score. CICADA score will not be filled.";
 
-    tree_->Fill();
+  tree_->Fill();
 }
 
-L1CaloSummaryTreeProducer::~L1CaloSummaryTreeProducer() {
-    delete caloSummaryData_;
-}
+L1CaloSummaryTreeProducer::~L1CaloSummaryTreeProducer() { delete caloSummaryData_; }
 
 DEFINE_FWK_MODULE(L1CaloSummaryTreeProducer);

--- a/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloSummaryTreeProducer.cc
@@ -59,7 +59,7 @@ void L1CaloSummaryTreeProducer::analyze(const edm::Event& iEvent, const edm::Eve
   iEvent.getByToken(regionToken_, regions);
 
   if (regions.isValid()) {
-    for (auto itr : *regions) {
+    for (const auto& itr : *regions) {
       caloSummaryData_->modelInput[itr.gctPhi()][itr.gctEta() - 4] =
           itr.et();  //4 is subtracted off of the Eta to account for the 4+4 forward/backward HF regions that are not used in CICADA. These take offset the iEta by 4
     }

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 
 from L1Trigger.L1TNtuples.l1CaloTowerTree_cfi import *
+from L1Trigger.L1TNtuples.l1CaloSummaryTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTfMuonShowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
@@ -24,6 +25,8 @@ l1CaloTowerEmuTree.ecalToken = cms.untracked.InputTag("simEcalTriggerPrimitiveDi
 l1CaloTowerEmuTree.hcalToken = cms.untracked.InputTag("simHcalTriggerPrimitiveDigis")
 l1CaloTowerEmuTree.l1TowerToken = cms.untracked.InputTag("simCaloStage2Layer1Digis")
 l1CaloTowerEmuTree.l1ClusterToken = cms.untracked.InputTag("simCaloStage2Digis", "MP")
+
+l1CaloSummaryEmuTree = l1CaloSummaryTree.clone()
 
 l1UpgradeEmuTree = l1UpgradeTree.clone(
     egToken = "simCaloStage1FinalDigis",
@@ -51,6 +54,7 @@ L1NtupleEMU = cms.Sequence(
   l1EventTree
   +l1UpgradeTfMuonEmuTree
   +l1CaloTowerEmuTree
+  +l1CaloSummaryEmuTree
   +l1UpgradeEmuTree
 #  +l1MuonEmuTree
   +l1uGTEmuTree

--- a/L1Trigger/L1TNtuples/python/l1CaloSummaryTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1CaloSummaryTree_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+l1CaloSummaryTree = cms.EDAnalyzer(
+    "L1CaloSummaryTreeProducer",
+    scoreToken = cms.untracked.InputTag("simCaloStage2Layer1Summary", "CICADAScore"),
+    regionToken = cms.untracked.InputTag("simCaloStage2Layer1Digis"),
+)

--- a/L1Trigger/L1TNtuples/src/classes.h
+++ b/L1Trigger/L1TNtuples/src/classes.h
@@ -32,3 +32,5 @@
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisRecoPhotonDataFormat.h"
 
 #include "L1Trigger/L1TNtuples/interface/L1AnalysisL1Upgrade.h"
+
+#include "L1Trigger/L1TNtuples/interface/L1AnalysisCaloSummaryDataFormat.h"

--- a/L1Trigger/L1TNtuples/src/classes_def.xml
+++ b/L1Trigger/L1TNtuples/src/classes_def.xml
@@ -34,4 +34,6 @@
 
 <class name="L1Analysis::L1AnalysisL1Upgrade" persistent="false"/>
 
+<class name="L1Analysis::L1AnalysisCaloSummaryDataFormat"/>
+
 </lcgdict>


### PR DESCRIPTION
### PR description:

This PR introduces the CaloSummary (CICADA) emualtion into L1 standard sequences by adding it to the L1TCalorimeter `simDigis` task. This is being done in preparation of integrating CICADA into the uGT (and uGT emulator) and in preparation for menu studies next year.

In addition, basic L1Ntuples infrastructure for looking at CICADA input and output have been added to the L1Ntuples as an emulator tree, taking by default it's input from the CaloL1Emulation, and the CICADA output by default from the CICADA emulation. Later, if desired, an non-emulator version of this tree could be run off an unpacked CICADA score and genuine tower regions in the raw data.

Some more slight tidying of the CaloSummary emulator has been down to remove ambiguity from other anomaly detection techniques by renaming variables/outputs from "anomaly" to "CICADA".

### PR validation:

All code compiles, passes tests, and has had code formatting applied. In addition, the addition of the CaloSummary to standard Sequences has been tested by running the standard L1 sequences `L1TReEmulFromRAW` (from `L1Trigger/Configuration/customiseReEmul`) and then the Ntuplization sequence `L1NtupleRAWEMU` (from `L1Trigger/L1TNtuples/customiseL1Ntuple`) on a file with RAW info available. This ran successfully, and an Ntuple with sensible information was produced.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and a backport will only be needed if L1/HLT trigger studies are performed on an earlier version of the emulator.
