### PR TITLE
Replace deprecated hash_set with unordered_set

### DIFF
--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -16,7 +16,7 @@
 #include <list>
 #include <map>
 #include <set>
-#include <ext/hash_set>
+#include <unordered_set>
 
 // for definition of QValue
 #include "DataFormats/Histograms/interface/MonitorElementCollection.h"
@@ -383,7 +383,7 @@ public:
   struct ImplPeer;
 
   using DirMap = std::set<std::string>;
-  typedef __gnu_cxx::hash_set<ObjType, HashOp, HashEqual> ObjectMap;
+  typedef std::unordered_set<ObjType, HashOp, HashEqual> ObjectMap;
   typedef std::map<lat::Socket *, ImplPeer> PeerMap;
   struct ImplPeer : Peer {
     ImplPeer() = default;

--- a/DQMServices/Core/src/DQMNet.cc
+++ b/DQMServices/Core/src/DQMNet.cc
@@ -1213,7 +1213,7 @@ DQMBasicNet::DQMBasicNet(const std::string &appname /* = "" */) : DQMImplNet<DQM
 }
 
 /// Give a hint of how much capacity to allocate for local objects.
-void DQMBasicNet::reserveLocalSpace(uint32_t size) { local_->objs.resize(size); }
+void DQMBasicNet::reserveLocalSpace(uint32_t size) { local_->objs.reserve(size); }
 
 /// Update the network cache for an object.  The caller must call
 /// sendLocalChanges() later to push out the changes.


### PR DESCRIPTION
#### PR description:

`hash_set` is a GNU extension, and was deprecated long ago. It is recommended to use [unordered_set](https://en.cppreference.com/w/cpp/container/unordered_set) instead.

#### PR validation:

Bot tests