### PR TITLE
MTD geometry: speed up MTD reco geometry construction

### DIFF
--- a/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
@@ -26,12 +26,13 @@ public:
   void veto(const std::string& veto) { veto_.emplace_back(veto); }
 
   bool accept(const DDExpandedView& ev) const final {
+    std::string currentName(ev.logicalPart().name().fullname());
     for (const auto& test : veto_) {
-      if (ev.logicalPart().name().fullname().find(test) != std::string::npos)
+      if (currentName.find(test) != std::string::npos)
         return false;
     }
     for (const auto& test : allowed_) {
-      if (ev.logicalPart().name().fullname().find(test) != std::string::npos)
+      if (currentName.find(test) != std::string::npos)
         return true;
     }
     return false;
@@ -48,6 +49,11 @@ std::unique_ptr<GeometricTimingDet> DDCmsMTDConstruction::construct(const DDComp
   filter.add("mtd:");
   filter.add("btl:");
   filter.add("etl:");
+
+  std::vector<std::string> volnames = {"FSide", "SupportPlate"};
+  for (auto const& theVol : volnames) {
+    filter.veto(theVol);
+  }
 
   DDFilteredView fv(cpv, filter);
 

--- a/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
+++ b/Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.cc
@@ -1,5 +1,3 @@
-//#define EDM_ML_DEBUG
-
 #include "Geometry/MTDNumberingBuilder/plugins/DDCmsMTDConstruction.h"
 
 #include <utility>
@@ -50,56 +48,6 @@ std::unique_ptr<GeometricTimingDet> DDCmsMTDConstruction::construct(const DDComp
   filter.add("mtd:");
   filter.add("btl:");
   filter.add("etl:");
-
-  std::vector<std::string> volnames = {"service",
-                                       "support",
-                                       "FSide",
-                                       "BSide",
-                                       "LSide",
-                                       "RSide",
-                                       "Between",
-                                       "SupportPlate",
-                                       "Shield",
-                                       "ThermalScreen",
-                                       "Aluminium_Disc",
-                                       "MIC6_Aluminium_Disc",
-                                       "ThermalPad",
-                                       "AlN",
-                                       "LairdFilm",
-                                       "ETROC",
-                                       "SensorModule",
-                                       "SensorModule_Front_Left",
-                                       "SensorModule_Front_Right",
-                                       "SensorModule_Back_Left",
-                                       "SensorModule_Back_Right",
-                                       "DiscSector",
-                                       "LGAD_Substrate",
-                                       "ConcentratorCard",
-                                       "PowerControlCard",
-                                       "CoolingPlate",
-                                       "FrontEndCard",
-                                       "FrontModerator",
-                                       "Cables",
-                                       "Cables1",
-                                       "Cables2",
-                                       "Cables3",
-                                       "Cables4",
-                                       "Cables5",
-                                       "Cables6",
-                                       "Cables7",
-                                       "PatchPanel",
-                                       "Notich_cables",
-                                       "ServicesExtVolume1",
-                                       "ServicesExtVolume2",
-                                       "glueLGAD",
-                                       "BumpBonds",
-                                       "ModulePCB",
-                                       "connectorsGap",
-                                       "ReadoutBoard",
-                                       "LGAD"};
-  for (auto const& theVol : volnames) {
-    filter.veto(theVol);
-  }
 
   DDFilteredView fv(cpv, filter);
 


### PR DESCRIPTION
#### PR description:

The DDD implementation of the MTD reconstruction geometry creation, in the ```DDCmsMTDConstruction``` class of ```Geometry/MTDNumberingBuilder``` is a killer for the startup CMSSW performances. It turns out that the veto filtering on non sensitive volumes is the key responsible for this, likely due to an excessive number of ```find``` of strings in the logical name of processed volumes. Just removing it, without impact on the geometry reconstructed, effectively solves the problem.

As a side note, the DD4hep version, implemented in parallel since 2020, does not suffer of this issue, using a different filtering approach. Unfortunately this is of little help, since we are still in the middle of the transition between different geometry back-ends.

Addressing https://github.com/cms-sw/cmssw/issues/43062 .

#### PR validation:

The MTD reconstruction geometry unit tests pass, showing that the same geometry as before is reconstructed. Both ```Tracer``` timing and igprof profiling show a sizeable improvement, from almost 50 down to 3 seconds on the machine used for tests.

Before:

```
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 26-Oct-2023 17:03:28.265 CEST
26-Oct-2023 17:03:28.26 CEST  ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1
26-Oct-2023 17:03:28.26 CEST  ++++++ starting: processing path 'p1' : stream = 0
26-Oct-2023 17:03:28.26 CEST  ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'prod' id = 3
26-Oct-2023 17:03:28.26 CEST  ++++++++ starting: prefetching for esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:03:28.26 CEST  ++++++++++ starting: prefetching for esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:03:28.26 CEST  ++++++++++ finished: prefetching for esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:03:28.26 CEST  ++++++++++ starting: processing esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:03:31.47 CEST  ++++++++++ finished: processing esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:03:31.47 CEST  ++++++++ finished: prefetching for esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:03:31.47 CEST  ++++++++ starting: processing esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:04:08.03 CEST  ++++++++ finished: processing esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:04:08.03 CEST  ++++++++ finished: prefetching before processing event for module: stream = 0 label = 'prod' id = 3
26-Oct-2023 17:04:08.03 CEST  ++++++++ starting: processing event for module: stream = 0 label = 'prod' id = 3
%MSG-i GeometricTimingDetAnalyzer:  GeometricTimingDetAnalyzer:prod  26-Oct-2023 17:04:08 CEST Run: 1 Event: 1
Beginning MTD GeometricTimingDet container dump 
%MSG
```

With this PR:


```
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 26-Oct-2023 17:22:07.701 CEST
26-Oct-2023 17:22:07.70 CEST  ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1
26-Oct-2023 17:22:07.70 CEST  ++++++ starting: processing path 'p1' : stream = 0
26-Oct-2023 17:22:07.70 CEST  ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'prod' id = 3
26-Oct-2023 17:22:07.70 CEST  ++++++++ starting: prefetching for esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:22:07.70 CEST  ++++++++++ starting: prefetching for esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:22:07.70 CEST  ++++++++++ finished: prefetching for esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:22:07.70 CEST  ++++++++++ starting: processing esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:22:10.70 CEST  ++++++++++ finished: processing esmodule: label = '' type = XMLIdealGeometryESSource in record = IdealGeometryRecord
26-Oct-2023 17:22:10.70 CEST  ++++++++ finished: prefetching for esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
26-Oct-2023 17:22:10.70 CEST  ++++++++ starting: processing esmodule: label = 'mtdNumberingGeometry' type = MTDGeometricTimingDetESModule in record = IdealGeometryRecord
%MSG-i MTDNumbering:   MTDGeometricTimingDetESModule:mtdNumberingGeometry@callESModule  26-Oct-2023 17:22:10 CEST Run: 1 Event: 1
Top level node = OCMS
%MSG
```