### PR TITLE
Use ratio timing for CPU algorithm in ECAL CPU vs. GPU validation

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cff.py
@@ -26,23 +26,24 @@ from RecoLocalCalo.EcalRecProducers.ecalMultifitParametersGPUESProducer_cfi impo
 # ECAL multifit running on GPU
 from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitProducerGPU_cfi import ecalUncalibRecHitProducerGPU as _ecalUncalibRecHitProducerGPU
 ecalMultiFitUncalibRecHitGPU = _ecalUncalibRecHitProducerGPU.clone(
-  digisLabelEB = cms.InputTag('ecalDigisGPU', 'ebDigis'),
-  digisLabelEE = cms.InputTag('ecalDigisGPU', 'eeDigis'),
+  digisLabelEB = 'ecalDigisGPU:ebDigis',
+  digisLabelEE = 'ecalDigisGPU:eeDigis',
 )
 
 # copy the uncalibrated rechits from GPU to CPU
 from RecoLocalCalo.EcalRecProducers.ecalCPUUncalibRecHitProducer_cfi import ecalCPUUncalibRecHitProducer as _ecalCPUUncalibRecHitProducer
 ecalMultiFitUncalibRecHitSoA = _ecalCPUUncalibRecHitProducer.clone(
-  recHitsInLabelEB = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEB'),
-  recHitsInLabelEE = cms.InputTag('ecalMultiFitUncalibRecHitGPU', 'EcalUncalibRecHitsEE'),
+  recHitsInLabelEB = 'ecalMultiFitUncalibRecHitGPU:EcalUncalibRecHitsEB',
+  recHitsInLabelEE = 'ecalMultiFitUncalibRecHitGPU:EcalUncalibRecHitsEE',
+  containsTimingInformation = True
 )
 
 # convert the uncalibrated rechits from SoA to legacy format
 from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitConvertGPU2CPUFormat_cfi import ecalUncalibRecHitConvertGPU2CPUFormat as _ecalUncalibRecHitConvertGPU2CPUFormat
 gpu.toModify(ecalMultiFitUncalibRecHit,
   cuda = _ecalUncalibRecHitConvertGPU2CPUFormat.clone(
-    recHitsLabelGPUEB = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEB'),
-    recHitsLabelGPUEE = cms.InputTag('ecalMultiFitUncalibRecHitSoA', 'EcalUncalibRecHitsEE'),
+    recHitsLabelGPUEB = 'ecalMultiFitUncalibRecHitSoA:EcalUncalibRecHitsEB',
+    recHitsLabelGPUEE = 'ecalMultiFitUncalibRecHitSoA:EcalUncalibRecHitsEE',
   )
 )
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -17,3 +17,16 @@ run3_ecal.toModify(ecalMultiFitUncalibRecHit,
     )
 )
 
+# this overrides the modifications made by run3_ecal if both modifiers are active
+from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
+gpuValidationEcal.toModify(ecalMultiFitUncalibRecHit,
+    algoPSet = dict(timealgo = 'RatioMethod',
+        outOfTimeThresholdGain12pEB = 5.,
+        outOfTimeThresholdGain12mEB = 5.,
+        outOfTimeThresholdGain61pEB = 5.,
+        outOfTimeThresholdGain61mEB = 5.,
+        timeCalibTag = ':',
+        timeOffsetTag = ':'
+    )
+)
+


### PR DESCRIPTION
#### PR description:

Since the ECAL time reconstruction on GPU uses the ratio method the CPU algorithm should use the same method for the CPU vs. GPU validation.
In addition, the calculated time information is stored in the legacy collection.

#### PR validation:

Tested with WF 12434.513 (ECAL GPU validation). The two timing algorithms match and the DQM histograms are filled.