### PR TITLE
Update Run3 MC GTs with corrected GEM geometry for GE21 demonstration chamber

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,31 +64,31 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     :    '131X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           :    '133X_mcRun3_2022_design_v1',
+    'phase1_2022_design'           :    '133X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '133X_mcRun3_2022_realistic_v1',
+    'phase1_2022_realistic'        :    '133X_mcRun3_2022_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' :    '133X_mcRun3_2022_realistic_postEE_v1',
+    'phase1_2022_realistic_postEE' :    '133X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          :    '133X_mcRun3_2022cosmics_realistic_deco_v1',
+    'phase1_2022_cosmics'          :    '133X_mcRun3_2022cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   :    '133X_mcRun3_2022cosmics_design_deco_v1',
+    'phase1_2022_cosmics_design'   :    '133X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '133X_mcRun3_2022_realistic_HI_v1',
+    'phase1_2022_realistic_hi'     :    '133X_mcRun3_2022_realistic_HI_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           :    '133X_mcRun3_2023_design_v1',
+    'phase1_2023_design'           :    '133X_mcRun3_2023_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '133X_mcRun3_2023_realistic_v1',
+    'phase1_2023_realistic'        :    '133X_mcRun3_2023_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '133X_mcRun3_2023_realistic_postBPix_v1',
+    'phase1_2023_realistic_postBPix'  : '133X_mcRun3_2023_realistic_postBPix_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          :    '133X_mcRun3_2023cosmics_realistic_deco_v1',
+    'phase1_2023_cosmics'          :    '133X_mcRun3_2023cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   :    '133X_mcRun3_2023cosmics_design_deco_v1',
+    'phase1_2023_cosmics_design'   :    '133X_mcRun3_2023cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '133X_mcRun3_2023_realistic_HI_v1',
+    'phase1_2023_realistic_hi'     :    '133X_mcRun3_2023_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '133X_mcRun3_2024_realistic_v1',
+    'phase1_2024_realistic'        :    '133X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '133X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:

The PR mainly updates the Run3 MC GTs with corrected GEM geometry for the GE21 demonstration chamber (See [1]). More details can also be found in the relevant CMS Talk post in [2]. 

In addition the 2022postEE, 2023 HI and 2024 MC GTs are updated as follows: 
- 2022 postEE GT with
   - `Summer22EE`  offline JECs ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_postEE_v2/133X_mcRun3_2022_realistic_postEE_v3)) See CMS Talk post [3][4]

- 2023 HI MC GT with 
   - 2023 postBPIx MC conditions (except the HI specific) for start-up 2023 HI GT([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v1/133X_mcRun3_2023_realistic_HI_v2)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455) [5]. 
   - 2023 HI L1T menu tag `L1Menu_CollisionsHeavyIons2023_v1_1_3_xml` ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v3/133X_mcRun3_2023_realistic_HI_v4)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/request-for-new-run3-hi-mc-gt-with-updated-l1-menu-in-13-2-x/30344) [6]
   - HLT JECs+PFHC+Hcal Res Corr ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v4/133X_mcRun3_2023_realistic_HI_v5)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455/2) [7]
   - 2023 HI Ecal conditions ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v5/133X_mcRun3_2023_realistic_HI_v6)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455/3) [8]

 - 2024 MC GT with
   - 2023 postBPIx MC conditions for starting GT for `Run3Winter24` campaign ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2024_realistic_v1/133X_mcRun3_2024_realistic_v2)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716) [9].
   - HLT JECs+PFHC+Hcal Res Corr ([Diff](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2024_realistic_v3/133X_mcRun3_2024_realistic_v4)) [See CMS Talk post](https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716/2) [10]
  
[1] https://github.com/cms-sw/cmssw/pull/43032
[2] https://cms-talk.web.cern.ch/t/mc-gt-update-ge-2-1-demonstration-chamber-geometry-for-run3-mc/30903
[3] https://cms-talk.web.cern.ch/t/new-gt-request-for-offline-analyses-with-new-jecs-for-summer22ee-mc-and-2022-prompt-fg/26530
[4] https://cms-talk.web.cern.ch/t/mc-offline-rereco-gts-for-2022-remini-nano-v12-in-130x/29645
[5] https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455
[6] https://cms-talk.web.cern.ch/t/request-for-new-run3-hi-mc-gt-with-updated-l1-menu-in-13-2-x/30344
[7] https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455/2
[8] https://cms-talk.web.cern.ch/t/call-for-conditions-for-2023-heavy-ion-mc/30455/3
[9] https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716
[10] https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716/2

**GT Differences**

- **Phase1 2022 design** :  Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_design_v1/133X_mcRun3_2022_design_v2

- **Phase1 2022 realistic** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_v1/133X_mcRun3_2022_realistic_v2

- **Phase1 2022 realistic postEE** : Updated GEM geometry + Summer22 offline JECs
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_postEE_v1/133X_mcRun3_2022_realistic_postEE_v3

- **Phase1 2022 cosmics** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022cosmics_realistic_deco_v1/133X_mcRun3_2022cosmics_realistic_deco_v2

- **Phase1 2022 cosmics design** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022cosmics_design_deco_v1/133X_mcRun3_2022cosmics_design_deco_v2

- **Phase1 2022 realistic hi** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_HI_v1/133X_mcRun3_2022_realistic_HI_v2

- **Phase1 2023 design** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_design_v1/133X_mcRun3_2023_design_v2

- **Phase1 2023 realistic** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_v1/133X_mcRun3_2023_realistic_v2

- **Phase1 2023 realistic postBPix** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_postBPix_v1/133X_mcRun3_2023_realistic_postBPix_v2

- **Phase1 2023 cosmics reaslistic** : Updated GEM geometry
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023cosmics_realistic_deco_v1/133X_mcRun3_2023cosmics_realistic_deco_v2

- **Phase1 2023 cosmics design** : Updated GEM geometry 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023cosmics_design_deco_v1/133X_mcRun3_2023cosmics_design_deco_v2

- **Phase1 2023 realistic hi** : Updated GEM geometry, 2023 postBPix MC conditions, 2023 HI L1T menu, HLT JECs+PFHC+HcalResCorr and finally the 2023 HI Ecal conditions
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v1/133X_mcRun3_2023_realistic_HI_v6

- **Phase1 2024 realistic** : Updated GEM geometry, 2023 postBPix MC conditions and HLT JECs+PFHC+HcalResCorr
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2024_realistic_v1/133X_mcRun3_2024_realistic_v4


#### PR validation:

Tested successfully with 
- `runTheMatrix.py -l 159.1,160.1,312.0,12034.0,12434.0,12834.0,11601.0,23234.0 -j10 --ibeos` 
- `runTheMatrix.py -l 12430.0,12440.0 --what upgrade -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 


