### PR TITLE
[13.1.X] Selected backports of Phase-2 HLT Validation (w.r.t SIM) 

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -29,6 +29,10 @@ validationHarvestingNoHLT = cms.Path(postValidation*postValidation_gen)
 validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
 #validationHarvestingNoHLT = cms.Sequence(postValidation*postValidation_gen)
 #validationHarvesting = cms.Sequence(postValidation*hltpostvalidation*postValidation_gen)
+validationHarvestingPhase2 = cms.Path(hltpostvalidation)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(validationHarvesting,validationHarvestingPhase2)
 
 _validationHarvesting_fastsim = validationHarvesting.copy()
 for _entry in [hltpostvalidation]:

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -47,6 +47,9 @@ for _entry in [hltassociation]:
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(prevalidation,_prevalidation_fastsim)
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(prevalidation, prevalidation.copyAndExclude([cms.SequencePlaceholder("mix"),globalPrevalidation,metPreValidSeq,jetPreValidSeq]))
+
 validationNoHLT = cms.Sequence(
                                genvalid_all
                                *globaldigisanalyze
@@ -56,6 +59,9 @@ validationNoHLT = cms.Sequence(
 validationNoHLT.remove(condDataValidation) # foca d'ovatta !
 validation = cms.Sequence(validationNoHLT
                          *hltvalidation)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(validation, validation.copyAndExclude([validationNoHLT]))
 
 validationNoHLTHiMix = cms.Sequence(
                                genvalid_all_hiMix

--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -39,6 +39,29 @@ hltpostvalidation = cms.Sequence(
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
+# Temporary Phase-2 configuration
+# Exclude everything except JetMET for now
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([postProcessorHLTtrackingSequence,
+                                                                                 postProcessorHLTvertexing,
+                                                                                 HLTMuonPostVal,
+                                                                                 HLTTauPostVal,
+                                                                                 EgammaPostVal,
+                                                                                 postProcessorHLTgsfTrackingSequence,
+                                                                                 postProcessorHLTmuonTrackingSequence,
+                                                                                 heavyFlavorValidationHarvestingSequence,
+                                                                                 #JetMETPostVal,
+                                                                                 #HLTAlCaPostVal,
+                                                                                 SusyExoPostVal,
+                                                                                 #ExamplePostVal,
+                                                                                 hltvalidationqt,
+                                                                                 HLTHiggsPostVal,
+                                                                                 hltExoticaPostProcessors,
+                                                                                 b2gHLTriggerValidationHarvest,
+                                                                                 HLTSMPPostVal,
+                                                                                 HltBTagPostVal])
+)
+
 # fastsim customs
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -39,6 +39,16 @@ hltassociation = cms.Sequence(
     )
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
+# Temporary Phase-2 config
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([hltMultiTrackValidation,
+                                                                           hltMultiPVValidation,
+                                                                           egammaSelectors,
+                                                                           ExoticaValidationProdSeq,
+                                                                           hltMultiTrackValidationGsfTracks,
+                                                                           hltMultiTrackValidationMuonTracks])
+)
+
 # hcal
 from DQMOffline.Trigger.HCALMonitoring_cff import *
 
@@ -60,6 +70,24 @@ hltvalidationWithMC = cms.Sequence(
     +hltbtagValidationSequence #too noisy for now
     +hltHCALdigisAnalyzer+hltHCALRecoAnalyzer+hltHCALNoiseRates # HCAL
 )
+
+# Temporary Phase-2 config
+# Exclude everything except JetMET for now
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([HLTMuonVal,
+                                                                                     HLTTauVal,
+                                                                                     egammaValidationSequence,
+                                                                                     heavyFlavorValidationSequence,
+                                                                                     #HLTJetMETValSeq,
+                                                                                     HLTSusyExoValSeq,
+                                                                                     HiggsValidationSequence,
+                                                                                     ExoticaValidationSequence,
+                                                                                     b2gHLTriggerValidation,
+                                                                                     SMPValidationSequence,
+                                                                                     hltbtagValidationSequence,
+                                                                                     hltHCALdigisAnalyzer,
+                                                                                     hltHCALRecoAnalyzer,
+                                                                                     hltHCALNoiseRates]))
 
 hltvalidationWithData = cms.Sequence(
 )

--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -41,9 +41,7 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 
 # Temporary Phase-2 config
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([hltMultiTrackValidation,
-                                                                           hltMultiPVValidation,
-                                                                           egammaSelectors,
+phase2_common.toReplaceWith(hltassociation, hltassociation.copyAndExclude([egammaSelectors,
                                                                            ExoticaValidationProdSeq,
                                                                            hltMultiTrackValidationGsfTracks,
                                                                            hltMultiTrackValidationMuonTracks])

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -20,4 +20,9 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     HLTriggerResults      = cms.InputTag("TriggerResults::HLT"),
 )
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(SingleJetMetPaths,
+                       PatternJetTrg = cms.untracked.string("HLT_(AK4)?PF(NoPU|Puppi)?Jet([0-9])+(_v[0-9]+)?$")
+                       )
+
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -1,20 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-#pfjetcoll="hltAK4PFJetsCorrected"
-pfjetcoll="hltAK4PFJets"
-pfjetcollPhase2 = "hltAK4PFPuppiJetsCorrected"
-
-foldernm="HLT/HLTJETMET/"
-
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
     triggerEventObject    = cms.untracked.InputTag("hltTriggerSummaryRAW","","HLT"),
-    DQMFolder             = cms.untracked.string(foldernm),
+    DQMFolder             = cms.untracked.string("HLT/HLTJETMET/"),
     PatternJetTrg         = cms.untracked.string("HLT_PF(NoPU)?Jet([0-9])+(_v[0-9]+)?$"),                                   
     PatternMetTrg         = cms.untracked.string("HLT_+[Calo|PF]+MET([0-9])+[_NotCleaned|_BeamHaloCleaned]+(_v[0-9]+)?$"),
     PatternMuTrg          = cms.untracked.string("HLT_Mu([0-9])+(_v[0-9]+)?$"),
     LogFileName           = cms.untracked.string('JetMETSingleJetValidation.log'),
-    PFJetAlgorithm        = cms.untracked.InputTag(pfjetcoll),
+    PFJetAlgorithm        = cms.untracked.InputTag("hltAK4PFJets"),
     GenJetAlgorithm       = cms.untracked.InputTag("ak4GenJets"),
     CaloMETCollection     = cms.untracked.InputTag("hltMet"),
     GenMETCollection      = cms.untracked.InputTag("genMetCalo"),
@@ -23,8 +17,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg = 'HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$',
-                       PFJetAlgorithm = cms.untracked.InputTag(pfjetcollPhase2)
+                       PatternJetTrg = "HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$",
+                       PFJetAlgorithm = "hltAK4PFPuppiJetsCorrected"
                        )
 
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
+++ b/HLTriggerOffline/JetMET/python/Validation/SingleJetValidation_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #pfjetcoll="hltAK4PFJetsCorrected"
 pfjetcoll="hltAK4PFJets"
+pfjetcollPhase2 = "hltAK4PFPuppiJetsCorrected"
 
 foldernm="HLT/HLTJETMET/"
 
@@ -22,7 +23,8 @@ SingleJetMetPaths = DQMEDAnalyzer('HLTJetMETValidation',
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(SingleJetMetPaths,
-                       PatternJetTrg = cms.untracked.string("HLT_(AK4)?PF(NoPU|Puppi)?Jet([0-9])+(_v[0-9]+)?$")
+                       PatternJetTrg = 'HLT_(AK4)?PFPuppiJet([0-9])+(_v[0-9]+)?$',
+                       PFJetAlgorithm = cms.untracked.InputTag(pfjetcollPhase2)
                        )
 
 SingleJetValidation = cms.Sequence(SingleJetMetPaths)

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -24,7 +24,7 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'TrackerPhase2Validation' : ['', 'trackerphase2ValidationSource', 'trackerphase2ValidationHarvesting'],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation', 'standardValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])

--- a/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
+++ b/Validation/RecoTrack/python/HLTmultiTrackValidator_cff.py
@@ -30,3 +30,9 @@ def _modifyForRun3(trackvalidator):
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(hltTrackValidator, _modifyForRun3)
+
+def _modifyForPhase2(trackvalidator):
+    trackvalidator.label = ["generalTracks::HLT","hltPhase2PixelTracks"]
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltTrackValidator, _modifyForPhase2)

--- a/Validation/RecoTrack/python/associators_cff.py
+++ b/Validation/RecoTrack/python/associators_cff.py
@@ -13,6 +13,13 @@ hltTPClusterProducer = _tpClusterProducer.clone(
     stripClusterSrc = "hltSiStripRawToClustersFacility",
 )
 
+def _modifyForPhase2(tpClusterProducer):
+    tpClusterProducer.pixelClusterSrc = "siPixelClusters::HLT"
+    tpClusterProducer.phase2OTClusterSrc = "siPhase2Clusters::HLT"
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltTPClusterProducer, _modifyForPhase2)
+
 hltTrackAssociatorByHits = SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone()
 hltTrackAssociatorByHits.cluster2TPSrc            = cms.InputTag("hltTPClusterProducer")
 hltTrackAssociatorByHits.UseGrouped               = cms.bool( False )
@@ -24,7 +31,6 @@ hltTrackAssociatorByDeltaR.method             = cms.string('momdr')
 hltTrackAssociatorByDeltaR.QCut               = cms.double(0.5)
 hltTrackAssociatorByDeltaR.ConsiderAllSimHits = cms.bool(True)
 
-
 # Note: the TrackAssociatorEDProducers defined below, and
 # tpToHLTtracksAssociationSequence sequence, are not currently needed
 # to run MTV for HLT, as it is configured to produce the
@@ -35,6 +41,8 @@ tpToHLTpixelTrackAssociation = _trackingParticleRecoTrackAsssociation.clone(
     associator = cms.InputTag('hltTrackAssociatorByHits'),
     ignoremissingtrackcollection = cms.untracked.bool(True)
 )
+
+phase2_tracker.toModify(tpToHLTpixelTrackAssociation, label_tr = "hltPhase2PixelTracks")
 
 tpToHLTiter0tracksAssociation = tpToHLTpixelTrackAssociation.clone(
     label_tr = cms.InputTag("hltIter0PFlowCtfWithMaterialTracks"),

--- a/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
+++ b/Validation/RecoVertex/python/HLTmultiPVvalidator_cff.py
@@ -22,7 +22,6 @@ vertexAssociatorByPositionAndTracks4pfMuonMergingTracks = _VertexAssociatorByPos
     trackAssociation = "tpToHLTpfMuonMergingTrackAssociation"
 )
 
-
 hltPixelPVanalysis = hltMultiPVanalysis.clone(
     do_generic_sim_plots  = True,
     trackAssociatorMap    = "tpToHLTpixelTrackAssociation",
@@ -33,6 +32,11 @@ hltPixelPVanalysis = hltMultiPVanalysis.clone(
     )
 )
 
+def _modifyPixelPVanalysisForPhase2(pvanalysis):
+    pvanalysis.vertexRecoCollections = ["hltPhase2PixelVertices"]
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(hltPixelPVanalysis, _modifyPixelPVanalysisForPhase2)
 
 hltPVanalysis = hltMultiPVanalysis.clone(
     trackAssociatorMap = "tpToHLTpfMuonMergingTrackAssociation",
@@ -42,12 +46,29 @@ hltPVanalysis = hltMultiPVanalysis.clone(
     #"hltFastPVPixelVertices"
     )
 )
+
+tpToHLTphase2TrackAssociation = tpToHLTpixelTrackAssociation.clone(
+    label_tr = "generalTracks::HLT"
+)
+vertexAssociatorByPositionAndTracks4phase2HLTTracks = _VertexAssociatorByPositionAndTracks.clone(
+    trackAssociation = "tpToHLTphase2TrackAssociation"
+)
+
+def _modifyFullPVanalysisForPhase2(pvanalysis):
+    pvanalysis.vertexRecoCollections = ["offlinePrimaryVertices::HLT"]
+    pvanalysis.trackAssociatorMap = "tpToHLTphase2TrackAssociation"
+    pvanalysis.vertexAssociator   = "vertexAssociatorByPositionAndTracks4phase2HLTTracks"
+
+phase2_tracker.toModify(hltPVanalysis, _modifyFullPVanalysisForPhase2)
+
 hltMultiPVAssociations = cms.Task(
     hltTrackAssociatorByHits,
     tpToHLTpixelTrackAssociation,
     vertexAssociatorByPositionAndTracks4pixelTracks,
     tpToHLTpfMuonMergingTrackAssociation,
-    vertexAssociatorByPositionAndTracks4pfMuonMergingTracks
+    vertexAssociatorByPositionAndTracks4pfMuonMergingTracks,
+    tpToHLTphase2TrackAssociation,
+    vertexAssociatorByPositionAndTracks4phase2HLTTracks
 )
 
 hltMultiPVValidation = cms.Sequence( 


### PR DESCRIPTION
#### PR description:

This PR is a combined backport of https://github.com/cms-sw/cmssw/pull/43094 and https://github.com/cms-sw/cmssw/pull/41898 and a companion of https://github.com/cms-sw/cmssw/pull/42827
Descriptions from the original PRs:

> This PR is the second attempt to include HLT validation for Phase-2. This PR starts with JetMET-only path for now.
The difference than original PR is to avoid a lot of empty histograms from HLT validation by enable one-by-one validation, starting from JetMET.

> This PR is a companion of https://github.com/cms-sw/cmssw/pull/42783.
Changes needed to the Tracking and Vertexing Validation (w.r.t. Simulation) @ HLT sequence for the Phase-2 setup.
This relies on the current naming of the tracking collections for the phase-2 HLT:

#### PR validation:

Run successfully `runTheMatrix.py -l 24834.0 -t 4 -j 8 --ibeos` and checked that HLT tracking and vertexing validation plots are filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Combined backport of https://github.com/cms-sw/cmssw/pull/43094 and https://github.com/cms-sw/cmssw/pull/41898.