### PR TITLE
Add minETA selection to HLT filter RecoTracker/DeDx/plugins/HLTDeDxFilter

### DIFF
--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -37,6 +37,7 @@ HLTDeDxFilter::HLTDeDxFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConf
   minDEDx_ = iConfig.getParameter<double>("minDEDx");
   minPT_ = iConfig.getParameter<double>("minPT");
   minNOM_ = iConfig.getParameter<double>("minNOM");
+  minETA_ = iConfig.getParameter<double>("minETA");
   maxETA_ = iConfig.getParameter<double>("maxETA");
   minNumValidHits_ = iConfig.getParameter<double>("minNumValidHits");
   maxNHitMissIn_ = iConfig.getParameter<double>("maxNHitMissIn");
@@ -68,6 +69,7 @@ void HLTDeDxFilter::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("minDEDx", 0.0);
   desc.add<double>("minPT", 0.0);
   desc.add<double>("minNOM", 0.0);
+  desc.add<double>("minETA", 0.0);
   desc.add<double>("maxETA", 5.5);
   desc.add<double>("minNumValidHits", 0);
   desc.add<double>("maxNHitMissIn", 99);
@@ -128,8 +130,8 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
   }
   for (unsigned int i = 0; i < trackCollection.size(); i++) {
     reco::TrackRef track = reco::TrackRef(trackCollectionHandle, i);
-    if (pt[i] > minPT_ && fabs(eta[i]) < maxETA_ && dEdxTrack[track].numberOfMeasurements() > minNOM_ &&
-        dEdxTrack[track].dEdx() > minDEDx_) {
+    if (pt[i] > minPT_ && std::abs(eta[i]) >= minETA_ && std::abs(eta[i]) < maxETA_ &&
+        dEdxTrack[track].numberOfMeasurements() > minNOM_ && dEdxTrack[track].dEdx() > minDEDx_) {
       if (track->numberOfValidHits() < minNumValidHits_)
         continue;
       if (track->hitPattern().trackerLayersWithoutMeasurement(reco::HitPattern::MISSING_INNER_HITS) > maxNHitMissIn_)

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -32,6 +32,7 @@ private:
   double minDEDx_;
   double minPT_;
   double minNOM_;
+  double minETA_;
   double maxETA_;
   double minNumValidHits_;
   double maxNHitMissIn_;


### PR DESCRIPTION
#### PR description:

Added one parameter to the HLT filter `RecoTracker/DeDx/plugins/HLTDeDxFilter` to set a minimum eta cut on the reconstructed tracker track. 

- This updated filter will be used in a new HLT path in 2024 to improve the high-pt muon efficiency in the CSC acceptance region (0.9 < eta < 2.4). More technical information can be found in this talk: https://indico.cern.ch/event/1336796/#45-studies-on-trigger-efficien
- The minETA default value is set to 0.0 to keep other HLT paths which use this filter (like `HLT_MET105_IsoTrk50_v13`) unaffected 


#### PR validation:

Validated and tested with `hltGetConfiguration`