### PR TITLE
[FW][LLVM17] Clang tidy warnings performance-copy/move fixed

### DIFF
--- a/DataFormats/Provenance/interface/Hash.h
+++ b/DataFormats/Provenance/interface/Hash.h
@@ -97,7 +97,7 @@ namespace edm {
       }
       //copy constructor will do compact form conversion
       if (meCF) {
-        Hash<I> temp(iOther);
+        Hash<I> temp(iOther);  // NOLINT(performance-unnecessary-copy-initialization)
         return op(this->hash_, temp.hash_);
       }
       Hash<I> temp(*this);

--- a/FWCore/MessageLogger/interface/ErrorObj.icc
+++ b/FWCore/MessageLogger/interface/ErrorObj.icc
@@ -65,7 +65,7 @@ namespace edm {
   }
 
   inline ErrorObj& ErrorObj::vformat(std::string_view format, fmt::format_args args) {
-    auto str = fmt::vformat(format, std::move(args));
+    auto str = fmt::vformat(format, args);
     if (!str.empty())
       emitToken(str);
     return *this;

--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -103,7 +103,7 @@ namespace edm {
 
     ThisLog& vformat(std::string_view fmt, fmt::format_args args) {
       if (ap.valid())
-        ap.vformat(fmt, std::move(args));
+        ap.vformat(fmt, args);
       return *this;
     }
 

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -47,7 +47,7 @@ namespace edm {
     template <typename... Args>
     MessageSender& vformat(std::string_view fmt, fmt::format_args args) {
       if (valid())
-        errorobj_p->vformat(fmt, std::move(args));
+        errorobj_p->vformat(fmt, args);
       return *this;
     }
 


### PR DESCRIPTION
Changes [a] suggested by `clang-tidy` from `LLVM 17.0.3`.

[a]
```
FWCore/MessageLogger/interface/ErrorObj.icc:68:37: warning: std::move of the variable 'args' of the trivially-copyable type 'fmt::format_args' (aka 'basic_format_args<basic_format_context<fmt::appender, char>>') has no effect; remove std::move() [performance-move-const-arg]
FWCore/MessageLogger/interface/MessageLogger.h:106:25: warning: std::move of the variable 'args' of the trivially-copyable type 'fmt::format_args' (aka 'basic_format_args<basic_format_context<fmt::appender, char>>') has no effect; remove std::move() [performance-move-const-arg]
FWCore/MessageLogger/interface/MessageSender.h:50:34: warning: std::move of the variable 'args' of the trivially-copyable type 'fmt::format_args' (aka 'basic_format_args<basic_format_context<fmt::appender, char>>') has no effect; remove std::move() [performance-move-const-arg]
```
```
DataFormats/Provenance/interface/Hash.h:100:17: warning: local copy 'temp' of the variable 'iOther' is never modified; consider avoiding the copy [performance-unnecessary-copy-initialization]
```