### PR TITLE
migrate `JetMETDQMDCSFilter` to use `DSCRecord`

### DIFF
--- a/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
+++ b/DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h
@@ -1,24 +1,19 @@
-#ifndef JetMETDQMDCSFilter_H
-#define JetMETDQMDCSFilter_H
+#ifndef DQMOffline_JetMET_JetMETDQMDCSFilter_H
+#define DQMOffline_JetMET_JetMETDQMDCSFilter_H
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "DataFormats/Scalers/interface/DcsStatus.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Scalers/interface/DcsStatus.h"
-
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
-
+#include "DataFormats/OnlineMetaData/interface/DCSRecord.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 class JetMETDQMDCSFilter {
 public:
@@ -30,13 +25,19 @@ public:
   ~JetMETDQMDCSFilter();
   bool filter(const edm::Event& evt, const edm::EventSetup& es);
   bool passPIX, passSiStrip, passECAL, passHBHE, passHF, passHO, passES, passMuon;
-  edm::EDGetTokenT<DcsStatusCollection> scalarsToken;
+  edm::EDGetTokenT<DcsStatusCollection> scalarsToken_;
+  edm::EDGetTokenT<DCSRecord> dcsRecordToken_;
 
 private:
+  template <typename T>
+  void checkDCSInfoPerPartition(const T& DCS);
+  void initializeVars();
   bool verbose_;
   bool filter_;
   bool detectorOn_;
   std::string detectorTypes_;
+  std::map<std::string, std::vector<int>> associationMap_;
+  std::map<std::string, bool> passPerDet_;
 };
 
 #endif

--- a/DQMOffline/JetMET/src/JetMETDQMDCSFilter.cc
+++ b/DQMOffline/JetMET/src/JetMETDQMDCSFilter.cc
@@ -1,19 +1,12 @@
 #include "DQMOffline/JetMET/interface/JetMETDQMDCSFilter.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Scalers/interface/DcsStatus.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-
-#include <iostream>
-
-//using namespace edm;
-//using namespace std;
-//using namespace reco;
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/Scalers/interface/DcsStatus.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 //
 // -- Constructor
@@ -22,17 +15,17 @@ JetMETDQMDCSFilter::JetMETDQMDCSFilter(const edm::ParameterSet& pset, edm::Consu
   verbose_ = pset.getUntrackedParameter<bool>("DebugOn", false);
   detectorTypes_ = pset.getUntrackedParameter<std::string>("DetectorTypes", "ecal:hcal");
   filter_ = !pset.getUntrackedParameter<bool>("alwaysPass", false);
+  scalarsToken_ = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
+  dcsRecordToken_ = iC.consumes<DCSRecord>(std::string("onlineMetaDataDigis"));
 
   detectorOn_ = false;
   if (verbose_)
-    std::cout << "JetMETDQMDCSFilter constructor: " << detectorTypes_ << std::endl;
+    edm::LogPrint("JetMETDQMDCSFilter") << " constructor: " << detectorTypes_ << std::endl;
 
-  passPIX = false, passSiStrip = false;
-  passECAL = false, passES = false;
-  passHBHE = false, passHF = false, passHO = false;
-  passMuon = false;
-  scalarsToken = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
+  // initialize variables
+  initializeVars();
 }
+
 JetMETDQMDCSFilter::JetMETDQMDCSFilter(const std::string& detectorTypes,
                                        edm::ConsumesCollector& iC,
                                        const bool verbose,
@@ -40,16 +33,32 @@ JetMETDQMDCSFilter::JetMETDQMDCSFilter(const std::string& detectorTypes,
   verbose_ = verbose;
   detectorTypes_ = detectorTypes;
   filter_ = !alwaysPass;
-  scalarsToken = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
+  scalarsToken_ = iC.consumes<DcsStatusCollection>(std::string("scalersRawToDigi"));
+  dcsRecordToken_ = iC.consumes<DCSRecord>(std::string("onlineMetaDataDigis"));
 
   detectorOn_ = false;
   if (verbose_)
-    std::cout << "JetMETDQMDCSFilter constructor: " << detectorTypes_ << std::endl;
+    edm::LogPrint("JetMETDQMDCSFilter") << " constructor: " << detectorTypes_ << std::endl;
 
+  // initialize variables
+  initializeVars();
+}
+
+// initialize
+void JetMETDQMDCSFilter::initializeVars() {
   passPIX = false, passSiStrip = false;
   passECAL = false, passES = false;
   passHBHE = false, passHF = false, passHO = false;
   passMuon = false;
+
+  passPerDet_ = {{"pixel", false},
+                 {"sistrip", false},
+                 {"ecal", false},
+                 {"hbhe", false},
+                 {"hf", false},
+                 {"ho", false},
+                 {"es", false},
+                 {"muon", false}};
 }
 
 //
@@ -57,7 +66,48 @@ JetMETDQMDCSFilter::JetMETDQMDCSFilter(const std::string& detectorTypes,
 //
 JetMETDQMDCSFilter::~JetMETDQMDCSFilter() {
   if (verbose_)
-    std::cout << "JetMETDQMDCSFilter destructor: " << std::endl;
+    edm::LogPrint("JetMETDQMDCSFilter") << " destructor: " << std::endl;
+}
+
+template <typename T>
+void JetMETDQMDCSFilter::checkDCSInfoPerPartition(const T& DCS) {
+  if (associationMap_.empty()) {
+    associationMap_ = {{"pixel", {T::BPIX, T::FPIX}},
+                       {"sistrip", {T::TIBTID, T::TOB, T::TECp, T::TECm}},
+                       {"ecal", {T::EBp, T::EBm, T::EEp, T::EEm}},
+                       {"hbhe", {T::HBHEa, T::HBHEb, T::HBHEc}},
+                       {"hf", {T::HF}},
+                       {"ho", {T::HO}},
+                       {"es", {T::ESp, T::ESm}},
+                       {"muon", {T::RPC, T::DT0, T::DTp, T::DTm, T::CSCp, T::CSCm}}};
+  }
+
+  for (const auto& [detName, listOfParts] : associationMap_) {
+    if (detectorTypes_.find(detName) != std::string::npos) {
+      bool ANDofParts{true};
+      for (const auto& part : listOfParts) {
+        if constexpr (std::is_same_v<T, DcsStatus>) {
+          ANDofParts &= DCS.ready(part);
+        } else if constexpr (std::is_same_v<T, DCSRecord>) {
+          ANDofParts &= DCS.highVoltageReady(part);
+        } else {
+          edm::LogError("JetMETDQMDCSFilter")
+              << __FILE__ << " " << __LINE__ << " passed a wrong object type, cannot deduce DCS information.\n"
+              << " returning true" << std::endl;
+          ANDofParts &= true;
+        }
+      }
+
+      if (ANDofParts) {
+        if (verbose_) {
+          edm::LogPrint("JetMETDQMDCSFilter") << detName << " on" << std::endl;
+        }
+        passPerDet_[detName] = true;
+      } else {
+        detectorOn_ = false;
+      }
+    }  // if it matches the requested detname
+  }    // loop on partitions
 }
 
 bool JetMETDQMDCSFilter::filter(const edm::Event& evt, const edm::EventSetup& es) {
@@ -69,88 +119,43 @@ bool JetMETDQMDCSFilter::filter(const edm::Event& evt, const edm::EventSetup& es
     return detectorOn_;
 
   edm::Handle<DcsStatusCollection> dcsStatus;
-  evt.getByToken(scalarsToken, dcsStatus);
+  evt.getByToken(scalarsToken_, dcsStatus);
+
+  edm::Handle<DCSRecord> dcsRecord;
+  evt.getByToken(dcsRecordToken_, dcsRecord);
 
   if (dcsStatus.isValid() && !dcsStatus->empty()) {
-    if (detectorTypes_.find("pixel") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::BPIX) && (*dcsStatus)[0].ready(DcsStatus::FPIX)) {
-        if (verbose_)
-          std::cout << "pixel on" << std::endl;
-        passPIX = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("sistrip") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::TIBTID) && (*dcsStatus)[0].ready(DcsStatus::TOB) &&
-          (*dcsStatus)[0].ready(DcsStatus::TECp) && (*dcsStatus)[0].ready(DcsStatus::TECm)) {
-        if (verbose_)
-          std::cout << "sistrip on" << std::endl;
-        passSiStrip = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("ecal") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::EBp) && (*dcsStatus)[0].ready(DcsStatus::EBm) &&
-          (*dcsStatus)[0].ready(DcsStatus::EEp) && (*dcsStatus)[0].ready(DcsStatus::EEm)) {
-        if (verbose_)
-          std::cout << "ecal on" << std::endl;
-        passECAL = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("hbhe") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::HBHEa) && (*dcsStatus)[0].ready(DcsStatus::HBHEb) &&
-          (*dcsStatus)[0].ready(DcsStatus::HBHEc)) {
-        if (verbose_)
-          std::cout << "hbhe on" << std::endl;
-        passHBHE = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("hf") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::HF)) {
-        if (verbose_)
-          std::cout << "hf on" << std::endl;
-        passHF = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("ho") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::HO)) {
-        if (verbose_)
-          std::cout << "ho on" << std::endl;
-        passHO = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("es") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::ESp) && (*dcsStatus)[0].ready(DcsStatus::ESm)) {
-        if (verbose_)
-          std::cout << "es on" << std::endl;
-        passES = true;
-      } else
-        detectorOn_ = false;
-    }
-
-    if (detectorTypes_.find("muon") != std::string::npos) {
-      if ((*dcsStatus)[0].ready(DcsStatus::RPC) && (*dcsStatus)[0].ready(DcsStatus::DT0) &&
-          (*dcsStatus)[0].ready(DcsStatus::DTp) && (*dcsStatus)[0].ready(DcsStatus::DTm) &&
-          (*dcsStatus)[0].ready(DcsStatus::CSCp) && (*dcsStatus)[0].ready(DcsStatus::CSCm)) {
-        if (verbose_)
-          std::cout << "muon on" << std::endl;
-        passMuon = true;
-      } else
-        detectorOn_ = false;
-    }
+    checkDCSInfoPerPartition((*dcsStatus)[0]);
+  } else if (dcsRecord.isValid()) {
+    checkDCSInfoPerPartition(*dcsRecord);
+  } else {
+    edm::LogError("JetMETDQMDCSFilter")
+        << "Error! can't get the product, neither DCSRecord, nor scalersRawToDigi: accept in any case!";
   }
+
+  // assign the values
+  passPIX = passPerDet_["pixel"];
+  passSiStrip = passPerDet_["sistrip"];
+  passECAL = passPerDet_["ecal"];
+  passES = passPerDet_["es"];
+  passHBHE = passPerDet_["hbhe"];
+  passHF = passPerDet_["hf"];
+  passHO = passPerDet_["ho"];
+  passMuon = passPerDet_["muon"];
+
+  if (verbose_) {
+    if (detectorOn_)
+      edm::LogPrint("JetMETDQMDCSFilter") << "event pass!";
+
+    std::stringstream ss;
+    for (const auto& [detName, result] : passPerDet_) {
+      if (detectorTypes_.find(detName) != std::string::npos) {
+        ss << "Passes " << detName << ": " << (result ? "True\n" : "False\n");
+      }
+    }
+
+    edm::LogPrint("JetMETDQMDCSFilter") << ss.str();
+  }
+
   return detectorOn_;
 }
-
-//#include "FWCore/Framework/interface/MakerMacros.h"
-//DEFINE_FWK_MODULE(JetMETDQMDCSFilter);


### PR DESCRIPTION
#### PR description:

I noticed that this class `JetMETDQMDCSFilter` used in the JME DQM at

https://github.com/cms-sw/cmssw/blob/a05e5a462c054b985d6bd9e9d85b02e725f3ee1e/DQMOffline/JetMET/src/JetAnalyzer.cc#L2478

was not migrated to use the `DCSRecord` from s/w FED instead of the `DCSStatus` from scalers. 
Since when SCAL was decomissoned at the beginning of Run 3, this is probably causing the have LS in which part of the detector is off to be accepted.

#### PR validation:

`cmssw` compiles. Also run ` runTheMatrix.py -l limited --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A