### PR TITLE
HCAL: setting hardcoded PFCuts conditions for Phase2

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalDbHardcode.h
@@ -101,7 +101,7 @@ public:
   HcalPedestalWidth makePedestalWidth(HcalGenericDetId fId, bool eff, const HcalTopology* topo, double intlumi);
   HcalGain makeGain(HcalGenericDetId fId, bool fSmear = false) const;
   HcalGainWidth makeGainWidth(HcalGenericDetId fId) const;
-  HcalPFCut makePFCut(HcalGenericDetId fId) const;
+  HcalPFCut makePFCut(HcalGenericDetId fId, double intlumi, bool noHE) const;
   HcalZSThreshold makeZSThreshold(HcalGenericDetId fId) const;
   HcalQIECoder makeQIECoder(HcalGenericDetId fId) const;
   HcalCalibrationQIECoder makeCalibrationQIECoder(HcalGenericDetId fId) const;

--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -178,9 +178,34 @@ HcalGainWidth HcalDbHardcode::makeGainWidth(HcalGenericDetId fId) const {  // Ge
   return result;
 }
 
-HcalPFCut HcalDbHardcode::makePFCut(HcalGenericDetId fId) const {  // GeV
+HcalPFCut HcalDbHardcode::makePFCut(HcalGenericDetId fId, double intLumi, bool noHE) const {  // GeV
+
+  // assign default dummy parameters
   float value0 = getParameters(fId).noiseThreshold();
   float value1 = getParameters(fId).seedThreshold();
+
+  // lumi-dependent stuff for Phase2
+
+  if (noHE && fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel) {  // HB Phase2
+
+    // from SLHCUpgradeSimulations/Configuration/python/aging.py
+    const double lumis[] = {300, 1000, 3000, 4500};  // integrated lumi points
+    // row by row initialization
+    const float cuts[4][4] = {{0.4, 0.5, 0.6, 0.6}, {0.8, 1.2, 1.2, 1.2}, {1.0, 2.0, 2.0, 2.0}, {1.25, 2.5, 2.5, 2.5}};
+    const float seeds[4][4] = {
+        {0.5, 0.625, 0.75, 0.75}, {1.0, 1.5, 1.5, 1.5}, {1.25, 2.5, 2.5, 2.5}, {1.5, 3.0, 3.0, 3.0}};
+    const double eps = 1.e-6;
+
+    HcalDetId hid(fId);
+    int depth_m1 = hid.depth() - 1;
+    for (int i = 0; i < 4; i++) {
+      if (std::abs(intLumi - lumis[i]) < eps) {
+        value0 = cuts[i][depth_m1];
+        value1 = seeds[i][depth_m1];
+      }
+    }
+  }
+
   HcalPFCut result(fId.rawId(), value0, value1);
   return result;
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -438,7 +438,7 @@ std::unique_ptr<HcalPFCuts> HcalHardcodeCalibrations::producePFCuts(const HcalPF
   for (auto cell : cells) {
     // Use only standard Hcal channels for now, no TrigPrims
     if (!cell.isHcalTrigTowerDetId()) {
-      HcalPFCut item = dbHardcode.makePFCut(cell);
+      HcalPFCut item = dbHardcode.makePFCut(cell, iLumi, dbHardcode.killHE());
       result->addValues(item);
     }
   }


### PR DESCRIPTION
#### PR description:

Needed in the context of https://github.com/cms-sw/cmssw/pull/43025
to use Conditions for all the eras,  including Phase2 
**No any regular wf is affected**

#### PR validation:

(1) dump of the relevant HcalPFCutsRcd from the Event for Phase2 with aging 1000/fb, i.e. 

```
from SLHCUpgradeSimulations.Configuration.aging import customise_aging_1000
process = customise_aging_1000(process)
```

Yields expected numbers: 

              eta             phi             dep             det     value0     value1      DetId
               -1               1               1              HB  0.8000000  1.0000000   43100401
               -1               1               2              HB  1.2000000  1.5000000   43200401
               -1               1               3              HB  1.2000000  1.5000000   43300401
               -1               1               4              HB  1.2000000  1.5000000   43400401
               -2               1               1              HB  0.8000000  1.0000000   43100801
               -2               1               2              HB  1.2000000  1.5000000   43200801
               -2               1               3              HB  1.2000000  1.5000000   43300801
               -2               1               4              HB  1.2000000  1.5000000   43400801
               ...


     
     

(2) runTheMatrix.py -l limited --ibeos --useInput all

