### PR TITLE
customize HLT offline DQM for Run3 PbPb and introduce HI 2023A relval workflow (with reHLT)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -238,6 +238,7 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from RecoLocalFastTime.Configuration.RecoLocalFastTime_EventContent_cff import *
 from RecoMTD.Configuration.RecoMTD_EventContent_cff import *
@@ -640,6 +641,19 @@ FEVTDEBUGHLTEventContent.outputCommands.extend(HLTDebugFEVT.outputCommands)
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_MergedTrackTruth_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_StripDigiSimLink_*')
 FEVTDEBUGHLTEventContent.outputCommands.append('keep *_*_PixelDigiSimLink_*')
+
+pp_on_PbPb_run3.toModify(FEVTDEBUGHLTEventContent,
+                         outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                             'keep *_hltMergedTracksPPOnAA_*_*',
+                             'keep *_hltVerticesPFFilterPPOnAA_*_*',
+                             'keep *_hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA_*_*',
+                             'keep *_hltPixelTracksPPOnAA_*_*',
+                             'keep *_hltPixelVerticesPPOnAA_*_*',
+                             'keep *_hltTrimmedPixelVerticesPPOnAA_*_*',
+                             'keep *_hltSiPixelClustersAfterSplittingPPOnAA_*_*',
+                             'keep *_hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression_*_*'
+                        ])
+
 approxSiStripClusters.toModify(FEVTDEBUGHLTEventContent,
                               outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
                                   'keep *_hltSiStripClusters2ApproxClusters_*_*',

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -568,6 +568,9 @@ workflows[141.008505] = ['Run3-2023_JetMET2023B_RecoPixelOnlyTripletsCPU',['RunJ
 workflows[141.008511] = ['Run3-2023_JetMET2023B_RecoECALOnlyCPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_ECALOnlyCPU','HARVESTRUN3_ECALOnly']]
 workflows[141.008521] = ['Run3-2023_JetMET2023B_RecoHCALOnlyCPU',['RunJetMET2023B','HLTDR3_2023','RECODR3_reHLT_HCALOnlyCPU','HARVESTRUN3_HCALOnly']]
 
+### run3-2023 (2023 HI data RawPrime with re-HLT)
+workflows[142.0] = ['',['RunHIPhysicsRawPrime2023A','HLTDR3_HI2023ARawprime','RECOHIRUN3_reHLT_2023','HARVESTRUN3_HI2023A']]
+
 ### fastsim ###
 workflows[5.1] = ['TTbarFS', ['TTbarFS','HARVESTFS']]
 workflows[5.2] = ['SingleMuPt10FS', ['SingleMuPt10FS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -615,6 +615,9 @@ steps['RunTau2023D']={'INPUT':InputInfo(dataSet='/Tau/Run2023D-v1/RAW',label='20
 steps['RunMuonEG2023D']={'INPUT':InputInfo(dataSet='/MuonEG/Run2023D-v1/RAW',label='2023D',events=100000,location='STD', ls=Run2023D)}
 steps['RunParkingDoubleMuonLowMass2023D']={'INPUT':InputInfo(dataSet='/ParkingDoubleMuonLowMass0/Run2023D-v1/RAW',label='2023D',events=100000,location='STD', ls=Run2023D)}
 
+RunHI2023={375491: [[100, 100]]}
+steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-v1/RAW',label='HI2023A',events=100000,location='STD', ls=RunHI2023)}
+
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
 steps['RunHLTPhy2015DHS']={'INPUT':InputInfo(dataSet='/HLTPhysics/Run2015D-v1/RAW',label='2015DHS',events=100000,location='STD', ls=Run2015DHS)}
@@ -2075,6 +2078,12 @@ steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--con
 
 steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2023,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
 
+steps['HLTDR3_HI2023ARawprime']=merge([{'-s':'L1REPACK:Full,HLT:HIon'},
+                                       {'--conditions':'auto:run3_hlt_HIon'},
+                                       {'--era' : 'Run3_pp_on_PbPb_approxSiStripClusters_2023'},
+                                       {'--customise' : 'HLTrigger/Configuration/CustomConfigs.customiseL1THLTforHIonRepackedRAWPrime'},
+                                       steps['HLTD']])
+
 # special setting for lumi section boundary crossing in RunEGamma2018Dml
 steps['HLTDR2_2018ml']=merge( [ {'--customise_commands':'"process.source.skipEvents=cms.untracked.uint32(7000)"'},steps['HLTDR2_2018'] ] )
 
@@ -2936,6 +2945,8 @@ steps['RECONANORUN3_ZB_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO
 steps['RECONANORUN3_ZB_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['RECONANORUN3_reHLT_2023']])
 steps['RECOCOSMRUN3_reHLT_2023']=merge([{'--scenario':'cosmics','-s':'RAW2DIGI,L1Reco,RECO,DQM','--datatier':'RECO,DQMIO','--eventcontent':'RECO,DQM'},steps['RECONANORUN3_reHLT_2023']])
 
+steps['RECOHIRUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@standardDQM','--datatier':'RECO,MINIAOD,DQMIO','--eventcontent':'RECO,MINIAOD,DQM','--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023','--conditions':'auto:run3_data_HIon'},steps['RECODR3_reHLT_2023']])
+
 # patatrack validation in data
 steps['RecoData_Patatrack_AllGPU_Validation_2023'] = merge([{'-s':'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
                                                              '--conditions':'auto:run3_data_prompt',
@@ -3613,6 +3624,9 @@ steps['HARVESTRUN3_ZB_2022']=merge([{'--data':'', '-s':'HARVESTING:@rerecoZeroBi
 steps['HARVESTRUN3_COS_2022']=merge([{'--data':'', '--scenario':'cosmics', '--era':'Run3', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
+
+steps['HARVESTRUN3_HI2023A']=merge([{'--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM'},steps['HARVESTRUN3_2022']])
+
 steps['HARVESTRUN3_ZB_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_ZB_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@rerecoZeroBias+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_COS_2023']=merge([{'--scenario':'cosmics', '--era':'Run3_2023', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTRUN3_2022']])

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -18,6 +18,10 @@ hltPixelVerticesMonitoring = hltVerticesMonitoring.clone(
     useHPforAlignmentPlots = False
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltPixelVerticesMonitoring,
+                        vertexLabel = "hltPixelVerticesPPOnAA")
+
 phase2_tracker.toModify(hltPixelVerticesMonitoring,
                         vertexLabel = "hltPhase2PixelVertices")
 
@@ -27,11 +31,19 @@ hltTrimmedPixelVerticesMonitoring = hltVerticesMonitoring.clone(
     ndof          = 1,
     useHPforAlignmentPlots = False
 )
+
+pp_on_PbPb_run3.toModify(hltTrimmedPixelVerticesMonitoring,
+                         vertexLabel = "hltTrimmedPixelVerticesPPOnAA")
+
 hltVerticesPFFilterMonitoring = hltVerticesMonitoring.clone(
     TopFolderName = "HLT/Vertexing/hltVerticesPFFilter",
     vertexLabel   = "hltVerticesPFFilter",
     useHPforAlignmentPlots = False
 )
+
+pp_on_PbPb_run3.toModify(hltVerticesPFFilterMonitoring,
+                         vertexLabel   = cms.InputTag("hltVerticesPFFilterPPOnAA"))
+
 hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone(
     TopFolderName = "HLT/Vertexing/hltVerticesL3PFBjets",
     vertexLabel   = "hltVerticesL3PFBjets",

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_Cluster_cff.py
@@ -303,6 +303,11 @@ hltSiPixelPhase1ClustersAnalyzer = DQMEDAnalyzer('SiPixelPhase1Clusters',
         triggerflag = hltSiPixelPhase1ClustersTriggers,
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltSiPixelPhase1ClustersAnalyzer,
+                         pixelSrc = "hltSiPixelClustersAfterSplittingPPOnAA",
+                         stripSrc = "hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression")
+
 hltSiPixelPhase1ClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1ClustersConf,
         geometry   = hltSiPixelPhase1Geometry

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_TrackCluster_cff.py
@@ -433,6 +433,10 @@ hltSiPixelPhase1TrackClustersAnalyzer = DQMEDAnalyzer('SiPixelPhase1TrackCluster
         geometry   = hltSiPixelPhase1Geometry
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltSiPixelPhase1TrackClustersAnalyzer,
+                         clusters   = "hltSiPixelClustersAfterSplittingPPOnAA")
+
 hltSiPixelPhase1TrackClustersHarvester = DQMEDHarvester("SiPixelPhase1Harvester",
         histograms = hltSiPixelPhase1TrackClustersConf,
         geometry   = hltSiPixelPhase1Geometry

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_cff.py
@@ -7,12 +7,21 @@ from DQM.SiPixelMonitorTrack.RefitterForPixelDQM import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelTemplateStoreESProducer_cfi import *
 
 hltSiPixelClusterShapeCache = siPixelClusterShapeCache.clone(src = 'hltSiPixelClusters')
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltSiPixelClusterShapeCache,
+                         src =  "hltSiPixelClustersAfterSplittingPPOnAA")
+
 hltrefittedForPixelDQM = refittedForPixelDQM.clone(src ='hltMergedTracks',
                                                    TTRHBuilder = 'WithTrackAngle') # no templates at HLT
+
+pp_on_PbPb_run3.toModify(hltrefittedForPixelDQM,
+                         src ='hltMergedTracksPPOnAA')
+
 sipixelMonitorHLTsequence = cms.Sequence(
     hltSiPixelClusterShapeCache
     + hltSiPixelPhase1ClustersAnalyzer
     + hltrefittedForPixelDQM
     + hltSiPixelPhase1TrackClustersAnalyzer,
     cms.Task(SiPixelTemplateStoreESProducer)
-)    
+)

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -16,6 +16,12 @@ HLTSiStripMonitorCluster = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.S
     ClusterHisto         = True,
     Mod_On               = False
 )
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(HLTSiStripMonitorCluster,
+                         ClusterProducerStrip = "hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression",
+                         ClusterProducerPix   = "hltSiPixelClustersAfterSplittingPPOnAA")
+
 HLTSiStripMonitorCluster.TH1TotalNumberOfClusters.subdetswitchon   = cms.bool(True)
 HLTSiStripMonitorCluster.TProfClustersApvCycle.subdetswitchon      = cms.bool(False)
 HLTSiStripMonitorCluster.TProfTotalNumberOfClusters.subdetswitchon = cms.bool(True)
@@ -144,6 +150,10 @@ hltTrackRefitterForSiStripMonitorTrack = TrackRefitter.clone(
     #TTRHBuilder             = 'hltESPTTRHBuilderAngleAndTemplate',
     TTRHBuilder             = 'hltESPTTRHBWithTrackAngle'
 )
+
+pp_on_PbPb_run3.toModify(hltTrackRefitterForSiStripMonitorTrack,
+                         src = 'hltMergedTracksPPOnAA')
+
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
 HLTSiStripMonitorTrack = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
     TrackProducer     = 'hltTrackRefitterForSiStripMonitorTrack',
@@ -154,6 +164,10 @@ HLTSiStripMonitorTrack = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStrip
     TopFolderName     = 'HLT/SiStrip',
     Mod_On            = False
 )
+
+pp_on_PbPb_run3.toModify(HLTSiStripMonitorTrack,
+                         Cluster_src       = 'hltHITrackingSiStripRawToClustersFacilityFullZeroSuppression')
+
 sistripMonitorHLTsequence = cms.Sequence(
     HLTSiStripMonitorCluster
     * hltTrackRefitterForSiStripMonitorTrack

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
@@ -22,6 +22,12 @@ hltMerged2highPurity = TrackToTrackComparisonHists.clone(
     monitoredPrimaryVertices = "hltVerticesPFSelector"
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(hltMerged2highPurity,
+                         topDirName               = "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurity",
+                         monitoredTrack           = "hltMergedTracksPPOnAA",
+                         monitoredPrimaryVertices = "hltVerticesPFFilterPPOnAA")                         
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltMerged2highPurity,
                         monitoredTrack           = cms.InputTag("generalTracks","","HLT"),
@@ -37,6 +43,11 @@ hltMerged2highPurityPV = TrackToTrackComparisonHists.clone(
     referencePrimaryVertices = "offlinePrimaryVertices",
     monitoredPrimaryVertices = "hltVerticesPFSelector"
 )
+
+pp_on_PbPb_run3.toModify(hltMerged2highPurityPV,
+                         topDirName               = "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurityPV",
+                         monitoredTrack           = "hltMergedTracksPPOnAA",
+                         monitoredPrimaryVertices = "hltVerticesPFFilterPPOnAA")                         
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(hltMerged2highPurityPV,

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -27,8 +27,6 @@ trackingForElectronsMonitorClientHLT = cms.Sequence(
     trackingForElectronsEffFromHitPatternHLT
 )
 
-
-
 TrackToTrackEfficiencies = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring(
         "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurity",
@@ -64,6 +62,12 @@ TrackToTrackEfficiencies = DQMEDHarvester("DQMGenericClient",
         "FakeRate_PU         'Relative Fake Rate vs PU;PU;relative efficiency'                  mon_unMatched_PU        mon_PU          eff",
     ),
 )
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(TrackToTrackEfficiencies,
+                         subDirs = [
+                             "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurity",
+                             "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurityPV"])
 
 trackEfficiencyMonitoringClientHLT = cms.Sequence(
     TrackToTrackEfficiencies

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -27,6 +27,11 @@ pixelTracksMonitoringHLT = trackingMonHLT.clone(
     doEffFromHitPatternVsLUMI = False
 )
 
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toModify(pixelTracksMonitoringHLT,
+                         TrackProducer    = 'hltPixelTracksPPOnAA',
+                         allTrackProducer = 'hltPixelTracksPPOnAA')
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(pixelTracksMonitoringHLT,
                         TrackProducer    = 'hltPhase2PixelTracks',
@@ -101,7 +106,10 @@ iterHLTTracksMonitoringHLT = trackingMonHLT.clone(
     doSIPPlots                = cms.bool(True)
 )
 
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+pp_on_PbPb_run3.toModify(iterHLTTracksMonitoringHLT,
+                         TrackProducer    = 'hltMergedTracksPPOnAA',
+                         allTrackProducer = 'hltMergedTracksPPOnAA')
+
 phase2_tracker.toModify(iterHLTTracksMonitoringHLT,
                         TrackProducer    = cms.InputTag("generalTracks","","HLT"),
                         allTrackProducer = cms.InputTag("generalTracks","","HLT"))
@@ -147,6 +155,10 @@ doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
     doEffFromHitPatternVsBX   = False,
     doEffFromHitPatternVsLUMI = False
 )
+
+pp_on_PbPb_run3.toModify(doubletRecoveryHPTracksMonitoringHLT,
+                         TrackProducer    = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA',
+                         allTrackProducer = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA')
 
 ############
 #### EGM tracks


### PR DESCRIPTION
#### PR description:

In the context of [CMSALCA-240](https://its.cern.ch/jira/browse/CMSALCA-240) it has become clear that in order to run alca validation workflows that re-run the HLT `HIon` menu, the collections saved in the step2 (with data-tier `FEVTDEBUGHLT`) are not sufficient for the scope of monitoring objects produced at the HLT (namely tracks and vertices, but also strip and pixel clusters).
This PRs, in presence of the `pp_on_PbPb_run3` modifier:
   * adds the collections needed for the validation in the `FEVTDEBUGHLTEventContent`; 
   * introduces a bunch of modifications of input collections of various monitoring sequences in the package `DQMOffline/Trigger`

In order to test the whole procedure I introduce a new workflow 142.0 (starting from `RunHI2023A` RawPrime data) that mimics the procedure in the ticket [CMSALCA-240](https://its.cern.ch/jira/browse/CMSALCA-240). 

#### PR validation:

Run successfully `runTheMatrix.py -l 142.0 -t 4 -j 8`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, perhaps to be backported to 13.2.X if there is still a necessity to run the alca validation.