### PR TITLE
Simulation: adapt Phase2SteppingAction to the Tracker-CALO direct boundary for back-scattering detection

### DIFF
--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -193,15 +193,27 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
       if (!trkinfo->crossedBoundary()) {
         trkinfo->setCrossedBoundary(theTrack);
       }
-    } else if (preStep->GetPhysicalVolume() == calo && postStep->GetPhysicalVolume() == cmse) {
+    } else if (preStep->GetPhysicalVolume() == calo && postStep->GetPhysicalVolume() != calo) {
+      bool backscattering(false);
+      if (postStep->GetPhysicalVolume() == tracker) {
+        backscattering = true;
+      } else if (postStep->GetPhysicalVolume() == cmse) {
+        // simple protection to avoid possible steps from calo towards the outer part of the detector, if allowed by geometry
+        // to be removed as soon as tracker-calo boundary becomes again the default
+        if (preStep->GetPosition().mag2() > postStep->GetPosition().mag2()) {
+          backscattering = true;
+        }
+      }
       // store transition calo -> cmse to tag backscattering
-      TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
-      if (!trkinfo->isInTrkFromBackscattering()) {
-        trkinfo->setInTrkFromBackscattering();
+      if (backscattering) {
+        TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
+        if (!trkinfo->isInTrkFromBackscattering()) {
+          trkinfo->setInTrkFromBackscattering();
 #ifdef DebugLog
-        LogDebug("SimG4CoreApplication") << "Setting flag for backscattering from CALO "
-                                         << trkinfo->isInTrkFromBackscattering();
+          LogDebug("SimG4CoreApplication")
+              << "Setting flag for backscattering from CALO " << trkinfo->isInTrkFromBackscattering();
 #endif
+        }
       }
     }
   } else {

--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -13,8 +13,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-//#define DebugLog
-
 Phase2SteppingAction::Phase2SteppingAction(const CMSSteppingVerbose* sv, const edm::ParameterSet& p, bool hasW)
     : steppingVerbose(sv), hasWatcher(hasW) {
   theCriticalEnergyForVacuum = (p.getParameter<double>("CriticalEnergyForVacuum") * CLHEP::MeV);
@@ -168,13 +166,13 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
       TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
       if (!trkinfo->isFromTtoBTL() && !trkinfo->isFromBTLtoT()) {
         trkinfo->setFromTtoBTL();
-#ifdef DebugLog
+#ifdef EDM_ML_DEBUG
         LogDebug("SimG4CoreApplication") << "Setting flag for Tracker -> BTL " << trkinfo->isFromTtoBTL()
                                          << " IdAtBTLentrance = " << trkinfo->mcTruthID();
 #endif
       } else {
         trkinfo->setBTLlooper();
-#ifdef DebugLog
+#ifdef EDM_ML_DEBUG
         LogDebug("SimG4CoreApplication") << "Setting flag for BTL looper " << trkinfo->isBTLlooper();
 #endif
       }
@@ -183,7 +181,7 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
       TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
       if (!trkinfo->isFromBTLtoT()) {
         trkinfo->setFromBTLtoT();
-#ifdef DebugLog
+#ifdef EDM_ML_DEBUG
         LogDebug("SimG4CoreApplication") << "Setting flag for BTL -> Tracker " << trkinfo->isFromBTLtoT();
 #endif
       }
@@ -209,7 +207,7 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
         TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
         if (!trkinfo->isInTrkFromBackscattering()) {
           trkinfo->setInTrkFromBackscattering();
-#ifdef DebugLog
+#ifdef EDM_ML_DEBUG
           LogDebug("SimG4CoreApplication")
               << "Setting flag for backscattering from CALO " << trkinfo->isInTrkFromBackscattering();
 #endif
@@ -219,7 +217,7 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
   } else {
     theTrack->SetTrackStatus(fStopAndKill);
     isKilled = true;
-#ifdef DebugLog
+#ifdef EDM_ML_DEBUG
     PrintKilledTrack(theTrack, tstat);
 #endif
   }


### PR DESCRIPTION
#### PR description:

This PR adapts, within the ```Phase2SteppingAction``` class, the  tracking mechanism for particles back-scattered from CALO volumes into the Tracker, introduced for BTL studies in #42455 , to the new situation produced by #43133 . In order to allow the code to work in a similar way both with CALO and Tracker volumes separated by CMSE, and when they are adjacent, the transition check is made more complex (to be removed as soon as we standardize on one choice only). A further check is added in the case of CALO -> CMSE transition, in order to ensure that it happens towards the inner part of the detector: this is done by testing the distance of the preStep and postStep position from the CMS origin.

I also took the freedom to move a debug preprocessor statement to the CMS standard flag EDM_ML_DEBUG, as usually done elsewhere.

#### PR validation:

Code compiles, runs, and debugging statements show the desired behaviour:

```
   53    85.15    69.58    296.8  0.003477        0     21.6      40.5                  CALOECTSFront Transportation
   54    85.09    69.49    296.5  0.003477        0     2.91      40.8                         CALOEC Transportation
%MSG-d SimG4CoreApplication:  (NoModuleName) 28-Oct-2023 15:42:40 CEST  pre-events Phase2SteppingAction.cc:213
Setting flag for backscattering from CALO 1
%MSG
   55     84.4     68.5    293.5  0.003477        0     32.3      44.1                           CALO Transportation
   56    80.58       63    276.9  0.003477        0      179        62                           CMSE Transportation
   57    78.55    60.07    268.1  0.003477        0     95.3      71.5                Phase2OTForward Transportation
```