### PR TITLE
Fix unittest by making a local copy of test configuration

### DIFF
--- a/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
+++ b/CalibPPS/ESProducers/test/script_test_many_writeTotemDAQMapping.py
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import sys
+import shutil
 
 # Script which reads data from DB/XML and writes them to file
 # Run with python3
@@ -26,7 +27,9 @@ if(len(sys.argv)>3):
   
 
 # For each file change the variable values in the config so that they match the selected XML file and then run the config
-test_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'test_writeTotemDAQMapping.py')
+test_script = 'test_writeTotemDAQMapping.py'
+orig_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),test_script)
+shutil.copyfile(orig_script, test_script)
 for fileContent in filesToRead:
     for fileInfo in fileContent["configuration"]:
         with open(test_script, 'r+') as f:
@@ -86,6 +89,4 @@ for fileContent in filesToRead:
             f.truncate()
             
             
-        subprocess.run(f'cmsRun {os.environ["CMSSW_BASE"]}/src/CalibPPS/ESProducers/test/test_writeTotemDAQMapping.py' , shell=True)
-
-    
+        subprocess.run(f'cmsRun ./{test_script}' , shell=True)

--- a/CondTools/CTPPS/test/script-ctpps-write-many-XML-to-SQLite.py
+++ b/CondTools/CTPPS/test/script-ctpps-write-many-XML-to-SQLite.py
@@ -4,6 +4,8 @@ import os
 import re
 import subprocess
 import sys
+import shutil
+
 # Script which reads data from XML and drops objects to SQLite
 # Run with python3
 
@@ -18,9 +20,12 @@ if(len(sys.argv)>2):
 
 
 # For each file change the variable values in the config so that they match the selected XML file and then run the config
+test_script = "write-ctpps-totem_daqmap_cfg.py"
+orig_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),test_script)
+shutil.copyfile(orig_script, test_script)
 for fileContent in filesToWrite:
     for fileInfo in fileContent["configuration"]:
-      with open(f'{os.environ["CMSSW_BASE"]}/src/CondTools/CTPPS/test/write-ctpps-totem_daqmap_cfg.py', 'r+') as f:        
+      with open(test_script, 'r+') as f:
           content = f.read()
           # replace values specific for selected detector
           content = re.sub(r'subSystemName =.*', f'subSystemName = "{fileContent["subSystemName"]}"', content)
@@ -56,5 +61,5 @@ for fileContent in filesToWrite:
           f.truncate()
             
             
-      subprocess.run(f'cmsRun {os.environ["CMSSW_BASE"]}/src/CondTools/CTPPS/test/write-ctpps-totem_daqmap_cfg.py' , shell=True)
+      subprocess.run(f'cmsRun ./{test_script}' , shell=True)
     


### PR DESCRIPTION
Unit test `CondTools/CTPPS/test_XMLToSQLiteMapping` was modifying configuration files in the cmssw/src tree. This can fail if the package , whereit tries to modify files, exists on the read-only file system e.g. cvmfs. This happens during PR tests when package with unit test is checked but not the package which contains the files to be modifies ( see https://github.com/cms-sw/cmssw/pull/43037#issuecomment-1780841332)

This PR makes a local copy of the test configuration 