### PR TITLE
Update ecalMultiFitUncalibRecHit_cfi.py

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -8,10 +8,12 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
 run3_ecal.toModify(ecalMultiFitUncalibRecHit,
     algoPSet = dict(timealgo = 'crossCorrelationMethod',
-        outOfTimeThresholdGain12pEB = 2.5,
-        outOfTimeThresholdGain12mEB = 2.5,
-        outOfTimeThresholdGain61pEB = 2.5,
-        outOfTimeThresholdGain61mEB = 2.5,
+        EBtimeNconst = 25.5,
+        EBtimeConstantTerm = 0.85,
+        outOfTimeThresholdGain12pEB = 3.0,
+        outOfTimeThresholdGain12mEB = 3.0,
+        outOfTimeThresholdGain61pEB = 3.0,
+        outOfTimeThresholdGain61mEB = 3.0,
         timeCalibTag = ':CC',
         timeOffsetTag = ':CC'
     )


### PR DESCRIPTION
Updating CC parameters to improve agreement with previous object reco using ratio timing algorithm setting for rechit kOOT flag.

#### PR description:

Modified ecalMultiFitUncalibRecHit_cfi.py to the following.

******************************
import  RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHitProducer_cfi as _mod

# producer of rechits starting from digis
ecalMultiFitUncalibRecHit = _mod.ecalMultiFitUncalibRecHitProducer.clone()

# use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
import FWCore.ParameterSet.Config as cms
from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
run3_ecal.toModify(ecalMultiFitUncalibRecHit,
    algoPSet = dict(timealgo = 'crossCorrelationMethod',
        EBtimeNconst = 25.5,
        EBtimeConstantTerm = 0.85,
        outOfTimeThresholdGain12pEB = 3.0,
        outOfTimeThresholdGain12mEB = 3.0,
        outOfTimeThresholdGain61pEB = 3.0,
        outOfTimeThresholdGain61mEB = 3.0,
        timeCalibTag = ':CC',
        timeOffsetTag = ':CC'
    )
)
*************************************

This PR modifies the outOfTimeThresholdGain’s to 3.0 and added EBtimeNconst = 25.5 &  EBtimeConstantTerm = 0.85 for CC timing algorithm.

#### PR validation:

This PR only changes config values and does not touch code.  The affect on object reco of these config changes has been studied.
