### PR TITLE
Remove defaulted constructors and operators of StdArray 

### DIFF
--- a/DataFormats/Common/interface/StdArray.h
+++ b/DataFormats/Common/interface/StdArray.h
@@ -52,14 +52,6 @@ namespace edm {
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    // Assignment operators
-
-    // copy assignment operator
-    constexpr StdArray& operator=(StdArray<T, N> const& init) = default;
-
-    // move assignment operator
-    constexpr StdArray& operator=(StdArray<T, N>&& init) = default;
-
     // Interoperability with std::array
 
     // copy assignment from an std::array

--- a/DataFormats/Common/interface/StdArray.h
+++ b/DataFormats/Common/interface/StdArray.h
@@ -53,7 +53,7 @@ namespace edm {
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
     // Constructors
-
+#if __cplusplus < 202002L
     // default constructor
     constexpr StdArray() = default;
 
@@ -62,7 +62,7 @@ namespace edm {
 
     // move constructor
     constexpr StdArray(StdArray<T, N>&& init) = default;
-
+#endif
     // copy assignment operator
     constexpr StdArray& operator=(StdArray<T, N> const& init) = default;
 

--- a/DataFormats/Common/interface/StdArray.h
+++ b/DataFormats/Common/interface/StdArray.h
@@ -52,17 +52,6 @@ namespace edm {
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    // Constructors
-#if __cplusplus < 202002L
-    // default constructor
-    constexpr StdArray() = default;
-
-    // copy constructor
-    constexpr StdArray(StdArray<T, N> const& init) = default;
-
-    // move constructor
-    constexpr StdArray(StdArray<T, N>&& init) = default;
-#endif
     // copy assignment operator
     constexpr StdArray& operator=(StdArray<T, N> const& init) = default;
 

--- a/DataFormats/Common/interface/StdArray.h
+++ b/DataFormats/Common/interface/StdArray.h
@@ -52,6 +52,8 @@ namespace edm {
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
+    // Assignment operators
+
     // copy assignment operator
     constexpr StdArray& operator=(StdArray<T, N> const& init) = default;
 


### PR DESCRIPTION
#### PR description:

Compilation of StdArray_t test [fails in CPP20 IBs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_CPP20_X_2023-10-30-1100/DataFormats/Common):

```
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/test/StdArray_t.cpp
CMSSW_CPU_TYPE= /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DCMSSW_GIT_HASH='CMSSW_13_3_CPP20_X_2023-10-30-1100' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_3_CPP20_X_2023-10-30-1100' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/boost/1.80.0-826a207b8543c52970cb1f72d50f068c/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.29.99-f64c115b93334fa10a42b4d2a530947f/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2021.9.0-7352cece9624dbf25b0dcb67cdd11a91/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/catch2/2.13.6-17102db92de47c6a473c6e67627c548a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fmt/8.0.1-54e94b39f5cf29341bb9c4765764e1ca/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tinyxml2/6.2.0-d17873b4d6a42a43226cf689f82ec1ef/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  -MMD -MF tmp/el8_amd64_gcc12/src/DataFormats/Common/test/StdArray_t/StdArray_t.cpp.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/test/StdArray_t.cpp -o tmp/el8_amd64_gcc12/src/DataFormats/Common/test/StdArray_t/StdArray_t.cpp.o
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/test/StdArray_t.cpp: In function 'void ____C_A_T_C_H____T_E_S_T____0()':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/test/StdArray_t.cpp:28:45: error: no matching function for call to 'edm::StdArray<int, 4>::StdArray(<brace-enclosed initializer list>)'
    28 |     edm::StdArray<int, 4> array{{0, 1, 2, 3}};
      |                                             ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/test/StdArray_t.cpp:4:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/interface/StdArray.h:64:15: note: candidate: 'constexpr edm::StdArray<T, N>::StdArray(edm::StdArray<T, N>&&) [with T = int; long unsigned int N = 4]'
   64 |     constexpr StdArray(StdArray<T, N>&& init) = default;
      |               ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/interface/StdArray.h:64:41: note:   no known conversion for argument 1 from '<brace-enclosed initializer list>' to 'edm::StdArray<int, 4>&&'
   64 |     constexpr StdArray(StdArray<T, N>&& init) = default;
      |                        ~~~~~~~~~~~~~~~~~^~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/interface/StdArray.h:61:15: note: candidate: 'constexpr edm::StdArray<T, N>::StdArray(const edm::StdArray<T, N>&) [with T = int; long unsigned int N = 4]'
   61 |     constexpr StdArray(StdArray<T, N> const& init) = default;
      |               ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/interface/StdArray.h:61:46: note:   no known conversion for argument 1 from '<brace-enclosed initializer list>' to 'const edm::StdArray<int, 4>&'
   61 |     constexpr StdArray(StdArray<T, N> const& init) = default;
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/d3d9f42af53f45146856f52283745854/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_CPP20_X_2023-10-30-1100/src/DataFormats/Common/interface/StdArray.h:58:15: note: candidate: 'constexpr edm::StdArray<T, N>::StdArray() [with T = int; long unsigned int N = 4]'
   58 |     constexpr StdArray() = default;
      |               ^~~~~~~~
```

This happens because the conditions for enabling [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization) changed in C++20 compared to C++17:

* no user-provided, inherited, or explicit constructors - until C++20
* no user-declared or inherited constructors - since C++20

This PR conditionally removes user-declared constructors when code is compiled with C++20.

#### PR validation:

Bot tests
