### PR TITLE
Replace C-style array with std::array in HLTHPDFilter

### DIFF
--- a/HLTrigger/JetMET/src/HLTHPDFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHPDFilter.cc
@@ -6,6 +6,8 @@
 
 #include "HLTrigger/JetMET/interface/HLTHPDFilter.h"
 
+#include <array>
+
 #include <cmath>
 
 #include <set>
@@ -104,7 +106,7 @@ bool HLTHPDFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(m_theRecHitCollectionToken, hbhe);
 
   // collect energies
-  float hpdEnergy[4][73];
+  std::array<std::array<float, 73>, 4> hpdEnergy;
   for (auto& i : hpdEnergy)
     for (size_t j = 0; j < 73; ++j)
       i[j] = 0;


### PR DESCRIPTION
#### PR description:

Compiling code with C-style arrays with LTO causes (false-positive) warnings about out-of-bounds array access:

```
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src/HLTrigger/JetMET/src/HLTHtMhtProducer.cc
CMSSW_CPU_TYPE= /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DKTDOUBLEPRECISION -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_13_3_UBSAN_X_2023-10-30-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_13_3_UBSAN_X_2023-10-30-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/coral/CORAL_2_3_21-9b0e9a4e5ce1db7efe2592df0a98b1b4/include/LCG -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/dd4hep/v01-25x-2a9828068af4eec84a52344803a8af94/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/alpaka/develop-20230621-328794fca9695cfc66a84565d03106ee/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libpng/1.6.37-7461873793d4834865bcbd73bf2bfcd6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/boost/1.80.0-826a207b8543c52970cb1f72d50f068c/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/clhep/2.4.7.1-5bfe601b6d65215d210a10fe9d6d7478/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cuda/12.2.1-bdf3fff69eaec65abe18a7569592cab6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/curl/7.79.0-959a9188e043d67b2825f64cfeb54266/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fastjet/3.4.1-d6668faee9110bc891e7090ec0e0dd34/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/giflib/5.2.0-07dfc72586a7288f078c7a02c8b17956/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gsl/2.6-f316a321a173f181b66df52be79d894b/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc/2.06.10-db64552c0ab28562be049cf5c3d31c99/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hls/2019.08-b8a1533230929513077d97b1507ff465/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hls4mlEmulatorExtras/1.1.1-c788aa889fa249afee5adfca90f0c6af/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/ktjet/1.06-0b0d3faafd7cdc466d18474233f10066/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libjpeg-turbo/2.0.2-cfe908f70a445c34076845aedc9ca824/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/protobuf/3.21.9-7bb304aed5f101dc4cfa3698ace8eb11/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.26.11-c05101b2284100127f71c8d1f927ca38/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/sqlite/3.36.0-fde8c1dbb8f282eaade54b13a9a9d4c6/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2021.9.0-e755918dac6a30ec36eff63ac4f7ddec/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/utm/utm_0.11.2-885e7c69003ff9d6b7ab83c9e89adb9a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/vdt/0.4.3-5a80085534117eaccb28e669c6da4b6f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xerces-c/3.1.3-c7b88eaa36d0408120f3c29826a04bf6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-36a69a0d7b82bf7496dcc3ff29886d0d/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fastjet-contrib/1.051-570c6920b35db425ce1cab8f69e60bb6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fmt/8.0.1-54e94b39f5cf29341bb9c4765764e1ca/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc3/3.2.5-7606a946f19ead73b3e143d4ce0e3e49/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/OpenBLAS/0.3.15-15504a5c800a9ecbbc2befbb991bead5/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tensorflow/2.12.0-58820c0e61027cc0ac481bd348a707b0/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tinyxml2/6.2.0-d17873b4d6a42a43226cf689f82ec1ef/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -Wno-error=unused-variable -DALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128 -DBOOST_DISABLE_ASSERTS -g  -fPIC  -MMD -MF tmp/el8_amd64_gcc12/src/HLTrigger/JetMET/src/HLTriggerJetMET/HLTHtMhtProducer.cc.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src/HLTrigger/JetMET/src/HLTHtMhtProducer.cc -o tmp/el8_amd64_gcc12/src/HLTrigger/JetMET/src/HLTriggerJetMET/HLTHtMhtProducer.cc.o
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src/HLTrigger/JetMET/src/HLTHPDFilter.cc: In member function 'virtual bool HLTHPDFilter::filter(edm::Event&, const edm::EventSetup&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src/HLTrigger/JetMET/src/HLTHPDFilter.cc:116:31: warning: array subscript [0, 3] is outside array bounds of 'float [4][73]' [-Warray-bounds]
   116 |       hpdEnergy[int(hpd.first)][hpd.second] += (*hbhe)[i].energy();
      |       ~~~~~~~~~~~~~~~~~~~~~~~~^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/35f83a44a33c65a9e4937c28d76d5391/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_13_3_UBSAN_X_2023-10-30-2300/src/HLTrigger/JetMET/src/HLTHPDFilter.cc:107:9: note: while referencing 'hpdEnergy'
  107 |   float hpdEnergy[4][73];
      |         ^~~~~~~~~
```

( [full log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_13_3_UBSAN_X_2023-10-30-2300/HLTrigger/JetMET) ). This PR replaces C-style 2D array with `std:array` of `std::array`.

#### PR validation:

Bot tests