### PR TITLE
Improve the error message when trying to call a kernel from a .cc file

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/config.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/config.h
@@ -55,6 +55,25 @@ namespace alpaka_cuda_async {
 
 }  // namespace alpaka_cuda_async
 
+#ifdef ALPAKA_HOST_ONLY
+
+namespace alpaka {
+
+  template <typename TApi, typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
+  class TaskKernelGpuUniformCudaHipRt final {
+    static_assert(std::is_same_v<TApi, alpaka::ApiCudaRt> and BOOST_LANG_CUDA,
+                  "You should move this files to a .dev.cc file under the alpaka/ subdirectory.");
+
+  public:
+    template <typename TWorkDiv>
+    ALPAKA_FN_HOST TaskKernelGpuUniformCudaHipRt(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args) {
+    }
+  };
+
+}  // namespace alpaka
+
+#endif  // ALPAKA_HOST_ONLY
+
 #ifdef ALPAKA_ACCELERATOR_NAMESPACE
 #define ALPAKA_DUPLICATE_NAMESPACE
 #else
@@ -80,6 +99,25 @@ namespace alpaka_rocm_async {
   using Acc3D = Acc<Dim3D>;
 
 }  // namespace alpaka_rocm_async
+
+#ifdef ALPAKA_HOST_ONLY
+
+namespace alpaka {
+
+  template <typename TApi, typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
+  class TaskKernelGpuUniformCudaHipRt final {
+    static_assert(std::is_same_v<TApi, alpaka::ApiHipRt> and BOOST_LANG_HIP,
+                  "You should move this files to a .dev.cc file under the alpaka/ subdirectory.");
+
+  public:
+    template <typename TWorkDiv>
+    ALPAKA_FN_HOST TaskKernelGpuUniformCudaHipRt(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args) {
+    }
+  };
+
+}  // namespace alpaka
+
+#endif  // ALPAKA_HOST_ONLY
 
 #ifdef ALPAKA_ACCELERATOR_NAMESPACE
 #define ALPAKA_DUPLICATE_NAMESPACE


### PR DESCRIPTION
#### PR description:

If somebody tries to launch an alpaka kernel from a .cc file the error message is hard to understand, _e.g._:
```
/data/user/fwyzard/alpaka-test/CMSSW_13_3_0_pre4/src/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.cc:55:24:   required from here
/data/cmssw/el8_amd64_gcc12/external/alpaka/develop-20230621-328794fca9695cfc66a84565d03106ee/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp:277:24: error: invalid use of incomplete type 'class alpaka::TaskKernelGpuUniformCudaHipRt<alpaka::ApiCudaRt, alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt, std::integral_constant<long unsigned int, 1>, unsigned int>, std::integral_constant<long unsigned int, 1>, unsigned int, alpaka_cuda_async::TestAlgoKernel, portabletest::TestSoALayout<>::ViewTemplateFreeParams<128, false, true, false>&, int, double&>'
  277 |                 return TaskKernelGpuUniformCudaHipRt<
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  278 |                     TApi,
      |                     ~~~~~
  279 |                     AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  280 |                     TDim,
      |                     ~~~~~
  281 |                     TIdx,
      |                     ~~~~~
  282 |                     TKernelFnObj,
      |                     ~~~~~~~~~~~~~
  283 |                     TArgs...>(workDiv, kernelFnObj, std::forward<TArgs>(args)...);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmssw/el8_amd64_gcc12/external/alpaka/develop-20230621-328794fca9695cfc66a84565d03106ee/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp:43:11: note: declaration of 'class alpaka::TaskKernelGpuUniformCudaHipRt<alpaka::ApiCudaRt, alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt, std::integral_constant<long unsigned int, 1>, unsigned int>, std::integral_constant<long unsigned int, 1>, unsigned int, alpaka_cuda_async::TestAlgoKernel, portabletest::TestSoALayout<>::ViewTemplateFreeParams<128, false, true, false>&, int, double&>'
   43 |     class TaskKernelGpuUniformCudaHipRt;
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

These changes make a more understandable error message appear instead:
```
/data/user/fwyzard/alpaka-test/CMSSW_13_3_0_pre4/src/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.cc:55:24:   required from here
/data/user/fwyzard/alpaka-test/CMSSW_13_3_0_pre4/src/HeterogeneousCore/AlpakaInterface/interface/config.h:64:63: error: static assertion failed: You should move this files to a .dev.cc file under the alpaka/ subdirectory.
   64 |     static_assert(std::is_same_v<TApi, alpaka::ApiCudaRt> and BOOST_LANG_CUDA,
      |                                                               ^~~~~~~~~~~~~~~
```

#### PR validation:

Unit tests pass (are not affected)