### PR TITLE
Use likelihood fit instead of chi-square fit for PFJetDQMPostProcessor plugin

### DIFF
--- a/Validation/RecoParticleFlow/plugins/PFJetDQMPostProcessor.cc
+++ b/Validation/RecoParticleFlow/plugins/PFJetDQMPostProcessor.cc
@@ -246,7 +246,7 @@ void PFJetDQMPostProcessor::fitResponse(TH1F* hreso,
   TF1* fg = new TF1("mygaus", "gaus", fitlow, fithigh);
   TF1* fg2 = new TF1("fg2", "TMath::Gaus(x,[0],[1],true)*[2]", fitlow, fithigh);
 
-  hreso->Fit("mygaus", "RQN");
+  hreso->Fit("mygaus", "RQNL");
 
   fg2->SetParameter(0, fg->GetParameter(1));
   fg2->SetParameter(1, fg->GetParameter(2));
@@ -259,7 +259,7 @@ void PFJetDQMPostProcessor::fitResponse(TH1F* hreso,
   // (3) and number of bins (100)
   fg2->FixParameter(2, ngenjet * 3. / 100.);
 
-  hreso->Fit("fg2", "RQN");
+  hreso->Fit("fg2", "RQNL");
 
   fitlow = fg2->GetParameter(0) - 1.5 * fg2->GetParameter(1);
   fitlow = TMath::Max(15. / ptlow, fitlow);


### PR DESCRIPTION
For ROOT 6.30 IBs , couple of relvals are failing with error [a]. Just like https://github.com/cms-sw/cmssw/pull/43106 . this PR proposes to use likelihood fit for `PFJetDQMPostProcessor`.  With this change, the failing relvals run successfully in ROOT630 IB [b]

[a]
```
An exception of category 'FatalRootError' occurred while
   [0] Processing end ProcessBlock
   [1] Calling method for module PFJetDQMPostProcessor/'pfJetDQMPostProcessor'
   Additional Info:
      [a] Fatal Root Error: @SUB=Minuit2
VariableMetricBuilder Initial matrix not pos.def.
```

[b]
```
25234.0_TTbar_14TeV+2026D99 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Thu Nov  2 12:57:36 2023-date Thu Nov  2 12:43:55 2023; exit: 0 0 0 0 0
26434.0_TTbar_14TeV+2026D102 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED Step4-PASSED  - time date Thu Nov  2 12:57:19 2023-date Thu Nov  2 12:43:56 2023; exit: 0 0 0 0 0
2 2 2 2 2 tests passed, 0 0 0 0 0 failed
```