### PR TITLE
Adding lumi=0 defaults to hardcode HB PFCuts for Phase2

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalDbHardcode.cc
@@ -184,11 +184,18 @@ HcalPFCut HcalDbHardcode::makePFCut(HcalGenericDetId fId, double intLumi, bool n
   float value0 = getParameters(fId).noiseThreshold();
   float value1 = getParameters(fId).seedThreshold();
 
-  // lumi-dependent stuff for Phase2
-
   if (noHE && fId.genericSubdet() == HcalGenericDetId::HcalGenBarrel) {  // HB Phase2
 
-    // from SLHCUpgradeSimulations/Configuration/python/aging.py
+    // aging-independent (lumi=0) intialization for Phase2 using "HBphase1" numbers
+    const float cuts_Phase1[] = {0.1, 0.2, 0.3, 0.3};
+    const float seeds_Phase1[] = {0.125, 0.25, 0.35, 0.35};
+
+    HcalDetId hid(fId);
+    int depth_m1 = hid.depth() - 1;
+    value0 = cuts_Phase1[depth_m1];
+    value1 = seeds_Phase1[depth_m1];
+
+    // lumi-dependent stuff for Phase2 from SLHCUpgradeSimulations/Configuration/python/aging.py
     const double lumis[] = {300, 1000, 3000, 4500};  // integrated lumi points
     // row by row initialization
     const float cuts[4][4] = {{0.4, 0.5, 0.6, 0.6}, {0.8, 1.2, 1.2, 1.2}, {1.0, 2.0, 2.0, 2.0}, {1.25, 2.5, 2.5, 2.5}};
@@ -196,8 +203,6 @@ HcalPFCut HcalDbHardcode::makePFCut(HcalGenericDetId fId, double intLumi, bool n
         {0.5, 0.625, 0.75, 0.75}, {1.0, 1.5, 1.5, 1.5}, {1.25, 2.5, 2.5, 2.5}, {1.5, 3.0, 3.0, 3.0}};
     const double eps = 1.e-6;
 
-    HcalDetId hid(fId);
-    int depth_m1 = hid.depth() - 1;
     for (int i = 0; i < 4; i++) {
       if (std::abs(intLumi - lumis[i]) < eps) {
         value0 = cuts[i][depth_m1];


### PR DESCRIPTION
#### PR description:

Specifications previously committed in #43139 don't precisely cover a special case of Phase2 wfs without aging, as discussed in 
https://github.com/cms-sw/cmssw/pull/43025#issuecomment-1790386958
This PR fills this gap.    
_No wfs expected to be affected at the moment._  

#### PR validation:

HcalPDCutsRcd dump for Phase2 without aging customization shows HB numbers corresponding to those from edmConfigDump of 24834.0_TTbar_14TeV+2026D98 (no aging) configs. 

```
              eta             phi             dep             det     value0     value1      DetId
               -1               1               1              HB  0.1000000  0.1250000   43100401
               -1               1               2              HB  0.2000000  0.2500000   43200401
               -1               1               3              HB  0.3000000  0.3500000   43300401
               -1               1               4              HB  0.3000000  0.3500000   43400401
               -2               1               1              HB  0.1000000  0.1250000   43100801
               -2               1               2              HB  0.2000000  0.2500000   43200801
               -2               1               3              HB  0.3000000  0.3500000   43300801
               -2               1               4              HB  0.3000000  0.3500000   43400801
```


