### PR TITLE
[Backport 7_1_X] Fix EmissionVetoHook for BB4L

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/EmissionVetoHook1.cc
@@ -433,7 +433,7 @@ bool EmissionVetoHook1::doVetoFSREmission(int, const Pythia8::Event &e, int iSys
   if (iSys != 0) return false;
 
   // only use for outside resonance vetos in combination with bb4l:FSREmission:veto
-  if (!inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto")==1) return false;
+  if (inResonance && settingsPtr->flag("POWHEG:bb4l:FSREmission:veto")==1) return false;
 
   // If we already have accepted 'vetoCount' emissions in a row, do nothing
   if (vetoOn && nAcceptSeq >= vetoCount) return false;


### PR DESCRIPTION
#### PR description:

This is a backport of #42264, fixing the Pythia EmissionVetoHook for BB4L, to CMSSW 7_1_X. This is needed for the ttbar spin entanglement analysis, which uses preLegacy 2016 data. For this analysis, a sample with the Powheg process "ttb_NLO_dec" is needed for a cross-check. This process has the same final state as BB4L (up to three real emissions) and thus uses the same hook.

#### PR validation:

See #42264.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #42264, as written above.
