### PR TITLE
fix for tracks with two ETL hits and no time assigned

### DIFF
--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1287,10 +1287,16 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
                 << " +/- " << thiterror;
             validmtd = true;
           } else {
-            LogTrace("TrackExtenderWithMTD")
-                << "TrackExtenderWithMTD: issue with layer2 extrapolation to layer1, time difference "
-                << (tofInfo.dt - mtdhit2->time()) << " larger than maximal uncertainty "
-                << (err1 + err2) * etlTimeChi2Cut_;
+            // if back extrapolated time of the outermost measurement not compatible with the innermost, keep the one with smallest error
+            if (err1 <= err2) {
+              thit = tofInfo.dt;
+              thiterror = tofInfo.dterror;
+              validmtd = true;
+            } else {
+              thit = mtdhit2->time();
+              thiterror = mtdhit2->timeError();
+              validmtd = true;
+            }
           }
         }
       }


### PR DESCRIPTION
#### PR description:
This PR includes a fix in the TrackExtenderWithMTD for tracks having two hits with valid time in ETL but which had no time assigned when failing the check on the time compatibility between the two hits (occurrence of such events is ~ 0.1%, consistent with tails of the deltaT distribution: https://cernbox.cern.ch/s/WnsJKVrRYK922b0). When the compatibility requirement fails, the time of the hit with the smallest error is now assigned to the track.

#### PR validation:
The code compiles and was tested running on the 24807.0 workflow.
