### PR TITLE
Add new SimBeamSpotHLLHC CondFormat

### DIFF
--- a/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
+++ b/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
@@ -938,7 +938,7 @@ namespace simBeamSpotPI {
   public:
     DisplayParametersDiff()
         : cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags>(
-              "Display of Sim BeamSpot parameters differences") {}
+              "Display of SimBeamSpot parameters differences") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
@@ -1071,5 +1071,472 @@ namespace simBeamSpotPI {
   };
 
 }  // namespace simBeamSpotPI
+
+// Similar namespace for SimBeamSpotHLLHCObject
+namespace simBeamSpotHLLHCPI {
+
+  enum parameters {
+    meanX = 1,                    // 1  - Positions
+    meanY = 2,                    // 2
+    meanZ = 3,                    // 3
+    eProton = 4,                  // 4  - LHC config
+    crabFrequency = 5,            // 5
+    rf800 = 6,                    // 6
+    crossingAngle = 7,            // 7 - Crossing and crabbing angles
+    crabbingAngleCrossing = 8,    // 8
+    crabbingAngleSeparation = 9,  // 9
+    betaCrossingPlane = 10,       // 10 - Betastar and emittance
+    betaSeparationPlane = 11,     // 11
+    horizontalEmittance = 12,     // 12
+    verticalEmittance = 13,       // 13
+    bunchLenght = 14,             // 14 - Additional parameters
+    timeOffset = 15,              // 15
+    END_OF_TYPES = 16,
+  };
+
+  /************************************************/
+  inline std::string getStringFromParamEnum(const parameters& parameter, const bool addUnits = false) {
+    switch (parameter) {
+      case meanX:
+        return (addUnits ? "MeanX [cm]" : "meanX");
+      case meanY:
+        return (addUnits ? "MeanY [cm]" : "meanY");
+      case meanZ:
+        return (addUnits ? "MeanZ [cm]" : "meanZ");
+      case eProton:
+        return (addUnits ? "E_{proton} [GeV]" : "eProton");
+      case crabFrequency:
+        return (addUnits ? "Crab freq. [MHz]" : "crabFrequency");
+      case rf800:
+        return (addUnits ? "RF800" : "rf800");
+      case crossingAngle:
+        return (addUnits ? "x-ing angle [#murad]" : "crossingAngle");
+      case crabbingAngleCrossing:
+        return (addUnits ? "Crab x-ing angle [#murad]" : "crabbingAngleCrossing");
+      case crabbingAngleSeparation:
+        return (addUnits ? "Crab sep. angle [#murad]" : "crabbingAngleSeparation");
+      case betaCrossingPlane:
+        return (addUnits ? "#beta x-ing plane [m]" : "betaCrossingPlane");
+      case betaSeparationPlane:
+        return (addUnits ? "#beta sep. plane [m]" : "betaSeparationPlane");
+      case horizontalEmittance:
+        return (addUnits ? "#epsilon_{horizontal} [mm]" : "horizontalEmittance");
+      case verticalEmittance:
+        return (addUnits ? "#epsilon_{vertical} [mm]" : "verticalEmittance");
+      case bunchLenght:
+        return (addUnits ? "Bunch lenght [m]" : "bunchLenght");
+      case timeOffset:
+        return (addUnits ? "TimeOffset [ns]" : "TimeOffset");
+      default:
+        return "should never be here";
+    }
+  }
+
+  /**
+   * Helper class for operations on the Sim Beam Spot HL-LHC Parameters
+   * It's a simplified representation of the beamspot
+   * data used as the underlying type for data transfers and comparisons
+   */
+  template <class PayloadType>
+  class SimBSHLLHCParamsHelper {
+    typedef std::array<double, parameters::END_OF_TYPES> bshelpdata;
+
+  public:
+    SimBSHLLHCParamsHelper(const std::shared_ptr<PayloadType>& bs) {
+      // fill in the values
+      m_values[parameters::meanX] = bs->meanX();
+      m_values[parameters::meanY] = bs->meanY();
+      m_values[parameters::meanZ] = bs->meanZ();
+      m_values[parameters::eProton] = bs->eProton();
+      m_values[parameters::crabFrequency] = bs->crabFrequency();
+      m_values[parameters::rf800] = bs->rf800();
+      m_values[parameters::crossingAngle] = bs->crossingAngle();
+      m_values[parameters::crabbingAngleCrossing] = bs->crabbingAngleCrossing();
+      m_values[parameters::crabbingAngleSeparation] = bs->crabbingAngleSeparation();
+      m_values[parameters::betaCrossingPlane] = bs->betaCrossingPlane();
+      m_values[parameters::betaSeparationPlane] = bs->betaSeparationPlane();
+      m_values[parameters::horizontalEmittance] = bs->horizontalEmittance();
+      m_values[parameters::verticalEmittance] = bs->verticalEmittance();
+      m_values[parameters::bunchLenght] = bs->bunchLenght();
+      m_values[parameters::timeOffset] = bs->timeOffset();
+    }
+
+    void printDebug(std::stringstream& ss) {
+      ss << "Dumping SimBeamSpotHLLHC parameters Data:" << std::endl;
+      for (uint i = parameters::meanX; i <= parameters::timeOffset; i++) {
+        parameters par = static_cast<parameters>(i);
+        ss << getStringFromParamEnum(par) << " : " << m_values[i] << std::endl;
+        ss << std::endl;
+      }
+    }
+
+    inline const bshelpdata centralValues() const { return m_values; }
+
+    // get the difference in values
+    const bshelpdata diffCentralValues(const SimBSHLLHCParamsHelper& bs2, const bool isPull = false) const {
+      bshelpdata ret;
+      for (uint i = parameters::meanX; i <= parameters::timeOffset; i++) {
+        ret[i] = this->centralValues()[i] - bs2.centralValues()[i];
+        if (isPull)
+          (this->centralValues()[i] != 0.) ? ret[i] /= this->centralValues()[i] : 0.;
+      }
+      return ret;
+    }
+
+  private:
+    bshelpdata m_values;
+  };
+
+  /************************************************
+    Display of Sim Beam Spot HL-LHC parameters
+  *************************************************/
+  template <class PayloadType>
+  class DisplayParameters : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
+  public:
+    DisplayParameters()
+        : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+              "Display of SimBeamSpotHLLHC parameters") {}
+
+    bool fill() override {
+      auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+      auto tagname = tag.name;
+      auto iov = tag.iovs.front();
+
+      gStyle->SetHistMinimumZero(kTRUE);
+
+      m_payload = this->fetchPayload(std::get<1>(iov));
+
+      std::function<double(parameters)> cutFunctor = [this](parameters my_param) {
+        double ret(-999.);
+        switch (my_param) {
+          case meanX:
+            return m_payload->meanX();
+          case meanY:
+            return m_payload->meanY();
+          case meanZ:
+            return m_payload->meanZ();
+          case eProton:
+            return m_payload->eProton();
+          case crabFrequency:
+            return m_payload->crabFrequency();
+          case rf800:
+            return m_payload->rf800();
+          case crossingAngle:
+            return m_payload->crossingAngle();
+          case crabbingAngleCrossing:
+            return m_payload->crabbingAngleCrossing();
+          case crabbingAngleSeparation:
+            return m_payload->crabbingAngleSeparation();
+          case betaCrossingPlane:
+            return m_payload->betaCrossingPlane();
+          case betaSeparationPlane:
+            return m_payload->betaSeparationPlane();
+          case horizontalEmittance:
+            return m_payload->horizontalEmittance();
+          case verticalEmittance:
+            return m_payload->verticalEmittance();
+          case bunchLenght:
+            return m_payload->bunchLenght();
+          case timeOffset:
+            return m_payload->timeOffset();
+          case END_OF_TYPES:
+            return ret;
+          default:
+            return ret;
+        }
+      };
+
+      TCanvas canvas("Sim Beam Spot HL-LHC Parameters Summary", "Sim BeamSpot HL-LHC Parameters summary", 1500, 1000);
+      canvas.Divide(2, 1);
+
+      // Fill canvans (1,1) with first 9 parameters
+      canvas.cd(1);
+      canvas.cd(1)->SetTopMargin(0.05);
+      canvas.cd(1)->SetBottomMargin(0.06);
+      canvas.cd(1)->SetLeftMargin(0.35);
+      canvas.cd(1)->SetRightMargin(0.01);
+      canvas.cd(1)->Modified();
+      canvas.cd(1)->SetGrid();
+
+      auto h2_SimBSHLLHCParameters = std::make_unique<TH2F>(
+          "Parameters", "", 1, 0.0, 1.0, parameters::crabbingAngleCrossing, 0, parameters::crabbingAngleCrossing);
+      h2_SimBSHLLHCParameters->SetStats(false);
+      h2_SimBSHLLHCParameters->GetXaxis()->SetBinLabel(1, "Value");
+
+      unsigned int yBin = 8;
+      for (int foo = parameters::meanX; foo <= parameters::crabbingAngleCrossing; foo++) {
+        parameters param = static_cast<parameters>(foo);
+        std::string theLabel = getStringFromParamEnum(param, true);
+        h2_SimBSHLLHCParameters->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
+        h2_SimBSHLLHCParameters->SetBinContent(1, yBin, cutFunctor(param));
+        yBin--;
+      }
+
+      h2_SimBSHLLHCParameters->GetXaxis()->LabelsOption("h");
+      h2_SimBSHLLHCParameters->GetYaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters->GetXaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters->SetMarkerSize(1.5);
+      h2_SimBSHLLHCParameters->Draw("TEXT");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.030);
+      ltx.SetTextAlign(11);
+
+      auto runLS = beamSpotPI::unpack(std::get<0>(iov));
+
+      ltx.DrawLatexNDC(
+          gPad->GetLeftMargin(),
+          1 - gPad->GetTopMargin() + 0.01,
+          (tagname + " IOV: #color[4]{" + std::to_string(runLS.first) + "," + std::to_string(runLS.second) + "}")
+              .c_str());
+
+      // Fill canvans (2,1) with second 9 parameters
+      canvas.cd(2);
+      canvas.cd(2)->SetTopMargin(0.05);
+      canvas.cd(2)->SetBottomMargin(0.06);
+      canvas.cd(2)->SetLeftMargin(0.35);
+      canvas.cd(2)->SetRightMargin(0.01);
+      canvas.cd(2)->Modified();
+      canvas.cd(2)->SetGrid();
+
+      const auto span = parameters::END_OF_TYPES - parameters::crabbingAngleSeparation;
+      auto h2_SimBSHLLHCParameters_Extras =
+          std::make_unique<TH2F>("Parameters Extras", "", 1, 0.0, 1.0, span, 0, static_cast<float>(span));
+      h2_SimBSHLLHCParameters_Extras->SetStats(false);
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->SetBinLabel(1, "Value");
+
+      unsigned int yBin_Extras = span;
+      for (int foo = parameters::crabbingAngleSeparation; foo <= parameters::timeOffset; foo++) {
+        parameters param = static_cast<parameters>(foo);
+        std::string theLabel = getStringFromParamEnum(param, true);
+        h2_SimBSHLLHCParameters_Extras->GetYaxis()->SetBinLabel(yBin_Extras, theLabel.c_str());
+        h2_SimBSHLLHCParameters_Extras->SetBinContent(1, yBin_Extras, cutFunctor(param));
+        yBin_Extras--;
+      }
+
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->LabelsOption("h");
+      h2_SimBSHLLHCParameters_Extras->GetYaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters_Extras->SetMarkerSize(1.5);
+      h2_SimBSHLLHCParameters_Extras->Draw("TEXT");
+
+      ltx.DrawLatexNDC(
+          gPad->GetLeftMargin(),
+          1 - gPad->GetTopMargin() + 0.01,
+          (tagname + " IOV: #color[4]{" + std::to_string(runLS.first) + "," + std::to_string(runLS.second) + "}")
+              .c_str());
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  protected:
+    std::shared_ptr<PayloadType> m_payload;
+
+  private:
+    static constexpr double cmToUm = 10000.f;
+  };
+
+  /********************************************************
+    Display of Sim Beam Spot HL-LHC parameters difference
+  ********************************************************/
+  template <class PayloadType, cond::payloadInspector::IOVMultiplicity nIOVs, int ntags>
+  class DisplayParametersDiff : public cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags> {
+  public:
+    DisplayParametersDiff()
+        : cond::payloadInspector::PlotImage<PayloadType, nIOVs, ntags>(
+              "Display of SimBeamSpotHLLHC parameters differences") {}
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      l_payload = this->fetchPayload(std::get<1>(lastiov));
+      f_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      TCanvas canvas("Sim Beam Spot HL-LHC Parameters Difference Summary",
+                     "Sim Beam Spot HL-LHC Parameters Difference summary",
+                     1500,
+                     1000);
+      canvas.Divide(2, 1);
+
+      // Histograms with parameters differences
+      // for the "text"-filled histogram
+      auto h2_SimBSHLLHCParameters = std::make_unique<TH2F>(
+          "Parameters", "", 1, 0.0, 1.0, parameters::crabbingAngleCrossing, 0, parameters::crabbingAngleCrossing);
+      h2_SimBSHLLHCParameters->SetStats(false);
+      h2_SimBSHLLHCParameters->GetXaxis()->SetBinLabel(1, "Value");
+      h2_SimBSHLLHCParameters->GetXaxis()->LabelsOption("h");
+      h2_SimBSHLLHCParameters->GetYaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters->GetXaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters->SetMarkerSize(1.5);
+
+      const auto span = parameters::END_OF_TYPES - parameters::crabbingAngleSeparation;
+      auto h2_SimBSHLLHCParameters_Extras =
+          std::make_unique<TH2F>("Parameters Extras", "", 1, 0.0, 1.0, span, 0, static_cast<float>(span));
+      h2_SimBSHLLHCParameters_Extras->SetStats(false);
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->SetBinLabel(1, "Value");
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->LabelsOption("h");
+      h2_SimBSHLLHCParameters_Extras->GetYaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters_Extras->GetXaxis()->SetLabelSize(0.05);
+      h2_SimBSHLLHCParameters_Extras->SetMarkerSize(1.5);
+
+      // prepare the arrays to fill the histogram
+      simBeamSpotHLLHCPI::SimBSHLLHCParamsHelper fBS(f_payload);
+      simBeamSpotHLLHCPI::SimBSHLLHCParamsHelper lBS(l_payload);
+
+#ifdef MM_DEBUG
+      std::stringstream ss1, ss2;
+      edm::LogPrint("") << "**** first payload";
+      fBS.printDebug(ss1);
+      edm::LogPrint("") << ss1.str();
+      edm::LogPrint("") << "**** last payload";
+      lBS.printDebug(ss2);
+      edm::LogPrint("") << ss2.str();
+#endif
+
+      const auto diffPars = fBS.diffCentralValues(lBS);
+
+      // fill "text"-filled histograms
+      unsigned int yBin = 8;
+      for (int foo = parameters::meanX; foo <= parameters::crabbingAngleCrossing; foo++) {
+        parameters param = static_cast<parameters>(foo);
+        std::string theLabel = simBeamSpotHLLHCPI::getStringFromParamEnum(param, true /*use units*/);
+        h2_SimBSHLLHCParameters->GetYaxis()->SetBinLabel(yBin, theLabel.c_str());
+        h2_SimBSHLLHCParameters->SetBinContent(1, yBin, diffPars[foo]); /* profiting of the parameters enum indexing */
+        yBin--;
+      }
+
+      unsigned int yBin_Extras = span;
+      for (int foo = parameters::crabbingAngleSeparation; foo <= parameters::timeOffset; foo++) {
+        parameters param = static_cast<parameters>(foo);
+        std::string theLabel = simBeamSpotHLLHCPI::getStringFromParamEnum(param, true /*use units*/);
+        h2_SimBSHLLHCParameters_Extras->GetYaxis()->SetBinLabel(yBin_Extras, theLabel.c_str());
+        h2_SimBSHLLHCParameters_Extras->SetBinContent(
+            1, yBin_Extras, diffPars[foo]); /* profiting of the parameters enum indexing */
+        yBin_Extras--;
+      }
+
+      // for the "colz"-filled histogram (clone from the text-based one)
+      auto h2_SimBSHLLHCShadow = (TH2F*)(h2_SimBSHLLHCParameters->Clone("shadow"));
+      h2_SimBSHLLHCShadow->GetZaxis()->SetTitle("#Delta Parameter(payload A - payload B)");
+      h2_SimBSHLLHCShadow->GetZaxis()->CenterTitle();
+      h2_SimBSHLLHCShadow->GetZaxis()->SetTitleOffset(1.5);
+
+      auto h2_SimBSHLLHCShadow_Extras = (TH2F*)(h2_SimBSHLLHCParameters_Extras->Clone("shadow"));
+      h2_SimBSHLLHCShadow_Extras->GetZaxis()->SetTitle("#Delta Parameter(payload A - payload B)");
+      h2_SimBSHLLHCShadow_Extras->GetZaxis()->CenterTitle();
+      h2_SimBSHLLHCShadow_Extras->GetZaxis()->SetTitleOffset(1.5);
+
+      // this is the fine gradient palette (blue to red)
+      double max = std::max(h2_SimBSHLLHCShadow->GetMaximum(), h2_SimBSHLLHCShadow_Extras->GetMaximum());
+      double min = std::min(h2_SimBSHLLHCShadow->GetMinimum(), h2_SimBSHLLHCShadow_Extras->GetMinimum());
+      double val_white = 0.;
+      double per_white = (max != min) ? ((val_white - min) / (max - min)) : 0.5;
+
+      const int number = 3;
+      double Red[number] = {0., 1., 1.};
+      double Green[number] = {0., 1., 0.};
+      double Blue[number] = {1., 1., 0.};
+      double Stops[number] = {0., per_white, 1.};
+      int nb = 256;
+      h2_SimBSHLLHCShadow->SetContour(nb);
+      h2_SimBSHLLHCShadow_Extras->SetContour(nb);
+      TColor::CreateGradientColorTable(number, Stops, Red, Green, Blue, nb);
+
+      // Fill canvas (1,1) with first 9 parameters differences
+      canvas.cd(1);
+      canvas.cd(1)->SetTopMargin(0.10);
+      canvas.cd(1)->SetBottomMargin(0.06);
+      canvas.cd(1)->SetLeftMargin(0.35);
+      canvas.cd(1)->SetRightMargin(0.25);
+      canvas.cd(1)->Modified();
+      canvas.cd(1)->SetGrid();
+      h2_SimBSHLLHCShadow->Draw("colz");
+      h2_SimBSHLLHCParameters->Draw("TEXTsame");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.025);
+      ltx.SetTextAlign(11);
+
+      // compute the (run,LS) pairs
+      auto l_runLS = beamSpotPI::unpack(std::get<0>(lastiov));
+      std::string l_runLSs = "(" + std::to_string(l_runLS.first) + "," + std::to_string(l_runLS.second) + ")";
+      auto f_runLS = beamSpotPI::unpack(std::get<0>(firstiov));
+      std::string f_runLSs = "(" + std::to_string(f_runLS.first) + "," + std::to_string(f_runLS.second) + ")";
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        ltx.DrawLatexNDC(
+            gPad->GetLeftMargin(),
+            1 - gPad->GetTopMargin() + 0.025,
+            (fmt::sprintf(
+                 "#splitline{A = #color[4]{%s}: %s}{B = #color[4]{%s}: %s}", f_tagname, f_runLSs, l_tagname, l_runLSs))
+                .c_str());
+      } else {
+        ltx.DrawLatexNDC(
+            gPad->GetLeftMargin(),
+            1 - gPad->GetTopMargin() + 0.025,
+            (fmt::sprintf("#splitline{#color[4]{%s}}{A = %s | B = %s}", f_tagname, l_runLSs, f_runLSs)).c_str());
+      }
+
+      // Fill canvas (2,1) with first 9 parameters differences
+      canvas.cd(2);
+      canvas.cd(2)->SetTopMargin(0.10);
+      canvas.cd(2)->SetBottomMargin(0.06);
+      canvas.cd(2)->SetLeftMargin(0.35);
+      canvas.cd(2)->SetRightMargin(0.20);
+      canvas.cd(2)->Modified();
+      canvas.cd(2)->SetGrid();
+      h2_SimBSHLLHCShadow_Extras->Draw("colz");
+      h2_SimBSHLLHCParameters_Extras->Draw("TEXTsame");
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        ltx.DrawLatexNDC(
+            gPad->GetLeftMargin(),
+            1 - gPad->GetTopMargin() + 0.025,
+            (fmt::sprintf(
+                 "#splitline{A = #color[4]{%s}: %s}{B = #color[4]{%s}: %s}", f_tagname, f_runLSs, l_tagname, l_runLSs))
+                .c_str());
+      } else {
+        ltx.DrawLatexNDC(
+            gPad->GetLeftMargin(),
+            1 - gPad->GetTopMargin() + 0.025,
+            (fmt::sprintf("#splitline{#color[4]{%s}}{A = %s | B = %s}", f_tagname, l_runLSs, f_runLSs)).c_str());
+      }
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  protected:
+    std::shared_ptr<PayloadType> f_payload;
+    std::shared_ptr<PayloadType> l_payload;
+  };
+
+}  // namespace simBeamSpotHLLHCPI
 
 #endif

--- a/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
+++ b/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
@@ -15,3 +15,9 @@
   <use name="CondCore/CondDB"/>
   <use name="boost_python"/>
 </library>
+
+<library file="SimBeamSpotHLLHC_PayloadInspector.cc" name="SimBeamSpotHLLHC_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/BeamSpotPlugins/plugins/SimBeamSpotHLLHC_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/SimBeamSpotHLLHC_PayloadInspector.cc
@@ -1,0 +1,30 @@
+#include "CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
+
+namespace {
+
+  /************************************************
+    Display of Sim Beam Spot HL-LHC parameters
+  *************************************************/
+
+  typedef simBeamSpotHLLHCPI::DisplayParameters<SimBeamSpotHLLHCObjects> SimBeamSpotHLLHCParameters;
+
+  /*********************************************************
+    Display of Sim Beam Spot HL-LHC parameters Differences
+  **********************************************************/
+
+  typedef simBeamSpotHLLHCPI::DisplayParametersDiff<SimBeamSpotHLLHCObjects, cond::payloadInspector::MULTI_IOV, 1>
+      SimBeamSpotHLLHCParametersDiffSingleTag;
+  typedef simBeamSpotHLLHCPI::DisplayParametersDiff<SimBeamSpotHLLHCObjects, cond::payloadInspector::SINGLE_IOV, 2>
+      SimBeamSpotHLLHCParametersDiffTwoTags;
+
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(SimBeamSpotHLLHC) {
+  PAYLOAD_INSPECTOR_CLASS(SimBeamSpotHLLHCParameters);
+  PAYLOAD_INSPECTOR_CLASS(SimBeamSpotHLLHCParametersDiffSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(SimBeamSpotHLLHCParametersDiffTwoTags);
+}

--- a/CondCore/BeamSpotPlugins/src/plugin.cc
+++ b/CondCore/BeamSpotPlugins/src/plugin.cc
@@ -1,13 +1,16 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
 #include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
-#include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
 #include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
-#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
-#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h"
 
 REGISTER_PLUGIN(BeamSpotObjectsRcd, BeamSpotObjects);
-REGISTER_PLUGIN(SimBeamSpotObjectsRcd, SimBeamSpotObjects);
 REGISTER_PLUGIN(BeamSpotOnlineHLTObjectsRcd, BeamSpotOnlineObjects);
 REGISTER_PLUGIN_NO_SERIAL(BeamSpotOnlineLegacyObjectsRcd, BeamSpotOnlineObjects);
+REGISTER_PLUGIN(SimBeamSpotObjectsRcd, SimBeamSpotObjects);
+REGISTER_PLUGIN(SimBeamSpotHLLHCObjectsRcd, SimBeamSpotHLLHCObjects);

--- a/CondCore/BeamSpotPlugins/test/testBeamSpotPayloadInspector.cpp
+++ b/CondCore/BeamSpotPlugins/test/testBeamSpotPayloadInspector.cpp
@@ -1,9 +1,10 @@
 #include <iostream>
 #include <sstream>
-#include "CondCore/Utilities/interface/PayloadInspector.h"
-#include "CondCore/BeamSpotPlugins/plugins/SimBeamSpot_PayloadInspector.cc"
 #include "CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc"
 #include "CondCore/BeamSpotPlugins/plugins/BeamSpotOnline_PayloadInspector.cc"
+#include "CondCore/BeamSpotPlugins/plugins/SimBeamSpot_PayloadInspector.cc"
+#include "CondCore/BeamSpotPlugins/plugins/SimBeamSpotHLLHC_PayloadInspector.cc"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -105,6 +106,27 @@ int main(int argc, char** argv) {
   SimBeamSpotParametersDiffTwoTags histoSimParametersDiffTwoTags;
   histoSimParametersDiffTwoTags.process(prepConnectionString, PI::mk_input(tag1, start, start, tag2, start, start));
   edm::LogPrint("testBeamSpotPayloadInspector") << histoSimParametersDiffTwoTags.data() << std::endl;
+
+  // SimBeamSpotHLLHC
+  tag = "SimBeamSpotHLLHC_test_tag_1_v0";
+
+  edm::LogPrint("testBeamSpotPayloadInspector") << "## Exercising SimBeamSpotHLLHC plots " << std::endl;
+
+  SimBeamSpotHLLHCParameters histoSimHLLHCParameters;
+  histoSimHLLHCParameters.process(prepConnectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimHLLHCParameters.data() << std::endl;
+
+  SimBeamSpotHLLHCParametersDiffSingleTag histoSimHLLHCParametersDiff;
+  histoSimHLLHCParametersDiff.process(prepConnectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimHLLHCParametersDiff.data() << std::endl;
+
+  tag1 = "SimBeamSpotHLLHC_test_tag_1_v0";
+  tag2 = "SimBeamSpotHLLHC_test_tag_2_v0";
+
+  SimBeamSpotHLLHCParametersDiffTwoTags histoSimHLLHCParametersDiffTwoTags;
+  histoSimHLLHCParametersDiffTwoTags.process(prepConnectionString,
+                                             PI::mk_input(tag1, start, start, tag2, start, start));
+  edm::LogPrint("testBeamSpotPayloadInspector") << histoSimHLLHCParametersDiffTwoTags.data() << std::endl;
 
   Py_Finalize();
 }

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -266,6 +266,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(RecoIdealGeometry);
   PAYLOAD_2XML_CLASS(RunInfo);
   PAYLOAD_2XML_CLASS(SimBeamSpotObjects);
+  PAYLOAD_2XML_CLASS(SimBeamSpotHLLHCObjects);
   PAYLOAD_2XML_CLASS(SiPhase2OuterTrackerLorentzAngle);
   PAYLOAD_2XML_CLASS(SiPixel2DTemplateDBObject);
   PAYLOAD_2XML_CLASS(SiPixelCPEGenericErrorParm);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -287,6 +287,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(RecoIdealGeometry)
       FETCH_PAYLOAD_CASE(RunInfo)
       FETCH_PAYLOAD_CASE(SimBeamSpotObjects)
+      FETCH_PAYLOAD_CASE(SimBeamSpotHLLHCObjects)
       FETCH_PAYLOAD_CASE(SiPhase2OuterTrackerLorentzAngle)
       FETCH_PAYLOAD_CASE(SiPixelCalibConfiguration)
       FETCH_PAYLOAD_CASE(SiPixelCPEGenericErrorParm)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -313,6 +313,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(RecoIdealGeometry)
         IMPORT_PAYLOAD_CASE(RunInfo)
         IMPORT_PAYLOAD_CASE(SimBeamSpotObjects)
+        IMPORT_PAYLOAD_CASE(SimBeamSpotHLLHCObjects)
         IMPORT_PAYLOAD_CASE(SiPhase2OuterTrackerLorentzAngle)
         IMPORT_PAYLOAD_CASE(SiPixelCalibConfiguration)
         IMPORT_PAYLOAD_CASE(SiPixelCPEGenericErrorParm)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -9,6 +9,7 @@
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
 #include "CondFormats/CastorObjects/interface/CastorElectronicsMap.h"
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorrs.h"
 #include "CondFormats/HIObjects/interface/CentralityTable.h"

--- a/CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h
@@ -1,0 +1,106 @@
+#ifndef SIMBEAMSPOTHLLHCOBJECTS_H
+#define SIMBEAMSPOTHLLHCOBJECTS_H
+
+/** \class SimBeamSpotHLLHCObjects
+ *
+ * Provide the vertex smearing parameters from DB
+ *
+ * This Object contains the parameters needed by the HLLHCEvtVtxGenerator generator:
+ *   Parameters used:
+ *      - fMeanX, fMeanY, fMeanZ
+ *      - fEProton, fCrabFrequency, fRF800
+ *      - fCrossingAngle
+ *      - fCrabbingAngleCrossing, fCrabbingAngleSeparation
+ *      - fBetaCrossingPlane, fBetaSeparationPlane
+ *      - fHorizontalEmittance, fVerticalEmittance
+ *      - fBunchLength
+ *      - fTimeOffset
+ *
+ */
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <sstream>
+
+class SimBeamSpotHLLHCObjects {
+public:
+  /// default constructor
+  SimBeamSpotHLLHCObjects() {
+    fMeanX = 0.0;
+    fMeanY = 0.0;
+    fMeanZ = 0.0;
+    fEProton = 0.0;
+    fCrabFrequency = 0.0;
+    fRF800 = 0.0;
+    fCrossingAngle = 0.0;
+    fCrabbingAngleCrossing = 0.0;
+    fCrabbingAngleSeparation = 0.0;
+    fBetaCrossingPlane = 0.0;
+    fBetaSeparationPlane = 0.0;
+    fHorizontalEmittance = 0.0;
+    fVerticalEmittance = 0.0;
+    fBunchLength = 0.0;
+    fTimeOffset = 0.0;
+  };
+
+  virtual ~SimBeamSpotHLLHCObjects(){};
+
+  /// set meanX, meanY, meanZ
+  void setMeanX(double val) { fMeanX = val; }
+  void setMeanY(double val) { fMeanY = val; }
+  void setMeanZ(double val) { fMeanZ = val; }
+  /// set EProton, fCrabFrequency, RF800
+  void setEProton(double val) { fEProton = val; }
+  void setCrabFrequency(double val) { fCrabFrequency = val; }
+  void setRF800(double val) { fRF800 = val; }
+  /// set Crossing and Crabbing angles
+  void setCrossingAngle(double val) { fCrossingAngle = val; }
+  void setCrabbingAngleCrossing(double val) { fCrabbingAngleCrossing = val; }
+  void setCrabbingAngleSeparation(double val) { fCrabbingAngleSeparation = val; }
+  /// set BetaStar and Emittance
+  void setBetaCrossingPlane(double val) { fBetaCrossingPlane = val; }
+  void setBetaSeparationPlane(double val) { fBetaSeparationPlane = val; }
+  void setHorizontalEmittance(double val) { fHorizontalEmittance = val; }
+  void setVerticalEmittance(double val) { fVerticalEmittance = val; }
+  /// set BunchLength and TimeOffset
+  void setBunchLength(double val) { fBunchLength = val; }
+  void setTimeOffset(double val) { fTimeOffset = val; }
+
+  /// get meanX, meanY, meanZ position
+  double meanX() const { return fMeanX; }
+  double meanY() const { return fMeanY; }
+  double meanZ() const { return fMeanZ; }
+  /// get EProton, fCrabFrequency, RF800
+  double eProton() const { return fEProton; }
+  double crabFrequency() const { return fCrabFrequency; }
+  double rf800() const { return fRF800; }
+  /// set Crossing and Crabbing angles
+  double crossingAngle() const { return fCrossingAngle; }
+  double crabbingAngleCrossing() const { return fCrabbingAngleCrossing; }
+  double crabbingAngleSeparation() const { return fCrabbingAngleSeparation; }
+  /// get BetaStar and Emittance
+  double betaCrossingPlane() const { return fBetaCrossingPlane; }
+  double betaSeparationPlane() const { return fBetaSeparationPlane; }
+  double horizontalEmittance() const { return fHorizontalEmittance; }
+  double verticalEmittance() const { return fVerticalEmittance; }
+  /// get BunchLength and TimeOffset
+  double bunchLenght() const { return fBunchLength; }
+  double timeOffset() const { return fTimeOffset; }
+
+  /// print sim beam spot parameters
+  void print(std::stringstream& ss) const;
+
+private:
+  double fMeanX, fMeanY, fMeanZ;
+  double fEProton, fCrabFrequency, fRF800;
+  double fCrossingAngle, fCrabbingAngleCrossing, fCrabbingAngleSeparation;
+  double fBetaCrossingPlane, fBetaSeparationPlane;
+  double fHorizontalEmittance, fVerticalEmittance;
+  double fBunchLength, fTimeOffset;
+
+  COND_SERIALIZABLE;
+};
+
+std::ostream& operator<<(std::ostream&, SimBeamSpotHLLHCObjects beam);
+
+#endif

--- a/CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h
+++ b/CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h
@@ -1,5 +1,5 @@
-#ifndef SIMBEAMSPOTHLLHCOBJECTS_H
-#define SIMBEAMSPOTHLLHCOBJECTS_H
+#ifndef CondFormats_BeamSpotObjects_SimBeamSpotHLLHCObjects_h
+#define CondFormats_BeamSpotObjects_SimBeamSpotHLLHCObjects_h
 
 /** \class SimBeamSpotHLLHCObjects
  *

--- a/CondFormats/BeamSpotObjects/src/SimBeamSpotHLLHCObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/SimBeamSpotHLLHCObjects.cc
@@ -1,0 +1,31 @@
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
+
+#include <iostream>
+
+void SimBeamSpotHLLHCObjects::print(std::stringstream& ss) const {
+  ss << "------------------------------------------------------------------------\n"
+     << "              Sim Beam Spot HL LHC Data\n\n"
+     << "    MeanX                  = " << meanX() << " [cm]\n"
+     << "    MeanY                  = " << meanY() << " [cm]\n"
+     << "    MeanZ                  = " << meanZ() << " [cm]\n"
+     << " E Proton                  = " << eProton() << " [GeV]\n"
+     << " Crab Frequency            = " << crabFrequency() << " [MHz]\n"
+     << " 800 MHz RF                ? " << rf800() << "\n"
+     << " Crossing Angle            = " << crossingAngle() << " [urad]\n"
+     << " Crabbing Angle Crossing   = " << crabbingAngleCrossing() << " [urad]\n"
+     << " Crabbing Angle Separation = " << crabbingAngleSeparation() << " [urad]\n"
+     << " Beta Crossing Plane       = " << betaCrossingPlane() << " [m]\n"
+     << " Beta Separation Plane     = " << betaSeparationPlane() << " [m]\n"
+     << " Horizontal Emittance      = " << horizontalEmittance() << " [mm]\n"
+     << " Vertical Emittance        = " << verticalEmittance() << " [mm]\n"
+     << " Bunch Lenght              = " << bunchLenght() << " [m]\n"
+     << " TimeOffset                = " << timeOffset() << " [ns]\n"
+     << "------------------------------------------------------------------------\n\n";
+}
+
+std::ostream& operator<<(std::ostream& os, SimBeamSpotHLLHCObjects beam) {
+  std::stringstream ss;
+  beam.print(ss);
+  os << ss.str();
+  return os;
+}

--- a/CondFormats/BeamSpotObjects/src/T_EventSetup_SimBeamSpotHLLHCObjects.cc
+++ b/CondFormats/BeamSpotObjects/src/T_EventSetup_SimBeamSpotHLLHCObjects.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+TYPELOOKUP_DATA_REG(SimBeamSpotHLLHCObjects);

--- a/CondFormats/BeamSpotObjects/src/classes_def.xml
+++ b/CondFormats/BeamSpotObjects/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-       <class name="BeamSpotObjects"/>       
-       <class name="SimBeamSpotObjects"/>       
+       <class name="BeamSpotObjects"/>
        <class name="BeamSpotOnlineObjects"/>
+       <class name="SimBeamSpotObjects"/>
+       <class name="SimBeamSpotHLLHCObjects"/>
 </lcgdict>  

--- a/CondFormats/BeamSpotObjects/src/headers.h
+++ b/CondFormats/BeamSpotObjects/src/headers.h
@@ -1,3 +1,4 @@
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
-#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"

--- a/CondFormats/BeamSpotObjects/test/testSerializationBeamSpotObjects.cpp
+++ b/CondFormats/BeamSpotObjects/test/testSerializationBeamSpotObjects.cpp
@@ -4,8 +4,9 @@
 
 int main() {
   testSerialization<BeamSpotObjects>();
-  testSerialization<SimBeamSpotObjects>();
   testSerialization<BeamSpotOnlineObjects>();
+  testSerialization<SimBeamSpotObjects>();
+  testSerialization<SimBeamSpotHLLHCObjects>();
 
   return 0;
 }

--- a/CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h
+++ b/CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h
@@ -1,0 +1,23 @@
+#ifndef DataRecord_SimBeamSpotHLLHCObjectsRcd_h
+#define DataRecord_SimBeamSpotHLLHCObjectsRcd_h
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SimBeamSpotHLLHCObjectsRcd
+//
+/**\class SimBeamSpotHLLHCObjectsRcd SimBeamSpotHLLHCObjectsRcd.h CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h
+
+ Description: Contains the Vertex Smearing parameters used by HLLHCEvtVtxGenerator (Phase 2 BeamSpot simulation)
+
+*/
+//
+// Author: Francesco Brivio (INFN Milano-Bicocca)
+// Created: Thu Nov 2 2023
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class SimBeamSpotHLLHCObjectsRcd : public edm::eventsetup::EventSetupRecordImplementation<SimBeamSpotHLLHCObjectsRcd> {
+};
+
+#endif

--- a/CondFormats/DataRecord/src/SimBeamSpotHLLHCObjectsRcd.cc
+++ b/CondFormats/DataRecord/src/SimBeamSpotHLLHCObjectsRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     DataRecord
+// Class  :     SimBeamSpotHLLHCObjectsRcd
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Author: Francesco Brivio (INFN Milano-Bicocca)
+// Created: Thu Nov 2 2023
+
+#include "CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(SimBeamSpotHLLHCObjectsRcd);

--- a/CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBReader.cc
+++ b/CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBReader.cc
@@ -1,0 +1,190 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamProfileHLLHC2DBReader
+// Class:      BeamProfileHLLHC2DBReader
+//
+/**\class BeamProfileHLLHC2DBReader BeamProfileHLLHC2DBReader.cc CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBReader.cc
+
+ Description: simple edm::one::EDAnalyzer to retrieve and ntuplize SimBeamSpotHLLHC data from the conditions database
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio
+//         Created:  11 June 2023
+//
+
+// system include files
+#include <fstream>
+#include <memory>
+#include <sstream>
+
+// user include files
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// For ROOT
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include <TTree.h>
+
+//
+// class declaration
+//
+
+class BeamProfileHLLHC2DBReader : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit BeamProfileHLLHC2DBReader(const edm::ParameterSet&);
+  ~BeamProfileHLLHC2DBReader() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  struct TheBSfromDB {
+    int run;
+    int ls;
+    double fMeanX, fMeanY, fMeanZ;
+    double fEProton, fCrabFrequency, fRF800;
+    double fCrossingAngle, fCrabbingAngleCrossing, fCrabbingAngleSeparation;
+    double fBetaCrossingPlane, fBetaSeparationPlane;
+    double fHorizontalEmittance, fVerticalEmittance;
+    double fBunchLength, fTimeOffset;
+    void init();
+  } theBSfromDB_;
+
+  const edm::ESGetToken<SimBeamSpotHLLHCObjects, SimBeamSpotHLLHCObjectsRcd> beamSpotToken_;
+  edm::Service<TFileService> tFileService;
+  TTree* bstree_;
+
+  // ----------member data ---------------------------
+  edm::ESWatcher<SimBeamSpotHLLHCObjectsRcd> watcher_;
+  std::unique_ptr<std::ofstream> output_;
+};
+
+// ------------ constructor  ------------
+BeamProfileHLLHC2DBReader::BeamProfileHLLHC2DBReader(const edm::ParameterSet& iConfig)
+    : beamSpotToken_(esConsumes()), bstree_(nullptr) {
+  //now do what ever initialization is needed
+  usesResource("TFileService");
+  std::string fileName(iConfig.getUntrackedParameter<std::string>("rawFileName"));
+  if (!fileName.empty()) {
+    output_ = std::make_unique<std::ofstream>(fileName.c_str());
+    if (!output_->good()) {
+      edm::LogError("IOproblem") << "Could not open output file " << fileName << ".";
+      output_.reset();
+    }
+  }
+}
+
+// ------------ SimBeamSpotHLLHCObjects initialization  ------------
+void BeamProfileHLLHC2DBReader::TheBSfromDB::init() {
+  float dummy_double = 0.0;
+  int dummy_int = 0;
+
+  run = dummy_int;
+  ls = dummy_int;
+  fMeanX = dummy_double;
+  fMeanY = dummy_double;
+  fMeanZ = dummy_double;
+  fEProton = dummy_double;
+  fCrabFrequency = dummy_double;
+  fRF800 = dummy_double;
+  fCrossingAngle = dummy_double;
+  fCrabbingAngleCrossing = dummy_double;
+  fCrabbingAngleSeparation = dummy_double;
+  fBetaCrossingPlane = dummy_double;
+  fBetaSeparationPlane = dummy_double;
+  fHorizontalEmittance = dummy_double;
+  fVerticalEmittance = dummy_double;
+  fBunchLength = dummy_double;
+  fTimeOffset = dummy_double;
+}
+
+// ------------ method called for each event  ------------
+void BeamProfileHLLHC2DBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  std::ostringstream output;
+
+  // initialize the ntuple
+  theBSfromDB_.init();
+
+  if (watcher_.check(iSetup)) {  // check for new IOV for this run / LS
+
+    output << " for runs: " << iEvent.id().run() << " - " << iEvent.id().luminosityBlock() << std::endl;
+
+    // Get SimBeamSpotHLLHCObjects from EventSetup:
+    const SimBeamSpotHLLHCObjects* mybeamspot = &iSetup.getData(beamSpotToken_);
+
+    theBSfromDB_.run = iEvent.id().run();
+    theBSfromDB_.ls = iEvent.id().luminosityBlock();
+    theBSfromDB_.fMeanX = mybeamspot->meanX();
+    theBSfromDB_.fMeanY = mybeamspot->meanY();
+    theBSfromDB_.fMeanZ = mybeamspot->meanZ();
+    theBSfromDB_.fEProton = mybeamspot->eProton();
+    theBSfromDB_.fCrabFrequency = mybeamspot->crabFrequency();
+    theBSfromDB_.fRF800 = mybeamspot->rf800();
+    theBSfromDB_.fCrossingAngle = mybeamspot->crossingAngle();
+    theBSfromDB_.fCrabbingAngleCrossing = mybeamspot->crabbingAngleCrossing();
+    theBSfromDB_.fCrabbingAngleSeparation = mybeamspot->crabbingAngleSeparation();
+    theBSfromDB_.fBetaCrossingPlane = mybeamspot->betaCrossingPlane();
+    theBSfromDB_.fBetaSeparationPlane = mybeamspot->betaSeparationPlane();
+    theBSfromDB_.fHorizontalEmittance = mybeamspot->horizontalEmittance();
+    theBSfromDB_.fVerticalEmittance = mybeamspot->verticalEmittance();
+    theBSfromDB_.fBunchLength = mybeamspot->bunchLenght();
+    theBSfromDB_.fTimeOffset = mybeamspot->timeOffset();
+    bstree_->Fill();
+    output << *mybeamspot << std::endl;
+  }
+
+  // Final output - either message logger or output file:
+  if (output_.get())
+    *output_ << output.str();
+  else
+    edm::LogInfo("BeamProfileHLLHC2DBReader") << output.str();
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void BeamProfileHLLHC2DBReader::beginJob() {
+  bstree_ = tFileService->make<TTree>("BSNtuple", "SimBeamSpotHLLHC analyzer ntuple");
+
+  //Tree Branches
+  bstree_->Branch("run", &theBSfromDB_.run, "run/I");
+  bstree_->Branch("ls", &theBSfromDB_.ls, "ls/I");
+  bstree_->Branch("MeanX", &theBSfromDB_.fMeanX, "MeanX/F");
+  bstree_->Branch("MeanY", &theBSfromDB_.fMeanY, "MeanY/F");
+  bstree_->Branch("MeanZ", &theBSfromDB_.fMeanZ, "MeanZ/F");
+  bstree_->Branch("EProton", &theBSfromDB_.fEProton, "EProton/F");
+  bstree_->Branch("CrabFrequency", &theBSfromDB_.fCrabFrequency, "CrabFrequency/F");
+  bstree_->Branch("RF800", &theBSfromDB_.fRF800, "RF800/O");
+  bstree_->Branch("CrossingAngle", &theBSfromDB_.fCrossingAngle, "CrossingAngle/F");
+  bstree_->Branch("CrabbingAngleCrossing", &theBSfromDB_.fCrabbingAngleCrossing, "CrabbingAngleCrossing/F");
+  bstree_->Branch("CrabbingAngleSeparation", &theBSfromDB_.fCrabbingAngleSeparation, "CrabbingAngleSeparation/F");
+  bstree_->Branch("BetaCrossingPlane", &theBSfromDB_.fBetaCrossingPlane, "BetaCrossingPlane/F");
+  bstree_->Branch("BetaSeparationPlane", &theBSfromDB_.fBetaSeparationPlane, "BetaSeparationPlane/F");
+  bstree_->Branch("HorizontalEmittance", &theBSfromDB_.fHorizontalEmittance, "HorizontalEmittance/F");
+  bstree_->Branch("VerticalEmittance", &theBSfromDB_.fVerticalEmittance, "VerticalEmittance/F");
+  bstree_->Branch("BunchLength", &theBSfromDB_.fBunchLength, "BunchLength/F");
+  bstree_->Branch("TimeOffset", &theBSfromDB_.fTimeOffset, "TimeOffset/F");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BeamProfileHLLHC2DBReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("rawFileName", {});
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamProfileHLLHC2DBReader);

--- a/CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBWriter.cc
+++ b/CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBWriter.cc
@@ -1,0 +1,106 @@
+// -*- C++ -*-
+//
+// Package:    BeamProfileHLLHC2DBWriter
+// Class:      BeamProfileHLLHC2DBWriter
+//
+/**\class BeamProfileHLLHC2DBWriter BeamProfileHLLHC2DBWriter.cc CondTools/BeamSpot/plugins/BeamProfileHLLHC2DBWriter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Francesco Brivio (INFN Milano-Bicocca)
+//         Created:  November 2, 2023
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+
+//
+// class declaration
+//
+class BeamProfileHLLHC2DBWriter : public edm::global::EDAnalyzer<> {
+public:
+  explicit BeamProfileHLLHC2DBWriter(const edm::ParameterSet&);
+  ~BeamProfileHLLHC2DBWriter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+  const std::string recordName_;
+  SimBeamSpotHLLHCObjects beamSpot_;
+};
+
+// ------------ constructor  ------------
+BeamProfileHLLHC2DBWriter::BeamProfileHLLHC2DBWriter(const edm::ParameterSet& iConfig)
+    : recordName_(iConfig.getParameter<std::string>("recordName")) {
+  beamSpot_.setMeanX(iConfig.getParameter<double>("MeanX"));
+  beamSpot_.setMeanY(iConfig.getParameter<double>("MeanY"));
+  beamSpot_.setMeanZ(iConfig.getParameter<double>("MeanZ"));
+  beamSpot_.setEProton(iConfig.getParameter<double>("EProton"));
+  beamSpot_.setCrabFrequency(iConfig.getParameter<double>("CrabFrequency"));
+  beamSpot_.setRF800(iConfig.getParameter<double>("RF800"));
+  beamSpot_.setCrossingAngle(iConfig.getParameter<double>("CrossingAngle"));
+  beamSpot_.setCrabbingAngleCrossing(iConfig.getParameter<double>("CrabbingAngleCrossing"));
+  beamSpot_.setCrabbingAngleSeparation(iConfig.getParameter<double>("CrabbingAngleSeparation"));
+  beamSpot_.setBetaCrossingPlane(iConfig.getParameter<double>("BetaCrossingPlane"));
+  beamSpot_.setBetaSeparationPlane(iConfig.getParameter<double>("BetaSeparationPlane"));
+  beamSpot_.setHorizontalEmittance(iConfig.getParameter<double>("HorizontalEmittance"));
+  beamSpot_.setVerticalEmittance(iConfig.getParameter<double>("VerticalEmittance"));
+  beamSpot_.setBunchLength(iConfig.getParameter<double>("BunchLength"));
+  beamSpot_.setTimeOffset(iConfig.getParameter<double>("TimeOffset"));
+}
+
+// ------------ method called for each event  ------------
+void BeamProfileHLLHC2DBWriter::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void BeamProfileHLLHC2DBWriter::endJob() {
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  poolDbService->createOneIOV<SimBeamSpotHLLHCObjects>(beamSpot_, poolDbService->beginOfTime(), recordName_);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BeamProfileHLLHC2DBWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("recordName", "SimBeamSpotHLLHCObjectsRcd")
+      ->setComment("name of the record to use for the PoolDBOutputService");
+  desc.add<double>("MeanX", 0.0)->setComment("in cm");
+  desc.add<double>("MeanY", 0.0)->setComment("in cm");
+  desc.add<double>("MeanZ", 0.0)->setComment("in cm");
+  desc.add<double>("EProton", 0.0)->setComment("in GeV");
+  desc.add<double>("CrabFrequency", 0.0)->setComment("in MHz");
+  desc.add<double>("RF800", 0.0)->setComment("800 MHz RF?");
+  desc.add<double>("CrossingAngle", 0.0)->setComment("in urad");
+  desc.add<double>("CrabbingAngleCrossing", 0.0)->setComment("in urad");
+  desc.add<double>("CrabbingAngleSeparation", 0.0)->setComment("in urad");
+  desc.add<double>("BetaCrossingPlane", 0.0)->setComment("in m");
+  desc.add<double>("BetaSeparationPlane", 0.0)->setComment("in m");
+  desc.add<double>("HorizontalEmittance", 0.0)->setComment("in mm");
+  desc.add<double>("VerticalEmittance", 0.0)->setComment("in mm");
+  desc.add<double>("BunchLength", 0.0)->setComment("in m");
+  desc.add<double>("TimeOffset", 0.0)->setComment("in ns");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamProfileHLLHC2DBWriter);

--- a/CondTools/BeamSpot/test/BeamProfileHLLHC2DBReader_cfg.py
+++ b/CondTools/BeamSpot/test/BeamProfileHLLHC2DBReader_cfg.py
@@ -1,0 +1,96 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("READ")
+
+options = VarParsing.VarParsing()
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "are we running the unit test?")
+options.register('inputTag',
+                 "myTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "output tag name")
+options.register('startRun',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "location of the input data")
+options.register('startLumi',
+                 1, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "IOV Start Lumi")
+options.parseArguments()
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000000                 # do not clog output with IO
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )   # large number of events is needed since we probe 5000LS for run (see below)
+
+####################################################################
+# Empty source 
+####################################################################
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.startRun),
+                            firstLuminosityBlock = cms.untracked.uint32(options.startRun),  # probe one LS after the other
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),        # probe one event per LS
+                            numberEventsInRun = cms.untracked.uint32(1),                    # a number of events > the number of LS possible in a real run (5000 s ~ 32 h)
+                            )
+
+####################################################################
+# Connect to conditions DB
+####################################################################
+
+if options.unitTest:
+    tag_name = 'simHLLHCBS_tag'
+else:
+    tag_name = options.inputTag
+
+# either from Global Tag
+# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+# from Configuration.AlCa.GlobalTag import GlobalTag
+# process.GlobalTag = GlobalTag(process.GlobalTag,"auto:phase2_realistic")
+
+# ...or specify database connection and tag...
+# from CondCore.CondDB.CondDB_cfi import *
+# CondDBSimBeamSpot = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+# process.dbInput = cms.ESSource("PoolDBESSource",
+#                                CondDBSimBeamSpot,
+#                                toGet = cms.VPSet(cms.PSet(record = cms.string('SimBeamSpotHLLHCObjectsRcd'),
+#                                                           tag = cms.string(tag_name)  # customize with input tag name
+#                                                           )
+#                                                  )
+#                                )
+
+# ...or specify local db file:
+from CondCore.CondDB.CondDB_cfi import *
+CondDBSimBeamSpot = CondDB.clone(connect = cms.string("sqlite_file:test_%s.db" % tag_name)) # customize with input db file
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    CondDBSimBeamSpot,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('SimBeamSpotHLLHCObjectsRcd'),
+        tag = cms.string(tag_name)  # customize with input tag name
+    ))
+)
+
+####################################################################
+# Load and configure analyzer
+####################################################################
+from CondTools.BeamSpot.beamProfileHLLHC2DBReader_cfi import beamProfileHLLHC2DBReader
+process.BeamProfileHLLHC2DBRead = beamProfileHLLHC2DBReader.clone(rawFileName = 'reference_SimBeamSpotHLLHCObjects.txt')
+
+####################################################################
+# Output file
+####################################################################
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string("reference_SimBeamSpotHLLHCObjects.root")
+                                   ) 
+
+# Put module in path:
+process.p = cms.Path(process.BeamProfileHLLHC2DBRead)

--- a/CondTools/BeamSpot/test/BeamProfileHLLHC2DBWriter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamProfileHLLHC2DBWriter_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("writeBeamProfileHLLHC2DB")
+
+options = VarParsing.VarParsing()
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "are we running the unit test?")
+options.register('inputTag',
+                 "myTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "output tag name")
+options.parseArguments()
+
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+from CondCore.CondDB.CondDB_cfi import *
+
+if options.unitTest :
+    tag_name = 'simHLLHCBS_tag'
+else:
+    tag_name = options.inputTag
+
+#################################
+# Produce a SQLITE FILE
+#################################
+CondDBSimBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % tag_name)) # choose an output name
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBSimBeamSpotObjects,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string("SimBeamSpotHLLHCObjectsRcd"), # SimBeamSpotHLLHCObjects record
+                                                                     tag = cms.string(tag_name))),                      # choose your favourite tag
+                                          loadBlobStreamer = cms.untracked.bool(False)
+                                          )
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+from CondTools.BeamSpot.beamProfileHLLHC2DBWriter_cfi import beamProfileHLLHC2DBWriter
+process.BeamProfileHLLHC2DBWriter = beamProfileHLLHC2DBWriter.clone(EProton = 6500,
+                                                                    CrabFrequency = 400,
+                                                                    RF800 = False,
+                                                                    CrossingAngle = 510,
+                                                                    CrabbingAngleCrossing = 380.0,
+                                                                    BetaCrossingPlane = 0.20,
+                                                                    BetaSeparationPlane = 0.20,
+                                                                    HorizontalEmittance = 2.5e-06,
+                                                                    VerticalEmittance = 2.05e-06,
+                                                                    BunchLength = 0.090,)
+
+process.p = cms.Path(process.BeamProfileHLLHC2DBWriter)

--- a/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
@@ -30,6 +30,9 @@ cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsWriter_cfg.py unitTest=True input
 printf "TESTING Writing SimBeamSpotObjectsRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamProfile2DBWriter_cfg.py unitTest=True || die "Failure writing payload for SimBeamSpotObjectsRcd" $?
 
+printf "TESTING Writing SimBeamSpotHLLHCObjectsRcd DB object ...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/BeamProfileHLLHC2DBWriter_cfg.py unitTest=True || die "Failure writing payload for SimBeamSpotHLLHCObjectsRcd" $?
+
 # test read
 printf "TESTING Reading BeamSpotOnlineLegacyObjectsRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineLegacyObjectsRcd || die "Failure reading payload for BeamSpotOnlineLegacyObjectsRcd" $?
@@ -47,3 +50,6 @@ cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=Tru
 
 printf "TESTING Reading SimBeamSpotObjectsRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamProfile2DBReader_cfg.py unitTest=True || die "Failure reading payload for SimBeamSpotObjectsRcd" $?
+
+printf "TESTING Reading SimBeamSpotHLLHCObjectsRcd DB object ...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/BeamProfileHLLHC2DBReader_cfg.py unitTest=True || die "Failure reading payload for SimBeamSpotHLLHCObjectsRcd" $?

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -42,8 +42,6 @@ VtxSmeared = {
     'HGCALCloseBy'  :                'IOMC.EventVertexGenerators.VtxSmearedHGCALCloseBy_cfi',
     'HLLHC'  :                       'IOMC.EventVertexGenerators.VtxSmearedHLLHC_cfi',
     'HLLHC14TeV'  :                  'IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi',
-    'HLLHC_CK'  :                    'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing_cfi',
-    'HLLHC_CK14TeV'  :               'IOMC.EventVertexGenerators.VtxSmearedHLLHCCrabKissing14TeV_cfi',
     'ShiftedCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedShiftedCollision2015_cfi',
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -12,6 +12,10 @@
  */
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "CondFormats/DataRecord/interface/SimBeamSpotHLLHCObjectsRcd.h"
+#include "CondFormats/BeamSpotObjects/interface/SimBeamSpotHLLHCObjects.h"
 
 #include <string>
 
@@ -33,7 +37,9 @@ public:
   /** Copy assignment operator */
   HLLHCEvtVtxGenerator& operator=(const HLLHCEvtVtxGenerator& rhs) = delete;
 
-  ~HLLHCEvtVtxGenerator() override;
+  ~HLLHCEvtVtxGenerator() override = default;
+
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -43,59 +49,29 @@ public:
   TMatrixD const* GetInvLorentzBoost() const override { return nullptr; };
 
 private:
-  //spatial and time offset for mean collision
-  const double fMeanX, fMeanY, fMeanZ, fTimeOffset;
+  // Configurable parameters
+  double fMeanX, fMeanY, fMeanZ, fTimeOffset;  //spatial and time offset for mean collision
+  double fEProton;                             // proton beam energy
+  double fCrossingAngle;                       // crossing angle
+  double fCrabFrequency;                       // crab cavity frequency
+  bool fRF800;                                 // 800 MHz RF?
+  double fBetaCrossingPlane;                   // beta crossing plane (m)
+  double fBetaSeparationPlane;                 // beta separation plane (m)
+  double fHorizontalEmittance;                 // horizontal emittance
+  double fVerticalEmittance;                   // vertical emittance
+  double fBunchLength;                         // bunch length
+  double fCrabbingAngleCrossing;               // crabbing angle crossing
+  double fCrabbingAngleSeparation;             // crabbing angle separation
 
-  //proton beam energy
-  const double momeV;
-  const double gamma;
-  const double beta;
-  const double betagamma;
-
-  //crossing angle
-  const double phi;
-
-  //crab cavity frequency
-  const double wcc;
-
-  // 800 MHz RF?
-  const bool RF800;
-
-  //beta crossing plane (m)
-  const double betx;
-
-  //beta separation plane (m)
-  const double bets;
-
-  //horizontal emittance
-  const double epsxn;
-
-  //vertical emittance
-  const double epssn;
-
-  //bunch length
-  const double sigs;
-
-  //crabbing angle crossing
-  const double alphax;
-
-  //crabbing angle separation
-  const double alphay;
-
-  // ratio of crabbing angle to crossing angle
-  const double oncc;
-
-  //normalized crossing emittance
-  const double epsx;
-
-  //normlaized separation emittance
-  const double epss;
-
-  //size in x
-  const double sigx;
-
-  // crossing angle * crab frequency
-  const double phiCR;
+  // Parameters inferred from configurables
+  double gamma;  // beam configurations
+  double beta;
+  double betagamma;
+  double oncc;   // ratio of crabbing angle to crossing angle
+  double epsx;   // normalized crossing emittance
+  double epss;   // normalized separation emittance
+  double sigx;   // size in x
+  double phiCR;  // crossing angle * crab frequency
 
   //width for y plane
   double sigma(double z, double epsilon, double beta, double betagamma) const;
@@ -105,6 +81,12 @@ private:
 
   // 4D intensity
   double intensity(double x, double y, double z, double t) const;
+
+  // Read from DB
+  bool readDB_;
+  void update(const edm::EventSetup& iEventSetup);
+  edm::ESWatcher<SimBeamSpotHLLHCObjectsRcd> parameterWatcher_;
+  edm::ESGetToken<SimBeamSpotHLLHCObjects, SimBeamSpotHLLHCObjectsRcd> beamToken_;
 };
 
 #endif

--- a/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/HLLHCEvtVtxGenerator.h
@@ -50,18 +50,18 @@ public:
 
 private:
   // Configurable parameters
-  double fMeanX, fMeanY, fMeanZ, fTimeOffset;  //spatial and time offset for mean collision
-  double fEProton;                             // proton beam energy
-  double fCrossingAngle;                       // crossing angle
-  double fCrabFrequency;                       // crab cavity frequency
-  bool fRF800;                                 // 800 MHz RF?
-  double fBetaCrossingPlane;                   // beta crossing plane (m)
-  double fBetaSeparationPlane;                 // beta separation plane (m)
-  double fHorizontalEmittance;                 // horizontal emittance
-  double fVerticalEmittance;                   // vertical emittance
-  double fBunchLength;                         // bunch length
-  double fCrabbingAngleCrossing;               // crabbing angle crossing
-  double fCrabbingAngleSeparation;             // crabbing angle separation
+  double fMeanX, fMeanY, fMeanZ, fTimeOffset_c_light;  //spatial and time offset for mean collision
+  double fEProton;                                     // proton beam energy
+  double fCrossingAngle;                               // crossing angle
+  double fCrabFrequency;                               // crab cavity frequency
+  bool fRF800;                                         // 800 MHz RF?
+  double fBetaCrossingPlane;                           // beta crossing plane (m)
+  double fBetaSeparationPlane;                         // beta separation plane (m)
+  double fHorizontalEmittance;                         // horizontal emittance
+  double fVerticalEmittance;                           // vertical emittance
+  double fBunchLength;                                 // bunch length
+  double fCrabbingAngleCrossing;                       // crabbing angle crossing
+  double fCrabbingAngleSeparation;                     // crabbing angle separation
 
   // Parameters inferred from configurables
   double gamma;  // beam configurations

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHLLHCCrabKissing14TeV_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHLLHCCrabKissing14TeV_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
-HLLHCCrabKissingVtxSmearingParameters14TeV=HLLHCCrabKissingVtxSmearingParameters.clone(EprotonInGeV = cms.double(7000.0))
-VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
-                            HLLHCCrabKissingVtxSmearingParameters14TeV,
-                            VtxSmearedCommon
-                            )
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedHLLHCCrabKissing_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedHLLHCCrabKissing_cfi.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
-VtxSmeared = cms.EDProducer("HLLHCEvtVtxGenerator",
-                            HLLHCCrabKissingVtxSmearingParameters,
-                            VtxSmearedCommon
-                            )
-

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -1089,23 +1089,3 @@ HLLHCVtxSmearingParameters = cms.PSet(
     CrabbingAngleCrossingInurad = cms.double(380.0),
     CrabbingAngleSeparationInurad = cms.double(0.0)
 )
-
-# Parameters for HL-LHC Crab-kissing operation 13 TeV
-HLLHCCrabKissingVtxSmearingParameters = cms.PSet(
-    MeanXIncm = cms.double(0.),
-    MeanYIncm = cms.double(0.),
-    MeanZIncm = cms.double(0.),
-    TimeOffsetInns = cms.double(0.0),
-    EprotonInGeV = cms.double(6500.0),
-    HalfCrossingAngleInurad = cms.double(200.0),
-    CrabAngleCrossingPlaneInurad = cms.double(200.0),
-    CrabFrequencyCrossingPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceCrossingPlaneInum = cms.double(2.5),
-    BetaStarCrossingPlaneInm = cms.double(0.30),
-    CrabAngleParallelPlaneInurad = cms.double(100.0),
-    CrabFrequencyParallelPlaneInMHz = cms.double(400.0),
-    NormalizedEmittanceParallelPlaneInum = cms.double(2.5),
-    BetaStarParallelPlaneInm = cms.double(0.075),
-    ZsizeInm = cms.double(0.15),
-    BeamProfile=cms.string("Flat")
-)

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -92,9 +92,9 @@ void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
   if (readDB_ && parameterWatcher_.check(iEventSetup)) {
     edm::ESHandle<SimBeamSpotHLLHCObjects> beamhandle = iEventSetup.getHandle(beamToken_);
     // Read configurable parameters
-    fMeanX = beamhandle->meanX() * cm;
-    fMeanY = beamhandle->meanY() * cm;
-    fMeanZ = beamhandle->meanZ() * cm;
+    fMeanX = beamhandle->meanX() * CLHEP::cm;
+    fMeanY = beamhandle->meanY() * CLHEP::cm;
+    fMeanZ = beamhandle->meanZ() * CLHEP::cm;
     fEProton = beamhandle->eProton() * 1e9;
     fCrossingAngle = beamhandle->crossingAngle() * 1e-6;
     fCrabFrequency = beamhandle->crabFrequency() * 1e6;
@@ -106,7 +106,7 @@ void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
     fBunchLength = beamhandle->bunchLenght();
     fCrabbingAngleCrossing = beamhandle->crabbingAngleCrossing() * 1e-6;
     fCrabbingAngleSeparation = beamhandle->crabbingAngleSeparation() * 1e-6;
-    fTimeOffset = beamhandle->timeOffset() * ns * c_light;
+    fTimeOffset = beamhandle->timeOffset() * CLHEP::ns * c_light;
     // Set parameters inferred from configurables
     gamma = fEProton / pmass + 1.0;
     beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -54,7 +54,7 @@ HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvt
     fMeanX = p.getParameter<double>("MeanXIncm") * CLHEP::cm;
     fMeanY = p.getParameter<double>("MeanYIncm") * CLHEP::cm;
     fMeanZ = p.getParameter<double>("MeanZIncm") * CLHEP::cm;
-    fTimeOffset = p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * CLHEP::c_light;
+    fTimeOffset_c_light = p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * CLHEP::c_light;
     fEProton = p.getParameter<double>("EprotonInGeV") * 1e9;
     fCrossingAngle = p.getParameter<double>("CrossingAngleInurad") * 1e-6;
     fCrabFrequency = p.getParameter<double>("CrabFrequencyInMHz") * 1e6;
@@ -67,7 +67,7 @@ HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvt
     fCrabbingAngleCrossing = p.getParameter<double>("CrabbingAngleCrossingInurad") * 1e-6;
     fCrabbingAngleSeparation = p.getParameter<double>("CrabbingAngleSeparationInurad") * 1e-6;
     // Set parameters inferred from configurables
-    gamma = fEProton / pmass + 1.0;
+    gamma = fEProton / pmass;
     beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));
     betagamma = beta * gamma;
     oncc = fCrabbingAngleCrossing / fCrossingAngle;
@@ -106,9 +106,9 @@ void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
     fBunchLength = beamhandle->bunchLenght();
     fCrabbingAngleCrossing = beamhandle->crabbingAngleCrossing() * 1e-6;
     fCrabbingAngleSeparation = beamhandle->crabbingAngleSeparation() * 1e-6;
-    fTimeOffset = beamhandle->timeOffset() * CLHEP::ns * CLHEP::c_light;
+    fTimeOffset_c_light = beamhandle->timeOffset() * CLHEP::ns * CLHEP::c_light;
     // Set parameters inferred from configurables
-    gamma = fEProton / pmass + 1.0;
+    gamma = fEProton / pmass;
     beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));
     betagamma = beta * gamma;
     oncc = fCrabbingAngleCrossing / fCrossingAngle;
@@ -153,7 +153,7 @@ HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine
   x += fMeanX;
   y += fMeanY;
   z += fMeanZ;
-  t += fTimeOffset;
+  t += fTimeOffset_c_light;
 
   return HepMC::FourVector(x, y, z, t);
 }

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -16,7 +16,6 @@
 using namespace std;
 
 namespace {
-
   constexpr double pmass = 0.9382720813e9;            // eV
   constexpr double gamma34 = 1.22541670246517764513;  // Gamma(3/4)
   constexpr double gamma14 = 3.62560990822190831193;  // Gamma(1/4)
@@ -48,35 +47,77 @@ void HLLHCEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& desc
   descriptions.add("HLLHCEvtVtxGenerator", desc);
 }
 
-HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p)
-    : BaseEvtVtxGenerator(p),
-      fMeanX(p.getParameter<double>("MeanXIncm") * CLHEP::cm),
-      fMeanY(p.getParameter<double>("MeanYIncm") * CLHEP::cm),
-      fMeanZ(p.getParameter<double>("MeanZIncm") * CLHEP::cm),
-      fTimeOffset(p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * c_light),
-      momeV(p.getParameter<double>("EprotonInGeV") * 1e9),
-      gamma(momeV / pmass + 1.0),
-      beta(std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)))),
-      betagamma(beta * gamma),
-      phi(p.getParameter<double>("CrossingAngleInurad") * 1e-6),
-      wcc(p.getParameter<double>("CrabFrequencyInMHz") * 1e6),
-      RF800(p.getParameter<bool>("RF800")),
-      betx(p.getParameter<double>("BetaCrossingPlaneInm")),
-      bets(p.getParameter<double>("BetaSeparationPlaneInm")),
-      epsxn(p.getParameter<double>("HorizontalEmittance")),
-      epssn(p.getParameter<double>("VerticalEmittance")),
-      sigs(p.getParameter<double>("BunchLengthInm")),
-      alphax(p.getParameter<double>("CrabbingAngleCrossingInurad") * 1e-6),
-      alphay(p.getParameter<double>("CrabbingAngleSeparationInurad") * 1e-6),
-      oncc(alphax / phi),
-      epsx(epsxn / (betagamma)),
-      epss(epsx),
-      sigx(std::sqrt(epsx * betx)),
-      phiCR(oncc * phi)
+HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p) {
+  readDB_ = p.getParameter<bool>("readDB");
+  if (!readDB_) {
+    // Read configurable parameters
+    fMeanX = p.getParameter<double>("MeanXIncm") * CLHEP::cm;
+    fMeanY = p.getParameter<double>("MeanYIncm") * CLHEP::cm;
+    fMeanZ = p.getParameter<double>("MeanZIncm") * CLHEP::cm;
+    fTimeOffset = p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * c_light;
+    fEProton = p.getParameter<double>("EprotonInGeV") * 1e9;
+    fCrossingAngle = p.getParameter<double>("CrossingAngleInurad") * 1e-6;
+    fCrabFrequency = p.getParameter<double>("CrabFrequencyInMHz") * 1e6;
+    fRF800 = p.getParameter<bool>("RF800");
+    fBetaCrossingPlane = p.getParameter<double>("BetaCrossingPlaneInm");
+    fBetaSeparationPlane = p.getParameter<double>("BetaSeparationPlaneInm");
+    fHorizontalEmittance = p.getParameter<double>("HorizontalEmittance");
+    fVerticalEmittance = p.getParameter<double>("VerticalEmittance");
+    fBunchLength = p.getParameter<double>("BunchLengthInm");
+    fCrabbingAngleCrossing = p.getParameter<double>("CrabbingAngleCrossingInurad") * 1e-6;
+    fCrabbingAngleSeparation = p.getParameter<double>("CrabbingAngleSeparationInurad") * 1e-6;
+    // Set parameters inferred from configurables
+    gamma = fEProton / pmass + 1.0;
+    beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));
+    betagamma = beta * gamma;
+    oncc = fCrabbingAngleCrossing / fCrossingAngle;
+    epsx = fHorizontalEmittance / (betagamma);
+    epss = epsx;
+    sigx = std::sqrt(epsx * fBetaCrossingPlane);
+    phiCR = oncc * fCrossingAngle;
+  }
+  if (readDB_) {
+    // NOTE: this is currently watching LS transitions, while it should watch Run transitions,
+    // even though in reality there is no Run Dependent MC (yet) in CMS
+    beamToken_ =
+        esConsumes<SimBeamSpotHLLHCObjects, SimBeamSpotHLLHCObjectsRcd, edm::Transition::BeginLuminosityBlock>();
+  }
+}
 
-{}
+void HLLHCEvtVtxGenerator::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& iEventSetup) {
+  update(iEventSetup);
+}
 
-HLLHCEvtVtxGenerator::~HLLHCEvtVtxGenerator() {}
+void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
+  if (readDB_ && parameterWatcher_.check(iEventSetup)) {
+    edm::ESHandle<SimBeamSpotHLLHCObjects> beamhandle = iEventSetup.getHandle(beamToken_);
+    // Read configurable parameters
+    fMeanX = beamhandle->meanX() * cm;
+    fMeanY = beamhandle->meanY() * cm;
+    fMeanZ = beamhandle->meanZ() * cm;
+    fEProton = beamhandle->eProton() * 1e9;
+    fCrossingAngle = beamhandle->crossingAngle() * 1e-6;
+    fCrabFrequency = beamhandle->crabFrequency() * 1e6;
+    fRF800 = beamhandle->rf800();
+    fBetaCrossingPlane = beamhandle->betaCrossingPlane();
+    fBetaSeparationPlane = beamhandle->betaSeparationPlane();
+    fHorizontalEmittance = beamhandle->horizontalEmittance();
+    fVerticalEmittance = beamhandle->verticalEmittance();
+    fBunchLength = beamhandle->bunchLenght();
+    fCrabbingAngleCrossing = beamhandle->crabbingAngleCrossing() * 1e-6;
+    fCrabbingAngleSeparation = beamhandle->crabbingAngleSeparation() * 1e-6;
+    fTimeOffset = beamhandle->timeOffset() * ns * c_light;
+    // Set parameters inferred from configurables
+    gamma = fEProton / pmass + 1.0;
+    beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));
+    betagamma = beta * gamma;
+    oncc = fCrabbingAngleCrossing / fCrossingAngle;
+    epsx = fHorizontalEmittance / (betagamma);
+    epss = epsx;
+    sigx = std::sqrt(epsx * fBetaCrossingPlane);
+    phiCR = oncc * fCrossingAngle;
+  }
+}
 
 HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine) const {
   double imax = intensity(0., 0., 0., 0.);
@@ -88,10 +129,10 @@ HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine
   auto shoot = [&]() { return CLHEP::RandFlat::shoot(engine); };
 
   do {
-    z = (shoot() - 0.5) * 6.0 * sigs;
-    t = (shoot() - 0.5) * 6.0 * sigs;
-    x = (shoot() - 0.5) * 12.0 * sigma(0.0, epsxn, betx, betagamma);
-    y = (shoot() - 0.5) * 12.0 * sigma(0.0, epssn, bets, betagamma);
+    z = (shoot() - 0.5) * 6.0 * fBunchLength;
+    t = (shoot() - 0.5) * 6.0 * fBunchLength;
+    x = (shoot() - 0.5) * 12.0 * sigma(0.0, fHorizontalEmittance, fBetaCrossingPlane, betagamma);
+    y = (shoot() - 0.5) * 12.0 * sigma(0.0, fVerticalEmittance, fBetaSeparationPlane, betagamma);
 
     i = intensity(x, y, z, t);
 
@@ -119,7 +160,6 @@ HepMC::FourVector HLLHCEvtVtxGenerator::newVertex(CLHEP::HepRandomEngine* engine
 
 double HLLHCEvtVtxGenerator::sigma(double z, double epsilon, double beta, double betagamma) const {
   double sigma = std::sqrt(epsilon * (beta + z * z / beta) / betagamma);
-
   return sigma;
 }
 
@@ -127,9 +167,9 @@ double HLLHCEvtVtxGenerator::intensity(double x, double y, double z, double t) c
   //---c in m/s --- remember t is already in meters
   constexpr double c = 2.99792458e+8;  // m/s
 
-  const double sigmay = sigma(z, epssn, bets, betagamma);
+  const double sigmay = sigma(z, fVerticalEmittance, fBetaSeparationPlane, betagamma);
 
-  const double alphay_mod = alphay * std::cos(wcc * (z - t) / c);
+  const double alphay_mod = fCrabbingAngleSeparation * std::cos(fCrabFrequency * (z - t) / c);
 
   const double cay = std::cos(alphay_mod);
   const double say = std::sin(alphay_mod);
@@ -146,17 +186,17 @@ double HLLHCEvtVtxGenerator::intensity(double x, double y, double z, double t) c
 double HLLHCEvtVtxGenerator::integrandCC(double x, double z, double ct) const {
   constexpr double local_c_light = 2.99792458e8;
 
-  const double k = wcc / local_c_light * two_pi;
+  const double k = fCrabFrequency / local_c_light * two_pi;
   const double k2 = k * k;
-  const double cos = std::cos(phi / 2.0);
-  const double sin = std::sin(phi / 2.0);
+  const double cos = std::cos(fCrossingAngle / 2.0);
+  const double sin = std::sin(fCrossingAngle / 2.0);
   const double cos2 = cos * cos;
   const double sin2 = sin * sin;
 
   const double sigx2 = sigx * sigx;
-  const double sigmax2 = sigx2 * (1 + z * z / (betx * betx));
+  const double sigmax2 = sigx2 * (1 + z * z / (fBetaCrossingPlane * fBetaCrossingPlane));
 
-  const double sigs2 = sigs * sigs;
+  const double sigs2 = fBunchLength * fBunchLength;
 
   constexpr double factorRMSgauss4 =
       1. / sqrt2 / gamma34 * gamma14;  // # Factor to take rms sigma as input of the supergaussian
@@ -167,7 +207,7 @@ double HLLHCEvtVtxGenerator::integrandCC(double x, double z, double ct) const {
 
   double result = -1.0;
 
-  if (!RF800) {
+  if (!fRF800) {
     const double norm = 2.0 / (two_pi * sigs2);
     const double cosks = std::cos(k * z);
     const double sinkct = std::sin(k * ct);
@@ -183,9 +223,10 @@ double HLLHCEvtVtxGenerator::integrandCC(double x, double z, double ct) const {
                       + x * ct * sin / sigs2                                // contribution from x integrand
                       + 2 * x * cos * cosks * sinkct * sinCR / k / sigmax2  // contribution from x integrand
                       //+(2*ct/k)*np.cos(k*s)*np.sin(k*ct) *(sin*sinCR)/(sigs2*cos)  # small term
-                      //+ct**2*(sin2/sigs4)/(cos2/sigmax2)				              # small term
+                      //+ct**2*(sin2/sigs4)/(cos2/sigmax2)                           # small term
                       ) /
-             (1.0 + (z * z) / (betx * betx)) / std::sqrt(1.0 + (z * z) / (bets * bets));
+             (1.0 + (z * z) / (fBetaCrossingPlane * fBetaCrossingPlane)) /
+             std::sqrt(1.0 + (z * z) / (fBetaSeparationPlane * fBetaSeparationPlane));
 
   } else {
     const double norm = 2.0 / (NormFactorGauss4 * sigs2 * factorRMSgauss4);
@@ -198,7 +239,8 @@ double HLLHCEvtVtxGenerator::integrandCC(double x, double z, double ct) const {
                  sin2 / (4 * k2 * sigmax2) *
                      (2 + 4 * k2 * z * z - std::cos(2 * k * (z - ct)) - std::cos(2 * k * (z + ct)) -
                       8 * k * CLHEP::s * std::cos(k * ct) * std::sin(k * z) - 4 * cosks * cosks * sinct * sinct)) /
-        std::sqrt((1 + z * z / (betx * betx)) / (1 + z * z / (bets * bets)));
+        std::sqrt((1 + z * z / (fBetaCrossingPlane * fBetaCrossingPlane)) /
+                  (1 + z * z / (fBetaSeparationPlane * fBetaSeparationPlane)));
   }
 
   return result;

--- a/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/HLLHCEvtVtxGenerator.cc
@@ -54,7 +54,7 @@ HLLHCEvtVtxGenerator::HLLHCEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvt
     fMeanX = p.getParameter<double>("MeanXIncm") * CLHEP::cm;
     fMeanY = p.getParameter<double>("MeanYIncm") * CLHEP::cm;
     fMeanZ = p.getParameter<double>("MeanZIncm") * CLHEP::cm;
-    fTimeOffset = p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * c_light;
+    fTimeOffset = p.getParameter<double>("TimeOffsetInns") * CLHEP::ns * CLHEP::c_light;
     fEProton = p.getParameter<double>("EprotonInGeV") * 1e9;
     fCrossingAngle = p.getParameter<double>("CrossingAngleInurad") * 1e-6;
     fCrabFrequency = p.getParameter<double>("CrabFrequencyInMHz") * 1e6;
@@ -106,7 +106,7 @@ void HLLHCEvtVtxGenerator::update(const edm::EventSetup& iEventSetup) {
     fBunchLength = beamhandle->bunchLenght();
     fCrabbingAngleCrossing = beamhandle->crabbingAngleCrossing() * 1e-6;
     fCrabbingAngleSeparation = beamhandle->crabbingAngleSeparation() * 1e-6;
-    fTimeOffset = beamhandle->timeOffset() * CLHEP::ns * c_light;
+    fTimeOffset = beamhandle->timeOffset() * CLHEP::ns * CLHEP::c_light;
     // Set parameters inferred from configurables
     gamma = fEProton / pmass + 1.0;
     beta = std::sqrt((1.0 - 1.0 / gamma) * ((1.0 + 1.0 / gamma)));


### PR DESCRIPTION
#### PR description:
First step of resolving https://github.com/cms-AlCaDB/AlCaTools/issues/95:
 - Added a new `SimBeamSpotHLLHC` CondFormat and relative record
    - Also added all the needed utilities to write/read/plot/inspect/test the new object
- Updated `HLLHCEvtVtxGenerator` plugin adding the possibility to read the smearing parameters from the DB 
- Removed the `CrabKissing` parameters:
  - Removing `HLLHC_CK` and `HLLHC_CK14TeV` scenarios which are not used anywhere in CMSSW and are not even supported by any c++ code since #16942

#### PR validation:
Code compiles and I ran successfully a few upgrade workflows.

#### Backport:
Not a backport, no backport needed.