### PR TITLE
Phase2-hgx348B Take care of handling both HGCal and HFNose access to Geometry and Topology classes

### DIFF
--- a/Geometry/CaloTopology/src/HGCalTopology.cc
+++ b/Geometry/CaloTopology/src/HGCalTopology.cc
@@ -1,3 +1,4 @@
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
@@ -25,7 +26,7 @@ HGCalTopology::HGCalTopology(const HGCalDDDConstants& hdcons, int det) : hdcons_
     subdet_ = (ForwardSubdetector)(det);
     kHGeomHalf_ = sectors_ * layers_;
     types_ = 2;
-  } else if (det == (int)(DetId::Forward)) {
+  } else if (det == static_cast<int>(DetId::Forward)) {
     det_ = DetId::Forward;
     subdet_ = HFNose;
     kHGeomHalf_ = sectors_ * layers_;
@@ -389,8 +390,8 @@ uint32_t HGCalTopology::detId2denseId(const DetId& idin) const {
 DetId HGCalTopology::denseId2detId(uint32_t hi) const {
   HGCalTopology::DecodedDetId id;
   if (validHashIndex(hi)) {
-    id.zSide = ((int)(hi) < kHGhalfType_ ? -1 : 1);
-    int di = ((int)(hi) % kHGhalfType_);
+    id.zSide = (static_cast<int>(hi) < kHGhalfType_ ? -1 : 1);
+    int di = (static_cast<int>(hi) % kHGhalfType_);
     if (waferHexagon6()) {
       int type = (di % types_);
       id.iType = (type == 0 ? -1 : 1);
@@ -466,7 +467,7 @@ bool HGCalTopology::valid(const DetId& idin) const {
   HGCalTopology::DecodedDetId id = decode(idin);
   bool flag;
   if (waferHexagon6()) {
-    flag = (idin.det() == det_ && idin.subdetId() == (int)(subdet_) && id.iCell1 >= 0 && id.iCell1 < cells_ &&
+    flag = (idin.det() == det_ && idin.subdetId() == static_cast<int>(subdet_) && id.iCell1 >= 0 && id.iCell1 < cells_ &&
             id.iLay > 0 && id.iLay <= layers_ && id.iSec1 >= 0 && id.iSec1 <= sectors_);
     if (flag)
       flag = hdcons_.isValidHex(id.iLay, id.iSec1, id.iCell1, true);
@@ -503,7 +504,7 @@ bool HGCalTopology::validModule(const DetId& idin, int cornerMin) const {
 }
 
 DetId HGCalTopology::offsetBy(const DetId startId, int nrStepsX, int nrStepsY) const {
-  if (startId.det() == DetId::Forward && startId.subdetId() == (int)(subdet_)) {
+  if (startId.det() == DetId::Forward && startId.subdetId() == static_cast<int>(subdet_)) {
     DetId id = changeXY(startId, nrStepsX, nrStepsY);
     if (valid(id))
       return id;
@@ -524,8 +525,8 @@ DetId HGCalTopology::switchZSide(const DetId startId) const {
 HGCalTopology::DecodedDetId HGCalTopology::geomDenseId2decId(const uint32_t& hi) const {
   HGCalTopology::DecodedDetId id;
   if (hi < totalGeomModules()) {
-    id.zSide = ((int)(hi) < kHGeomHalf_ ? -1 : 1);
-    int di = ((int)(hi) % kHGeomHalf_);
+    id.zSide = (static_cast<int>(hi) < kHGeomHalf_ ? -1 : 1);
+    int di = (static_cast<int>(hi) % kHGeomHalf_);
     if (waferHexagon6()) {
       id.iSec1 = (di % sectors_);
       di = (di - id.iSec1) / sectors_;
@@ -582,8 +583,13 @@ void HGCalTopology::addHGCSiliconId(
                                 << hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV, false);
 #endif
   if (hdcons_.isValidHex8(lay, waferU, waferV, cellU, cellV, false)) {
-    HGCSiliconDetId id((DetId::Detector)(det), zside, type, lay, waferU, waferV, cellU, cellV);
-    ids.emplace_back(DetId(id));
+    if (det == static_cast<int>(ForwardSubdetector::HFNose)) {
+      HFNoseDetId id(DetId::Forward, zside, type, lay, waferU, waferV, cellU, cellV);
+      ids.emplace_back(DetId(id));
+    } else {
+      HGCSiliconDetId id((DetId::Detector)(det), zside, type, lay, waferU, waferV, cellU, cellV);
+      ids.emplace_back(DetId(id));
+    }
   }
 }
 
@@ -608,7 +614,7 @@ HGCalTopology::DecodedDetId HGCalTopology::decode(const DetId& startId) const {
     idx.iSec2 = 0;
     idx.iType = id.type();
     idx.zSide = id.zside();
-    idx.det = (int)(id.subdet());
+    idx.det = static_cast<int>(id.subdet());
   } else if (det_ == DetId::Forward && subdet_ == ForwardSubdetector::HFNose) {
     HFNoseDetId id(startId);
     idx.iCell1 = id.cellU();
@@ -618,7 +624,7 @@ HGCalTopology::DecodedDetId HGCalTopology::decode(const DetId& startId) const {
     idx.iSec2 = id.waferV();
     idx.iType = id.type();
     idx.zSide = id.zside();
-    idx.det = (int)(id.subdet());
+    idx.det = static_cast<int>(id.subdet());
   } else {
     HGCSiliconDetId id(startId);
     idx.iCell1 = id.cellU();
@@ -628,7 +634,7 @@ HGCalTopology::DecodedDetId HGCalTopology::decode(const DetId& startId) const {
     idx.iSec2 = id.waferV();
     idx.iType = id.type();
     idx.zSide = id.zside();
-    idx.det = (int)(id.subdet());
+    idx.det = static_cast<int>(id.subdet());
   }
   return idx;
 }

--- a/Geometry/CaloTopology/src/HGCalTopology.cc
+++ b/Geometry/CaloTopology/src/HGCalTopology.cc
@@ -467,8 +467,8 @@ bool HGCalTopology::valid(const DetId& idin) const {
   HGCalTopology::DecodedDetId id = decode(idin);
   bool flag;
   if (waferHexagon6()) {
-    flag = (idin.det() == det_ && idin.subdetId() == static_cast<int>(subdet_) && id.iCell1 >= 0 && id.iCell1 < cells_ &&
-            id.iLay > 0 && id.iLay <= layers_ && id.iSec1 >= 0 && id.iSec1 <= sectors_);
+    flag = (idin.det() == det_ && idin.subdetId() == static_cast<int>(subdet_) && id.iCell1 >= 0 &&
+            id.iCell1 < cells_ && id.iLay > 0 && id.iLay <= layers_ && id.iSec1 >= 0 && id.iSec1 <= sectors_);
     if (flag)
       flag = hdcons_.isValidHex(id.iLay, id.iSec1, id.iCell1, true);
   } else if (tileTrapezoid()) {

--- a/Geometry/CaloTopology/test/HGCalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HGCalTopologyTester.cc
@@ -15,6 +15,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
 #include "Geometry/CaloTopology/interface/HGCalTopology.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 
@@ -73,8 +74,10 @@ void HGCalTopologyTester::doTest(const HGCalTopology& topology) {
   if (topology.waferHexagon8() || topology.tileTrapezoid()) {
     for (unsigned int i = 0; i < type_.size(); ++i) {
       DetId id;
-      if (detectorName_ == "HGCalEESensitive") {
-        id = HGCSiliconDetId(DetId::HGCalEE, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
+      if (topology.isHFNose()) {
+	id = HFNoseDetId(1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
+      } else if (detectorName_ == "HGCalEESensitive") {
+	id = HGCSiliconDetId(DetId::HGCalEE, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHESiliconSensitive") {
         id = HGCSiliconDetId(DetId::HGCalHSi, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHEScintillatorSensitive") {
@@ -84,7 +87,13 @@ void HGCalTopologyTester::doTest(const HGCalTopology& topology) {
       }
       std::vector<DetId> ids = topology.neighbors(id);
       unsigned int k(0);
-      if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
+      if (topology.isHFNose()) {
+        edm::LogVerbatim("HGCalGeom") << (HFNoseDetId)(id) << " has " << ids.size() << " neighbours:";
+        for (const auto& idn : ids) {
+          edm::LogVerbatim("HGCalGeom") << "[" << k << "] " << (HFNoseDetId)(idn);
+          ++k;
+        }
+      } else if (id.det() == DetId::HGCalEE || id.det() == DetId::HGCalHSi) {
         edm::LogVerbatim("HGCalGeom") << (HGCSiliconDetId)(id) << " has " << ids.size() << " neighbours:";
         for (const auto& idn : ids) {
           edm::LogVerbatim("HGCalGeom") << "[" << k << "] " << (HGCSiliconDetId)(idn);

--- a/Geometry/CaloTopology/test/HGCalTopologyTester.cc
+++ b/Geometry/CaloTopology/test/HGCalTopologyTester.cc
@@ -75,9 +75,9 @@ void HGCalTopologyTester::doTest(const HGCalTopology& topology) {
     for (unsigned int i = 0; i < type_.size(); ++i) {
       DetId id;
       if (topology.isHFNose()) {
-	id = HFNoseDetId(1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
+        id = HFNoseDetId(1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalEESensitive") {
-	id = HGCSiliconDetId(DetId::HGCalEE, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
+        id = HGCSiliconDetId(DetId::HGCalEE, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHESiliconSensitive") {
         id = HGCSiliconDetId(DetId::HGCalHSi, 1, type_[i], layer_[i], sec1_[i], sec2_[i], cell1_[i], cell2_[i]);
       } else if (detectorName_ == "HGCalHEScintillatorSensitive") {

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -73,7 +73,10 @@ void HGCalGeometry::newCell(
   } else {
     cells = m_topology.dddConstants().numberCellsHexagon(id.iLay, id.iSec1, id.iSec2, false);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "NewCell " << HGCSiliconDetId(detId) << " GEOM " << HGCSiliconDetId(geomId);
+    if (detId.det() == DetId::Forward)
+      edm::LogVerbatim("HGCalGeom") << "NewCell " << HFNoseDetId(detId) << " GEOM " << HFNoseDetId(geomId);
+    else
+      edm::LogVerbatim("HGCalGeom") << "NewCell " << HGCSiliconDetId(detId) << " GEOM " << HGCSiliconDetId(geomId);
 #endif
   }
   const uint32_t cellIndex(m_topology.detId2denseGeomId(geomId));
@@ -136,7 +139,10 @@ void HGCalGeometry::newCell(
             m_validIds.emplace_back(idc);
 #ifdef EDM_ML_DEBUG
             ++cellSelect;
-            edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HGCSiliconDetId(idc);
+	    if (idc.det() == DetId::Forward)
+	      edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HFNoseDetId(idc);
+	    else
+	      edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HGCSiliconDetId(idc);
 #endif
           }
         }
@@ -217,10 +223,12 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                       << lcoord.y() << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iCell1
                                       << " Global " << glob;
     } else {
-      if (debug)
-        edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay
-                                      << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
-                                      << id.iCell2;
+      if (debug) {
+	if (detid.det() == DetId::Forward)
+	  edm::LogVerbatim("HGCalGeom") << "getPosition for " << HFNoseDetId(detid) << " Layer " << id.iLay << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
+	else
+	  edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
+      }
       xy = m_topology.dddConstants().locateCell(
           id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);
       double xx = id.zSide * xy.first;

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -139,10 +139,10 @@ void HGCalGeometry::newCell(
             m_validIds.emplace_back(idc);
 #ifdef EDM_ML_DEBUG
             ++cellSelect;
-	    if (idc.det() == DetId::Forward)
-	      edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HFNoseDetId(idc);
-	    else
-	      edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HGCSiliconDetId(idc);
+            if (idc.det() == DetId::Forward)
+              edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HFNoseDetId(idc);
+            else
+              edm::LogVerbatim("HGCalGeom") << "Valid Id [" << u << ", " << v << "] " << HGCSiliconDetId(idc);
 #endif
           }
         }
@@ -224,10 +224,13 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                       << " Global " << glob;
     } else {
       if (debug) {
-	if (detid.det() == DetId::Forward)
-	  edm::LogVerbatim("HGCalGeom") << "getPosition for " << HFNoseDetId(detid) << " Layer " << id.iLay << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
-	else
-	  edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
+        if (detid.det() == DetId::Forward)
+          edm::LogVerbatim("HGCalGeom") << "getPosition for " << HFNoseDetId(detid) << " Layer " << id.iLay << " Wafer "
+                                        << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
+        else
+          edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay
+                                        << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
+                                        << id.iCell2;
       }
       xy = m_topology.dddConstants().locateCell(
           id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);


### PR DESCRIPTION
#### PR description:

Take care of handling both HGCal and HFNose access to Geometry and Topology classes. Takes care of invalid. DetId issue for the workflow 23234.0

#### PR validation:

Tested using the workflow 23234.0 in debug mode

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not special. Maybe the bug fix to be back ported for some earlier release which needs phase2 23234.0 for validation