### PR TITLE
Add Run3 promptData JetID

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -36,14 +36,14 @@ looseJetId = cms.EDProducer("PatJetIDValueMapProducer",
 )
 tightJetId = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN3WINTER22CHS'),
+        version = cms.string('RUN3CHSruns2022FGruns2023CD'),
         quality = cms.string('TIGHT'),
     ),
     src = cms.InputTag("updatedJets")
 )
 tightJetIdLepVeto = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN3WINTER22CHS'),
+        version = cms.string('RUN3CHSruns2022FGruns2023CD'),
         quality = cms.string('TIGHTLEPVETO'),
     ),
     src = cms.InputTag("updatedJets")
@@ -61,9 +61,9 @@ run2_jme_2016.toModify(
 )
 
 run3_jme_Winter22runsBCDEprompt.toModify(
-    tightJetId.filterParams, version = "RUN3WINTER22CHSrunsBCDEprompt"
+    tightJetId.filterParams, version = "RUN3CHSruns2022BCDEprompt"
 ).toModify(
-    tightJetIdLepVeto.filterParams, version = "RUN3WINTER22CHSrunsBCDEprompt"
+    tightJetIdLepVeto.filterParams, version = "RUN3CHSruns2022BCDEprompt"
 )
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -28,14 +28,14 @@ updatedJetsPuppi = updatedPatJets.clone(
 
 tightJetPuppiId = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN3WINTER22PUPPI'),
+        version = cms.string('RUN3PUPPIruns2022FGruns2023CD'),
         quality = cms.string('TIGHT'),
     ),
     src = cms.InputTag("updatedJetsPuppi")
 )
 tightJetPuppiIdLepVeto = cms.EDProducer("PatJetIDValueMapProducer",
     filterParams=cms.PSet(
-        version = cms.string('RUN3WINTER22PUPPI'),
+        version = cms.string('RUN3PUPPIruns2022FGruns2023CD'),
         quality = cms.string('TIGHTLEPVETO'),
     ),
     src = cms.InputTag("updatedJetsPuppi")
@@ -54,9 +54,9 @@ run2_jme_2016.toModify(
 )
 
 run3_jme_Winter22runsBCDEprompt.toModify(
-    tightJetPuppiId.filterParams, version = "RUN3WINTER22PUPPIrunsBCDEprompt"
+    tightJetPuppiId.filterParams, version = "RUN3PUPPIruns2022BCDEprompt"
 ).toModify(
-    tightJetPuppiIdLepVeto.filterParams, version = "RUN3WINTER22PUPPIrunsBCDEprompt"
+    tightJetPuppiIdLepVeto.filterParams, version = "RUN3PUPPIruns2022BCDEprompt"
 )
 
 #HF shower shape recomputation

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -37,10 +37,10 @@ public:  // interface
     SUMMER18PUPPI,
     RUN2UL16CHS,
     RUN2UL16PUPPI,
-    RUN3WINTER22CHSrunsBCDEprompt,
-    RUN3WINTER22PUPPIrunsBCDEprompt,
-    RUN3WINTER22CHS,
-    RUN3WINTER22PUPPI,
+    RUN3CHSrunsBCDEprompt,
+    RUN3PUPPIrunsBCDEprompt,
+    RUN3CHSruns2022FGruns2023CD,
+    RUN3PUPPIruns2022FGruns2023CD,
     RUN2ULCHS,
     RUN2ULPUPPI,
     N_VERSIONS
@@ -80,16 +80,17 @@ public:  // interface
       version_ = RUN2ULCHS;
     else if (versionStr == "RUN2ULPUPPI")
       version_ = RUN2ULPUPPI;
-    else if (versionStr == "RUN3WINTER22CHSrunsBCDEprompt")
-      version_ = RUN3WINTER22CHSrunsBCDEprompt;
-    else if (versionStr == "RUN3WINTER22PUPPIrunsBCDEprompt")
-      version_ = RUN3WINTER22PUPPIrunsBCDEprompt;
-    else if (versionStr == "RUN3WINTER22CHS")
-      version_ = RUN3WINTER22CHS;
-    else if (versionStr == "RUN3WINTER22PUPPI")
-      version_ = RUN3WINTER22PUPPI;
+    else if (versionStr == "RUN3CHSrunsBCDEprompt")
+      version_ = RUN3CHSrunsBCDEprompt;
+    else if (versionStr == "RUN3PUPPIrunsBCDEprompt")
+      version_ = RUN3PUPPIrunsBCDEprompt;
+    else if (versionStr == "RUN3CHSruns2022FGruns2023CD")
+      version_ = RUN3CHSruns2022FGruns2023CD;
+    else if (versionStr == "RUN3PUPPIruns2022FGruns2023CD")
+      version_ = RUN3PUPPIruns2022FGruns2023CD;
     else
-      version_ = RUN3WINTER22PUPPI;  //set RUN3WINTER22PUPPI as default //this is extremely unsafe
+      version_ =
+          RUN3PUPPIruns2022FGruns2023CD;  //set RUN3PUPPIruns2022FGruns2023CD as default //this is extremely unsafe
 
     if (qualityStr == "LOOSE")
       quality_ = LOOSE;
@@ -131,22 +132,23 @@ public:  // interface
   static edm::ParameterSetDescription getDescription() {
     edm::ParameterSetDescription desc;
 
-    desc.ifValue(edm::ParameterDescription<std::string>("version", "RUN3WINTER22PUPPI", true, edm::Comment("")),
-                 edm::allowedValues<std::string>("FIRSTDATA",
-                                                 "RUNIISTARTUP",
-                                                 "WINTER16",
-                                                 "WINTER17",
-                                                 "WINTER17PUPPI",
-                                                 "SUMMER18",
-                                                 "SUMMER18PUPPI",
-                                                 "RUN2UL16CHS",
-                                                 "RUN2UL16PUPPI",
-                                                 "RUN2ULCHS",
-                                                 "RUN2ULPUPPI",
-                                                 "RUN3WINTER22CHSrunsBCDEprompt",
-                                                 "RUN3WINTER22PUPPIrunsBCDEprompt",
-                                                 "RUN3WINTER22CHS",
-                                                 "RUN3WINTER22PUPPI"));
+    desc.ifValue(
+        edm::ParameterDescription<std::string>("version", "RUN3PUPPIruns2022FGruns2023CD", true, edm::Comment("")),
+        edm::allowedValues<std::string>("FIRSTDATA",
+                                        "RUNIISTARTUP",
+                                        "WINTER16",
+                                        "WINTER17",
+                                        "WINTER17PUPPI",
+                                        "SUMMER18",
+                                        "SUMMER18PUPPI",
+                                        "RUN2UL16CHS",
+                                        "RUN2UL16PUPPI",
+                                        "RUN2ULCHS",
+                                        "RUN2ULPUPPI",
+                                        "RUN3CHSrunsBCDEprompt",
+                                        "RUN3PUPPIrunsBCDEprompt",
+                                        "RUN3CHSruns2022FGruns2023CD",
+                                        "RUN3PUPPIruns2022FGruns2023CD"));
     desc.ifValue(edm::ParameterDescription<std::string>("quality", "TIGHT", true, edm::Comment("")),
                  edm::allowedValues<std::string>("LOOSE", "TIGHT", "TIGHTLEPVETO"));
     desc.addOptional<std::vector<std::string>>("cutsToIgnore")->setComment("");
@@ -211,9 +213,9 @@ public:  // interface
   bool operator()(const pat::Jet &jet, pat::strbitset &ret) override {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
         version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
-        version_ == RUN2UL16PUPPI || version_ == RUN3WINTER22CHSrunsBCDEprompt ||
-        version_ == RUN3WINTER22PUPPIrunsBCDEprompt || version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI ||
-        version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
+        version_ == RUN2UL16PUPPI || version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+        version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD || version_ == RUN2ULCHS ||
+        version_ == RUN2ULPUPPI) {
       if (jet.currentJECLevel() == "Uncorrected" || !jet.jecSetsAvailable())
         return firstDataCuts(jet, ret, version_);
       else
@@ -231,9 +233,9 @@ public:  // interface
   bool operator()(const reco::PFJet &jet, pat::strbitset &ret) {
     if (version_ == FIRSTDATA || version_ == RUNIISTARTUP || version_ == WINTER16 || version_ == WINTER17 ||
         version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2UL16CHS ||
-        version_ == RUN2UL16PUPPI || version_ == RUN3WINTER22CHSrunsBCDEprompt ||
-        version_ == RUN3WINTER22PUPPIrunsBCDEprompt || version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI ||
-        version_ == RUN2ULCHS || version_ == RUN2ULPUPPI) {
+        version_ == RUN2UL16PUPPI || version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+        version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD || version_ == RUN2ULCHS ||
+        version_ == RUN2ULPUPPI) {
       return firstDataCuts(jet, ret, version_);
     } else {
       return false;
@@ -380,13 +382,13 @@ public:  // interface
     float etaB = 2.4;
     // Cuts for |eta| < 2.6 for Summer18
     if (version_ == SUMMER18 || version_ == SUMMER18PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI ||
-        version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
-        version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
+        version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+        version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD)
       etaB = 2.6;
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
-         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN3WINTER22CHSrunsBCDEprompt &&
-         version_ != RUN3WINTER22PUPPIrunsBCDEprompt && version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI &&
-         version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
+         version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN3CHSrunsBCDEprompt &&
+         version_ != RUN3PUPPIrunsBCDEprompt && version_ != RUN3CHSruns2022FGruns2023CD &&
+         version_ != RUN3PUPPIruns2022FGruns2023CD && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI) ||
         quality_ != TIGHT) {
       if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > etaB))
         passCut(ret, indexCEF_);
@@ -593,8 +595,8 @@ public:  // interface
           (nneutrals < cut(indexNNeutrals_FW_U_, int()) || std::abs(jet.eta()) <= 3.0))
         passCut(ret, indexNNeutrals_FW_U_);
 
-    } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
-               (version_ == RUN3WINTER22CHS)) {
+    } else if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3CHSrunsBCDEprompt) ||
+               (version_ == RUN3CHSruns2022FGruns2023CD)) {
       // Cuts for |eta| <= 2.6 for SUMMER18 scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.6))
@@ -606,6 +608,8 @@ public:  // interface
       if (quality_ == TIGHTLEPVETO) {
         if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.6))
           passCut(ret, indexMUF_);
+        if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.6))  //edw
+          passCut(ret, indexCEF_);
       }
 
       // Cuts for 2.6 <= |eta| <= 2.7 for SUMMER18 scenario
@@ -647,8 +651,8 @@ public:  // interface
         passCut(ret, indexNNeutrals_FW_);
     }
 
-    else if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) ||
-             (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) || (version_ == RUN3WINTER22PUPPI)) {
+    else if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3PUPPIrunsBCDEprompt) ||
+             (version_ == RUN3PUPPIruns2022FGruns2023CD)) {
       // Cuts for |eta| <= 2.6 for SUMMER18PUPPI scenario
       if (ignoreCut(indexNConstituents_) ||
           (nconstituents > cut(indexNConstituents_, int()) || std::abs(jet.eta()) > 2.6))
@@ -660,6 +664,8 @@ public:  // interface
       if (quality_ == TIGHTLEPVETO) {
         if (ignoreCut(indexMUF_) || (muf < cut(indexMUF_, double()) || std::abs(jet.eta()) > 2.6))
           passCut(ret, indexMUF_);
+        if (ignoreCut(indexCEF_) || (cef < cut(indexCEF_, double()) || std::abs(jet.eta()) > 2.6))  //edw
+          passCut(ret, indexCEF_);
       }
 
       // Cuts for 2.6 <= |eta| <= 2.7 for SUMMER18PUPPI scenario
@@ -709,8 +715,8 @@ private:  // member variables
     push_back("NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
-         version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
-         version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI) ||
+         version_ != RUN3CHSrunsBCDEprompt && version_ != RUN3PUPPIrunsBCDEprompt &&
+         version_ != RUN3CHSruns2022FGruns2023CD && version_ != RUN3PUPPIruns2022FGruns2023CD) ||
         quality_ != TIGHT)
       push_back("CEF");
     push_back("NEF");
@@ -775,8 +781,7 @@ private:  // member variables
         push_back("MUF");
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
-        (version_ == RUN3WINTER22CHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");
@@ -793,8 +798,41 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) ||
-        (version_ == RUN3WINTER22PUPPI)) {
+    if ((version_ == RUN3CHSrunsBCDEprompt)) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("NCH_TR");
+      push_back("NEF_EC_U");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("NHF_FW");
+      push_back("nNeutrals_FW");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("CEF");
+        push_back("MUF");
+        push_back("MUF_TR");
+        push_back("CEF_TR");
+      }
+    }
+    if ((version_ == RUN3CHSruns2022FGruns2023CD)) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("NCH_TR");
+      push_back("NHF_EC");
+      push_back("NEF_EC_U");
+      push_back("nNeutrals_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW");
+
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("CEF");
+        push_back("MUF");
+        push_back("MUF_TR");
+        push_back("CEF_TR");
+      }
+    }
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI)) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NHF_EC");
@@ -809,11 +847,24 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
+    if ((version_ == RUN3PUPPIrunsBCDEprompt) || (version_ == RUN3PUPPIruns2022FGruns2023CD)) {
+      push_back("NHF_TR");
+      push_back("NEF_TR");
+      push_back("NHF_EC");
+      push_back("NEF_FW");
+      push_back("nNeutrals_FW_L");
 
+      if (quality_ == TIGHTLEPVETO) {
+        push_back("CEF");
+        push_back("MUF");
+        push_back("MUF_TR");
+        push_back("CEF_TR");
+      }
+    }
     if ((version_ == WINTER17 || version_ == WINTER17PUPPI || version_ == SUMMER18 || version_ == SUMMER18PUPPI ||
          version_ == RUN2UL16CHS || version_ == RUN2UL16PUPPI || version_ == RUN2ULCHS || version_ == RUN2ULPUPPI ||
-         version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
-         version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) &&
+         version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+         version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD) &&
         quality_ == LOOSE) {
       edm::LogWarning("BadJetIDVersion")
           << "The LOOSE operating point is only supported for the WINTER16 JetID version -- defaulting to TIGHT";
@@ -843,13 +894,13 @@ private:  // member variables
       set("NHF", 0.9);
       if (version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
           version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
-          version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
-          version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI)
+          version_ != RUN3CHSrunsBCDEprompt && version_ != RUN3PUPPIrunsBCDEprompt &&
+          version_ != RUN3CHSruns2022FGruns2023CD && version_ != RUN3PUPPIruns2022FGruns2023CD)
         set("CEF", 0.99);
-      if (version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
-          version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
+      if (version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+          version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD)
         set("CHF", 0.01);
-      if (version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI)
+      if (version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD)
         set("NHF", 0.99);
       set("NEF", 0.9);
       set("NCH", 0);
@@ -911,32 +962,54 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN2ULCHS || version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22CHS) {
+      } else if (version_ == RUN2ULCHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NCH_TR", 0);
         set("NEF_EC_L", 0.01);
         set("NEF_EC_U", 0.99);
-        set("nNeutrals_EC", 2);
+        set("nNeutrals_EC", 1);
         set("NHF_FW", 0.2);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
-      } else if (version_ == RUN2ULPUPPI || version_ == RUN3WINTER22PUPPIrunsBCDEprompt) {
+      } else if (version_ == RUN3CHSrunsBCDEprompt) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
-        set("NHF_EC", 0.9999);
-        set("NHF_FW", -1.0);
+        set("NCH_TR", 0);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
         set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN3CHSruns2022FGruns2023CD) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NCH_TR", 0);
+        set("NEF_EC_U", 0.99);
+        set("NHF_EC", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.4);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2ULPUPPI) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.99);
+        set("NHF_FW", -1.0);
+        set("NEF_FW", 0.4);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN3WINTER22PUPPI) {
+      } else if (version_ == RUN3PUPPIrunsBCDEprompt) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("NHF_EC", 0.9999);
-        set("NHF_FW", -1.0);
         set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+      } else if (version_ == RUN3PUPPIruns2022FGruns2023CD) {
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.99);
+        set("NEF_FW", 0.4);
         set("nNeutrals_FW_L", 1);
-        set("nNeutrals_FW_U", 999999);
       }
     } else if (quality_ == TIGHTLEPVETO) {
       set("CHF", 0.0);
@@ -954,10 +1027,10 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
       }
-      if (version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22PUPPIrunsBCDEprompt ||
-          version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) {
+      if (version_ == RUN3CHSrunsBCDEprompt || version_ == RUN3PUPPIrunsBCDEprompt ||
+          version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD) {
         set("CHF", 0.01);
-      } else if (version_ == RUN3WINTER22CHS || version_ == RUN3WINTER22PUPPI) {
+      } else if (version_ == RUN3CHSruns2022FGruns2023CD || version_ == RUN3PUPPIruns2022FGruns2023CD) {
         set("NHF", 0.99);
       } else if (version_ == WINTER17PUPPI) {
         set("NHF_EC", 0.99);
@@ -1024,7 +1097,7 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN2ULCHS || version_ == RUN3WINTER22CHSrunsBCDEprompt || version_ == RUN3WINTER22CHS) {
+      } else if (version_ == RUN2ULCHS) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -1032,11 +1105,33 @@ private:  // member variables
         set("CEF_TR", 0.8);
         set("NEF_EC_L", 0.01);
         set("NEF_EC_U", 0.99);
-        set("nNeutrals_EC", 2);
+        set("nNeutrals_EC", 1);
         set("NHF_FW", 0.2);
         set("NEF_FW", 0.90);
         set("nNeutrals_FW", 10);
-      } else if (version_ == RUN2ULPUPPI || version_ == RUN3WINTER22PUPPIrunsBCDEprompt) {
+      } else if (version_ == RUN3CHSrunsBCDEprompt) {
+        set("MUF_TR", 0.8);
+        set("CEF_TR", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NCH_TR", 0);
+        set("NEF_EC_U", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NHF_FW", 0.2);
+        set("NEF_FW", 0.90);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN3CHSruns2022FGruns2023CD) {
+        set("MUF_TR", 0.8);
+        set("CEF_TR", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NCH_TR", 0);
+        set("NEF_EC_U", 0.99);
+        set("NHF_EC", 0.99);
+        set("nNeutrals_EC", 1);
+        set("NEF_FW", 0.4);
+        set("nNeutrals_FW", 10);
+      } else if (version_ == RUN2ULPUPPI) {
         set("NHF_TR", 0.9);
         set("NEF_TR", 0.99);
         set("MUF_TR", 0.8);
@@ -1046,16 +1141,22 @@ private:  // member variables
         set("NEF_FW", 0.90);
         set("nNeutrals_FW_L", 2);
         set("nNeutrals_FW_U", 999999);
-      } else if (version_ == RUN3WINTER22PUPPI) {
-        set("NHF_TR", 0.9);
-        set("NEF_TR", 0.99);
+      } else if (version_ == RUN3PUPPIrunsBCDEprompt) {
         set("MUF_TR", 0.8);
         set("CEF_TR", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
         set("NHF_EC", 0.9999);
-        set("NHF_FW", -1.0);
         set("NEF_FW", 0.90);
+        set("nNeutrals_FW_L", 2);
+      } else if (version_ == RUN3PUPPIruns2022FGruns2023CD) {
+        set("MUF_TR", 0.8);
+        set("CEF_TR", 0.8);
+        set("NHF_TR", 0.9);
+        set("NEF_TR", 0.99);
+        set("NHF_EC", 0.99);
+        set("NEF_FW", 0.4);
         set("nNeutrals_FW_L", 1);
-        set("nNeutrals_FW_U", 999999);
       }
     }
   }
@@ -1066,8 +1167,8 @@ private:  // member variables
     indexNHF_ = index_type(&bits_, "NHF");
     if ((version_ != WINTER17 && version_ != WINTER17PUPPI && version_ != SUMMER18 && version_ != SUMMER18PUPPI &&
          version_ != RUN2UL16CHS && version_ != RUN2UL16PUPPI && version_ != RUN2ULCHS && version_ != RUN2ULPUPPI &&
-         version_ != RUN3WINTER22CHSrunsBCDEprompt && version_ != RUN3WINTER22PUPPIrunsBCDEprompt &&
-         version_ != RUN3WINTER22CHS && version_ != RUN3WINTER22PUPPI) ||
+         version_ != RUN3CHSrunsBCDEprompt && version_ != RUN3PUPPIrunsBCDEprompt &&
+         version_ != RUN3CHSruns2022FGruns2023CD && version_ != RUN3PUPPIruns2022FGruns2023CD) ||
         quality_ != TIGHT)
       indexCEF_ = index_type(&bits_, "CEF");
 
@@ -1108,8 +1209,8 @@ private:  // member variables
         indexMUF_ = index_type(&bits_, "MUF");
       }
     }
-    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3WINTER22CHSrunsBCDEprompt) ||
-        (version_ == RUN3WINTER22CHS)) {
+    if ((version_ == SUMMER18) || (version_ == RUN2ULCHS) || (version_ == RUN3CHSrunsBCDEprompt) ||
+        (version_ == RUN3CHSruns2022FGruns2023CD)) {
       indexNHF_TR_ = index_type(&bits_, "NHF_TR");
       indexNEF_TR_ = index_type(&bits_, "NEF_TR");
       indexNCH_TR_ = index_type(&bits_, "NCH_TR");
@@ -1125,8 +1226,8 @@ private:  // member variables
         indexCEF_TR_ = index_type(&bits_, "CEF_TR");
       }
     }
-    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3WINTER22PUPPIrunsBCDEprompt) ||
-        (version_ == RUN3WINTER22PUPPI)) {
+    if ((version_ == SUMMER18PUPPI) || (version_ == RUN2ULPUPPI) || (version_ == RUN3PUPPIrunsBCDEprompt) ||
+        (version_ == RUN3PUPPIruns2022FGruns2023CD)) {
       indexNHF_TR_ = index_type(&bits_, "NHF_TR");
       indexNEF_TR_ = index_type(&bits_, "NEF_TR");
       indexNHF_EC_ = index_type(&bits_, "NHF_EC");

--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -798,7 +798,7 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == RUN3CHSrunsBCDEprompt)) {
+    if (version_ == RUN3CHSrunsBCDEprompt) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");
@@ -815,7 +815,7 @@ private:  // member variables
         push_back("CEF_TR");
       }
     }
-    if ((version_ == RUN3CHSruns2022FGruns2023CD)) {
+    if (version_ == RUN3CHSruns2022FGruns2023CD) {
       push_back("NHF_TR");
       push_back("NEF_TR");
       push_back("NCH_TR");


### PR DESCRIPTION
#### PR description:

@laurenhay  @rkogler 

The JetID criteria for the prompt reco 2022 and 2023 data have been implemented.
The criteria can be found in
https://twiki.cern.ch/twiki/bin/view/CMS/JetID13p6TeV

#### PR validation:
I have run successfully the following checks:
scram b code-checks
scram b code-format


<!-- Please delete the text above after you verified all points of the checklist  -->
