### PR TITLE
APE tool: Hit validation plots added

### DIFF
--- a/Alignment/APEEstimation/test/plottingTools/granularity.py
+++ b/Alignment/APEEstimation/test/plottingTools/granularity.py
@@ -35,3 +35,12 @@ phaseOneGranularity.names["Y"] = ["PIXEL",]
 
 # this name is used by default by other plotting tools
 standardGranularity = phaseOneGranularity
+
+# Granularity for Validation plots in ApeEstimator2 part of allData.root
+validationGranularity = Granularity()
+validationGranularity.sectors["X"].append( (1,8) ) # Only X is needed here, names are not required
+
+# By default, these 8 sectors are included for the ValidationSectors granularity:
+# BpixLayer1Out, BpixLayer3In, FpixMinusLayer1, TibLayer1RphiOut, TibLayer4In, TobLayer1StereoOut, TobLayer5Out, TecPlusRing7
+# This can be changed in apeEstimator_cfg or in SectorBuilder_cff
+# For these sectors, additional hit validation plots are created


### PR DESCRIPTION
#### PR description:

Added more functionality to validation plotting of APE tool. New functionality allows to plot hit/residual-specific distributions (e.g. hit resolution, cluster width, track-hit-residual resolution) for specific sectors. These distributions are already produced by the APE tool, but so far there was no tool that read them out. They might be useful for debugging purposes or for tuning hit selection criteria.

#### PR validation:

Tested with one file from a previous measurement. 

Probably does not need backports, as the changes are not critical to the functionality of the tool. 
