### PR TITLE
PPS - RawToDigi update to handle mappings from CondDB [update of PR 42711]

### DIFF
--- a/DQM/CTPPS/test/strip_dqm_test_xml_cfg.py
+++ b/DQM/CTPPS/test/strip_dqm_test_xml_cfg.py
@@ -1,0 +1,76 @@
+# This config can be used for tests of XML files containing mappings.
+# Since data in CondDB has same labels ESPrefer is needed.
+# For internal and testing purposes only
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('RECODQM', Run3)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
+process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM framework
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = "CTPPS"
+process.dqmEnv.eventInfoFolder = "EventInfo"
+process.dqmSaver.path = ""
+process.dqmSaver.tag = "CTPPS"
+
+# data source
+process.source = cms.Source("NewEventStreamFileReader",
+  fileNames = cms.untracked.vstring(
+         'file:/eos/cms/store/t0streamer/Data/PhysicsZeroBias2/000/369/585/run369585_ls0044_streamPhysicsZeroBias2_StorageManager.dat'
+  ),
+)
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag = GlobalTag(process.GlobalTag, autoCond['run3_data_prompt'], '')
+
+# raw-to-digi conversion
+process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_xml_cff")
+
+# prefer mappings from XML files
+process.es_prefer_totemTimingMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TotemTiming", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TotemTiming"))
+process.es_prefer_totemDiamondMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TimingDiamond", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TimingDiamond"))
+process.es_prefer_totemT2Mapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TotemT2", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TotemT2"))
+process.es_prefer_TrackingStripMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TrackingStrip", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TrackingStrip"))
+
+# local RP reconstruction chain with standard settings
+process.load("RecoPPS.Configuration.recoCTPPS_cff")
+process.load('Geometry.VeryForwardGeometry.geometryRPFromDD_2021_cfi')
+# CTPPS DQM modules
+process.load("DQM.CTPPS.ctppsDQM_cff")
+process.ctppsDiamondDQMSource.excludeMultipleHits = cms.bool(True)
+process.ctppsDiamondDQMSource.plotOnline = cms.untracked.bool(True)
+process.ctppsDiamondDQMSource.plotOffline = cms.untracked.bool(False)
+process.path = cms.Path(
+    process.ctppsRawToDigi*
+    process.recoCTPPS*
+    process.ctppsDQMCalibrationSource*
+    process.ctppsDQMCalibrationHarvest
+)
+
+process.end_path = cms.EndPath(
+    process.dqmEnv +
+    process.dqmSaver
+)
+
+process.schedule = cms.Schedule(
+    process.path,
+    process.end_path
+)

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -42,7 +42,7 @@
 #include "EventFilter/CTPPSRawToDigi/interface/ElectronicIndex.h"
 #include "FWCore/Utilities/interface/typedefs.h"
 
-#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h"
 
 #include <cstdint>
 #include <vector>
@@ -67,7 +67,8 @@ public:
 
   typedef std::unordered_map<cms_uint32_t, DetDigis> Digis;
 
-  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping, CTPPSPixelErrorSummary&);
+  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping,
+                          CTPPSRawToDigiErrorSummary&);
 
   void setErrorStatus(bool theErrorStatus);
 
@@ -117,7 +118,7 @@ private:
   int m_allDetDigis;
   int m_hasDetDigis;
   CTPPSPixelIndices m_Indices;
-  CTPPSPixelErrorSummary& m_ErrorSummary;
+  CTPPSRawToDigiErrorSummary& m_ErrorSummary;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
@@ -15,7 +15,7 @@
 
 #include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
-#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -46,7 +46,7 @@ private:
 
   std::string mappingLabel_;
 
-  CTPPSPixelErrorSummary eSummary_;
+  CTPPSRawToDigiErrorSummary eSummary_;
 
   bool includeErrors_;
   bool isRun3_;

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h
@@ -1,12 +1,12 @@
-#ifndef EventFilter_CTPPSRawToDigi_CTPPSPixelErrorSummary
-#define EventFilter_CTPPSRawToDigi_CTPPSPixelErrorSummary
+#ifndef EventFilter_CTPPSRawToDigi_CTPPSRawToDigiErrorSummary
+#define EventFilter_CTPPSRawToDigi_CTPPSRawToDigiErrorSummary
 
 #include <string>
 #include <map>
 
-class CTPPSPixelErrorSummary {
+class CTPPSRawToDigiErrorSummary {
 public:
-  CTPPSPixelErrorSummary(const std::string& category, const std::string& name, bool debug = false)
+  CTPPSRawToDigiErrorSummary(const std::string& category, const std::string& name, bool debug = false)
       : m_debug(debug), m_category(category), m_name(name) {}
 
   void add(const std::string& message, const std::string& details = "");

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelDigiToRaw.cc
@@ -52,7 +52,7 @@ Implementation:
 #include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
 #include "CondFormats/PPSObjects/interface/CTPPSPixelFramePosition.h"
-#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h"
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -83,7 +83,7 @@ private:
   edm::ESGetToken<CTPPSPixelDAQMapping, CTPPSPixelDAQMappingRcd> tCTPPSPixelDAQMapping_;
   std::vector<CTPPSPixelDataFormatter::PPSPixelIndex> v_iDdet2fed_;
   CTPPSPixelFramePosition fPos_;
-  CTPPSPixelErrorSummary eSummary_;
+  CTPPSRawToDigiErrorSummary eSummary_;
   bool isRun3_;
 };
 

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -169,14 +169,14 @@ template <typename DigiType>
 void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   // get DAQ mapping
   ESHandle<TotemDAQMapping> mapping = es.getHandle(totemMappingToken);
-  if (!mapping) {
+  if (!mapping.isValid() || mapping.failedToGet()) {
     LogError("TotemVFATRawToDigi") << "TotemVFATRawToDigi: no mapping found for " << subSystemName;
   }
 
   // get analysis mask to mask channels
   TotemAnalysisMask analysisMask;
   ESHandle<TotemAnalysisMask> analysisMaskHandle = es.getHandle(analysisMaskToken);
-  if (analysisMaskHandle) {
+  if (analysisMaskHandle.isValid() && !analysisMaskHandle.failedToGet()) {
     analysisMask = *analysisMaskHandle;
   } else {
     LogWarning("TotemVFATRawToDigi") << "TotemVFATRawToDigi: no mask found for " << subSystemName;

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -170,7 +170,6 @@ void TotemVFATRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
 
 template <typename DigiType>
 void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
-
   // mapping and analysis mask
   ESHandle<TotemDAQMapping> mapping;
   ESHandle<TotemAnalysisMask> analysisMaskHandle;
@@ -190,14 +189,14 @@ void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   SimpleVFATFrameCollection vfatCollection;
   for (const auto &fedId : fedIds) {
     const FEDRawData &data = rawData->FEDData(fedId);
-    if (data.size() > 0){
+    if (data.size() > 0) {
       rawDataUnpacker.run(fedId, data, fedInfo, vfatCollection);
       data_exist = true;
     }
   }
 
   // get mapping records and do raw-to-digi conversion only if some data exists
-  if( data_exist ){
+  if (data_exist) {
     // get DAQ mapping
     mapping = es.getHandle(totemMappingToken);
     if (!mapping.isValid() || mapping.failedToGet()) {

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -170,22 +170,11 @@ void TotemVFATRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
 
 template <typename DigiType>
 void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
-  // get DAQ mapping
-  ESHandle<TotemDAQMapping> mapping = es.getHandle(totemMappingToken);
-  if (!mapping.isValid() || mapping.failedToGet()) {
-    throw cms::Exception("TotemVFATRawToDigi::TotemVFATRawToDigi")
-        << "No DAQMapping found for " << subSystemName << "." << endl;
-  }
 
-  // get analysis mask to mask channels
+  // mapping and analysis mask
+  ESHandle<TotemDAQMapping> mapping;
+  ESHandle<TotemAnalysisMask> analysisMaskHandle;
   TotemAnalysisMask analysisMask;
-  ESHandle<TotemAnalysisMask> analysisMaskHandle = es.getHandle(analysisMaskToken);
-  if (analysisMaskHandle.isValid() && !analysisMaskHandle.failedToGet()) {
-    analysisMask = *analysisMaskHandle;
-  } else {
-    errSummary.add(fmt::format("No AnalysisMask found for {0}", subSystemName), "");
-    analysisMask = TotemAnalysisMask();
-  }
 
   // raw data handle
   edm::Handle<FEDRawDataCollection> rawData;
@@ -197,15 +186,37 @@ void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   DetSetVector<TotemVFATStatus> conversionStatus;
 
   // raw-data unpacking
+  bool data_exist = false;
   SimpleVFATFrameCollection vfatCollection;
   for (const auto &fedId : fedIds) {
     const FEDRawData &data = rawData->FEDData(fedId);
-    if (data.size() > 0)
+    if (data.size() > 0){
       rawDataUnpacker.run(fedId, data, fedInfo, vfatCollection);
+      data_exist = true;
+    }
   }
 
-  // raw-to-digi conversion
-  rawToDigiConverter.run(vfatCollection, *mapping, analysisMask, digi, conversionStatus);
+  // get mapping records and do raw-to-digi conversion only if some data exists
+  if( data_exist ){
+    // get DAQ mapping
+    mapping = es.getHandle(totemMappingToken);
+    if (!mapping.isValid() || mapping.failedToGet()) {
+      throw cms::Exception("TotemVFATRawToDigi::TotemVFATRawToDigi")
+          << "No DAQMapping found for " << subSystemName << "." << endl;
+    }
+
+    // get analysis mask to mask channels
+    analysisMaskHandle = es.getHandle(analysisMaskToken);
+    if (analysisMaskHandle.isValid() && !analysisMaskHandle.failedToGet()) {
+      analysisMask = *analysisMaskHandle;
+    } else {
+      errSummary.add(fmt::format("No AnalysisMask found for {0}", subSystemName), "");
+      analysisMask = TotemAnalysisMask();
+    }
+
+    // raw-to-digi conversion
+    rawToDigiConverter.run(vfatCollection, *mapping, analysisMask, digi, conversionStatus);
+  }
 
   // commit products to event
   event.put(make_unique<vector<TotemFEDInfo>>(fedInfo), subSystemName);

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -1,51 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 # ---------- Si strips ----------
-totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TrackingStrip"),
-  sampicSubDetId = cms.uint32(6),
-  configuration = cms.VPSet(
-    # 2016, before TS2
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 280385:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_to_fill_5288.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, during TS2
-    cms.PSet(
-      validityRange = cms.EventRange("280386:min - 281600:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, after TS2
-    cms.PSet(
-      validityRange = cms.EventRange("281601:min - 290872:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_from_fill_5330.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2017
-    cms.PSet(
-      validityRange = cms.EventRange("290873:min - 311625:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2017.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("311626:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
-      maskFileNames = cms.vstring()
-    )
-
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
 totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
@@ -56,86 +11,14 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 #  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = True
 
 # ---------- diamonds ----------
-totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TimingDiamond"),
-  sampicSubDetId = cms.uint32(6),
-  configuration = cms.VPSet(
-    # 2016, before diamonds inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 283819:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, after diamonds inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("283820:min - 292520:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2017
-    cms.PSet(
-      validityRange = cms.EventRange("292521:min - 310000:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2017.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("310001:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 362919:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2023
-    cms.PSet(
-      validityRange = cms.EventRange("362920:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml"),
-      maskFileNames = cms.vstring()
-    )
-
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
 ctppsDiamondRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem Timing ----------
-totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TotemTiming"),
-  sampicSubDetId = cms.uint32(5),
-  configuration = cms.VPSet(
-    # 2017, before detector inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 310000:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("310001:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml"),
-      maskFileNames = cms.vstring()
-    )
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
 totemTimingRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem nT2 ----------
-from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
 from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
 totemT2Digis.rawDataTag = "rawDataCollector"
 
@@ -147,7 +30,6 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = 6)
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_xml_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_xml_cff.py
@@ -1,0 +1,160 @@
+import FWCore.ParameterSet.Config as cms
+
+# ---------- Si strips ----------
+totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TrackingStrip"),
+  sampicSubDetId = cms.uint32(6),
+  configuration = cms.VPSet(
+    # 2016, before TS2
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 280385:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_to_fill_5288.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, during TS2
+    cms.PSet(
+      validityRange = cms.EventRange("280386:min - 281600:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, after TS2
+    cms.PSet(
+      validityRange = cms.EventRange("281601:min - 290872:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_from_fill_5330.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2017
+    cms.PSet(
+      validityRange = cms.EventRange("290873:min - 311625:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2017.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("311626:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
+      maskFileNames = cms.vstring()
+    )
+
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
+totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
+
+# various error/warning/info output may be enabled with these flags
+#  totemRPRawToDigi.RawUnpacking.verbosity = 1
+#  totemRPRawToDigi.RawToDigi.verbosity = 1 # or higher number for more output
+#  totemRPRawToDigi.RawToDigi.printErrorSummary = True
+#  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = True
+
+# ---------- diamonds ----------
+totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TimingDiamond"),
+  sampicSubDetId = cms.uint32(6),
+  configuration = cms.VPSet(
+    # 2016, before diamonds inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 283819:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, after diamonds inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("283820:min - 292520:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2017
+    cms.PSet(
+      validityRange = cms.EventRange("292521:min - 310000:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2017.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("310001:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 362919:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2023
+    cms.PSet(
+      validityRange = cms.EventRange("362920:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml"),
+      maskFileNames = cms.vstring()
+    )
+
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
+ctppsDiamondRawToDigi.rawDataTag = "rawDataCollector"
+
+# ---------- Totem Timing ----------
+totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TotemTiming"),
+  sampicSubDetId = cms.uint32(5),
+  configuration = cms.VPSet(
+    # 2017, before detector inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 310000:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("310001:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml"),
+      maskFileNames = cms.vstring()
+    )
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
+totemTimingRawToDigi.rawDataTag = "rawDataCollector"
+
+# ---------- Totem nT2 ----------
+from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
+from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
+totemT2Digis.rawDataTag = "rawDataCollector"
+
+# ---------- pixels ----------
+from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
+ctppsPixelDigis.inputLabel = "rawDataCollector"
+
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = 6)
+
+# raw-to-digi task and sequence
+ctppsRawToDigiTask = cms.Task(
+  totemRPRawToDigi,
+  ctppsDiamondRawToDigi,
+  totemTimingRawToDigi,
+  totemT2Digis,
+  ctppsPixelDigis
+)
+ctppsRawToDigi = cms.Sequence(ctppsRawToDigiTask)

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -38,7 +38,7 @@ namespace {
 }  // namespace
 
 CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping,
-                                                 CTPPSPixelErrorSummary& eSummary)
+                                                 CTPPSRawToDigiErrorSummary& eSummary)
     : m_WordCounter(0),
       m_Mapping(mapping),
       m_ErrorSummary(eSummary)

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSRawToDigiErrorSummary.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSRawToDigiErrorSummary.cc
@@ -1,9 +1,9 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelErrorSummary.h"
+#include "EventFilter/CTPPSRawToDigi/interface/CTPPSRawToDigiErrorSummary.h"
 #include <iostream>
 #include <algorithm>
 
-void CTPPSPixelErrorSummary::add(const std::string& message, const std::string& details) {
+void CTPPSRawToDigiErrorSummary::add(const std::string& message, const std::string& details) {
   const auto eIt = m_errors.find(message);
   if (eIt == m_errors.end()) {
     m_errors.emplace(message, 1);
@@ -19,7 +19,7 @@ void CTPPSPixelErrorSummary::add(const std::string& message, const std::string& 
   }
 }
 
-void CTPPSPixelErrorSummary::printSummary() const {
+void CTPPSRawToDigiErrorSummary::printSummary() const {
   if (!m_errors.empty()) {
     std::stringstream message;
     message << m_name << " errors:";


### PR DESCRIPTION
#### PR description:

This is an update of PR #42711. I had troubles to rebase it on top of newest CMSSW and found it easier to make a new PR.
This may also facilitate testing with the last update.

This PR is a next step in a way to resolve an issue from https://github.com/cms-sw/cmssw/pull/40765 - Transfer of all PPS detectors' mappings from XML to CondDB.

In this PR:

Updates of [TotemVFATRawToDigi.cc](https://github.com/CTPPS/cmssw/blob/6105ec09f9adba0ecaa36a6ab1ac23f249a67c6f/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc)

add use of new TotemAnalysisMaskRcd separated from TotemReadoutRcd and introduced in https://github.com/cms-sw/cmssw/pull/42471;
handle retrieving objects from records using EventSetup::getHandle()
Changes in [ctppsRawToDigi_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-1eb4c964687bc0dbea0102fa7d717cc7f42908aa1979fbc22cde1db187b8e3fa):

remove imports of XML files containing mappings - now mappings will be taken from a GT
New config fragment: [ctppsRawToDigi_xml_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-ca62e8d0446df10a4cd189d5eabaecbaf40ca005968588089ab54e075954ad6a) which is an old [ctppsRawToDigi_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-1eb4c964687bc0dbea0102fa7d717cc7f42908aa1979fbc22cde1db187b8e3fa) - it imports XML files with mappings

New config ([strip_dqm_test_xml_cfg.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-59e872634532ac0d26ee88ec4b59dd48d6ddca7dc15965feeb025016c3a7d278)) to read mappings from XML instead of GT (just for test and internal use)

#### PR validation:

<p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(14, 17, 22); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">We have created Tags containing records with mappings for each detector. Created Tags:</p>

TAG | Record
-- | --
PPSDAQMapping_TrackingStrip_test_v1 | TotemReadoutRcd
PPSDAQMapping_TimingDiamond_test_v1 | TotemReadoutRcd
PPSDAQMapping_TotemTiming_test_v1 | TotemReadoutRcd
PPSDAQMapping_TotemT2_test_v1 | TotemReadoutRcd
PPSAnalysisMask_test_v1 | TotemAnalysisMaskRcd

<p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(14, 17, 22); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">To validate changes in TotemVFATRawToDigi I ran the rawToDigi and the reconstruction (<code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted)); border-radius: 6px;">process.ctppsRawToDigi</code><span> </span>and<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted)); border-radius: 6px;">process.recoCTPPS</code><span> </span>in config's<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted)); border-radius: 6px;">process.path</code>) with the use of Tags and then with the use of XML files. Because TotemAnalysisMaskRcd cannot be taken from XML in both cases it was loaded from a Tag - but it shouldn't make any difference since this record contains empty object and no data.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(14, 17, 22); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Then I compared plots generated with the use of Tags with plots generated with the use of XMLs. They looked the same.</p><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(14, 17, 22); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This test has been done for all detectors (TimingDiamond, TrackingStrips, TotemT2, TotemTiming) and here are the resulting plots:<span> </span><a href="https://cernbox.cern.ch/s/jQ1ofbYnBNbiCOs" rel="nofollow" style="box-sizing: border-box; background-color: transparent; color: var(--fgColor-accent, var(--color-accent-fg)); text-decoration: underline; text-underline-offset: 0.2rem;">https://cernbox.cern.ch/s/jQ1ofbYnBNbiCOs</a></p>