### PR TITLE
Phase 2 L1 cmsDriver/Menu Infrastructure

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1012,6 +1012,7 @@ class ConfigBuilder(object):
         self.DIGIDefaultCFF="Configuration/StandardSequences/Digi_cff"
         self.DIGI2RAWDefaultCFF="Configuration/StandardSequences/DigiToRaw_cff"
         self.L1EMDefaultCFF='Configuration/StandardSequences/SimL1Emulator_cff'
+        self.P2L1GTDefaultCFF = 'Configuration/StandardSequences/SimPhase2L1GlobalTriggerEmulator_cff'
         self.L1MENUDefaultCFF="Configuration/StandardSequences/L1TriggerDefaultMenu_cff"
         self.HLTDefaultCFF="Configuration/StandardSequences/HLTtable_cff"
         self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_Data_cff"
@@ -1050,6 +1051,7 @@ class ConfigBuilder(object):
         self.DIGI2RAWDefaultSeq='DigiToRaw'
         self.HLTDefaultSeq='GRun'
         self.L1DefaultSeq=None
+        self.P2L1GTDefaultSeq=None
         self.L1REPACKDefaultSeq='GT'
         self.HARVESTINGDefaultSeq=None
         self.ALCAHARVESTDefaultSeq=None
@@ -1571,6 +1573,40 @@ class ConfigBuilder(object):
         _,_repackSeq,_ = self.loadDefaultOrSpecifiedCFF(stepSpec,self.REPACKDefaultCFF)
         self.scheduleSequence(_repackSeq,'digi2repack_step')
         return
+
+    def loadPhase2GTMenu(self, menuFile: str):
+        import importlib
+        menuPath = f'L1Trigger.Configuration.Phase2GTMenus.{menuFile}'
+        menuModule = importlib.import_module(menuPath)
+        
+        theMenu = menuModule.menu
+        triggerPaths = [] #we get a list of paths in each of these files to schedule
+
+        for triggerPathFile in theMenu:
+            self.loadAndRemember(triggerPathFile) #this load and remember will set the algo variable of the algoblock later
+
+            triggerPathModule = importlib.import_module(triggerPathFile)
+            for objName in dir(triggerPathModule):
+                obj = getattr(triggerPathModule, objName)
+                objType = type(obj)
+                if objType == cms.Path:
+                    triggerPaths.append(objName)
+        
+        triggerScheduleList = [getattr(self.process, name) for name in triggerPaths] #get the actual paths to put in the schedule
+        self.schedule.extend(triggerScheduleList) #put them in the schedule for later
+    
+    # create the L1 GT step
+    # We abuse the stepSpec a bit as a way to specify a menu
+    def prepare_P2L1GT(self, stepSpec=None):
+        """ Run the GT emulation sequence on top of the L1 emulation step """
+        self.loadAndRemember(self.P2L1GTDefaultCFF)
+        self.scheduleSequence('l1tGTProducerSequence', 'Phase2L1GTProducer')
+        self.scheduleSequence('l1tGTAlgoBlockProducerSequence', 'Phase2L1GTAlgoBlockProducer')
+        if stepSpec == None:
+            defaultMenuFile = "prototype_2023_v1_0_0"
+            self.loadPhase2GTMenu(menuFile = defaultMenuFile)
+        else:
+            self.loadPhase2GTMenu(menuFile = stepSpec)
 
     def prepare_L1(self, stepSpec = None):
         """ Enrich the schedule with the L1 simulation step"""

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1012,7 +1012,7 @@ class ConfigBuilder(object):
         self.DIGIDefaultCFF="Configuration/StandardSequences/Digi_cff"
         self.DIGI2RAWDefaultCFF="Configuration/StandardSequences/DigiToRaw_cff"
         self.L1EMDefaultCFF='Configuration/StandardSequences/SimL1Emulator_cff'
-        self.P2L1GTDefaultCFF = 'Configuration/StandardSequences/SimPhase2L1GlobalTriggerEmulator_cff'
+        self.L1P2GTDefaultCFF = 'Configuration/StandardSequences/SimPhase2L1GlobalTriggerEmulator_cff'
         self.L1MENUDefaultCFF="Configuration/StandardSequences/L1TriggerDefaultMenu_cff"
         self.HLTDefaultCFF="Configuration/StandardSequences/HLTtable_cff"
         self.RAW2DIGIDefaultCFF="Configuration/StandardSequences/RawToDigi_Data_cff"
@@ -1051,7 +1051,7 @@ class ConfigBuilder(object):
         self.DIGI2RAWDefaultSeq='DigiToRaw'
         self.HLTDefaultSeq='GRun'
         self.L1DefaultSeq=None
-        self.P2L1GTDefaultSeq=None
+        self.L1P2GTDefaultSeq=None
         self.L1REPACKDefaultSeq='GT'
         self.HARVESTINGDefaultSeq=None
         self.ALCAHARVESTDefaultSeq=None
@@ -1597,9 +1597,9 @@ class ConfigBuilder(object):
     
     # create the L1 GT step
     # We abuse the stepSpec a bit as a way to specify a menu
-    def prepare_P2L1GT(self, stepSpec=None):
+    def prepare_L1P2GT(self, stepSpec=None):
         """ Run the GT emulation sequence on top of the L1 emulation step """
-        self.loadAndRemember(self.P2L1GTDefaultCFF)
+        self.loadAndRemember(self.L1P2GTDefaultCFF)
         self.scheduleSequence('l1tGTProducerSequence', 'Phase2L1GTProducer')
         self.scheduleSequence('l1tGTAlgoBlockProducerSequence', 'Phase2L1GTAlgoBlockProducer')
         if stepSpec == None:

--- a/Configuration/StandardSequences/python/SimPhase2L1GlobalTriggerEmulator_cff.py
+++ b/Configuration/StandardSequences/python/SimPhase2L1GlobalTriggerEmulator_cff.py
@@ -1,0 +1,5 @@
+# Make the phase 2 GT book end configs available as standard sequences for the cmsDriver
+# Written by: Andrew Loeliger
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.Configuration.SimPhase2L1GlobalTrigger_cff import *

--- a/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/prototypeSeeds.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/SeedDefinitions/prototypeSeeds.py
@@ -1,0 +1,4 @@
+# Concatenate prototype menu seeds somewhere easy to handle
+from L1Trigger.Phase2L1GT.l1tGTMenu_hadr_metSeeds_cff import *
+
+from L1Trigger.Phase2L1GT.l1tGTMenu_lepSeeds_cff import *

--- a/L1Trigger/Configuration/python/Phase2GTMenus/prototype_2023_v1_0_0.py
+++ b/L1Trigger/Configuration/python/Phase2GTMenus/prototype_2023_v1_0_0.py
@@ -1,0 +1,5 @@
+# The first prototype menu
+
+menu = [
+    'L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.prototypeSeeds'
+]

--- a/L1Trigger/Configuration/python/SimPhase2L1GlobalTrigger_cff.py
+++ b/L1Trigger/Configuration/python/SimPhase2L1GlobalTrigger_cff.py
@@ -1,0 +1,20 @@
+# Make Phase 2 Global Trigger "book end" configurations available as an L1 Configuration file
+# To be made available later in Configuration/StandardSequences.
+# It's a little circuitous, I admit, but seems correct to be available _everywhere_
+# Written by: Andrew Loeliger
+
+import FWCore.ParameterSet.Config as cms
+
+# Get the GT Producer/first of the "book end"s, responsible for GT inputs
+from L1Trigger.Phase2L1GT.l1tGTProducer_cff import l1tGTProducer
+
+l1tGTProducerSequence = cms.Sequence(
+    l1tGTProducer
+)
+
+# Get the Algo Block/second of the "book end"s, responsible for trigger results
+from L1Trigger.Phase2L1GT.l1tGTAlgoBlockProducer_cff import l1tGTAlgoBlockProducer
+
+l1tGTAlgoBlockProducerSequence = cms.Sequence(
+    l1tGTAlgoBlockProducer
+)


### PR DESCRIPTION
### PR description:

This PR is intended to start formalizing the Phase 2 L1 sequence in CMSSW. This initial commit adds a prototype way of specifying a menu to emulate (likely to be changed later when GT/Menu experts agree on what a menu should formally be), and a cmsDriver step for the Phase2 L1 GT (separate from L1 by formal request of the GT team) that draws on and loads the python configured menu of Phase2 L1 GT. Separate test menus can be loaded using the step specification of the phase 2 GT step, but that behavior is something of an afterthought on my part and can be changed if not the intended use of that function.

The ultimate goal of this PR, or follow-up PRs, is a specific L1 testing workflow under `Configuration/PyReleaseValidation` for use in automated testing as requested by upgrade coordination

@artlbv @jheikkil @qvyz 

### PR validation:

A test CMSDriver command using a CMSSW_13_1 Phase 2 MC release was tested locally using these modifications:

```
cmsDriver.py step1 --conditions 125X_mcRun4_realistic_v2 -n 2 --era Phase2C17I13M9 --eventcontent FEVTDEBUGHLT -s RAW2DIGI,L1,P2L1GT --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT --geometry Extended2026D88 --nThreads 1 --filein file:./RAW-MiniAOD-standard.root --mc --inputCommands='keep *, drop l1tPFJets_*_*_*' --outputCommands='keep *P2GT*_*_*_*, drop l1tPFJets_*_*_*' --python_filename rerunL1_only_cfg.py
```
This ran on multiple events with no mis-configuration issues.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and is not likely to be backported
