### PR TITLE
Adding MinBias generator skims

### DIFF
--- a/Configuration/Skimming/python/PDWG_MCMinBiasGen_cff.py
+++ b/Configuration/Skimming/python/PDWG_MCMinBiasGen_cff.py
@@ -1,0 +1,70 @@
+# Minbias generator skims
+# 1) 1 muon with pt > 7, |eta|<2.5 --> 1Mu
+# 2) 2 muons with pt > 2 and 2, |eta|<2.5 --> 2Mu
+# 3) 2 muons with pt > 4 and 3, |eta|<2.5, opposite sign, mass [0.2,8.5] --> OS2Mu
+# 4) 2 muons with pt > 4 and 4, |eta|<2.5, opposite sign, mass [4.9,5.9] --> OS2MuB
+# 5) 3 muons with pt > 5/2/2, |eta|<2.5 --> 3Mu
+
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.EventContent.EventContent_cff import RAWSIMEventContent
+MinBiasGenSkimFilter1 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(7.0),
+          NumRequired = cms.int32(1),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter2 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(2.0),
+          NumRequired = cms.int32(2),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter3 = cms.EDFilter("MCParticlePairFilter",
+          Status = cms.untracked.vint32(1, 1),
+          MinPt = cms.untracked.vdouble(4., 3.),
+          MaxEta = cms.untracked.vdouble(2.5, 2.5),
+          MinEta = cms.untracked.vdouble(-2.5, -2.5),
+          ParticleCharge = cms.untracked.int32(-1),
+          MaxInvMass = cms.untracked.double(8.5),
+          MinInvMass = cms.untracked.double(0.2),
+          ParticleID1 = cms.untracked.vint32(13),
+          ParticleID2 = cms.untracked.vint32(13)
+      )
+MinBiasGenSkimFilter4 = cms.EDFilter("MCParticlePairFilter",
+          Status = cms.untracked.vint32(1, 1),
+          MinPt = cms.untracked.vdouble(4., 4.),
+          MaxEta = cms.untracked.vdouble(2.5, 2.5),
+          MinEta = cms.untracked.vdouble(-2.5, -2.5),
+          ParticleCharge = cms.untracked.int32(-1),
+          MaxInvMass = cms.untracked.double(5.9),
+          MinInvMass = cms.untracked.double(4.9),
+          ParticleID1 = cms.untracked.vint32(13),
+          ParticleID2 = cms.untracked.vint32(13)
+      )
+MinBiasGenSkimFilter5 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(2.0),
+          NumRequired = cms.int32(3),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter6 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(5.0),
+          NumRequired = cms.int32(1),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+
+MinBiasGenSkimSeq1Mu = cms.Sequence( MinBiasGenSkimFilter1 )
+MinBiasGenSkimSeq2Mu = cms.Sequence( MinBiasGenSkimFilter2 )
+MinBiasGenSkimSeqOS2Mu = cms.Sequence( MinBiasGenSkimFilter3 )
+MinBiasGenSkimSeqOS2MuB = cms.Sequence( MinBiasGenSkimFilter4 )
+MinBiasGenSkimSeq3Mu = cms.Sequence( MinBiasGenSkimFilter5 * MinBiasGenSkimFilter6)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -80,6 +80,123 @@ SKIMStreamevtSplitSkimP4 = cms.FilteredStream(
     )
 
 #####################
+# Minbias generator skims
+# 1) 1 muon with pt > 7, |eta|<2.5 --> 1Mu
+# 2) 2 muons with pt > 2 and 2, |eta|<2.5 --> 2Mu
+# 3) 2 muons with pt > 4 and 3, |eta|<2.5, opposite sign, mass [0.2,8.5] --> OS2Mu
+# 4) 2 muons with pt > 4 and 4, |eta|<2.5, opposite sign, mass [4.9,5.9] --> OS2MuB
+# 5) 3 muons with pt > 5/2/2, |eta|<2.5 --> 3Mu
+
+from Configuration.EventContent.EventContent_cff import RAWSIMEventContent
+MinBiasGenSkimFilter1 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(7.0),
+          NumRequired = cms.int32(1),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter2 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(2.0),
+          NumRequired = cms.int32(2),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter3 = cms.EDFilter("MCParticlePairFilter",
+          Status = cms.untracked.vint32(1, 1),
+          MinPt = cms.untracked.vdouble(4., 3.),
+          MaxEta = cms.untracked.vdouble(2.5, 2.5),
+          MinEta = cms.untracked.vdouble(-2.5, -2.5),
+          ParticleCharge = cms.untracked.int32(-1),
+          MaxInvMass = cms.untracked.double(8.5),
+          MinInvMass = cms.untracked.double(0.2),
+          ParticleID1 = cms.untracked.vint32(13),
+          ParticleID2 = cms.untracked.vint32(13)
+      )
+MinBiasGenSkimFilter4 = cms.EDFilter("MCParticlePairFilter",
+          Status = cms.untracked.vint32(1, 1),
+          MinPt = cms.untracked.vdouble(4., 4.),
+          MaxEta = cms.untracked.vdouble(2.5, 2.5),
+          MinEta = cms.untracked.vdouble(-2.5, -2.5),
+          ParticleCharge = cms.untracked.int32(-1),
+          MaxInvMass = cms.untracked.double(5.9),
+          MinInvMass = cms.untracked.double(4.9),
+          ParticleID1 = cms.untracked.vint32(13),
+          ParticleID2 = cms.untracked.vint32(13)
+      )
+MinBiasGenSkimFilter5 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(2.0),
+          NumRequired = cms.int32(3),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+MinBiasGenSkimFilter6 = cms.EDFilter("MCMultiParticleFilter",
+          Status = cms.vint32(1),
+          ParticleID = cms.vint32(13),
+          PtMin = cms.vdouble(5.0),
+          NumRequired = cms.int32(1),
+          EtaMax = cms.vdouble(2.5),
+          AcceptMore = cms.bool(True)
+      )
+
+MinBiasGenSkimSeq1Mu = cms.Sequence( MinBiasGenSkimFilter1 )
+MinBiasGenSkimSeq2Mu = cms.Sequence( MinBiasGenSkimFilter2 )
+MinBiasGenSkimSeqOS2Mu = cms.Sequence( MinBiasGenSkimFilter3 )
+MinBiasGenSkimSeqOS2MuB = cms.Sequence( MinBiasGenSkimFilter4 )
+MinBiasGenSkimSeq3Mu = cms.Sequence( MinBiasGenSkimFilter5 * MinBiasGenSkimFilter6)
+
+MinBiasGenSkimPath1Mu = cms.Path(MinBiasGenSkimSeq1Mu )
+MinBiasGenSkimPath2Mu = cms.Path( MinBiasGenSkimSeq2Mu )
+MinBiasGenSkimPathOS2Mu = cms.Path( MinBiasGenSkimSeqOS2Mu )
+MinBiasGenSkimPathOS2MuB = cms.Path( MinBiasGenSkimSeqOS2MuB )
+MinBiasGenSkimPath3Mu = cms.Path( MinBiasGenSkimSeq3Mu )
+
+SKIMStreamMinBiasGenSkim1Mu = cms.FilteredStream(
+    responsible = 'GEN',
+    name = 'MinBiasGenSkim1Mu',
+    paths = ( MinBiasGenSkimPath1Mu),
+    content = RAWSIMEventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('GEN')
+)
+SKIMStreamMinBiasGenSkim2Mu = cms.FilteredStream(
+    responsible = 'GEN',
+    name = 'MinBiasGenSkim2Mu',
+    paths = ( MinBiasGenSkimPath2Mu ),
+    content = RAWSIMEventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('GEN')
+)
+SKIMStreamMinBiasGenSkimOS2Mu = cms.FilteredStream(
+    responsible = 'GEN',
+    name = 'MinBiasGenSkimOS2Mu',
+    paths = ( MinBiasGenSkimPathOS2Mu ),
+    content = RAWSIMEventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('GEN')
+)
+SKIMStreamMinBiasGenSkimOS2MuB = cms.FilteredStream(
+    responsible = 'GEN',
+    name = 'MinBiasGenSkimOS2MuB',
+    paths = ( MinBiasGenSkimPathOS2MuB ),
+    content = RAWSIMEventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('GEN')
+)
+SKIMStreamMinBiasGenSkim3Mu = cms.FilteredStream(
+    responsible = 'GEN',
+    name = 'MinBiasGenSkim3Mu',
+    paths = ( MinBiasGenSkimPath3Mu ),
+    content = RAWSIMEventContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('GEN')
+)
+
+#####################
 
 from Configuration.Skimming.PDWG_BPHSkim_cff import *
 BPHSkimPath = cms.Path(BPHSkimSequence)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -87,67 +87,7 @@ SKIMStreamevtSplitSkimP4 = cms.FilteredStream(
 # 4) 2 muons with pt > 4 and 4, |eta|<2.5, opposite sign, mass [4.9,5.9] --> OS2MuB
 # 5) 3 muons with pt > 5/2/2, |eta|<2.5 --> 3Mu
 
-from Configuration.EventContent.EventContent_cff import RAWSIMEventContent
-MinBiasGenSkimFilter1 = cms.EDFilter("MCMultiParticleFilter",
-          Status = cms.vint32(1),
-          ParticleID = cms.vint32(13),
-          PtMin = cms.vdouble(7.0),
-          NumRequired = cms.int32(1),
-          EtaMax = cms.vdouble(2.5),
-          AcceptMore = cms.bool(True)
-      )
-MinBiasGenSkimFilter2 = cms.EDFilter("MCMultiParticleFilter",
-          Status = cms.vint32(1),
-          ParticleID = cms.vint32(13),
-          PtMin = cms.vdouble(2.0),
-          NumRequired = cms.int32(2),
-          EtaMax = cms.vdouble(2.5),
-          AcceptMore = cms.bool(True)
-      )
-MinBiasGenSkimFilter3 = cms.EDFilter("MCParticlePairFilter",
-          Status = cms.untracked.vint32(1, 1),
-          MinPt = cms.untracked.vdouble(4., 3.),
-          MaxEta = cms.untracked.vdouble(2.5, 2.5),
-          MinEta = cms.untracked.vdouble(-2.5, -2.5),
-          ParticleCharge = cms.untracked.int32(-1),
-          MaxInvMass = cms.untracked.double(8.5),
-          MinInvMass = cms.untracked.double(0.2),
-          ParticleID1 = cms.untracked.vint32(13),
-          ParticleID2 = cms.untracked.vint32(13)
-      )
-MinBiasGenSkimFilter4 = cms.EDFilter("MCParticlePairFilter",
-          Status = cms.untracked.vint32(1, 1),
-          MinPt = cms.untracked.vdouble(4., 4.),
-          MaxEta = cms.untracked.vdouble(2.5, 2.5),
-          MinEta = cms.untracked.vdouble(-2.5, -2.5),
-          ParticleCharge = cms.untracked.int32(-1),
-          MaxInvMass = cms.untracked.double(5.9),
-          MinInvMass = cms.untracked.double(4.9),
-          ParticleID1 = cms.untracked.vint32(13),
-          ParticleID2 = cms.untracked.vint32(13)
-      )
-MinBiasGenSkimFilter5 = cms.EDFilter("MCMultiParticleFilter",
-          Status = cms.vint32(1),
-          ParticleID = cms.vint32(13),
-          PtMin = cms.vdouble(2.0),
-          NumRequired = cms.int32(3),
-          EtaMax = cms.vdouble(2.5),
-          AcceptMore = cms.bool(True)
-      )
-MinBiasGenSkimFilter6 = cms.EDFilter("MCMultiParticleFilter",
-          Status = cms.vint32(1),
-          ParticleID = cms.vint32(13),
-          PtMin = cms.vdouble(5.0),
-          NumRequired = cms.int32(1),
-          EtaMax = cms.vdouble(2.5),
-          AcceptMore = cms.bool(True)
-      )
-
-MinBiasGenSkimSeq1Mu = cms.Sequence( MinBiasGenSkimFilter1 )
-MinBiasGenSkimSeq2Mu = cms.Sequence( MinBiasGenSkimFilter2 )
-MinBiasGenSkimSeqOS2Mu = cms.Sequence( MinBiasGenSkimFilter3 )
-MinBiasGenSkimSeqOS2MuB = cms.Sequence( MinBiasGenSkimFilter4 )
-MinBiasGenSkimSeq3Mu = cms.Sequence( MinBiasGenSkimFilter5 * MinBiasGenSkimFilter6)
+from Configuration.Skimming.PDWG_MCMinBiasGen_cff import *
 
 MinBiasGenSkimPath1Mu = cms.Path(MinBiasGenSkimSeq1Mu )
 MinBiasGenSkimPath2Mu = cms.Path( MinBiasGenSkimSeq2Mu )


### PR DESCRIPTION
#### PR description:

As requested in [https://its.cern.ch/jira/browse/PDMVMCPROD-100](https://its.cern.ch/jira/browse/PDMVMCPROD-100)
5 new skims have been created based on the following criteria at generator:

- 1 muon with pt > 7, |eta|<2.5 --> MinBiasGenSkim1Mu
- 2 muons with pt > 2 and 2, |eta|<2.5 --> MinBiasGenSkim2Mu
- 2 muons with pt > 4 and 3, |eta|<2.5, opposite sign, mass [0.2,8.5] --> MinBiasGenSkimOS2Mu
- 2 muons with pt > 4 and 4, |eta|<2.5, opposite sign, mass [4.9,5.9] --> MinBiasGenSkimOS2MuB
- 3 muons with pt > 5/2/2, |eta|<2.5 --> MinBiasGenSkim3Mu

These criteria were discussed in [https://indico.cern.ch/event/1282524/#6-report-on-inclusive-mc](https://indico.cern.ch/event/1282524/#6-report-on-inclusive-mc)

#### PR validation:

Test command:
- Get https://cms-pdmv-prod.web.cern.ch/mcm/public/restapi/requests/get_fragment/BPH-GenericNoSmearGEN-00001/0 as InclusiveDileptonMinBias.py
- cmsDriver.py Configuration/GenProduction/python/InclusiveDileptonMinBias.py --python_filename test.py --eventcontent RAWSIM --datatier GEN --fileout file:test.root --conditions auto:phase1_2022_realistic --beamspot Realistic25ns13p6TeVEarly2022Collision --step GEN,SKIM:MinBiasGenSkim1Mu+MinBiasGenSkim2Mu+MinBiasGenSkimOS2Mu+MinBiasGenSkimOS2MuB+MinBiasGenSkim3Mu --geometry DB:Extended --era Run3 --no_exec --mc -n 1000000 --nThreads 4

Should be able to see 5 skim files are produced according.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 12_4_X for production.
