### PR TITLE
[13_3_X] Add SimBeamSpotObject record to Run-1/2/3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,27 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'                  :    '131X_mcRun1_design_v2',
+    'run1_design'                  :    '131X_mcRun1_design_v3',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'                      :    '131X_mcRun1_realistic_v2',
+    'run1_mc'                      :    '131X_mcRun1_realistic_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'                   :    '131X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'                   :    '131X_mcRun1_HeavyIon_v3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'                 :    '131X_mcRun2_startup_v2',
+    'run2_mc_50ns'                 :    '131X_mcRun2_startup_v3',
     # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'             :    '131X_mcRun2_asymptotic_l1stage1_v2',
+    'run2_mc_l1stage1'             :    '131X_mcRun2_asymptotic_l1stage1_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'                  :    '131X_mcRun2_design_v2',
+    'run2_design'                  :    '131X_mcRun2_design_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'              :    '131X_mcRun2_asymptotic_preVFP_v2',
+    'run2_mc_pre_vfp'              :    '131X_mcRun2_asymptotic_preVFP_v3',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'                      :    '131X_mcRun2_asymptotic_v2',
+    'run2_mc'                      :    '131X_mcRun2_asymptotic_v3',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'              :    '131X_mcRun2cosmics_asymptotic_deco_v2',
+    'run2_mc_cosmics'              :    '131X_mcRun2cosmics_asymptotic_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'                   :    '131X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'                   :    '131X_mcRun2_HeavyIon_v3',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'                   :    '131X_mcRun2_pA_v2',
+    'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
     'run2_data'                    :    '133X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
@@ -42,53 +42,53 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-19 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'           :    '131X_mc2017_design_v2',
+    'phase1_2017_design'           :    '131X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'        :    '131X_mc2017_realistic_v2',
+    'phase1_2017_realistic'        :    '131X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'          :    '131X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'          :    '131X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak'     :    '131X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak'     :    '131X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'           :    '131X_upgrade2018_design_v2',
+    'phase1_2018_design'           :    '131X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'        :    '131X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'        :    '131X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic run-dependent (RD) conditions for full Phase1 2018 detector
-    'phase1_2018_realistic_rd'     :    '131X_upgrade2018_realistic_RD_v2',
+    'phase1_2018_realistic_rd'     :    '131X_upgrade2018_realistic_RD_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi'     :    '131X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi'     :    '131X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :    '131X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :    '131X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'          :    '131X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'          :    '131X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak'     :    '131X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak'     :    '131X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           :    '133X_mcRun3_2022_design_v2',
+    'phase1_2022_design'           :    '133X_mcRun3_2022_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '133X_mcRun3_2022_realistic_v2',
+    'phase1_2022_realistic'        :    '133X_mcRun3_2022_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' :    '133X_mcRun3_2022_realistic_postEE_v3',
+    'phase1_2022_realistic_postEE' :    '133X_mcRun3_2022_realistic_postEE_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          :    '133X_mcRun3_2022cosmics_realistic_deco_v2',
+    'phase1_2022_cosmics'          :    '133X_mcRun3_2022cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   :    '133X_mcRun3_2022cosmics_design_deco_v2',
+    'phase1_2022_cosmics_design'   :    '133X_mcRun3_2022cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '133X_mcRun3_2022_realistic_HI_v2',
+    'phase1_2022_realistic_hi'     :    '133X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           :    '133X_mcRun3_2023_design_v2',
+    'phase1_2023_design'           :    '133X_mcRun3_2023_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '133X_mcRun3_2023_realistic_v2',
+    'phase1_2023_realistic'        :    '133X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '133X_mcRun3_2023_realistic_postBPix_v2',
+    'phase1_2023_realistic_postBPix'  : '133X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          :    '133X_mcRun3_2023cosmics_realistic_deco_v2',
+    'phase1_2023_cosmics'          :    '133X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   :    '133X_mcRun3_2023cosmics_design_deco_v2',
+    'phase1_2023_cosmics_design'   :    '133X_mcRun3_2023cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '133X_mcRun3_2023_realistic_HI_v6',
+    'phase1_2023_realistic_hi'     :    '133X_mcRun3_2023_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '133X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        :    '133X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '133X_mcRun4_realistic_v1'
 }


### PR DESCRIPTION
#### PR description:
Backport of #43197 

This PR adds the `SimBeamSpotObject` tags to all Run-1/2/3 MC GTs. See master PR for more details.

#### PR validation:
See master PR

#### Backport:
Backport of #43197 