### PR TITLE
Improve calo particle debugging

### DIFF
--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -125,7 +125,7 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
 
   edm::Handle<std::vector<SimTrack>> simTracksH;
   edm::Handle<std::vector<reco::GenParticle>> genParticlesH;
-  edm::Handle<std::vector<int> > genBarcodesH;
+  edm::Handle<std::vector<int>> genBarcodesH;
   edm::Handle<std::vector<SimVertex>> simVerticesH;
   edm::Handle<std::vector<TrackingParticle>> trackingParticlesH;
   edm::Handle<std::vector<CaloParticle>> caloParticlesH;
@@ -156,22 +156,21 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   std::map<int, float> detIdToTotalSimEnergy;
   fillSimHits(detIdToTotalSimEnergy, iEvent, iSetup);
 
-
   std::map<int, int> trackid_to_track_index;
   LogVerbatim("CaloParticleDebuggerSimTracks") << "\n\n**Printing SimTracks information **";
   LogVerbatim("CaloParticleDebuggerSimTracks") << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx";
-  for (size_t i=0; i < tracks.size(); ++i) {
+  for (size_t i = 0; i < tracks.size(); ++i) {
     auto const& t = tracks[i];
-    LogVerbatim("CaloParticleDebuggerSimTracks") << i << "\t" << t.trackId() << "\t" << t
-        << "  Crossed  Boundary: " << t.crossedBoundary() << "  Position Boundary: " << t.getPositionAtBoundary()
-        << "  Momentum Boundary: " << t.getMomentumAtBoundary() << "  Vtx:               " << t.vertIndex()
-        << "  Momemtum Origin:   " << t.momentum();
+    LogVerbatim("CaloParticleDebuggerSimTracks")
+        << i << "\t" << t.trackId() << "\t" << t << "  Crossed  Boundary: " << t.crossedBoundary()
+        << "  Position Boundary: " << t.getPositionAtBoundary() << "  Momentum Boundary: " << t.getMomentumAtBoundary()
+        << "  Vtx:               " << t.vertIndex() << "  Momemtum Origin:   " << t.momentum();
     trackid_to_track_index[t.trackId()] = i;
   }
 
   LogVerbatim("CaloParticleDebuggerGenParticles") << "\n\n**Printing GenParticles information **";
   LogVerbatim("CaloParticleDebuggerGenParticles") << "BARCODE\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)";
-  for (size_t i=0; i < genParticles.size(); ++i) {
+  for (size_t i = 0; i < genParticles.size(); ++i) {
     auto const& gp = genParticles[i];
     LogVerbatim("CaloParticleDebuggerGenParticles")
         << genBarcodes[i] << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex();
@@ -179,31 +178,30 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
 
   LogVerbatim("CaloParticleDebuggerSimVertices") << "\n\n**Printing SimVertex information **";
   LogVerbatim("CaloParticleDebuggerSimVertices") << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID";
-  for (size_t i=0; i < vertices.size(); ++i) {
+  for (size_t i = 0; i < vertices.size(); ++i) {
     auto const& v = vertices[i];
     LogVerbatim("CaloParticleDebuggerSimVertices") << i << "\t" << v;
   }
 
   LogVerbatim("CaloParticleDebuggerTrackingParticles") << "\n\n**Printing TrackingParticles information **";
-  for (size_t i=0; i < trackingpart.size(); ++i) {
+  for (size_t i = 0; i < trackingpart.size(); ++i) {
     auto const& tp = trackingpart[i];
     LogVerbatim("CaloParticleDebuggerTrackingParticles") << i << "\t" << tp;
   }
 
   LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n**Printing CaloParticles information **";
-  for (size_t i=0; i < calopart.size(); ++i) {
+  for (size_t i = 0; i < calopart.size(); ++i) {
     auto const& cp = calopart[i];
-    LogVerbatim("CaloParticleDebuggerCaloParticles")
-        << "\n\n"
-        << i << "\tType: " << cp.pdgId()
-        << "\tEnergy: " << cp.energy() << "\tBarcode: " << cp.g4Tracks()[0].genpartIndex()
-        << " G4_trackID: " << cp.g4Tracks()[0].trackId();  // << cp ;
+    LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n"
+                                                     << i << "\tType: " << cp.pdgId() << "\tEnergy: " << cp.energy()
+                                                     << "\tBarcode: " << cp.g4Tracks()[0].genpartIndex()
+                                                     << " G4_trackID: " << cp.g4Tracks()[0].trackId();  // << cp ;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
     LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall simclusters in CP: " << cp.simClusters().size();
     // All the next mess just to print the simClusters ordered
     auto const& simcs = cp.simClusters();
-    for (size_t j=0; j < simcs.size(); ++j) {
+    for (size_t j = 0; j < simcs.size(); ++j) {
       LogVerbatim("CaloParticleDebuggerCaloParticles") << *(simcs[j]);
     }
 
@@ -220,12 +218,11 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   }
 
   LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n**Printing SimClusters information **";
-  for (size_t i=0; i < simclusters.size(); ++i) {
+  for (size_t i = 0; i < simclusters.size(); ++i) {
     auto const& simcl = simclusters[i];
     LogVerbatim("CaloParticleDebuggerSimClusters")
         << "\n\n"
-        << i << "\tType: " << simcl.pdgId()
-        << "\tEnergy: " << simcl.energy() << "\tKey: " << i;  // << simcl ;
+        << i << "\tType: " << simcl.pdgId() << "\tEnergy: " << simcl.energy() << "\tKey: " << i;  // << simcl ;
     auto const& simtrack = simcl.g4Tracks()[0];
     LogVerbatim("CaloParticleDebuggerSimClusters") << "  Crossed  Boundary: " << simtrack.crossedBoundary()
                                                    << "  Position Boundary: " << simtrack.getPositionAtBoundary()

--- a/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
+++ b/SimGeneral/Debugging/plugins/CaloParticleDebugger.cc
@@ -58,6 +58,7 @@ private:
   void fillSimHits(std::map<int, float>&, const edm::Event&, const edm::EventSetup&);
   edm::InputTag simTracks_;
   edm::InputTag genParticles_;
+  edm::InputTag genBarcodes_;
   edm::InputTag simVertices_;
   edm::InputTag trackingParticles_;
   edm::InputTag caloParticles_;
@@ -65,6 +66,7 @@ private:
   std::vector<edm::InputTag> collectionTags_;
   edm::EDGetTokenT<std::vector<SimTrack>> simTracksToken_;
   edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticlesToken_;
+  edm::EDGetTokenT<std::vector<int>> genBarcodesToken_;
   edm::EDGetTokenT<std::vector<SimVertex>> simVerticesToken_;
   edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticlesToken_;
   edm::EDGetTokenT<std::vector<CaloParticle>> caloParticlesToken_;
@@ -89,6 +91,7 @@ private:
 CaloParticleDebugger::CaloParticleDebugger(const edm::ParameterSet& iConfig)
     : simTracks_(iConfig.getParameter<edm::InputTag>("simTracks")),
       genParticles_(iConfig.getParameter<edm::InputTag>("genParticles")),
+      genBarcodes_(iConfig.getParameter<edm::InputTag>("genBarcodes")),
       simVertices_(iConfig.getParameter<edm::InputTag>("simVertices")),
       trackingParticles_(iConfig.getParameter<edm::InputTag>("trackingParticles")),
       caloParticles_(iConfig.getParameter<edm::InputTag>("caloParticles")),
@@ -97,6 +100,7 @@ CaloParticleDebugger::CaloParticleDebugger(const edm::ParameterSet& iConfig)
   edm::ConsumesCollector&& iC = consumesCollector();
   simTracksToken_ = iC.consumes<std::vector<SimTrack>>(simTracks_);
   genParticlesToken_ = iC.consumes<std::vector<reco::GenParticle>>(genParticles_);
+  genBarcodesToken_ = iC.consumes<std::vector<int>>(genBarcodes_);
   simVerticesToken_ = iC.consumes<std::vector<SimVertex>>(simVertices_);
   trackingParticlesToken_ = iC.consumes<std::vector<TrackingParticle>>(trackingParticles_);
   caloParticlesToken_ = iC.consumes<std::vector<CaloParticle>>(caloParticles_);
@@ -118,11 +122,10 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
   using namespace edm;
   using std::begin;
   using std::end;
-  using std::iota;
-  using std::sort;
 
   edm::Handle<std::vector<SimTrack>> simTracksH;
   edm::Handle<std::vector<reco::GenParticle>> genParticlesH;
+  edm::Handle<std::vector<int> > genBarcodesH;
   edm::Handle<std::vector<SimVertex>> simVerticesH;
   edm::Handle<std::vector<TrackingParticle>> trackingParticlesH;
   edm::Handle<std::vector<CaloParticle>> caloParticlesH;
@@ -130,113 +133,78 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
 
   iEvent.getByToken(simTracksToken_, simTracksH);
   auto const& tracks = *simTracksH.product();
-  std::vector<int> sorted_tracks_idx(tracks.size());
-  iota(begin(sorted_tracks_idx), end(sorted_tracks_idx), 0);
-  sort(begin(sorted_tracks_idx), end(sorted_tracks_idx), [&tracks](int i, int j) {
-    return tracks[i].momentum().eta() < tracks[j].momentum().eta();
-  });
 
   iEvent.getByToken(genParticlesToken_, genParticlesH);
   auto const& genParticles = *genParticlesH.product();
-  std::vector<int> sorted_genParticles_idx(genParticles.size());
-  iota(begin(sorted_genParticles_idx), end(sorted_genParticles_idx), 0);
-  sort(begin(sorted_genParticles_idx), end(sorted_genParticles_idx), [&genParticles](int i, int j) {
-    return genParticles[i].momentum().eta() < genParticles[j].momentum().eta();
-  });
+
+  iEvent.getByToken(genBarcodesToken_, genBarcodesH);
+  auto const& genBarcodes = *genBarcodesH.product();
 
   iEvent.getByToken(simVerticesToken_, simVerticesH);
   auto const& vertices = *simVerticesH.product();
-  std::vector<int> sorted_vertices_idx(vertices.size());
-  iota(begin(sorted_vertices_idx), end(sorted_vertices_idx), 0);
-  sort(begin(sorted_vertices_idx), end(sorted_vertices_idx), [&vertices](int i, int j) {
-    return vertices[i].vertexId() < vertices[j].vertexId();
-  });
 
   iEvent.getByToken(trackingParticlesToken_, trackingParticlesH);
   auto const& trackingpart = *trackingParticlesH.product();
-  std::vector<int> sorted_tp_idx(trackingpart.size());
-  iota(begin(sorted_tp_idx), end(sorted_tp_idx), 0);
-  sort(begin(sorted_tp_idx), end(sorted_tp_idx), [&trackingpart](int i, int j) {
-    return trackingpart[i].eta() < trackingpart[j].eta();
-  });
 
   iEvent.getByToken(caloParticlesToken_, caloParticlesH);
   auto const& calopart = *caloParticlesH.product();
-  std::vector<int> sorted_cp_idx(calopart.size());
-  iota(begin(sorted_cp_idx), end(sorted_cp_idx), 0);
-  sort(begin(sorted_cp_idx), end(sorted_cp_idx), [&calopart](int i, int j) {
-    return calopart[i].eta() < calopart[j].eta();
-  });
 
   iEvent.getByToken(simClustersToken_, simClustersH);
   auto const& simclusters = *simClustersH.product();
-  std::vector<int> sorted_simcl_idx(simclusters.size());
-  iota(begin(sorted_simcl_idx), end(sorted_simcl_idx), 0);
-  sort(begin(sorted_simcl_idx), end(sorted_simcl_idx), [&simclusters](int i, int j) {
-    return simclusters[i].eta() < simclusters[j].eta();
-  });
 
   // Let's first fill in hits information
   std::map<int, float> detIdToTotalSimEnergy;
   fillSimHits(detIdToTotalSimEnergy, iEvent, iSetup);
 
-  int idx = 0;
 
   std::map<int, int> trackid_to_track_index;
   LogVerbatim("CaloParticleDebuggerSimTracks") << "\n\n**Printing SimTracks information **";
   LogVerbatim("CaloParticleDebuggerSimTracks") << "IDX\tTrackId\tPDGID\tMOMENTUM(x,y,z,E)\tVertexIdx\tGenPartIdx";
-  for (auto i : sorted_tracks_idx) {
+  for (size_t i=0; i < tracks.size(); ++i) {
     auto const& t = tracks[i];
-    LogVerbatim("CaloParticleDebuggerSimTracks") << idx << "\t" << t.trackId() << "\t" << t;
-    LogVerbatim("CaloParticleDebuggerSimTracks")
-        << "Crossed  Boundary: " << t.crossedBoundary() << "  Position Boundary: " << t.getPositionAtBoundary()
+    LogVerbatim("CaloParticleDebuggerSimTracks") << i << "\t" << t.trackId() << "\t" << t
+        << "  Crossed  Boundary: " << t.crossedBoundary() << "  Position Boundary: " << t.getPositionAtBoundary()
         << "  Momentum Boundary: " << t.getMomentumAtBoundary() << "  Vtx:               " << t.vertIndex()
         << "  Momemtum Origin:   " << t.momentum();
-    trackid_to_track_index[t.trackId()] = idx;
-    idx++;
+    trackid_to_track_index[t.trackId()] = i;
   }
 
   LogVerbatim("CaloParticleDebuggerGenParticles") << "\n\n**Printing GenParticles information **";
-  LogVerbatim("CaloParticleDebuggerGenParticles") << "IDX\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)";
-  for (auto i : sorted_genParticles_idx) {
+  LogVerbatim("CaloParticleDebuggerGenParticles") << "BARCODE\tPDGID\tMOMENTUM(x,y,z)\tVertex(x,y,z)";
+  for (size_t i=0; i < genParticles.size(); ++i) {
     auto const& gp = genParticles[i];
     LogVerbatim("CaloParticleDebuggerGenParticles")
-        << i << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex();
+        << genBarcodes[i] << "\t" << gp.pdgId() << "\t" << gp.momentum() << "\t" << gp.vertex();
   }
 
   LogVerbatim("CaloParticleDebuggerSimVertices") << "\n\n**Printing SimVertex information **";
   LogVerbatim("CaloParticleDebuggerSimVertices") << "IDX\tPOSITION(x,y,z)\tPARENT_INDEX\tVERTEX_ID";
-  for (auto i : sorted_vertices_idx) {
+  for (size_t i=0; i < vertices.size(); ++i) {
     auto const& v = vertices[i];
     LogVerbatim("CaloParticleDebuggerSimVertices") << i << "\t" << v;
   }
 
   LogVerbatim("CaloParticleDebuggerTrackingParticles") << "\n\n**Printing TrackingParticles information **";
-  for (auto i : sorted_tp_idx) {
+  for (size_t i=0; i < trackingpart.size(); ++i) {
     auto const& tp = trackingpart[i];
     LogVerbatim("CaloParticleDebuggerTrackingParticles") << i << "\t" << tp;
   }
 
   LogVerbatim("CaloParticleDebuggerCaloParticles") << "\n\n**Printing CaloParticles information **";
-  idx = 0;
-  for (auto i : sorted_cp_idx) {
+  for (size_t i=0; i < calopart.size(); ++i) {
     auto const& cp = calopart[i];
     LogVerbatim("CaloParticleDebuggerCaloParticles")
         << "\n\n"
-        << idx++ << " |Eta|: " << std::abs(cp.momentum().eta()) << "\tType: " << cp.pdgId()
-        << "\tEnergy: " << cp.energy() << "\tIdx: " << cp.g4Tracks()[0].trackId();  // << cp ;
+        << i << "\tType: " << cp.pdgId()
+        << "\tEnergy: " << cp.energy() << "\tBarcode: " << cp.g4Tracks()[0].genpartIndex()
+        << " G4_trackID: " << cp.g4Tracks()[0].trackId();  // << cp ;
     double total_sim_energy = 0.;
     double total_cp_energy = 0.;
     LogVerbatim("CaloParticleDebuggerCaloParticles") << "--> Overall simclusters in CP: " << cp.simClusters().size();
     // All the next mess just to print the simClusters ordered
     auto const& simcs = cp.simClusters();
-    std::vector<int> sorted_sc_idx(simcs.size());
-    iota(begin(sorted_sc_idx), end(sorted_sc_idx), 0);
-    sort(begin(sorted_sc_idx), end(sorted_sc_idx), [&simcs](int i, int j) {
-      return simcs[i]->momentum().eta() < simcs[j]->momentum().eta();
-    });
-    for (auto i : sorted_sc_idx) {
-      LogVerbatim("CaloParticleDebuggerCaloParticles") << *(simcs[i]);
+    for (size_t j=0; j < simcs.size(); ++j) {
+      LogVerbatim("CaloParticleDebuggerCaloParticles") << *(simcs[j]);
     }
 
     for (auto const& sc : cp.simClusters()) {
@@ -251,13 +219,12 @@ void CaloParticleDebugger::analyze(const edm::Event& iEvent, const edm::EventSet
         << "--> Overall SC energy (sum using CaloP energies): " << total_cp_energy;
   }
 
-  idx = 0;
   LogVerbatim("CaloParticleDebuggerSimClusters") << "\n\n**Printing SimClusters information **";
-  for (auto i : sorted_simcl_idx) {
+  for (size_t i=0; i < simclusters.size(); ++i) {
     auto const& simcl = simclusters[i];
     LogVerbatim("CaloParticleDebuggerSimClusters")
         << "\n\n"
-        << idx++ << " |Eta|: " << std::abs(simcl.momentum().eta()) << "\tType: " << simcl.pdgId()
+        << i << "\tType: " << simcl.pdgId()
         << "\tEnergy: " << simcl.energy() << "\tKey: " << i;  // << simcl ;
     auto const& simtrack = simcl.g4Tracks()[0];
     LogVerbatim("CaloParticleDebuggerSimClusters") << "  Crossed  Boundary: " << simtrack.crossedBoundary()
@@ -361,6 +328,7 @@ void CaloParticleDebugger::fillDescriptions(edm::ConfigurationDescriptions& desc
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("simTracks", edm::InputTag("g4SimHits"));
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
+  desc.add<edm::InputTag>("genBarcodes", edm::InputTag("genParticles"));
   desc.add<edm::InputTag>("simVertices", edm::InputTag("g4SimHits"));
   desc.add<edm::InputTag>("trackingParticles", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("caloParticles", edm::InputTag("mix", "MergedCaloTruth"));

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -8,10 +8,10 @@ options.parseArguments()
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D96Reco_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 


### PR DESCRIPTION
#### PR description:

Improve `CaloParticle` debugging code by adding barcode information.
Remove useless eta-sorting and use the original one.

#### PR validation:

Tested locally by running the corresponding Python snippet in the `test` directory.
