### PR TITLE
Add PPS DAQ mapping to 13_3_X real data Run2 and Run3 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,13 +24,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '133X_dataRun2_v1',
+    'run2_data'                    :    '133X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             :    '133X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'             :    '133X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      :    '133X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'      :    '133X_dataRun2_PromptLike_HI_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              :    '133X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'              :    '133X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 HLT: identical to the online GT (132X_dataRun3_HLT_v2) but with snapshot at 2023-10-04 21:27:37 (UTC)
     'run3_hlt'                     :    '133X_dataRun3_HLT_frozen_v1',
     # GlobalTag for Run3 data relvals (express GT) - 132X_dataRun3_Express_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
@@ -38,9 +38,9 @@ autoCond = {
     # GlobalTag for Run3 data relvals (prompt GT) - 132X_dataRun3_Prompt_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
     'run3_data_prompt'             :    '133X_dataRun3_Prompt_frozen_v1',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-19 12:00:00 (UTC)
-    'run3_data'                    :    '133X_dataRun3_v3',
+    'run3_data'                    :    '133X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-19 12:00:00 (UTC)
-    'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v2',
+    'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,11 +32,11 @@ autoCond = {
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '133X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 HLT: identical to the online GT (132X_dataRun3_HLT_v2) but with snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_hlt'                     :    '133X_dataRun3_HLT_frozen_v1',
+    'run3_hlt'                     :    '133X_dataRun3_HLT_frozen_v2',
     # GlobalTag for Run3 data relvals (express GT) - 132X_dataRun3_Express_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_data_express'            :    '133X_dataRun3_Express_frozen_v1',
+    'run3_data_express'            :    '133X_dataRun3_Express_frozen_v2',
     # GlobalTag for Run3 data relvals (prompt GT) - 132X_dataRun3_Prompt_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_data_prompt'             :    '133X_dataRun3_Prompt_frozen_v1',
+    'run3_data_prompt'             :    '133X_dataRun3_Prompt_frozen_v2',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-19 12:00:00 (UTC)
     'run3_data'                    :    '133X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-19 12:00:00 (UTC)


### PR DESCRIPTION
#### PR description:

It adds the PPS DAQ mapping to 13_3_X real data GTs. 
At the moment, no MC GTs are updated for it, because MC workflows do not consume the added payload yet.

They were announced in [this CMSTalk post](https://cms-talk.web.cern.ch/t/queues-133x-mc-and-data-queues-opened/29683/5)

=== Data Tags (all added with "hlt" synchronization):

PPSDAQMapping_TimingDiamond_v1
PPSDAQMapping_TrackingStrip_v1
PPSDAQMapping_TotemTiming_v1
PPSDAQMapping_TotemT2_v1
PPSAnalysisMask_v1

=== GT diffs

`run2_data:` https : //cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_v1/133X_dataRun2_v2
`run2_data_HEfail` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_HEfail_v1/133X_dataRun2_Hefail_v2
`run2_data_promptlike_hi` : `https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_PromptLike_HI_v1/133X_dataRun2_PromptLike_HI_v2`
`run2_hlt_relval` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_HLT_relval_v1/133X_dataRun2_HLT_relval_v2
`run3_hlt` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_HLT_frozen_v1/133X_dataRun3_HLT_frozen_v2
`run3_data_express` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_Express_frozen_v1/133X_dataRun3_Express_frozen_v2
`run3_data_prompt` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_Prompt_frozen_v1/133X_dataRun3_Prompt_frozen_v2
`run3_data` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_v3/133X_dataRun3_v4
`run3_data_PromptAnalysis` : https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_PromptAnalysis_v2/133X_dataRun3_PromptAnalysis_v3

