### PR TITLE
Avoid catch exception when accessing vertex collection

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -283,10 +283,10 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   //edm::Handle<VertexCollection> vertices;
   edm::Handle<std::vector<Vertex>> vertices;
 
-  try {
-    vertices = iEvent.getHandle(theVertexCollectionToken_);
-  } catch (cms::Exception& er) {
-    LogTrace("PrimaryVertexValidation") << "caught std::exception " << er.what() << std::endl;
+  vertices = iEvent.getHandle(theVertexCollectionToken_);
+  if (!vertices.isValid()) {
+    LogTrace("PrimaryVertexValidation") << "Handle missing product" << std::endl;
+    return;
   }
 
   std::vector<Vertex> vsorted = *(vertices);


### PR DESCRIPTION
#### PR description:

To comply the edm exception use https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEdmExceptionUse, here we try to clean up the unnecessary exception catch and throw. This PR checks the collection validity after accessing through token.

#### PR validation:

Tested locally with code-checks and code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
