### PR TITLE
Avoid unnecessary Framework delays closing luminosity blocks

### DIFF
--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -87,8 +87,8 @@ namespace edm {
     EventProcessingState eventProcessingState() const { return eventProcessingState_; }
     void setEventProcessingState(EventProcessingState val) { eventProcessingState_ = val; }
 
-    bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_; }
-    void startNextLumiOrEndRun() { startedNextLumiOrEndedRun_ = true; }
+    bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_.load(); }
+    void startNextLumiOrEndRun() { startedNextLumiOrEndedRun_.store(true); }
 
     bool didGlobalBeginSucceed() const { return globalBeginSucceeded_; }
     void globalBeginDidSucceed() { globalBeginSucceeded_ = true; }
@@ -107,7 +107,7 @@ namespace edm {
     edm::Timestamp endTime_{};
     std::atomic<char> endTimeSetStatus_{0};
     EventProcessingState eventProcessingState_{EventProcessingState::kProcessing};
-    bool startedNextLumiOrEndedRun_{false};  //read/write in m_sourceQueue
+    std::atomic<bool> startedNextLumiOrEndedRun_{false};
     bool globalBeginSucceeded_{false};
     bool cleaningUpAfterException_{false};
   };

--- a/FWCore/Integration/test/testLateLumiClosure_cfg.py
+++ b/FWCore/Integration/test/testLateLumiClosure_cfg.py
@@ -1,3 +1,20 @@
+# This test originally demonstrated a problem
+# reported online. The problem has since been
+# fixed by a modification in the function
+# EventProcessor::handleNextEventForStreamAsync.
+# I've left unmodified a description of the
+# problem below. It is still interesting to keep
+# this configuration around and running as it
+# still demonstrates the circumstances in a
+# way that none of the other tests replicate
+# and shows that the problem is fixed if one
+# examines the log output. Note that it is not
+# coded as a pass/fail test because the timing
+# could vary and we don't want a test that
+# occasionally fails. It might sometimes still
+# exhibit the problem behavior if for example
+# a thread hangs.
+
 # Demonstrates a problem first noticed online. Say there
 # are 3 lumis. The first and last lumis have events.
 # The middle one has no events. We are using


### PR DESCRIPTION



#### PR description:

This pull request fixes a problem related luminosity blocks being closed later than necessary in some cases. It was noticed online in heavy ion runs. It should only be a problem online and not occur offline. The initial report and detailed description of the problem are in Issue #42931. There are two items listed in the opening comment of that issue. This PR only addresses the first of those two items. "Lumisections that no longer receive events are closed late". It does not help with the second item.

The changes should not affect the behavior for the first stream that notices that a luminosity block has ended. Other streams  though will notice the stream has ended and immediately call streamEndLumiAsync instead of waiting for it to be called by a task in the source serial queue. The delay is caused when that queue is blocked.

This PR should not affect the output of modules or anything else. It only affects the order in which things run. There are already many unit tests that verify the correct things are running and producing proper output. Those did not need modification. One unit test (see FWCore/Integration/test/testLateLumiClosure_cfg.py) is designed to demonstrate the problem. One can see the behavior in the log output of that test. Comparing the output with and without this PR shows that this PR fixes the problem. It is difficult to make this into a pass or fail type of test because timing can vary from one execution to the next. But I manually ran that test and verified that most of the time the problem is fixed by this PR (every time when I manually ran it). We usually do not want a unit test that occasionally fails. For example, behavior can be affected when the operating system pauses a thread due to contention issues.

This does add a small amount of overhead to execute the new code. I expect that to be negligible. In running the full complement of Core unit tests, I added counters that showed that out of 10's of thousands of calls the spin wait was hit briefly twice. The faster closing of the Lumi occurred hundred of times. In terms of performance I would guess this would be a net improvement. The original problem would be worst in cases like heavy ion runs where there are more events that take an unusually long time to process.

A note for those reviewing the code changes. The code-format tool changed the indentation on many lines in EventProcessor.cc. It looks like I changed more lines of code than I actually changed. The first part is really changed up to line 2223, then there is a big block where the only change is indentation, and at the end new code is added starting at line 2282. All the changes in the middle are just indentation from code-format.

#### PR validation:

Existing Core unit tests pass. testLateLumiClosure_cfg.py exhibits the expected improvement in closing lumis
