### PR TITLE
Read VertexSmearing from GT in Run-1/2/3 MC

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2566,7 +2566,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2017_design',
         'HLTmenu': '@relval2017',
         'Era' : 'Run2_2017',
-        'BeamSpot': 'GaussSigmaZ4cm',
+        'BeamSpot': 'DBdesign',
         'ScenToRun' : ['GenSim','Digi','RecoFakeHLT','HARVESTFakeHLT'],
     },
     '2018' : {
@@ -2574,7 +2574,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2018_realistic',
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
-        'BeamSpot': 'Realistic25ns13TeVEarly2018Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoFakeHLT','HARVESTFakeHLT','ALCA','Nano'],
     },
     '2018Design' : {
@@ -2582,7 +2582,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2018_design',
         'HLTmenu': '@relval2018',
         'Era' : 'Run2_2018',
-        'BeamSpot': 'GaussSigmaZ4cm',
+        'BeamSpot': 'DBdesign',
         'ScenToRun' : ['GenSim','Digi','RecoFakeHLT','HARVESTFakeHLT'],
     },
     '2021' : {
@@ -2590,7 +2590,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2022_realistic',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3',
-        'BeamSpot': 'Realistic25ns13p6TeVEOY2022Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2021Design' : {
@@ -2598,7 +2598,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2022_design',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3',
-        'BeamSpot': 'GaussSigmaZ4cm',
+        'BeamSpot': 'DBdesign',
         'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT'],
     },
     '2023' : {
@@ -2606,7 +2606,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2023_realistic',
         'HLTmenu': '@relval2023',
         'Era' : 'Run3_2023',
-        'BeamSpot': 'Realistic25ns13p6TeVEarly2023Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
     '2024' : {
@@ -2614,7 +2614,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2024_realistic',
         'HLTmenu': '@relval2023',
         'Era' : 'Run3',
-        'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
     '2021FS' : {
@@ -2622,7 +2622,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2022_realistic',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3_FastSim',
-        'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
     },
     '2021postEE' : {
@@ -2630,7 +2630,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2022_realistic_postEE',
         'HLTmenu': '@relval2022',
         'Era' : 'Run3',
-        'BeamSpot': 'Realistic25ns13p6TeVEarly2022Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2023FS' : {
@@ -2638,7 +2638,7 @@ upgradeProperties[2017] = {
         'GT' : 'auto:phase1_2023_realistic',
         'HLTmenu': '@relval2023',
         'Era' : 'Run3_2023_FastSim',
-        'BeamSpot': 'Realistic25ns13p6TeVEarly2023Collision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['Gen','FastSimRun3','HARVESTFastRun3'],
     },
     '2022HI' : {
@@ -2646,7 +2646,7 @@ upgradeProperties[2017] = {
         'GT':'auto:phase1_2022_realistic_hi', 
         'HLTmenu': '@fake2',
         'Era':'Run3_pp_on_PbPb',
-        'BeamSpot': 'Realistic2022PbPbCollision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
     '2022HIRP' : {
@@ -2654,7 +2654,7 @@ upgradeProperties[2017] = {
         'GT':'auto:phase1_2022_realistic_hi', 
         'HLTmenu': '@fake2',
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
-        'BeamSpot': 'Realistic2022PbPbCollision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
     '2023HI' : {
@@ -2662,7 +2662,7 @@ upgradeProperties[2017] = {
         'GT':'auto:phase1_2023_realistic_hi', 
         'HLTmenu': '@fake2',
         'Era':'Run3_pp_on_PbPb',
-        'BeamSpot': 'Realistic2022PbPbCollision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },
     '2023HIRP' : {
@@ -2670,7 +2670,7 @@ upgradeProperties[2017] = {
         'GT':'auto:phase1_2023_realistic_hi', 
         'HLTmenu': '@fake2',
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
-        'BeamSpot': 'Realistic2022PbPbCollision',
+        'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     }
 }

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -1,4 +1,6 @@
 VtxSmeared = {
+    'DBdesign':                      'IOMC.EventVertexGenerators.VtxSmearedDesign_cfi',
+    'DBrealistic':                   'IOMC.EventVertexGenerators.VtxSmearedRealistic_cfi',
     'NoSmear':                       'Configuration.StandardSequences.VtxSmearedNoSmear_cff',              
     'BetafuncEarlyCollision':        'IOMC.EventVertexGenerators.VtxSmearedBetafuncEarlyCollision_cfi',    
     'BeamProfile':                   'IOMC.EventVertexGenerators.VtxSmearedBeamProfile_cfi',               

--- a/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/BetafuncEvtVtxGenerator.h
@@ -20,6 +20,7 @@ ________________________________________________________________________
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
 #include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
@@ -36,6 +37,8 @@ public:
   /** Copy assignment operator */
   BetafuncEvtVtxGenerator& operator=(const BetafuncEvtVtxGenerator& rhs) = delete;
   ~BetafuncEvtVtxGenerator() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 

--- a/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
+++ b/IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h
@@ -9,6 +9,7 @@
 
 #include "IOMC/EventVertexGenerators/interface/BaseEvtVtxGenerator.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "CondFormats/DataRecord/interface/SimBeamSpotObjectsRcd.h"
 #include "CondFormats/BeamSpotObjects/interface/SimBeamSpotObjects.h"
@@ -25,6 +26,8 @@ public:
   /** Copy assignment operator */
   GaussEvtVtxGenerator& operator=(const GaussEvtVtxGenerator& rhs) = delete;
   ~GaussEvtVtxGenerator() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 

--- a/IOMC/EventVertexGenerators/python/VtxSmearedDesign_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedDesign_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Load GaussEvtVtxGenerator and read parameters from GT (SimBeamSpotObjectRcd)
+from IOMC.EventVertexGenerators.GaussEvtVtxGenerator_cfi import GaussEvtVtxGenerator
+VtxSmeared = GaussEvtVtxGenerator.clone(
+    src = "generator:unsmeared",
+    readDB = True
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Load BetafuncEvtVtxGenerator and read parameters from GT (SimBeamSpotObjectRcd)
+from IOMC.EventVertexGenerators.BetafuncEvtVtxGenerator_cfi import BetafuncEvtVtxGenerator
+VtxSmeared = BetafuncEvtVtxGenerator.clone(
+    src = "generator:unsmeared",
+    readDB = True
+)

--- a/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BetafuncEvtVtxGenerator.cc
@@ -24,10 +24,7 @@ ________________________________________________________________________
 #include "CLHEP/Random/RandGaussQ.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
-//#include "CLHEP/Vector/ThreeVector.h"
 #include "HepMC/SimpleVector.h"
-
-#include <iostream>
 
 BetafuncEvtVtxGenerator::BetafuncEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p), boost_(4, 4) {
   readDB_ = p.getParameter<bool>("readDB");
@@ -140,3 +137,19 @@ void BetafuncEvtVtxGenerator::sigmaZ(double s) {
 }
 
 TMatrixD const* BetafuncEvtVtxGenerator::GetInvLorentzBoost() const { return &boost_; }
+
+void BetafuncEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("X0", 0.0)->setComment("in cm");
+  desc.add<double>("Y0", 0.0)->setComment("in cm");
+  desc.add<double>("Z0", 0.0)->setComment("in cm");
+  desc.add<double>("SigmaZ", 0.0)->setComment("in cm");
+  desc.add<double>("BetaStar", 0.0)->setComment("in cm");
+  desc.add<double>("Emittance", 0.0)->setComment("in cm");
+  desc.add<double>("Alpha", 0.0)->setComment("in radians");
+  desc.add<double>("Phi", 0.0)->setComment("in radians");
+  desc.add<double>("TimeOffset", 0.0)->setComment("in ns");
+  desc.add<edm::InputTag>("src");
+  desc.add<bool>("readDB");
+  descriptions.add("BetafuncEvtVtxGenerator", desc);
+}

--- a/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/GaussEvtVtxGenerator.cc
@@ -1,14 +1,10 @@
-
-
 #include "IOMC/EventVertexGenerators/interface/GaussEvtVtxGenerator.h"
-#include "FWCore/Utilities/interface/Exception.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "CLHEP/Random/RandGaussQ.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
-//#include "CLHEP/Vector/ThreeVector.h"
 #include "HepMC/SimpleVector.h"
 
 GaussEvtVtxGenerator::GaussEvtVtxGenerator(const edm::ParameterSet& p) : BaseEvtVtxGenerator(p) {
@@ -94,4 +90,18 @@ void GaussEvtVtxGenerator::sigmaZ(double s) {
     throw cms::Exception("LogicError") << "Error in GaussEvtVtxGenerator::sigmaZ: "
                                        << "Illegal resolution in Z (negative)";
   }
+}
+
+void GaussEvtVtxGenerator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("MeanX", 0.0)->setComment("in cm");
+  desc.add<double>("MeanY", 0.0)->setComment("in cm");
+  desc.add<double>("MeanZ", 0.0)->setComment("in cm");
+  desc.add<double>("SigmaX", 0.0)->setComment("in cm");
+  desc.add<double>("SigmaY", 0.0)->setComment("in cm");
+  desc.add<double>("SigmaZ", 0.0)->setComment("in cm");
+  desc.add<double>("TimeOffset", 0.0)->setComment("in ns");
+  desc.add<edm::InputTag>("src");
+  desc.add<bool>("readDB");
+  descriptions.add("GaussEvtVtxGenerator", desc);
 }


### PR DESCRIPTION
#### PR description:
Following the inclusion of the `SimBeamSpotObject` tags in all Run-1/2/3 MC GTs in #43197, this PR aims at modifying the corresponding MC workflows to actually consume it.
This has several advantages:
 - makes obsolete the need to build a new release each time a new vertex smearing scenario is introduced (more than twice per year), easing operations for both ORP and PPD
 - this should also ease operations for PdmV by removing the need of updating the `--beamspot` cmsdriver argument for each different campaign (MC production and relvals)

Following the conservation law, of course the burden is now completely moved onto @cms-sw/alca-l2 and BeamSpot experts! 😉

Two new VtxSmearingParameters configs are defined:
 - `IOMC.EventVertexGenerators.VtxSmearedDesign_cfi` which uses the GaussEvtVtxGenerator
 - `IOMC.EventVertexGenerators.VtxSmearedRealistic_cfi` which uses the BetafuncEvtVtxGenerator
 - both are reading the configurable parameters from the DB

The new configs are used in `Configuration/StandardSequences/python/VtxSmeared.py` by defining two new keys:
 - `DBdesign` for the MC productions in ideal conditions (GaussSmearing)
 - `DBrealistic` for the MC production in realistic conditions (BetafuncSmearing)

#### PR validation:
Successfully tested wf `12434.0` which shows as (updated) step1 driver:
```
cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 \
  --conditions auto:phase1_2023_realistic \
  --beamspot DBrealistic \
  --datatier GEN-SIM --eventcontent FEVTDEBUG \
  --geometry DB:Extended --era Run3_2023 --relval 9000,100 
```
Given the `SimBeamSpot` tags introduced in the GTs mimic exactly the previously used parameters, we don't expect any difference in the test comparisons. 

#### Backport:
Not a backport, but a 13_3_X backport will be provided.
