### PR TITLE
[13_3_0] SIM: fixed ZDC simulation

### DIFF
--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -37,7 +37,8 @@ private:
 
   const G4VPhysicalVolume* tracker{nullptr};
   const G4VPhysicalVolume* calo{nullptr};
-  const CMSSteppingVerbose* steppingVerbose;
+  const CMSSteppingVerbose* steppingVerbose{nullptr};
+  const G4LogicalVolume* m_CMStoZDC{nullptr};
   double theCriticalEnergyForVacuum;
   double theCriticalDensity;
   double maxTrackTime;
@@ -66,7 +67,7 @@ private:
 
 inline bool SteppingAction::isInsideDeadRegion(const G4Region* reg) const {
   bool res = false;
-  for (auto& region : deadRegions) {
+  for (auto const& region : deadRegions) {
     if (reg == region) {
       res = true;
       break;


### PR DESCRIPTION
#### PR description:
This is a backport of #43243 .

CMS simulation use to kill all particles, which left central detector in area beyond some distance. The fix means that neutrons, anti-neutrons, and gamma are not killed outside central detector, when travel in the volume "CMStoZDC".

#### PR validation:
private

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: this is a backport to 13_3_0, if ZDC simulation is required for early releases it should be also backported. 

