### PR TITLE
Remove catch clause for TH1.Fit() in Alignment/OfflineValidation/plugins/TrackerOfflineValidation{Summary}.cc

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -2020,28 +2020,26 @@ std::pair<float, float> TrackerOfflineValidation::fitResiduals(TH1* hist) const 
   float mean = hist->GetMean();
   float sigma = hist->GetRMS();
 
-  try {  // for < CMSSW_2_2_0 since ROOT warnings from fit are converted to exceptions
-    // Remove the try/catch for more recent CMSSW!
-    // first fit: two RMS around mean
-    TF1 func("tmp", "gaus", mean - 2. * sigma, mean + 2. * sigma);
-    if (0 == hist->Fit(&func, "QNR")) {  // N: do not blow up file by storing fit!
-      mean = func.GetParameter(1);
-      sigma = func.GetParameter(2);
-      // second fit: three sigma of first fit around mean of first fit
-      func.SetRange(mean - 3. * sigma, mean + 3. * sigma);
-      // I: integral gives more correct results if binning is too wide
-      // L: Likelihood can treat empty bins correctly (if hist not weighted...)
-      if (0 == hist->Fit(&func, "Q0LR")) {
-        if (hist->GetFunction(func.GetName())) {  // Take care that it is later on drawn:
-          hist->GetFunction(func.GetName())->ResetBit(TF1::kNotDraw);
-        }
-        fitResult.first = func.GetParameter(1);
-        fitResult.second = func.GetParameter(2);
+  // Remove the try/catch for more recent CMSSW!
+  // first fit: two RMS around mean
+  TF1 func("tmp", "gaus", mean - 2. * sigma, mean + 2. * sigma);
+  if (0 == hist->Fit(&func, "QNR")) {  // N: do not blow up file by storing fit!
+    mean = func.GetParameter(1);
+    sigma = func.GetParameter(2);
+    // second fit: three sigma of first fit around mean of first fit
+    func.SetRange(mean - 3. * sigma, mean + 3. * sigma);
+    // I: integral gives more correct results if binning is too wide
+    // L: Likelihood can treat empty bins correctly (if hist not weighted...)
+    if (0 == hist->Fit(&func, "Q0LR")) {
+      if (hist->GetFunction(func.GetName())) {  // Take care that it is later on drawn:
+        hist->GetFunction(func.GetName())->ResetBit(TF1::kNotDraw);
       }
+      fitResult.first = func.GetParameter(1);
+      fitResult.second = func.GetParameter(2);
     }
-  } catch (cms::Exception const& e) {
+  } else {
     edm::LogWarning("Alignment") << "@SUB=TrackerOfflineValidation::fitResiduals"
-                                 << "Caught this exception during ROOT fit: " << e.what();
+                                 << "fit performed not successfully.";
   }
   return fitResult;
 }


### PR DESCRIPTION
#### PR description:

Part of code cleaning campaign [slides](https://drive.google.com/file/d/1NupHuyuWHc2G6B70IKW2A30zeJ-lsOkA/view?usp=sharing) regarding the edm exception use guideline https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEdmExceptionUse . As commented in the original source, TH1.Fit() does not emit warning with exceptions, the catch clause is then of no use. Code modified to prompt for the fitting result.

#### PR validation:
Local tested with scram build code-checks and code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
