### PR TITLE
Add CaloIdL_MW seeded filter and split the legs of CaloIdL_TrackIdL_IsoVL filter on nanoAOD filterBits

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -63,7 +63,8 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEle*WPTight*TrackIsoFilter*')","1e (WPTight)"),
                 mksel("filter('hltEle*WPLoose*TrackIsoFilter')","1e (WPLoose)"),
                 mksel("filter('*OverlapFilter*IsoEle*PFTau*')","OverlapFilter PFTau"),
-                mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVL*Filter')","2e"),
+                mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg1Filter')","2e (Leg 1)"),
+                mksel("filter('hltEle*Ele*CaloIdLTrackIdLIsoVLTrackIsoLeg2Filter')","2e (Leg 2)"),
                 mksel("filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*')","1e-1mu"),
                 mksel("filter('hlt*OverlapFilterIsoEle*PFTau*')","1e-1tau"),
                 mksel("filter('hltEle*Ele*Ele*CaloIdLTrackIdLDphiLeg*Filter')","3e"),
@@ -73,6 +74,7 @@ triggerObjectTable = triggerObjectTableProducer.clone(
                 mksel("filter('hltEle*CaloIdVTGsfTrkIdTGsfDphiFilter')","1e (CaloIdVT_GsfTrkIdT)"),
                 mksel("path('HLT_Ele*PFJet*')","1e (PFJet)"),
                 mksel(["hltEG175HEFilter","hltEG200HEFilter"],"1e (Photon175_OR_Photon200)"),
+                mksel("filter('hltEle*CaloIdLMWPMS2Filter')","2e (CaloIdL_MW seeded)"),
                 mksel("filter('hltDiEle*CaloIdLMWPMS2UnseededFilter')","2e (CaloIdL_MW unseeded)")
                 )
         ),


### PR DESCRIPTION
#### PR description:

In https://github.com/cms-sw/cmssw/pull/41827, @RSalvatico added the `CaloIdL_MW` unseeded leg filter to nanoAOD filterBits.
In this PR, we propose to also add the seeded leg filter of `CaloIdL_MW` and also remove the Leg1/Leg2 wildcard from `'hltEle*Ele*CaloIdLTrackIdLIsoVL*Filter'`.
This will make the study of double-electron triggers easier on nanoAOD since we will be able to easier tell apart the 2 legs of such triggers.
This change is technically free in terms of size, because the filterBits are already an `int32` and we're only making use of 14 of those bits for Electrons. With this PR, we'll just start making use of 16 bits and still have another 16 available.
It would be really nice if we can target NanoAODv13.


