### PR TITLE
Phase2-hgx349 Modify the material budget script to enable obtaining material budget plots for HFNose

### DIFF
--- a/Validation/Geometry/macros/MatBudgetVolume.C
+++ b/Validation/Geometry/macros/MatBudgetVolume.C
@@ -84,8 +84,20 @@ int styleLay[nlay] = {20, 20, 20, 20, 20, 21, 22, 23, 24, 25, 26, 27, 32, 34};
 int legends[nlay] = {1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 std::string title[nlay] = {
     "Beam Pipe", "", "", "", "", "Tracker", "ECAL", "HCAL", "HGCAL", "HF", "Magnet", "MUON", "Forward", "HFNose"};
-std::string names[nlay] = {
-    "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "CALOEC", "VCAL", "MGNT", "MUON", "OQUA", "HFNoseVol"};
+std::string names[nlay] = {"BEAM",
+                           "BEAM1",
+                           "BEAM2",
+                           "BEAM3",
+                           "BEAM4",
+                           "Tracker",
+                           "ECAL",
+                           "HCal",
+                           "CALOEC",
+                           "VCAL",
+                           "MGNT",
+                           "MUON",
+                           "OQUA",
+                           "HFNoseVol"};
 
 void etaPhiPlot(TString fileName, std::string plot, bool drawLeg, bool ifEta, double maxEta, std::string tag) {
   TFile *hcalFile = new TFile(fileName);

--- a/Validation/Geometry/macros/MatBudgetVolume.C
+++ b/Validation/Geometry/macros/MatBudgetVolume.C
@@ -75,17 +75,17 @@ void etaPhiPlotComp4(std::string filePreFix = "files/matbdgRun3",
                      bool debug = false);
 void setStyle();
 
-const int nlay = 13;
-const int ngrp = 9;
-int nlayers[ngrp] = {5, 1, 1, 1, 1, 1, 1, 1, 1};
-int nflayer[ngrp] = {0, 5, 6, 7, 8, 9, 10, 11, 12};
-int colorLay[nlay] = {2, 2, 2, 2, 2, 3, 5, 4, 8, 6, 3, 7, 1};
-int styleLay[nlay] = {20, 20, 20, 20, 20, 21, 22, 23, 24, 25, 26, 27, 30};
-int legends[nlay] = {1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1};
+const int nlay = 14;
+const int ngrp = 10;
+int nlayers[ngrp] = {5, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+int nflayer[ngrp] = {0, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+int colorLay[nlay] = {2, 2, 2, 2, 2, 3, 5, 4, 1, 6, 3, 7, 22, 46};
+int styleLay[nlay] = {20, 20, 20, 20, 20, 21, 22, 23, 24, 25, 26, 27, 32, 34};
+int legends[nlay] = {1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 std::string title[nlay] = {
-    "Beam Pipe", "", "", "", "", "Tracker", "ECAL", "HCAL", "HGCAL", "HF", "Magnet", "MUON", "Forward"};
+    "Beam Pipe", "", "", "", "", "Tracker", "ECAL", "HCAL", "HGCAL", "HF", "Magnet", "MUON", "Forward", "HFNose"};
 std::string names[nlay] = {
-    "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "CALOEC", "VCAL", "MGNT", "MUON", "OQUA"};
+    "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "CALOEC", "VCAL", "MGNT", "MUON", "OQUA", "HFNoseVol"};
 
 void etaPhiPlot(TString fileName, std::string plot, bool drawLeg, bool ifEta, double maxEta, std::string tag) {
   TFile *hcalFile = new TFile(fileName);

--- a/Validation/Geometry/python/materialBudgetVolume_cfi.py
+++ b/Validation/Geometry/python/materialBudgetVolume_cfi.py
@@ -3,9 +3,11 @@ from SimG4Core.Configuration.SimG4Core_cff import *
 
 g4SimHits.Watchers = cms.VPSet(cms.PSet(
     MaterialBudgetVolume = cms.PSet(
-        lvNames = cms.vstring('BEAM', 'BEAM1', 'BEAM2', 'BEAM3', 'BEAM4', 'Tracker', 'ECAL', 'HCal', 'VCAL', 'MGNT', 'MUON', 'OQUA', 'CALOEC'),
-        lvLevels = cms.vint32(3, 3, 3, 3, 3, 3, 4, 4, 3, 4, 3, 3, 4),
+        lvNames = cms.vstring('BEAM', 'BEAM1', 'BEAM2', 'BEAM3', 'BEAM4', 'Tracker', 'ECAL', 'HCal', 'VCAL', 'MGNT', 'MUON', 'OQUA', 'CALOEC', 'HFNoseVol'),
+        lvLevels = cms.vint32(3, 3, 3, 3, 3, 3, 4, 4, 3, 4, 3, 3, 4, 3),
         useDD4hep = cms.bool(False),
+        rMax = cms.double(-1.),
+        zMax = cms.double(-1.),
     ),
     type = cms.string('MaterialBudgetVolume'),
 ))

--- a/Validation/Geometry/src/MaterialBudgetVolume.cc
+++ b/Validation/Geometry/src/MaterialBudgetVolume.cc
@@ -63,11 +63,13 @@ private:
   void endOfEvent(edm::MaterialInformationContainer& matbg);
   bool loadLV();
   int findLV(const G4VTouchable*);
+  bool stopAfter(const G4Step*);
 
 private:
   std::vector<std::string> lvNames_;
   std::vector<int> lvLevel_;
   int iaddLevel_;
+  double rMax_, zMax_;
   bool init_;
   std::map<int, std::pair<G4LogicalVolume*, int> > mapLV_;
   std::vector<MatInfo> lengths_;
@@ -80,9 +82,11 @@ MaterialBudgetVolume::MaterialBudgetVolume(const edm::ParameterSet& p) : init_(f
   lvNames_ = m_p.getParameter<std::vector<std::string> >("lvNames");
   lvLevel_ = m_p.getParameter<std::vector<int> >("lvLevels");
   iaddLevel_ = (m_p.getParameter<bool>("useDD4hep")) ? 1 : 0;
+  rMax_ = m_p.getParameter<double>("rMax") * CLHEP::m;
+  zMax_ = m_p.getParameter<double>("zMax") * CLHEP::m;
 
   edm::LogVerbatim("MaterialBudget") << "MaterialBudgetVolume: Studies Material budget for " << lvNames_.size()
-                                     << " volumes with addLevel " << iaddLevel_;
+                                     << " volumes with addLevel " << iaddLevel_ << " and with rMax " << rMax_ << " mm; zMax " << zMax_ << " mm";
   std::ostringstream st1;
   for (unsigned int k = 0; k < lvNames_.size(); ++k)
     st1 << " [" << k << "] " << lvNames_[k] << " at " << lvLevel_[k];
@@ -151,6 +155,12 @@ void MaterialBudgetVolume::update(const G4Step* aStep) {
                                      << touch->GetVolume(0)->GetLogicalVolume()->GetName() << " Index " << index
                                      << " Step " << step << " RadL " << step / radl << " IntL " << step / intl;
 #endif
+
+  //----- Stop tracking after selected position
+  if (stopAfter(aStep)) {
+    G4Track* track = aStep->GetTrack();
+    track->SetTrackStatus(fStopAndKill);
+  }
 }
 
 void MaterialBudgetVolume::update(const EndOfTrack* trk) {
@@ -240,6 +250,23 @@ int MaterialBudgetVolume::findLV(const G4VTouchable* touch) {
   }
 #endif
   return level;
+}
+
+bool MaterialBudgetVolume::stopAfter(const G4Step* aStep) {
+  bool flag(false);
+  if ((rMax_ > 0.0) && (zMax_ > 0.0)) {
+    G4ThreeVector hitPoint = aStep->GetPreStepPoint()->GetPosition();
+    double rr = hitPoint.perp();
+    double zz = std::abs(hitPoint.z());
+
+    if (rr > rMax_ || zz > zMax_) {
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("MaterialBudget") << " MaterialBudgetHcal::StopAfter R = " << rr << " and Z = " << zz;
+#endif
+      flag = true;
+    }
+  }
+  return flag;
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/Geometry/src/MaterialBudgetVolume.cc
+++ b/Validation/Geometry/src/MaterialBudgetVolume.cc
@@ -86,7 +86,8 @@ MaterialBudgetVolume::MaterialBudgetVolume(const edm::ParameterSet& p) : init_(f
   zMax_ = m_p.getParameter<double>("zMax") * CLHEP::m;
 
   edm::LogVerbatim("MaterialBudget") << "MaterialBudgetVolume: Studies Material budget for " << lvNames_.size()
-                                     << " volumes with addLevel " << iaddLevel_ << " and with rMax " << rMax_ << " mm; zMax " << zMax_ << " mm";
+                                     << " volumes with addLevel " << iaddLevel_ << " and with rMax " << rMax_
+                                     << " mm; zMax " << zMax_ << " mm";
   std::ostringstream st1;
   for (unsigned int k = 0; k < lvNames_.size(); ++k)
     st1 << " [" << k << "] " << lvNames_[k] << " at " << lvLevel_[k];

--- a/Validation/Geometry/src/MaterialBudgetVolumeAnalysis.cc
+++ b/Validation/Geometry/src/MaterialBudgetVolumeAnalysis.cc
@@ -70,8 +70,20 @@ MaterialBudgetVolumeAnalysis::MaterialBudgetVolumeAnalysis(const edm::ParameterS
 
 void MaterialBudgetVolumeAnalysis::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  std::vector<std::string> names = {
-    "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "MUON", "VCAL", "MGNT", "OQUA", "CALOEC", "HFNoseVol"};
+  std::vector<std::string> names = {"BEAM",
+                                    "BEAM1",
+                                    "BEAM2",
+                                    "BEAM3",
+                                    "BEAM4",
+                                    "Tracker",
+                                    "ECAL",
+                                    "HCal",
+                                    "MUON",
+                                    "VCAL",
+                                    "MGNT",
+                                    "OQUA",
+                                    "CALOEC",
+                                    "HFNoseVol"};
   desc.add<std::vector<std::string> >("names", names);
   desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "MaterialInformation"));
   desc.add<int>("nBinEta", 300);

--- a/Validation/Geometry/src/MaterialBudgetVolumeAnalysis.cc
+++ b/Validation/Geometry/src/MaterialBudgetVolumeAnalysis.cc
@@ -71,7 +71,7 @@ MaterialBudgetVolumeAnalysis::MaterialBudgetVolumeAnalysis(const edm::ParameterS
 void MaterialBudgetVolumeAnalysis::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   std::vector<std::string> names = {
-      "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "MUON", "VCAL", "MGNT", "OQUA", "CALOEC"};
+    "BEAM", "BEAM1", "BEAM2", "BEAM3", "BEAM4", "Tracker", "ECAL", "HCal", "MUON", "VCAL", "MGNT", "OQUA", "CALOEC", "HFNoseVol"};
   desc.add<std::vector<std::string> >("names", names);
   desc.add<edm::InputTag>("inputTag", edm::InputTag("g4SimHits", "MaterialInformation"));
   desc.add<int>("nBinEta", 300);

--- a/Validation/Geometry/test/runMaterialBudgetHFNose_cfg.py
+++ b/Validation/Geometry/test/runMaterialBudgetHFNose_cfg.py
@@ -1,9 +1,10 @@
 ###############################################################################
 # Way to use this:
-#   cmsRun runMaterialBudgetVolume2026DDD_cfg.py geometry=D92
+#   cmsRun runMaterialBudgetHFNose_cfg.py geometry=D94 type=DD4hep pos=Start
 #
-#   Options for geometry D86, D88, D91, D92, D93, D94, D95, D96, D97, D98,
-#                        D99, D100, D101, D102, D103
+#   Options for geometry D92, D94
+#   Options for type DD4hep, DDD
+#   Options for pos Start, End
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
@@ -14,10 +15,20 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 ### SETUP OPTIONS
 options = VarParsing.VarParsing('standard')
 options.register('geometry',
-                 "D88",
+                 "D94",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D86, D88, D91, D92, D93, D94, D95, D96, D97, D98, D99, D100, D101, D102, D103")
+                  "geometry of operations: D92, D94")
+options.register('type',
+                 "DDD",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "type of operations: DDD, DD4hep")
+options.register('pos',
+                 "Start",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "type of operations: Start, End")
 ### get and parse the command line arguments
 options.parseArguments()
 
@@ -27,23 +38,51 @@ print(options)
 # Use the options
 
 if (options.geometry == "D94"):
+    nose = 1
+else:
+    nose = 0
+
+if (options.type == "DD4hep"):
+    flag = "DD4hep"
+    ddFlag = True
+else:
+    flag = ""
+    ddFlag = False
+
+if (options.pos == "End"):
+    zMax = 10.560
+    tag = "End"
+else:
+    zMax = 9.6072
+    tag = "Front"
+
+from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+if (nose == 1):
     from Configuration.Eras.Era_Phase2C20I13M9_cff import Phase2C20I13M9
-    process = cms.Process('MaterialBudgetVolume',Phase2C20I13M9)
+    if (ddFlag == True):
+        process = cms.Process('MaterialBudgetVolume',Phase2C20I13M9,dd4hep)
+    else:
+        process = cms.Process('MaterialBudgetVolume',Phase2C20I13M9)
 else:
     from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
-    process = cms.Process('MaterialBudgetVolume',Phase2C17I13M9)
+    if (ddFlag == True):
+        process = cms.Process('MaterialBudgetVolume',Phase2C17I13M9,dd4hep)
+    else:
+        process = cms.Process('MaterialBudgetVolume',Phase2C17I13M9)
 
-geomFile = "Configuration.Geometry.GeometryExtended2026" + options.geometry + "Reco_cff"
-fileName = "matbdg" + options.geometry + "DDD" + ".root"
+geomFile = "Configuration.Geometry.Geometry" + flag + "Extended2026" + options.geometry + "Reco_cff"
+fileName = "matbdgHFNose" + flag + options.geometry + tag + ".root"
 
 print("Geometry file Name: ", geomFile)
 print("Root file Name:     ", fileName)
+print("nose Flag:          ", nose)
+print("ddFlag Flag:        ", ddFlag)
+print("zMax (m):           ", zMax)
 
 process.load(geomFile)
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("SimG4Core.Application.g4SimHits_cfi")
-process.load("Validation.Geometry.materialBudgetVolume_cfi")
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
@@ -72,6 +111,16 @@ process.g4SimHits.Physics.type = 'SimG4Core/Physics/DummyPhysics'
 process.g4SimHits.StackingAction.TrackNeutrino = True
 process.g4SimHits.Physics.DummyEMPhysics = True
 process.g4SimHits.Physics.CutsPerRegion = False
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    MaterialBudgetVolume = cms.PSet(
+        lvNames = cms.vstring('BEAM', 'BEAM1', 'BEAM2', 'BEAM3', 'BEAM4', 'Tracker', 'ECAL', 'HCal', 'VCAL', 'MGNT', 'MUON', 'OQUA', 'CALOEC', 'HFNoseVol'),
+        lvLevels = cms.vint32(3, 3, 3, 3, 3, 3, 4, 4, 3, 4, 3, 3, 4, 3),
+        useDD4hep = cms.bool(ddFlag),
+        rMax = cms.double(1.8),
+        zMax = cms.double(zMax),
+    ),
+    type = cms.string('MaterialBudgetVolume'),
+))
 
 process.load("Validation.Geometry.materialBudgetVolumeAnalysis_cfi")
 process.p1 = cms.Path(process.g4SimHits+process.materialBudgetVolumeAnalysis)

--- a/Validation/Geometry/test/runMaterialBudgetVolume2026DD4hep_cfg.py
+++ b/Validation/Geometry/test/runMaterialBudgetVolume2026DD4hep_cfg.py
@@ -3,11 +3,11 @@
 #   cmsRun runMaterialBudgetVolume2026DD4hep_cfg.py geometry=D92
 #
 #   Options for geometry D86, D88, D91, D92, D93, D94, D95, D96, D97, D98,
-#                        D99, D100, D101
+#                        D99, D100, D101, D102, D103
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, importlib, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################
@@ -17,7 +17,7 @@ options.register('geometry',
                  "D88",
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
-                  "geometry of operations: D86, D88, D91, D92, D93, D94, D95, D96, D97, D98, D99, D100, D101")
+                  "geometry of operations: D86, D88, D91, D92, D93, D94, D95, D96, D97, D98, D99, D100, D101, D102, D103")
 ### get and parse the command line arguments
 options.parseArguments()
 

--- a/Validation/Geometry/test/runMaterialBudgetVolumeDB_cfg.py
+++ b/Validation/Geometry/test/runMaterialBudgetVolumeDB_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, importlib, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################

--- a/Validation/Geometry/test/runMaterialBudgetVolumeXML_cfg.py
+++ b/Validation/Geometry/test/runMaterialBudgetVolumeXML_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, importlib, re
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################


### PR DESCRIPTION
#### PR description:

Modify the material budget script to obtain material budget plots for HFNose (scanning till the beginning and the end of the HFNose)

#### PR validation:

Obtained the plots with the 2026D94 scenario before and after HFNose 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special