### PR TITLE
Phase2-hgx349A Correct DDHGCalMixRotatedCassette code by eliminating an unwanted statement in the DDD and Dd4hep versions

### DIFF
--- a/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalMixRotatedCassette.cc
@@ -595,7 +595,6 @@ void DDHGCalMixRotatedCassette::positionMix(const DDLogicalPart& glog,
 #endif
     }
     ++copyNumberCoverTop_;
-    zpos += hthickl;
   }
 
   // Make the bottom part next

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedCassette.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalMixRotatedCassette.cc
@@ -528,7 +528,6 @@ struct HGCalMixRotatedCassette {
 #endif
       }
       ++copyNumberCoverTop_;
-      zpos += hthickl;
     }
 
     // Make the bottom part next


### PR DESCRIPTION
#### PR description:

Correct DDHGCalMixRotatedCassette code by eliminating an unwanted statement in the DDD and Dd4hep versions

#### PR validation:

Checked with the overlap testing code

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special