### PR TITLE
MTD validation: add plugin to monitor impact of MTD on electron isolation

### DIFF
--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -9,8 +9,9 @@ from Validation.MtdValidation.etlSimHitsValid_cfi import etlSimHitsValid
 from Validation.MtdValidation.etlDigiHitsValid_cfi import etlDigiHitsValid
 from Validation.MtdValidation.mtdTracksValid_cfi import mtdTracksValid
 from Validation.MtdValidation.vertices4DValid_cfi import vertices4DValid
+from Validation.MtdValidation.mtdEleIsoValid_cfi import mtdEleIsoValid
 
 mtdSimValid  = cms.Sequence(btlSimHitsValid  + etlSimHitsValid )
 mtdDigiValid = cms.Sequence(btlDigiHitsValid + etlDigiHitsValid)
-mtdRecoValid = cms.Sequence(btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid)
+mtdRecoValid = cms.Sequence(btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid + mtdEleIsoValid)
 

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -29,3 +29,4 @@
 <use name="root"/>
 <use name="gsl"/>
 <flags EDM_PLUGIN="1"/>
+

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -29,4 +29,3 @@
 <use name="root"/>
 <use name="gsl"/>
 <flags EDM_PLUGIN="1"/>
-

--- a/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
@@ -1,0 +1,1985 @@
+#include <string>
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+
+class MtdEleIsoHarvester : public DQMEDHarvester {
+public:
+  explicit MtdEleIsoHarvester(const edm::ParameterSet& iConfig);
+  ~MtdEleIsoHarvester() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
+
+private:
+  void computeEfficiency1D(MonitorElement* num, MonitorElement* den, MonitorElement* result);
+
+  const std::string folder_;
+
+  // --- Histograms
+  MonitorElement* mePtEffnoMTD_Sig_EB_;
+  MonitorElement* meEtaEffnoMTD_Sig_EB_;
+  MonitorElement* mePhiEffnoMTD_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_1_Sig_EB_;
+  MonitorElement* meEtaEffMTD_1_Sig_EB_;
+  MonitorElement* mePhiEffMTD_1_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_2_Sig_EB_;
+  MonitorElement* meEtaEffMTD_2_Sig_EB_;
+  MonitorElement* mePhiEffMTD_2_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_3_Sig_EB_;
+  MonitorElement* meEtaEffMTD_3_Sig_EB_;
+  MonitorElement* mePhiEffMTD_3_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_4_Sig_EB_;
+  MonitorElement* meEtaEffMTD_4_Sig_EB_;
+  MonitorElement* mePhiEffMTD_4_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_5_Sig_EB_;
+  MonitorElement* meEtaEffMTD_5_Sig_EB_;
+  MonitorElement* mePhiEffMTD_5_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_6_Sig_EB_;
+  MonitorElement* meEtaEffMTD_6_Sig_EB_;
+  MonitorElement* mePhiEffMTD_6_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_7_Sig_EB_;
+  MonitorElement* meEtaEffMTD_7_Sig_EB_;
+  MonitorElement* mePhiEffMTD_7_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_sim_1_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_2_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_3_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_4_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_5_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_6_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_7_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_sim_4sigma_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_3sigma_Sig_EB_;
+  MonitorElement* mePtEffMTD_sim_2sigma_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_4sigma_Sig_EB_;
+  // MonitorElement* meEtaEffMTD_4sigma_Sig_EB_;
+  // MonitorElement* mePhiEffMTD_4sigma_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_3sigma_Sig_EB_;
+  // MonitorElement* meEtaEffMTD_3sigma_Sig_EB_;
+  // MonitorElement* mePhiEffMTD_3sigma_Sig_EB_;
+
+  MonitorElement* mePtEffMTD_2sigma_Sig_EB_;
+  // MonitorElement* meEtaEffMTD_2sigma_Sig_EB_;
+  // MonitorElement* mePhiEffMTD_2sigma_Sig_EB_;
+
+  MonitorElement* mePtEffnoMTD_Sig_EE_;
+  MonitorElement* meEtaEffnoMTD_Sig_EE_;
+  MonitorElement* mePhiEffnoMTD_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_1_Sig_EE_;
+  MonitorElement* meEtaEffMTD_1_Sig_EE_;
+  MonitorElement* mePhiEffMTD_1_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_2_Sig_EE_;
+  MonitorElement* meEtaEffMTD_2_Sig_EE_;
+  MonitorElement* mePhiEffMTD_2_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_3_Sig_EE_;
+  MonitorElement* meEtaEffMTD_3_Sig_EE_;
+  MonitorElement* mePhiEffMTD_3_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_4_Sig_EE_;
+  MonitorElement* meEtaEffMTD_4_Sig_EE_;
+  MonitorElement* mePhiEffMTD_4_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_5_Sig_EE_;
+  MonitorElement* meEtaEffMTD_5_Sig_EE_;
+  MonitorElement* mePhiEffMTD_5_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_6_Sig_EE_;
+  MonitorElement* meEtaEffMTD_6_Sig_EE_;
+  MonitorElement* mePhiEffMTD_6_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_7_Sig_EE_;
+  MonitorElement* meEtaEffMTD_7_Sig_EE_;
+  MonitorElement* mePhiEffMTD_7_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_sim_1_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_2_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_3_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_4_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_5_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_6_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_7_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_sim_4sigma_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_3sigma_Sig_EE_;
+  MonitorElement* mePtEffMTD_sim_2sigma_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_4sigma_Sig_EE_;
+  // MonitorElement* meEtaEffMTD_4sigma_Sig_EE_;
+  // MonitorElement* mePhiEffMTD_4sigma_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_3sigma_Sig_EE_;
+  // MonitorElement* meEtaEffMTD_3sigma_Sig_EE_;
+  // MonitorElement* mePhiEffMTD_3sigma_Sig_EE_;
+
+  MonitorElement* mePtEffMTD_2sigma_Sig_EE_;
+  // MonitorElement* meEtaEffMTD_2sigma_Sig_EE_;
+  // MonitorElement* mePhiEffMTD_2sigma_Sig_EE_;
+
+  MonitorElement* mePtEffnoMTD_Bkg_EB_;
+  MonitorElement* meEtaEffnoMTD_Bkg_EB_;
+  MonitorElement* mePhiEffnoMTD_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_1_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_1_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_1_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_2_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_2_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_2_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_3_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_3_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_3_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_4_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_4_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_4_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_5_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_5_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_5_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_6_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_6_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_6_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_7_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_7_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_7_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_sim_1_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_2_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_3_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_4_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_5_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_6_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_7_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_sim_4sigma_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_3sigma_Bkg_EB_;
+  MonitorElement* mePtEffMTD_sim_2sigma_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_4sigma_Bkg_EB_;
+  // MonitorElement* meEtaEffMTD_4sigma_Bkg_EB_;
+  // MonitorElement* mePhiEffMTD_4sigma_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_3sigma_Bkg_EB_;
+  // MonitorElement* meEtaEffMTD_3sigma_Bkg_EB_;
+  // MonitorElement* mePhiEffMTD_3sigma_Bkg_EB_;
+
+  MonitorElement* mePtEffMTD_2sigma_Bkg_EB_;
+  // MonitorElement* meEtaEffMTD_2sigma_Bkg_EB_;
+  // MonitorElement* mePhiEffMTD_2sigma_Bkg_EB_;
+
+  MonitorElement* mePtEffnoMTD_Bkg_EE_;
+  MonitorElement* meEtaEffnoMTD_Bkg_EE_;
+  MonitorElement* mePhiEffnoMTD_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_1_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_1_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_1_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_2_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_2_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_2_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_3_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_3_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_3_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_4_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_4_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_4_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_5_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_5_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_5_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_6_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_6_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_6_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_7_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_7_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_7_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_sim_1_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_2_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_3_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_4_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_5_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_6_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_7_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_sim_4sigma_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_3sigma_Bkg_EE_;
+  MonitorElement* mePtEffMTD_sim_2sigma_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_4sigma_Bkg_EE_;
+  // MonitorElement* meEtaEffMTD_4sigma_Bkg_EE_;
+  // MonitorElement* mePhiEffMTD_4sigma_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_3sigma_Bkg_EE_;
+  // MonitorElement* meEtaEffMTD_3sigma_Bkg_EE_;
+  // MonitorElement* mePhiEffMTD_3sigma_Bkg_EE_;
+
+  MonitorElement* mePtEffMTD_2sigma_Bkg_EE_;
+  // MonitorElement* meEtaEffMTD_2sigma_Bkg_EE_;
+  // MonitorElement* mePhiEffMTD_2sigma_Bkg_EE_;
+};
+
+// ------------ constructor and destructor --------------
+MtdEleIsoHarvester::MtdEleIsoHarvester(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")) {}
+
+MtdEleIsoHarvester::~MtdEleIsoHarvester() {}
+
+// auxiliary method to compute efficiency from the ratio of two 1D MonitorElement
+void MtdEleIsoHarvester::computeEfficiency1D(MonitorElement* num, MonitorElement* den, MonitorElement* result) {
+  for (int ibin = 1; ibin <= den->getNbinsX(); ibin++) {
+    double eff = num->getBinContent(ibin) / den->getBinContent(ibin);
+    double bin_err = sqrt((num->getBinContent(ibin) * (den->getBinContent(ibin) - num->getBinContent(ibin))) /
+                          pow(den->getBinContent(ibin), 3));
+    if (den->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    result->setBinContent(ibin, eff);
+    result->setBinError(ibin, bin_err);
+  }
+}
+
+// ------------ endjob tasks ----------------------------
+void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
+  // --- Get the monitoring histograms
+
+  // For promt (signal)
+  MonitorElement* meEle_pt_tot_Sig_EB_ = igetter.get(folder_ + "Ele_pT_tot_Sig_EB");
+  MonitorElement* meEle_pt_sim_tot_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_tot_Sig_EB");
+  MonitorElement* meEle_pt_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_pT_noMTD_Sig_EB");
+
+  MonitorElement* meEle_eta_tot_Sig_EB_ = igetter.get(folder_ + "Ele_eta_tot_Sig_EB");
+  MonitorElement* meEle_eta_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_eta_noMTD_Sig_EB");
+
+  MonitorElement* meEle_phi_tot_Sig_EB_ = igetter.get(folder_ + "Ele_phi_tot_Sig_EB");
+  MonitorElement* meEle_phi_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_phi_noMTD_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_1_Sig_EB");
+  MonitorElement* meEle_eta_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_1_Sig_EB");
+  MonitorElement* meEle_phi_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_1_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_2_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2_Sig_EB");
+  MonitorElement* meEle_eta_MTD_2_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2_Sig_EB");
+  MonitorElement* meEle_phi_MTD_2_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_3_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3_Sig_EB");
+  MonitorElement* meEle_eta_MTD_3_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3_Sig_EB");
+  MonitorElement* meEle_phi_MTD_3_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_4_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4_Sig_EB");
+  MonitorElement* meEle_eta_MTD_4_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4_Sig_EB");
+  MonitorElement* meEle_phi_MTD_4_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_5_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_5_Sig_EB");
+  MonitorElement* meEle_eta_MTD_5_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_5_Sig_EB");
+  MonitorElement* meEle_phi_MTD_5_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_5_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_6_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_6_Sig_EB");
+  MonitorElement* meEle_eta_MTD_6_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_6_Sig_EB");
+  MonitorElement* meEle_phi_MTD_6_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_6_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_7_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_7_Sig_EB");
+  MonitorElement* meEle_eta_MTD_7_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_7_Sig_EB");
+  MonitorElement* meEle_phi_MTD_7_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_7_Sig_EB");
+
+  MonitorElement* meEle_pt_sim_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_1_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_2_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_3_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_4_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_5_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_5_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_6_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_6_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_7_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_7_Sig_EB");
+
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2sigma_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3sigma_Sig_EB");
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Sig_EB");
+  // MonitorElement* meEle_eta_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EB");
+  // MonitorElement* meEle_phi_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Sig_EB");
+  // MonitorElement* meEle_eta_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EB");
+  // MonitorElement* meEle_phi_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EB");
+
+  MonitorElement* meEle_pt_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Sig_EB");
+  // MonitorElement* meEle_eta_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EB");
+  // MonitorElement* meEle_phi_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EB");
+
+  MonitorElement* meEle_pt_tot_Sig_EE_ = igetter.get(folder_ + "Ele_pT_tot_Sig_EE");
+  MonitorElement* meEle_pt_sim_tot_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_tot_Sig_EE");
+  MonitorElement* meEle_pt_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_pT_noMTD_Sig_EE");
+
+  MonitorElement* meEle_eta_tot_Sig_EE_ = igetter.get(folder_ + "Ele_eta_tot_Sig_EE");
+  MonitorElement* meEle_eta_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_eta_noMTD_Sig_EE");
+
+  MonitorElement* meEle_phi_tot_Sig_EE_ = igetter.get(folder_ + "Ele_phi_tot_Sig_EE");
+  MonitorElement* meEle_phi_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_phi_noMTD_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_1_Sig_EE");
+  MonitorElement* meEle_eta_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_1_Sig_EE");
+  MonitorElement* meEle_phi_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_1_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_2_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2_Sig_EE");
+  MonitorElement* meEle_eta_MTD_2_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2_Sig_EE");
+  MonitorElement* meEle_phi_MTD_2_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_3_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3_Sig_EE");
+  MonitorElement* meEle_eta_MTD_3_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3_Sig_EE");
+  MonitorElement* meEle_phi_MTD_3_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_4_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4_Sig_EE");
+  MonitorElement* meEle_eta_MTD_4_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4_Sig_EE");
+  MonitorElement* meEle_phi_MTD_4_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_5_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_5_Sig_EE");
+  MonitorElement* meEle_eta_MTD_5_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_5_Sig_EE");
+  MonitorElement* meEle_phi_MTD_5_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_5_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_6_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_6_Sig_EE");
+  MonitorElement* meEle_eta_MTD_6_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_6_Sig_EE");
+  MonitorElement* meEle_phi_MTD_6_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_6_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_7_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_7_Sig_EE");
+  MonitorElement* meEle_eta_MTD_7_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_7_Sig_EE");
+  MonitorElement* meEle_phi_MTD_7_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_7_Sig_EE");
+
+  MonitorElement* meEle_pt_sim_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_1_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_2_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_3_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_4_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_5_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_5_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_6_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_6_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_7_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_7_Sig_EE");
+
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2sigma_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3sigma_Sig_EE");
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Sig_EE");
+  // MonitorElement* meEle_eta_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EE");
+  // MonitorElement* meEle_phi_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Sig_EE");
+  // MonitorElement* meEle_eta_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EE");
+  // MonitorElement* meEle_phi_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EE");
+
+  MonitorElement* meEle_pt_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Sig_EE");
+  // MonitorElement* meEle_eta_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EE");
+  // MonitorElement* meEle_phi_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EE");
+
+  // for non-promt (background)
+  MonitorElement* meEle_pt_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_tot_Bkg_EB");
+  MonitorElement* meEle_pt_sim_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_tot_Bkg_EB");
+  MonitorElement* meEle_pt_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_noMTD_Bkg_EB");
+
+  MonitorElement* meEle_eta_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_tot_Bkg_EB");
+  MonitorElement* meEle_eta_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_noMTD_Bkg_EB");
+
+  MonitorElement* meEle_phi_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_tot_Bkg_EB");
+  MonitorElement* meEle_phi_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_noMTD_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_1_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_1_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_1_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_2_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_2_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_2_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_3_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_3_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_3_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_4_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_4_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_4_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_5_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_5_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_5_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_5_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_5_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_5_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_6_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_6_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_6_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_6_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_6_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_6_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_7_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_7_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_7_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_7_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_7_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_7_Bkg_EB");
+
+  MonitorElement* meEle_pt_sim_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_1_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_2_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_3_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_4_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_5_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_5_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_6_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_6_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_7_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_7_Bkg_EB");
+
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2sigma_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3sigma_Bkg_EB");
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Bkg_EB");
+  // MonitorElement* meEle_eta_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EB");
+  // MonitorElement* meEle_phi_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Bkg_EB");
+  // MonitorElement* meEle_eta_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EB");
+  // MonitorElement* meEle_phi_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EB");
+
+  MonitorElement* meEle_pt_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Bkg_EB");
+  // MonitorElement* meEle_eta_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EB");
+  // MonitorElement* meEle_phi_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EB");
+
+  MonitorElement* meEle_pt_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_tot_Bkg_EE");
+  MonitorElement* meEle_pt_sim_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_tot_Bkg_EE");
+  MonitorElement* meEle_pt_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_noMTD_Bkg_EE");
+
+  MonitorElement* meEle_eta_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_tot_Bkg_EE");
+  MonitorElement* meEle_eta_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_noMTD_Bkg_EE");
+
+  MonitorElement* meEle_phi_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_tot_Bkg_EE");
+  MonitorElement* meEle_phi_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_noMTD_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_1_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_1_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_1_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_2_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_2_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_2_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_3_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_3_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_3_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_4_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_4_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_4_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_5_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_5_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_5_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_5_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_5_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_5_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_6_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_6_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_6_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_6_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_6_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_6_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_7_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_7_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_7_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_7_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_7_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_7_Bkg_EE");
+
+  MonitorElement* meEle_pt_sim_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_1_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_2_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_3_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_4_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_5_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_5_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_6_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_6_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_7_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_7_Bkg_EE");
+
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_2sigma_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_3sigma_Bkg_EE");
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Bkg_EE");
+  // MonitorElement* meEle_eta_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EE");
+  // MonitorElement* meEle_phi_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Bkg_EE");
+  // MonitorElement* meEle_eta_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EE");
+  // MonitorElement* meEle_phi_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EE");
+
+  MonitorElement* meEle_pt_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Bkg_EE");
+  // MonitorElement* meEle_eta_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EE");
+  // MonitorElement* meEle_phi_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EE");
+
+  if (!meEle_pt_tot_Sig_EB_ || !meEle_pt_MTD_1_Sig_EB_ || !meEle_pt_MTD_2_Sig_EB_ || !meEle_pt_MTD_3_Sig_EB_ ||
+      !meEle_pt_MTD_4_Sig_EB_ || !meEle_pt_MTD_5_Sig_EB_ || !meEle_pt_MTD_6_Sig_EB_ || !meEle_pt_MTD_7_Sig_EB_ ||
+      !meEle_pt_noMTD_Sig_EB_ || !meEle_eta_tot_Sig_EB_ || !meEle_eta_MTD_1_Sig_EB_ || !meEle_eta_MTD_2_Sig_EB_ ||
+      !meEle_eta_MTD_3_Sig_EB_ || !meEle_eta_MTD_4_Sig_EB_ || !meEle_eta_MTD_5_Sig_EB_ || !meEle_eta_MTD_6_Sig_EB_ ||
+      !meEle_eta_MTD_7_Sig_EB_ || !meEle_eta_noMTD_Sig_EB_ || !meEle_phi_tot_Sig_EB_ || !meEle_phi_MTD_1_Sig_EB_ ||
+      !meEle_phi_MTD_2_Sig_EB_ || !meEle_phi_MTD_3_Sig_EB_ || !meEle_phi_MTD_4_Sig_EB_ || !meEle_phi_MTD_5_Sig_EB_ ||
+      !meEle_phi_MTD_6_Sig_EB_ || !meEle_phi_MTD_7_Sig_EB_ || !meEle_phi_noMTD_Sig_EB_ || !meEle_pt_tot_Sig_EE_ ||
+      !meEle_pt_MTD_1_Sig_EE_ || !meEle_pt_MTD_2_Sig_EE_ || !meEle_pt_MTD_3_Sig_EE_ || !meEle_pt_MTD_4_Sig_EE_ ||
+      !meEle_pt_MTD_5_Sig_EE_ || !meEle_pt_MTD_6_Sig_EE_ || !meEle_pt_MTD_7_Sig_EE_ || !meEle_pt_noMTD_Sig_EE_ ||
+      !meEle_eta_tot_Sig_EE_ || !meEle_eta_MTD_1_Sig_EE_ || !meEle_eta_MTD_2_Sig_EE_ || !meEle_eta_MTD_3_Sig_EE_ ||
+      !meEle_eta_MTD_4_Sig_EE_ || !meEle_eta_MTD_5_Sig_EE_ || !meEle_eta_MTD_6_Sig_EE_ || !meEle_eta_MTD_7_Sig_EE_ ||
+      !meEle_eta_noMTD_Sig_EE_ || !meEle_phi_tot_Sig_EE_ || !meEle_phi_MTD_1_Sig_EE_ || !meEle_phi_MTD_2_Sig_EE_ ||
+      !meEle_phi_MTD_3_Sig_EE_ || !meEle_phi_MTD_4_Sig_EE_ || !meEle_phi_MTD_5_Sig_EE_ || !meEle_phi_MTD_6_Sig_EE_ ||
+      !meEle_phi_MTD_7_Sig_EE_ || !meEle_phi_noMTD_Sig_EE_ || !meEle_pt_tot_Bkg_EB_ || !meEle_pt_MTD_1_Bkg_EB_ ||
+      !meEle_pt_MTD_2_Bkg_EB_ || !meEle_pt_MTD_3_Bkg_EB_ || !meEle_pt_MTD_4_Bkg_EB_ || !meEle_pt_MTD_5_Bkg_EB_ ||
+      !meEle_pt_MTD_6_Bkg_EB_ || !meEle_pt_MTD_7_Bkg_EB_ || !meEle_pt_noMTD_Bkg_EB_ || !meEle_eta_tot_Bkg_EB_ ||
+      !meEle_eta_MTD_1_Bkg_EB_ || !meEle_eta_MTD_2_Bkg_EB_ || !meEle_eta_MTD_3_Bkg_EB_ || !meEle_eta_MTD_4_Bkg_EB_ ||
+      !meEle_eta_MTD_5_Bkg_EB_ || !meEle_eta_MTD_6_Bkg_EB_ || !meEle_eta_MTD_7_Bkg_EB_ || !meEle_eta_noMTD_Bkg_EB_ ||
+      !meEle_phi_tot_Bkg_EB_ || !meEle_phi_MTD_1_Bkg_EB_ || !meEle_phi_MTD_2_Bkg_EB_ || !meEle_phi_MTD_3_Bkg_EB_ ||
+      !meEle_phi_MTD_4_Bkg_EB_ || !meEle_phi_MTD_5_Bkg_EB_ || !meEle_phi_MTD_6_Bkg_EB_ || !meEle_phi_MTD_7_Bkg_EB_ ||
+      !meEle_phi_noMTD_Bkg_EB_ || !meEle_pt_tot_Bkg_EE_ || !meEle_pt_MTD_1_Bkg_EE_ || !meEle_pt_MTD_2_Bkg_EE_ ||
+      !meEle_pt_MTD_3_Bkg_EE_ || !meEle_pt_MTD_4_Bkg_EE_ || !meEle_pt_MTD_5_Bkg_EE_ || !meEle_pt_MTD_6_Bkg_EE_ ||
+      !meEle_pt_MTD_7_Bkg_EE_ || !meEle_pt_noMTD_Bkg_EE_ || !meEle_eta_tot_Bkg_EE_ || !meEle_eta_MTD_1_Bkg_EE_ ||
+      !meEle_eta_MTD_2_Bkg_EE_ || !meEle_eta_MTD_3_Bkg_EE_ || !meEle_eta_MTD_4_Bkg_EE_ || !meEle_eta_MTD_5_Bkg_EE_ ||
+      !meEle_eta_MTD_6_Bkg_EE_ || !meEle_eta_MTD_7_Bkg_EE_ || !meEle_eta_noMTD_Bkg_EE_ || !meEle_phi_tot_Bkg_EE_ ||
+      !meEle_phi_MTD_1_Bkg_EE_ || !meEle_phi_MTD_2_Bkg_EE_ || !meEle_phi_MTD_3_Bkg_EE_ || !meEle_phi_MTD_4_Bkg_EE_ ||
+      !meEle_phi_MTD_5_Bkg_EE_ || !meEle_phi_MTD_6_Bkg_EE_ || !meEle_phi_MTD_7_Bkg_EE_ || !meEle_phi_noMTD_Bkg_EE_ ||
+      !meEle_pt_sim_MTD_1_Sig_EB_ || !meEle_pt_sim_MTD_2_Sig_EB_ || !meEle_pt_sim_MTD_3_Sig_EB_ ||
+      !meEle_pt_sim_MTD_4_Sig_EB_ || !meEle_pt_sim_MTD_5_Sig_EB_ || !meEle_pt_sim_MTD_6_Sig_EB_ ||
+      !meEle_pt_sim_MTD_7_Sig_EB_ || !meEle_pt_sim_MTD_1_Sig_EE_ || !meEle_pt_sim_MTD_2_Sig_EE_ ||
+      !meEle_pt_sim_MTD_3_Sig_EE_ || !meEle_pt_sim_MTD_4_Sig_EE_ || !meEle_pt_sim_MTD_5_Sig_EE_ ||
+      !meEle_pt_sim_MTD_6_Sig_EE_ || !meEle_pt_sim_MTD_7_Sig_EE_ || !meEle_pt_sim_MTD_1_Bkg_EB_ ||
+      !meEle_pt_sim_MTD_2_Bkg_EB_ || !meEle_pt_sim_MTD_3_Bkg_EB_ || !meEle_pt_sim_MTD_4_Bkg_EB_ ||
+      !meEle_pt_sim_MTD_5_Bkg_EB_ || !meEle_pt_sim_MTD_6_Bkg_EB_ || !meEle_pt_sim_MTD_7_Bkg_EB_ ||
+      !meEle_pt_sim_MTD_1_Bkg_EE_ || !meEle_pt_sim_MTD_2_Bkg_EE_ || !meEle_pt_sim_MTD_3_Bkg_EE_ ||
+      !meEle_pt_sim_MTD_4_Bkg_EE_ || !meEle_pt_sim_MTD_5_Bkg_EE_ || !meEle_pt_sim_MTD_6_Bkg_EE_ ||
+      !meEle_pt_sim_MTD_7_Bkg_EE_ || !meEle_pt_MTD_4sigma_Sig_EB_ || !meEle_pt_MTD_3sigma_Sig_EB_ ||
+      !meEle_pt_MTD_2sigma_Sig_EB_ || !meEle_pt_MTD_4sigma_Sig_EE_ || !meEle_pt_MTD_3sigma_Sig_EE_ ||
+      !meEle_pt_MTD_2sigma_Sig_EE_ || !meEle_pt_MTD_4sigma_Bkg_EB_ || !meEle_pt_MTD_3sigma_Bkg_EB_ ||
+      !meEle_pt_MTD_2sigma_Bkg_EB_ || !meEle_pt_MTD_4sigma_Bkg_EE_ || !meEle_pt_MTD_3sigma_Bkg_EE_ ||
+      !meEle_pt_MTD_2sigma_Bkg_EE_ || !meEle_pt_sim_MTD_4sigma_Sig_EB_ || !meEle_pt_sim_MTD_3sigma_Sig_EB_ ||
+      !meEle_pt_sim_MTD_2sigma_Sig_EB_ || !meEle_pt_sim_MTD_4sigma_Sig_EE_ || !meEle_pt_sim_MTD_3sigma_Sig_EE_ ||
+      !meEle_pt_sim_MTD_2sigma_Sig_EE_ || !meEle_pt_sim_MTD_4sigma_Bkg_EB_ || !meEle_pt_sim_MTD_3sigma_Bkg_EB_ ||
+      !meEle_pt_sim_MTD_2sigma_Bkg_EB_ || !meEle_pt_sim_MTD_4sigma_Bkg_EE_ || !meEle_pt_sim_MTD_3sigma_Bkg_EE_ ||
+      !meEle_pt_sim_MTD_2sigma_Bkg_EE_) {
+    // !meEle_eta_MTD_4sigma_Sig_EB_ || !meEle_eta_MTD_3sigma_Sig_EB_ || !meEle_eta_MTD_2sigma_Sig_EB_ ||
+    // !meEle_phi_MTD_4sigma_Sig_EB_ || !meEle_phi_MTD_3sigma_Sig_EB_ || !meEle_phi_MTD_2sigma_Sig_EB_ ||
+    // !meEle_eta_MTD_4sigma_Sig_EE_ || !meEle_eta_MTD_3sigma_Sig_EE_ || !meEle_eta_MTD_2sigma_Sig_EE_ ||
+    // !meEle_phi_MTD_4sigma_Sig_EE_ || !meEle_phi_MTD_3sigma_Sig_EE_ || !meEle_phi_MTD_2sigma_Sig_EE_ ) {
+    // !meEle_eta_MTD_4sigma_Bkg_EB_ || !meEle_eta_MTD_3sigma_Bkg_EB_ || !meEle_eta_MTD_2sigma_Bkg_EB_ ||
+    // !meEle_phi_MTD_4sigma_Bkg_EB_ || !meEle_phi_MTD_3sigma_Bkg_EB_ || !meEle_phi_MTD_2sigma_Bkg_EB_ ||
+    // !meEle_eta_MTD_4sigma_Bkg_EE_ || !meEle_eta_MTD_3sigma_Bkg_EE_ || !meEle_eta_MTD_2sigma_Bkg_EE_ ||
+    // !meEle_phi_MTD_4sigma_Bkg_EE_ || !meEle_phi_MTD_3sigma_Bkg_EE_ || !meEle_phi_MTD_2sigma_Bkg_EE_) {
+    edm::LogError("MtdEleIsoHarvester") << "Monitoring histograms not found!" << std::endl;
+    return;
+  }
+
+  // --- Book  histograms
+  ibook.cd(folder_);
+  // ele iso addition starts; MTD vs noMTD case
+  /////////////////////////////////////////////////////// For promt (signal)
+
+  mePtEffMTD_1_Sig_EB_ = ibook.book1D("pTeffMTD_1_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_1_Sig_EB_);
+
+  mePtEffMTD_2_Sig_EB_ = ibook.book1D("pTeffMTD_2_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_2_Sig_EB_);
+
+  mePtEffMTD_3_Sig_EB_ = ibook.book1D("pTeffMTD_3_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_3_Sig_EB_);
+
+  mePtEffMTD_4_Sig_EB_ = ibook.book1D("pTeffMTD_4_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_4_Sig_EB_);
+
+  mePtEffMTD_5_Sig_EB_ = ibook.book1D("pTeffMTD_5_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_5_Sig_EB_);
+
+  mePtEffMTD_6_Sig_EB_ = ibook.book1D("pTeffMTD_6_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_6_Sig_EB_);
+
+  mePtEffMTD_7_Sig_EB_ = ibook.book1D("pTeffMTD_7_Sig_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_7_Sig_EB_);
+
+  mePtEffMTD_sim_1_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_1_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_1_Sig_EB_);
+
+  mePtEffMTD_sim_2_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2_Sig_EB_);
+
+  mePtEffMTD_sim_3_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3_Sig_EB_);
+
+  mePtEffMTD_sim_4_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4_Sig_EB_);
+
+  mePtEffMTD_sim_5_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_5_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_5_Sig_EB_);
+
+  mePtEffMTD_sim_6_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_6_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_6_Sig_EB_);
+
+  mePtEffMTD_sim_7_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_7_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_7_Sig_EB_);
+
+  mePtEffMTD_4sigma_Sig_EB_ = ibook.book1D("pTeffMTD_4sigma_Sig_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_4sigma_Sig_EB_);
+
+  mePtEffMTD_3sigma_Sig_EB_ = ibook.book1D("pTeffMTD_3sigma_Sig_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_3sigma_Sig_EB_);
+
+  mePtEffMTD_2sigma_Sig_EB_ = ibook.book1D("pTeffMTD_2sigma_Sig_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_2sigma_Sig_EB_);
+
+  mePtEffMTD_sim_4sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_4sigma_Sig_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4sigma_Sig_EB_);
+
+  mePtEffMTD_sim_3sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_3sigma_Sig_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3sigma_Sig_EB_);
+
+  mePtEffMTD_sim_2sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_2sigma_Sig_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2sigma_Sig_EB_);
+
+  meEtaEffMTD_1_Sig_EB_ = ibook.book1D("EtaEffMTD_1_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_1_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_1_Sig_EB_);
+
+  meEtaEffMTD_2_Sig_EB_ = ibook.book1D("EtaEffMTD_2_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2_Sig_EB_);
+
+  meEtaEffMTD_3_Sig_EB_ = ibook.book1D("EtaEffMTD_3_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3_Sig_EB_);
+
+  meEtaEffMTD_4_Sig_EB_ = ibook.book1D("EtaEffMTD_4_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4_Sig_EB_);
+
+  meEtaEffMTD_5_Sig_EB_ = ibook.book1D("EtaEffMTD_5_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_5_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_5_Sig_EB_);
+
+  meEtaEffMTD_6_Sig_EB_ = ibook.book1D("EtaEffMTD_6_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_6_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_6_Sig_EB_);
+
+  meEtaEffMTD_7_Sig_EB_ = ibook.book1D("EtaEffMTD_7_Sig_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_7_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_7_Sig_EB_);
+
+  // meEtaEffMTD_4sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_4sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4sigma_Sig_EB_);
+
+  // meEtaEffMTD_3sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_3sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3sigma_Sig_EB_);
+
+  // meEtaEffMTD_2sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_2sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2sigma_Sig_EB_);
+
+  mePhiEffMTD_1_Sig_EB_ = ibook.book1D("PhiEffMTD_1_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_1_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_1_Sig_EB_);
+
+  mePhiEffMTD_2_Sig_EB_ = ibook.book1D("PhiEffMTD_2_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2_Sig_EB_);
+
+  mePhiEffMTD_3_Sig_EB_ = ibook.book1D("PhiEffMTD_3_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3_Sig_EB_);
+
+  mePhiEffMTD_4_Sig_EB_ = ibook.book1D("PhiEffMTD_4_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4_Sig_EB_);
+
+  mePhiEffMTD_5_Sig_EB_ = ibook.book1D("PhiEffMTD_5_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_5_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_5_Sig_EB_);
+
+  mePhiEffMTD_6_Sig_EB_ = ibook.book1D("PhiEffMTD_6_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_6_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_6_Sig_EB_);
+
+  mePhiEffMTD_7_Sig_EB_ = ibook.book1D("PhiEffMTD_7_Sig_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_7_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_7_Sig_EB_);
+
+  // mePhiEffMTD_4sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_4sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4sigma_Sig_EB_);
+
+  // meEtaEffMTD_3sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_3sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3sigma_Sig_EB_);
+
+  // meEtaEffMTD_2sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_2sigma_Sig_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2sigma_Sig_EB_);
+
+  mePtEffnoMTD_Sig_EB_ = ibook.book1D("pTeffnoMTD_Sig_EB",
+                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffnoMTD_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_noMTD_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffnoMTD_Sig_EB_);
+
+  meEtaEffnoMTD_Sig_EB_ = ibook.book1D("EtaEffnoMTD_Sig_EB",
+                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffnoMTD_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_noMTD_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffnoMTD_Sig_EB_);
+
+  mePhiEffnoMTD_Sig_EB_ = ibook.book1D("PhiEffnoMTD_Sig_EB",
+                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffnoMTD_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_noMTD_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffnoMTD_Sig_EB_);
+
+  // Ele iso addition ends
+  // For endcap now
+
+  mePtEffMTD_1_Sig_EE_ = ibook.book1D("pTeffMTD_1_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_1_Sig_EE_);
+
+  mePtEffMTD_2_Sig_EE_ = ibook.book1D("pTeffMTD_2_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_2_Sig_EE_);
+
+  mePtEffMTD_3_Sig_EE_ = ibook.book1D("pTeffMTD_3_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_3_Sig_EE_);
+
+  mePtEffMTD_4_Sig_EE_ = ibook.book1D("pTeffMTD_4_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_4_Sig_EE_);
+
+  mePtEffMTD_5_Sig_EE_ = ibook.book1D("pTeffMTD_5_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_5_Sig_EE_);
+
+  mePtEffMTD_6_Sig_EE_ = ibook.book1D("pTeffMTD_6_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_6_Sig_EE_);
+
+  mePtEffMTD_7_Sig_EE_ = ibook.book1D("pTeffMTD_7_Sig_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_7_Sig_EE_);
+
+  mePtEffMTD_sim_1_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_1_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_1_Sig_EE_);
+
+  mePtEffMTD_sim_2_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2_Sig_EE_);
+
+  mePtEffMTD_sim_3_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3_Sig_EE_);
+
+  mePtEffMTD_sim_4_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4_Sig_EE_);
+
+  mePtEffMTD_sim_5_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_5_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_5_Sig_EE_);
+
+  mePtEffMTD_sim_6_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_6_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_6_Sig_EE_);
+
+  mePtEffMTD_sim_7_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_7_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_7_Sig_EE_);
+
+  mePtEffMTD_4sigma_Sig_EE_ = ibook.book1D("pTeffMTD_4sigma_Sig_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_4sigma_Sig_EE_);
+
+  mePtEffMTD_3sigma_Sig_EE_ = ibook.book1D("pTeffMTD_3sigma_Sig_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_3sigma_Sig_EE_);
+
+  mePtEffMTD_2sigma_Sig_EE_ = ibook.book1D("pTeffMTD_2sigma_Sig_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_2sigma_Sig_EE_);
+
+  mePtEffMTD_sim_4sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_4sigma_Sig_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4sigma_Sig_EE_);
+
+  mePtEffMTD_sim_3sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_3sigma_Sig_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3sigma_Sig_EE_);
+
+  mePtEffMTD_sim_2sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_2sigma_Sig_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2sigma_Sig_EE_);
+
+  meEtaEffMTD_1_Sig_EE_ = ibook.book1D("EtaEffMTD_1_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_1_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_1_Sig_EE_);
+
+  meEtaEffMTD_2_Sig_EE_ = ibook.book1D("EtaEffMTD_2_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2_Sig_EE_);
+
+  meEtaEffMTD_3_Sig_EE_ = ibook.book1D("EtaEffMTD_3_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3_Sig_EE_);
+
+  meEtaEffMTD_4_Sig_EE_ = ibook.book1D("EtaEffMTD_4_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4_Sig_EE_);
+
+  meEtaEffMTD_5_Sig_EE_ = ibook.book1D("EtaEffMTD_5_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_5_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_5_Sig_EE_);
+
+  meEtaEffMTD_6_Sig_EE_ = ibook.book1D("EtaEffMTD_6_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_6_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_6_Sig_EE_);
+
+  meEtaEffMTD_7_Sig_EE_ = ibook.book1D("EtaEffMTD_7_Sig_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_7_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_7_Sig_EE_);
+
+  // meEtaEffMTD_4sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_4sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4sigma_Sig_EE_);
+
+  // meEtaEffMTD_3sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_3sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3sigma_Sig_EE_);
+
+  // meEtaEffMTD_2sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_2sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2sigma_Sig_EE_);
+
+  mePhiEffMTD_1_Sig_EE_ = ibook.book1D("PhiEffMTD_1_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_1_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_1_Sig_EE_);
+
+  mePhiEffMTD_2_Sig_EE_ = ibook.book1D("PhiEffMTD_2_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2_Sig_EE_);
+
+  mePhiEffMTD_3_Sig_EE_ = ibook.book1D("PhiEffMTD_3_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3_Sig_EE_);
+
+  mePhiEffMTD_4_Sig_EE_ = ibook.book1D("PhiEffMTD_4_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4_Sig_EE_);
+
+  mePhiEffMTD_5_Sig_EE_ = ibook.book1D("PhiEffMTD_5_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_5_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_5_Sig_EE_);
+
+  mePhiEffMTD_6_Sig_EE_ = ibook.book1D("PhiEffMTD_6_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_6_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_6_Sig_EE_);
+
+  mePhiEffMTD_7_Sig_EE_ = ibook.book1D("PhiEffMTD_7_Sig_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_7_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_7_Sig_EE_);
+
+  // mePhiEffMTD_4sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_4sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4sigma_Sig_EE_);
+
+  // meEtaEffMTD_3sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_3sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3sigma_Sig_EE_);
+
+  // meEtaEffMTD_2sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_2sigma_Sig_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2sigma_Sig_EE_);
+
+  mePtEffnoMTD_Sig_EE_ = ibook.book1D("pTeffnoMTD_Sig_EE",
+                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffnoMTD_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_noMTD_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffnoMTD_Sig_EE_);
+
+  meEtaEffnoMTD_Sig_EE_ = ibook.book1D("EtaEffnoMTD_Sig_EE",
+                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffnoMTD_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_noMTD_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffnoMTD_Sig_EE_);
+
+  mePhiEffnoMTD_Sig_EE_ = ibook.book1D("PhiEffnoMTD_Sig_EE",
+                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffnoMTD_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_noMTD_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffnoMTD_Sig_EE_);
+
+  /////////////////////////////////////////////////////// For non-promt (background)
+
+  mePtEffMTD_1_Bkg_EB_ = ibook.book1D("pTeffMTD_1_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_1_Bkg_EB_);
+
+  mePtEffMTD_2_Bkg_EB_ = ibook.book1D("pTeffMTD_2_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_2_Bkg_EB_);
+
+  mePtEffMTD_3_Bkg_EB_ = ibook.book1D("pTeffMTD_3_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_3_Bkg_EB_);
+
+  mePtEffMTD_4_Bkg_EB_ = ibook.book1D("pTeffMTD_4_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_4_Bkg_EB_);
+
+  mePtEffMTD_5_Bkg_EB_ = ibook.book1D("pTeffMTD_5_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_5_Bkg_EB_);
+
+  mePtEffMTD_6_Bkg_EB_ = ibook.book1D("pTeffMTD_6_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_6_Bkg_EB_);
+
+  mePtEffMTD_7_Bkg_EB_ = ibook.book1D("pTeffMTD_7_Bkg_EB",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_7_Bkg_EB_);
+
+  mePtEffMTD_sim_1_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_1_Bkg_EB_);
+
+  mePtEffMTD_sim_2_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2_Bkg_EB_);
+
+  mePtEffMTD_sim_3_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3_Bkg_EB_);
+
+  mePtEffMTD_sim_4_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4_Bkg_EB_);
+
+  mePtEffMTD_sim_5_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_5_Bkg_EB_);
+
+  mePtEffMTD_sim_6_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_6_Bkg_EB_);
+
+  mePtEffMTD_sim_7_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EB_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_7_Bkg_EB_);
+
+  mePtEffMTD_4sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_4sigma_Bkg_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_4sigma_Bkg_EB_);
+
+  mePtEffMTD_3sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_3sigma_Bkg_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_3sigma_Bkg_EB_);
+
+  mePtEffMTD_2sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_2sigma_Bkg_EB",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_2sigma_Bkg_EB_);
+
+  mePtEffMTD_sim_4sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4sigma_Bkg_EB_);
+
+  mePtEffMTD_sim_3sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3sigma_Bkg_EB_);
+
+  mePtEffMTD_sim_2sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EB",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2sigma_Bkg_EB_);
+
+  meEtaEffMTD_1_Bkg_EB_ = ibook.book1D("EtaEffMTD_1_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_1_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_1_Bkg_EB_);
+
+  meEtaEffMTD_2_Bkg_EB_ = ibook.book1D("EtaEffMTD_2_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2_Bkg_EB_);
+
+  meEtaEffMTD_3_Bkg_EB_ = ibook.book1D("EtaEffMTD_3_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3_Bkg_EB_);
+
+  meEtaEffMTD_4_Bkg_EB_ = ibook.book1D("EtaEffMTD_4_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4_Bkg_EB_);
+
+  meEtaEffMTD_5_Bkg_EB_ = ibook.book1D("EtaEffMTD_5_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_5_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_5_Bkg_EB_);
+
+  meEtaEffMTD_6_Bkg_EB_ = ibook.book1D("EtaEffMTD_6_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_6_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_6_Bkg_EB_);
+
+  meEtaEffMTD_7_Bkg_EB_ = ibook.book1D("EtaEffMTD_7_Bkg_EB",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_7_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_7_Bkg_EB_);
+
+  // meEtaEffMTD_4sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_4sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4sigma_Bkg_EB_);
+
+  // meEtaEffMTD_3sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_3sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3sigma_Bkg_EB_);
+
+  // meEtaEffMTD_2sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_2sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2sigma_Bkg_EB_);
+
+  mePhiEffMTD_1_Bkg_EB_ = ibook.book1D("PhiEffMTD_1_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_1_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_1_Bkg_EB_);
+
+  mePhiEffMTD_2_Bkg_EB_ = ibook.book1D("PhiEffMTD_2_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2_Bkg_EB_);
+
+  mePhiEffMTD_3_Bkg_EB_ = ibook.book1D("PhiEffMTD_3_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3_Bkg_EB_);
+
+  mePhiEffMTD_4_Bkg_EB_ = ibook.book1D("PhiEffMTD_4_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4_Bkg_EB_);
+
+  mePhiEffMTD_5_Bkg_EB_ = ibook.book1D("PhiEffMTD_5_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_5_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_5_Bkg_EB_);
+
+  mePhiEffMTD_6_Bkg_EB_ = ibook.book1D("PhiEffMTD_6_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_6_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_6_Bkg_EB_);
+
+  mePhiEffMTD_7_Bkg_EB_ = ibook.book1D("PhiEffMTD_7_Bkg_EB",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_7_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_7_Bkg_EB_);
+
+  // mePhiEffMTD_4sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_4sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4sigma_Bkg_EB_);
+
+  // meEtaEffMTD_3sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_3sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3sigma_Bkg_EB_);
+
+  // meEtaEffMTD_2sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_2sigma_Bkg_EB",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2sigma_Bkg_EB_);
+
+  mePtEffnoMTD_Bkg_EB_ = ibook.book1D("pTeffnoMTD_Bkg_EB",
+                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffnoMTD_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_noMTD_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffnoMTD_Bkg_EB_);
+
+  meEtaEffnoMTD_Bkg_EB_ = ibook.book1D("EtaEffnoMTD_Bkg_EB",
+                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffnoMTD_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_noMTD_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffnoMTD_Bkg_EB_);
+
+  mePhiEffnoMTD_Bkg_EB_ = ibook.book1D("PhiEffnoMTD_Bkg_EB",
+                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffnoMTD_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_noMTD_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffnoMTD_Bkg_EB_);
+
+  // Ele iso addition ends
+  // For endcap now
+
+  mePtEffMTD_1_Bkg_EE_ = ibook.book1D("pTeffMTD_1_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_1_Bkg_EE_);
+
+  mePtEffMTD_2_Bkg_EE_ = ibook.book1D("pTeffMTD_2_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_2_Bkg_EE_);
+
+  mePtEffMTD_3_Bkg_EE_ = ibook.book1D("pTeffMTD_3_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_3_Bkg_EE_);
+
+  mePtEffMTD_4_Bkg_EE_ = ibook.book1D("pTeffMTD_4_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_4_Bkg_EE_);
+
+  mePtEffMTD_5_Bkg_EE_ = ibook.book1D("pTeffMTD_5_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_5_Bkg_EE_);
+
+  mePtEffMTD_6_Bkg_EE_ = ibook.book1D("pTeffMTD_6_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_6_Bkg_EE_);
+
+  mePtEffMTD_7_Bkg_EE_ = ibook.book1D("pTeffMTD_7_Bkg_EE",
+                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_7_Bkg_EE_);
+
+  mePtEffMTD_sim_1_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_1_Bkg_EE_);
+
+  mePtEffMTD_sim_2_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2_Bkg_EE_);
+
+  mePtEffMTD_sim_3_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3_Bkg_EE_);
+
+  mePtEffMTD_sim_4_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4_Bkg_EE_);
+
+  mePtEffMTD_sim_5_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_5_Bkg_EE_);
+
+  mePtEffMTD_sim_6_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_6_Bkg_EE_);
+
+  mePtEffMTD_sim_7_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EE_",
+                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_7_Bkg_EE_);
+
+  mePtEffMTD_4sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_4sigma_Bkg_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_4sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_4sigma_Bkg_EE_);
+
+  mePtEffMTD_3sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_3sigma_Bkg_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_3sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_3sigma_Bkg_EE_);
+
+  mePtEffMTD_2sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_2sigma_Bkg_EE",
+                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_MTD_2sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_2sigma_Bkg_EE_);
+
+  mePtEffMTD_sim_4sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4sigma_Bkg_EE_);
+
+  mePtEffMTD_sim_3sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3sigma_Bkg_EE_);
+
+  mePtEffMTD_sim_2sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EE",
+                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
+                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_sim_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2sigma_Bkg_EE_);
+
+  meEtaEffMTD_1_Bkg_EE_ = ibook.book1D("EtaEffMTD_1_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_1_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_1_Bkg_EE_);
+
+  meEtaEffMTD_2_Bkg_EE_ = ibook.book1D("EtaEffMTD_2_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2_Bkg_EE_);
+
+  meEtaEffMTD_3_Bkg_EE_ = ibook.book1D("EtaEffMTD_3_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3_Bkg_EE_);
+
+  meEtaEffMTD_4_Bkg_EE_ = ibook.book1D("EtaEffMTD_4_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4_Bkg_EE_);
+
+  meEtaEffMTD_5_Bkg_EE_ = ibook.book1D("EtaEffMTD_5_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_5_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_5_Bkg_EE_);
+
+  meEtaEffMTD_6_Bkg_EE_ = ibook.book1D("EtaEffMTD_6_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_6_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_6_Bkg_EE_);
+
+  meEtaEffMTD_7_Bkg_EE_ = ibook.book1D("EtaEffMTD_7_Bkg_EE",
+                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_7_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_7_Bkg_EE_);
+
+  // meEtaEffMTD_4sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_4sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4sigma_Bkg_EE_);
+
+  // meEtaEffMTD_3sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_3sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3sigma_Bkg_EE_);
+
+  // meEtaEffMTD_2sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_2sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
+  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // meEtaEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2sigma_Bkg_EE_);
+
+  mePhiEffMTD_1_Bkg_EE_ = ibook.book1D("PhiEffMTD_1_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_1_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_1_Bkg_EE_);
+
+  mePhiEffMTD_2_Bkg_EE_ = ibook.book1D("PhiEffMTD_2_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2_Bkg_EE_);
+
+  mePhiEffMTD_3_Bkg_EE_ = ibook.book1D("PhiEffMTD_3_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3_Bkg_EE_);
+
+  mePhiEffMTD_4_Bkg_EE_ = ibook.book1D("PhiEffMTD_4_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4_Bkg_EE_);
+
+  mePhiEffMTD_5_Bkg_EE_ = ibook.book1D("PhiEffMTD_5_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_5_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_5_Bkg_EE_);
+
+  mePhiEffMTD_6_Bkg_EE_ = ibook.book1D("PhiEffMTD_6_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_6_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_6_Bkg_EE_);
+
+  mePhiEffMTD_7_Bkg_EE_ = ibook.book1D("PhiEffMTD_7_Bkg_EE",
+                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_7_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_7_Bkg_EE_);
+
+  // mePhiEffMTD_4sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_4sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4sigma_Bkg_EE_);
+
+  // meEtaEffMTD_3sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_3sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3sigma_Bkg_EE_);
+
+  // meEtaEffMTD_2sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_2sigma_Bkg_EE",
+  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
+  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  // mePhiEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  // computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2sigma_Bkg_EE_);
+
+  mePtEffnoMTD_Bkg_EE_ = ibook.book1D("pTeffnoMTD_Bkg_EE",
+                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffnoMTD_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_pt_noMTD_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffnoMTD_Bkg_EE_);
+
+  meEtaEffnoMTD_Bkg_EE_ = ibook.book1D("EtaEffnoMTD_Bkg_EE",
+                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffnoMTD_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_noMTD_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffnoMTD_Bkg_EE_);
+
+  mePhiEffnoMTD_Bkg_EE_ = ibook.book1D("PhiEffnoMTD_Bkg_EE",
+                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffnoMTD_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_noMTD_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffnoMTD_Bkg_EE_);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ----------
+void MtdEleIsoHarvester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/ElectronIso/");
+
+  descriptions.add("MtdEleIsoPostProcessor", desc);
+}
+
+DEFINE_FWK_MODULE(MtdEleIsoHarvester);

--- a/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
@@ -24,12 +24,12 @@ private:
   void computeEfficiency1D(MonitorElement* num, MonitorElement* den, MonitorElement* result);
 
   const std::string folder_;
+  const bool optionalPlots_;
 
   // --- Histograms
   MonitorElement* mePtEffnoMTD_Sig_EB_;
   MonitorElement* meEtaEffnoMTD_Sig_EB_;
   MonitorElement* mePhiEffnoMTD_Sig_EB_;
-
   MonitorElement* mePtEffMTD_1_Sig_EB_;
   MonitorElement* meEtaEffMTD_1_Sig_EB_;
   MonitorElement* mePhiEffMTD_1_Sig_EB_;
@@ -66,21 +66,23 @@ private:
   MonitorElement* mePtEffMTD_sim_6_Sig_EB_;
   MonitorElement* mePtEffMTD_sim_7_Sig_EB_;
 
+  MonitorElement* mePtEffgen_Sig_EB_;
+
   MonitorElement* mePtEffMTD_sim_4sigma_Sig_EB_;
   MonitorElement* mePtEffMTD_sim_3sigma_Sig_EB_;
   MonitorElement* mePtEffMTD_sim_2sigma_Sig_EB_;
 
   MonitorElement* mePtEffMTD_4sigma_Sig_EB_;
-  // MonitorElement* meEtaEffMTD_4sigma_Sig_EB_;
-  // MonitorElement* mePhiEffMTD_4sigma_Sig_EB_;
+  MonitorElement* meEtaEffMTD_4sigma_Sig_EB_;
+  MonitorElement* mePhiEffMTD_4sigma_Sig_EB_;
 
   MonitorElement* mePtEffMTD_3sigma_Sig_EB_;
-  // MonitorElement* meEtaEffMTD_3sigma_Sig_EB_;
-  // MonitorElement* mePhiEffMTD_3sigma_Sig_EB_;
+  MonitorElement* meEtaEffMTD_3sigma_Sig_EB_;
+  MonitorElement* mePhiEffMTD_3sigma_Sig_EB_;
 
   MonitorElement* mePtEffMTD_2sigma_Sig_EB_;
-  // MonitorElement* meEtaEffMTD_2sigma_Sig_EB_;
-  // MonitorElement* mePhiEffMTD_2sigma_Sig_EB_;
+  MonitorElement* meEtaEffMTD_2sigma_Sig_EB_;
+  MonitorElement* mePhiEffMTD_2sigma_Sig_EB_;
 
   MonitorElement* mePtEffnoMTD_Sig_EE_;
   MonitorElement* meEtaEffnoMTD_Sig_EE_;
@@ -122,26 +124,27 @@ private:
   MonitorElement* mePtEffMTD_sim_6_Sig_EE_;
   MonitorElement* mePtEffMTD_sim_7_Sig_EE_;
 
+  MonitorElement* mePtEffgen_Sig_EE_;
+
   MonitorElement* mePtEffMTD_sim_4sigma_Sig_EE_;
   MonitorElement* mePtEffMTD_sim_3sigma_Sig_EE_;
   MonitorElement* mePtEffMTD_sim_2sigma_Sig_EE_;
 
   MonitorElement* mePtEffMTD_4sigma_Sig_EE_;
-  // MonitorElement* meEtaEffMTD_4sigma_Sig_EE_;
-  // MonitorElement* mePhiEffMTD_4sigma_Sig_EE_;
+  MonitorElement* meEtaEffMTD_4sigma_Sig_EE_;
+  MonitorElement* mePhiEffMTD_4sigma_Sig_EE_;
 
   MonitorElement* mePtEffMTD_3sigma_Sig_EE_;
-  // MonitorElement* meEtaEffMTD_3sigma_Sig_EE_;
-  // MonitorElement* mePhiEffMTD_3sigma_Sig_EE_;
+  MonitorElement* meEtaEffMTD_3sigma_Sig_EE_;
+  MonitorElement* mePhiEffMTD_3sigma_Sig_EE_;
 
   MonitorElement* mePtEffMTD_2sigma_Sig_EE_;
-  // MonitorElement* meEtaEffMTD_2sigma_Sig_EE_;
-  // MonitorElement* mePhiEffMTD_2sigma_Sig_EE_;
+  MonitorElement* meEtaEffMTD_2sigma_Sig_EE_;
+  MonitorElement* mePhiEffMTD_2sigma_Sig_EE_;
 
   MonitorElement* mePtEffnoMTD_Bkg_EB_;
   MonitorElement* meEtaEffnoMTD_Bkg_EB_;
   MonitorElement* mePhiEffnoMTD_Bkg_EB_;
-
   MonitorElement* mePtEffMTD_1_Bkg_EB_;
   MonitorElement* meEtaEffMTD_1_Bkg_EB_;
   MonitorElement* mePhiEffMTD_1_Bkg_EB_;
@@ -178,26 +181,27 @@ private:
   MonitorElement* mePtEffMTD_sim_6_Bkg_EB_;
   MonitorElement* mePtEffMTD_sim_7_Bkg_EB_;
 
+  MonitorElement* mePtEffgen_Bkg_EB_;
+
   MonitorElement* mePtEffMTD_sim_4sigma_Bkg_EB_;
   MonitorElement* mePtEffMTD_sim_3sigma_Bkg_EB_;
   MonitorElement* mePtEffMTD_sim_2sigma_Bkg_EB_;
 
   MonitorElement* mePtEffMTD_4sigma_Bkg_EB_;
-  // MonitorElement* meEtaEffMTD_4sigma_Bkg_EB_;
-  // MonitorElement* mePhiEffMTD_4sigma_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_4sigma_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_4sigma_Bkg_EB_;
 
   MonitorElement* mePtEffMTD_3sigma_Bkg_EB_;
-  // MonitorElement* meEtaEffMTD_3sigma_Bkg_EB_;
-  // MonitorElement* mePhiEffMTD_3sigma_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_3sigma_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_3sigma_Bkg_EB_;
 
   MonitorElement* mePtEffMTD_2sigma_Bkg_EB_;
-  // MonitorElement* meEtaEffMTD_2sigma_Bkg_EB_;
-  // MonitorElement* mePhiEffMTD_2sigma_Bkg_EB_;
+  MonitorElement* meEtaEffMTD_2sigma_Bkg_EB_;
+  MonitorElement* mePhiEffMTD_2sigma_Bkg_EB_;
 
   MonitorElement* mePtEffnoMTD_Bkg_EE_;
   MonitorElement* meEtaEffnoMTD_Bkg_EE_;
   MonitorElement* mePhiEffnoMTD_Bkg_EE_;
-
   MonitorElement* mePtEffMTD_1_Bkg_EE_;
   MonitorElement* meEtaEffMTD_1_Bkg_EE_;
   MonitorElement* mePhiEffMTD_1_Bkg_EE_;
@@ -234,26 +238,29 @@ private:
   MonitorElement* mePtEffMTD_sim_6_Bkg_EE_;
   MonitorElement* mePtEffMTD_sim_7_Bkg_EE_;
 
+  MonitorElement* mePtEffgen_Bkg_EE_;
+
   MonitorElement* mePtEffMTD_sim_4sigma_Bkg_EE_;
   MonitorElement* mePtEffMTD_sim_3sigma_Bkg_EE_;
   MonitorElement* mePtEffMTD_sim_2sigma_Bkg_EE_;
 
   MonitorElement* mePtEffMTD_4sigma_Bkg_EE_;
-  // MonitorElement* meEtaEffMTD_4sigma_Bkg_EE_;
-  // MonitorElement* mePhiEffMTD_4sigma_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_4sigma_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_4sigma_Bkg_EE_;
 
   MonitorElement* mePtEffMTD_3sigma_Bkg_EE_;
-  // MonitorElement* meEtaEffMTD_3sigma_Bkg_EE_;
-  // MonitorElement* mePhiEffMTD_3sigma_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_3sigma_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_3sigma_Bkg_EE_;
 
   MonitorElement* mePtEffMTD_2sigma_Bkg_EE_;
-  // MonitorElement* meEtaEffMTD_2sigma_Bkg_EE_;
-  // MonitorElement* mePhiEffMTD_2sigma_Bkg_EE_;
+  MonitorElement* meEtaEffMTD_2sigma_Bkg_EE_;
+  MonitorElement* mePhiEffMTD_2sigma_Bkg_EE_;
 };
 
 // ------------ constructor and destructor --------------
 MtdEleIsoHarvester::MtdEleIsoHarvester(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")) {}
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      optionalPlots_(iConfig.getParameter<bool>("option_plots")) {}
 
 MtdEleIsoHarvester::~MtdEleIsoHarvester() {}
 
@@ -275,18 +282,17 @@ void MtdEleIsoHarvester::computeEfficiency1D(MonitorElement* num, MonitorElement
 // ------------ endjob tasks ----------------------------
 void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
-
   // For promt (signal)
   MonitorElement* meEle_pt_tot_Sig_EB_ = igetter.get(folder_ + "Ele_pT_tot_Sig_EB");
   MonitorElement* meEle_pt_sim_tot_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_tot_Sig_EB");
   MonitorElement* meEle_pt_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_pT_noMTD_Sig_EB");
+  MonitorElement* meEle_pt_gen_Sig_EB_ = igetter.get(folder_ + "Ele_pT_gen_Sig_EB");
 
   MonitorElement* meEle_eta_tot_Sig_EB_ = igetter.get(folder_ + "Ele_eta_tot_Sig_EB");
   MonitorElement* meEle_eta_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_eta_noMTD_Sig_EB");
 
   MonitorElement* meEle_phi_tot_Sig_EB_ = igetter.get(folder_ + "Ele_phi_tot_Sig_EB");
   MonitorElement* meEle_phi_noMTD_Sig_EB_ = igetter.get(folder_ + "Ele_phi_noMTD_Sig_EB");
-
   MonitorElement* meEle_pt_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_1_Sig_EB");
   MonitorElement* meEle_eta_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_1_Sig_EB");
   MonitorElement* meEle_phi_MTD_1_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_1_Sig_EB");
@@ -328,27 +334,27 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Sig_EB");
 
   MonitorElement* meEle_pt_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Sig_EB");
-  // MonitorElement* meEle_eta_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EB");
-  // MonitorElement* meEle_phi_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EB");
+  MonitorElement* meEle_eta_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EB");
+  MonitorElement* meEle_phi_MTD_2sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EB");
 
   MonitorElement* meEle_pt_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Sig_EB");
-  // MonitorElement* meEle_eta_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EB");
-  // MonitorElement* meEle_phi_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EB");
+  MonitorElement* meEle_eta_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EB");
+  MonitorElement* meEle_phi_MTD_3sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EB");
 
   MonitorElement* meEle_pt_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Sig_EB");
-  // MonitorElement* meEle_eta_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EB");
-  // MonitorElement* meEle_phi_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EB");
+  MonitorElement* meEle_eta_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EB");
+  MonitorElement* meEle_phi_MTD_4sigma_Sig_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EB");
 
   MonitorElement* meEle_pt_tot_Sig_EE_ = igetter.get(folder_ + "Ele_pT_tot_Sig_EE");
   MonitorElement* meEle_pt_sim_tot_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_tot_Sig_EE");
   MonitorElement* meEle_pt_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_pT_noMTD_Sig_EE");
+  MonitorElement* meEle_pt_gen_Sig_EE_ = igetter.get(folder_ + "Ele_pT_gen_Sig_EE");
 
   MonitorElement* meEle_eta_tot_Sig_EE_ = igetter.get(folder_ + "Ele_eta_tot_Sig_EE");
   MonitorElement* meEle_eta_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_eta_noMTD_Sig_EE");
 
   MonitorElement* meEle_phi_tot_Sig_EE_ = igetter.get(folder_ + "Ele_phi_tot_Sig_EE");
   MonitorElement* meEle_phi_noMTD_Sig_EE_ = igetter.get(folder_ + "Ele_phi_noMTD_Sig_EE");
-
   MonitorElement* meEle_pt_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_1_Sig_EE");
   MonitorElement* meEle_eta_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_1_Sig_EE");
   MonitorElement* meEle_phi_MTD_1_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_1_Sig_EE");
@@ -390,28 +396,28 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Sig_EE");
 
   MonitorElement* meEle_pt_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Sig_EE");
-  // MonitorElement* meEle_eta_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EE");
-  // MonitorElement* meEle_phi_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EE");
+  MonitorElement* meEle_eta_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Sig_EE");
+  MonitorElement* meEle_phi_MTD_2sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Sig_EE");
 
   MonitorElement* meEle_pt_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Sig_EE");
-  // MonitorElement* meEle_eta_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EE");
-  // MonitorElement* meEle_phi_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EE");
+  MonitorElement* meEle_eta_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Sig_EE");
+  MonitorElement* meEle_phi_MTD_3sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Sig_EE");
 
   MonitorElement* meEle_pt_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Sig_EE");
-  // MonitorElement* meEle_eta_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EE");
-  // MonitorElement* meEle_phi_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EE");
+  MonitorElement* meEle_eta_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Sig_EE");
+  MonitorElement* meEle_phi_MTD_4sigma_Sig_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Sig_EE");
 
   // for non-promt (background)
   MonitorElement* meEle_pt_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_tot_Bkg_EB");
   MonitorElement* meEle_pt_sim_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_tot_Bkg_EB");
   MonitorElement* meEle_pt_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_noMTD_Bkg_EB");
+  MonitorElement* meEle_pt_gen_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_gen_Bkg_EB");
 
   MonitorElement* meEle_eta_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_tot_Bkg_EB");
   MonitorElement* meEle_eta_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_noMTD_Bkg_EB");
 
   MonitorElement* meEle_phi_tot_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_tot_Bkg_EB");
   MonitorElement* meEle_phi_noMTD_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_noMTD_Bkg_EB");
-
   MonitorElement* meEle_pt_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_1_Bkg_EB");
   MonitorElement* meEle_eta_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_1_Bkg_EB");
   MonitorElement* meEle_phi_MTD_1_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_1_Bkg_EB");
@@ -453,27 +459,27 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Bkg_EB");
 
   MonitorElement* meEle_pt_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Bkg_EB");
-  // MonitorElement* meEle_eta_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EB");
-  // MonitorElement* meEle_phi_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_2sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EB");
 
   MonitorElement* meEle_pt_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Bkg_EB");
-  // MonitorElement* meEle_eta_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EB");
-  // MonitorElement* meEle_phi_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_3sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EB");
 
   MonitorElement* meEle_pt_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Bkg_EB");
-  // MonitorElement* meEle_eta_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EB");
-  // MonitorElement* meEle_phi_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EB");
+  MonitorElement* meEle_eta_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EB");
+  MonitorElement* meEle_phi_MTD_4sigma_Bkg_EB_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EB");
 
   MonitorElement* meEle_pt_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_tot_Bkg_EE");
   MonitorElement* meEle_pt_sim_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_tot_Bkg_EE");
   MonitorElement* meEle_pt_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_noMTD_Bkg_EE");
+  MonitorElement* meEle_pt_gen_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_gen_Bkg_EE");
 
   MonitorElement* meEle_eta_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_tot_Bkg_EE");
   MonitorElement* meEle_eta_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_noMTD_Bkg_EE");
 
   MonitorElement* meEle_phi_tot_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_tot_Bkg_EE");
   MonitorElement* meEle_phi_noMTD_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_noMTD_Bkg_EE");
-
   MonitorElement* meEle_pt_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_1_Bkg_EE");
   MonitorElement* meEle_eta_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_1_Bkg_EE");
   MonitorElement* meEle_phi_MTD_1_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_1_Bkg_EE");
@@ -515,401 +521,440 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_sim_MTD_4sigma_Bkg_EE");
 
   MonitorElement* meEle_pt_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_2sigma_Bkg_EE");
-  // MonitorElement* meEle_eta_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EE");
-  // MonitorElement* meEle_phi_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_2sigma_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_2sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_2sigma_Bkg_EE");
 
   MonitorElement* meEle_pt_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_3sigma_Bkg_EE");
-  // MonitorElement* meEle_eta_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EE");
-  // MonitorElement* meEle_phi_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EE");
+  MonitorElement* meEle_eta_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_3sigma_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_3sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_3sigma_Bkg_EE");
 
   MonitorElement* meEle_pt_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_pT_MTD_4sigma_Bkg_EE");
-  // MonitorElement* meEle_eta_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EE");
-  // MonitorElement* meEle_phi_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EE");
-
-  if (!meEle_pt_tot_Sig_EB_ || !meEle_pt_MTD_1_Sig_EB_ || !meEle_pt_MTD_2_Sig_EB_ || !meEle_pt_MTD_3_Sig_EB_ ||
-      !meEle_pt_MTD_4_Sig_EB_ || !meEle_pt_MTD_5_Sig_EB_ || !meEle_pt_MTD_6_Sig_EB_ || !meEle_pt_MTD_7_Sig_EB_ ||
-      !meEle_pt_noMTD_Sig_EB_ || !meEle_eta_tot_Sig_EB_ || !meEle_eta_MTD_1_Sig_EB_ || !meEle_eta_MTD_2_Sig_EB_ ||
-      !meEle_eta_MTD_3_Sig_EB_ || !meEle_eta_MTD_4_Sig_EB_ || !meEle_eta_MTD_5_Sig_EB_ || !meEle_eta_MTD_6_Sig_EB_ ||
-      !meEle_eta_MTD_7_Sig_EB_ || !meEle_eta_noMTD_Sig_EB_ || !meEle_phi_tot_Sig_EB_ || !meEle_phi_MTD_1_Sig_EB_ ||
-      !meEle_phi_MTD_2_Sig_EB_ || !meEle_phi_MTD_3_Sig_EB_ || !meEle_phi_MTD_4_Sig_EB_ || !meEle_phi_MTD_5_Sig_EB_ ||
-      !meEle_phi_MTD_6_Sig_EB_ || !meEle_phi_MTD_7_Sig_EB_ || !meEle_phi_noMTD_Sig_EB_ || !meEle_pt_tot_Sig_EE_ ||
-      !meEle_pt_MTD_1_Sig_EE_ || !meEle_pt_MTD_2_Sig_EE_ || !meEle_pt_MTD_3_Sig_EE_ || !meEle_pt_MTD_4_Sig_EE_ ||
-      !meEle_pt_MTD_5_Sig_EE_ || !meEle_pt_MTD_6_Sig_EE_ || !meEle_pt_MTD_7_Sig_EE_ || !meEle_pt_noMTD_Sig_EE_ ||
-      !meEle_eta_tot_Sig_EE_ || !meEle_eta_MTD_1_Sig_EE_ || !meEle_eta_MTD_2_Sig_EE_ || !meEle_eta_MTD_3_Sig_EE_ ||
-      !meEle_eta_MTD_4_Sig_EE_ || !meEle_eta_MTD_5_Sig_EE_ || !meEle_eta_MTD_6_Sig_EE_ || !meEle_eta_MTD_7_Sig_EE_ ||
-      !meEle_eta_noMTD_Sig_EE_ || !meEle_phi_tot_Sig_EE_ || !meEle_phi_MTD_1_Sig_EE_ || !meEle_phi_MTD_2_Sig_EE_ ||
-      !meEle_phi_MTD_3_Sig_EE_ || !meEle_phi_MTD_4_Sig_EE_ || !meEle_phi_MTD_5_Sig_EE_ || !meEle_phi_MTD_6_Sig_EE_ ||
-      !meEle_phi_MTD_7_Sig_EE_ || !meEle_phi_noMTD_Sig_EE_ || !meEle_pt_tot_Bkg_EB_ || !meEle_pt_MTD_1_Bkg_EB_ ||
-      !meEle_pt_MTD_2_Bkg_EB_ || !meEle_pt_MTD_3_Bkg_EB_ || !meEle_pt_MTD_4_Bkg_EB_ || !meEle_pt_MTD_5_Bkg_EB_ ||
-      !meEle_pt_MTD_6_Bkg_EB_ || !meEle_pt_MTD_7_Bkg_EB_ || !meEle_pt_noMTD_Bkg_EB_ || !meEle_eta_tot_Bkg_EB_ ||
-      !meEle_eta_MTD_1_Bkg_EB_ || !meEle_eta_MTD_2_Bkg_EB_ || !meEle_eta_MTD_3_Bkg_EB_ || !meEle_eta_MTD_4_Bkg_EB_ ||
-      !meEle_eta_MTD_5_Bkg_EB_ || !meEle_eta_MTD_6_Bkg_EB_ || !meEle_eta_MTD_7_Bkg_EB_ || !meEle_eta_noMTD_Bkg_EB_ ||
-      !meEle_phi_tot_Bkg_EB_ || !meEle_phi_MTD_1_Bkg_EB_ || !meEle_phi_MTD_2_Bkg_EB_ || !meEle_phi_MTD_3_Bkg_EB_ ||
-      !meEle_phi_MTD_4_Bkg_EB_ || !meEle_phi_MTD_5_Bkg_EB_ || !meEle_phi_MTD_6_Bkg_EB_ || !meEle_phi_MTD_7_Bkg_EB_ ||
-      !meEle_phi_noMTD_Bkg_EB_ || !meEle_pt_tot_Bkg_EE_ || !meEle_pt_MTD_1_Bkg_EE_ || !meEle_pt_MTD_2_Bkg_EE_ ||
-      !meEle_pt_MTD_3_Bkg_EE_ || !meEle_pt_MTD_4_Bkg_EE_ || !meEle_pt_MTD_5_Bkg_EE_ || !meEle_pt_MTD_6_Bkg_EE_ ||
-      !meEle_pt_MTD_7_Bkg_EE_ || !meEle_pt_noMTD_Bkg_EE_ || !meEle_eta_tot_Bkg_EE_ || !meEle_eta_MTD_1_Bkg_EE_ ||
-      !meEle_eta_MTD_2_Bkg_EE_ || !meEle_eta_MTD_3_Bkg_EE_ || !meEle_eta_MTD_4_Bkg_EE_ || !meEle_eta_MTD_5_Bkg_EE_ ||
-      !meEle_eta_MTD_6_Bkg_EE_ || !meEle_eta_MTD_7_Bkg_EE_ || !meEle_eta_noMTD_Bkg_EE_ || !meEle_phi_tot_Bkg_EE_ ||
-      !meEle_phi_MTD_1_Bkg_EE_ || !meEle_phi_MTD_2_Bkg_EE_ || !meEle_phi_MTD_3_Bkg_EE_ || !meEle_phi_MTD_4_Bkg_EE_ ||
-      !meEle_phi_MTD_5_Bkg_EE_ || !meEle_phi_MTD_6_Bkg_EE_ || !meEle_phi_MTD_7_Bkg_EE_ || !meEle_phi_noMTD_Bkg_EE_ ||
-      !meEle_pt_sim_MTD_1_Sig_EB_ || !meEle_pt_sim_MTD_2_Sig_EB_ || !meEle_pt_sim_MTD_3_Sig_EB_ ||
-      !meEle_pt_sim_MTD_4_Sig_EB_ || !meEle_pt_sim_MTD_5_Sig_EB_ || !meEle_pt_sim_MTD_6_Sig_EB_ ||
-      !meEle_pt_sim_MTD_7_Sig_EB_ || !meEle_pt_sim_MTD_1_Sig_EE_ || !meEle_pt_sim_MTD_2_Sig_EE_ ||
-      !meEle_pt_sim_MTD_3_Sig_EE_ || !meEle_pt_sim_MTD_4_Sig_EE_ || !meEle_pt_sim_MTD_5_Sig_EE_ ||
-      !meEle_pt_sim_MTD_6_Sig_EE_ || !meEle_pt_sim_MTD_7_Sig_EE_ || !meEle_pt_sim_MTD_1_Bkg_EB_ ||
-      !meEle_pt_sim_MTD_2_Bkg_EB_ || !meEle_pt_sim_MTD_3_Bkg_EB_ || !meEle_pt_sim_MTD_4_Bkg_EB_ ||
-      !meEle_pt_sim_MTD_5_Bkg_EB_ || !meEle_pt_sim_MTD_6_Bkg_EB_ || !meEle_pt_sim_MTD_7_Bkg_EB_ ||
-      !meEle_pt_sim_MTD_1_Bkg_EE_ || !meEle_pt_sim_MTD_2_Bkg_EE_ || !meEle_pt_sim_MTD_3_Bkg_EE_ ||
-      !meEle_pt_sim_MTD_4_Bkg_EE_ || !meEle_pt_sim_MTD_5_Bkg_EE_ || !meEle_pt_sim_MTD_6_Bkg_EE_ ||
-      !meEle_pt_sim_MTD_7_Bkg_EE_ || !meEle_pt_MTD_4sigma_Sig_EB_ || !meEle_pt_MTD_3sigma_Sig_EB_ ||
-      !meEle_pt_MTD_2sigma_Sig_EB_ || !meEle_pt_MTD_4sigma_Sig_EE_ || !meEle_pt_MTD_3sigma_Sig_EE_ ||
-      !meEle_pt_MTD_2sigma_Sig_EE_ || !meEle_pt_MTD_4sigma_Bkg_EB_ || !meEle_pt_MTD_3sigma_Bkg_EB_ ||
-      !meEle_pt_MTD_2sigma_Bkg_EB_ || !meEle_pt_MTD_4sigma_Bkg_EE_ || !meEle_pt_MTD_3sigma_Bkg_EE_ ||
-      !meEle_pt_MTD_2sigma_Bkg_EE_ || !meEle_pt_sim_MTD_4sigma_Sig_EB_ || !meEle_pt_sim_MTD_3sigma_Sig_EB_ ||
-      !meEle_pt_sim_MTD_2sigma_Sig_EB_ || !meEle_pt_sim_MTD_4sigma_Sig_EE_ || !meEle_pt_sim_MTD_3sigma_Sig_EE_ ||
-      !meEle_pt_sim_MTD_2sigma_Sig_EE_ || !meEle_pt_sim_MTD_4sigma_Bkg_EB_ || !meEle_pt_sim_MTD_3sigma_Bkg_EB_ ||
-      !meEle_pt_sim_MTD_2sigma_Bkg_EB_ || !meEle_pt_sim_MTD_4sigma_Bkg_EE_ || !meEle_pt_sim_MTD_3sigma_Bkg_EE_ ||
-      !meEle_pt_sim_MTD_2sigma_Bkg_EE_) {
-    // !meEle_eta_MTD_4sigma_Sig_EB_ || !meEle_eta_MTD_3sigma_Sig_EB_ || !meEle_eta_MTD_2sigma_Sig_EB_ ||
-    // !meEle_phi_MTD_4sigma_Sig_EB_ || !meEle_phi_MTD_3sigma_Sig_EB_ || !meEle_phi_MTD_2sigma_Sig_EB_ ||
-    // !meEle_eta_MTD_4sigma_Sig_EE_ || !meEle_eta_MTD_3sigma_Sig_EE_ || !meEle_eta_MTD_2sigma_Sig_EE_ ||
-    // !meEle_phi_MTD_4sigma_Sig_EE_ || !meEle_phi_MTD_3sigma_Sig_EE_ || !meEle_phi_MTD_2sigma_Sig_EE_ ) {
-    // !meEle_eta_MTD_4sigma_Bkg_EB_ || !meEle_eta_MTD_3sigma_Bkg_EB_ || !meEle_eta_MTD_2sigma_Bkg_EB_ ||
-    // !meEle_phi_MTD_4sigma_Bkg_EB_ || !meEle_phi_MTD_3sigma_Bkg_EB_ || !meEle_phi_MTD_2sigma_Bkg_EB_ ||
-    // !meEle_eta_MTD_4sigma_Bkg_EE_ || !meEle_eta_MTD_3sigma_Bkg_EE_ || !meEle_eta_MTD_2sigma_Bkg_EE_ ||
-    // !meEle_phi_MTD_4sigma_Bkg_EE_ || !meEle_phi_MTD_3sigma_Bkg_EE_ || !meEle_phi_MTD_2sigma_Bkg_EE_) {
-    edm::LogError("MtdEleIsoHarvester") << "Monitoring histograms not found!" << std::endl;
-    return;
+  MonitorElement* meEle_eta_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_eta_MTD_4sigma_Bkg_EE");
+  MonitorElement* meEle_phi_MTD_4sigma_Bkg_EE_ = igetter.get(folder_ + "Ele_phi_MTD_4sigma_Bkg_EE");
+  if (optionalPlots_) {
+    if (!meEle_pt_tot_Sig_EB_ || !meEle_pt_MTD_1_Sig_EB_ || !meEle_pt_MTD_2_Sig_EB_ || !meEle_pt_MTD_3_Sig_EB_ ||
+        !meEle_pt_MTD_4_Sig_EB_ || !meEle_pt_MTD_5_Sig_EB_ || !meEle_pt_MTD_6_Sig_EB_ || !meEle_pt_MTD_7_Sig_EB_ ||
+        !meEle_pt_noMTD_Sig_EB_ || !meEle_eta_tot_Sig_EB_ || !meEle_eta_MTD_1_Sig_EB_ || !meEle_eta_MTD_2_Sig_EB_ ||
+        !meEle_eta_MTD_3_Sig_EB_ || !meEle_eta_MTD_4_Sig_EB_ || !meEle_eta_MTD_5_Sig_EB_ || !meEle_eta_MTD_6_Sig_EB_ ||
+        !meEle_eta_MTD_7_Sig_EB_ || !meEle_eta_noMTD_Sig_EB_ || !meEle_phi_tot_Sig_EB_ || !meEle_phi_MTD_1_Sig_EB_ ||
+        !meEle_phi_MTD_2_Sig_EB_ || !meEle_phi_MTD_3_Sig_EB_ || !meEle_phi_MTD_4_Sig_EB_ || !meEle_phi_MTD_5_Sig_EB_ ||
+        !meEle_phi_MTD_6_Sig_EB_ || !meEle_phi_MTD_7_Sig_EB_ || !meEle_phi_noMTD_Sig_EB_ || !meEle_pt_tot_Sig_EE_ ||
+        !meEle_pt_MTD_1_Sig_EE_ || !meEle_pt_MTD_2_Sig_EE_ || !meEle_pt_MTD_3_Sig_EE_ || !meEle_pt_MTD_4_Sig_EE_ ||
+        !meEle_pt_MTD_5_Sig_EE_ || !meEle_pt_MTD_6_Sig_EE_ || !meEle_pt_MTD_7_Sig_EE_ || !meEle_pt_noMTD_Sig_EE_ ||
+        !meEle_eta_tot_Sig_EE_ || !meEle_eta_MTD_1_Sig_EE_ || !meEle_eta_MTD_2_Sig_EE_ || !meEle_eta_MTD_3_Sig_EE_ ||
+        !meEle_eta_MTD_4_Sig_EE_ || !meEle_eta_MTD_5_Sig_EE_ || !meEle_eta_MTD_6_Sig_EE_ || !meEle_eta_MTD_7_Sig_EE_ ||
+        !meEle_eta_noMTD_Sig_EE_ || !meEle_phi_tot_Sig_EE_ || !meEle_phi_MTD_1_Sig_EE_ || !meEle_phi_MTD_2_Sig_EE_ ||
+        !meEle_phi_MTD_3_Sig_EE_ || !meEle_phi_MTD_4_Sig_EE_ || !meEle_phi_MTD_5_Sig_EE_ || !meEle_phi_MTD_6_Sig_EE_ ||
+        !meEle_phi_MTD_7_Sig_EE_ || !meEle_phi_noMTD_Sig_EE_ || !meEle_pt_tot_Bkg_EB_ || !meEle_pt_MTD_1_Bkg_EB_ ||
+        !meEle_pt_MTD_2_Bkg_EB_ || !meEle_pt_MTD_3_Bkg_EB_ || !meEle_pt_MTD_4_Bkg_EB_ || !meEle_pt_MTD_5_Bkg_EB_ ||
+        !meEle_pt_MTD_6_Bkg_EB_ || !meEle_pt_MTD_7_Bkg_EB_ || !meEle_pt_noMTD_Bkg_EB_ || !meEle_eta_tot_Bkg_EB_ ||
+        !meEle_eta_MTD_1_Bkg_EB_ || !meEle_eta_MTD_2_Bkg_EB_ || !meEle_eta_MTD_3_Bkg_EB_ || !meEle_eta_MTD_4_Bkg_EB_ ||
+        !meEle_eta_MTD_5_Bkg_EB_ || !meEle_eta_MTD_6_Bkg_EB_ || !meEle_eta_MTD_7_Bkg_EB_ || !meEle_eta_noMTD_Bkg_EB_ ||
+        !meEle_phi_tot_Bkg_EB_ || !meEle_phi_MTD_1_Bkg_EB_ || !meEle_phi_MTD_2_Bkg_EB_ || !meEle_phi_MTD_3_Bkg_EB_ ||
+        !meEle_phi_MTD_4_Bkg_EB_ || !meEle_phi_MTD_5_Bkg_EB_ || !meEle_phi_MTD_6_Bkg_EB_ || !meEle_phi_MTD_7_Bkg_EB_ ||
+        !meEle_phi_noMTD_Bkg_EB_ || !meEle_pt_tot_Bkg_EE_ || !meEle_pt_MTD_1_Bkg_EE_ || !meEle_pt_MTD_2_Bkg_EE_ ||
+        !meEle_pt_MTD_3_Bkg_EE_ || !meEle_pt_MTD_4_Bkg_EE_ || !meEle_pt_MTD_5_Bkg_EE_ || !meEle_pt_MTD_6_Bkg_EE_ ||
+        !meEle_pt_MTD_7_Bkg_EE_ || !meEle_pt_noMTD_Bkg_EE_ || !meEle_eta_tot_Bkg_EE_ || !meEle_eta_MTD_1_Bkg_EE_ ||
+        !meEle_eta_MTD_2_Bkg_EE_ || !meEle_eta_MTD_3_Bkg_EE_ || !meEle_eta_MTD_4_Bkg_EE_ || !meEle_eta_MTD_5_Bkg_EE_ ||
+        !meEle_eta_MTD_6_Bkg_EE_ || !meEle_eta_MTD_7_Bkg_EE_ || !meEle_eta_noMTD_Bkg_EE_ || !meEle_phi_tot_Bkg_EE_ ||
+        !meEle_phi_MTD_1_Bkg_EE_ || !meEle_phi_MTD_2_Bkg_EE_ || !meEle_phi_MTD_3_Bkg_EE_ || !meEle_phi_MTD_4_Bkg_EE_ ||
+        !meEle_phi_MTD_5_Bkg_EE_ || !meEle_phi_MTD_6_Bkg_EE_ || !meEle_phi_MTD_7_Bkg_EE_ || !meEle_phi_noMTD_Bkg_EE_ ||
+        !meEle_pt_sim_MTD_1_Sig_EB_ || !meEle_pt_sim_MTD_2_Sig_EB_ || !meEle_pt_sim_MTD_3_Sig_EB_ ||
+        !meEle_pt_sim_MTD_4_Sig_EB_ || !meEle_pt_sim_MTD_5_Sig_EB_ || !meEle_pt_sim_MTD_6_Sig_EB_ ||
+        !meEle_pt_sim_MTD_7_Sig_EB_ || !meEle_pt_sim_MTD_1_Sig_EE_ || !meEle_pt_sim_MTD_2_Sig_EE_ ||
+        !meEle_pt_sim_MTD_3_Sig_EE_ || !meEle_pt_sim_MTD_4_Sig_EE_ || !meEle_pt_sim_MTD_5_Sig_EE_ ||
+        !meEle_pt_sim_MTD_6_Sig_EE_ || !meEle_pt_sim_MTD_7_Sig_EE_ || !meEle_pt_sim_MTD_1_Bkg_EB_ ||
+        !meEle_pt_sim_MTD_2_Bkg_EB_ || !meEle_pt_sim_MTD_3_Bkg_EB_ || !meEle_pt_sim_MTD_4_Bkg_EB_ ||
+        !meEle_pt_sim_MTD_5_Bkg_EB_ || !meEle_pt_sim_MTD_6_Bkg_EB_ || !meEle_pt_sim_MTD_7_Bkg_EB_ ||
+        !meEle_pt_sim_MTD_1_Bkg_EE_ || !meEle_pt_sim_MTD_2_Bkg_EE_ || !meEle_pt_sim_MTD_3_Bkg_EE_ ||
+        !meEle_pt_sim_MTD_4_Bkg_EE_ || !meEle_pt_sim_MTD_5_Bkg_EE_ || !meEle_pt_sim_MTD_6_Bkg_EE_ ||
+        !meEle_pt_sim_MTD_7_Bkg_EE_ || !meEle_pt_MTD_4sigma_Sig_EB_ || !meEle_pt_MTD_3sigma_Sig_EB_ ||
+        !meEle_pt_MTD_2sigma_Sig_EB_ || !meEle_pt_MTD_4sigma_Sig_EE_ || !meEle_pt_MTD_3sigma_Sig_EE_ ||
+        !meEle_pt_MTD_2sigma_Sig_EE_ || !meEle_pt_MTD_4sigma_Bkg_EB_ || !meEle_pt_MTD_3sigma_Bkg_EB_ ||
+        !meEle_pt_MTD_2sigma_Bkg_EB_ || !meEle_pt_MTD_4sigma_Bkg_EE_ || !meEle_pt_MTD_3sigma_Bkg_EE_ ||
+        !meEle_pt_MTD_2sigma_Bkg_EE_ || !meEle_pt_sim_MTD_4sigma_Sig_EB_ || !meEle_pt_sim_MTD_3sigma_Sig_EB_ ||
+        !meEle_pt_sim_MTD_2sigma_Sig_EB_ || !meEle_pt_sim_MTD_4sigma_Sig_EE_ || !meEle_pt_sim_MTD_3sigma_Sig_EE_ ||
+        !meEle_pt_sim_MTD_2sigma_Sig_EE_ || !meEle_pt_sim_MTD_4sigma_Bkg_EB_ || !meEle_pt_sim_MTD_3sigma_Bkg_EB_ ||
+        !meEle_pt_sim_MTD_2sigma_Bkg_EB_ || !meEle_pt_sim_MTD_4sigma_Bkg_EE_ || !meEle_pt_sim_MTD_3sigma_Bkg_EE_ ||
+        !meEle_pt_sim_MTD_2sigma_Bkg_EE_ || !meEle_pt_gen_Sig_EB_ || !meEle_pt_gen_Sig_EE_ || !meEle_pt_gen_Bkg_EB_ ||
+        !meEle_pt_gen_Bkg_EE_ || !meEle_eta_MTD_4sigma_Sig_EB_ || !meEle_eta_MTD_3sigma_Sig_EB_ ||
+        !meEle_eta_MTD_2sigma_Sig_EB_ || !meEle_phi_MTD_4sigma_Sig_EB_ || !meEle_phi_MTD_3sigma_Sig_EB_ ||
+        !meEle_phi_MTD_2sigma_Sig_EB_ || !meEle_eta_MTD_4sigma_Sig_EE_ || !meEle_eta_MTD_3sigma_Sig_EE_ ||
+        !meEle_eta_MTD_2sigma_Sig_EE_ || !meEle_phi_MTD_4sigma_Sig_EE_ || !meEle_phi_MTD_3sigma_Sig_EE_ ||
+        !meEle_phi_MTD_2sigma_Sig_EE_ || !meEle_eta_MTD_4sigma_Bkg_EB_ || !meEle_eta_MTD_3sigma_Bkg_EB_ ||
+        !meEle_eta_MTD_2sigma_Bkg_EB_ || !meEle_phi_MTD_4sigma_Bkg_EB_ || !meEle_phi_MTD_3sigma_Bkg_EB_ ||
+        !meEle_phi_MTD_2sigma_Bkg_EB_ || !meEle_eta_MTD_4sigma_Bkg_EE_ || !meEle_eta_MTD_3sigma_Bkg_EE_ ||
+        !meEle_eta_MTD_2sigma_Bkg_EE_ || !meEle_phi_MTD_4sigma_Bkg_EE_ || !meEle_phi_MTD_3sigma_Bkg_EE_ ||
+        !meEle_phi_MTD_2sigma_Bkg_EE_) {
+      edm::LogError("MtdEleIsoHarvester") << "Monitoring histograms not found!" << std::endl;
+      return;
+    }
+  } else {
+    if (!meEle_pt_tot_Sig_EB_ || !meEle_pt_noMTD_Sig_EB_ || !meEle_eta_tot_Sig_EB_ || !meEle_eta_noMTD_Sig_EB_ ||
+        !meEle_phi_tot_Sig_EB_ || !meEle_phi_noMTD_Sig_EB_ || !meEle_pt_tot_Sig_EE_ || !meEle_pt_noMTD_Sig_EE_ ||
+        !meEle_eta_tot_Sig_EE_ || !meEle_eta_noMTD_Sig_EE_ || !meEle_phi_tot_Sig_EE_ || !meEle_phi_noMTD_Sig_EE_ ||
+        !meEle_pt_tot_Bkg_EB_ || !meEle_pt_noMTD_Bkg_EB_ || !meEle_eta_tot_Bkg_EB_ || !meEle_eta_noMTD_Bkg_EB_ ||
+        !meEle_phi_tot_Bkg_EB_ || !meEle_phi_noMTD_Bkg_EB_ || !meEle_pt_tot_Bkg_EE_ || !meEle_pt_noMTD_Bkg_EE_ ||
+        !meEle_eta_tot_Bkg_EE_ || !meEle_eta_noMTD_Bkg_EE_ || !meEle_phi_tot_Bkg_EE_ || !meEle_phi_noMTD_Bkg_EE_ ||
+        !meEle_pt_MTD_4sigma_Sig_EB_ || !meEle_pt_MTD_3sigma_Sig_EB_ || !meEle_pt_MTD_2sigma_Sig_EB_ ||
+        !meEle_pt_MTD_4sigma_Sig_EE_ || !meEle_pt_MTD_3sigma_Sig_EE_ || !meEle_pt_MTD_2sigma_Sig_EE_ ||
+        !meEle_pt_MTD_4sigma_Bkg_EB_ || !meEle_pt_MTD_3sigma_Bkg_EB_ || !meEle_pt_MTD_2sigma_Bkg_EB_ ||
+        !meEle_pt_MTD_4sigma_Bkg_EE_ || !meEle_pt_MTD_3sigma_Bkg_EE_ || !meEle_pt_MTD_2sigma_Bkg_EE_ ||
+        !meEle_pt_sim_MTD_4sigma_Sig_EB_ || !meEle_pt_sim_MTD_3sigma_Sig_EB_ || !meEle_pt_sim_MTD_2sigma_Sig_EB_ ||
+        !meEle_pt_sim_MTD_4sigma_Sig_EE_ || !meEle_pt_sim_MTD_3sigma_Sig_EE_ || !meEle_pt_sim_MTD_2sigma_Sig_EE_ ||
+        !meEle_pt_sim_MTD_4sigma_Bkg_EB_ || !meEle_pt_sim_MTD_3sigma_Bkg_EB_ || !meEle_pt_sim_MTD_2sigma_Bkg_EB_ ||
+        !meEle_pt_sim_MTD_4sigma_Bkg_EE_ || !meEle_pt_sim_MTD_3sigma_Bkg_EE_ || !meEle_pt_sim_MTD_2sigma_Bkg_EE_ ||
+        !meEle_eta_MTD_4sigma_Sig_EB_ || !meEle_eta_MTD_3sigma_Sig_EB_ || !meEle_eta_MTD_2sigma_Sig_EB_ ||
+        !meEle_phi_MTD_4sigma_Sig_EB_ || !meEle_phi_MTD_3sigma_Sig_EB_ || !meEle_phi_MTD_2sigma_Sig_EB_ ||
+        !meEle_eta_MTD_4sigma_Sig_EE_ || !meEle_eta_MTD_3sigma_Sig_EE_ || !meEle_eta_MTD_2sigma_Sig_EE_ ||
+        !meEle_phi_MTD_4sigma_Sig_EE_ || !meEle_phi_MTD_3sigma_Sig_EE_ || !meEle_phi_MTD_2sigma_Sig_EE_ ||
+        !meEle_eta_MTD_4sigma_Bkg_EB_ || !meEle_eta_MTD_3sigma_Bkg_EB_ || !meEle_eta_MTD_2sigma_Bkg_EB_ ||
+        !meEle_phi_MTD_4sigma_Bkg_EB_ || !meEle_phi_MTD_3sigma_Bkg_EB_ || !meEle_phi_MTD_2sigma_Bkg_EB_ ||
+        !meEle_eta_MTD_4sigma_Bkg_EE_ || !meEle_eta_MTD_3sigma_Bkg_EE_ || !meEle_eta_MTD_2sigma_Bkg_EE_ ||
+        !meEle_phi_MTD_4sigma_Bkg_EE_ || !meEle_phi_MTD_3sigma_Bkg_EE_ || !meEle_phi_MTD_2sigma_Bkg_EE_) {
+      edm::LogError("MtdEleIsoHarvester") << "Monitoring histograms not found!" << std::endl;
+      return;
+    }
   }
-
   // --- Book  histograms
   ibook.cd(folder_);
   // ele iso addition starts; MTD vs noMTD case
   /////////////////////////////////////////////////////// For promt (signal)
+  if (optionalPlots_) {
+    mePtEffMTD_1_Sig_EB_ = ibook.book1D("pTeffMTD_1_Sig_EB",
+                                        " MTD isolation Efficiency 1 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_1_Sig_EB_);
 
-  mePtEffMTD_1_Sig_EB_ = ibook.book1D("pTeffMTD_1_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_1_Sig_EB_);
+    mePtEffMTD_2_Sig_EB_ = ibook.book1D("pTeffMTD_2_Sig_EB",
+                                        " MTD isolation Efficiency 2 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_2_Sig_EB_);
 
-  mePtEffMTD_2_Sig_EB_ = ibook.book1D("pTeffMTD_2_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_2_Sig_EB_);
+    mePtEffMTD_3_Sig_EB_ = ibook.book1D("pTeffMTD_3_Sig_EB",
+                                        " MTD isolation Efficiency 3 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_3_Sig_EB_);
 
-  mePtEffMTD_3_Sig_EB_ = ibook.book1D("pTeffMTD_3_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_3_Sig_EB_);
+    mePtEffMTD_4_Sig_EB_ = ibook.book1D("pTeffMTD_4_Sig_EB",
+                                        " MTD isolation Efficiency 4 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_4_Sig_EB_);
 
-  mePtEffMTD_4_Sig_EB_ = ibook.book1D("pTeffMTD_4_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_4_Sig_EB_);
+    mePtEffMTD_5_Sig_EB_ = ibook.book1D("pTeffMTD_5_Sig_EB",
+                                        " MTD isolation Efficiency 5 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_5_Sig_EB_);
 
-  mePtEffMTD_5_Sig_EB_ = ibook.book1D("pTeffMTD_5_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_5_Sig_EB_);
+    mePtEffMTD_6_Sig_EB_ = ibook.book1D("pTeffMTD_6_Sig_EB",
+                                        " MTD isolation Efficiency 6 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_6_Sig_EB_);
 
-  mePtEffMTD_6_Sig_EB_ = ibook.book1D("pTeffMTD_6_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_6_Sig_EB_);
+    mePtEffMTD_7_Sig_EB_ = ibook.book1D("pTeffMTD_7_Sig_EB",
+                                        " MTD isolation Efficiency 7 Signal Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EB_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_7_Sig_EB_);
 
-  mePtEffMTD_7_Sig_EB_ = ibook.book1D("pTeffMTD_7_Sig_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_7_Sig_EB_);
+    mePtEffMTD_sim_1_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EB",
+                                            " MTD isolation Efficiency 1 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_1_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_1_Sig_EB_);
 
-  mePtEffMTD_sim_1_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_1_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_1_Sig_EB_);
+    mePtEffMTD_sim_2_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EB",
+                                            " MTD isolation Efficiency 2 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2_Sig_EB_);
 
-  mePtEffMTD_sim_2_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2_Sig_EB_);
+    mePtEffMTD_sim_3_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EB",
+                                            " MTD isolation Efficiency 3 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3_Sig_EB_);
 
-  mePtEffMTD_sim_3_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3_Sig_EB_);
+    mePtEffMTD_sim_4_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EB",
+                                            " MTD isolation Efficiency 4 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4_Sig_EB_);
 
-  mePtEffMTD_sim_4_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4_Sig_EB_);
+    mePtEffMTD_sim_5_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EB",
+                                            " MTD isolation Efficiency 5 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_5_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_5_Sig_EB_);
 
-  mePtEffMTD_sim_5_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_5_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_5_Sig_EB_);
+    mePtEffMTD_sim_6_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EB",
+                                            " MTD isolation Efficiency 6 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_6_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_6_Sig_EB_);
 
-  mePtEffMTD_sim_6_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_6_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_6_Sig_EB_);
+    mePtEffMTD_sim_7_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EB",
+                                            " MTD isolation Efficiency 7 SIM Signal barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_7_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_7_Sig_EB_);
 
-  mePtEffMTD_sim_7_Sig_EB_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_7_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_7_Sig_EB_);
+    mePtEffMTD_sim_4sigma_Sig_EB_ =
+        ibook.book1D("pTeffMTD_sim_4sigma_Sig_EB",
+                     " MTD isolation Efficiency SIM - 4 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4sigma_Sig_EB_);
 
-  mePtEffMTD_4sigma_Sig_EB_ = ibook.book1D("pTeffMTD_4sigma_Sig_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Sig_EB_ =
+        ibook.book1D("pTeffMTD_sim_3sigma_Sig_EB",
+                     " MTD isolation Efficiency SIM - 3 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3sigma_Sig_EB_);
+
+    mePtEffMTD_sim_2sigma_Sig_EB_ =
+        ibook.book1D("pTeffMTD_sim_2sigma_Sig_EB",
+                     " MTD isolation Efficiency SIM - 2 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2sigma_Sig_EB_);
+
+    meEtaEffMTD_1_Sig_EB_ = ibook.book1D("EtaEffMTD_1_Sig_EB",
+                                         " MTD isolation Efficiency 1 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_1_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_1_Sig_EB_);
+
+    meEtaEffMTD_2_Sig_EB_ = ibook.book1D("EtaEffMTD_2_Sig_EB",
+                                         " MTD isolation Efficiency 2 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_2_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2_Sig_EB_);
+
+    meEtaEffMTD_3_Sig_EB_ = ibook.book1D("EtaEffMTD_3_Sig_EB",
+                                         " MTD isolation Efficiency 3 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_3_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3_Sig_EB_);
+
+    meEtaEffMTD_4_Sig_EB_ = ibook.book1D("EtaEffMTD_4_Sig_EB",
+                                         " MTD isolation Efficiency 4 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_4_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4_Sig_EB_);
+
+    meEtaEffMTD_5_Sig_EB_ = ibook.book1D("EtaEffMTD_5_Sig_EB",
+                                         " MTD isolation Efficiency 5 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_5_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_5_Sig_EB_);
+
+    meEtaEffMTD_6_Sig_EB_ = ibook.book1D("EtaEffMTD_6_Sig_EB",
+                                         " MTD isolation Efficiency 6 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_6_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_6_Sig_EB_);
+
+    meEtaEffMTD_7_Sig_EB_ = ibook.book1D("EtaEffMTD_7_Sig_EB",
+                                         " MTD isolation Efficiency 7 Signal Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EB_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_7_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_7_Sig_EB_);
+
+    mePhiEffMTD_1_Sig_EB_ = ibook.book1D("PhiEffMTD_1_Sig_EB",
+                                         " MTD isolation Efficiency 1 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_1_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_1_Sig_EB_);
+
+    mePhiEffMTD_2_Sig_EB_ = ibook.book1D("PhiEffMTD_2_Sig_EB",
+                                         " MTD isolation Efficiency 2 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_2_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2_Sig_EB_);
+
+    mePhiEffMTD_3_Sig_EB_ = ibook.book1D("PhiEffMTD_3_Sig_EB",
+                                         " MTD isolation Efficiency 3 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_3_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3_Sig_EB_);
+
+    mePhiEffMTD_4_Sig_EB_ = ibook.book1D("PhiEffMTD_4_Sig_EB",
+                                         " MTD isolation Efficiency 4 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_4_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4_Sig_EB_);
+
+    mePhiEffMTD_5_Sig_EB_ = ibook.book1D("PhiEffMTD_5_Sig_EB",
+                                         " MTD isolation Efficiency 5 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_5_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_5_Sig_EB_);
+
+    mePhiEffMTD_6_Sig_EB_ = ibook.book1D("PhiEffMTD_6_Sig_EB",
+                                         " MTD isolation Efficiency 6 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_6_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_6_Sig_EB_);
+
+    mePhiEffMTD_7_Sig_EB_ = ibook.book1D("PhiEffMTD_7_Sig_EB",
+                                         " MTD isolation Efficiency 7 Signal Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EB_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_7_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_7_Sig_EB_);
+  }
+
+  mePtEffMTD_4sigma_Sig_EB_ =
+      ibook.book1D("pTeffMTD_4sigma_Sig_EB",
+                   "MTD isolation Efficiency - 4 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EB_->getNbinsX(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_4sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_4sigma_Sig_EB_);
 
-  mePtEffMTD_3sigma_Sig_EB_ = ibook.book1D("pTeffMTD_3sigma_Sig_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Sig_EB_ =
+      ibook.book1D("pTeffMTD_3sigma_Sig_EB",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EB_->getNbinsX(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_3sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_3sigma_Sig_EB_);
 
-  mePtEffMTD_2sigma_Sig_EB_ = ibook.book1D("pTeffMTD_2sigma_Sig_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EB_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Sig_EB_ =
+      ibook.book1D("pTeffMTD_2sigma_Sig_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EB_->getNbinsX(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_2sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_2sigma_Sig_EB_);
 
-  mePtEffMTD_sim_4sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_4sigma_Sig_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_4sigma_Sig_EB_);
+  meEtaEffMTD_4sigma_Sig_EB_ =
+      ibook.book1D("EtaEffMTD_4sigma_Sig_EB",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Signal Barrel VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EB_->getNbinsX(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4sigma_Sig_EB_);
 
-  mePtEffMTD_sim_3sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_3sigma_Sig_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_3sigma_Sig_EB_);
+  meEtaEffMTD_3sigma_Sig_EB_ =
+      ibook.book1D("EtaEffMTD_3sigma_Sig_EB",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Signal Barrel VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EB_->getNbinsX(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3sigma_Sig_EB_);
 
-  mePtEffMTD_sim_2sigma_Sig_EB_ = ibook.book1D("pTeffMTD_sim_2sigma_Sig_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffMTD_sim_2sigma_Sig_EB_);
+  meEtaEffMTD_2sigma_Sig_EB_ =
+      ibook.book1D("EtaEffMTD_2sigma_Sig_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Barrel VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EB_->getNbinsX(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2sigma_Sig_EB_);
+  mePhiEffMTD_4sigma_Sig_EB_ =
+      ibook.book1D("PhiEffMTD_4sigma_Sig_EB",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Signal Barrel VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EB_->getNbinsX(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4sigma_Sig_EB_);
 
-  meEtaEffMTD_1_Sig_EB_ = ibook.book1D("EtaEffMTD_1_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_1_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_1_Sig_EB_);
+  mePhiEffMTD_3sigma_Sig_EB_ =
+      ibook.book1D("PhiEffMTD_3sigma_Sig_EB",
+                   " MTD isolation Efficiency - 3  sigma compatibility - Signal Barrel VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EB_->getNbinsX(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3sigma_Sig_EB_);
 
-  meEtaEffMTD_2_Sig_EB_ = ibook.book1D("EtaEffMTD_2_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_2_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2_Sig_EB_);
-
-  meEtaEffMTD_3_Sig_EB_ = ibook.book1D("EtaEffMTD_3_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_3_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3_Sig_EB_);
-
-  meEtaEffMTD_4_Sig_EB_ = ibook.book1D("EtaEffMTD_4_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_4_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4_Sig_EB_);
-
-  meEtaEffMTD_5_Sig_EB_ = ibook.book1D("EtaEffMTD_5_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_5_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_5_Sig_EB_);
-
-  meEtaEffMTD_6_Sig_EB_ = ibook.book1D("EtaEffMTD_6_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_6_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_6_Sig_EB_);
-
-  meEtaEffMTD_7_Sig_EB_ = ibook.book1D("EtaEffMTD_7_Sig_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EB_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_7_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_7_Sig_EB_);
-
-  // meEtaEffMTD_4sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_4sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_4sigma_Sig_EB_);
-
-  // meEtaEffMTD_3sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_3sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_3sigma_Sig_EB_);
-
-  // meEtaEffMTD_2sigma_Sig_EB_ = ibook.book1D("EtaEffMTD_2sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffMTD_2sigma_Sig_EB_);
-
-  mePhiEffMTD_1_Sig_EB_ = ibook.book1D("PhiEffMTD_1_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_1_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_1_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_1_Sig_EB_);
-
-  mePhiEffMTD_2_Sig_EB_ = ibook.book1D("PhiEffMTD_2_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_2_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_2_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2_Sig_EB_);
-
-  mePhiEffMTD_3_Sig_EB_ = ibook.book1D("PhiEffMTD_3_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_3_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_3_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3_Sig_EB_);
-
-  mePhiEffMTD_4_Sig_EB_ = ibook.book1D("PhiEffMTD_4_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_4_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_4_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4_Sig_EB_);
-
-  mePhiEffMTD_5_Sig_EB_ = ibook.book1D("PhiEffMTD_5_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_5_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_5_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_5_Sig_EB_);
-
-  mePhiEffMTD_6_Sig_EB_ = ibook.book1D("PhiEffMTD_6_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_6_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_6_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_6_Sig_EB_);
-
-  mePhiEffMTD_7_Sig_EB_ = ibook.book1D("PhiEffMTD_7_Sig_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EB_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_7_Sig_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_7_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_7_Sig_EB_);
-
-  // mePhiEffMTD_4sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_4sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_4sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_4sigma_Sig_EB_);
-
-  // meEtaEffMTD_3sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_3sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_3sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_3sigma_Sig_EB_);
-
-  // meEtaEffMTD_2sigma_Sig_EB_ = ibook.book1D("PhiEffMTD_2sigma_Sig_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2sigma_Sig_EB_);
+  mePhiEffMTD_2sigma_Sig_EB_ =
+      ibook.book1D("PhiEffMTD_2sigma_Sig_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Barrel VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EB_->getNbinsX(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2sigma_Sig_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffMTD_2sigma_Sig_EB_);
 
   mePtEffnoMTD_Sig_EB_ = ibook.book1D("pTeffnoMTD_Sig_EB",
-                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      " noMTD isolation Efficiency - Signal Barrel VS pT;p_{T};Efficiency",
                                       meEle_pt_tot_Sig_EB_->getNbinsX(),
                                       meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
                                       meEle_pt_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
@@ -917,7 +962,7 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_pt_noMTD_Sig_EB_, meEle_pt_tot_Sig_EB_, mePtEffnoMTD_Sig_EB_);
 
   meEtaEffnoMTD_Sig_EB_ = ibook.book1D("EtaEffnoMTD_Sig_EB",
-                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       " noMTD isolation Efficiency - Signal Barrel VS Eta;#eta;Efficiency",
                                        meEle_eta_tot_Sig_EB_->getNbinsX(),
                                        meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_eta_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
@@ -925,338 +970,367 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_eta_noMTD_Sig_EB_, meEle_eta_tot_Sig_EB_, meEtaEffnoMTD_Sig_EB_);
 
   mePhiEffnoMTD_Sig_EB_ = ibook.book1D("PhiEffnoMTD_Sig_EB",
-                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       " noMTD isolation Efficiency - Signal Barrel VS Phi;#phi;Efficiency",
                                        meEle_phi_tot_Sig_EB_->getNbinsX(),
                                        meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_phi_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
   mePhiEffnoMTD_Sig_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_phi_noMTD_Sig_EB_, meEle_phi_tot_Sig_EB_, mePhiEffnoMTD_Sig_EB_);
 
-  // Ele iso addition ends
-  // For endcap now
+  if (optionalPlots_) {
+    mePtEffgen_Sig_EB_ = ibook.book1D("pTeffMTD_gen_Sig_EB",
+                                      " MTD isolation Efficiency - genInfo - Signal Barrel VS pT;p_{T};Efficiency",
+                                      meEle_pt_sim_tot_Sig_EB_->getNbinsX(),
+                                      meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_sim_tot_Sig_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffgen_Sig_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_gen_Sig_EB_, meEle_pt_sim_tot_Sig_EB_, mePtEffgen_Sig_EB_);
 
-  mePtEffMTD_1_Sig_EE_ = ibook.book1D("pTeffMTD_1_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_1_Sig_EE_);
+    // Ele iso addition ends
+    // For endcap now
+    mePtEffMTD_1_Sig_EE_ = ibook.book1D("pTeffMTD_1_Sig_EE",
+                                        " MTD isolation Efficiency - 1 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_1_Sig_EE_);
 
-  mePtEffMTD_2_Sig_EE_ = ibook.book1D("pTeffMTD_2_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_2_Sig_EE_);
+    mePtEffMTD_2_Sig_EE_ = ibook.book1D("pTeffMTD_2_Sig_EE",
+                                        " MTD isolation Efficiency - 2 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_2_Sig_EE_);
 
-  mePtEffMTD_3_Sig_EE_ = ibook.book1D("pTeffMTD_3_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_3_Sig_EE_);
+    mePtEffMTD_3_Sig_EE_ = ibook.book1D("pTeffMTD_3_Sig_EE",
+                                        " MTD isolation Efficiency - 3 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_3_Sig_EE_);
 
-  mePtEffMTD_4_Sig_EE_ = ibook.book1D("pTeffMTD_4_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_4_Sig_EE_);
+    mePtEffMTD_4_Sig_EE_ = ibook.book1D("pTeffMTD_4_Sig_EE",
+                                        " MTD isolation Efficiency - 4 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_4_Sig_EE_);
 
-  mePtEffMTD_5_Sig_EE_ = ibook.book1D("pTeffMTD_5_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_5_Sig_EE_);
+    mePtEffMTD_5_Sig_EE_ = ibook.book1D("pTeffMTD_5_Sig_EE",
+                                        " MTD isolation Efficiency - 5 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_5_Sig_EE_);
 
-  mePtEffMTD_6_Sig_EE_ = ibook.book1D("pTeffMTD_6_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_6_Sig_EE_);
+    mePtEffMTD_6_Sig_EE_ = ibook.book1D("pTeffMTD_6_Sig_EE",
+                                        " MTD isolation Efficiency - 6 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_6_Sig_EE_);
 
-  mePtEffMTD_7_Sig_EE_ = ibook.book1D("pTeffMTD_7_Sig_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_7_Sig_EE_);
+    mePtEffMTD_7_Sig_EE_ = ibook.book1D("pTeffMTD_7_Sig_EE",
+                                        " MTD isolation Efficiency - 7 Signal Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Sig_EE_->getNbinsX(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_7_Sig_EE_);
 
-  mePtEffMTD_sim_1_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_1_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_1_Sig_EE_);
+    mePtEffMTD_sim_1_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_1_Sig_EE_",
+                                            " MTD isolation Efficiency - 1 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_1_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_1_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_1_Sig_EE_);
 
-  mePtEffMTD_sim_2_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2_Sig_EE_);
+    mePtEffMTD_sim_2_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_2_Sig_EE_",
+                                            " MTD isolation Efficiency - 2 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2_Sig_EE_);
 
-  mePtEffMTD_sim_3_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3_Sig_EE_);
+    mePtEffMTD_sim_3_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_3_Sig_EE_",
+                                            " MTD isolation Efficiency - 3 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3_Sig_EE_);
 
-  mePtEffMTD_sim_4_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4_Sig_EE_);
+    mePtEffMTD_sim_4_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_4_Sig_EE_",
+                                            " MTD isolation Efficiency - 4 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4_Sig_EE_);
 
-  mePtEffMTD_sim_5_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_5_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_5_Sig_EE_);
+    mePtEffMTD_sim_5_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_5_Sig_EE_",
+                                            " MTD isolation Efficiency - 5 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_5_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_5_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_5_Sig_EE_);
 
-  mePtEffMTD_sim_6_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_6_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_6_Sig_EE_);
+    mePtEffMTD_sim_6_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_6_Sig_EE_",
+                                            " MTD isolation Efficiency - 6 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_6_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_6_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_6_Sig_EE_);
 
-  mePtEffMTD_sim_7_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_7_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_7_Sig_EE_);
+    mePtEffMTD_sim_7_Sig_EE_ = ibook.book1D("mePtEffMTD_sim_7_Sig_EE_",
+                                            " MTD isolation Efficiency - 7 SIM Signal Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_7_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_7_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_7_Sig_EE_);
 
-  mePtEffMTD_4sigma_Sig_EE_ = ibook.book1D("pTeffMTD_4sigma_Sig_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4sigma_Sig_EE_ =
+        ibook.book1D("pTeffMTD_sim_4sigma_Sig_EE",
+                     " MTD isolation Efficiency SIM - 4 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4sigma_Sig_EE_);
+
+    mePtEffMTD_sim_3sigma_Sig_EE_ =
+        ibook.book1D("pTeffMTD_sim_3sigma_Sig_EE",
+                     " MTD isolation Efficiency SIM - 3 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3sigma_Sig_EE_);
+
+    mePtEffMTD_sim_2sigma_Sig_EE_ =
+        ibook.book1D("pTeffMTD_sim_2sigma_Sig_EE",
+                     " MTD isolation Efficiency SIM - 2 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2sigma_Sig_EE_);
+
+    meEtaEffMTD_1_Sig_EE_ = ibook.book1D("EtaEffMTD_1_Sig_EE",
+                                         " MTD isolation Efficiency 1 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_1_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_1_Sig_EE_);
+
+    meEtaEffMTD_2_Sig_EE_ = ibook.book1D("EtaEffMTD_2_Sig_EE",
+                                         " MTD isolation Efficiency 2 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_2_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2_Sig_EE_);
+
+    meEtaEffMTD_3_Sig_EE_ = ibook.book1D("EtaEffMTD_3_Sig_EE",
+                                         " MTD isolation Efficiency 3 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_3_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3_Sig_EE_);
+
+    meEtaEffMTD_4_Sig_EE_ = ibook.book1D("EtaEffMTD_4_Sig_EE",
+                                         " MTD isolation Efficiency 4 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_4_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4_Sig_EE_);
+
+    meEtaEffMTD_5_Sig_EE_ = ibook.book1D("EtaEffMTD_5_Sig_EE",
+                                         " MTD isolation Efficiency 5 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_5_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_5_Sig_EE_);
+
+    meEtaEffMTD_6_Sig_EE_ = ibook.book1D("EtaEffMTD_6_Sig_EE",
+                                         " MTD isolation Efficiency 6 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_6_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_6_Sig_EE_);
+
+    meEtaEffMTD_7_Sig_EE_ = ibook.book1D("EtaEffMTD_7_Sig_EE",
+                                         " MTD isolation Efficiency 7 Signal Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Sig_EE_->getNbinsX(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_7_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_7_Sig_EE_);
+
+    mePhiEffMTD_1_Sig_EE_ = ibook.book1D("PhiEffMTD_1_Sig_EE",
+                                         " MTD isolation Efficiency - 1 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_1_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_1_Sig_EE_);
+
+    mePhiEffMTD_2_Sig_EE_ = ibook.book1D("PhiEffMTD_2_Sig_EE",
+                                         " MTD isolation Efficiency - 2 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_2_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2_Sig_EE_);
+
+    mePhiEffMTD_3_Sig_EE_ = ibook.book1D("PhiEffMTD_3_Sig_EE",
+                                         " MTD isolation Efficiency - 3 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_3_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3_Sig_EE_);
+
+    mePhiEffMTD_4_Sig_EE_ = ibook.book1D("PhiEffMTD_4_Sig_EE",
+                                         " MTD isolation Efficiency - 4 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_4_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4_Sig_EE_);
+
+    mePhiEffMTD_5_Sig_EE_ = ibook.book1D("PhiEffMTD_5_Sig_EE",
+                                         " MTD isolation Efficiency - 5 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_5_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_5_Sig_EE_);
+
+    mePhiEffMTD_6_Sig_EE_ = ibook.book1D("PhiEffMTD_6_Sig_EE",
+                                         " MTD isolation Efficiency - 6 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_6_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_6_Sig_EE_);
+
+    mePhiEffMTD_7_Sig_EE_ = ibook.book1D("PhiEffMTD_7_Sig_EE",
+                                         " MTD isolation Efficiency - 7 Signal Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Sig_EE_->getNbinsX(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_7_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_7_Sig_EE_);
+
+    mePtEffgen_Sig_EE_ = ibook.book1D("pTeffMTD_gen_Sig_EE",
+                                      " MTD isolation Efficiency - genInfo - Signal Endcap VS pT;p_{T};Efficiency",
+                                      meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
+                                      meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffgen_Sig_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_gen_Sig_EE_, meEle_pt_sim_tot_Sig_EE_, mePtEffgen_Sig_EE_);
+  }
+
+  mePtEffMTD_4sigma_Sig_EE_ =
+      ibook.book1D("pTeffMTD_4sigma_Sig_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EE_->getNbinsX(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_4sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_4sigma_Sig_EE_);
 
-  mePtEffMTD_3sigma_Sig_EE_ = ibook.book1D("pTeffMTD_3sigma_Sig_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Sig_EE_ =
+      ibook.book1D("pTeffMTD_3sigma_Sig_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EE_->getNbinsX(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_3sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_3sigma_Sig_EE_);
 
-  mePtEffMTD_2sigma_Sig_EE_ = ibook.book1D("pTeffMTD_2sigma_Sig_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Sig_EE_->getNbinsX(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Sig_EE_ =
+      ibook.book1D("pTeffMTD_2sigma_Sig_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Sig_EE_->getNbinsX(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_2sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_2sigma_Sig_EE_);
 
-  mePtEffMTD_sim_4sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_4sigma_Sig_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_4sigma_Sig_EE_);
+  meEtaEffMTD_4sigma_Sig_EE_ =
+      ibook.book1D("EtaEffMTD_4sigma_Sig_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Signal Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EE_->getNbinsX(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4sigma_Sig_EE_);
 
-  mePtEffMTD_sim_3sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_3sigma_Sig_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_3sigma_Sig_EE_);
+  meEtaEffMTD_3sigma_Sig_EE_ =
+      ibook.book1D("EtaEffMTD_3sigma_Sig_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Signal Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EE_->getNbinsX(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3sigma_Sig_EE_);
 
-  mePtEffMTD_sim_2sigma_Sig_EE_ = ibook.book1D("pTeffMTD_sim_2sigma_Sig_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Sig_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffMTD_sim_2sigma_Sig_EE_);
+  meEtaEffMTD_2sigma_Sig_EE_ =
+      ibook.book1D("EtaEffMTD_2sigma_Sig_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Sig_EE_->getNbinsX(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2sigma_Sig_EE_);
 
-  meEtaEffMTD_1_Sig_EE_ = ibook.book1D("EtaEffMTD_1_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_1_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_1_Sig_EE_);
+  mePhiEffMTD_4sigma_Sig_EE_ =
+      ibook.book1D("PhiEffMTD_4sigma_Sig_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Signal Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EE_->getNbinsX(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4sigma_Sig_EE_);
 
-  meEtaEffMTD_2_Sig_EE_ = ibook.book1D("EtaEffMTD_2_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_2_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2_Sig_EE_);
+  mePhiEffMTD_3sigma_Sig_EE_ =
+      ibook.book1D("PhiEffMTD_3sigma_Sig_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Signal Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EE_->getNbinsX(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3sigma_Sig_EE_);
 
-  meEtaEffMTD_3_Sig_EE_ = ibook.book1D("EtaEffMTD_3_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_3_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3_Sig_EE_);
-
-  meEtaEffMTD_4_Sig_EE_ = ibook.book1D("EtaEffMTD_4_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_4_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4_Sig_EE_);
-
-  meEtaEffMTD_5_Sig_EE_ = ibook.book1D("EtaEffMTD_5_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_5_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_5_Sig_EE_);
-
-  meEtaEffMTD_6_Sig_EE_ = ibook.book1D("EtaEffMTD_6_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_6_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_6_Sig_EE_);
-
-  meEtaEffMTD_7_Sig_EE_ = ibook.book1D("EtaEffMTD_7_Sig_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Sig_EE_->getNbinsX(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_7_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_7_Sig_EE_);
-
-  // meEtaEffMTD_4sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_4sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_4sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_4sigma_Sig_EE_);
-
-  // meEtaEffMTD_3sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_3sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_3sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_3sigma_Sig_EE_);
-
-  // meEtaEffMTD_2sigma_Sig_EE_ = ibook.book1D("EtaEffMTD_2sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_2sigma_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffMTD_2sigma_Sig_EE_);
-
-  mePhiEffMTD_1_Sig_EE_ = ibook.book1D("PhiEffMTD_1_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_1_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_1_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_1_Sig_EE_);
-
-  mePhiEffMTD_2_Sig_EE_ = ibook.book1D("PhiEffMTD_2_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_2_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_2_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2_Sig_EE_);
-
-  mePhiEffMTD_3_Sig_EE_ = ibook.book1D("PhiEffMTD_3_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_3_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_3_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3_Sig_EE_);
-
-  mePhiEffMTD_4_Sig_EE_ = ibook.book1D("PhiEffMTD_4_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_4_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_4_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4_Sig_EE_);
-
-  mePhiEffMTD_5_Sig_EE_ = ibook.book1D("PhiEffMTD_5_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_5_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_5_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_5_Sig_EE_);
-
-  mePhiEffMTD_6_Sig_EE_ = ibook.book1D("PhiEffMTD_6_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_6_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_6_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_6_Sig_EE_);
-
-  mePhiEffMTD_7_Sig_EE_ = ibook.book1D("PhiEffMTD_7_Sig_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Sig_EE_->getNbinsX(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_7_Sig_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_7_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_7_Sig_EE_);
-
-  // mePhiEffMTD_4sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_4sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_4sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_4sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_4sigma_Sig_EE_);
-
-  // meEtaEffMTD_3sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_3sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_3sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_3sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_3sigma_Sig_EE_);
-
-  // meEtaEffMTD_2sigma_Sig_EE_ = ibook.book1D("PhiEffMTD_2sigma_Sig_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Sig_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2sigma_Sig_EE_);
+  mePhiEffMTD_2sigma_Sig_EE_ =
+      ibook.book1D("PhiEffMTD_2sigma_Sig_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Signal Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Sig_EE_->getNbinsX(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2sigma_Sig_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2sigma_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffMTD_2sigma_Sig_EE_);
 
   mePtEffnoMTD_Sig_EE_ = ibook.book1D("pTeffnoMTD_Sig_EE",
-                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      " noMTD isolation Efficiency - Signal Endcap VS pT;p_{T};Efficiency",
                                       meEle_pt_tot_Sig_EE_->getNbinsX(),
                                       meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
                                       meEle_pt_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
@@ -1264,7 +1338,7 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_pt_noMTD_Sig_EE_, meEle_pt_tot_Sig_EE_, mePtEffnoMTD_Sig_EE_);
 
   meEtaEffnoMTD_Sig_EE_ = ibook.book1D("EtaEffnoMTD_Sig_EE",
-                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       " noMTD isolation Efficiency - Signal Endcap VS Eta;#eta;Efficiency",
                                        meEle_eta_tot_Sig_EE_->getNbinsX(),
                                        meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_eta_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
@@ -1272,7 +1346,7 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_eta_noMTD_Sig_EE_, meEle_eta_tot_Sig_EE_, meEtaEffnoMTD_Sig_EE_);
 
   mePhiEffnoMTD_Sig_EE_ = ibook.book1D("PhiEffnoMTD_Sig_EE",
-                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       " noMTD isolation Efficiency - Signal Endcap VS Phi;#phi;Efficiency",
                                        meEle_phi_tot_Sig_EE_->getNbinsX(),
                                        meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_phi_tot_Sig_EE_->getTH1()->GetXaxis()->GetXmax());
@@ -1280,329 +1354,340 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_phi_noMTD_Sig_EE_, meEle_phi_tot_Sig_EE_, mePhiEffnoMTD_Sig_EE_);
 
   /////////////////////////////////////////////////////// For non-promt (background)
+  if (optionalPlots_) {
+    mePtEffMTD_1_Bkg_EB_ = ibook.book1D("pTeffMTD_1_Bkg_EB",
+                                        " MTD isolation Efficiency - 1 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_1_Bkg_EB_);
 
-  mePtEffMTD_1_Bkg_EB_ = ibook.book1D("pTeffMTD_1_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_1_Bkg_EB_);
+    mePtEffMTD_2_Bkg_EB_ = ibook.book1D("pTeffMTD_2_Bkg_EB",
+                                        " MTD isolation Efficiency - 2 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_2_Bkg_EB_);
 
-  mePtEffMTD_2_Bkg_EB_ = ibook.book1D("pTeffMTD_2_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_2_Bkg_EB_);
+    mePtEffMTD_3_Bkg_EB_ = ibook.book1D("pTeffMTD_3_Bkg_EB",
+                                        " MTD isolation Efficiency - 3 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_3_Bkg_EB_);
 
-  mePtEffMTD_3_Bkg_EB_ = ibook.book1D("pTeffMTD_3_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_3_Bkg_EB_);
+    mePtEffMTD_4_Bkg_EB_ = ibook.book1D("pTeffMTD_4_Bkg_EB",
+                                        " MTD isolation Efficiency - 4 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_4_Bkg_EB_);
 
-  mePtEffMTD_4_Bkg_EB_ = ibook.book1D("pTeffMTD_4_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_4_Bkg_EB_);
+    mePtEffMTD_5_Bkg_EB_ = ibook.book1D("pTeffMTD_5_Bkg_EB",
+                                        " MTD isolation Efficiency - 5 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_5_Bkg_EB_);
 
-  mePtEffMTD_5_Bkg_EB_ = ibook.book1D("pTeffMTD_5_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_5_Bkg_EB_);
+    mePtEffMTD_6_Bkg_EB_ = ibook.book1D("pTeffMTD_6_Bkg_EB",
+                                        " MTD isolation Efficiency - 6 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_6_Bkg_EB_);
 
-  mePtEffMTD_6_Bkg_EB_ = ibook.book1D("pTeffMTD_6_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_6_Bkg_EB_);
+    mePtEffMTD_7_Bkg_EB_ = ibook.book1D("pTeffMTD_7_Bkg_EB",
+                                        " MTD isolation Efficiency - 7 Bkg Barrel VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_7_Bkg_EB_);
 
-  mePtEffMTD_7_Bkg_EB_ = ibook.book1D("pTeffMTD_7_Bkg_EB",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_7_Bkg_EB_);
+    mePtEffMTD_sim_1_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 1 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_1_Bkg_EB_);
 
-  mePtEffMTD_sim_1_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_1_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_1_Bkg_EB_);
+    mePtEffMTD_sim_2_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 2 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2_Bkg_EB_);
 
-  mePtEffMTD_sim_2_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2_Bkg_EB_);
+    mePtEffMTD_sim_3_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 3 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3_Bkg_EB_);
 
-  mePtEffMTD_sim_3_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3_Bkg_EB_);
+    mePtEffMTD_sim_4_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 4 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4_Bkg_EB_);
 
-  mePtEffMTD_sim_4_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4_Bkg_EB_);
+    mePtEffMTD_sim_5_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 5 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_5_Bkg_EB_);
 
-  mePtEffMTD_sim_5_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_5_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_5_Bkg_EB_);
+    mePtEffMTD_sim_6_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 6 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_6_Bkg_EB_);
 
-  mePtEffMTD_sim_6_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_6_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_6_Bkg_EB_);
+    mePtEffMTD_sim_7_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EB_",
+                                            " MTD isolation Efficiency SIM - 7 Bkg Barrel VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_7_Bkg_EB_);
 
-  mePtEffMTD_sim_7_Bkg_EB_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EB_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_7_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_7_Bkg_EB_);
+    mePtEffMTD_sim_4sigma_Bkg_EB_ =
+        ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EB",
+                     " MTD isolation Efficiency SIM - 4 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4sigma_Bkg_EB_);
 
-  mePtEffMTD_4sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_4sigma_Bkg_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Bkg_EB_ =
+        ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EB",
+                     " MTD isolation Efficiency SIM - 3 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3sigma_Bkg_EB_);
+
+    mePtEffMTD_sim_2sigma_Bkg_EB_ =
+        ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EB",
+                     " MTD isolation Efficiency SIM - 2 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2sigma_Bkg_EB_);
+
+    meEtaEffMTD_1_Bkg_EB_ = ibook.book1D("EtaEffMTD_1_Bkg_EB",
+                                         " MTD isolation Efficiency - 1 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_1_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_1_Bkg_EB_);
+
+    meEtaEffMTD_2_Bkg_EB_ = ibook.book1D("EtaEffMTD_2_Bkg_EB",
+                                         " MTD isolation Efficiency - 2 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_2_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2_Bkg_EB_);
+
+    meEtaEffMTD_3_Bkg_EB_ = ibook.book1D("EtaEffMTD_3_Bkg_EB",
+                                         " MTD isolation Efficiency - 3 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_3_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3_Bkg_EB_);
+
+    meEtaEffMTD_4_Bkg_EB_ = ibook.book1D("EtaEffMTD_4_Bkg_EB",
+                                         " MTD isolation Efficiency - 4 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_4_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4_Bkg_EB_);
+
+    meEtaEffMTD_5_Bkg_EB_ = ibook.book1D("EtaEffMTD_5_Bkg_EB",
+                                         " MTD isolation Efficiency - 5 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_5_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_5_Bkg_EB_);
+
+    meEtaEffMTD_6_Bkg_EB_ = ibook.book1D("EtaEffMTD_6_Bkg_EB",
+                                         " MTD isolation Efficiency - 6 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_6_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_6_Bkg_EB_);
+
+    meEtaEffMTD_7_Bkg_EB_ = ibook.book1D("EtaEffMTD_7_Bkg_EB",
+                                         " MTD isolation Efficiency - 7 Bkg Barrel VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_7_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_7_Bkg_EB_);
+
+    mePhiEffMTD_1_Bkg_EB_ = ibook.book1D("PhiEffMTD_1_Bkg_EB",
+                                         " MTD isolation Efficiency - 1 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_1_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_1_Bkg_EB_);
+
+    mePhiEffMTD_2_Bkg_EB_ = ibook.book1D("PhiEffMTD_2_Bkg_EB",
+                                         " MTD isolation Efficiency - 2 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_2_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2_Bkg_EB_);
+
+    mePhiEffMTD_3_Bkg_EB_ = ibook.book1D("PhiEffMTD_3_Bkg_EB",
+                                         " MTD isolation Efficiency - 3 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_3_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3_Bkg_EB_);
+
+    mePhiEffMTD_4_Bkg_EB_ = ibook.book1D("PhiEffMTD_4_Bkg_EB",
+                                         " MTD isolation Efficiency - 4 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_4_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4_Bkg_EB_);
+
+    mePhiEffMTD_5_Bkg_EB_ = ibook.book1D("PhiEffMTD_5_Bkg_EB",
+                                         " MTD isolation Efficiency - 5 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_5_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_5_Bkg_EB_);
+
+    mePhiEffMTD_6_Bkg_EB_ = ibook.book1D("PhiEffMTD_6_Bkg_EB",
+                                         " MTD isolation Efficiency - 6 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_6_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_6_Bkg_EB_);
+
+    mePhiEffMTD_7_Bkg_EB_ = ibook.book1D("PhiEffMTD_7_Bkg_EB",
+                                         " MTD isolation Efficiency - 7 Bkg Barrel VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_7_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_7_Bkg_EB_);
+  }
+  meEtaEffMTD_4sigma_Bkg_EB_ =
+      ibook.book1D("EtaEffMTD_4sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4sigma_Bkg_EB_);
+
+  meEtaEffMTD_3sigma_Bkg_EB_ =
+      ibook.book1D("EtaEffMTD_3sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3sigma_Bkg_EB_);
+
+  meEtaEffMTD_2sigma_Bkg_EB_ =
+      ibook.book1D("EtaEffMTD_2sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EB_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2sigma_Bkg_EB_);
+
+  mePhiEffMTD_4sigma_Bkg_EB_ =
+      ibook.book1D("PhiEffMTD_4sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4sigma_Bkg_EB_);
+
+  mePhiEffMTD_3sigma_Bkg_EB_ =
+      ibook.book1D("PhiEffMTD_3sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3sigma_Bkg_EB_);
+
+  mePhiEffMTD_2sigma_Bkg_EB_ =
+      ibook.book1D("PhiEffMTD_2sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EB_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2sigma_Bkg_EB_);
+
+  mePtEffMTD_4sigma_Bkg_EB_ =
+      ibook.book1D("pTeffMTD_4sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_4sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_4sigma_Bkg_EB_);
 
-  mePtEffMTD_3sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_3sigma_Bkg_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Bkg_EB_ =
+      ibook.book1D("pTeffMTD_3sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_3sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_3sigma_Bkg_EB_);
 
-  mePtEffMTD_2sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_2sigma_Bkg_EB",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EB_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Bkg_EB_ =
+      ibook.book1D("pTeffMTD_2sigma_Bkg_EB",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Bkg Barrel VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EB_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_2sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_2sigma_Bkg_EB_);
-
-  mePtEffMTD_sim_4sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_4sigma_Bkg_EB_);
-
-  mePtEffMTD_sim_3sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_3sigma_Bkg_EB_);
-
-  mePtEffMTD_sim_2sigma_Bkg_EB_ = ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EB",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffMTD_sim_2sigma_Bkg_EB_);
-
-  meEtaEffMTD_1_Bkg_EB_ = ibook.book1D("EtaEffMTD_1_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_1_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_1_Bkg_EB_);
-
-  meEtaEffMTD_2_Bkg_EB_ = ibook.book1D("EtaEffMTD_2_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_2_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2_Bkg_EB_);
-
-  meEtaEffMTD_3_Bkg_EB_ = ibook.book1D("EtaEffMTD_3_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_3_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3_Bkg_EB_);
-
-  meEtaEffMTD_4_Bkg_EB_ = ibook.book1D("EtaEffMTD_4_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_4_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4_Bkg_EB_);
-
-  meEtaEffMTD_5_Bkg_EB_ = ibook.book1D("EtaEffMTD_5_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_5_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_5_Bkg_EB_);
-
-  meEtaEffMTD_6_Bkg_EB_ = ibook.book1D("EtaEffMTD_6_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_6_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_6_Bkg_EB_);
-
-  meEtaEffMTD_7_Bkg_EB_ = ibook.book1D("EtaEffMTD_7_Bkg_EB",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_7_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_7_Bkg_EB_);
-
-  // meEtaEffMTD_4sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_4sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_4sigma_Bkg_EB_);
-
-  // meEtaEffMTD_3sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_3sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_3sigma_Bkg_EB_);
-
-  // meEtaEffMTD_2sigma_Bkg_EB_ = ibook.book1D("EtaEffMTD_2sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffMTD_2sigma_Bkg_EB_);
-
-  mePhiEffMTD_1_Bkg_EB_ = ibook.book1D("PhiEffMTD_1_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_1_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_1_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_1_Bkg_EB_);
-
-  mePhiEffMTD_2_Bkg_EB_ = ibook.book1D("PhiEffMTD_2_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_2_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_2_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2_Bkg_EB_);
-
-  mePhiEffMTD_3_Bkg_EB_ = ibook.book1D("PhiEffMTD_3_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_3_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_3_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3_Bkg_EB_);
-
-  mePhiEffMTD_4_Bkg_EB_ = ibook.book1D("PhiEffMTD_4_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_4_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_4_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4_Bkg_EB_);
-
-  mePhiEffMTD_5_Bkg_EB_ = ibook.book1D("PhiEffMTD_5_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_5_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_5_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_5_Bkg_EB_);
-
-  mePhiEffMTD_6_Bkg_EB_ = ibook.book1D("PhiEffMTD_6_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_6_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_6_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_6_Bkg_EB_);
-
-  mePhiEffMTD_7_Bkg_EB_ = ibook.book1D("PhiEffMTD_7_Bkg_EB",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EB_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_7_Bkg_EB_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_7_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_7_Bkg_EB_);
-
-  // mePhiEffMTD_4sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_4sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_4sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_4sigma_Bkg_EB_);
-
-  // meEtaEffMTD_3sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_3sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_3sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_3sigma_Bkg_EB_);
-
-  // meEtaEffMTD_2sigma_Bkg_EB_ = ibook.book1D("PhiEffMTD_2sigma_Bkg_EB",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EB_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_2sigma_Bkg_EB_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffMTD_2sigma_Bkg_EB_);
-
   mePtEffnoMTD_Bkg_EB_ = ibook.book1D("pTeffnoMTD_Bkg_EB",
-                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      " noMTD isolation Efficiency - Bkg Barrel VS pT;p_{T};Efficiency",
                                       meEle_pt_tot_Bkg_EB_->getNbinsX(),
                                       meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
                                       meEle_pt_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
@@ -1610,7 +1695,7 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_pt_noMTD_Bkg_EB_, meEle_pt_tot_Bkg_EB_, mePtEffnoMTD_Bkg_EB_);
 
   meEtaEffnoMTD_Bkg_EB_ = ibook.book1D("EtaEffnoMTD_Bkg_EB",
-                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       " noMTD isolation Efficiency - Bkg Barrel VS pT;p_{T};Efficiency",
                                        meEle_eta_tot_Bkg_EB_->getNbinsX(),
                                        meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_eta_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
@@ -1618,338 +1703,360 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_eta_noMTD_Bkg_EB_, meEle_eta_tot_Bkg_EB_, meEtaEffnoMTD_Bkg_EB_);
 
   mePhiEffnoMTD_Bkg_EB_ = ibook.book1D("PhiEffnoMTD_Bkg_EB",
-                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       " noMTD isolation Efficiency - Bkg Barrel VS pT;p_{T};Efficiency",
                                        meEle_phi_tot_Bkg_EB_->getNbinsX(),
                                        meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_phi_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
   mePhiEffnoMTD_Bkg_EB_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_phi_noMTD_Bkg_EB_, meEle_phi_tot_Bkg_EB_, mePhiEffnoMTD_Bkg_EB_);
 
-  // Ele iso addition ends
-  // For endcap now
+  if (optionalPlots_) {
+    mePtEffgen_Bkg_EB_ = ibook.book1D("pTeffMTD_gen_Bkg_EB",
+                                      " MTD isolation Efficiency - genInfo - Bkg Barrel VS pT;p_{T};Efficiency",
+                                      meEle_pt_sim_tot_Bkg_EB_->getNbinsX(),
+                                      meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_sim_tot_Bkg_EB_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffgen_Bkg_EB_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_gen_Bkg_EB_, meEle_pt_sim_tot_Bkg_EB_, mePtEffgen_Bkg_EB_);
 
-  mePtEffMTD_1_Bkg_EE_ = ibook.book1D("pTeffMTD_1_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_1_Bkg_EE_);
+    // Ele iso addition ends
+    // For endcap now
+    mePtEffMTD_1_Bkg_EE_ = ibook.book1D("pTeffMTD_1_Bkg_EE",
+                                        " MTD isolation Efficiency - 1 BkgL Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_1_Bkg_EE_);
 
-  mePtEffMTD_2_Bkg_EE_ = ibook.book1D("pTeffMTD_2_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_2_Bkg_EE_);
+    mePtEffMTD_2_Bkg_EE_ = ibook.book1D("pTeffMTD_2_Bkg_EE",
+                                        " MTD isolation Efficiency - 2 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_2_Bkg_EE_);
 
-  mePtEffMTD_3_Bkg_EE_ = ibook.book1D("pTeffMTD_3_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_3_Bkg_EE_);
+    mePtEffMTD_3_Bkg_EE_ = ibook.book1D("pTeffMTD_3_Bkg_EE",
+                                        " MTD isolation Efficiency - 3 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_3_Bkg_EE_);
 
-  mePtEffMTD_4_Bkg_EE_ = ibook.book1D("pTeffMTD_4_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_4_Bkg_EE_);
+    mePtEffMTD_4_Bkg_EE_ = ibook.book1D("pTeffMTD_4_Bkg_EE",
+                                        " MTD isolation Efficiency - 4 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_4_Bkg_EE_);
 
-  mePtEffMTD_5_Bkg_EE_ = ibook.book1D("pTeffMTD_5_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_5_Bkg_EE_);
+    mePtEffMTD_5_Bkg_EE_ = ibook.book1D("pTeffMTD_5_Bkg_EE",
+                                        " MTD isolation Efficiency - 5 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_5_Bkg_EE_);
 
-  mePtEffMTD_6_Bkg_EE_ = ibook.book1D("pTeffMTD_6_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_6_Bkg_EE_);
+    mePtEffMTD_6_Bkg_EE_ = ibook.book1D("pTeffMTD_6_Bkg_EE",
+                                        " MTD isolation Efficiency - 6 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_6_Bkg_EE_);
 
-  mePtEffMTD_7_Bkg_EE_ = ibook.book1D("pTeffMTD_7_Bkg_EE",
-                                      " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                      meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                      meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_7_Bkg_EE_);
+    mePtEffMTD_7_Bkg_EE_ = ibook.book1D("pTeffMTD_7_Bkg_EE",
+                                        " MTD isolation Efficiency - 7 Bkg Endcap VS pT;p_{T};Efficiency",
+                                        meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                        meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_7_Bkg_EE_);
 
-  mePtEffMTD_sim_1_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_1_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_1_Bkg_EE_);
+    mePtEffMTD_sim_1_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_1_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 1 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_1_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_1_Bkg_EE_);
 
-  mePtEffMTD_sim_2_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2_Bkg_EE_);
+    mePtEffMTD_sim_2_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_2_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 2 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2_Bkg_EE_);
 
-  mePtEffMTD_sim_3_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3_Bkg_EE_);
+    mePtEffMTD_sim_3_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_3_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 3 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3_Bkg_EE_);
 
-  mePtEffMTD_sim_4_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4_Bkg_EE_);
+    mePtEffMTD_sim_4_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_4_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 4 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4_Bkg_EE_);
 
-  mePtEffMTD_sim_5_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_5_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_5_Bkg_EE_);
+    mePtEffMTD_sim_5_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_5_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 5 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_5_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_5_Bkg_EE_);
 
-  mePtEffMTD_sim_6_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_6_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_6_Bkg_EE_);
+    mePtEffMTD_sim_6_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_6_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 6 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_6_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_6_Bkg_EE_);
 
-  mePtEffMTD_sim_7_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EE_",
-                                          " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                          meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                          meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_7_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_7_Bkg_EE_);
-
-  mePtEffMTD_4sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_4sigma_Bkg_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_7_Bkg_EE_ = ibook.book1D("mePtEffMTD_sim_7_Bkg_EE_",
+                                            " MTD isolation Efficiency SIM - 7 Bkg Endcap VS pT;p_{T};Efficiency",
+                                            meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                            meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_7_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_7_Bkg_EE_);
+  }
+  mePtEffMTD_4sigma_Bkg_EE_ =
+      ibook.book1D("pTeffMTD_4sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_4sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_4sigma_Bkg_EE_);
 
-  mePtEffMTD_3sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_3sigma_Bkg_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_3sigma_Bkg_EE_ =
+      ibook.book1D("pTeffMTD_3sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_3sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_3sigma_Bkg_EE_);
 
-  mePtEffMTD_2sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_2sigma_Bkg_EE",
-                                           " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                           meEle_pt_tot_Bkg_EE_->getNbinsX(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                           meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePtEffMTD_2sigma_Bkg_EE_ =
+      ibook.book1D("pTeffMTD_2sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                   meEle_pt_tot_Bkg_EE_->getNbinsX(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
   mePtEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_pt_MTD_2sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_2sigma_Bkg_EE_);
 
-  mePtEffMTD_sim_4sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4sigma_Bkg_EE_);
+  if (optionalPlots_) {
+    mePtEffMTD_sim_4sigma_Bkg_EE_ =
+        ibook.book1D("pTeffMTD_sim_4sigma_Bkg_EE",
+                     " MTD isolation Efficiency SIM - 4 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_4sigma_Bkg_EE_);
 
-  mePtEffMTD_sim_3sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3sigma_Bkg_EE_);
+    mePtEffMTD_sim_3sigma_Bkg_EE_ =
+        ibook.book1D("pTeffMTD_sim_3sigma_Bkg_EE",
+                     " MTD isolation Efficiency SIM - 3 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_3sigma_Bkg_EE_);
 
-  mePtEffMTD_sim_2sigma_Bkg_EE_ = ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EE",
-                                               " MTD isolation Efficiency VS pT;#pT;Efficiency",
-                                               meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                               meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePtEffMTD_sim_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2sigma_Bkg_EE_);
+    mePtEffMTD_sim_2sigma_Bkg_EE_ =
+        ibook.book1D("pTeffMTD_sim_2sigma_Bkg_EE",
+                     " MTD isolation Efficiency SIM - 2 sigma compatibility - Bkg Endcap VS pT;p_{T};Efficiency",
+                     meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                     meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffMTD_sim_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_sim_MTD_2sigma_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffMTD_sim_2sigma_Bkg_EE_);
 
-  meEtaEffMTD_1_Bkg_EE_ = ibook.book1D("EtaEffMTD_1_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_1_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_1_Bkg_EE_);
+    meEtaEffMTD_1_Bkg_EE_ = ibook.book1D("EtaEffMTD_1_Bkg_EE",
+                                         " MTD isolation Efficiency - 1 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_1_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_1_Bkg_EE_);
 
-  meEtaEffMTD_2_Bkg_EE_ = ibook.book1D("EtaEffMTD_2_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_2_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2_Bkg_EE_);
+    meEtaEffMTD_2_Bkg_EE_ = ibook.book1D("EtaEffMTD_2_Bkg_EE",
+                                         " MTD isolation Efficiency - 2 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_2_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2_Bkg_EE_);
 
-  meEtaEffMTD_3_Bkg_EE_ = ibook.book1D("EtaEffMTD_3_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_3_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3_Bkg_EE_);
+    meEtaEffMTD_3_Bkg_EE_ = ibook.book1D("EtaEffMTD_3_Bkg_EE",
+                                         " MTD isolation Efficiency - 3 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_3_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3_Bkg_EE_);
 
-  meEtaEffMTD_4_Bkg_EE_ = ibook.book1D("EtaEffMTD_4_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_4_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4_Bkg_EE_);
+    meEtaEffMTD_4_Bkg_EE_ = ibook.book1D("EtaEffMTD_4_Bkg_EE",
+                                         " MTD isolation Efficiency - 4 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_4_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4_Bkg_EE_);
 
-  meEtaEffMTD_5_Bkg_EE_ = ibook.book1D("EtaEffMTD_5_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_5_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_5_Bkg_EE_);
+    meEtaEffMTD_5_Bkg_EE_ = ibook.book1D("EtaEffMTD_5_Bkg_EE",
+                                         " MTD isolation Efficiency - 5 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_5_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_5_Bkg_EE_);
 
-  meEtaEffMTD_6_Bkg_EE_ = ibook.book1D("EtaEffMTD_6_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_6_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_6_Bkg_EE_);
+    meEtaEffMTD_6_Bkg_EE_ = ibook.book1D("EtaEffMTD_6_Bkg_EE",
+                                         " MTD isolation Efficiency - 6 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_6_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_6_Bkg_EE_);
 
-  meEtaEffMTD_7_Bkg_EE_ = ibook.book1D("EtaEffMTD_7_Bkg_EE",
-                                       " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-                                       meEle_eta_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  meEtaEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_eta_MTD_7_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_7_Bkg_EE_);
+    meEtaEffMTD_7_Bkg_EE_ = ibook.book1D("EtaEffMTD_7_Bkg_EE",
+                                         " MTD isolation Efficiency - 7 Bkg Endcap VS Eta;#eta;Efficiency",
+                                         meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    meEtaEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_eta_MTD_7_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_7_Bkg_EE_);
 
-  // meEtaEffMTD_4sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_4sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4sigma_Bkg_EE_);
+    mePhiEffMTD_1_Bkg_EE_ = ibook.book1D("PhiEffMTD_1_Bkg_EE",
+                                         " MTD isolation Efficiency - 1 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_1_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_1_Bkg_EE_);
 
-  // meEtaEffMTD_3sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_3sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3sigma_Bkg_EE_);
+    mePhiEffMTD_2_Bkg_EE_ = ibook.book1D("PhiEffMTD_2_Bkg_EE",
+                                         " MTD isolation Efficiency - 2 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_2_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2_Bkg_EE_);
 
-  // meEtaEffMTD_2sigma_Bkg_EE_ = ibook.book1D("EtaEffMTD_2sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Eta;#eta;Efficiency",
-  //                                     meEle_eta_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // meEtaEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2sigma_Bkg_EE_);
+    mePhiEffMTD_3_Bkg_EE_ = ibook.book1D("PhiEffMTD_3_Bkg_EE",
+                                         " MTD isolation Efficiency - 3 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_3_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3_Bkg_EE_);
 
-  mePhiEffMTD_1_Bkg_EE_ = ibook.book1D("PhiEffMTD_1_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_1_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_1_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_1_Bkg_EE_);
+    mePhiEffMTD_4_Bkg_EE_ = ibook.book1D("PhiEffMTD_4_Bkg_EE",
+                                         " MTD isolation Efficiency - 4 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_4_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4_Bkg_EE_);
 
-  mePhiEffMTD_2_Bkg_EE_ = ibook.book1D("PhiEffMTD_2_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_2_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_2_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2_Bkg_EE_);
+    mePhiEffMTD_5_Bkg_EE_ = ibook.book1D("PhiEffMTD_5_Bkg_EE",
+                                         " MTD isolation Efficiency - 5 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_5_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_5_Bkg_EE_);
 
-  mePhiEffMTD_3_Bkg_EE_ = ibook.book1D("PhiEffMTD_3_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_3_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_3_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3_Bkg_EE_);
+    mePhiEffMTD_6_Bkg_EE_ = ibook.book1D("PhiEffMTD_6_Bkg_EE",
+                                         " MTD isolation Efficiency - 6 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_6_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_6_Bkg_EE_);
 
-  mePhiEffMTD_4_Bkg_EE_ = ibook.book1D("PhiEffMTD_4_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_4_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_4_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4_Bkg_EE_);
+    mePhiEffMTD_7_Bkg_EE_ = ibook.book1D("PhiEffMTD_7_Bkg_EE",
+                                         " MTD isolation Efficiency - 7 Bkg Endcap VS Phi;#phi;Efficiency",
+                                         meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                         meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePhiEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_phi_MTD_7_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_7_Bkg_EE_);
+  }
 
-  mePhiEffMTD_5_Bkg_EE_ = ibook.book1D("PhiEffMTD_5_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_5_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_5_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_5_Bkg_EE_);
+  meEtaEffMTD_4sigma_Bkg_EE_ =
+      ibook.book1D("EtaEffMTD_4sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibiliy - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_4sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_4sigma_Bkg_EE_);
 
-  mePhiEffMTD_6_Bkg_EE_ = ibook.book1D("PhiEffMTD_6_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_6_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_6_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_6_Bkg_EE_);
+  meEtaEffMTD_3sigma_Bkg_EE_ =
+      ibook.book1D("EtaEffMTD_3sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibiliy - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_3sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_3sigma_Bkg_EE_);
 
-  mePhiEffMTD_7_Bkg_EE_ = ibook.book1D("PhiEffMTD_7_Bkg_EE",
-                                       " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-                                       meEle_phi_tot_Bkg_EE_->getNbinsX(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-                                       meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  mePhiEffMTD_7_Bkg_EE_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meEle_phi_MTD_7_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_7_Bkg_EE_);
+  meEtaEffMTD_2sigma_Bkg_EE_ =
+      ibook.book1D("EtaEffMTD_2sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibiliy - Bkg Endcap VS Eta;#eta;Efficiency",
+                   meEle_eta_tot_Bkg_EE_->getNbinsX(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  meEtaEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_eta_MTD_2sigma_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffMTD_2sigma_Bkg_EE_);
 
-  // mePhiEffMTD_4sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_4sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4sigma_Bkg_EE_);
+  mePhiEffMTD_4sigma_Bkg_EE_ =
+      ibook.book1D("PhiEffMTD_4sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 4 sigma compatibiliy - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_4sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_4sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_4sigma_Bkg_EE_);
 
-  // meEtaEffMTD_3sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_3sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3sigma_Bkg_EE_);
+  mePhiEffMTD_3sigma_Bkg_EE_ =
+      ibook.book1D("PhiEffMTD_3sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 3 sigma compatibiliy - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_3sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_3sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_3sigma_Bkg_EE_);
 
-  // meEtaEffMTD_2sigma_Bkg_EE_ = ibook.book1D("PhiEffMTD_2sigma_Bkg_EE",
-  //                                     " MTD isolation Efficiency VS Phi;#phi;Efficiency",
-  //                                     meEle_phi_tot_Bkg_EE_->getNbinsX(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
-  //                                     meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
-  // mePhiEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
-  // computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2sigma_Bkg_EE_);
+  mePhiEffMTD_2sigma_Bkg_EE_ =
+      ibook.book1D("PhiEffMTD_2sigma_Bkg_EE",
+                   " MTD isolation Efficiency - 2 sigma compatibiliy - Bkg Endcap VS Phi;#phi;Efficiency",
+                   meEle_phi_tot_Bkg_EE_->getNbinsX(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                   meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+  mePhiEffMTD_2sigma_Bkg_EE_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meEle_phi_MTD_2sigma_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffMTD_2sigma_Bkg_EE_);
 
   mePtEffnoMTD_Bkg_EE_ = ibook.book1D("pTeffnoMTD_Bkg_EE",
-                                      " noMTD isolation Efficiency VS pT;#pT;Efficiency",
+                                      " noMTD isolation Efficiency - Bkg Endcap VS pT;p_{T};Efficiency",
                                       meEle_pt_tot_Bkg_EE_->getNbinsX(),
                                       meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
                                       meEle_pt_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
@@ -1957,7 +2064,7 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_pt_noMTD_Bkg_EE_, meEle_pt_tot_Bkg_EE_, mePtEffnoMTD_Bkg_EE_);
 
   meEtaEffnoMTD_Bkg_EE_ = ibook.book1D("EtaEffnoMTD_Bkg_EE",
-                                       " noMTD isolation Efficiency VS Eta;#eta;Efficiency",
+                                       " noMTD isolation Efficiency - Bkg Endcap VS Eta;#eta;Efficiency",
                                        meEle_eta_tot_Bkg_EE_->getNbinsX(),
                                        meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_eta_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
@@ -1965,12 +2072,22 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meEle_eta_noMTD_Bkg_EE_, meEle_eta_tot_Bkg_EE_, meEtaEffnoMTD_Bkg_EE_);
 
   mePhiEffnoMTD_Bkg_EE_ = ibook.book1D("PhiEffnoMTD_Bkg_EE",
-                                       " noMTD isolation Efficiency VS Phi;#phi;Efficiency",
+                                       " noMTD isolation Efficiency - Bkg Endcap VS Phi;#phi;Efficiency",
                                        meEle_phi_tot_Bkg_EE_->getNbinsX(),
                                        meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
                                        meEle_phi_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
   mePhiEffnoMTD_Bkg_EE_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meEle_phi_noMTD_Bkg_EE_, meEle_phi_tot_Bkg_EE_, mePhiEffnoMTD_Bkg_EE_);
+
+  if (optionalPlots_) {
+    mePtEffgen_Bkg_EE_ = ibook.book1D("pTeffMTD_gen_Bkg_EE",
+                                      " MTD isolation Efficiency - genInfo - Bkg Endcap VS pT;p_{T};Efficiency",
+                                      meEle_pt_sim_tot_Bkg_EE_->getNbinsX(),
+                                      meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmin(),
+                                      meEle_pt_sim_tot_Bkg_EE_->getTH1()->GetXaxis()->GetXmax());
+    mePtEffgen_Bkg_EE_->getTH1()->SetMinimum(0.);
+    computeEfficiency1D(meEle_pt_gen_Bkg_EE_, meEle_pt_sim_tot_Bkg_EE_, mePtEffgen_Bkg_EE_);
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------
@@ -1978,6 +2095,7 @@ void MtdEleIsoHarvester::fillDescriptions(edm::ConfigurationDescriptions& descri
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("folder", "MTD/ElectronIso/");
+  desc.add<bool>("option_plots", false);
 
   descriptions.add("MtdEleIsoPostProcessor", desc);
 }

--- a/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoHarvester.cc
@@ -600,10 +600,6 @@ void MtdEleIsoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
         !meEle_pt_MTD_4sigma_Sig_EE_ || !meEle_pt_MTD_3sigma_Sig_EE_ || !meEle_pt_MTD_2sigma_Sig_EE_ ||
         !meEle_pt_MTD_4sigma_Bkg_EB_ || !meEle_pt_MTD_3sigma_Bkg_EB_ || !meEle_pt_MTD_2sigma_Bkg_EB_ ||
         !meEle_pt_MTD_4sigma_Bkg_EE_ || !meEle_pt_MTD_3sigma_Bkg_EE_ || !meEle_pt_MTD_2sigma_Bkg_EE_ ||
-        !meEle_pt_sim_MTD_4sigma_Sig_EB_ || !meEle_pt_sim_MTD_3sigma_Sig_EB_ || !meEle_pt_sim_MTD_2sigma_Sig_EB_ ||
-        !meEle_pt_sim_MTD_4sigma_Sig_EE_ || !meEle_pt_sim_MTD_3sigma_Sig_EE_ || !meEle_pt_sim_MTD_2sigma_Sig_EE_ ||
-        !meEle_pt_sim_MTD_4sigma_Bkg_EB_ || !meEle_pt_sim_MTD_3sigma_Bkg_EB_ || !meEle_pt_sim_MTD_2sigma_Bkg_EB_ ||
-        !meEle_pt_sim_MTD_4sigma_Bkg_EE_ || !meEle_pt_sim_MTD_3sigma_Bkg_EE_ || !meEle_pt_sim_MTD_2sigma_Bkg_EE_ ||
         !meEle_eta_MTD_4sigma_Sig_EB_ || !meEle_eta_MTD_3sigma_Sig_EB_ || !meEle_eta_MTD_2sigma_Sig_EB_ ||
         !meEle_phi_MTD_4sigma_Sig_EB_ || !meEle_phi_MTD_3sigma_Sig_EB_ || !meEle_phi_MTD_2sigma_Sig_EB_ ||
         !meEle_eta_MTD_4sigma_Sig_EE_ || !meEle_eta_MTD_3sigma_Sig_EE_ || !meEle_eta_MTD_2sigma_Sig_EE_ ||

--- a/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
@@ -1,0 +1,4080 @@
+///*
+#include <string>
+#include <tuple>
+#include <numeric>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <memory>  // unique_ptr
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/Common/interface/ValidHandle.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/ForwardDetId/interface/ETLDetId.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "SimDataFormats/Associations/interface/TrackToGenParticleAssociator.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+#include "HepMC/GenRanges.h"
+#include "CLHEP/Units/PhysicalConstants.h"
+
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"  // Adding header files for electrons
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"         // Adding header files for electrons
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+// eff vs PU test libraries
+
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "SimTracker/VertexAssociation/interface/calculateVertexSharedTracks.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
+#include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/Point3D.h"
+
+// end of test libraries
+
+class MtdEleIsoValidation : public DQMEDAnalyzer {
+public:
+  explicit MtdEleIsoValidation(const edm::ParameterSet&);
+  ~MtdEleIsoValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  const bool mvaGenSel(const HepMC::GenParticle&, const float&);
+  const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&, const double&, const double&);
+  const bool mvaGenRecMatch(const HepMC::GenParticle&, const double&, const reco::TrackBase&);
+  bool pdgCheck(int pdg);
+
+  // ------------ member data ------------
+
+  const std::string folder_;
+  const float trackMinPt_;
+  const float trackMinEta_;
+  const float trackMaxEta_;
+  const double rel_iso_cut_;
+
+  bool track_match_PV_;
+  bool dt_sig_vtx_;
+  bool dt_sig_track_;
+  bool dt_distributions_;
+
+  static constexpr float min_dR_cut = 0.01;
+  static constexpr float max_dR_cut = 0.3;
+  static constexpr float min_pt_cut_EB = 0.7;
+  static constexpr float min_pt_cut_EE = 0.4;
+  static constexpr float max_dz_cut_EB = 0.5;
+  static constexpr float max_dz_cut_EE = 0.5;
+  static constexpr float max_dz_vtx_cut = 0.5;
+  static constexpr float max_dxy_vtx_cut = 0.2;
+  // timing cuts - has to be 7 values here!!! Code created for 7 dt values!! Values for resolution 100;90;80;70;60;50;40 ps
+  //const std::vector<double> max_dt_vtx_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12};  // default cuts
+  //const std::vector<double> max_dt_track_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12}; // default cuts
+  const std::vector<double> max_dt_vtx_cut{0.30, 0.24, 0.18, 0.15, 0.12, 0.08, 0.04};    // test cuts
+  const std::vector<double> max_dt_track_cut{0.30, 0.24, 0.18, 0.15, 0.12, 0.08, 0.04};  // test cuts
+  const std::vector<double> max_dt_significance_cut{4.0, 3.0, 2.0};                      // test cuts
+  static constexpr float min_strip_cut = 0.01;
+  static constexpr float min_track_mtd_mva_cut = 0.5;
+  const std::vector<double> pT_bins_dt_distrb{10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
+  const std::vector<double> eta_bins_dt_distrib{0.0, 0.5, 1.0, 1.5, 2.0, 2.4};
+  static constexpr double avg_sim_sigTrk_t_err = 0.03239;  // avg error/resolution for SIM tracks in nanoseconds
+  static constexpr double avg_sim_PUtrack_t_err = 0.03465;
+  static constexpr double avg_sim_vertex_t_err = 0.1;
+
+  edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
+  edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
+
+  edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectronToken_EB_;  // Adding token for electron collection
+  edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectronToken_EE_;
+  edm::EDGetTokenT<reco::GenParticleCollection> GenParticleToken_;
+
+  edm::EDGetTokenT<edm::HepMCProduct> HepMCProductToken_;
+
+  edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
+
+  edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> SigmatmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0SrcToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SrcToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0PidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0PidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SafePidToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> trackMVAQualToken_;
+
+  edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> particleTableToken_;
+
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;  // From Aurora
+  edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;         // From Aurora
+
+  // Signal histograms
+
+  MonitorElement* meEle_no_dt_check_;
+  MonitorElement* meTrk_genMatch_check_;
+  MonitorElement* meEle_test_check_;
+
+  MonitorElement* meEle_avg_error_SigTrk_check_;
+  MonitorElement* meEle_avg_error_PUTrk_check_;
+  MonitorElement* meEle_avg_error_vtx_check_;
+
+  MonitorElement* meEleISO_Ntracks_Sig_EB_;  // Adding histograms for barrel electrons (isolation stuff)
+  MonitorElement* meEleISO_chIso_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_1_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_1_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_1_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_5_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_5_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_5_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_6_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_6_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_6_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_7_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_7_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_7_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_1_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_1_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_1_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_5_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_5_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_5_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_6_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_6_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_6_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_7_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_7_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_;
+
+  MonitorElement* meEle_pt_tot_Sig_EB_;
+  MonitorElement* meEle_pt_sim_tot_Sig_EB_;
+  MonitorElement* meEle_eta_tot_Sig_EB_;
+  MonitorElement* meEle_phi_tot_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_1_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_1_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_1_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_1_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_2_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_2_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_2_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_2_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_3_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_3_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_3_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_3_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_4_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_4_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_4_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_4_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_5_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_5_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_5_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_5_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_6_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_6_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_6_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_6_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_7_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_7_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_7_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_7_Sig_EB_;
+
+  MonitorElement* meEle_pt_noMTD_Sig_EB_;
+  MonitorElement* meEle_eta_noMTD_Sig_EB_;
+  MonitorElement* meEle_phi_noMTD_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_2sigma_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_3sigma_Sig_EB_;
+
+  MonitorElement* meEle_pt_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEle_eta_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEle_phi_MTD_4sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_Sig_EE_;  // Adding histograms for endcap electrons (isolation stuff)
+  MonitorElement* meEleISO_chIso_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_1_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_1_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_1_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_5_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_5_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_5_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_6_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_6_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_6_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_7_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_7_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_7_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_1_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_1_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_1_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_5_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_5_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_5_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_6_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_6_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_6_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_7_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_7_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_;
+
+  MonitorElement* meEle_pt_tot_Sig_EE_;
+  MonitorElement* meEle_pt_sim_tot_Sig_EE_;
+  MonitorElement* meEle_eta_tot_Sig_EE_;
+  MonitorElement* meEle_phi_tot_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_1_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_1_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_1_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_1_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_2_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_2_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_2_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_2_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_3_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_3_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_3_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_3_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_4_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_4_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_4_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_4_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_5_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_5_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_5_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_5_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_6_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_6_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_6_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_6_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_7_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_7_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_7_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_7_Sig_EE_;
+
+  MonitorElement* meEle_pt_noMTD_Sig_EE_;
+  MonitorElement* meEle_eta_noMTD_Sig_EE_;
+  MonitorElement* meEle_phi_noMTD_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_2sigma_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_3sigma_Sig_EE_;
+
+  MonitorElement* meEle_pt_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEle_eta_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEle_phi_MTD_4sigma_Sig_EE_;
+
+  // Signal histograms end
+
+  // Background histograms
+  MonitorElement* meEleISO_Ntracks_Bkg_EB_;  // Adding histograms for barrel electrons (isolation stuff)
+  MonitorElement* meEleISO_chIso_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_1_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_1_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_1_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_5_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_5_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_5_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_6_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_6_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_6_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_7_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_7_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_7_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_1_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_1_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_5_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_5_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_6_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_6_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_7_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_7_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_;
+
+  MonitorElement* meEle_pt_tot_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_tot_Bkg_EB_;
+  MonitorElement* meEle_eta_tot_Bkg_EB_;
+  MonitorElement* meEle_phi_tot_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_1_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_1_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_1_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_1_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_2_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_2_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_2_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_2_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_3_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_3_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_3_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_3_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_4_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_4_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_4_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_4_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_5_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_5_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_5_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_5_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_6_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_6_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_6_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_6_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_7_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_7_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_7_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_7_Bkg_EB_;
+
+  MonitorElement* meEle_pt_noMTD_Bkg_EB_;
+  MonitorElement* meEle_eta_noMTD_Bkg_EB_;
+  MonitorElement* meEle_phi_noMTD_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_2sigma_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_3sigma_Bkg_EB_;
+
+  MonitorElement* meEle_pt_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEle_eta_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEle_phi_MTD_4sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_Bkg_EE_;  // Adding histograms for endcap electrons (isolation stuff)
+  MonitorElement* meEleISO_chIso_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_1_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_1_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_1_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_5_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_5_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_5_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_6_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_6_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_6_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_7_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_7_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_7_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_1_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_1_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_5_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_5_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_6_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_6_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_7_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_7_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_;
+
+  MonitorElement* meEle_pt_tot_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_tot_Bkg_EE_;
+  MonitorElement* meEle_eta_tot_Bkg_EE_;
+  MonitorElement* meEle_phi_tot_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_1_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_1_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_1_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_1_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_2_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_2_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_2_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_2_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_3_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_3_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_3_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_3_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_4_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_4_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_4_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_4_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_5_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_5_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_5_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_5_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_6_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_6_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_6_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_6_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_7_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_7_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_7_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_7_Bkg_EE_;
+
+  MonitorElement* meEle_pt_noMTD_Bkg_EE_;
+  MonitorElement* meEle_eta_noMTD_Bkg_EE_;
+  MonitorElement* meEle_phi_noMTD_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_2sigma_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_3sigma_Bkg_EE_;
+
+  MonitorElement* meEle_pt_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEle_pt_sim_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEle_eta_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEle_phi_MTD_4sigma_Bkg_EE_;
+  // Background histograms end
+
+  // histograms for dt distributions in pT/eta bins
+
+  MonitorElement* meEle_dt_general_pT_1;
+  MonitorElement* meEle_dt_general_pT_2;
+  MonitorElement* meEle_dt_general_pT_3;
+  MonitorElement* meEle_dt_general_pT_4;
+  MonitorElement* meEle_dt_general_pT_5;
+  MonitorElement* meEle_dt_general_pT_6;
+  MonitorElement* meEle_dt_general_pT_7;
+  MonitorElement* meEle_dt_general_pT_8;
+  MonitorElement* meEle_dt_general_pT_9;
+
+  MonitorElement* meEle_dtSignif_general_pT_1;
+  MonitorElement* meEle_dtSignif_general_pT_2;
+  MonitorElement* meEle_dtSignif_general_pT_3;
+  MonitorElement* meEle_dtSignif_general_pT_4;
+  MonitorElement* meEle_dtSignif_general_pT_5;
+  MonitorElement* meEle_dtSignif_general_pT_6;
+  MonitorElement* meEle_dtSignif_general_pT_7;
+  MonitorElement* meEle_dtSignif_general_pT_8;
+  MonitorElement* meEle_dtSignif_general_pT_9;
+
+  MonitorElement* meEle_dt_general_eta_1;
+  MonitorElement* meEle_dt_general_eta_2;
+  MonitorElement* meEle_dt_general_eta_3;
+  MonitorElement* meEle_dt_general_eta_4;
+  MonitorElement* meEle_dt_general_eta_5;
+
+  MonitorElement* meEle_dtSignif_general_eta_1;
+  MonitorElement* meEle_dtSignif_general_eta_2;
+  MonitorElement* meEle_dtSignif_general_eta_3;
+  MonitorElement* meEle_dtSignif_general_eta_4;
+  MonitorElement* meEle_dtSignif_general_eta_5;
+
+  // promt part for histogram vectors
+  std::vector<MonitorElement*> Ntracks_EB_list_Sig;
+  std::vector<MonitorElement*> ch_iso_EB_list_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_EB_list_Sig;
+
+  std::vector<MonitorElement*> Ntracks_EE_list_Sig;
+  std::vector<MonitorElement*> ch_iso_EE_list_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_EE_list_Sig;
+
+  std::vector<MonitorElement*> Ntracks_sim_EB_list_Sig;
+  std::vector<MonitorElement*> ch_iso_sim_EB_list_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EB_list_Sig;
+
+  std::vector<MonitorElement*> Ntracks_sim_EE_list_Sig;
+  std::vector<MonitorElement*> ch_iso_sim_EE_list_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EE_list_Sig;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EB_list_Sig;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EB_list_Sig;
+  std::vector<MonitorElement*> Ele_eta_MTD_EB_list_Sig;
+  std::vector<MonitorElement*> Ele_phi_MTD_EB_list_Sig;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EE_list_Sig;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EE_list_Sig;
+  std::vector<MonitorElement*> Ele_eta_MTD_EE_list_Sig;
+  std::vector<MonitorElement*> Ele_phi_MTD_EE_list_Sig;
+
+  std::vector<MonitorElement*> Ntracks_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> ch_iso_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_EB_list_Significance_Sig;
+
+  std::vector<MonitorElement*> Ntracks_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> ch_iso_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_EE_list_Significance_Sig;
+
+  std::vector<MonitorElement*> Ntracks_sim_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> ch_iso_sim_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EB_list_Significance_Sig;
+
+  std::vector<MonitorElement*> Ntracks_sim_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> ch_iso_sim_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EE_list_Significance_Sig;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_eta_MTD_EB_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_phi_MTD_EB_list_Significance_Sig;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_eta_MTD_EE_list_Significance_Sig;
+  std::vector<MonitorElement*> Ele_phi_MTD_EE_list_Significance_Sig;
+
+  // Non-promt part for histogram vectors
+  std::vector<MonitorElement*> Ntracks_EB_list_Bkg;
+  std::vector<MonitorElement*> ch_iso_EB_list_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_EB_list_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_EE_list_Bkg;
+  std::vector<MonitorElement*> ch_iso_EE_list_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_EE_list_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_sim_EB_list_Bkg;
+  std::vector<MonitorElement*> ch_iso_sim_EB_list_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EB_list_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_sim_EE_list_Bkg;
+  std::vector<MonitorElement*> ch_iso_sim_EE_list_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EE_list_Bkg;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EB_list_Bkg;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EB_list_Bkg;
+  std::vector<MonitorElement*> Ele_eta_MTD_EB_list_Bkg;
+  std::vector<MonitorElement*> Ele_phi_MTD_EB_list_Bkg;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EE_list_Bkg;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EE_list_Bkg;
+  std::vector<MonitorElement*> Ele_eta_MTD_EE_list_Bkg;
+  std::vector<MonitorElement*> Ele_phi_MTD_EE_list_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> ch_iso_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_EB_list_Significance_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> ch_iso_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_EE_list_Significance_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_sim_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> ch_iso_sim_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EB_list_Significance_Bkg;
+
+  std::vector<MonitorElement*> Ntracks_sim_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> ch_iso_sim_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> rel_ch_iso_sim_EE_list_Significance_Bkg;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_eta_MTD_EB_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_phi_MTD_EB_list_Significance_Bkg;
+
+  std::vector<MonitorElement*> Ele_pT_MTD_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_pT_sim_MTD_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_eta_MTD_EE_list_Significance_Bkg;
+  std::vector<MonitorElement*> Ele_phi_MTD_EE_list_Significance_Bkg;
+
+  // dt distribution part for histogram vectors
+  std::vector<MonitorElement*> general_pT_list;
+  std::vector<MonitorElement*> general_eta_list;
+
+  std::vector<MonitorElement*> general_pT_Signif_list;
+  std::vector<MonitorElement*> general_eta_Signif_list;
+};
+
+// ------------ constructor and destructor --------------
+MtdEleIsoValidation::MtdEleIsoValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      trackMinPt_(iConfig.getParameter<double>("trackMinimumPt")),
+      trackMinEta_(iConfig.getParameter<double>("trackMinimumEta")),
+      trackMaxEta_(iConfig.getParameter<double>("trackMaximumEta")),
+      rel_iso_cut_(iConfig.getParameter<double>("rel_iso_cut")),
+      track_match_PV_(iConfig.getParameter<bool>("optionTrackMatchToPV")),
+      dt_sig_vtx_(iConfig.getParameter<bool>("option_dtToPV")),
+      dt_sig_track_(iConfig.getParameter<bool>("option_dtToTrack")),
+      dt_distributions_(iConfig.getParameter<bool>("option_dtDistributions")) {
+  //Ntracks_EB_list_Sig(iConfig.getParameter<std::vector<MonitorElement*>>("Ntracks_EB_list_Sig_test")) { // Example that does not work, but does work for double type
+
+  GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
+  RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
+  RecVertexToken_ =
+      consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTag_vtx"));  // Vtx 4D collection
+
+  GsfElectronToken_EB_ = consumes<reco::GsfElectronCollection>(
+      iConfig.getParameter<edm::InputTag>("inputEle_EB"));  // Barrel electron collection input/token
+  GsfElectronToken_EE_ = consumes<reco::GsfElectronCollection>(
+      iConfig.getParameter<edm::InputTag>("inputEle_EE"));  // Endcap electron collection input/token
+  GenParticleToken_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("inputGenP"));
+
+  HepMCProductToken_ = consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("inputTagH"));
+  trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
+  pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
+  tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
+  SigmatmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtd"));
+  t0SrcToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0Src"));
+  Sigmat0SrcToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0Src"));
+  t0PidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0PID"));
+  Sigmat0PidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0PID"));
+  t0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0SafePID"));
+  Sigmat0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0SafePID"));
+  trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
+
+  trackingParticleCollectionToken_ =
+      consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));  // From Aurora
+  recoToSimAssociationToken_ =
+      consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));  // From Aurora
+
+  particleTableToken_ = esConsumes<HepPDT::ParticleDataTable, edm::DefaultRecord>();
+}
+
+MtdEleIsoValidation::~MtdEleIsoValidation() {}
+
+// ------------ method called for each event  ------------
+void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace geant_units::operators;
+  using namespace std;
+
+  //auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
+  //edm::Handle<reco::TrackCollection> GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
+  auto GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
+
+  //auto RecVertexHandle_ = makeValid(iEvent.getHandle(RecVertexToken_));
+  auto VertexHandle_ = iEvent.getHandle(RecVertexToken_);
+
+  std::vector<reco::Vertex> vertices = *VertexHandle_;
+
+  const auto& t0Pid = iEvent.get(t0PidToken_);
+  const auto& Sigmat0Pid = iEvent.get(Sigmat0PidToken_);
+  const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
+  //const auto& tMtd = iEvent.get(tmtdToken_);
+  //const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
+  //const auto& t0Src = iEvent.get(t0SrcToken_);
+  //const auto& Sigmat0Src = iEvent.get(Sigmat0SrcToken_);
+  //const auto& t0Safe = iEvent.get(t0SafePidToken_);
+  //const auto& Sigmat0Safe = iEvent.get(Sigmat0SafePidToken_);
+  //const auto& trackAssoc = iEvent.get(trackAssocToken_);
+  //const auto& pathLength = iEvent.get(pathLengthToken_);
+
+  auto eleHandle_EB = makeValid(iEvent.getHandle(GsfElectronToken_EB_));
+  reco::GsfElectronCollection eleColl_EB = *(eleHandle_EB.product());
+
+  auto eleHandle_EE = makeValid(iEvent.getHandle(GsfElectronToken_EE_));
+  reco::GsfElectronCollection eleColl_EE = *(eleHandle_EE.product());
+
+  auto GenPartHandle =
+      makeValid(iEvent.getHandle(GenParticleToken_));  // Aurora uses getByToken, result should be the same
+  reco::GenParticleCollection GenPartColl = *(GenPartHandle.product());
+
+  auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));  // From Aurora
+  const reco::RecoToSimCollection* r2s_ = recoToSimH.product();               // From Aurora
+
+  // Creating combined electron collection
+
+  std::vector<reco::GsfElectron> localEleCollection;
+  localEleCollection.reserve(
+      eleColl_EB.size() + eleColl_EE.size());  // From Aurora, added for saving memory and running time (reserve memory)
+
+  for (const auto& ele_EB : eleColl_EB) {
+    if (ele_EB.isEB()) {
+      localEleCollection.emplace_back(ele_EB);  // changed to emplace_back instead of push_back (From Aurora)
+    }
+  }
+
+  for (const auto& ele_EE : eleColl_EE) {
+    if (ele_EE.isEE()) {
+      localEleCollection.emplace_back(ele_EE);  // changed to emplace_back instead of push_back (From Aurora)
+    }
+  }
+  localEleCollection.shrink_to_fit();  // From Aurora, optimize vector momery size
+
+  // timing cut type check (if both true, only check cut wrt. vtx not electron track)
+  if (dt_sig_vtx_ && dt_sig_track_) {
+    dt_sig_track_ = false;
+    std::cout
+        << "Both timing cut types chosen!!! Fix this at the configuration setup. Default timing wrt. vtx chosen!!!!"
+        << std::endl;
+  }
+
+  // Selecting the PV from 3D and 4D vertex collections
+
+  reco::Vertex Vtx_chosen;
+
+  // This part has to be included, because in ~1% of the events, the "good" vertex is the 1st one not the 0th one in the collection
+  for (int iVtx = 0; iVtx < (int)vertices.size(); iVtx++) {
+    const reco::Vertex& vertex = vertices.at(iVtx);
+
+    if (!vertex.isFake() && vertex.ndof() >= 4) {
+      Vtx_chosen = vertex;
+      break;
+    }
+  }
+  // Vertex selection ends
+
+  // auto isPrompt = [](int pdg) {
+  //   pdg = std::abs(pdg);
+  //   return (pdg == 23 or pdg == 24 or pdg==15 or pdg==11); // some electrons are mothers to themselves?
+  // };
+
+  //for (const auto& ele : eleColl_EB){
+  for (const auto& ele : localEleCollection) {
+    bool ele_Promt = false;
+
+    float ele_track_source_dz = fabs(ele.gsfTrack()->dz(Vtx_chosen.position()));
+    float ele_track_source_dxy = fabs(ele.gsfTrack()->dxy(Vtx_chosen.position()));
+
+    const reco::TrackRef ele_TrkRef = ele.core()->ctfTrack();
+    double tsim = -1.;
+    double ele_sim_pt = -1.;
+
+    if (ele.pt() > 10 && fabs(ele.eta()) < 2.4 && ele_track_source_dz < max_dz_vtx_cut &&
+        ele_track_source_dxy < max_dxy_vtx_cut) {  // selecting "good" RECO electrons
+
+      // Do the RECO-GEN match through RECOtoSIMcollection link (From Aurora)
+
+      const reco::TrackBaseRef trkrefb(ele_TrkRef);
+
+      auto found = r2s_->find(trkrefb);  // find the track link?
+      if (found != r2s_->end()) {
+        const auto& tp = (found->val)[0];
+        tsim = (tp.first)->parentVertex()->position().t() * 1e9;
+        ele_sim_pt = (tp.first)->pt();
+        // check that the genParticle vector is not empty
+        if (((found->val)[0]).first->status() != -99) {
+          const auto genParticle = *(tp.first->genParticles()[0]);
+          // check if prompt (not from hadron, muon, or tau decay) and final state
+          // or if is a direct decay product of a prompt tau and is final state
+          //if ((genParticle.isPromptFinalState() or genParticle.isDirectPromptTauDecayProductFinalState()) and isPrompt(genParticle.mother()->pdgId())) {
+          if ((genParticle.isPromptFinalState() or genParticle.isDirectPromptTauDecayProductFinalState()) and
+              pdgCheck(genParticle.mother()->pdgId())) {
+            ele_Promt = true;
+          }
+        }
+      }
+
+      meEle_test_check_->Fill(tsim);
+
+      // old matching
+      // math::XYZVector EleMomentum = ele.momentum();
+
+      // for (const auto& genParticle : GenPartColl) {
+      //   math::XYZVector GenPartMomentum = genParticle.momentum();
+      //   double dr_match = reco::deltaR(GenPartMomentum, EleMomentum);
+
+      //   if (((genParticle.pdgId() == 11 && ele.charge() == -1) || (genParticle.pdgId() == -11 && ele.charge() == 1)) &&
+      //       dr_match < 0.10) {  // dR match check and charge match check
+
+      //     if (genParticle.mother()->pdgId() == 23 || fabs(genParticle.mother()->pdgId()) == 24 ||
+      //         fabs(genParticle.mother()->pdgId()) ==
+      //             15) {  // check if ele mother is Z,W or tau (W->tau->ele decays, as these still should be quite isolated)
+      //       ele_Promt = true;  // ele is defined as promt
+      //     }
+      //     break;
+
+      //   } else {
+      //     continue;
+      //   }
+      // }
+    } else {
+      continue;
+    }
+
+    math::XYZVector EleSigTrackMomentumAtVtx = ele.gsfTrack()->momentum();  // not sure if correct, but works
+    double EleSigTrackEtaAtVtx = ele.gsfTrack()->eta();
+
+    double ele_sigTrkTime = -1;  // electron signal track MTD information
+    double ele_sigTrkTimeErr = -1;
+    double ele_sigTrkMtdMva = -1;
+
+    // Removed track dR matching as we have track references (From Aurora)
+    if (ele_TrkRef.isNonnull()) {  // if we found a track match, we add MTD timing information for it
+
+      bool Barrel_ele = ele.isEB();  // for track pT/dz cuts (Different for EB and EE in TDR)
+
+      float min_pt_cut = Barrel_ele ? min_pt_cut_EB : min_pt_cut_EE;
+      float max_dz_cut = Barrel_ele ? max_dz_cut_EB : max_dz_cut_EE;
+
+      ele_sigTrkTime = t0Pid[ele_TrkRef];
+      ele_sigTrkTimeErr = Sigmat0Pid[ele_TrkRef];
+      ele_sigTrkMtdMva = mtdQualMVA[ele_TrkRef];
+      ele_sigTrkTimeErr = (ele_sigTrkMtdMva > min_track_mtd_mva_cut) ? ele_sigTrkTimeErr : -1;
+
+      meEle_avg_error_SigTrk_check_->Fill(ele_sigTrkTimeErr);
+
+      if (ele_Promt) {
+        // For signal (promt)
+        if (Barrel_ele) {
+          meEle_pt_tot_Sig_EB_->Fill(ele.pt());  // All selected electron information for efficiency plots later
+          meEle_pt_sim_tot_Sig_EB_->Fill(ele_sim_pt);
+          meEle_eta_tot_Sig_EB_->Fill(ele.eta());
+          meEle_phi_tot_Sig_EB_->Fill(ele.phi());
+        } else {
+          meEle_pt_tot_Sig_EE_->Fill(ele.pt());  // All selected electron information for efficiency plots later
+          meEle_pt_sim_tot_Sig_EE_->Fill(ele_sim_pt);
+          meEle_eta_tot_Sig_EE_->Fill(ele.eta());
+          meEle_phi_tot_Sig_EE_->Fill(ele.phi());
+        }
+      } else {
+        // For background (non-promt)
+        if (Barrel_ele) {
+          meEle_pt_tot_Bkg_EB_->Fill(ele.pt());
+          meEle_pt_sim_tot_Bkg_EB_->Fill(ele_sim_pt);
+          meEle_eta_tot_Bkg_EB_->Fill(ele.eta());
+          meEle_phi_tot_Bkg_EB_->Fill(ele.phi());
+        } else {
+          meEle_pt_tot_Bkg_EE_->Fill(ele.pt());
+          meEle_pt_sim_tot_Bkg_EE_->Fill(ele_sim_pt);
+          meEle_eta_tot_Bkg_EE_->Fill(ele.eta());
+          meEle_phi_tot_Bkg_EE_->Fill(ele.phi());
+        }
+      }
+
+      int N_tracks_noMTD = 0;  // values for no MTD case
+      double pT_sum_noMTD = 0;
+      double rel_pT_sum_noMTD = 0;
+      std::vector<int> N_tracks_MTD{0, 0, 0, 0, 0, 0, 0};  // values for MTD case - 7 timing cuts // RECO
+      std::vector<double> pT_sum_MTD{0, 0, 0, 0, 0, 0, 0};
+      std::vector<double> rel_pT_sum_MTD{0, 0, 0, 0, 0, 0, 0};
+
+      std::vector<int> N_tracks_sim_MTD{0, 0, 0, 0, 0, 0, 0};  // SIM
+      std::vector<double> pT_sum_sim_MTD{0, 0, 0, 0, 0, 0, 0};
+      std::vector<double> rel_pT_sum_sim_MTD{0, 0, 0, 0, 0, 0, 0};
+
+      std::vector<int> N_tracks_MTD_significance{0, 0, 0};  // values for MTD case - 3 significance cuts // RECO
+      std::vector<double> pT_sum_MTD_significance{0, 0, 0};
+      std::vector<double> rel_pT_sum_MTD_significance{0, 0, 0};
+
+      std::vector<int> N_tracks_sim_MTD_significance{0, 0, 0};  // SIM
+      std::vector<double> pT_sum_sim_MTD_significance{0, 0, 0};
+      std::vector<double> rel_pT_sum_sim_MTD_significance{0, 0, 0};
+
+      int general_index = 0;
+      for (const auto& trackGen : *GenRecTrackHandle) {
+        const reco::TrackRef trackref_general(GenRecTrackHandle, general_index);
+        general_index++;
+
+        if (trackref_general == ele_TrkRef)  // Skip electron track (From Aurora)
+          continue;
+
+        if (trackGen.pt() < min_pt_cut) {  // track pT cut
+          continue;
+        }
+
+        if (fabs(trackGen.vz() - ele.gsfTrack()->vz()) > max_dz_cut) {  // general track vs signal track dz cut
+          continue;
+        }
+
+        if (track_match_PV_) {
+          if (Vtx_chosen.trackWeight(trackref_general) < 0.5) {  // cut for general track matching to PV
+            continue;
+          }
+        }
+
+        double dr_check = reco::deltaR(trackGen.momentum(), EleSigTrackMomentumAtVtx);
+        double deta = fabs(trackGen.eta() - EleSigTrackEtaAtVtx);
+
+        if (dr_check > min_dR_cut && dr_check < max_dR_cut &&
+            deta > min_strip_cut) {  // checking if the track is inside isolation cone
+
+          ++N_tracks_noMTD;
+          pT_sum_noMTD += trackGen.pt();
+        } else {
+          continue;
+        }
+
+        // checking the MTD timing cuts
+
+        // Track SIM information (From Aurora)
+        const reco::TrackBaseRef trkrefBase(trackref_general);
+
+        auto TPmatched = r2s_->find(trkrefBase);
+        double tsim_trk = -1.;
+        double trk_ptSim = -1.;
+        //int genMatched = 0;
+        if (TPmatched != r2s_->end()) {
+          // reco track matched to a TP
+          const auto& tp = (TPmatched->val)[0];
+          tsim_trk = (tp.first)->parentVertex()->position().t() * 1e9;
+          trk_ptSim = (tp.first)->pt();
+          //     // check that the genParticle vector is not empty
+          //       if (((TPmatched->val)[0]).first->status() != -99) {
+          //     genMatched = 1;
+          //     }
+        }
+
+        //   meTrk_genMatch_check_->Fill(genMatched);
+
+        meEle_test_check_->Fill(trk_ptSim);
+
+        double TrkMTDTime = t0Pid[trackref_general];  // MTD timing info for particular track fron general tracks
+        double TrkMTDTimeErr = Sigmat0Pid[trackref_general];
+        double TrkMTDMva = mtdQualMVA[trackref_general];
+        TrkMTDTimeErr = (TrkMTDMva > min_track_mtd_mva_cut) ? TrkMTDTimeErr : -1;  // track MTD MVA cut/check
+
+        meEle_avg_error_PUTrk_check_->Fill(TrkMTDTimeErr);
+
+        if (dt_sig_track_) {
+          double dt_sigTrk = 0;  // dt regular track vs signal track (absolute value)
+          double dt_sigTrk_signif = 0;
+
+          double dt_sim_sigTrk = 0;  // for SIM case
+          double dt_sim_sigTrk_signif = 0;
+
+          // SIM CASE trk-SigTrk STARTS
+          if (fabs(tsim_trk) > 0 && fabs(tsim) > 0 && trk_ptSim > 0) {
+            dt_sim_sigTrk = fabs(tsim_trk - tsim);
+            dt_sim_sigTrk_signif =
+                dt_sim_sigTrk /
+                std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
+                          avg_sim_sigTrk_t_err * avg_sim_sigTrk_t_err);  // FIX ERRORS FOR SIGNIFICANCE IN SIM CASE
+
+            // absolute timing cuts
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+              if (dt_sim_sigTrk < max_dt_track_cut[i]) {
+                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+              }
+            }
+            // significance cuts
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
+              if (dt_sim_sigTrk_signif < max_dt_significance_cut[i]) {
+                N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
+                pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+              }
+            }
+
+          } else {  // if there is no error for MTD information, we count the MTD isolation case same as noMTD
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+              N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+              pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+            }
+
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
+              N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
+              pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+            }
+          }
+          // SIM CASE trk-SigTrk ENDS
+
+          // Regular RECO MTD check
+          if (TrkMTDTimeErr > 0 && ele_sigTrkTimeErr > 0) {
+            dt_sigTrk = fabs(TrkMTDTime - ele_sigTrkTime);
+            dt_sigTrk_signif =
+                dt_sigTrk / std::sqrt(TrkMTDTimeErr * TrkMTDTimeErr + ele_sigTrkTimeErr * ele_sigTrkTimeErr);
+
+            meEle_no_dt_check_->Fill(1);
+            // absolute timing cuts
+            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+              if (dt_sigTrk < max_dt_track_cut[i]) {
+                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
+                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+              }
+            }
+            // significance cuts
+            for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
+              if (dt_sigTrk_signif < max_dt_significance_cut[i]) {
+                N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;
+                pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();
+              }
+            }
+
+          } else {  // if there is no error for MTD information, we count the MTD isolation case same as noMTD
+            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+              N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
+              pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT sum
+            }
+
+            for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
+              N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;          // N_tracks_noMTD
+              pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();  // pT sum
+            }
+            meEle_no_dt_check_->Fill(0);
+          }
+
+          if (dt_distributions_) {
+            for (long unsigned int i = 0; i < (pT_bins_dt_distrb.size() - 1); i++) {
+              //stuff general pT
+              if (ele.pt() > pT_bins_dt_distrb[i] && ele.pt() < pT_bins_dt_distrb[i + 1]) {
+                general_pT_list[i]->Fill(dt_sigTrk);
+                general_pT_Signif_list[i]->Fill(dt_sigTrk_signif);
+              }
+            }
+
+            for (long unsigned int i = 0; i < (eta_bins_dt_distrib.size() - 1); i++) {
+              //stuff general eta
+              if (fabs(ele.eta()) > eta_bins_dt_distrib[i] && fabs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
+                general_eta_list[i]->Fill(dt_sigTrk);
+                general_eta_Signif_list[i]->Fill(dt_sigTrk_signif);
+              }
+            }
+          }  // End of optional dt distributions plots
+        }
+
+        if (dt_sig_vtx_) {
+          double dt_vtx = 0;  // dt regular track vs vtx
+          double dt_vtx_signif = 0;
+
+          double dt_sim_vtx = 0;  // dt regular track vs vtx
+          double dt_sim_vtx_signif = 0;
+
+          //SIM CASE trk-vertex STARTS
+          if (fabs(tsim_trk) > 0 && Vtx_chosen.tError() > 0 && trk_ptSim > 0) {
+            dt_sim_vtx = fabs(tsim_trk - Vtx_chosen.t());
+            dt_sim_vtx_signif = dt_sim_vtx / std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
+                                                       Vtx_chosen.tError() * Vtx_chosen.tError());
+            // absolute timing cuts
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+              if (dt_sim_vtx < max_dt_vtx_cut[i]) {
+                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+              }
+            }
+            // significance timing cuts
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
+              if (dt_sim_vtx_signif < max_dt_significance_cut[i]) {
+                N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
+                pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+              }
+            }
+
+          } else {
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+              N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;      // N_tracks_noMTD
+              pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;  // pT_sum_noMTD
+            }
+
+            for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
+              N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;      // N_tracks_noMTD
+              pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;  // pT sum
+            }
+          }  // SIM CASE trk-vertex ENDS
+
+          //Regular RECO MTD case
+          if (TrkMTDTimeErr > 0 && Vtx_chosen.tError() > 0) {
+            dt_vtx = fabs(TrkMTDTime - Vtx_chosen.t());
+            dt_vtx_signif =
+                dt_vtx / std::sqrt(TrkMTDTimeErr * TrkMTDTimeErr + Vtx_chosen.tError() * Vtx_chosen.tError());
+
+            meEle_no_dt_check_->Fill(1);
+            meEle_avg_error_vtx_check_->Fill(Vtx_chosen.tError());
+
+            // absolute timing cuts
+            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+              if (dt_vtx < max_dt_vtx_cut[i]) {
+                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
+                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+              }
+            }
+            // significance timing cuts
+            for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
+              if (dt_vtx_signif < max_dt_significance_cut[i]) {
+                N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;
+                pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();
+              }
+            }
+
+          } else {
+            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+              N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
+              pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT_sum_noMTD
+            }
+
+            for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
+              N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;          // N_tracks_noMTD
+              pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();  // pT sum
+            }
+            meEle_no_dt_check_->Fill(0);
+          }
+
+          /// Optional dt distribution plots
+          if (dt_distributions_) {
+            for (long unsigned int i = 0; i < (pT_bins_dt_distrb.size() - 1); i++) {
+              //stuff general pT
+              if (ele.pt() > pT_bins_dt_distrb[i] && ele.pt() < pT_bins_dt_distrb[i + 1]) {
+                general_pT_list[i]->Fill(dt_vtx);
+                general_pT_Signif_list[i]->Fill(dt_vtx_signif);
+              }
+            }
+
+            for (long unsigned int i = 0; i < (eta_bins_dt_distrib.size() - 1); i++) {
+              //stuff general eta
+              if (fabs(ele.eta()) > eta_bins_dt_distrib[i] && fabs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
+                general_eta_list[i]->Fill(dt_vtx);
+                general_eta_Signif_list[i]->Fill(dt_vtx_signif);
+              }
+            }
+          }  // End of optional dt distributions plots
+        }
+      }
+
+      rel_pT_sum_noMTD = pT_sum_noMTD / ele.gsfTrack()->pt();  // rel_ch_iso calculation
+      for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+        rel_pT_sum_MTD[i] = pT_sum_MTD[i] / ele.gsfTrack()->pt();
+        rel_pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] / ele_sim_pt;
+      }
+
+      for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
+        rel_pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] / ele.gsfTrack()->pt();
+        rel_pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] / ele_sim_pt;
+      }
+
+      if (ele_Promt) {  // promt part
+        if (Barrel_ele) {
+          meEleISO_Ntracks_Sig_EB_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_chIso_Sig_EB_->Fill(pT_sum_noMTD);
+          meEleISO_rel_chIso_Sig_EB_->Fill(rel_pT_sum_noMTD);
+
+          for (long unsigned int j = 0; j < Ntracks_EB_list_Sig.size(); j++) {
+            Ntracks_EB_list_Sig[j]->Fill(N_tracks_MTD[j]);
+            ch_iso_EB_list_Sig[j]->Fill(pT_sum_MTD[j]);
+            rel_ch_iso_EB_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
+
+            Ntracks_sim_EB_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
+            ch_iso_sim_EB_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
+            rel_ch_iso_sim_EB_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+          }
+
+          for (long unsigned int j = 0; j < Ntracks_EB_list_Significance_Sig.size(); j++) {
+            Ntracks_EB_list_Significance_Sig[j]->Fill(N_tracks_MTD_significance[j]);
+            ch_iso_EB_list_Significance_Sig[j]->Fill(pT_sum_MTD_significance[j]);
+            rel_ch_iso_EB_list_Significance_Sig[j]->Fill(rel_pT_sum_MTD_significance[j]);
+
+            Ntracks_sim_EB_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
+            ch_iso_sim_EB_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
+            rel_ch_iso_sim_EB_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+          }
+
+          if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
+            meEle_pt_noMTD_Sig_EB_->Fill(ele.pt());
+            meEle_eta_noMTD_Sig_EB_->Fill(ele.eta());
+            meEle_phi_noMTD_Sig_EB_->Fill(ele.phi());
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EB_list_Sig.size(); k++) {
+            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EB_list_Sig[k]->Fill(ele.pt());
+              Ele_eta_MTD_EB_list_Sig[k]->Fill(ele.eta());
+              Ele_phi_MTD_EB_list_Sig[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EB_list_Sig[k]->Fill(ele_sim_pt);
+            }
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EB_list_Significance_Sig.size(); k++) {
+            if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EB_list_Significance_Sig[k]->Fill(ele.pt());
+              Ele_eta_MTD_EB_list_Significance_Sig[k]->Fill(ele.eta());
+              Ele_phi_MTD_EB_list_Significance_Sig[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EB_list_Significance_Sig[k]->Fill(ele_sim_pt);
+            }
+          }
+
+        } else {  // for endcap
+
+          meEleISO_Ntracks_Sig_EE_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_chIso_Sig_EE_->Fill(pT_sum_noMTD);
+          meEleISO_rel_chIso_Sig_EE_->Fill(rel_pT_sum_noMTD);
+
+          for (long unsigned int j = 0; j < Ntracks_EE_list_Sig.size(); j++) {
+            Ntracks_EE_list_Sig[j]->Fill(N_tracks_MTD[j]);
+            ch_iso_EE_list_Sig[j]->Fill(pT_sum_MTD[j]);
+            rel_ch_iso_EE_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
+
+            Ntracks_sim_EE_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
+            ch_iso_sim_EE_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
+            rel_ch_iso_sim_EE_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+          }
+
+          for (long unsigned int j = 0; j < Ntracks_EE_list_Significance_Sig.size(); j++) {
+            Ntracks_EE_list_Significance_Sig[j]->Fill(N_tracks_MTD_significance[j]);
+            ch_iso_EE_list_Significance_Sig[j]->Fill(pT_sum_MTD_significance[j]);
+            rel_ch_iso_EE_list_Significance_Sig[j]->Fill(rel_pT_sum_MTD_significance[j]);
+
+            Ntracks_sim_EE_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
+            ch_iso_sim_EE_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
+            rel_ch_iso_sim_EE_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+          }
+
+          if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
+            meEle_pt_noMTD_Sig_EE_->Fill(ele.pt());
+            meEle_eta_noMTD_Sig_EE_->Fill(ele.eta());
+            meEle_phi_noMTD_Sig_EE_->Fill(ele.phi());
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EE_list_Sig.size(); k++) {
+            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EE_list_Sig[k]->Fill(ele.pt());
+              Ele_eta_MTD_EE_list_Sig[k]->Fill(ele.eta());
+              Ele_phi_MTD_EE_list_Sig[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EE_list_Sig[k]->Fill(ele_sim_pt);
+            }
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Sig.size(); k++) {
+            if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EE_list_Significance_Sig[k]->Fill(ele.pt());
+              Ele_eta_MTD_EE_list_Significance_Sig[k]->Fill(ele.eta());
+              Ele_phi_MTD_EE_list_Significance_Sig[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EE_list_Significance_Sig[k]->Fill(ele_sim_pt);
+            }
+          }
+        }
+      } else {  // non-promt part
+        if (Barrel_ele) {
+          meEleISO_Ntracks_Bkg_EB_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_chIso_Bkg_EB_->Fill(pT_sum_noMTD);
+          meEleISO_rel_chIso_Bkg_EB_->Fill(rel_pT_sum_noMTD);
+
+          for (long unsigned int j = 0; j < Ntracks_EB_list_Bkg.size(); j++) {
+            Ntracks_EB_list_Bkg[j]->Fill(N_tracks_MTD[j]);
+            ch_iso_EB_list_Bkg[j]->Fill(pT_sum_MTD[j]);
+            rel_ch_iso_EB_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
+
+            Ntracks_sim_EB_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
+            ch_iso_sim_EB_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
+            rel_ch_iso_sim_EB_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+          }
+
+          for (long unsigned int j = 0; j < Ntracks_EB_list_Significance_Bkg.size(); j++) {
+            Ntracks_EB_list_Significance_Bkg[j]->Fill(N_tracks_MTD_significance[j]);
+            ch_iso_EB_list_Significance_Bkg[j]->Fill(pT_sum_MTD_significance[j]);
+            rel_ch_iso_EB_list_Significance_Bkg[j]->Fill(rel_pT_sum_MTD_significance[j]);
+
+            Ntracks_sim_EB_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
+            ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
+            rel_ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+          }
+
+          if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
+            meEle_pt_noMTD_Bkg_EB_->Fill(ele.pt());
+            meEle_eta_noMTD_Bkg_EB_->Fill(ele.eta());
+            meEle_phi_noMTD_Bkg_EB_->Fill(ele.phi());
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EB_list_Bkg.size(); k++) {
+            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EB_list_Bkg[k]->Fill(ele.pt());
+              Ele_eta_MTD_EB_list_Bkg[k]->Fill(ele.eta());
+              Ele_phi_MTD_EB_list_Bkg[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EB_list_Bkg[k]->Fill(ele_sim_pt);
+            }
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EB_list_Significance_Bkg.size(); k++) {
+            if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EB_list_Significance_Bkg[k]->Fill(ele.pt());
+              Ele_eta_MTD_EB_list_Significance_Bkg[k]->Fill(ele.eta());
+              Ele_phi_MTD_EB_list_Significance_Bkg[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EB_list_Significance_Bkg[k]->Fill(ele_sim_pt);
+            }
+          }
+
+        } else {                                           // for endcap
+          meEleISO_Ntracks_Bkg_EE_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_chIso_Bkg_EE_->Fill(pT_sum_noMTD);
+          meEleISO_rel_chIso_Bkg_EE_->Fill(rel_pT_sum_noMTD);
+
+          for (long unsigned int j = 0; j < Ntracks_EE_list_Bkg.size(); j++) {
+            Ntracks_EE_list_Bkg[j]->Fill(N_tracks_MTD[j]);
+            ch_iso_EE_list_Bkg[j]->Fill(pT_sum_MTD[j]);
+            rel_ch_iso_EE_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
+
+            Ntracks_sim_EE_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
+            ch_iso_sim_EE_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
+            rel_ch_iso_sim_EE_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+          }
+
+          for (long unsigned int j = 0; j < Ntracks_EE_list_Significance_Bkg.size(); j++) {
+            Ntracks_EE_list_Significance_Bkg[j]->Fill(N_tracks_MTD_significance[j]);
+            ch_iso_EE_list_Significance_Bkg[j]->Fill(pT_sum_MTD_significance[j]);
+            rel_ch_iso_EE_list_Significance_Bkg[j]->Fill(rel_pT_sum_MTD_significance[j]);
+
+            Ntracks_sim_EE_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
+            ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
+            rel_ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+          }
+
+          if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
+            meEle_pt_noMTD_Bkg_EE_->Fill(ele.pt());
+            meEle_eta_noMTD_Bkg_EE_->Fill(ele.eta());
+            meEle_phi_noMTD_Bkg_EE_->Fill(ele.phi());
+          }
+
+          for (long unsigned int k = 0; k < Ntracks_EE_list_Bkg.size(); k++) {
+            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EE_list_Bkg[k]->Fill(ele.pt());
+              Ele_eta_MTD_EE_list_Bkg[k]->Fill(ele.eta());
+              Ele_phi_MTD_EE_list_Bkg[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EE_list_Bkg[k]->Fill(ele_sim_pt);
+            }
+          }
+          for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Bkg.size(); k++) {
+            if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
+              Ele_pT_MTD_EE_list_Significance_Bkg[k]->Fill(ele.pt());
+              Ele_eta_MTD_EE_list_Significance_Bkg[k]->Fill(ele.eta());
+              Ele_phi_MTD_EE_list_Significance_Bkg[k]->Fill(ele.phi());
+
+              Ele_pT_sim_MTD_EE_list_Significance_Bkg[k]->Fill(ele_sim_pt);
+            }
+          }
+        }
+      }
+    }  // electron matched to a track
+  }    // electron collection inside single event
+}
+
+// ------------ method for histogram booking ------------
+void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run const& run, edm::EventSetup const& iSetup) {
+  ibook.setCurrentFolder(folder_);
+
+  // histogram booking
+
+  meEle_avg_error_SigTrk_check_ =
+      ibook.book1D("SigTrk_avg_timming_err", "Average signal electron track MTD timing uncertainty", 200, 0, 2);
+  meEle_avg_error_PUTrk_check_ =
+      ibook.book1D("PUTrk_avg_timming_err", "Average PU track MTD timing uncertainty", 200, 0, 2);
+  meEle_avg_error_vtx_check_ = ibook.book1D("Vtx_avg_timming_err", "Average veretex timing uncertainty", 200, 0, 2);
+
+  meEle_test_check_ = ibook.book1D("test_hist", "test_hist", 102, -2, 100);
+
+  meEle_no_dt_check_ =
+      ibook.book1D("Track_dt_info_check",
+                   "Tracks dt check - ratio between tracks with (value 1) and without (value 0) timing info",
+                   2,
+                   0,
+                   2);
+
+  meTrk_genMatch_check_ =
+      ibook.book1D("Track_genMatch_info_check", "Track MTD genMatch check - tracks for MTD timing checked", 2, 0, 2);
+
+  // signal
+  meEleISO_Ntracks_Sig_EB_ = ibook.book1D("Ele_Iso_Ntracks_Sig_EB",
+                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          20,
+                                          0,
+                                          20);  // hists for electrons
+
+  meEleISO_chIso_Sig_EB_ = ibook.book1D(
+      "Ele_chIso_sum_Sig_EB", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
+
+  meEleISO_rel_chIso_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_1_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+
+  meEleISO_chIso_MTD_1_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_1_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_1_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+
+  meEleISO_chIso_MTD_2_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_3_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_4_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_5_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_5_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_5_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_5_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_6_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_6_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_6_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_6_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_7_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_7_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_7_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_7_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_1_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+
+  meEleISO_chIso_MTD_sim_1_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_1_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+
+  meEleISO_chIso_MTD_sim_2_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_3_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_4_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_5_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_5_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_5_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_6_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_6_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_6_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_7_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_7_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_7_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEle_pt_tot_Sig_EB_ =
+      ibook.book1D("Ele_pT_tot_Sig_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+  meEle_pt_noMTD_Sig_EB_ = ibook.book1D("Ele_pT_noMTD_Sig_EB", "Electron pT noMTD", 30, 10, 100);
+
+  meEle_pt_sim_tot_Sig_EB_ =
+      ibook.book1D("Ele_pT_sim_tot_Sig_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+
+  meEle_eta_tot_Sig_EB_ = ibook.book1D("Ele_eta_tot_Sig_EB", "Electron eta tot", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Sig_EB_ = ibook.book1D("Ele_eta_noMTD_Sig_EB", "Electron eta noMTD", 128, -3.2, 3.2);
+
+  meEle_phi_tot_Sig_EB_ = ibook.book1D("Ele_phi_tot_Sig_EB", "Electron phi tot", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Sig_EB_ = ibook.book1D("Ele_phi_noMTD_Sig_EB", "Electron phi noMTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_MTD_1_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_1_Sig_EB_ = ibook.book1D("Ele_eta_MTD_1_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_1_Sig_EB_ = ibook.book1D("Ele_phi_MTD_1_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_MTD_5_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_5_Sig_EB_ = ibook.book1D("Ele_eta_MTD_5_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_5_Sig_EB_ = ibook.book1D("Ele_phi_MTD_5_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_MTD_6_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_6_Sig_EB_ = ibook.book1D("Ele_eta_MTD_6_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_6_Sig_EB_ = ibook.book1D("Ele_phi_MTD_6_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_MTD_7_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_7_Sig_EB_ = ibook.book1D("Ele_eta_MTD_7_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_7_Sig_EB_ = ibook.book1D("Ele_phi_MTD_7_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_sim_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_1_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_2_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_3_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_4_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_5_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_6_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_7_Sig_EB", "Electron pT MTD", 30, 10, 100);
+
+  meEle_pt_sim_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+
+  meEleISO_Ntracks_Sig_EE_ = ibook.book1D("Ele_Iso_Ntracks_Sig_EE",
+                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          20,
+                                          0,
+                                          20);  // hists for electrons
+  meEleISO_chIso_Sig_EE_ = ibook.book1D(
+      "Ele_chIso_sum_Sig_EE", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
+  meEleISO_rel_chIso_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_1_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_1_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_1_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_1_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_2_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_3_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_4_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_5_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_5_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_5_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_5_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_6_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_6_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_6_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_6_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_7_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_7_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_7_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_7_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_1_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_1_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_1_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_2_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_3_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_4_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_5_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_5_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_5_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_6_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_6_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_6_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_7_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_7_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_7_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEle_pt_tot_Sig_EE_ =
+      ibook.book1D("Ele_pT_tot_Sig_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+  meEle_pt_noMTD_Sig_EE_ = ibook.book1D("Ele_pT_noMTD_Sig_EE", "Electron pT noMTD", 30, 10, 100);
+
+  meEle_pt_sim_tot_Sig_EE_ =
+      ibook.book1D("Ele_pT_sim_tot_Sig_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+
+  meEle_eta_tot_Sig_EE_ = ibook.book1D("Ele_eta_tot_Sig_EE", "Electron eta tot", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Sig_EE_ = ibook.book1D("Ele_eta_noMTD_Sig_EE", "Electron eta noMTD", 128, -3.2, 3.2);
+
+  meEle_phi_tot_Sig_EE_ = ibook.book1D("Ele_phi_tot_Sig_EE", "Electron phi tot", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Sig_EE_ = ibook.book1D("Ele_phi_noMTD_Sig_EE", "Electron phi noMTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_MTD_1_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_1_Sig_EE_ = ibook.book1D("Ele_eta_MTD_1_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_1_Sig_EE_ = ibook.book1D("Ele_phi_MTD_1_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_MTD_5_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_5_Sig_EE_ = ibook.book1D("Ele_eta_MTD_5_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_5_Sig_EE_ = ibook.book1D("Ele_phi_MTD_5_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_MTD_6_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_6_Sig_EE_ = ibook.book1D("Ele_eta_MTD_6_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_6_Sig_EE_ = ibook.book1D("Ele_phi_MTD_6_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_MTD_7_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_7_Sig_EE_ = ibook.book1D("Ele_eta_MTD_7_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_7_Sig_EE_ = ibook.book1D("Ele_phi_MTD_7_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_sim_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_1_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_2_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_3_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_4_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_5_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_6_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_7_Sig_EE", "Electron pT MTD", 30, 10, 100);
+
+  meEle_pt_sim_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+
+  // background
+  meEleISO_Ntracks_Bkg_EB_ = ibook.book1D("Ele_Iso_Ntracks_Bkg_EB",
+                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          20,
+                                          0,
+                                          20);  // hists for electrons
+  meEleISO_chIso_Bkg_EB_ = ibook.book1D(
+      "Ele_chIso_sum_Bkg_EB", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
+  meEleISO_rel_chIso_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_1_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_1_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_1_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_1_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_2_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_3_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_4_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_5_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_5_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_5_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_5_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_6_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_6_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_6_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_6_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_7_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_7_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_7_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_7_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_1_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_1_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_2_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_3_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_4_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_5_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_5_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_6_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_6_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_7_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_7_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EB",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EB",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EB",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEle_pt_tot_Bkg_EB_ =
+      ibook.book1D("Ele_pT_tot_Bkg_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+  meEle_pt_noMTD_Bkg_EB_ = ibook.book1D("Ele_pT_noMTD_Bkg_EB", "Electron pT noMTD", 30, 10, 100);
+
+  meEle_pt_sim_tot_Bkg_EB_ =
+      ibook.book1D("Ele_pT_sim_tot_Bkg_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+
+  meEle_eta_tot_Bkg_EB_ = ibook.book1D("Ele_eta_tot_Bkg_EB", "Electron eta tot", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Bkg_EB_ = ibook.book1D("Ele_eta_noMTD_Bkg_EB", "Electron eta noMTD", 128, -3.2, 3.2);
+
+  meEle_phi_tot_Bkg_EB_ = ibook.book1D("Ele_phi_tot_Bkg_EB", "Electron phi tot", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Bkg_EB_ = ibook.book1D("Ele_phi_noMTD_Bkg_EB", "Electron phi noMTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_1_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_1_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_5_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_5_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_6_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_6_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_7_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_7_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_sim_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+
+  meEle_pt_sim_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+
+  meEleISO_Ntracks_Bkg_EE_ = ibook.book1D("Ele_Iso_Ntracks_Bkg_EE",
+                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          20,
+                                          0,
+                                          20);  // hists for electrons
+  meEleISO_chIso_Bkg_EE_ = ibook.book1D(
+      "Ele_chIso_sum_Bkg_EE", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
+  meEleISO_rel_chIso_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_1_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_1_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_1_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_1_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_2_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_3_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_4_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_5_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_5_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_5_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_5_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_6_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_6_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_6_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_6_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_7_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_7_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_7_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_7_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_1_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_1_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_2_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_3_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_4_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_5_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_5_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_6_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_6_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_7_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);  // hists for electrons
+  meEleISO_chIso_MTD_sim_7_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EE",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   20,
+                   0,
+                   20);
+  meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EE",
+                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   2000,
+                   0,
+                   20);
+  meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_ =
+      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EE",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   1000,
+                   0,
+                   4);
+
+  meEle_pt_tot_Bkg_EE_ =
+      ibook.book1D("Ele_pT_tot_Bkg_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+  meEle_pt_noMTD_Bkg_EE_ = ibook.book1D("Ele_pT_noMTD_Bkg_EE", "Electron pT noMTD", 30, 10, 100);
+
+  meEle_pt_sim_tot_Bkg_EE_ =
+      ibook.book1D("Ele_pT_sim_tot_Bkg_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+
+  meEle_eta_tot_Bkg_EE_ = ibook.book1D("Ele_eta_tot_Bkg_EE", "Electron eta tot", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Bkg_EE_ = ibook.book1D("Ele_eta_noMTD_Bkg_EE", "Electron eta noMTD", 128, -3.2, 3.2);
+
+  meEle_phi_tot_Bkg_EE_ = ibook.book1D("Ele_phi_tot_Bkg_EE", "Electron phi tot", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Bkg_EE_ = ibook.book1D("Ele_phi_noMTD_Bkg_EE", "Electron phi noMTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_1_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_1_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_5_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_5_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_6_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_6_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_7_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_7_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_eta_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+
+  meEle_pt_sim_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+
+  meEle_pt_sim_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_sim_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+
+  meEle_dt_general_pT_1 =
+      ibook.book1D("Iso_track_dt_general_pT_10_20", "Iso cone track dt distribution in pT bin 10-20 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_2 =
+      ibook.book1D("Iso_track_dt_general_pT_20_30", "Iso cone track dt distribution in pT bin 20-30 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_3 =
+      ibook.book1D("Iso_track_dt_general_pT_30_40", "Iso cone track dt distribution in pT bin 30-40 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_4 =
+      ibook.book1D("Iso_track_dt_general_pT_40_50", "Iso cone track dt distribution in pT bin 40-50 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_5 =
+      ibook.book1D("Iso_track_dt_general_pT_50_60", "Iso cone track dt distribution in pT bin 50-60 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_6 =
+      ibook.book1D("Iso_track_dt_general_pT_60_70", "Iso cone track dt distribution in pT bin 60-70 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_7 =
+      ibook.book1D("Iso_track_dt_general_pT_70_80", "Iso cone track dt distribution in pT bin 70-80 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_8 =
+      ibook.book1D("Iso_track_dt_general_pT_80_90", "Iso cone track dt distribution in pT bin 80-90 GeV ", 100, 0, 1);
+  meEle_dt_general_pT_9 =
+      ibook.book1D("Iso_track_dt_general_pT_90_100", "Iso cone track dt distribution in pT bin 90-100 GeV ", 100, 0, 1);
+
+  meEle_dtSignif_general_pT_1 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_10_20", "Iso cone track dt distribution in pT bin 10-20 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_2 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_20_30", "Iso cone track dt distribution in pT bin 20-30 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_3 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_30_40", "Iso cone track dt distribution in pT bin 30-40 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_4 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_40_50", "Iso cone track dt distribution in pT bin 40-50 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_5 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_50_60", "Iso cone track dt distribution in pT bin 50-60 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_6 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_60_70", "Iso cone track dt distribution in pT bin 60-70 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_7 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_70_80", "Iso cone track dt distribution in pT bin 70-80 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_8 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_80_90", "Iso cone track dt distribution in pT bin 80-90 GeV ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_9 = ibook.book1D(
+      "Iso_track_dtSignif_general_pT_90_100", "Iso cone track dt distribution in pT bin 90-100 GeV ", 1000, 0, 10);
+
+  meEle_dt_general_eta_1 =
+      ibook.book1D("Iso_track_dt_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ", 100, 0, 1);
+  meEle_dt_general_eta_2 =
+      ibook.book1D("Iso_track_dt_general_eta_05_10", "Iso cone track dt distribution in eta bin 0.5-1.0 ", 100, 0, 1);
+  meEle_dt_general_eta_3 =
+      ibook.book1D("Iso_track_dt_general_eta_10_15", "Iso cone track dt distribution in eta bin 1.0-1.5 ", 100, 0, 1);
+  meEle_dt_general_eta_4 =
+      ibook.book1D("Iso_track_dt_general_eta_15_20", "Iso cone track dt distribution in eta bin 1.5-2.0 ", 100, 0, 1);
+  meEle_dt_general_eta_5 =
+      ibook.book1D("Iso_track_dt_general_eta_20_24", "Iso cone track dt distribution in eta bin 2.0-2.4 ", 100, 0, 1);
+
+  meEle_dtSignif_general_eta_1 = ibook.book1D(
+      "Iso_track_dtSignif_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ", 1000, 0, 10);
+  meEle_dtSignif_general_eta_2 = ibook.book1D(
+      "Iso_track_dtSignif_general_eta_05_10", "Iso cone track dt distribution in eta bin 0.5-1.0 ", 1000, 0, 10);
+  meEle_dtSignif_general_eta_3 = ibook.book1D(
+      "Iso_track_dtSignif_general_eta_10_15", "Iso cone track dt distribution in eta bin 1.0-1.5 ", 1000, 0, 10);
+  meEle_dtSignif_general_eta_4 = ibook.book1D(
+      "Iso_track_dtSignif_general_eta_15_20", "Iso cone track dt distribution in eta bin 1.5-2.0 ", 1000, 0, 10);
+  meEle_dtSignif_general_eta_5 = ibook.book1D(
+      "Iso_track_dtSignif_general_eta_20_24", "Iso cone track dt distribution in eta bin 2.0-2.4 ", 1000, 0, 10);
+
+  // defining vectors for more efficient hist filling
+  // Promt part
+  Ntracks_EB_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EB_,
+                         meEleISO_Ntracks_MTD_2_Sig_EB_,
+                         meEleISO_Ntracks_MTD_3_Sig_EB_,
+                         meEleISO_Ntracks_MTD_4_Sig_EB_,
+                         meEleISO_Ntracks_MTD_5_Sig_EB_,
+                         meEleISO_Ntracks_MTD_6_Sig_EB_,
+                         meEleISO_Ntracks_MTD_7_Sig_EB_};
+  ch_iso_EB_list_Sig = {meEleISO_chIso_MTD_1_Sig_EB_,
+                        meEleISO_chIso_MTD_2_Sig_EB_,
+                        meEleISO_chIso_MTD_3_Sig_EB_,
+                        meEleISO_chIso_MTD_4_Sig_EB_,
+                        meEleISO_chIso_MTD_5_Sig_EB_,
+                        meEleISO_chIso_MTD_6_Sig_EB_,
+                        meEleISO_chIso_MTD_7_Sig_EB_};
+  rel_ch_iso_EB_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_2_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_3_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_4_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_5_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_6_Sig_EB_,
+                            meEleISO_rel_chIso_MTD_7_Sig_EB_};
+
+  Ntracks_EB_list_Significance_Sig = {
+      meEleISO_Ntracks_MTD_4sigma_Sig_EB_, meEleISO_Ntracks_MTD_3sigma_Sig_EB_, meEleISO_Ntracks_MTD_2sigma_Sig_EB_};
+  ch_iso_EB_list_Significance_Sig = {
+      meEleISO_chIso_MTD_4sigma_Sig_EB_, meEleISO_chIso_MTD_3sigma_Sig_EB_, meEleISO_chIso_MTD_2sigma_Sig_EB_};
+  rel_ch_iso_EB_list_Significance_Sig = {meEleISO_rel_chIso_MTD_4sigma_Sig_EB_,
+                                         meEleISO_rel_chIso_MTD_3sigma_Sig_EB_,
+                                         meEleISO_rel_chIso_MTD_2sigma_Sig_EB_};
+
+  Ntracks_EE_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EE_,
+                         meEleISO_Ntracks_MTD_2_Sig_EE_,
+                         meEleISO_Ntracks_MTD_3_Sig_EE_,
+                         meEleISO_Ntracks_MTD_4_Sig_EE_,
+                         meEleISO_Ntracks_MTD_5_Sig_EE_,
+                         meEleISO_Ntracks_MTD_6_Sig_EE_,
+                         meEleISO_Ntracks_MTD_7_Sig_EE_};
+  ch_iso_EE_list_Sig = {meEleISO_chIso_MTD_1_Sig_EE_,
+                        meEleISO_chIso_MTD_2_Sig_EE_,
+                        meEleISO_chIso_MTD_3_Sig_EE_,
+                        meEleISO_chIso_MTD_4_Sig_EE_,
+                        meEleISO_chIso_MTD_5_Sig_EE_,
+                        meEleISO_chIso_MTD_6_Sig_EE_,
+                        meEleISO_chIso_MTD_7_Sig_EE_};
+  rel_ch_iso_EE_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_2_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_3_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_4_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_5_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_6_Sig_EE_,
+                            meEleISO_rel_chIso_MTD_7_Sig_EE_};
+
+  Ntracks_EE_list_Significance_Sig = {
+      meEleISO_Ntracks_MTD_4sigma_Sig_EE_, meEleISO_Ntracks_MTD_3sigma_Sig_EE_, meEleISO_Ntracks_MTD_2sigma_Sig_EE_};
+  ch_iso_EE_list_Significance_Sig = {
+      meEleISO_chIso_MTD_4sigma_Sig_EE_, meEleISO_chIso_MTD_3sigma_Sig_EE_, meEleISO_chIso_MTD_2sigma_Sig_EE_};
+  rel_ch_iso_EE_list_Significance_Sig = {meEleISO_rel_chIso_MTD_4sigma_Sig_EE_,
+                                         meEleISO_rel_chIso_MTD_3sigma_Sig_EE_,
+                                         meEleISO_rel_chIso_MTD_2sigma_Sig_EE_};
+
+  Ele_pT_MTD_EB_list_Sig = {meEle_pt_MTD_1_Sig_EB_,
+                            meEle_pt_MTD_2_Sig_EB_,
+                            meEle_pt_MTD_3_Sig_EB_,
+                            meEle_pt_MTD_4_Sig_EB_,
+                            meEle_pt_MTD_5_Sig_EB_,
+                            meEle_pt_MTD_6_Sig_EB_,
+                            meEle_pt_MTD_7_Sig_EB_};
+  Ele_eta_MTD_EB_list_Sig = {meEle_eta_MTD_1_Sig_EB_,
+                             meEle_eta_MTD_2_Sig_EB_,
+                             meEle_eta_MTD_3_Sig_EB_,
+                             meEle_eta_MTD_4_Sig_EB_,
+                             meEle_eta_MTD_5_Sig_EB_,
+                             meEle_eta_MTD_6_Sig_EB_,
+                             meEle_eta_MTD_7_Sig_EB_};
+  Ele_phi_MTD_EB_list_Sig = {meEle_phi_MTD_1_Sig_EB_,
+                             meEle_phi_MTD_2_Sig_EB_,
+                             meEle_phi_MTD_3_Sig_EB_,
+                             meEle_phi_MTD_4_Sig_EB_,
+                             meEle_phi_MTD_5_Sig_EB_,
+                             meEle_phi_MTD_6_Sig_EB_,
+                             meEle_phi_MTD_7_Sig_EB_};
+
+  Ele_pT_MTD_EB_list_Significance_Sig = {
+      meEle_pt_MTD_4sigma_Sig_EB_, meEle_pt_MTD_3sigma_Sig_EB_, meEle_pt_MTD_2sigma_Sig_EB_};
+  Ele_eta_MTD_EB_list_Significance_Sig = {
+      meEle_eta_MTD_4sigma_Sig_EB_, meEle_eta_MTD_3sigma_Sig_EB_, meEle_eta_MTD_2sigma_Sig_EB_};
+  Ele_phi_MTD_EB_list_Significance_Sig = {
+      meEle_phi_MTD_4sigma_Sig_EB_, meEle_phi_MTD_3sigma_Sig_EB_, meEle_phi_MTD_2sigma_Sig_EB_};
+
+  Ele_pT_MTD_EE_list_Sig = {meEle_pt_MTD_1_Sig_EE_,
+                            meEle_pt_MTD_2_Sig_EE_,
+                            meEle_pt_MTD_3_Sig_EE_,
+                            meEle_pt_MTD_4_Sig_EE_,
+                            meEle_pt_MTD_5_Sig_EE_,
+                            meEle_pt_MTD_6_Sig_EE_,
+                            meEle_pt_MTD_7_Sig_EE_};
+  Ele_eta_MTD_EE_list_Sig = {meEle_eta_MTD_1_Sig_EE_,
+                             meEle_eta_MTD_2_Sig_EE_,
+                             meEle_eta_MTD_3_Sig_EE_,
+                             meEle_eta_MTD_4_Sig_EE_,
+                             meEle_eta_MTD_5_Sig_EE_,
+                             meEle_eta_MTD_6_Sig_EE_,
+                             meEle_eta_MTD_7_Sig_EE_};
+  Ele_phi_MTD_EE_list_Sig = {meEle_phi_MTD_1_Sig_EE_,
+                             meEle_phi_MTD_2_Sig_EE_,
+                             meEle_phi_MTD_3_Sig_EE_,
+                             meEle_phi_MTD_4_Sig_EE_,
+                             meEle_phi_MTD_5_Sig_EE_,
+                             meEle_phi_MTD_6_Sig_EE_,
+                             meEle_phi_MTD_7_Sig_EE_};
+
+  Ele_pT_MTD_EE_list_Significance_Sig = {
+      meEle_pt_MTD_4sigma_Sig_EE_, meEle_pt_MTD_3sigma_Sig_EE_, meEle_pt_MTD_2sigma_Sig_EE_};
+  Ele_eta_MTD_EE_list_Significance_Sig = {
+      meEle_eta_MTD_4sigma_Sig_EE_, meEle_eta_MTD_3sigma_Sig_EE_, meEle_eta_MTD_2sigma_Sig_EE_};
+  Ele_phi_MTD_EE_list_Significance_Sig = {
+      meEle_phi_MTD_4sigma_Sig_EE_, meEle_phi_MTD_3sigma_Sig_EE_, meEle_phi_MTD_2sigma_Sig_EE_};
+
+  // For SIM CASE
+
+  Ntracks_sim_EB_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_2_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_3_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_4_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_5_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_6_Sig_EB_,
+                             meEleISO_Ntracks_MTD_sim_7_Sig_EB_};
+  ch_iso_sim_EB_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_2_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_3_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_4_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_5_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_6_Sig_EB_,
+                            meEleISO_chIso_MTD_sim_7_Sig_EB_};
+  rel_ch_iso_sim_EB_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_2_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_3_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_4_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_5_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_6_Sig_EB_,
+                                meEleISO_rel_chIso_MTD_sim_7_Sig_EB_};
+
+  Ntracks_sim_EB_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_,
+                                          meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_,
+                                          meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_};
+  ch_iso_sim_EB_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EB_,
+                                         meEleISO_chIso_MTD_sim_3sigma_Sig_EB_,
+                                         meEleISO_chIso_MTD_sim_2sigma_Sig_EB_};
+  rel_ch_iso_sim_EB_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_,
+                                             meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_,
+                                             meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_};
+
+  Ntracks_sim_EE_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_2_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_3_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_4_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_5_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_6_Sig_EE_,
+                             meEleISO_Ntracks_MTD_sim_7_Sig_EE_};
+  ch_iso_sim_EE_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_2_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_3_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_4_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_5_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_6_Sig_EE_,
+                            meEleISO_chIso_MTD_sim_7_Sig_EE_};
+  rel_ch_iso_sim_EE_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_2_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_3_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_4_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_5_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_6_Sig_EE_,
+                                meEleISO_rel_chIso_MTD_sim_7_Sig_EE_};
+
+  Ntracks_sim_EE_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_,
+                                          meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_,
+                                          meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_};
+  ch_iso_sim_EE_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EE_,
+                                         meEleISO_chIso_MTD_sim_3sigma_Sig_EE_,
+                                         meEleISO_chIso_MTD_sim_2sigma_Sig_EE_};
+  rel_ch_iso_sim_EE_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_,
+                                             meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_,
+                                             meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_};
+
+  Ele_pT_sim_MTD_EB_list_Sig = {meEle_pt_sim_MTD_1_Sig_EB_,
+                                meEle_pt_sim_MTD_2_Sig_EB_,
+                                meEle_pt_sim_MTD_3_Sig_EB_,
+                                meEle_pt_sim_MTD_4_Sig_EB_,
+                                meEle_pt_sim_MTD_5_Sig_EB_,
+                                meEle_pt_sim_MTD_6_Sig_EB_,
+                                meEle_pt_sim_MTD_7_Sig_EB_};
+
+  Ele_pT_sim_MTD_EB_list_Significance_Sig = {
+      meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_sim_MTD_2sigma_Sig_EB_};
+
+  Ele_pT_sim_MTD_EE_list_Sig = {meEle_pt_sim_MTD_1_Sig_EE_,
+                                meEle_pt_sim_MTD_2_Sig_EE_,
+                                meEle_pt_sim_MTD_3_Sig_EE_,
+                                meEle_pt_sim_MTD_4_Sig_EE_,
+                                meEle_pt_sim_MTD_5_Sig_EE_,
+                                meEle_pt_sim_MTD_6_Sig_EE_,
+                                meEle_pt_sim_MTD_7_Sig_EE_};
+
+  Ele_pT_sim_MTD_EE_list_Significance_Sig = {
+      meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_sim_MTD_2sigma_Sig_EE_};
+
+  // Non-promt part
+  Ntracks_EB_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_2_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_3_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_4_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_5_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_6_Bkg_EB_,
+                         meEleISO_Ntracks_MTD_7_Bkg_EB_};
+  ch_iso_EB_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EB_,
+                        meEleISO_chIso_MTD_2_Bkg_EB_,
+                        meEleISO_chIso_MTD_3_Bkg_EB_,
+                        meEleISO_chIso_MTD_4_Bkg_EB_,
+                        meEleISO_chIso_MTD_5_Bkg_EB_,
+                        meEleISO_chIso_MTD_6_Bkg_EB_,
+                        meEleISO_chIso_MTD_7_Bkg_EB_};
+  rel_ch_iso_EB_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_2_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_3_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_4_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_5_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_6_Bkg_EB_,
+                            meEleISO_rel_chIso_MTD_7_Bkg_EB_};
+
+  Ntracks_EB_list_Significance_Bkg = {
+      meEleISO_Ntracks_MTD_4sigma_Bkg_EB_, meEleISO_Ntracks_MTD_3sigma_Bkg_EB_, meEleISO_Ntracks_MTD_2sigma_Bkg_EB_};
+  ch_iso_EB_list_Significance_Bkg = {
+      meEleISO_chIso_MTD_4sigma_Bkg_EB_, meEleISO_chIso_MTD_3sigma_Bkg_EB_, meEleISO_chIso_MTD_2sigma_Bkg_EB_};
+  rel_ch_iso_EB_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_,
+                                         meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_,
+                                         meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_};
+
+  Ntracks_EE_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_2_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_3_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_4_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_5_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_6_Bkg_EE_,
+                         meEleISO_Ntracks_MTD_7_Bkg_EE_};
+  ch_iso_EE_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EE_,
+                        meEleISO_chIso_MTD_2_Bkg_EE_,
+                        meEleISO_chIso_MTD_3_Bkg_EE_,
+                        meEleISO_chIso_MTD_4_Bkg_EE_,
+                        meEleISO_chIso_MTD_5_Bkg_EE_,
+                        meEleISO_chIso_MTD_6_Bkg_EE_,
+                        meEleISO_chIso_MTD_7_Bkg_EE_};
+  rel_ch_iso_EE_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_2_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_3_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_4_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_5_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_6_Bkg_EE_,
+                            meEleISO_rel_chIso_MTD_7_Bkg_EE_};
+
+  Ntracks_EE_list_Significance_Bkg = {
+      meEleISO_Ntracks_MTD_4sigma_Bkg_EE_, meEleISO_Ntracks_MTD_3sigma_Bkg_EE_, meEleISO_Ntracks_MTD_2sigma_Bkg_EE_};
+  ch_iso_EE_list_Significance_Bkg = {
+      meEleISO_chIso_MTD_4sigma_Bkg_EE_, meEleISO_chIso_MTD_3sigma_Bkg_EE_, meEleISO_chIso_MTD_2sigma_Bkg_EE_};
+  rel_ch_iso_EE_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_,
+                                         meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_,
+                                         meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_};
+
+  Ele_pT_MTD_EB_list_Bkg = {meEle_pt_MTD_1_Bkg_EB_,
+                            meEle_pt_MTD_2_Bkg_EB_,
+                            meEle_pt_MTD_3_Bkg_EB_,
+                            meEle_pt_MTD_4_Bkg_EB_,
+                            meEle_pt_MTD_5_Bkg_EB_,
+                            meEle_pt_MTD_6_Bkg_EB_,
+                            meEle_pt_MTD_7_Bkg_EB_};
+  Ele_eta_MTD_EB_list_Bkg = {meEle_eta_MTD_1_Bkg_EB_,
+                             meEle_eta_MTD_2_Bkg_EB_,
+                             meEle_eta_MTD_3_Bkg_EB_,
+                             meEle_eta_MTD_4_Bkg_EB_,
+                             meEle_eta_MTD_5_Bkg_EB_,
+                             meEle_eta_MTD_6_Bkg_EB_,
+                             meEle_eta_MTD_7_Bkg_EB_};
+  Ele_phi_MTD_EB_list_Bkg = {meEle_phi_MTD_1_Bkg_EB_,
+                             meEle_phi_MTD_2_Bkg_EB_,
+                             meEle_phi_MTD_3_Bkg_EB_,
+                             meEle_phi_MTD_4_Bkg_EB_,
+                             meEle_phi_MTD_5_Bkg_EB_,
+                             meEle_phi_MTD_6_Bkg_EB_,
+                             meEle_phi_MTD_7_Bkg_EB_};
+
+  Ele_pT_MTD_EB_list_Significance_Bkg = {
+      meEle_pt_MTD_4sigma_Bkg_EB_, meEle_pt_MTD_3sigma_Bkg_EB_, meEle_pt_MTD_2sigma_Bkg_EB_};
+  Ele_eta_MTD_EB_list_Significance_Bkg = {
+      meEle_eta_MTD_4sigma_Bkg_EB_, meEle_eta_MTD_3sigma_Bkg_EB_, meEle_eta_MTD_2sigma_Bkg_EB_};
+  Ele_phi_MTD_EB_list_Significance_Bkg = {
+      meEle_phi_MTD_4sigma_Bkg_EB_, meEle_phi_MTD_3sigma_Bkg_EB_, meEle_phi_MTD_2sigma_Bkg_EB_};
+
+  Ele_pT_MTD_EE_list_Bkg = {meEle_pt_MTD_1_Bkg_EE_,
+                            meEle_pt_MTD_2_Bkg_EE_,
+                            meEle_pt_MTD_3_Bkg_EE_,
+                            meEle_pt_MTD_4_Bkg_EE_,
+                            meEle_pt_MTD_5_Bkg_EE_,
+                            meEle_pt_MTD_6_Bkg_EE_,
+                            meEle_pt_MTD_7_Bkg_EE_};
+  Ele_eta_MTD_EE_list_Bkg = {meEle_eta_MTD_1_Bkg_EE_,
+                             meEle_eta_MTD_2_Bkg_EE_,
+                             meEle_eta_MTD_3_Bkg_EE_,
+                             meEle_eta_MTD_4_Bkg_EE_,
+                             meEle_eta_MTD_5_Bkg_EE_,
+                             meEle_eta_MTD_6_Bkg_EE_,
+                             meEle_eta_MTD_7_Bkg_EE_};
+  Ele_phi_MTD_EE_list_Bkg = {meEle_phi_MTD_1_Bkg_EE_,
+                             meEle_phi_MTD_2_Bkg_EE_,
+                             meEle_phi_MTD_3_Bkg_EE_,
+                             meEle_phi_MTD_4_Bkg_EE_,
+                             meEle_phi_MTD_5_Bkg_EE_,
+                             meEle_phi_MTD_6_Bkg_EE_,
+                             meEle_phi_MTD_7_Bkg_EE_};
+
+  Ele_pT_MTD_EE_list_Significance_Bkg = {
+      meEle_pt_MTD_4sigma_Bkg_EE_, meEle_pt_MTD_3sigma_Bkg_EE_, meEle_pt_MTD_2sigma_Bkg_EE_};
+  Ele_eta_MTD_EE_list_Significance_Bkg = {
+      meEle_eta_MTD_4sigma_Bkg_EE_, meEle_eta_MTD_3sigma_Bkg_EE_, meEle_eta_MTD_2sigma_Bkg_EE_};
+  Ele_phi_MTD_EE_list_Significance_Bkg = {
+      meEle_phi_MTD_4sigma_Bkg_EE_, meEle_phi_MTD_3sigma_Bkg_EE_, meEle_phi_MTD_2sigma_Bkg_EE_};
+
+  // SIM CASE
+
+  Ntracks_sim_EB_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_2_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_3_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_4_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_5_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_6_Bkg_EB_,
+                             meEleISO_Ntracks_MTD_sim_7_Bkg_EB_};
+  ch_iso_sim_EB_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_2_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_3_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_4_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_5_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_6_Bkg_EB_,
+                            meEleISO_chIso_MTD_sim_7_Bkg_EB_};
+  rel_ch_iso_sim_EB_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_,
+                                meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_};
+
+  Ntracks_sim_EB_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_,
+                                          meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_,
+                                          meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_};
+  ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_,
+                                         meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_,
+                                         meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_};
+  rel_ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_,
+                                             meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_,
+                                             meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_};
+
+  Ntracks_sim_EE_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_2_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_3_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_4_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_5_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_6_Bkg_EE_,
+                             meEleISO_Ntracks_MTD_sim_7_Bkg_EE_};
+  ch_iso_sim_EE_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_2_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_3_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_4_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_5_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_6_Bkg_EE_,
+                            meEleISO_chIso_MTD_sim_7_Bkg_EE_};
+  rel_ch_iso_sim_EE_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_,
+                                meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_};
+
+  Ntracks_sim_EE_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_,
+                                          meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_,
+                                          meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_};
+  ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_,
+                                         meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_,
+                                         meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_};
+  rel_ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_,
+                                             meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_,
+                                             meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_};
+
+  Ele_pT_sim_MTD_EB_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EB_,
+                                meEle_pt_sim_MTD_2_Bkg_EB_,
+                                meEle_pt_sim_MTD_3_Bkg_EB_,
+                                meEle_pt_sim_MTD_4_Bkg_EB_,
+                                meEle_pt_sim_MTD_5_Bkg_EB_,
+                                meEle_pt_sim_MTD_6_Bkg_EB_,
+                                meEle_pt_sim_MTD_7_Bkg_EB_};
+
+  Ele_pT_sim_MTD_EB_list_Significance_Bkg = {
+      meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_sim_MTD_2sigma_Bkg_EB_};
+
+  Ele_pT_sim_MTD_EE_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EE_,
+                                meEle_pt_sim_MTD_2_Bkg_EE_,
+                                meEle_pt_sim_MTD_3_Bkg_EE_,
+                                meEle_pt_sim_MTD_4_Bkg_EE_,
+                                meEle_pt_sim_MTD_5_Bkg_EE_,
+                                meEle_pt_sim_MTD_6_Bkg_EE_,
+                                meEle_pt_sim_MTD_7_Bkg_EE_};
+
+  Ele_pT_sim_MTD_EE_list_Significance_Bkg = {
+      meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_sim_MTD_2sigma_Bkg_EE_};
+
+  // dt distribution hist vecotrs
+
+  general_pT_list = {meEle_dt_general_pT_1,
+                     meEle_dt_general_pT_2,
+                     meEle_dt_general_pT_3,
+                     meEle_dt_general_pT_4,
+                     meEle_dt_general_pT_5,
+                     meEle_dt_general_pT_6,
+                     meEle_dt_general_pT_7,
+                     meEle_dt_general_pT_8,
+                     meEle_dt_general_pT_9};
+
+  general_pT_Signif_list = {meEle_dtSignif_general_pT_1,
+                            meEle_dtSignif_general_pT_2,
+                            meEle_dtSignif_general_pT_3,
+                            meEle_dtSignif_general_pT_4,
+                            meEle_dtSignif_general_pT_5,
+                            meEle_dtSignif_general_pT_6,
+                            meEle_dtSignif_general_pT_7,
+                            meEle_dtSignif_general_pT_8,
+                            meEle_dtSignif_general_pT_9};
+
+  general_eta_list = {meEle_dt_general_eta_1,
+                      meEle_dt_general_eta_2,
+                      meEle_dt_general_eta_3,
+                      meEle_dt_general_eta_4,
+                      meEle_dt_general_eta_5};
+
+  general_eta_Signif_list = {meEle_dtSignif_general_eta_1,
+                             meEle_dtSignif_general_eta_2,
+                             meEle_dtSignif_general_eta_3,
+                             meEle_dtSignif_general_eta_4,
+                             meEle_dtSignif_general_eta_5};
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+
+void MtdEleIsoValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "MTD/ElectronIso");
+  desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
+  desc.add<edm::InputTag>(
+      "inputTag_vtx",
+      edm::InputTag("offlinePrimaryVertices4D"));  //  "offlinePrimaryVertices4D" or "offlinePrimaryVertices" (3D case)
+  desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
+
+  desc.add<edm::InputTag>(
+      "inputEle_EB",
+      edm::InputTag("gedGsfElectrons"));  // Adding the elecollection, barrel ecal and track driven electrons
+  //desc.add<edm::InputTag>("inputEle", edm::InputTag("ecalDrivenGsfElectrons")); // barrel + endcap, but without track seeded electrons
+  desc.add<edm::InputTag>("inputEle_EE", edm::InputTag("ecalDrivenGsfElectronsHGC"));  // only endcap electrons
+  desc.add<edm::InputTag>("inputGenP", edm::InputTag("genParticles"));
+  desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));                            // From Aurora
+  desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));  // From Aurora
+
+  desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
+  desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
+  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
+  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0"));
+  desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD:generalTrackassoc"))
+      ->setComment("Association between General and MTD Extended tracks");
+  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
+  desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe"));
+  desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe"));
+  desc.add<edm::InputTag>("sigmat0PID", edm::InputTag("tofPID:sigmat0"));
+  desc.add<edm::InputTag>("t0PID", edm::InputTag("tofPID:t0"));
+  desc.add<edm::InputTag>("trackMVAQual", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
+  desc.add<double>("trackMinimumPt", 1.0);  // [GeV]
+  desc.add<double>("trackMinimumEta", 1.5);
+  desc.add<double>("trackMaximumEta", 3.2);
+  desc.add<double>("rel_iso_cut", 0.08);
+  //desc.add<std::vector<MonitorElement*>>("Ntracks_EB_list_Sig_test", {meEleISO_Ntracks_MTD_1_Sig_EB_,meEleISO_Ntracks_MTD_2_Sig_EB_,meEleISO_Ntracks_MTD_3_Sig_EB_,meEleISO_Ntracks_MTD_4_Sig_EB_,meEleISO_Ntracks_MTD_5_Sig_EB_,meEleISO_Ntracks_MTD_6_Sig_EB_,meEleISO_Ntracks_MTD_7_Sig_EB_}); // example that does not work...
+  desc.add<bool>("optionTrackMatchToPV", false);
+  desc.add<bool>("option_dtToPV", false);
+  desc.add<bool>("option_dtToTrack", true);
+  desc.add<bool>("option_dtDistributions", false);
+
+  descriptions.add("mtdEleIsoValid", desc);
+}
+
+bool MtdEleIsoValidation::pdgCheck(int pdg) {
+  bool pass;
+  pdg = std::abs(pdg);
+  if (pdg == 11 || pdg == 15 || pdg == 23 || pdg == 24) {
+    pass = true;
+  } else {
+    pass = false;
+  }
+  return pass;
+}
+
+DEFINE_FWK_MODULE(MtdEleIsoValidation);
+
+//*/

--- a/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
@@ -101,7 +101,6 @@ private:
 
   const bool track_match_PV_;
   const bool dt_sig_track_;
-  const bool dt_distributions_;
   const bool optionalPlots_;
 
   const float min_dR_cut;
@@ -753,44 +752,6 @@ private:
   MonitorElement* meEle_phi_MTD_4sigma_Bkg_EE_;
   // Background histograms end
 
-  // histograms for dt distributions in pT/eta bins
-
-  MonitorElement* meEle_dt_general_pT_1;
-  MonitorElement* meEle_dt_general_pT_2;
-  MonitorElement* meEle_dt_general_pT_3;
-  MonitorElement* meEle_dt_general_pT_4;
-  MonitorElement* meEle_dt_general_pT_5;
-  MonitorElement* meEle_dt_general_pT_6;
-  MonitorElement* meEle_dt_general_pT_7;
-  MonitorElement* meEle_dt_general_pT_8;
-  MonitorElement* meEle_dt_general_pT_9;
-
-  MonitorElement* meEle_dtSignif_general_pT_1;
-  MonitorElement* meEle_dtSignif_general_pT_2;
-  MonitorElement* meEle_dtSignif_general_pT_3;
-  MonitorElement* meEle_dtSignif_general_pT_4;
-  MonitorElement* meEle_dtSignif_general_pT_5;
-  MonitorElement* meEle_dtSignif_general_pT_6;
-  MonitorElement* meEle_dtSignif_general_pT_7;
-  MonitorElement* meEle_dtSignif_general_pT_8;
-  MonitorElement* meEle_dtSignif_general_pT_9;
-
-  MonitorElement* meEle_dt_general_eta_1;
-  MonitorElement* meEle_dt_general_eta_2;
-  MonitorElement* meEle_dt_general_eta_3;
-  MonitorElement* meEle_dt_general_eta_4;
-  MonitorElement* meEle_dt_general_eta_5;
-  MonitorElement* meEle_dt_general_eta_6;
-  MonitorElement* meEle_dt_general_eta_7;
-
-  MonitorElement* meEle_dtSignif_general_eta_1;
-  MonitorElement* meEle_dtSignif_general_eta_2;
-  MonitorElement* meEle_dtSignif_general_eta_3;
-  MonitorElement* meEle_dtSignif_general_eta_4;
-  MonitorElement* meEle_dtSignif_general_eta_5;
-  MonitorElement* meEle_dtSignif_general_eta_6;
-  MonitorElement* meEle_dtSignif_general_eta_7;
-
   // promt part for histogram vectors
   std::vector<MonitorElement*> Ntracks_EB_list_Sig;
   std::vector<MonitorElement*> ch_iso_EB_list_Sig;
@@ -906,6 +867,7 @@ private:
 };
 
 // ------------ constructor and destructor --------------
+
 MtdEleIsoValidation::MtdEleIsoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       trackMinPt_(iConfig.getParameter<double>("trackMinimumPt")),
@@ -914,7 +876,6 @@ MtdEleIsoValidation::MtdEleIsoValidation(const edm::ParameterSet& iConfig)
       rel_iso_cut_(iConfig.getParameter<double>("rel_iso_cut")),
       track_match_PV_(iConfig.getParameter<bool>("optionTrackMatchToPV")),
       dt_sig_track_(iConfig.getParameter<bool>("option_dtToTrack")),
-      dt_distributions_(iConfig.getParameter<bool>("option_dtDistributions")),
       optionalPlots_(iConfig.getParameter<bool>("option_plots")),
       min_dR_cut(iConfig.getParameter<double>("min_dR_cut")),
       max_dR_cut(iConfig.getParameter<double>("max_dR_cut")),
@@ -1010,8 +971,8 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   for (const auto& ele : localEleCollection) {
     bool ele_Promt = false;
 
-    float ele_track_source_dz = fabs(ele.gsfTrack()->dz(Vtx_chosen.position()));
-    float ele_track_source_dxy = fabs(ele.gsfTrack()->dxy(Vtx_chosen.position()));
+    float ele_track_source_dz = std::abs(ele.gsfTrack()->dz(Vtx_chosen.position()));
+    float ele_track_source_dxy = std::abs(ele.gsfTrack()->dxy(Vtx_chosen.position()));
 
     const reco::TrackRef ele_TrkRef = ele.core()->ctfTrack();
     double tsim_ele = -1.;
@@ -1021,7 +982,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     // selecting "good" RECO electrons
     // PARAM
-    if (ele.pt() < 10 || fabs(ele.eta()) > 2.4 || ele_track_source_dz > max_dz_vtx_cut ||
+    if (ele.pt() < 10 || std::abs(ele.eta()) > 2.4 || ele_track_source_dz > max_dz_vtx_cut ||
         ele_track_source_dxy > max_dxy_vtx_cut)
       continue;
 
@@ -1073,13 +1034,13 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           // All selected electron information for efficiency plots later
           meEle_pt_tot_Sig_EB_->Fill(ele.pt());
           meEle_pt_sim_tot_Sig_EB_->Fill(ele_sim_pt);
-          meEle_eta_tot_Sig_EB_->Fill(ele.eta());
+          meEle_eta_tot_Sig_EB_->Fill(std::abs(ele.eta()));
           meEle_phi_tot_Sig_EB_->Fill(ele.phi());
         } else {
           // All selected electron information for efficiency plots later
           meEle_pt_tot_Sig_EE_->Fill(ele.pt());
           meEle_pt_sim_tot_Sig_EE_->Fill(ele_sim_pt);
-          meEle_eta_tot_Sig_EE_->Fill(ele.eta());
+          meEle_eta_tot_Sig_EE_->Fill(std::abs(ele.eta()));
           meEle_phi_tot_Sig_EE_->Fill(ele.phi());
         }
       } else {
@@ -1087,12 +1048,12 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         if (Barrel_ele) {
           meEle_pt_tot_Bkg_EB_->Fill(ele.pt());
           meEle_pt_sim_tot_Bkg_EB_->Fill(ele_sim_pt);
-          meEle_eta_tot_Bkg_EB_->Fill(ele.eta());
+          meEle_eta_tot_Bkg_EB_->Fill(std::abs(ele.eta()));
           meEle_phi_tot_Bkg_EB_->Fill(ele.phi());
         } else {
           meEle_pt_tot_Bkg_EE_->Fill(ele.pt());
           meEle_pt_sim_tot_Bkg_EE_->Fill(ele_sim_pt);
-          meEle_eta_tot_Bkg_EE_->Fill(ele.eta());
+          meEle_eta_tot_Bkg_EE_->Fill(std::abs(ele.eta()));
           meEle_phi_tot_Bkg_EE_->Fill(ele.phi());
         }
       }
@@ -1131,7 +1092,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         if (trackGen.pt() < min_pt_cut) {
           continue;
         }
-        if (fabs(trackGen.vz() - ele.gsfTrack()->vz()) > max_dz_cut) {
+        if (std::abs(trackGen.vz() - ele.gsfTrack()->vz()) > max_dz_cut) {
           continue;
         }
 
@@ -1143,7 +1104,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }
 
         double dR = reco::deltaR(trackGen.momentum(), EleSigTrackMomentumAtVtx);
-        double deta = fabs(trackGen.eta() - EleSigTrackEtaAtVtx);
+        double deta = std::abs(trackGen.eta() - EleSigTrackEtaAtVtx);
 
         // restrict to tracks in the isolation cone
         if (dR < min_dR_cut || dR > max_dR_cut || deta < min_strip_cut)
@@ -1193,8 +1154,8 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           double dt_sim_sigTrk_signif = 0;
 
           // MTD SIM CASE
-          if (fabs(tsim_trk) > 0 && fabs(tsim_ele) > 0 && trk_ptSim > 0) {
-            dt_sim_sigTrk = fabs(tsim_trk - tsim_ele);
+          if (std::abs(tsim_trk) > 0 && std::abs(tsim_ele) > 0 && trk_ptSim > 0) {
+            dt_sim_sigTrk = std::abs(tsim_trk - tsim_ele);
             dt_sim_sigTrk_signif = dt_sim_sigTrk / std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
                                                              avg_sim_sigTrk_t_err * avg_sim_sigTrk_t_err);
 
@@ -1231,7 +1192,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           // MTD reco case
           if (TrkMTDTimeErr > 0 && ele_sigTrkTimeErr > 0) {
-            dt_sigTrk = fabs(TrkMTDTime - ele_sigTrkTime);
+            dt_sigTrk = std::abs(TrkMTDTime - ele_sigTrkTime);
             dt_sigTrk_signif =
                 dt_sigTrk / std::sqrt(TrkMTDTimeErr * TrkMTDTimeErr + ele_sigTrkTimeErr * ele_sigTrkTimeErr);
 
@@ -1268,7 +1229,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meEle_no_dt_check_->Fill(0);
           }
 
-          if (dt_distributions_) {
+          if (optionalPlots_) {
             for (long unsigned int i = 0; i < (pT_bins_dt_distrb.size() - 1); i++) {
               //stuff general pT
               if (ele.pt() > pT_bins_dt_distrb[i] && ele.pt() < pT_bins_dt_distrb[i + 1]) {
@@ -1279,7 +1240,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
             for (long unsigned int i = 0; i < (eta_bins_dt_distrib.size() - 1); i++) {
               //stuff general eta
-              if (fabs(ele.eta()) > eta_bins_dt_distrib[i] && fabs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
+              if (std::abs(ele.eta()) > eta_bins_dt_distrib[i] && std::abs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
                 general_eta_list[i]->Fill(dt_sigTrk);
                 general_eta_Signif_list[i]->Fill(dt_sigTrk_signif);
               }
@@ -1295,8 +1256,8 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           double dt_sim_vtx_signif = 0;
 
           // MTD SIM case
-          if (fabs(tsim_trk) > 0 && Vtx_chosen.tError() > 0 && trk_ptSim > 0) {
-            dt_sim_vtx = fabs(tsim_trk - Vtx_chosen.t());
+          if (std::abs(tsim_trk) > 0 && Vtx_chosen.tError() > 0 && trk_ptSim > 0) {
+            dt_sim_vtx = std::abs(tsim_trk - Vtx_chosen.t());
             dt_sim_vtx_signif = dt_sim_vtx / std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
                                                        Vtx_chosen.tError() * Vtx_chosen.tError());
             if (optionalPlots_) {
@@ -1330,7 +1291,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           // MTD RECO case
           if (TrkMTDTimeErr > 0 && Vtx_chosen.tError() > 0) {
-            dt_vtx = fabs(TrkMTDTime - Vtx_chosen.t());
+            dt_vtx = std::abs(TrkMTDTime - Vtx_chosen.t());
             dt_vtx_signif =
                 dt_vtx / std::sqrt(TrkMTDTimeErr * TrkMTDTimeErr + Vtx_chosen.tError() * Vtx_chosen.tError());
 
@@ -1367,7 +1328,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
 
           // Optional dt distribution plots
-          if (dt_distributions_) {
+          if (optionalPlots_) {
             for (long unsigned int i = 0; i < (pT_bins_dt_distrb.size() - 1); i++) {
               //stuff general pT
               if (ele.pt() > pT_bins_dt_distrb[i] && ele.pt() < pT_bins_dt_distrb[i + 1]) {
@@ -1378,7 +1339,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
             for (long unsigned int i = 0; i < (eta_bins_dt_distrib.size() - 1); i++) {
               //stuff general eta
-              if (fabs(ele.eta()) > eta_bins_dt_distrib[i] && fabs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
+              if (std::abs(ele.eta()) > eta_bins_dt_distrib[i] && std::abs(ele.eta()) < eta_bins_dt_distrib[i + 1]) {
                 general_eta_list[i]->Fill(dt_vtx);
                 general_eta_Signif_list[i]->Fill(dt_vtx_signif);
               }
@@ -1437,14 +1398,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
             meEle_pt_noMTD_Sig_EB_->Fill(ele.pt());
-            meEle_eta_noMTD_Sig_EB_->Fill(ele.eta());
+            meEle_eta_noMTD_Sig_EB_->Fill(std::abs(ele.eta()));
             meEle_phi_noMTD_Sig_EB_->Fill(ele.phi());
           }
           if (optionalPlots_) {
             for (long unsigned int k = 0; k < Ntracks_EB_list_Sig.size(); k++) {
               if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
                 Ele_pT_MTD_EB_list_Sig[k]->Fill(ele.pt());
-                Ele_eta_MTD_EB_list_Sig[k]->Fill(ele.eta());
+                Ele_eta_MTD_EB_list_Sig[k]->Fill(std::abs(ele.eta()));
                 Ele_phi_MTD_EB_list_Sig[k]->Fill(ele.phi());
 
                 Ele_pT_sim_MTD_EB_list_Sig[k]->Fill(ele_sim_pt);
@@ -1460,7 +1421,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           for (long unsigned int k = 0; k < Ntracks_EB_list_Significance_Sig.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EB_list_Significance_Sig[k]->Fill(ele.pt());
-              Ele_eta_MTD_EB_list_Significance_Sig[k]->Fill(ele.eta());
+              Ele_eta_MTD_EB_list_Significance_Sig[k]->Fill(std::abs(ele.eta()));
               Ele_phi_MTD_EB_list_Significance_Sig[k]->Fill(ele.phi());
             }
             if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
@@ -1501,14 +1462,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
             meEle_pt_noMTD_Sig_EE_->Fill(ele.pt());
-            meEle_eta_noMTD_Sig_EE_->Fill(ele.eta());
+            meEle_eta_noMTD_Sig_EE_->Fill(std::abs(ele.eta()));
             meEle_phi_noMTD_Sig_EE_->Fill(ele.phi());
           }
           if (optionalPlots_) {
             for (long unsigned int k = 0; k < Ntracks_EE_list_Sig.size(); k++) {
               if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
                 Ele_pT_MTD_EE_list_Sig[k]->Fill(ele.pt());
-                Ele_eta_MTD_EE_list_Sig[k]->Fill(ele.eta());
+                Ele_eta_MTD_EE_list_Sig[k]->Fill(std::abs(ele.eta()));
                 Ele_phi_MTD_EE_list_Sig[k]->Fill(ele.phi());
 
                 Ele_pT_sim_MTD_EE_list_Sig[k]->Fill(ele_sim_pt);
@@ -1523,7 +1484,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Sig.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EE_list_Significance_Sig[k]->Fill(ele.pt());
-              Ele_eta_MTD_EE_list_Significance_Sig[k]->Fill(ele.eta());
+              Ele_eta_MTD_EE_list_Significance_Sig[k]->Fill(std::abs(ele.eta()));
               Ele_phi_MTD_EE_list_Significance_Sig[k]->Fill(ele.phi());
 
               if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
@@ -1565,14 +1526,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
             meEle_pt_noMTD_Bkg_EB_->Fill(ele.pt());
-            meEle_eta_noMTD_Bkg_EB_->Fill(ele.eta());
+            meEle_eta_noMTD_Bkg_EB_->Fill(std::abs(ele.eta()));
             meEle_phi_noMTD_Bkg_EB_->Fill(ele.phi());
           }
           if (optionalPlots_) {
             for (long unsigned int k = 0; k < Ntracks_EB_list_Bkg.size(); k++) {
               if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
                 Ele_pT_MTD_EB_list_Bkg[k]->Fill(ele.pt());
-                Ele_eta_MTD_EB_list_Bkg[k]->Fill(ele.eta());
+                Ele_eta_MTD_EB_list_Bkg[k]->Fill(std::abs(ele.eta()));
                 Ele_phi_MTD_EB_list_Bkg[k]->Fill(ele.phi());
 
                 Ele_pT_sim_MTD_EB_list_Bkg[k]->Fill(ele_sim_pt);
@@ -1587,7 +1548,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           for (long unsigned int k = 0; k < Ntracks_EB_list_Significance_Bkg.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EB_list_Significance_Bkg[k]->Fill(ele.pt());
-              Ele_eta_MTD_EB_list_Significance_Bkg[k]->Fill(ele.eta());
+              Ele_eta_MTD_EB_list_Significance_Bkg[k]->Fill(std::abs(ele.eta()));
               Ele_phi_MTD_EB_list_Significance_Bkg[k]->Fill(ele.phi());
 
               if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
@@ -1628,14 +1589,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
             meEle_pt_noMTD_Bkg_EE_->Fill(ele.pt());
-            meEle_eta_noMTD_Bkg_EE_->Fill(ele.eta());
+            meEle_eta_noMTD_Bkg_EE_->Fill(std::abs(ele.eta()));
             meEle_phi_noMTD_Bkg_EE_->Fill(ele.phi());
           }
           if (optionalPlots_) {
             for (long unsigned int k = 0; k < Ntracks_EE_list_Bkg.size(); k++) {
               if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
                 Ele_pT_MTD_EE_list_Bkg[k]->Fill(ele.pt());
-                Ele_eta_MTD_EE_list_Bkg[k]->Fill(ele.eta());
+                Ele_eta_MTD_EE_list_Bkg[k]->Fill(std::abs(ele.eta()));
                 Ele_phi_MTD_EE_list_Bkg[k]->Fill(ele.phi());
 
                 Ele_pT_sim_MTD_EE_list_Bkg[k]->Fill(ele_sim_pt);
@@ -1651,7 +1612,7 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Bkg.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EE_list_Significance_Bkg[k]->Fill(ele.pt());
-              Ele_eta_MTD_EE_list_Significance_Bkg[k]->Fill(ele.eta());
+              Ele_eta_MTD_EE_list_Significance_Bkg[k]->Fill(std::abs(ele.eta()));
               Ele_phi_MTD_EE_list_Significance_Bkg[k]->Fill(ele.phi());
 
               if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
@@ -1667,6 +1628,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 // ------------ method for histogram booking ------------
 void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run const& run, edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
+
+  // for regular Validation use a reduced binning, for detailed analysis and ROC curves use the larger one
+  int nbin_1 = 40;
+  int nbin_2 = 40;
+  if (optionalPlots_) {
+    nbin_1 = 1000;
+    nbin_2 = 2000;
+  }
 
   // histogram booking
 
@@ -1702,14 +1671,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEleISO_chIso_Sig_EB_ = ibook.book1D(
       "Ele_chIso_sum_Sig_EB",
       "Track pT sum in isolation cone around electron track after basic cuts - Signal Barrel;p_{T} (GeV);Counts",
-      2000,
+      nbin_2,
       0,
       20);
 
   meEleISO_rel_chIso_Sig_EB_ = ibook.book1D(
       "Ele_rel_chIso_sum_Sig_EB",
       "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Barrel;Isolation;Counts",
-      1000,
+      nbin_1,
       0,
       4);
   if (optionalPlots_) {
@@ -1723,13 +1692,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_1_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_1_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_1_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_1_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
     // gen
@@ -1743,14 +1712,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_gen_Sig_EB_ = ibook.book1D("Ele_chIso_sum_gen_Sig_EB",
                                               "Track pT sum in isolation cone around electron track after basic cuts "
                                               "using genInfo - Signal Barrel;p_{T} (GeV);Counts",
-                                              2000,
+                                              nbin_2,
                                               0,
                                               20);
 
     meEleISO_rel_chIso_gen_Sig_EB_ = ibook.book1D("Ele_rel_chIso_sum_gen_Sig_EB",
                                                   "Track relative pT sum in isolation cone around electron track after "
                                                   "basic cuts using genInfo - Signal Barrel;Isolation;Counts",
-                                                  1000,
+                                                  nbin_1,
                                                   0,
                                                   4);
 
@@ -1764,13 +1733,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_2_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_2_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_2_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_2_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1783,13 +1752,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_3_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_3_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_3_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_3_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1802,13 +1771,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_4_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_4_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_4_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_4_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1821,13 +1790,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_5_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_5_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_5_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_5_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1840,13 +1809,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_6_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_6_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_6_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_6_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1859,13 +1828,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_7_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_7_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_7_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_7_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1879,13 +1848,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_1_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_1_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_1_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_1_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1899,13 +1868,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_2_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_2_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_2_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_2_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1918,13 +1887,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_3_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_3_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_3_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_3_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1937,13 +1906,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_4_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_4_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_4_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_4_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1956,13 +1925,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_5_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_5_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_5_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_5_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1975,13 +1944,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_6_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_6_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_6_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_6_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -1994,13 +1963,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_7_Sig_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_7_Sig_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_7_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_7_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
   }
@@ -2015,14 +1984,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 4 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Sig_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EB",
                    "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
                    "compatibiliy - Signal Barrel;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -2037,14 +2006,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 3 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EB",
                                                        "Track relative pT sum in isolation cone around electron track "
                                                        "after basic cuts with MTD - 3 sigma;Isolation;Counts"
                                                        "compatibiliy - Signal Barrel",
-                                                       1000,
+                                                       nbin_1,
                                                        0,
                                                        4);
 
@@ -2059,14 +2028,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 2 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Sig_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EB",
                    "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
                    "compatibiliy - Signal Barrel;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -2079,14 +2048,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_pT_sim_tot_Sig_EB", "Electron SIM pT tot - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_eta_tot_Sig_EB_ =
-      ibook.book1D("Ele_eta_tot_Sig_EB", "Electron eta tot - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_tot_Sig_EB", "Electron eta tot - Signal Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_eta_noMTD_Sig_EB_ =
-      ibook.book1D("Ele_eta_noMTD_Sig_EB", "Electron eta noMTD - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_noMTD_Sig_EB", "Electron eta noMTD - Signal Barrel;#eta;Counts", 32, 0., 1.6);
 
   meEle_phi_tot_Sig_EB_ =
-      ibook.book1D("Ele_phi_tot_Sig_EB", "Electron phi tot - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_tot_Sig_EB", "Electron phi tot - Signal Barrel;#phi;Counts", 64, -3.2, 3.2);
   meEle_phi_noMTD_Sig_EB_ =
-      ibook.book1D("Ele_phi_noMTD_Sig_EB", "Electron phi noMTD - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_noMTD_Sig_EB", "Electron phi noMTD - Signal Barrel;#phi;Counts", 64, -3.2, 3.2);
 
   if (optionalPlots_) {
     meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_ =
@@ -2100,14 +2069,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD - 4 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
         "compatibiliy - Signal Barrel;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2122,14 +2091,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD - 3 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 3 sigma "
         "compatibiliy - Signal Barrel;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2144,51 +2113,51 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD - 2 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
         "compatibiliy - Signal Barrel;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
     meEle_pt_gen_Sig_EB_ =
         ibook.book1D("Ele_pT_gen_Sig_EB", "Electron pT genInfo - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
     meEle_eta_gen_Sig_EB_ =
-        ibook.book1D("Ele_eta_gen_Sig_EB", "Electron eta genInfo - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_eta_gen_Sig_EB", "Electron eta genInfo - Signal Barrel;#eta;Counts", 32, 0., 1.6);
     meEle_phi_gen_Sig_EB_ =
-        ibook.book1D("Ele_phi_gen_Sig_EB", "Electron phi genInfo - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_phi_gen_Sig_EB", "Electron phi genInfo - Signal Barrel;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_MTD_1_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_1_Sig_EB_ = ibook.book1D("Ele_eta_MTD_1_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_1_Sig_EB_ = ibook.book1D("Ele_phi_MTD_1_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_1_Sig_EB_ = ibook.book1D("Ele_eta_MTD_1_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_1_Sig_EB_ = ibook.book1D("Ele_phi_MTD_1_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_2_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_2_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_2_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_2_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_3_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_3_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_3_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_3_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_4_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_4_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_4_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_4_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_MTD_5_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_5_Sig_EB_ = ibook.book1D("Ele_eta_MTD_5_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_5_Sig_EB_ = ibook.book1D("Ele_phi_MTD_5_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_5_Sig_EB_ = ibook.book1D("Ele_eta_MTD_5_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_5_Sig_EB_ = ibook.book1D("Ele_phi_MTD_5_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_MTD_6_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_6_Sig_EB_ = ibook.book1D("Ele_eta_MTD_6_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_6_Sig_EB_ = ibook.book1D("Ele_phi_MTD_6_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_6_Sig_EB_ = ibook.book1D("Ele_eta_MTD_6_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_6_Sig_EB_ = ibook.book1D("Ele_phi_MTD_6_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_MTD_7_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_7_Sig_EB_ = ibook.book1D("Ele_eta_MTD_7_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_7_Sig_EB_ = ibook.book1D("Ele_phi_MTD_7_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_7_Sig_EB_ = ibook.book1D("Ele_eta_MTD_7_Sig_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_7_Sig_EB_ = ibook.book1D("Ele_phi_MTD_7_Sig_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_sim_MTD_1_Sig_EB_ =
         ibook.book1D("Ele_pT_sim_MTD_1_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
@@ -2212,14 +2181,11 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EB",
-                                              "Electron eta MTD - 4 sigma compatibility - Signal Barrel;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_4sigma_Sig_EB_ = ibook.book1D(
+      "Ele_eta_MTD_4sigma_Sig_EB", "Electron eta MTD - 4 sigma compatibility - Signal Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EB",
                                               "Electron phi MTD - 4 sigma compatibility - Signal Barrel;#phi;Counts",
-                                              128,
+                                              64,
                                               -3.2,
                                               3.2);
 
@@ -2229,14 +2195,11 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EB",
-                                              "Electron eta MTD - 3 sigma compatibility - Signal Barrel;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_3sigma_Sig_EB_ = ibook.book1D(
+      "Ele_eta_MTD_3sigma_Sig_EB", "Electron eta MTD - 3 sigma compatibility - Signal Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EB",
                                               "Electron phi MTD - 3 sigma compatibility - Signal Barrel;#phi;Counts",
-                                              128,
+                                              64,
                                               -3.2,
                                               3.2);
 
@@ -2246,14 +2209,11 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EB",
-                                              "Electron eta MTD - 2 sigma compatibility - Signal Barrel;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_2sigma_Sig_EB_ = ibook.book1D(
+      "Ele_eta_MTD_2sigma_Sig_EB", "Electron eta MTD - 2 sigma compatibility - Signal Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EB",
                                               "Electron phi MTD - 2 sigma compatibility - Signal Barrel;#phi;Counts",
-                                              128,
+                                              64,
                                               -3.2,
                                               3.2);
 
@@ -2266,13 +2226,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEleISO_chIso_Sig_EE_ = ibook.book1D(
       "Ele_chIso_sum_Sig_EE",
       "Track pT sum in isolation cone around electron track after basic cuts - Signal Endcap;p_{T} (GeV);Counts",
-      2000,
+      nbin_2,
       0,
       20);
   meEleISO_rel_chIso_Sig_EE_ = ibook.book1D(
       "Ele_rel_chIso_sum_Sig_EE",
       "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Endcap;Isolation;Counts",
-      1000,
+      nbin_1,
       0,
       4);
 
@@ -2305,13 +2265,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_1_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_1_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_1_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_1_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2324,13 +2284,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_2_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_2_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_2_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_2_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2343,13 +2303,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_gen_Sig_EE_ =
         ibook.book1D("Ele_chIso_sum_gen_Sig_EE",
                      "Track pT sum in isolation cone around electron track after basic cuts - Signal Endcap",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_gen_Sig_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_gen_Sig_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Endcap",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -2362,13 +2322,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_3_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_3_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_3_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_3_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2381,13 +2341,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_4_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_4_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_4_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_4_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2400,13 +2360,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_5_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_5_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_5_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_5_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2419,13 +2379,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_6_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_6_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_6_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_6_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2438,13 +2398,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_7_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_7_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_7_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_7_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2457,13 +2417,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_1_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_1_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_1_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_1_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2476,13 +2436,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_2_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_2_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_2_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_2_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2495,13 +2455,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_3_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_3_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_3_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_3_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2514,13 +2474,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_4_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_4_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_4_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_4_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2533,13 +2493,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_5_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_5_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_5_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_5_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2552,13 +2512,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_6_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_6_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_6_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_6_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2571,13 +2531,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_7_Sig_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_7_Sig_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_7_Sig_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_7_Sig_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
   }
@@ -2592,14 +2552,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EE",
                    "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
                    "significance - Signal Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -2614,14 +2574,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EE",
                    "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 3 sigma "
                    "significance - Signal Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -2636,14 +2596,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EE",
                    "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
                    "significance - Signal Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -2656,14 +2616,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_pT_sim_tot_Sig_EE", "Electron pT tot - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_eta_tot_Sig_EE_ =
-      ibook.book1D("Ele_eta_tot_Sig_EE", "Electron eta tot - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_tot_Sig_EE", "Electron eta tot - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
   meEle_eta_noMTD_Sig_EE_ =
-      ibook.book1D("Ele_eta_noMTD_Sig_EE", "Electron eta noMTD - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_noMTD_Sig_EE", "Electron eta noMTD - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
 
   meEle_phi_tot_Sig_EE_ =
-      ibook.book1D("Ele_phi_tot_Sig_EE", "Electron phi tot - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_tot_Sig_EE", "Electron phi tot - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
   meEle_phi_noMTD_Sig_EE_ =
-      ibook.book1D("Ele_phi_noMTD_Sig_EE", "Electron phi noMTD - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_noMTD_Sig_EE", "Electron phi noMTD - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   if (optionalPlots_) {
     meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_ =
@@ -2677,14 +2637,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
                      "sigma significance - Signal Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -2699,14 +2659,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
                      "sigma significance - Signal Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -2721,50 +2681,50 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
                      "sigma significance - Signal Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
     meEle_pt_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_MTD_1_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_1_Sig_EE_ = ibook.book1D("Ele_eta_MTD_1_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_1_Sig_EE_ = ibook.book1D("Ele_phi_MTD_1_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_1_Sig_EE_ = ibook.book1D("Ele_eta_MTD_1_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_1_Sig_EE_ = ibook.book1D("Ele_phi_MTD_1_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
     meEle_pt_gen_Sig_EE_ =
         ibook.book1D("Ele_pT_gen_Sig_EE", "Electron pT genInfo - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
     meEle_eta_gen_Sig_EE_ =
-        ibook.book1D("Ele_eta_gen_Sig_EE", "Electron eta genInfo - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_eta_gen_Sig_EE", "Electron eta genInfo - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
     meEle_phi_gen_Sig_EE_ =
-        ibook.book1D("Ele_phi_gen_Sig_EE", "Electron phi genInfo - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_phi_gen_Sig_EE", "Electron phi genInfo - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_2_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_2_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_2_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_2_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_3_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_3_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_3_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_3_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_4_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_4_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_4_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_4_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_MTD_5_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_5_Sig_EE_ = ibook.book1D("Ele_eta_MTD_5_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_5_Sig_EE_ = ibook.book1D("Ele_phi_MTD_5_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_5_Sig_EE_ = ibook.book1D("Ele_eta_MTD_5_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_5_Sig_EE_ = ibook.book1D("Ele_phi_MTD_5_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_MTD_6_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_6_Sig_EE_ = ibook.book1D("Ele_eta_MTD_6_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_6_Sig_EE_ = ibook.book1D("Ele_phi_MTD_6_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_6_Sig_EE_ = ibook.book1D("Ele_eta_MTD_6_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_6_Sig_EE_ = ibook.book1D("Ele_phi_MTD_6_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_MTD_7_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_7_Sig_EE_ = ibook.book1D("Ele_eta_MTD_7_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_7_Sig_EE_ = ibook.book1D("Ele_phi_MTD_7_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_7_Sig_EE_ = ibook.book1D("Ele_eta_MTD_7_Sig_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_7_Sig_EE_ = ibook.book1D("Ele_phi_MTD_7_Sig_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_sim_MTD_1_Sig_EE_ =
         ibook.book1D("Ele_pT_sim_MTD_1_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
@@ -2807,16 +2767,10 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EE",
-                                              "Electron eta MTD - 4 sigma significance - Signal Endcap;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
-  meEle_phi_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EE",
-                                              "Electron phi MTD - 4 sigma significance - Signal Endcap;#phi;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_4sigma_Sig_EE_ = ibook.book1D(
+      "Ele_eta_MTD_4sigma_Sig_EE", "Electron eta MTD - 4 sigma significance - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
+  meEle_phi_MTD_4sigma_Sig_EE_ = ibook.book1D(
+      "Ele_phi_MTD_4sigma_Sig_EE", "Electron phi MTD - 4 sigma significance - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_3sigma_Sig_EE_ =
       ibook.book1D("Ele_pT_MTD_3sigma_Sig_EE",
@@ -2824,16 +2778,10 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EE",
-                                              "Electron eta MTD - 3 sigma significance - Signal Endcap;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
-  meEle_phi_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EE",
-                                              "Electron phi MTD - 3 sigma significance - Signal Endcap;#phi;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_3sigma_Sig_EE_ = ibook.book1D(
+      "Ele_eta_MTD_3sigma_Sig_EE", "Electron eta MTD - 3 sigma significance - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
+  meEle_phi_MTD_3sigma_Sig_EE_ = ibook.book1D(
+      "Ele_phi_MTD_3sigma_Sig_EE", "Electron phi MTD - 3 sigma significance - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_2sigma_Sig_EE_ =
       ibook.book1D("Ele_pT_MTD_2sigma_Sig_EE",
@@ -2841,16 +2789,10 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    30,
                    10,
                    100);
-  meEle_eta_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EE",
-                                              "Electron eta MTD - 2 sigma significance - Signal Endcap;#eta;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
-  meEle_phi_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EE",
-                                              "Electron phi MTD - 2 sigma significance - Signal Endcap;#phi;Counts",
-                                              128,
-                                              -3.2,
-                                              3.2);
+  meEle_eta_MTD_2sigma_Sig_EE_ = ibook.book1D(
+      "Ele_eta_MTD_2sigma_Sig_EE", "Electron eta MTD - 2 sigma significance - Signal Endcap;#eta;Counts", 32, 1.6, 3.2);
+  meEle_phi_MTD_2sigma_Sig_EE_ = ibook.book1D(
+      "Ele_phi_MTD_2sigma_Sig_EE", "Electron phi MTD - 2 sigma significance - Signal Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   // background
   meEleISO_Ntracks_Bkg_EB_ = ibook.book1D(
@@ -2862,13 +2804,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEleISO_chIso_Bkg_EB_ = ibook.book1D(
       "Ele_chIso_sum_Bkg_EB",
       "Track pT sum in isolation cone around electron track after basic cuts - Bkg Barrel;p_{T} (GeV);Counts",
-      2000,
+      nbin_2,
       0,
       20);
   meEleISO_rel_chIso_Bkg_EB_ = ibook.book1D(
       "Ele_rel_chIso_sum_Bkg_EB",
       "Track relative pT sum in isolation cone around electron track after basic cuts - Bkg Barrel;Isolation;Counts",
-      1000,
+      nbin_1,
       0,
       4);
   if (optionalPlots_) {
@@ -2881,13 +2823,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_1_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_1_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_1_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_1_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2900,13 +2842,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_2_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_2_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_2_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_2_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
     meEleISO_Ntracks_gen_Bkg_EB_ = ibook.book1D("Ele_Iso_Ntracks_gen_Bkg_EB",
@@ -2918,13 +2860,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_gen_Bkg_EB_ = ibook.book1D("Ele_chIso_sum_gen_Bkg_EB",
                                               "Track pT sum in isolation cone around electron track after basic cuts "
                                               "using genInfo - Bkg Barrel;p_{T} (GeV);Counts",
-                                              2000,
+                                              nbin_2,
                                               0,
                                               20);
     meEleISO_rel_chIso_gen_Bkg_EB_ = ibook.book1D("Ele_rel_chIso_sum_gen_Bkg_EB",
                                                   "Track relative pT sum in isolation cone around electron track after "
                                                   "basic cuts using genInfo - Bkg Barrel;Isolation;Counts",
-                                                  1000,
+                                                  nbin_1,
                                                   0,
                                                   4);
     meEleISO_Ntracks_MTD_3_Bkg_EB_ =
@@ -2936,13 +2878,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_3_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_3_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_3_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_3_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2955,13 +2897,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_4_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_4_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_4_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_4_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2974,13 +2916,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_5_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_5_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_5_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_5_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -2993,13 +2935,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_6_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_6_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_6_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_6_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3012,13 +2954,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_7_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_7_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_7_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_7_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3031,13 +2973,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_1_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_1_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_1_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3050,13 +2992,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_2_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_2_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_2_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3069,13 +3011,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_3_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_3_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_3_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3088,13 +3030,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_4_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_4_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_4_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3107,13 +3049,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_5_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_5_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_5_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3126,13 +3068,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_6_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_6_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_6_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3145,13 +3087,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_7_Bkg_EB_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_7_Bkg_EB",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_7_Bkg_EB",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
   }
@@ -3166,14 +3108,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 4 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EB",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 4 sigma significance - Bkg Barrel;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3188,14 +3130,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 3 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EB",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 3 sigma significance - Bkg Barrel;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3210,14 +3152,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EB",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 2 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EB",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 2 sigma significance - Bkg Barrel;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3229,15 +3171,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEle_pt_sim_tot_Bkg_EB_ =
       ibook.book1D("Ele_pT_sim_tot_Bkg_EB", "Electron pT tot - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Bkg_EB_ =
-      ibook.book1D("Ele_eta_tot_Bkg_EB", "Electron eta tot - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_tot_Bkg_EB_ = ibook.book1D("Ele_eta_tot_Bkg_EB", "Electron eta tot - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_eta_noMTD_Bkg_EB_ =
-      ibook.book1D("Ele_eta_noMTD_Bkg_EB", "Electron eta noMTD - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_noMTD_Bkg_EB", "Electron eta noMTD - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
 
   meEle_phi_tot_Bkg_EB_ =
-      ibook.book1D("Ele_phi_tot_Bkg_EB", "Electron phi tot - Bkg Barrel;#phi;#Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_tot_Bkg_EB", "Electron phi tot - Bkg Barrel;#phi;#Counts", 64, -3.2, 3.2);
   meEle_phi_noMTD_Bkg_EB_ =
-      ibook.book1D("Ele_phi_noMTD_Bkg_EB", "Electron phi noMTD - Bkg Barrel;#phi;#Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_noMTD_Bkg_EB", "Electron phi noMTD - Bkg Barrel;#phi;#Counts", 64, -3.2, 3.2);
 
   if (optionalPlots_) {
     meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_ =
@@ -3251,14 +3192,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 4 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EB",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
                      "sigma significance - Bkg Barrel;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -3273,14 +3214,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 3 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EB",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
                      "sigma significance - Bkg Barrel;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -3295,50 +3236,50 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EB",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 2 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EB",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
                      "sigma significance - Bkg Barrel;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
     meEle_pt_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_1_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_1_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_1_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_1_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
     meEle_pt_gen_Bkg_EB_ =
         ibook.book1D("Ele_pT_gen_Bkg_EB", "Electron pT genInfo - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
     meEle_eta_gen_Bkg_EB_ =
-        ibook.book1D("Ele_eta_gen_Bkg_EB", "Electron eta genInfo - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_eta_gen_Bkg_EB", "Electron eta genInfo - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
     meEle_phi_gen_Bkg_EB_ =
-        ibook.book1D("Ele_phi_gen_Bkg_EB", "Electron phi genInfo - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_phi_gen_Bkg_EB", "Electron phi genInfo - Bkg Barrel;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_2_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_2_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_2_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_2_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_3_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_3_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_3_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_3_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_4_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_4_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_4_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_4_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_5_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_5_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_5_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_5_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_6_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_6_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_6_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_6_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_7_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_7_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_7_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EB", "Electron eta MTD;#eta;Counts", 32, 0., 1.6);
+    meEle_phi_MTD_7_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EB", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_sim_MTD_1_Bkg_EB_ =
         ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
@@ -3361,9 +3302,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_4sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_eta_MTD_4sigma_Bkg_EB", "Electron eta MTD - 4 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_4sigma_Bkg_EB", "Electron eta MTD - 4 sigma compatibility - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_4sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_phi_MTD_4sigma_Bkg_EB", "Electron phi MTD - 4 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_4sigma_Bkg_EB", "Electron phi MTD - 4 sigma compatibility - Bkg Barrel;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EB",
                                              "Electron pT MTD - 3 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
@@ -3371,9 +3312,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_3sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_eta_MTD_3sigma_Bkg_EB", "Electron eta MTD - 3 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_3sigma_Bkg_EB", "Electron eta MTD - 3 sigma compatibility - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_3sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_phi_MTD_3sigma_Bkg_EB", "Electron phi MTD - 3 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_3sigma_Bkg_EB", "Electron phi MTD - 3 sigma compatibility - Bkg Barrel;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EB",
                                              "Electron pT MTD - 2 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
@@ -3381,9 +3322,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_2sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_eta_MTD_2sigma_Bkg_EB", "Electron eta MTD - 2 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_2sigma_Bkg_EB", "Electron eta MTD - 2 sigma compatibility - Bkg Barrel;#eta;Counts", 32, 0., 1.6);
   meEle_phi_MTD_2sigma_Bkg_EB_ = ibook.book1D(
-      "Ele_phi_MTD_2sigma_Bkg_EB", "Electron phi MTD - 2 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_2sigma_Bkg_EB", "Electron phi MTD - 2 sigma compatibility - Bkg Barrel;#phi;Counts", 64, -3.2, 3.2);
 
   meEleISO_Ntracks_Bkg_EE_ = ibook.book1D(
       "Ele_Iso_Ntracks_Bkg_EE",
@@ -3394,13 +3335,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEleISO_chIso_Bkg_EE_ = ibook.book1D(
       "Ele_chIso_sum_Bkg_EE",
       "Track pT sum in isolation cone around electron track after basic cuts - Bkg Endcap;p_{T} (GeV);Counts",
-      2000,
+      nbin_2,
       0,
       20);
   meEleISO_rel_chIso_Bkg_EE_ = ibook.book1D(
       "Ele_rel_chIso_sum_Bkg_EE",
       "Track relative pT sum in isolation cone around electron track after basic cuts - Bkg Endcap;Isolation;Counts",
-      1000,
+      nbin_1,
       0,
       4);
   if (optionalPlots_) {
@@ -3432,13 +3373,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_1_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_1_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_1_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_1_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3451,13 +3392,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_2_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_2_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_2_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_2_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
     meEleISO_Ntracks_gen_Bkg_EE_ = ibook.book1D("Ele_Iso_Ntracks_gen_Bkg_EE",
@@ -3469,13 +3410,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_gen_Bkg_EE_ = ibook.book1D("Ele_chIso_sum_gen_Bkg_EE",
                                               "Track pT sum in isolation cone around electron track after basic cuts "
                                               "using genInfo - Bkg Endcap;p_{T} (GeV);Counts",
-                                              2000,
+                                              nbin_2,
                                               0,
                                               20);
     meEleISO_rel_chIso_gen_Bkg_EE_ = ibook.book1D("Ele_rel_chIso_sum_gen_Bkg_EE",
                                                   "Track relative pT sum in isolation cone around electron track after "
                                                   "basic cuts using genInfo - Bkg Endcap;Isolation;Counts",
-                                                  1000,
+                                                  nbin_1,
                                                   0,
                                                   4);
 
@@ -3488,13 +3429,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_3_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_3_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_3_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_3_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3507,13 +3448,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_4_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_4_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_4_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_4_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3526,13 +3467,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_5_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_5_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_5_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_5_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3545,13 +3486,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_6_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_6_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_6_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_6_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3564,13 +3505,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_7_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_7_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_7_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_7_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3583,13 +3524,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_1_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_1_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_1_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3602,13 +3543,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_2_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_2_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_2_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3621,13 +3562,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_3_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_3_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_3_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3640,13 +3581,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_4_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_4_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_4_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3659,13 +3600,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_5_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_5_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_5_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3678,13 +3619,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_6_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_6_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_6_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
 
@@ -3697,13 +3638,13 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     meEleISO_chIso_MTD_sim_7_Bkg_EE_ = ibook.book1D(
         "Ele_chIso_sum_MTD_sim_7_Bkg_EE",
         "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
-        2000,
+        nbin_2,
         0,
         20);
     meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_ = ibook.book1D(
         "Ele_rel_chIso_sum_MTD_sim_7_Bkg_EE",
         "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
-        1000,
+        nbin_1,
         0,
         4);
   }
@@ -3718,14 +3659,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EE",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 4 sigma compatibility - Bkg Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3740,14 +3681,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EE",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 3 sigma compatibility - Bkg Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3762,14 +3703,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EE",
                    "Track pT sum in isolation cone around electron track after basic "
                    "cuts with MTD - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                   2000,
+                   nbin_2,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EE",
                    "Track relative pT sum in isolation cone around electron track "
                    "after basic cuts with MTD - 2 sigma compatibility - Bkg Endcap;Isolation;Counts",
-                   1000,
+                   nbin_1,
                    0,
                    4);
 
@@ -3781,15 +3722,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meEle_pt_sim_tot_Bkg_EE_ =
       ibook.book1D("Ele_pT_sim_tot_Bkg_EE", "Electron pT tot - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Bkg_EE_ =
-      ibook.book1D("Ele_eta_tot_Bkg_EE", "Electron eta tot - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_tot_Bkg_EE_ = ibook.book1D("Ele_eta_tot_Bkg_EE", "Electron eta tot - Bkg Endcap;#eta;Counts", 32, 1.6, 3.2);
   meEle_eta_noMTD_Bkg_EE_ =
-      ibook.book1D("Ele_eta_noMTD_Bkg_EE", "Electron eta noMTD - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_eta_noMTD_Bkg_EE", "Electron eta noMTD - Bkg Endcap;#eta;Counts", 32, 1.6, 3.2);
 
   meEle_phi_tot_Bkg_EE_ =
-      ibook.book1D("Ele_phi_tot_Bkg_EE", "Electron phi tot - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_tot_Bkg_EE", "Electron phi tot - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
   meEle_phi_noMTD_Bkg_EE_ =
-      ibook.book1D("Ele_phi_noMTD_Bkg_EE", "Electron phi noMTD - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+      ibook.book1D("Ele_phi_noMTD_Bkg_EE", "Electron phi noMTD - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
   if (optionalPlots_) {
     meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_ =
         ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EE",
@@ -3802,14 +3742,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
                      "sigma compatibility - Bkg Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -3824,14 +3764,14 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
                      "sigma compatibility - Bkg Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
@@ -3846,50 +3786,50 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
         ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EE",
                      "Track pT sum in isolation cone around electron track after "
                      "basic cuts with MTD SIM - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
-                     2000,
+                     nbin_2,
                      0,
                      20);
     meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_ =
         ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EE",
                      "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
                      "sigma compatibility - Bkg Endcap;Isolation;Counts",
-                     1000,
+                     nbin_1,
                      0,
                      4);
 
     meEle_pt_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_1_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_1_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_1_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_1_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
     meEle_pt_gen_Bkg_EE_ =
         ibook.book1D("Ele_pT_gen_Bkg_EE", "Electron pT genInfo - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
     meEle_eta_gen_Bkg_EE_ =
-        ibook.book1D("Ele_eta_gen_Bkg_EE", "Electron eta genInfo - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_eta_gen_Bkg_EE", "Electron eta genInfo - Bkg Endcap;#eta;Counts", 32, 1.6, 3.2);
     meEle_phi_gen_Bkg_EE_ =
-        ibook.book1D("Ele_phi_gen_Bkg_EE", "Electron phi genInfo - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+        ibook.book1D("Ele_phi_gen_Bkg_EE", "Electron phi genInfo - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_2_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_2_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_2_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_2_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_3_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_3_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_3_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_3_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_4_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_4_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_4_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_4_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_5_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_5_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_5_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_5_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_6_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_6_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_6_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_6_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
-    meEle_eta_MTD_7_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
-    meEle_phi_MTD_7_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_eta_MTD_7_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EE", "Electron eta MTD;#eta;Counts", 32, 1.6, 3.2);
+    meEle_phi_MTD_7_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EE", "Electron phi MTD;#phi;Counts", 64, -3.2, 3.2);
 
     meEle_pt_sim_MTD_1_Bkg_EE_ =
         ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
@@ -3913,9 +3853,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_4sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_eta_MTD_4sigma_Bkg_EE", "Electron eta MTD - 4 sigma compatibility - Bkg Endcapi;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_4sigma_Bkg_EE", "Electron eta MTD - 4 sigma compatibility - Bkg Endcapi;#eta;Counts", 32, 1.6, 3.2);
   meEle_phi_MTD_4sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_phi_MTD_4sigma_Bkg_EE", "Electron phi MTD - 4 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_4sigma_Bkg_EE", "Electron phi MTD - 4 sigma compatibility - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EE",
                                              "Electron pT MTD - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
@@ -3923,9 +3863,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_3sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_eta_MTD_3sigma_Bkg_EE", "Electron eta MTD - 3 sigma compatibility - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_3sigma_Bkg_EE", "Electron eta MTD - 3 sigma compatibility - Bkg Endcap;#eta;Counts", 32, 1.6, 3.2);
   meEle_phi_MTD_3sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_phi_MTD_3sigma_Bkg_EE", "Electron phi MTD - 3 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_3sigma_Bkg_EE", "Electron phi MTD - 3 sigma compatibility - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   meEle_pt_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EE",
                                              "Electron pT MTD - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
@@ -3933,9 +3873,9 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                              10,
                                              100);
   meEle_eta_MTD_2sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_eta_MTD_2sigma_Bkg_EE", "Electron eta MTD - 2 sigma compatibility - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+      "Ele_eta_MTD_2sigma_Bkg_EE", "Electron eta MTD - 2 sigma compatibility - Bkg Endcap;#eta;Counts", 32, 1.6, 3.2);
   meEle_phi_MTD_2sigma_Bkg_EE_ = ibook.book1D(
-      "Ele_phi_MTD_2sigma_Bkg_EE", "Electron phi MTD - 2 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+      "Ele_phi_MTD_2sigma_Bkg_EE", "Electron phi MTD - 2 sigma compatibility - Bkg Endcap;#phi;Counts", 64, -3.2, 3.2);
 
   if (optionalPlots_) {
     meEle_pt_sim_MTD_4sigma_Bkg_EE_ =
@@ -3957,167 +3897,6 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                      10,
                      100);
   }
-
-  meEle_dt_general_pT_1 = ibook.book1D("Iso_track_dt_general_pT_10_20",
-                                       "Iso cone track dt distribution in pT bin 10-20 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_2 = ibook.book1D("Iso_track_dt_general_pT_20_30",
-                                       "Iso cone track dt distribution in pT bin 20-30 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_3 = ibook.book1D("Iso_track_dt_general_pT_30_40",
-                                       "Iso cone track dt distribution in pT bin 30-40 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_4 = ibook.book1D("Iso_track_dt_general_pT_40_50",
-                                       "Iso cone track dt distribution in pT bin 40-50 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_5 = ibook.book1D("Iso_track_dt_general_pT_50_60",
-                                       "Iso cone track dt distribution in pT bin 50-60 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_6 = ibook.book1D("Iso_track_dt_general_pT_60_70",
-                                       "Iso cone track dt distribution in pT bin 60-70 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_7 = ibook.book1D("Iso_track_dt_general_pT_70_80",
-                                       "Iso cone track dt distribution in pT bin 70-80 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_8 = ibook.book1D("Iso_track_dt_general_pT_80_90",
-                                       "Iso cone track dt distribution in pT bin 80-90 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-  meEle_dt_general_pT_9 = ibook.book1D("Iso_track_dt_general_pT_90_100",
-                                       "Iso cone track dt distribution in pT bin 90-100 GeV ;Time (ns);Counts",
-                                       100,
-                                       0,
-                                       1);
-
-  meEle_dtSignif_general_pT_1 = ibook.book1D("Iso_track_dtSignif_general_pT_10_20",
-                                             "Iso cone track dt distribution in pT bin 10-20 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_2 = ibook.book1D("Iso_track_dtSignif_general_pT_20_30",
-                                             "Iso cone track dt distribution in pT bin 20-30 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_3 = ibook.book1D("Iso_track_dtSignif_general_pT_30_40",
-                                             "Iso cone track dt distribution in pT bin 30-40 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_4 = ibook.book1D("Iso_track_dtSignif_general_pT_40_50",
-                                             "Iso cone track dt distribution in pT bin 40-50 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_5 = ibook.book1D("Iso_track_dtSignif_general_pT_50_60",
-                                             "Iso cone track dt distribution in pT bin 50-60 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_6 = ibook.book1D("Iso_track_dtSignif_general_pT_60_70",
-                                             "Iso cone track dt distribution in pT bin 60-70 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_7 = ibook.book1D("Iso_track_dtSignif_general_pT_70_80",
-                                             "Iso cone track dt distribution in pT bin 70-80 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_8 = ibook.book1D("Iso_track_dtSignif_general_pT_80_90",
-                                             "Iso cone track dt distribution in pT bin 80-90 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-  meEle_dtSignif_general_pT_9 = ibook.book1D("Iso_track_dtSignif_general_pT_90_100",
-                                             "Iso cone track dt distribution in pT bin 90-100 GeV ;Time (ns);Counts",
-                                             1000,
-                                             0,
-                                             10);
-
-  meEle_dt_general_eta_1 = ibook.book1D(
-      "Iso_track_dt_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ;Time (ns);Counts", 100, 0, 1);
-  meEle_dt_general_eta_2 = ibook.book1D("Iso_track_dt_general_eta_05_10",
-                                        "Iso cone track dt distribution in eta bin 0.5-1.0 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-  meEle_dt_general_eta_3 = ibook.book1D("Iso_track_dt_general_eta_10_15",
-                                        "Iso cone track dt distribution in eta bin 1.0-1.5 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-  meEle_dt_general_eta_4 = ibook.book1D("Iso_track_dt_general_eta_15_20",
-                                        "Iso cone track dt distribution in eta bin 1.5-2.0 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-  meEle_dt_general_eta_5 = ibook.book1D("Iso_track_dt_general_eta_20_24",
-                                        "Iso cone track dt distribution in eta bin 2.0-2.4 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-  meEle_dt_general_eta_6 = ibook.book1D("Iso_track_dt_general_eta_24_27",
-                                        "Iso cone track dt distribution in eta bin 2.4-2.7 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-  meEle_dt_general_eta_7 = ibook.book1D("Iso_track_dt_general_eta_27_30",
-                                        "Iso cone track dt distribution in eta bin 2.7-3.0 ;Time (ns);Counts",
-                                        100,
-                                        0,
-                                        1);
-
-  meEle_dtSignif_general_eta_1 = ibook.book1D("Iso_track_dtSignif_general_eta_0_05",
-                                              "Iso cone track dt distribution in eta bin 0.0-0.5 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_2 = ibook.book1D("Iso_track_dtSignif_general_eta_05_10",
-                                              "Iso cone track dt distribution in eta bin 0.5-1.0 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_3 = ibook.book1D("Iso_track_dtSignif_general_eta_10_15",
-                                              "Iso cone track dt distribution in eta bin 1.0-1.5 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_4 = ibook.book1D("Iso_track_dtSignif_general_eta_15_20",
-                                              "Iso cone track dt distribution in eta bin 1.5-2.0 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_5 = ibook.book1D("Iso_track_dtSignif_general_eta_20_24",
-                                              "Iso cone track dt distribution in eta bin 2.0-2.4 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_6 = ibook.book1D("Iso_track_dtSignif_general_eta_24_27",
-                                              "Iso cone track dt distribution in eta bin 2.4-2.7 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
-  meEle_dtSignif_general_eta_7 = ibook.book1D("Iso_track_dtSignif_general_eta_27_30",
-                                              "Iso cone track dt distribution in eta bin 2.7-3.0 ;Time (ns);Counts",
-                                              1000,
-                                              0,
-                                              10);
 
   // defining vectors for more efficient hist filling
   // Promt part
@@ -4541,42 +4320,6 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     Ele_pT_sim_MTD_EE_list_Significance_Bkg = {
         meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_sim_MTD_2sigma_Bkg_EE_};
   }
-  // dt distribution hist vecotrs
-
-  general_pT_list = {meEle_dt_general_pT_1,
-                     meEle_dt_general_pT_2,
-                     meEle_dt_general_pT_3,
-                     meEle_dt_general_pT_4,
-                     meEle_dt_general_pT_5,
-                     meEle_dt_general_pT_6,
-                     meEle_dt_general_pT_7,
-                     meEle_dt_general_pT_8,
-                     meEle_dt_general_pT_9};
-
-  general_pT_Signif_list = {meEle_dtSignif_general_pT_1,
-                            meEle_dtSignif_general_pT_2,
-                            meEle_dtSignif_general_pT_3,
-                            meEle_dtSignif_general_pT_4,
-                            meEle_dtSignif_general_pT_5,
-                            meEle_dtSignif_general_pT_6,
-                            meEle_dtSignif_general_pT_7,
-                            meEle_dtSignif_general_pT_8,
-                            meEle_dtSignif_general_pT_9};
-  general_eta_list = {meEle_dt_general_eta_1,
-                      meEle_dt_general_eta_2,
-                      meEle_dt_general_eta_3,
-                      meEle_dt_general_eta_4,
-                      meEle_dt_general_eta_5,
-                      meEle_dt_general_eta_6,
-                      meEle_dt_general_eta_7};
-
-  general_eta_Signif_list = {meEle_dtSignif_general_eta_1,
-                             meEle_dtSignif_general_eta_2,
-                             meEle_dtSignif_general_eta_3,
-                             meEle_dtSignif_general_eta_4,
-                             meEle_dtSignif_general_eta_5,
-                             meEle_dtSignif_general_eta_6,
-                             meEle_dtSignif_general_eta_7};
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -4603,7 +4346,6 @@ void MtdEleIsoValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("rel_iso_cut", 0.08);
   desc.add<bool>("optionTrackMatchToPV", false);
   desc.add<bool>("option_dtToTrack", true);  // default is dt with track, if false will do dt to vertex
-  desc.add<bool>("option_dtDistributions", false);
   desc.add<bool>("option_plots", false);
   desc.add<double>("min_dR_cut", 0.01);
   desc.add<double>("max_dR_cut", 0.3);

--- a/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdEleIsoValidation.cc
@@ -1,4 +1,3 @@
-///*
 #include <string>
 #include <tuple>
 #include <numeric>
@@ -8,7 +7,7 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <memory>  // unique_ptr
+#include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -61,12 +60,12 @@
 #include "HepMC/GenRanges.h"
 #include "CLHEP/Units/PhysicalConstants.h"
 
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"  // Adding header files for electrons
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"         // Adding header files for electrons
+// Adding header files for electrons
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 // eff vs PU test libraries
-
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
@@ -75,8 +74,6 @@
 #include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Point3D.h"
-
-// end of test libraries
 
 class MtdEleIsoValidation : public DQMEDAnalyzer {
 public:
@@ -93,7 +90,6 @@ private:
   const bool mvaGenSel(const HepMC::GenParticle&, const float&);
   const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&, const double&, const double&);
   const bool mvaGenRecMatch(const HepMC::GenParticle&, const double&, const reco::TrackBase&);
-  bool pdgCheck(int pdg);
 
   // ------------ member data ------------
 
@@ -103,75 +99,59 @@ private:
   const float trackMaxEta_;
   const double rel_iso_cut_;
 
-  bool track_match_PV_;
-  bool dt_sig_vtx_;
-  bool dt_sig_track_;
-  bool dt_distributions_;
+  const bool track_match_PV_;
+  const bool dt_sig_track_;
+  const bool dt_distributions_;
+  const bool optionalPlots_;
 
-  static constexpr float min_dR_cut = 0.01;
-  static constexpr float max_dR_cut = 0.3;
-  static constexpr float min_pt_cut_EB = 0.7;
-  static constexpr float min_pt_cut_EE = 0.4;
-  static constexpr float max_dz_cut_EB = 0.5;
-  static constexpr float max_dz_cut_EE = 0.5;
-  static constexpr float max_dz_vtx_cut = 0.5;
-  static constexpr float max_dxy_vtx_cut = 0.2;
-  // timing cuts - has to be 7 values here!!! Code created for 7 dt values!! Values for resolution 100;90;80;70;60;50;40 ps
-  //const std::vector<double> max_dt_vtx_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12};  // default cuts
-  //const std::vector<double> max_dt_track_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12}; // default cuts
-  const std::vector<double> max_dt_vtx_cut{0.30, 0.24, 0.18, 0.15, 0.12, 0.08, 0.04};    // test cuts
-  const std::vector<double> max_dt_track_cut{0.30, 0.24, 0.18, 0.15, 0.12, 0.08, 0.04};  // test cuts
-  const std::vector<double> max_dt_significance_cut{4.0, 3.0, 2.0};                      // test cuts
-  static constexpr float min_strip_cut = 0.01;
-  static constexpr float min_track_mtd_mva_cut = 0.5;
+  const float min_dR_cut;
+  const float max_dR_cut;
+  const float min_pt_cut_EB;
+  const float min_pt_cut_EE;
+  const float max_dz_cut_EB;
+  const float max_dz_cut_EE;
+  const float max_dz_vtx_cut;
+  const float max_dxy_vtx_cut;
+  const float min_strip_cut;
+  const float min_track_mtd_mva_cut;
+  const std::vector<double> max_dt_vtx_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12};
+  const std::vector<double> max_dt_track_cut{0.30, 0.27, 0.24, 0.21, 0.18, 0.15, 0.12};
+  const std::vector<double> max_dt_significance_cut{4.0, 3.0, 2.0};
   const std::vector<double> pT_bins_dt_distrb{10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
-  const std::vector<double> eta_bins_dt_distrib{0.0, 0.5, 1.0, 1.5, 2.0, 2.4};
-  static constexpr double avg_sim_sigTrk_t_err = 0.03239;  // avg error/resolution for SIM tracks in nanoseconds
+  const std::vector<double> eta_bins_dt_distrib{0.0, 0.5, 1.0, 1.5, 2.0, 2.4, 2.7, 3};
+  static constexpr double avg_sim_sigTrk_t_err = 0.03239;
   static constexpr double avg_sim_PUtrack_t_err = 0.03465;
-  static constexpr double avg_sim_vertex_t_err = 0.1;
 
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
 
-  edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectronToken_EB_;  // Adding token for electron collection
+  edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectronToken_EB_;
   edm::EDGetTokenT<reco::GsfElectronCollection> GsfElectronToken_EE_;
   edm::EDGetTokenT<reco::GenParticleCollection> GenParticleToken_;
 
   edm::EDGetTokenT<edm::HepMCProduct> HepMCProductToken_;
 
-  edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
-
-  edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> SigmatmtdToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> t0SrcToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SrcToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> t0PidToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0PidToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> t0SafePidToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> Sigmat0SafePidToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> trackMVAQualToken_;
 
-  edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> particleTableToken_;
-
-  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;  // From Aurora
-  edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;         // From Aurora
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
+  edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
 
   // Signal histograms
 
   MonitorElement* meEle_no_dt_check_;
   MonitorElement* meTrk_genMatch_check_;
-  MonitorElement* meEle_test_check_;
 
   MonitorElement* meEle_avg_error_SigTrk_check_;
   MonitorElement* meEle_avg_error_PUTrk_check_;
   MonitorElement* meEle_avg_error_vtx_check_;
 
-  MonitorElement* meEleISO_Ntracks_Sig_EB_;  // Adding histograms for barrel electrons (isolation stuff)
+  // Adding histograms for barrel electrons
+  MonitorElement* meEleISO_Ntracks_Sig_EB_;
   MonitorElement* meEleISO_chIso_Sig_EB_;
   MonitorElement* meEleISO_rel_chIso_Sig_EB_;
-
   MonitorElement* meEleISO_Ntracks_MTD_1_Sig_EB_;
   MonitorElement* meEleISO_chIso_MTD_1_Sig_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_1_Sig_EB_;
@@ -199,18 +179,6 @@ private:
   MonitorElement* meEleISO_Ntracks_MTD_7_Sig_EB_;
   MonitorElement* meEleISO_chIso_MTD_7_Sig_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_7_Sig_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EB_;
-  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EB_;
-  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EB_;
-  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EB_;
 
   MonitorElement* meEleISO_Ntracks_MTD_sim_1_Sig_EB_;
   MonitorElement* meEleISO_chIso_MTD_sim_1_Sig_EB_;
@@ -240,6 +208,22 @@ private:
   MonitorElement* meEleISO_chIso_MTD_sim_7_Sig_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Sig_EB_;
 
+  MonitorElement* meEleISO_Ntracks_gen_Sig_EB_;
+  MonitorElement* meEleISO_chIso_gen_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_gen_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EB_;
+
   MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_;
   MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Sig_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_;
@@ -253,10 +237,9 @@ private:
   MonitorElement* meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_;
 
   MonitorElement* meEle_pt_tot_Sig_EB_;
-  MonitorElement* meEle_pt_sim_tot_Sig_EB_;
+  MonitorElement* meEle_pt_sim_tot_Sig_EB_;  // for GEN case is the same
   MonitorElement* meEle_eta_tot_Sig_EB_;
   MonitorElement* meEle_phi_tot_Sig_EB_;
-
   MonitorElement* meEle_pt_MTD_1_Sig_EB_;
   MonitorElement* meEle_pt_sim_MTD_1_Sig_EB_;
   MonitorElement* meEle_eta_MTD_1_Sig_EB_;
@@ -296,6 +279,10 @@ private:
   MonitorElement* meEle_eta_noMTD_Sig_EB_;
   MonitorElement* meEle_phi_noMTD_Sig_EB_;
 
+  MonitorElement* meEle_pt_gen_Sig_EB_;
+  MonitorElement* meEle_eta_gen_Sig_EB_;
+  MonitorElement* meEle_phi_gen_Sig_EB_;
+
   MonitorElement* meEle_pt_MTD_2sigma_Sig_EB_;
   MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EB_;
   MonitorElement* meEle_eta_MTD_2sigma_Sig_EB_;
@@ -311,10 +298,10 @@ private:
   MonitorElement* meEle_eta_MTD_4sigma_Sig_EB_;
   MonitorElement* meEle_phi_MTD_4sigma_Sig_EB_;
 
-  MonitorElement* meEleISO_Ntracks_Sig_EE_;  // Adding histograms for endcap electrons (isolation stuff)
+  // Adding histograms for endcap electrons
+  MonitorElement* meEleISO_Ntracks_Sig_EE_;
   MonitorElement* meEleISO_chIso_Sig_EE_;
   MonitorElement* meEleISO_rel_chIso_Sig_EE_;
-
   MonitorElement* meEleISO_Ntracks_MTD_1_Sig_EE_;
   MonitorElement* meEleISO_chIso_MTD_1_Sig_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_1_Sig_EE_;
@@ -343,18 +330,6 @@ private:
   MonitorElement* meEleISO_chIso_MTD_7_Sig_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_7_Sig_EE_;
 
-  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EE_;
-  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EE_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EE_;
-  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EE_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EE_;
-  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EE_;
-
   MonitorElement* meEleISO_Ntracks_MTD_sim_1_Sig_EE_;
   MonitorElement* meEleISO_chIso_MTD_sim_1_Sig_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_1_Sig_EE_;
@@ -382,6 +357,22 @@ private:
   MonitorElement* meEleISO_Ntracks_MTD_sim_7_Sig_EE_;
   MonitorElement* meEleISO_chIso_MTD_sim_7_Sig_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_gen_Sig_EE_;
+  MonitorElement* meEleISO_chIso_gen_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_gen_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Sig_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Sig_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Sig_EE_;
 
   MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_;
   MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Sig_EE_;
@@ -439,6 +430,10 @@ private:
   MonitorElement* meEle_eta_noMTD_Sig_EE_;
   MonitorElement* meEle_phi_noMTD_Sig_EE_;
 
+  MonitorElement* meEle_pt_gen_Sig_EE_;
+  MonitorElement* meEle_eta_gen_Sig_EE_;
+  MonitorElement* meEle_phi_gen_Sig_EE_;
+
   MonitorElement* meEle_pt_MTD_2sigma_Sig_EE_;
   MonitorElement* meEle_pt_sim_MTD_2sigma_Sig_EE_;
   MonitorElement* meEle_eta_MTD_2sigma_Sig_EE_;
@@ -457,10 +452,10 @@ private:
   // Signal histograms end
 
   // Background histograms
-  MonitorElement* meEleISO_Ntracks_Bkg_EB_;  // Adding histograms for barrel electrons (isolation stuff)
+  // Adding histograms for barrel electrons
+  MonitorElement* meEleISO_Ntracks_Bkg_EB_;
   MonitorElement* meEleISO_chIso_Bkg_EB_;
   MonitorElement* meEleISO_rel_chIso_Bkg_EB_;
-
   MonitorElement* meEleISO_Ntracks_MTD_1_Bkg_EB_;
   MonitorElement* meEleISO_chIso_MTD_1_Bkg_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_1_Bkg_EB_;
@@ -488,18 +483,6 @@ private:
   MonitorElement* meEleISO_Ntracks_MTD_7_Bkg_EB_;
   MonitorElement* meEleISO_chIso_MTD_7_Bkg_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_7_Bkg_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EB_;
-  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EB_;
-  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EB_;
-  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EB_;
-  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_;
 
   MonitorElement* meEleISO_Ntracks_MTD_sim_1_Bkg_EB_;
   MonitorElement* meEleISO_chIso_MTD_sim_1_Bkg_EB_;
@@ -529,6 +512,22 @@ private:
   MonitorElement* meEleISO_chIso_MTD_sim_7_Bkg_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_;
 
+  MonitorElement* meEleISO_Ntracks_gen_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_gen_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_gen_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EB_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_;
+
   MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_;
   MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_;
@@ -545,7 +544,6 @@ private:
   MonitorElement* meEle_pt_sim_tot_Bkg_EB_;
   MonitorElement* meEle_eta_tot_Bkg_EB_;
   MonitorElement* meEle_phi_tot_Bkg_EB_;
-
   MonitorElement* meEle_pt_MTD_1_Bkg_EB_;
   MonitorElement* meEle_pt_sim_MTD_1_Bkg_EB_;
   MonitorElement* meEle_eta_MTD_1_Bkg_EB_;
@@ -585,6 +583,10 @@ private:
   MonitorElement* meEle_eta_noMTD_Bkg_EB_;
   MonitorElement* meEle_phi_noMTD_Bkg_EB_;
 
+  MonitorElement* meEle_pt_gen_Bkg_EB_;
+  MonitorElement* meEle_eta_gen_Bkg_EB_;
+  MonitorElement* meEle_phi_gen_Bkg_EB_;
+
   MonitorElement* meEle_pt_MTD_2sigma_Bkg_EB_;
   MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EB_;
   MonitorElement* meEle_eta_MTD_2sigma_Bkg_EB_;
@@ -600,10 +602,10 @@ private:
   MonitorElement* meEle_eta_MTD_4sigma_Bkg_EB_;
   MonitorElement* meEle_phi_MTD_4sigma_Bkg_EB_;
 
-  MonitorElement* meEleISO_Ntracks_Bkg_EE_;  // Adding histograms for endcap electrons (isolation stuff)
+  // Adding histograms for endcap electrons
+  MonitorElement* meEleISO_Ntracks_Bkg_EE_;
   MonitorElement* meEleISO_chIso_Bkg_EE_;
   MonitorElement* meEleISO_rel_chIso_Bkg_EE_;
-
   MonitorElement* meEleISO_Ntracks_MTD_1_Bkg_EE_;
   MonitorElement* meEleISO_chIso_MTD_1_Bkg_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_1_Bkg_EE_;
@@ -631,18 +633,6 @@ private:
   MonitorElement* meEleISO_Ntracks_MTD_7_Bkg_EE_;
   MonitorElement* meEleISO_chIso_MTD_7_Bkg_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_7_Bkg_EE_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EE_;
-  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EE_;
-  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_;
-
-  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EE_;
-  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EE_;
-  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_;
 
   MonitorElement* meEleISO_Ntracks_MTD_sim_1_Bkg_EE_;
   MonitorElement* meEleISO_chIso_MTD_sim_1_Bkg_EE_;
@@ -672,6 +662,22 @@ private:
   MonitorElement* meEleISO_chIso_MTD_sim_7_Bkg_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_;
 
+  MonitorElement* meEleISO_Ntracks_gen_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_gen_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_gen_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_2sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_3sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_;
+
+  MonitorElement* meEleISO_Ntracks_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_chIso_MTD_4sigma_Bkg_EE_;
+  MonitorElement* meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_;
+
   MonitorElement* meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_;
   MonitorElement* meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_;
   MonitorElement* meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_;
@@ -688,7 +694,6 @@ private:
   MonitorElement* meEle_pt_sim_tot_Bkg_EE_;
   MonitorElement* meEle_eta_tot_Bkg_EE_;
   MonitorElement* meEle_phi_tot_Bkg_EE_;
-
   MonitorElement* meEle_pt_MTD_1_Bkg_EE_;
   MonitorElement* meEle_pt_sim_MTD_1_Bkg_EE_;
   MonitorElement* meEle_eta_MTD_1_Bkg_EE_;
@@ -727,6 +732,10 @@ private:
   MonitorElement* meEle_pt_noMTD_Bkg_EE_;
   MonitorElement* meEle_eta_noMTD_Bkg_EE_;
   MonitorElement* meEle_phi_noMTD_Bkg_EE_;
+
+  MonitorElement* meEle_pt_gen_Bkg_EE_;
+  MonitorElement* meEle_eta_gen_Bkg_EE_;
+  MonitorElement* meEle_phi_gen_Bkg_EE_;
 
   MonitorElement* meEle_pt_MTD_2sigma_Bkg_EE_;
   MonitorElement* meEle_pt_sim_MTD_2sigma_Bkg_EE_;
@@ -771,12 +780,16 @@ private:
   MonitorElement* meEle_dt_general_eta_3;
   MonitorElement* meEle_dt_general_eta_4;
   MonitorElement* meEle_dt_general_eta_5;
+  MonitorElement* meEle_dt_general_eta_6;
+  MonitorElement* meEle_dt_general_eta_7;
 
   MonitorElement* meEle_dtSignif_general_eta_1;
   MonitorElement* meEle_dtSignif_general_eta_2;
   MonitorElement* meEle_dtSignif_general_eta_3;
   MonitorElement* meEle_dtSignif_general_eta_4;
   MonitorElement* meEle_dtSignif_general_eta_5;
+  MonitorElement* meEle_dtSignif_general_eta_6;
+  MonitorElement* meEle_dtSignif_general_eta_7;
 
   // promt part for histogram vectors
   std::vector<MonitorElement*> Ntracks_EB_list_Sig;
@@ -900,11 +913,19 @@ MtdEleIsoValidation::MtdEleIsoValidation(const edm::ParameterSet& iConfig)
       trackMaxEta_(iConfig.getParameter<double>("trackMaximumEta")),
       rel_iso_cut_(iConfig.getParameter<double>("rel_iso_cut")),
       track_match_PV_(iConfig.getParameter<bool>("optionTrackMatchToPV")),
-      dt_sig_vtx_(iConfig.getParameter<bool>("option_dtToPV")),
       dt_sig_track_(iConfig.getParameter<bool>("option_dtToTrack")),
-      dt_distributions_(iConfig.getParameter<bool>("option_dtDistributions")) {
-  //Ntracks_EB_list_Sig(iConfig.getParameter<std::vector<MonitorElement*>>("Ntracks_EB_list_Sig_test")) { // Example that does not work, but does work for double type
-
+      dt_distributions_(iConfig.getParameter<bool>("option_dtDistributions")),
+      optionalPlots_(iConfig.getParameter<bool>("option_plots")),
+      min_dR_cut(iConfig.getParameter<double>("min_dR_cut")),
+      max_dR_cut(iConfig.getParameter<double>("max_dR_cut")),
+      min_pt_cut_EB(iConfig.getParameter<double>("min_pt_cut_EB")),
+      min_pt_cut_EE(iConfig.getParameter<double>("min_pt_cut_EE")),
+      max_dz_cut_EB(iConfig.getParameter<double>("max_dz_cut_EB")),
+      max_dz_cut_EE(iConfig.getParameter<double>("max_dz_cut_EE")),
+      max_dz_vtx_cut(iConfig.getParameter<double>("max_dz_vtx_cut")),
+      max_dxy_vtx_cut(iConfig.getParameter<double>("max_dxy_vtx_cut")),
+      min_strip_cut(iConfig.getParameter<double>("min_strip_cut")),
+      min_track_mtd_mva_cut(iConfig.getParameter<double>("min_track_mtd_mva_cut")) {
   GenRecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagG"));
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ =
@@ -917,24 +938,14 @@ MtdEleIsoValidation::MtdEleIsoValidation(const edm::ParameterSet& iConfig)
   GenParticleToken_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("inputGenP"));
 
   HepMCProductToken_ = consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("inputTagH"));
-  trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
-  pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
-  tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
-  SigmatmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtd"));
-  t0SrcToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0Src"));
-  Sigmat0SrcToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0Src"));
   t0PidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0PID"));
   Sigmat0PidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0PID"));
-  t0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0SafePID"));
-  Sigmat0SafePidToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0SafePID"));
   trackMVAQualToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("trackMVAQual"));
 
   trackingParticleCollectionToken_ =
-      consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));  // From Aurora
+      consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));
   recoToSimAssociationToken_ =
-      consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));  // From Aurora
-
-  particleTableToken_ = esConsumes<HepPDT::ParticleDataTable, edm::DefaultRecord>();
+      consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
 }
 
 MtdEleIsoValidation::~MtdEleIsoValidation() {}
@@ -945,26 +956,14 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   using namespace geant_units::operators;
   using namespace std;
 
-  //auto GenRecTrackHandle = makeValid(iEvent.getHandle(GenRecTrackToken_));
-  //edm::Handle<reco::TrackCollection> GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
   auto GenRecTrackHandle = iEvent.getHandle(GenRecTrackToken_);
 
-  //auto RecVertexHandle_ = makeValid(iEvent.getHandle(RecVertexToken_));
-  auto VertexHandle_ = iEvent.getHandle(RecVertexToken_);
-
-  std::vector<reco::Vertex> vertices = *VertexHandle_;
+  auto VertexHandle = iEvent.getHandle(RecVertexToken_);
+  std::vector<reco::Vertex> vertices = *VertexHandle;
 
   const auto& t0Pid = iEvent.get(t0PidToken_);
   const auto& Sigmat0Pid = iEvent.get(Sigmat0PidToken_);
   const auto& mtdQualMVA = iEvent.get(trackMVAQualToken_);
-  //const auto& tMtd = iEvent.get(tmtdToken_);
-  //const auto& SigmatMtd = iEvent.get(SigmatmtdToken_);
-  //const auto& t0Src = iEvent.get(t0SrcToken_);
-  //const auto& Sigmat0Src = iEvent.get(Sigmat0SrcToken_);
-  //const auto& t0Safe = iEvent.get(t0SafePidToken_);
-  //const auto& Sigmat0Safe = iEvent.get(Sigmat0SafePidToken_);
-  //const auto& trackAssoc = iEvent.get(trackAssocToken_);
-  //const auto& pathLength = iEvent.get(pathLengthToken_);
 
   auto eleHandle_EB = makeValid(iEvent.getHandle(GsfElectronToken_EB_));
   reco::GsfElectronCollection eleColl_EB = *(eleHandle_EB.product());
@@ -972,61 +971,42 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto eleHandle_EE = makeValid(iEvent.getHandle(GsfElectronToken_EE_));
   reco::GsfElectronCollection eleColl_EE = *(eleHandle_EE.product());
 
-  auto GenPartHandle =
-      makeValid(iEvent.getHandle(GenParticleToken_));  // Aurora uses getByToken, result should be the same
+  auto GenPartHandle = makeValid(iEvent.getHandle(GenParticleToken_));
   reco::GenParticleCollection GenPartColl = *(GenPartHandle.product());
 
-  auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));  // From Aurora
-  const reco::RecoToSimCollection* r2s_ = recoToSimH.product();               // From Aurora
+  auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
+  const reco::RecoToSimCollection* r2s_ = recoToSimH.product();
 
   // Creating combined electron collection
-
   std::vector<reco::GsfElectron> localEleCollection;
-  localEleCollection.reserve(
-      eleColl_EB.size() + eleColl_EE.size());  // From Aurora, added for saving memory and running time (reserve memory)
-
+  localEleCollection.reserve(eleColl_EB.size() + eleColl_EE.size());
   for (const auto& ele_EB : eleColl_EB) {
     if (ele_EB.isEB()) {
-      localEleCollection.emplace_back(ele_EB);  // changed to emplace_back instead of push_back (From Aurora)
+      localEleCollection.emplace_back(ele_EB);
     }
   }
-
   for (const auto& ele_EE : eleColl_EE) {
     if (ele_EE.isEE()) {
-      localEleCollection.emplace_back(ele_EE);  // changed to emplace_back instead of push_back (From Aurora)
+      localEleCollection.emplace_back(ele_EE);
     }
   }
-  localEleCollection.shrink_to_fit();  // From Aurora, optimize vector momery size
-
-  // timing cut type check (if both true, only check cut wrt. vtx not electron track)
-  if (dt_sig_vtx_ && dt_sig_track_) {
-    dt_sig_track_ = false;
-    std::cout
-        << "Both timing cut types chosen!!! Fix this at the configuration setup. Default timing wrt. vtx chosen!!!!"
-        << std::endl;
-  }
-
-  // Selecting the PV from 3D and 4D vertex collections
+  localEleCollection.shrink_to_fit();
 
   reco::Vertex Vtx_chosen;
-
   // This part has to be included, because in ~1% of the events, the "good" vertex is the 1st one not the 0th one in the collection
   for (int iVtx = 0; iVtx < (int)vertices.size(); iVtx++) {
     const reco::Vertex& vertex = vertices.at(iVtx);
-
     if (!vertex.isFake() && vertex.ndof() >= 4) {
       Vtx_chosen = vertex;
       break;
     }
   }
-  // Vertex selection ends
 
-  // auto isPrompt = [](int pdg) {
-  //   pdg = std::abs(pdg);
-  //   return (pdg == 23 or pdg == 24 or pdg==15 or pdg==11); // some electrons are mothers to themselves?
-  // };
+  auto pdgCheck = [](int pdg) {
+    pdg = std::abs(pdg);
+    return (pdg == 23 or pdg == 24 or pdg == 15 or pdg == 11);  // some electrons are mothers to themselves?
+  };
 
-  //for (const auto& ele : eleColl_EB){
   for (const auto& ele : localEleCollection) {
     bool ele_Promt = false;
 
@@ -1034,92 +1014,70 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     float ele_track_source_dxy = fabs(ele.gsfTrack()->dxy(Vtx_chosen.position()));
 
     const reco::TrackRef ele_TrkRef = ele.core()->ctfTrack();
-    double tsim = -1.;
+    double tsim_ele = -1.;
     double ele_sim_pt = -1.;
+    double ele_sim_phi = -1.;
+    double ele_sim_eta = -1.;
 
-    if (ele.pt() > 10 && fabs(ele.eta()) < 2.4 && ele_track_source_dz < max_dz_vtx_cut &&
-        ele_track_source_dxy < max_dxy_vtx_cut) {  // selecting "good" RECO electrons
+    // selecting "good" RECO electrons
+    // PARAM
+    if (ele.pt() < 10 || fabs(ele.eta()) > 2.4 || ele_track_source_dz > max_dz_vtx_cut ||
+        ele_track_source_dxy > max_dxy_vtx_cut)
+      continue;
 
-      // Do the RECO-GEN match through RECOtoSIMcollection link (From Aurora)
-
-      const reco::TrackBaseRef trkrefb(ele_TrkRef);
-
-      auto found = r2s_->find(trkrefb);  // find the track link?
-      if (found != r2s_->end()) {
-        const auto& tp = (found->val)[0];
-        tsim = (tp.first)->parentVertex()->position().t() * 1e9;
-        ele_sim_pt = (tp.first)->pt();
-        // check that the genParticle vector is not empty
-        if (((found->val)[0]).first->status() != -99) {
-          const auto genParticle = *(tp.first->genParticles()[0]);
-          // check if prompt (not from hadron, muon, or tau decay) and final state
-          // or if is a direct decay product of a prompt tau and is final state
-          //if ((genParticle.isPromptFinalState() or genParticle.isDirectPromptTauDecayProductFinalState()) and isPrompt(genParticle.mother()->pdgId())) {
-          if ((genParticle.isPromptFinalState() or genParticle.isDirectPromptTauDecayProductFinalState()) and
-              pdgCheck(genParticle.mother()->pdgId())) {
-            ele_Promt = true;
-          }
+    // association with tracking particle to have sim info
+    const reco::TrackBaseRef trkrefb(ele_TrkRef);
+    auto found = r2s_->find(trkrefb);
+    if (found != r2s_->end()) {
+      const auto& tp = (found->val)[0];
+      tsim_ele = (tp.first)->parentVertex()->position().t() * 1e9;
+      ele_sim_pt = (tp.first)->pt();
+      ele_sim_phi = (tp.first)->phi();
+      ele_sim_eta = (tp.first)->eta();
+      // check that the genParticle vector is not empty
+      if (tp.first->status() != -99) {
+        const auto genParticle = *(tp.first->genParticles()[0]);
+        // check if prompt (not from hadron, muon, or tau decay) and final state
+        // or if is a direct decay product of a prompt tau and is final state
+        if ((genParticle.isPromptFinalState() or genParticle.isDirectPromptTauDecayProductFinalState()) and
+            pdgCheck(genParticle.mother()->pdgId())) {
+          ele_Promt = true;
+          // TODO get simtrackster from mtd, simtrack to tp and check that a recocluster was there
         }
       }
-
-      meEle_test_check_->Fill(tsim);
-
-      // old matching
-      // math::XYZVector EleMomentum = ele.momentum();
-
-      // for (const auto& genParticle : GenPartColl) {
-      //   math::XYZVector GenPartMomentum = genParticle.momentum();
-      //   double dr_match = reco::deltaR(GenPartMomentum, EleMomentum);
-
-      //   if (((genParticle.pdgId() == 11 && ele.charge() == -1) || (genParticle.pdgId() == -11 && ele.charge() == 1)) &&
-      //       dr_match < 0.10) {  // dR match check and charge match check
-
-      //     if (genParticle.mother()->pdgId() == 23 || fabs(genParticle.mother()->pdgId()) == 24 ||
-      //         fabs(genParticle.mother()->pdgId()) ==
-      //             15) {  // check if ele mother is Z,W or tau (W->tau->ele decays, as these still should be quite isolated)
-      //       ele_Promt = true;  // ele is defined as promt
-      //     }
-      //     break;
-
-      //   } else {
-      //     continue;
-      //   }
-      // }
-    } else {
-      continue;
     }
 
-    math::XYZVector EleSigTrackMomentumAtVtx = ele.gsfTrack()->momentum();  // not sure if correct, but works
+    math::XYZVector EleSigTrackMomentumAtVtx = ele.gsfTrack()->momentum();
     double EleSigTrackEtaAtVtx = ele.gsfTrack()->eta();
 
-    double ele_sigTrkTime = -1;  // electron signal track MTD information
+    double ele_sigTrkTime = -1;
     double ele_sigTrkTimeErr = -1;
     double ele_sigTrkMtdMva = -1;
 
-    // Removed track dR matching as we have track references (From Aurora)
-    if (ele_TrkRef.isNonnull()) {  // if we found a track match, we add MTD timing information for it
-
-      bool Barrel_ele = ele.isEB();  // for track pT/dz cuts (Different for EB and EE in TDR)
-
+    // if we found a track match, we add MTD timing information for it
+    if (ele_TrkRef.isNonnull()) {
+      // track pT/dz cuts
+      bool Barrel_ele = ele.isEB();
       float min_pt_cut = Barrel_ele ? min_pt_cut_EB : min_pt_cut_EE;
       float max_dz_cut = Barrel_ele ? max_dz_cut_EB : max_dz_cut_EE;
 
       ele_sigTrkTime = t0Pid[ele_TrkRef];
-      ele_sigTrkTimeErr = Sigmat0Pid[ele_TrkRef];
       ele_sigTrkMtdMva = mtdQualMVA[ele_TrkRef];
-      ele_sigTrkTimeErr = (ele_sigTrkMtdMva > min_track_mtd_mva_cut) ? ele_sigTrkTimeErr : -1;
+      ele_sigTrkTimeErr = (ele_sigTrkMtdMva > min_track_mtd_mva_cut) ? Sigmat0Pid[ele_TrkRef] : -1;
 
       meEle_avg_error_SigTrk_check_->Fill(ele_sigTrkTimeErr);
 
       if (ele_Promt) {
         // For signal (promt)
         if (Barrel_ele) {
-          meEle_pt_tot_Sig_EB_->Fill(ele.pt());  // All selected electron information for efficiency plots later
+          // All selected electron information for efficiency plots later
+          meEle_pt_tot_Sig_EB_->Fill(ele.pt());
           meEle_pt_sim_tot_Sig_EB_->Fill(ele_sim_pt);
           meEle_eta_tot_Sig_EB_->Fill(ele.eta());
           meEle_phi_tot_Sig_EB_->Fill(ele.phi());
         } else {
-          meEle_pt_tot_Sig_EE_->Fill(ele.pt());  // All selected electron information for efficiency plots later
+          // All selected electron information for efficiency plots later
+          meEle_pt_tot_Sig_EE_->Fill(ele.pt());
           meEle_pt_sim_tot_Sig_EE_->Fill(ele_sim_pt);
           meEle_eta_tot_Sig_EE_->Fill(ele.eta());
           meEle_phi_tot_Sig_EE_->Fill(ele.phi());
@@ -1139,22 +1097,25 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         }
       }
 
-      int N_tracks_noMTD = 0;  // values for no MTD case
+      int N_tracks_noMTD = 0;
       double pT_sum_noMTD = 0;
       double rel_pT_sum_noMTD = 0;
-      std::vector<int> N_tracks_MTD{0, 0, 0, 0, 0, 0, 0};  // values for MTD case - 7 timing cuts // RECO
+      std::vector<int> N_tracks_MTD{0, 0, 0, 0, 0, 0, 0};
       std::vector<double> pT_sum_MTD{0, 0, 0, 0, 0, 0, 0};
       std::vector<double> rel_pT_sum_MTD{0, 0, 0, 0, 0, 0, 0};
 
-      std::vector<int> N_tracks_sim_MTD{0, 0, 0, 0, 0, 0, 0};  // SIM
+      std::vector<int> N_tracks_sim_MTD{0, 0, 0, 0, 0, 0, 0};
       std::vector<double> pT_sum_sim_MTD{0, 0, 0, 0, 0, 0, 0};
       std::vector<double> rel_pT_sum_sim_MTD{0, 0, 0, 0, 0, 0, 0};
+      int N_tracks_gen = 0;
+      double pT_sum_gen = 0;
+      double rel_pT_sum_gen = 0;
 
-      std::vector<int> N_tracks_MTD_significance{0, 0, 0};  // values for MTD case - 3 significance cuts // RECO
+      std::vector<int> N_tracks_MTD_significance{0, 0, 0};
       std::vector<double> pT_sum_MTD_significance{0, 0, 0};
       std::vector<double> rel_pT_sum_MTD_significance{0, 0, 0};
 
-      std::vector<int> N_tracks_sim_MTD_significance{0, 0, 0};  // SIM
+      std::vector<int> N_tracks_sim_MTD_significance{0, 0, 0};
       std::vector<double> pT_sum_sim_MTD_significance{0, 0, 0};
       std::vector<double> rel_pT_sum_sim_MTD_significance{0, 0, 0};
 
@@ -1163,140 +1124,146 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         const reco::TrackRef trackref_general(GenRecTrackHandle, general_index);
         general_index++;
 
-        if (trackref_general == ele_TrkRef)  // Skip electron track (From Aurora)
+        // Skip electron track
+        if (trackref_general == ele_TrkRef)
           continue;
 
-        if (trackGen.pt() < min_pt_cut) {  // track pT cut
+        if (trackGen.pt() < min_pt_cut) {
+          continue;
+        }
+        if (fabs(trackGen.vz() - ele.gsfTrack()->vz()) > max_dz_cut) {
           continue;
         }
 
-        if (fabs(trackGen.vz() - ele.gsfTrack()->vz()) > max_dz_cut) {  // general track vs signal track dz cut
-          continue;
-        }
-
+        // cut for general track matching to PV
         if (track_match_PV_) {
-          if (Vtx_chosen.trackWeight(trackref_general) < 0.5) {  // cut for general track matching to PV
+          if (Vtx_chosen.trackWeight(trackref_general) < 0.5) {
             continue;
           }
         }
 
-        double dr_check = reco::deltaR(trackGen.momentum(), EleSigTrackMomentumAtVtx);
+        double dR = reco::deltaR(trackGen.momentum(), EleSigTrackMomentumAtVtx);
         double deta = fabs(trackGen.eta() - EleSigTrackEtaAtVtx);
 
-        if (dr_check > min_dR_cut && dr_check < max_dR_cut &&
-            deta > min_strip_cut) {  // checking if the track is inside isolation cone
-
-          ++N_tracks_noMTD;
-          pT_sum_noMTD += trackGen.pt();
-        } else {
+        // restrict to tracks in the isolation cone
+        if (dR < min_dR_cut || dR > max_dR_cut || deta < min_strip_cut)
           continue;
-        }
 
-        // checking the MTD timing cuts
+        // no MTD case
+        ++N_tracks_noMTD;
+        pT_sum_noMTD += trackGen.pt();
 
-        // Track SIM information (From Aurora)
+        // MTD case
         const reco::TrackBaseRef trkrefBase(trackref_general);
-
         auto TPmatched = r2s_->find(trkrefBase);
         double tsim_trk = -1.;
         double trk_ptSim = -1.;
-        //int genMatched = 0;
+        bool genMatched = false;
         if (TPmatched != r2s_->end()) {
           // reco track matched to a TP
           const auto& tp = (TPmatched->val)[0];
           tsim_trk = (tp.first)->parentVertex()->position().t() * 1e9;
           trk_ptSim = (tp.first)->pt();
-          //     // check that the genParticle vector is not empty
-          //       if (((TPmatched->val)[0]).first->status() != -99) {
-          //     genMatched = 1;
-          //     }
+          // check that the genParticle vector is not empty
+          if (tp.first->status() != -99) {
+            genMatched = true;
+            meTrk_genMatch_check_->Fill(1);
+          } else {
+            meTrk_genMatch_check_->Fill(0);
+          }
         }
 
-        //   meTrk_genMatch_check_->Fill(genMatched);
-
-        meEle_test_check_->Fill(trk_ptSim);
-
-        double TrkMTDTime = t0Pid[trackref_general];  // MTD timing info for particular track fron general tracks
-        double TrkMTDTimeErr = Sigmat0Pid[trackref_general];
+        double TrkMTDTime = t0Pid[trackref_general];
         double TrkMTDMva = mtdQualMVA[trackref_general];
-        TrkMTDTimeErr = (TrkMTDMva > min_track_mtd_mva_cut) ? TrkMTDTimeErr : -1;  // track MTD MVA cut/check
+        double TrkMTDTimeErr = (TrkMTDMva > min_track_mtd_mva_cut) ? Sigmat0Pid[trackref_general] : -1;
 
         meEle_avg_error_PUTrk_check_->Fill(TrkMTDTimeErr);
 
-        if (dt_sig_track_) {
-          double dt_sigTrk = 0;  // dt regular track vs signal track (absolute value)
-          double dt_sigTrk_signif = 0;
+        // MTD GEN case
+        if (genMatched) {
+          N_tracks_gen++;
+          pT_sum_gen += trk_ptSim;
+        }
 
-          double dt_sim_sigTrk = 0;  // for SIM case
+        // dt with the track
+        if (dt_sig_track_) {
+          double dt_sigTrk = 0;
+          double dt_sigTrk_signif = 0;
+          double dt_sim_sigTrk = 0;
           double dt_sim_sigTrk_signif = 0;
 
-          // SIM CASE trk-SigTrk STARTS
-          if (fabs(tsim_trk) > 0 && fabs(tsim) > 0 && trk_ptSim > 0) {
-            dt_sim_sigTrk = fabs(tsim_trk - tsim);
-            dt_sim_sigTrk_signif =
-                dt_sim_sigTrk /
-                std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
-                          avg_sim_sigTrk_t_err * avg_sim_sigTrk_t_err);  // FIX ERRORS FOR SIGNIFICANCE IN SIM CASE
+          // MTD SIM CASE
+          if (fabs(tsim_trk) > 0 && fabs(tsim_ele) > 0 && trk_ptSim > 0) {
+            dt_sim_sigTrk = fabs(tsim_trk - tsim_ele);
+            dt_sim_sigTrk_signif = dt_sim_sigTrk / std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
+                                                             avg_sim_sigTrk_t_err * avg_sim_sigTrk_t_err);
 
-            // absolute timing cuts
-            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
-              if (dt_sim_sigTrk < max_dt_track_cut[i]) {
-                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
-                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+            if (optionalPlots_) {
+              // absolute timing cuts
+              for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+                if (dt_sim_sigTrk < max_dt_track_cut[i]) {
+                  N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+                  pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+                }
               }
             }
             // significance cuts
             for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
               if (dt_sim_sigTrk_signif < max_dt_significance_cut[i]) {
-                N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
-                pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+                N_tracks_sim_MTD_significance[i]++;
+                pT_sum_sim_MTD_significance[i] += trk_ptSim;
               }
             }
 
-          } else {  // if there is no error for MTD information, we count the MTD isolation case same as noMTD
-            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
-              N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
-              pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+          } else {
+            // if there is no error for MTD information, we count the MTD isolation case same as noMTD
+            if (optionalPlots_) {
+              for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+              }
             }
-
             for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
-              N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
-              pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+              N_tracks_sim_MTD_significance[i]++;
+              pT_sum_sim_MTD_significance[i] += trk_ptSim;
             }
           }
-          // SIM CASE trk-SigTrk ENDS
 
-          // Regular RECO MTD check
+          // MTD reco case
           if (TrkMTDTimeErr > 0 && ele_sigTrkTimeErr > 0) {
             dt_sigTrk = fabs(TrkMTDTime - ele_sigTrkTime);
             dt_sigTrk_signif =
                 dt_sigTrk / std::sqrt(TrkMTDTimeErr * TrkMTDTimeErr + ele_sigTrkTimeErr * ele_sigTrkTimeErr);
 
             meEle_no_dt_check_->Fill(1);
-            // absolute timing cuts
-            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
-              if (dt_sigTrk < max_dt_track_cut[i]) {
-                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
-                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+            if (optionalPlots_) {
+              // absolute timing cuts
+              for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+                if (dt_sigTrk < max_dt_track_cut[i]) {
+                  N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
+                  pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+                }
               }
             }
             // significance cuts
             for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
               if (dt_sigTrk_signif < max_dt_significance_cut[i]) {
-                N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;
-                pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();
+                N_tracks_MTD_significance[i]++;
+                pT_sum_MTD_significance[i] += trackGen.pt();
               }
             }
 
-          } else {  // if there is no error for MTD information, we count the MTD isolation case same as noMTD
-            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
-              N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
-              pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT sum
+          } else {
+            // if there is no error for MTD information, we count the MTD isolation case same as noMTD
+            if (optionalPlots_) {
+              for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
+                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT sum
+              }
             }
-
             for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
-              N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;          // N_tracks_noMTD
-              pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();  // pT sum
+              N_tracks_MTD_significance[i]++;
+              pT_sum_MTD_significance[i] += trackGen.pt();
             }
             meEle_no_dt_check_->Fill(0);
           }
@@ -1318,48 +1285,50 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               }
             }
           }  // End of optional dt distributions plots
-        }
 
-        if (dt_sig_vtx_) {
+          // dt with the vertex
+        } else {
           double dt_vtx = 0;  // dt regular track vs vtx
           double dt_vtx_signif = 0;
 
           double dt_sim_vtx = 0;  // dt regular track vs vtx
           double dt_sim_vtx_signif = 0;
 
-          //SIM CASE trk-vertex STARTS
+          // MTD SIM case
           if (fabs(tsim_trk) > 0 && Vtx_chosen.tError() > 0 && trk_ptSim > 0) {
             dt_sim_vtx = fabs(tsim_trk - Vtx_chosen.t());
             dt_sim_vtx_signif = dt_sim_vtx / std::sqrt(avg_sim_PUtrack_t_err * avg_sim_PUtrack_t_err +
                                                        Vtx_chosen.tError() * Vtx_chosen.tError());
-            // absolute timing cuts
-            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
-              if (dt_sim_vtx < max_dt_vtx_cut[i]) {
-                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
-                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+            if (optionalPlots_) {
+              // absolute timing cuts
+              for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+                if (dt_sim_vtx < max_dt_vtx_cut[i]) {
+                  N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;
+                  pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;
+                }
               }
             }
             // significance timing cuts
             for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
               if (dt_sim_vtx_signif < max_dt_significance_cut[i]) {
-                N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;
-                pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;
+                N_tracks_sim_MTD_significance[i]++;
+                pT_sum_sim_MTD_significance[i] += trk_ptSim;
               }
             }
-
           } else {
-            for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
-              N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;      // N_tracks_noMTD
-              pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;  // pT_sum_noMTD
+            if (optionalPlots_) {
+              for (long unsigned int i = 0; i < N_tracks_sim_MTD.size(); i++) {
+                N_tracks_sim_MTD[i] = N_tracks_sim_MTD[i] + 1;      // N_tracks_noMTD
+                pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] + trk_ptSim;  // pT_sum_noMTD
+              }
             }
-
             for (long unsigned int i = 0; i < N_tracks_sim_MTD_significance.size(); i++) {
-              N_tracks_sim_MTD_significance[i] = N_tracks_sim_MTD_significance[i] + 1;      // N_tracks_noMTD
-              pT_sum_sim_MTD_significance[i] = pT_sum_sim_MTD_significance[i] + trk_ptSim;  // pT sum
+              N_tracks_sim_MTD_significance[i]++;
+              pT_sum_sim_MTD_significance[i] += trk_ptSim;
             }
-          }  // SIM CASE trk-vertex ENDS
+          }
 
-          //Regular RECO MTD case
+          // MTD RECO case
           if (TrkMTDTimeErr > 0 && Vtx_chosen.tError() > 0) {
             dt_vtx = fabs(TrkMTDTime - Vtx_chosen.t());
             dt_vtx_signif =
@@ -1367,36 +1336,37 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
             meEle_no_dt_check_->Fill(1);
             meEle_avg_error_vtx_check_->Fill(Vtx_chosen.tError());
-
-            // absolute timing cuts
-            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
-              if (dt_vtx < max_dt_vtx_cut[i]) {
-                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
-                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+            if (optionalPlots_) {
+              // absolute timing cuts
+              for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+                if (dt_vtx < max_dt_vtx_cut[i]) {
+                  N_tracks_MTD[i] = N_tracks_MTD[i] + 1;
+                  pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();
+                }
               }
             }
             // significance timing cuts
             for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
               if (dt_vtx_signif < max_dt_significance_cut[i]) {
-                N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;
-                pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();
+                N_tracks_MTD_significance[i]++;
+                pT_sum_MTD_significance[i] += trackGen.pt();
               }
             }
-
           } else {
-            for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
-              N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
-              pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT_sum_noMTD
+            if (optionalPlots_) {
+              for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+                N_tracks_MTD[i] = N_tracks_MTD[i] + 1;          // N_tracks_noMTD
+                pT_sum_MTD[i] = pT_sum_MTD[i] + trackGen.pt();  // pT_sum_noMTD
+              }
             }
-
             for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
-              N_tracks_MTD_significance[i] = N_tracks_MTD_significance[i] + 1;          // N_tracks_noMTD
-              pT_sum_MTD_significance[i] = pT_sum_MTD_significance[i] + trackGen.pt();  // pT sum
+              N_tracks_MTD_significance[i]++;
+              pT_sum_MTD_significance[i] += trackGen.pt();
             }
             meEle_no_dt_check_->Fill(0);
           }
 
-          /// Optional dt distribution plots
+          // Optional dt distribution plots
           if (dt_distributions_) {
             for (long unsigned int i = 0; i < (pT_bins_dt_distrb.size() - 1); i++) {
               //stuff general pT
@@ -1416,11 +1386,16 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }  // End of optional dt distributions plots
         }
       }
-
       rel_pT_sum_noMTD = pT_sum_noMTD / ele.gsfTrack()->pt();  // rel_ch_iso calculation
-      for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
-        rel_pT_sum_MTD[i] = pT_sum_MTD[i] / ele.gsfTrack()->pt();
-        rel_pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] / ele_sim_pt;
+      if (optionalPlots_) {
+        for (long unsigned int i = 0; i < N_tracks_MTD.size(); i++) {
+          rel_pT_sum_MTD[i] = pT_sum_MTD[i] / ele.gsfTrack()->pt();
+          rel_pT_sum_sim_MTD[i] = pT_sum_sim_MTD[i] / ele_sim_pt;
+        }
+        // now compute the isolation
+        rel_pT_sum_noMTD = pT_sum_noMTD / ele.gsfTrack()->pt();
+
+        rel_pT_sum_gen = pT_sum_gen / ele.gsfTrack()->pt();
       }
 
       for (long unsigned int i = 0; i < N_tracks_MTD_significance.size(); i++) {
@@ -1430,18 +1405,22 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       if (ele_Promt) {  // promt part
         if (Barrel_ele) {
-          meEleISO_Ntracks_Sig_EB_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_Ntracks_Sig_EB_->Fill(N_tracks_noMTD);
           meEleISO_chIso_Sig_EB_->Fill(pT_sum_noMTD);
           meEleISO_rel_chIso_Sig_EB_->Fill(rel_pT_sum_noMTD);
+          if (optionalPlots_) {
+            for (long unsigned int j = 0; j < Ntracks_EB_list_Sig.size(); j++) {
+              Ntracks_EB_list_Sig[j]->Fill(N_tracks_MTD[j]);
+              ch_iso_EB_list_Sig[j]->Fill(pT_sum_MTD[j]);
+              rel_ch_iso_EB_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
 
-          for (long unsigned int j = 0; j < Ntracks_EB_list_Sig.size(); j++) {
-            Ntracks_EB_list_Sig[j]->Fill(N_tracks_MTD[j]);
-            ch_iso_EB_list_Sig[j]->Fill(pT_sum_MTD[j]);
-            rel_ch_iso_EB_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
-
-            Ntracks_sim_EB_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
-            ch_iso_sim_EB_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
-            rel_ch_iso_sim_EB_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+              Ntracks_sim_EB_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
+              ch_iso_sim_EB_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
+              rel_ch_iso_sim_EB_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+            }
+            meEleISO_Ntracks_gen_Sig_EB_->Fill(N_tracks_gen);
+            meEleISO_chIso_gen_Sig_EB_->Fill(pT_sum_gen);
+            meEleISO_rel_chIso_gen_Sig_EB_->Fill(rel_pT_sum_gen);
           }
 
           for (long unsigned int j = 0; j < Ntracks_EB_list_Significance_Sig.size(); j++) {
@@ -1449,9 +1428,11 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             ch_iso_EB_list_Significance_Sig[j]->Fill(pT_sum_MTD_significance[j]);
             rel_ch_iso_EB_list_Significance_Sig[j]->Fill(rel_pT_sum_MTD_significance[j]);
 
-            Ntracks_sim_EB_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
-            ch_iso_sim_EB_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
-            rel_ch_iso_sim_EB_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            if (optionalPlots_) {
+              Ntracks_sim_EB_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
+              ch_iso_sim_EB_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
+              rel_ch_iso_sim_EB_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            }
           }
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
@@ -1459,14 +1440,20 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meEle_eta_noMTD_Sig_EB_->Fill(ele.eta());
             meEle_phi_noMTD_Sig_EB_->Fill(ele.phi());
           }
+          if (optionalPlots_) {
+            for (long unsigned int k = 0; k < Ntracks_EB_list_Sig.size(); k++) {
+              if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+                Ele_pT_MTD_EB_list_Sig[k]->Fill(ele.pt());
+                Ele_eta_MTD_EB_list_Sig[k]->Fill(ele.eta());
+                Ele_phi_MTD_EB_list_Sig[k]->Fill(ele.phi());
 
-          for (long unsigned int k = 0; k < Ntracks_EB_list_Sig.size(); k++) {
-            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
-              Ele_pT_MTD_EB_list_Sig[k]->Fill(ele.pt());
-              Ele_eta_MTD_EB_list_Sig[k]->Fill(ele.eta());
-              Ele_phi_MTD_EB_list_Sig[k]->Fill(ele.phi());
-
-              Ele_pT_sim_MTD_EB_list_Sig[k]->Fill(ele_sim_pt);
+                Ele_pT_sim_MTD_EB_list_Sig[k]->Fill(ele_sim_pt);
+              }
+            }
+            if (rel_pT_sum_gen < rel_iso_cut_) {
+              meEle_pt_gen_Sig_EB_->Fill(ele_sim_pt);
+              meEle_eta_gen_Sig_EB_->Fill(ele_sim_eta);
+              meEle_phi_gen_Sig_EB_->Fill(ele_sim_phi);
             }
           }
 
@@ -1475,25 +1462,29 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
               Ele_pT_MTD_EB_list_Significance_Sig[k]->Fill(ele.pt());
               Ele_eta_MTD_EB_list_Significance_Sig[k]->Fill(ele.eta());
               Ele_phi_MTD_EB_list_Significance_Sig[k]->Fill(ele.phi());
-
-              Ele_pT_sim_MTD_EB_list_Significance_Sig[k]->Fill(ele_sim_pt);
             }
+            if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
+              Ele_pT_sim_MTD_EB_list_Significance_Sig[k]->Fill(ele_sim_pt);
           }
 
         } else {  // for endcap
 
-          meEleISO_Ntracks_Sig_EE_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_Ntracks_Sig_EE_->Fill(N_tracks_noMTD);
           meEleISO_chIso_Sig_EE_->Fill(pT_sum_noMTD);
           meEleISO_rel_chIso_Sig_EE_->Fill(rel_pT_sum_noMTD);
+          if (optionalPlots_) {
+            for (long unsigned int j = 0; j < Ntracks_EE_list_Sig.size(); j++) {
+              Ntracks_EE_list_Sig[j]->Fill(N_tracks_MTD[j]);
+              ch_iso_EE_list_Sig[j]->Fill(pT_sum_MTD[j]);
+              rel_ch_iso_EE_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
 
-          for (long unsigned int j = 0; j < Ntracks_EE_list_Sig.size(); j++) {
-            Ntracks_EE_list_Sig[j]->Fill(N_tracks_MTD[j]);
-            ch_iso_EE_list_Sig[j]->Fill(pT_sum_MTD[j]);
-            rel_ch_iso_EE_list_Sig[j]->Fill(rel_pT_sum_MTD[j]);
-
-            Ntracks_sim_EE_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
-            ch_iso_sim_EE_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
-            rel_ch_iso_sim_EE_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+              Ntracks_sim_EE_list_Sig[j]->Fill(N_tracks_sim_MTD[j]);
+              ch_iso_sim_EE_list_Sig[j]->Fill(pT_sum_sim_MTD[j]);
+              rel_ch_iso_sim_EE_list_Sig[j]->Fill(rel_pT_sum_sim_MTD[j]);
+            }
+            meEleISO_Ntracks_gen_Sig_EE_->Fill(N_tracks_gen);
+            meEleISO_chIso_gen_Sig_EE_->Fill(pT_sum_gen);
+            meEleISO_rel_chIso_gen_Sig_EE_->Fill(rel_pT_sum_gen);
           }
 
           for (long unsigned int j = 0; j < Ntracks_EE_list_Significance_Sig.size(); j++) {
@@ -1501,9 +1492,11 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             ch_iso_EE_list_Significance_Sig[j]->Fill(pT_sum_MTD_significance[j]);
             rel_ch_iso_EE_list_Significance_Sig[j]->Fill(rel_pT_sum_MTD_significance[j]);
 
-            Ntracks_sim_EE_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
-            ch_iso_sim_EE_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
-            rel_ch_iso_sim_EE_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            if (optionalPlots_) {
+              Ntracks_sim_EE_list_Significance_Sig[j]->Fill(N_tracks_sim_MTD_significance[j]);
+              ch_iso_sim_EE_list_Significance_Sig[j]->Fill(pT_sum_sim_MTD_significance[j]);
+              rel_ch_iso_sim_EE_list_Significance_Sig[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            }
           }
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
@@ -1511,41 +1504,51 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meEle_eta_noMTD_Sig_EE_->Fill(ele.eta());
             meEle_phi_noMTD_Sig_EE_->Fill(ele.phi());
           }
+          if (optionalPlots_) {
+            for (long unsigned int k = 0; k < Ntracks_EE_list_Sig.size(); k++) {
+              if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+                Ele_pT_MTD_EE_list_Sig[k]->Fill(ele.pt());
+                Ele_eta_MTD_EE_list_Sig[k]->Fill(ele.eta());
+                Ele_phi_MTD_EE_list_Sig[k]->Fill(ele.phi());
 
-          for (long unsigned int k = 0; k < Ntracks_EE_list_Sig.size(); k++) {
-            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
-              Ele_pT_MTD_EE_list_Sig[k]->Fill(ele.pt());
-              Ele_eta_MTD_EE_list_Sig[k]->Fill(ele.eta());
-              Ele_phi_MTD_EE_list_Sig[k]->Fill(ele.phi());
-
-              Ele_pT_sim_MTD_EE_list_Sig[k]->Fill(ele_sim_pt);
+                Ele_pT_sim_MTD_EE_list_Sig[k]->Fill(ele_sim_pt);
+              }
+            }
+            if (rel_pT_sum_gen < rel_iso_cut_) {
+              meEle_pt_gen_Sig_EE_->Fill(ele_sim_pt);
+              meEle_eta_gen_Sig_EE_->Fill(ele_sim_eta);
+              meEle_phi_gen_Sig_EE_->Fill(ele_sim_phi);
             }
           }
-
           for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Sig.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EE_list_Significance_Sig[k]->Fill(ele.pt());
               Ele_eta_MTD_EE_list_Significance_Sig[k]->Fill(ele.eta());
               Ele_phi_MTD_EE_list_Significance_Sig[k]->Fill(ele.phi());
 
-              Ele_pT_sim_MTD_EE_list_Significance_Sig[k]->Fill(ele_sim_pt);
+              if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
+                Ele_pT_sim_MTD_EE_list_Significance_Sig[k]->Fill(ele_sim_pt);
             }
           }
         }
       } else {  // non-promt part
         if (Barrel_ele) {
-          meEleISO_Ntracks_Bkg_EB_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+          meEleISO_Ntracks_Bkg_EB_->Fill(N_tracks_noMTD);
           meEleISO_chIso_Bkg_EB_->Fill(pT_sum_noMTD);
           meEleISO_rel_chIso_Bkg_EB_->Fill(rel_pT_sum_noMTD);
+          if (optionalPlots_) {
+            for (long unsigned int j = 0; j < Ntracks_EB_list_Bkg.size(); j++) {
+              Ntracks_EB_list_Bkg[j]->Fill(N_tracks_MTD[j]);
+              ch_iso_EB_list_Bkg[j]->Fill(pT_sum_MTD[j]);
+              rel_ch_iso_EB_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
 
-          for (long unsigned int j = 0; j < Ntracks_EB_list_Bkg.size(); j++) {
-            Ntracks_EB_list_Bkg[j]->Fill(N_tracks_MTD[j]);
-            ch_iso_EB_list_Bkg[j]->Fill(pT_sum_MTD[j]);
-            rel_ch_iso_EB_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
-
-            Ntracks_sim_EB_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
-            ch_iso_sim_EB_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
-            rel_ch_iso_sim_EB_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+              Ntracks_sim_EB_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
+              ch_iso_sim_EB_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
+              rel_ch_iso_sim_EB_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+            }
+            meEleISO_Ntracks_gen_Bkg_EB_->Fill(N_tracks_gen);
+            meEleISO_chIso_gen_Bkg_EB_->Fill(pT_sum_gen);
+            meEleISO_rel_chIso_gen_Bkg_EB_->Fill(rel_pT_sum_gen);
           }
 
           for (long unsigned int j = 0; j < Ntracks_EB_list_Significance_Bkg.size(); j++) {
@@ -1553,9 +1556,11 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             ch_iso_EB_list_Significance_Bkg[j]->Fill(pT_sum_MTD_significance[j]);
             rel_ch_iso_EB_list_Significance_Bkg[j]->Fill(rel_pT_sum_MTD_significance[j]);
 
-            Ntracks_sim_EB_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
-            ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
-            rel_ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            if (optionalPlots_) {
+              Ntracks_sim_EB_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
+              ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
+              rel_ch_iso_sim_EB_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            }
           }
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
@@ -1563,40 +1568,50 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meEle_eta_noMTD_Bkg_EB_->Fill(ele.eta());
             meEle_phi_noMTD_Bkg_EB_->Fill(ele.phi());
           }
+          if (optionalPlots_) {
+            for (long unsigned int k = 0; k < Ntracks_EB_list_Bkg.size(); k++) {
+              if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+                Ele_pT_MTD_EB_list_Bkg[k]->Fill(ele.pt());
+                Ele_eta_MTD_EB_list_Bkg[k]->Fill(ele.eta());
+                Ele_phi_MTD_EB_list_Bkg[k]->Fill(ele.phi());
 
-          for (long unsigned int k = 0; k < Ntracks_EB_list_Bkg.size(); k++) {
-            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
-              Ele_pT_MTD_EB_list_Bkg[k]->Fill(ele.pt());
-              Ele_eta_MTD_EB_list_Bkg[k]->Fill(ele.eta());
-              Ele_phi_MTD_EB_list_Bkg[k]->Fill(ele.phi());
-
-              Ele_pT_sim_MTD_EB_list_Bkg[k]->Fill(ele_sim_pt);
+                Ele_pT_sim_MTD_EB_list_Bkg[k]->Fill(ele_sim_pt);
+              }
+            }
+            if (rel_pT_sum_gen < rel_iso_cut_) {
+              meEle_pt_gen_Bkg_EB_->Fill(ele_sim_pt);
+              meEle_eta_gen_Bkg_EB_->Fill(ele_sim_eta);
+              meEle_phi_gen_Bkg_EB_->Fill(ele_sim_phi);
             }
           }
-
           for (long unsigned int k = 0; k < Ntracks_EB_list_Significance_Bkg.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EB_list_Significance_Bkg[k]->Fill(ele.pt());
               Ele_eta_MTD_EB_list_Significance_Bkg[k]->Fill(ele.eta());
               Ele_phi_MTD_EB_list_Significance_Bkg[k]->Fill(ele.phi());
 
-              Ele_pT_sim_MTD_EB_list_Significance_Bkg[k]->Fill(ele_sim_pt);
+              if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
+                Ele_pT_sim_MTD_EB_list_Significance_Bkg[k]->Fill(ele_sim_pt);
             }
           }
 
-        } else {                                           // for endcap
-          meEleISO_Ntracks_Bkg_EE_->Fill(N_tracks_noMTD);  // Filling hists for Ntraks and chIso sums for noMTD case //
+        } else {  // for endcap
+          meEleISO_Ntracks_Bkg_EE_->Fill(N_tracks_noMTD);
           meEleISO_chIso_Bkg_EE_->Fill(pT_sum_noMTD);
           meEleISO_rel_chIso_Bkg_EE_->Fill(rel_pT_sum_noMTD);
+          if (optionalPlots_) {
+            for (long unsigned int j = 0; j < Ntracks_EE_list_Bkg.size(); j++) {
+              Ntracks_EE_list_Bkg[j]->Fill(N_tracks_MTD[j]);
+              ch_iso_EE_list_Bkg[j]->Fill(pT_sum_MTD[j]);
+              rel_ch_iso_EE_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
 
-          for (long unsigned int j = 0; j < Ntracks_EE_list_Bkg.size(); j++) {
-            Ntracks_EE_list_Bkg[j]->Fill(N_tracks_MTD[j]);
-            ch_iso_EE_list_Bkg[j]->Fill(pT_sum_MTD[j]);
-            rel_ch_iso_EE_list_Bkg[j]->Fill(rel_pT_sum_MTD[j]);
-
-            Ntracks_sim_EE_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
-            ch_iso_sim_EE_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
-            rel_ch_iso_sim_EE_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+              Ntracks_sim_EE_list_Bkg[j]->Fill(N_tracks_sim_MTD[j]);
+              ch_iso_sim_EE_list_Bkg[j]->Fill(pT_sum_sim_MTD[j]);
+              rel_ch_iso_sim_EE_list_Bkg[j]->Fill(rel_pT_sum_sim_MTD[j]);
+            }
+            meEleISO_Ntracks_gen_Bkg_EE_->Fill(N_tracks_gen);
+            meEleISO_chIso_gen_Bkg_EE_->Fill(pT_sum_gen);
+            meEleISO_rel_chIso_gen_Bkg_EE_->Fill(rel_pT_sum_gen);
           }
 
           for (long unsigned int j = 0; j < Ntracks_EE_list_Significance_Bkg.size(); j++) {
@@ -1604,9 +1619,11 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             ch_iso_EE_list_Significance_Bkg[j]->Fill(pT_sum_MTD_significance[j]);
             rel_ch_iso_EE_list_Significance_Bkg[j]->Fill(rel_pT_sum_MTD_significance[j]);
 
-            Ntracks_sim_EE_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
-            ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
-            rel_ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            if (optionalPlots_) {
+              Ntracks_sim_EE_list_Significance_Bkg[j]->Fill(N_tracks_sim_MTD_significance[j]);
+              ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(pT_sum_sim_MTD_significance[j]);
+              rel_ch_iso_sim_EE_list_Significance_Bkg[j]->Fill(rel_pT_sum_sim_MTD_significance[j]);
+            }
           }
 
           if (rel_pT_sum_noMTD < rel_iso_cut_) {  // filling hists for iso efficiency calculations
@@ -1614,23 +1631,31 @@ void MtdEleIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
             meEle_eta_noMTD_Bkg_EE_->Fill(ele.eta());
             meEle_phi_noMTD_Bkg_EE_->Fill(ele.phi());
           }
+          if (optionalPlots_) {
+            for (long unsigned int k = 0; k < Ntracks_EE_list_Bkg.size(); k++) {
+              if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
+                Ele_pT_MTD_EE_list_Bkg[k]->Fill(ele.pt());
+                Ele_eta_MTD_EE_list_Bkg[k]->Fill(ele.eta());
+                Ele_phi_MTD_EE_list_Bkg[k]->Fill(ele.phi());
 
-          for (long unsigned int k = 0; k < Ntracks_EE_list_Bkg.size(); k++) {
-            if (rel_pT_sum_MTD[k] < rel_iso_cut_) {
-              Ele_pT_MTD_EE_list_Bkg[k]->Fill(ele.pt());
-              Ele_eta_MTD_EE_list_Bkg[k]->Fill(ele.eta());
-              Ele_phi_MTD_EE_list_Bkg[k]->Fill(ele.phi());
-
-              Ele_pT_sim_MTD_EE_list_Bkg[k]->Fill(ele_sim_pt);
+                Ele_pT_sim_MTD_EE_list_Bkg[k]->Fill(ele_sim_pt);
+              }
+            }
+            if (rel_pT_sum_gen < rel_iso_cut_) {
+              meEle_pt_gen_Bkg_EE_->Fill(ele_sim_pt);
+              meEle_eta_gen_Bkg_EE_->Fill(ele_sim_eta);
+              meEle_phi_gen_Bkg_EE_->Fill(ele_sim_phi);
             }
           }
+
           for (long unsigned int k = 0; k < Ntracks_EE_list_Significance_Bkg.size(); k++) {
             if (rel_pT_sum_MTD_significance[k] < rel_iso_cut_) {
               Ele_pT_MTD_EE_list_Significance_Bkg[k]->Fill(ele.pt());
               Ele_eta_MTD_EE_list_Significance_Bkg[k]->Fill(ele.eta());
               Ele_phi_MTD_EE_list_Significance_Bkg[k]->Fill(ele.phi());
 
-              Ele_pT_sim_MTD_EE_list_Significance_Bkg[k]->Fill(ele_sim_pt);
+              if (optionalPlots_ and rel_pT_sum_sim_MTD_significance[k] < rel_iso_cut_)
+                Ele_pT_sim_MTD_EE_list_Significance_Bkg[k]->Fill(ele_sim_pt);
             }
           }
         }
@@ -1646,12 +1671,15 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   // histogram booking
 
   meEle_avg_error_SigTrk_check_ =
-      ibook.book1D("SigTrk_avg_timming_err", "Average signal electron track MTD timing uncertainty", 200, 0, 2);
-  meEle_avg_error_PUTrk_check_ =
-      ibook.book1D("PUTrk_avg_timming_err", "Average PU track MTD timing uncertainty", 200, 0, 2);
-  meEle_avg_error_vtx_check_ = ibook.book1D("Vtx_avg_timming_err", "Average veretex timing uncertainty", 200, 0, 2);
-
-  meEle_test_check_ = ibook.book1D("test_hist", "test_hist", 102, -2, 100);
+      ibook.book1D("SigTrk_avg_timing_err",
+                   "Average signal electron track MTD timing uncertainty;Time Error (ns);Counts",
+                   200,
+                   0,
+                   0.1);
+  meEle_avg_error_PUTrk_check_ = ibook.book1D(
+      "PUTrk_avg_timing_err", "Average PU track MTD timing uncertainty;Time Error (ns);Counts", 200, 0, 0.1);
+  meEle_avg_error_vtx_check_ =
+      ibook.book1D("Vtx_avg_timing_err", "Average vertex timing uncertainty;Time Error (ns);Counts", 200, 0, 0.1);
 
   meEle_no_dt_check_ =
       ibook.book1D("Track_dt_info_check",
@@ -1660,1937 +1688,2462 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                    0,
                    2);
 
-  meTrk_genMatch_check_ =
-      ibook.book1D("Track_genMatch_info_check", "Track MTD genMatch check - tracks for MTD timing checked", 2, 0, 2);
+  meTrk_genMatch_check_ = ibook.book1D(
+      "Track_genMatch_info_check", "Check on tracks matched with a GenParticle (matched=1, non matched=0)", 2, 0, 2);
 
   // signal
   meEleISO_Ntracks_Sig_EB_ = ibook.book1D("Ele_Iso_Ntracks_Sig_EB",
-                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          "Number of tracks in isolation cone around electron track after basic cuts - "
+                                          "Signal Barrel;Number of tracks;Counts",
                                           20,
                                           0,
-                                          20);  // hists for electrons
+                                          20);
 
   meEleISO_chIso_Sig_EB_ = ibook.book1D(
-      "Ele_chIso_sum_Sig_EB", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
+      "Ele_chIso_sum_Sig_EB",
+      "Track pT sum in isolation cone around electron track after basic cuts - Signal Barrel;p_{T} (GeV);Counts",
+      2000,
+      0,
+      20);
 
-  meEleISO_rel_chIso_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts",
-                   1000,
-                   0,
-                   4);
+  meEleISO_rel_chIso_Sig_EB_ = ibook.book1D(
+      "Ele_rel_chIso_sum_Sig_EB",
+      "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Barrel;Isolation;Counts",
+      1000,
+      0,
+      4);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_1_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
 
-  meEleISO_Ntracks_MTD_1_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
+    meEleISO_chIso_MTD_1_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_1_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_1_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_1_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+    // gen
+    meEleISO_Ntracks_gen_Sig_EB_ = ibook.book1D("Ele_Iso_Ntracks_gen_Sig_EB",
+                                                "Number of tracks in isolation cone around electron track after basic "
+                                                "cuts using genInfo - Signal Barrel;Number of tracks;Counts",
+                                                20,
+                                                0,
+                                                20);
 
-  meEleISO_chIso_MTD_1_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_1_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_1_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_chIso_gen_Sig_EB_ = ibook.book1D("Ele_chIso_sum_gen_Sig_EB",
+                                              "Track pT sum in isolation cone around electron track after basic cuts "
+                                              "using genInfo - Signal Barrel;p_{T} (GeV);Counts",
+                                              2000,
+                                              0,
+                                              20);
 
-  meEleISO_Ntracks_MTD_2_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
+    meEleISO_rel_chIso_gen_Sig_EB_ = ibook.book1D("Ele_rel_chIso_sum_gen_Sig_EB",
+                                                  "Track relative pT sum in isolation cone around electron track after "
+                                                  "basic cuts using genInfo - Signal Barrel;Isolation;Counts",
+                                                  1000,
+                                                  0,
+                                                  4);
 
-  meEleISO_chIso_MTD_2_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_2_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_2_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_2_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
 
-  meEleISO_Ntracks_MTD_3_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_3_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_3_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_3_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_chIso_MTD_2_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_2_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_2_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_2_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_4_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_4_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_4_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_4_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_3_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_3_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_3_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_3_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_3_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_5_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_5_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_5_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_5_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_4_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_4_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_4_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_4_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_4_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_6_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_6_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_6_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_6_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_5_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_5_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_5_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_5_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_5_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_7_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_7_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_7_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_7_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_6_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_6_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_6_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_6_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_6_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
+    meEleISO_Ntracks_MTD_7_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_7_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_7_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_7_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_7_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_1_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+
+    meEleISO_chIso_MTD_sim_1_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_1_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_1_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_1_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_2_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+
+    meEleISO_chIso_MTD_sim_2_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_2_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_2_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_2_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_3_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_3_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_3_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_3_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_4_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_4_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_4_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_4_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_5_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_5_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_5_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_5_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_5_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_6_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_6_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_6_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_6_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_6_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_7_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_7_Sig_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_7_Sig_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_7_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_7_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+  }
   meEleISO_Ntracks_MTD_4sigma_Sig_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 4 sigma compatibiliy - "
+                   "Signal Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_4sigma_Sig_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 4 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Sig_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
+                   "compatibiliy - Signal Barrel;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_3sigma_Sig_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 3 sigma compatibiliy - "
+                   "Signal Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_3sigma_Sig_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 3 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
-  meEleISO_rel_chIso_MTD_3sigma_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+  meEleISO_rel_chIso_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EB",
+                                                       "Track relative pT sum in isolation cone around electron track "
+                                                       "after basic cuts with MTD - 3 sigma;Isolation;Counts"
+                                                       "compatibiliy - Signal Barrel",
+                                                       1000,
+                                                       0,
+                                                       4);
 
   meEleISO_Ntracks_MTD_2sigma_Sig_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 2 sigma compatibiliy - "
+                   "Signal Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_2sigma_Sig_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 2 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Sig_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_1_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-
-  meEleISO_chIso_MTD_sim_1_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_1_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-
-  meEleISO_chIso_MTD_sim_2_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_3_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_4_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_5_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_5_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_5_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_6_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_6_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_6_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_7_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_7_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_7_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_4sigma_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_3sigma_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_2sigma_Sig_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
+                   "compatibiliy - Signal Barrel;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEle_pt_tot_Sig_EB_ =
-      ibook.book1D("Ele_pT_tot_Sig_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
-  meEle_pt_noMTD_Sig_EB_ = ibook.book1D("Ele_pT_noMTD_Sig_EB", "Electron pT noMTD", 30, 10, 100);
+      ibook.book1D("Ele_pT_tot_Sig_EB", "Electron pT tot - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
+  meEle_pt_noMTD_Sig_EB_ =
+      ibook.book1D("Ele_pT_noMTD_Sig_EB", "Electron pT noMTD - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_pt_sim_tot_Sig_EB_ =
-      ibook.book1D("Ele_pT_sim_tot_Sig_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+      ibook.book1D("Ele_pT_sim_tot_Sig_EB", "Electron SIM pT tot - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Sig_EB_ = ibook.book1D("Ele_eta_tot_Sig_EB", "Electron eta tot", 128, -3.2, 3.2);
-  meEle_eta_noMTD_Sig_EB_ = ibook.book1D("Ele_eta_noMTD_Sig_EB", "Electron eta noMTD", 128, -3.2, 3.2);
+  meEle_eta_tot_Sig_EB_ =
+      ibook.book1D("Ele_eta_tot_Sig_EB", "Electron eta tot - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Sig_EB_ =
+      ibook.book1D("Ele_eta_noMTD_Sig_EB", "Electron eta noMTD - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
 
-  meEle_phi_tot_Sig_EB_ = ibook.book1D("Ele_phi_tot_Sig_EB", "Electron phi tot", 128, -3.2, 3.2);
-  meEle_phi_noMTD_Sig_EB_ = ibook.book1D("Ele_phi_noMTD_Sig_EB", "Electron phi noMTD", 128, -3.2, 3.2);
+  meEle_phi_tot_Sig_EB_ =
+      ibook.book1D("Ele_phi_tot_Sig_EB", "Electron phi tot - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Sig_EB_ =
+      ibook.book1D("Ele_phi_noMTD_Sig_EB", "Electron phi noMTD - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_MTD_1_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_1_Sig_EB_ = ibook.book1D("Ele_eta_MTD_1_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_1_Sig_EB_ = ibook.book1D("Ele_phi_MTD_1_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EB",
+                     "Number of tracks in isolation cone around electron track after basic cuts with MTD - 4 sigma "
+                     "compatibiliy - Signal Barrel;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4sigma_Sig_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD - 4 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
+        "compatibiliy - Signal Barrel;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEle_pt_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EB",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD  - 3 sigma compatibiliy - Signal Barrel;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3sigma_Sig_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD - 3 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 3 sigma "
+        "compatibiliy - Signal Barrel;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEle_pt_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_ = ibook.book1D(
+        "Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EB",
+        "Tracks in isolation cone around electron track after basic cuts with MTD - 2 sigma compatibiliy - "
+        "Signal Barrel;Number of tracks;Counts",
+        20,
+        0,
+        20);
+    meEleISO_chIso_MTD_sim_2sigma_Sig_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD - 2 sigma compatibiliy - Signal Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
+        "compatibiliy - Signal Barrel;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEle_pt_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_gen_Sig_EB_ =
+        ibook.book1D("Ele_pT_gen_Sig_EB", "Electron pT genInfo - Signal Barrel;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_gen_Sig_EB_ =
+        ibook.book1D("Ele_eta_gen_Sig_EB", "Electron eta genInfo - Signal Barrel;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_gen_Sig_EB_ =
+        ibook.book1D("Ele_phi_gen_Sig_EB", "Electron phi genInfo - Signal Barrel;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_MTD_5_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_5_Sig_EB_ = ibook.book1D("Ele_eta_MTD_5_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_5_Sig_EB_ = ibook.book1D("Ele_phi_MTD_5_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_MTD_1_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_1_Sig_EB_ = ibook.book1D("Ele_eta_MTD_1_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_1_Sig_EB_ = ibook.book1D("Ele_phi_MTD_1_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_MTD_6_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_6_Sig_EB_ = ibook.book1D("Ele_eta_MTD_6_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_6_Sig_EB_ = ibook.book1D("Ele_phi_MTD_6_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_2_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_2_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_MTD_7_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_7_Sig_EB_ = ibook.book1D("Ele_eta_MTD_7_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_7_Sig_EB_ = ibook.book1D("Ele_phi_MTD_7_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_3_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_3_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_MTD_4_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_4_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_4_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_MTD_5_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_5_Sig_EB_ = ibook.book1D("Ele_eta_MTD_5_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_5_Sig_EB_ = ibook.book1D("Ele_phi_MTD_5_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_MTD_6_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_6_Sig_EB_ = ibook.book1D("Ele_eta_MTD_6_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_6_Sig_EB_ = ibook.book1D("Ele_phi_MTD_6_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_1_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_1_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_2_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_3_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_4_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_4_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_5_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_5_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_6_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_6_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_7_Sig_EB", "Electron pT MTD", 30, 10, 100);
+    meEle_pt_MTD_7_Sig_EB_ = ibook.book1D("Ele_pT_MTD_7_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_7_Sig_EB_ = ibook.book1D("Ele_eta_MTD_7_Sig_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_7_Sig_EB_ = ibook.book1D("Ele_phi_MTD_7_Sig_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EB", "Electron pT MTD", 30, 10, 100);
+    meEle_pt_sim_MTD_1_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_1_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_2_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_2_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_3_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_3_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_4_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_4_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_5_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_5_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_6_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_6_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_7_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_7_Sig_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+  }
+
+  meEle_pt_MTD_4sigma_Sig_EB_ =
+      ibook.book1D("Ele_pT_MTD_4sigma_Sig_EB",
+                   "Electron pT MTD - 4 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EB",
+                                              "Electron eta MTD - 4 sigma compatibility - Signal Barrel;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_4sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EB",
+                                              "Electron phi MTD - 4 sigma compatibility - Signal Barrel;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+
+  meEle_pt_MTD_3sigma_Sig_EB_ =
+      ibook.book1D("Ele_pT_MTD_3sigma_Sig_EB",
+                   "Electron pT MTD - 3 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EB",
+                                              "Electron eta MTD - 3 sigma compatibility - Signal Barrel;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_3sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EB",
+                                              "Electron phi MTD - 3 sigma compatibility - Signal Barrel;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+
+  meEle_pt_MTD_2sigma_Sig_EB_ =
+      ibook.book1D("Ele_pT_MTD_2sigma_Sig_EB",
+                   "Electron pT MTD - 2 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EB",
+                                              "Electron eta MTD - 2 sigma compatibility - Signal Barrel;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_2sigma_Sig_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EB",
+                                              "Electron phi MTD - 2 sigma compatibility - Signal Barrel;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
 
   meEleISO_Ntracks_Sig_EE_ = ibook.book1D("Ele_Iso_Ntracks_Sig_EE",
-                                          "Tracks in isolation cone around electron track after basic cuts",
+                                          "Number of tracks in isolation cone around electron track after basic cuts - "
+                                          "Signal Endcap;Number of tracks;Counts",
                                           20,
                                           0,
-                                          20);  // hists for electrons
+                                          20);
   meEleISO_chIso_Sig_EE_ = ibook.book1D(
-      "Ele_chIso_sum_Sig_EE", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
-  meEleISO_rel_chIso_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts",
-                   1000,
-                   0,
-                   4);
+      "Ele_chIso_sum_Sig_EE",
+      "Track pT sum in isolation cone around electron track after basic cuts - Signal Endcap;p_{T} (GeV);Counts",
+      2000,
+      0,
+      20);
+  meEleISO_rel_chIso_Sig_EE_ = ibook.book1D(
+      "Ele_rel_chIso_sum_Sig_EE",
+      "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Endcap;Isolation;Counts",
+      1000,
+      0,
+      4);
 
-  meEleISO_Ntracks_MTD_1_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_1_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_1_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_1_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+  if (optionalPlots_) {
+    meEle_pt_sim_MTD_4sigma_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EB",
+                     "Electron pT MTD SIM - 4 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_3sigma_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EB",
+                     "Electron pT MTD SIM - 3 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_2sigma_Sig_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EB",
+                     "Electron pT MTD SIM - 2 sigma compatibility - Signal Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
 
-  meEleISO_Ntracks_MTD_2_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_2_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_2_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_2_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_1_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_1_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_1_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_1_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_1_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_1_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_3_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_3_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_3_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_3_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_2_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_2_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_2_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_2_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_2_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_2_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_4_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_4_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_4_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_4_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_gen_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_gen_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts using genInfo - Signal Endcap",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_gen_Sig_EE_ =
+        ibook.book1D("Ele_chIso_sum_gen_Sig_EE",
+                     "Track pT sum in isolation cone around electron track after basic cuts - Signal Endcap",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_gen_Sig_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_gen_Sig_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts - Signal Endcap",
+                     1000,
+                     0,
+                     4);
 
-  meEleISO_Ntracks_MTD_5_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_5_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_5_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_5_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_3_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_3_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_3_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_3_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_3_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_3_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_6_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_6_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_6_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_6_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_4_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_4_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_4_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_4_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_4_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_4_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_7_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_7_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_7_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_7_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_5_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_5_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_5_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_5_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_5_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_5_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
+    meEleISO_Ntracks_MTD_6_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_6_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_6_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_6_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_6_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_6_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_7_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_7_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_7_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_7_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_7_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_7_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_1_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_1_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_1_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_1_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_1_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_2_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_2_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_2_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_2_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_3_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_3_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_3_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_3_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_4_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_4_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_4_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_4_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_5_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_5_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_5_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_5_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_5_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_6_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_6_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_6_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_6_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_6_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_7_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_7_Sig_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_7_Sig_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_7_Sig_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_7_Sig_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+  }
   meEleISO_Ntracks_MTD_4sigma_Sig_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 4 sigma significance - "
+                   "Signal Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_4sigma_Sig_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 4 sigma "
+                   "significance - Signal Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_3sigma_Sig_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 3 sigma significance - "
+                   "Signal Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_3sigma_Sig_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 3 sigma "
+                   "significance - Signal Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_2sigma_Sig_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 2 sigma significance - "
+                   "Signal Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_2sigma_Sig_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Sig_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_1_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_1_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_1_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_2_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_3_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_4_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_5_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_5_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_5_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_6_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_6_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_6_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_7_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_7_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_7_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_4sigma_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_3sigma_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_2sigma_Sig_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD - 2 sigma "
+                   "significance - Signal Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEle_pt_tot_Sig_EE_ =
-      ibook.book1D("Ele_pT_tot_Sig_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
-  meEle_pt_noMTD_Sig_EE_ = ibook.book1D("Ele_pT_noMTD_Sig_EE", "Electron pT noMTD", 30, 10, 100);
+      ibook.book1D("Ele_pT_tot_Sig_EE", "Electron pT tot - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
+  meEle_pt_noMTD_Sig_EE_ =
+      ibook.book1D("Ele_pT_noMTD_Sig_EE", "Electron pT noMTD - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_pt_sim_tot_Sig_EE_ =
-      ibook.book1D("Ele_pT_sim_tot_Sig_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+      ibook.book1D("Ele_pT_sim_tot_Sig_EE", "Electron pT tot - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Sig_EE_ = ibook.book1D("Ele_eta_tot_Sig_EE", "Electron eta tot", 128, -3.2, 3.2);
-  meEle_eta_noMTD_Sig_EE_ = ibook.book1D("Ele_eta_noMTD_Sig_EE", "Electron eta noMTD", 128, -3.2, 3.2);
+  meEle_eta_tot_Sig_EE_ =
+      ibook.book1D("Ele_eta_tot_Sig_EE", "Electron eta tot - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Sig_EE_ =
+      ibook.book1D("Ele_eta_noMTD_Sig_EE", "Electron eta noMTD - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
 
-  meEle_phi_tot_Sig_EE_ = ibook.book1D("Ele_phi_tot_Sig_EE", "Electron phi tot", 128, -3.2, 3.2);
-  meEle_phi_noMTD_Sig_EE_ = ibook.book1D("Ele_phi_noMTD_Sig_EE", "Electron phi noMTD", 128, -3.2, 3.2);
+  meEle_phi_tot_Sig_EE_ =
+      ibook.book1D("Ele_phi_tot_Sig_EE", "Electron phi tot - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Sig_EE_ =
+      ibook.book1D("Ele_phi_noMTD_Sig_EE", "Electron phi noMTD - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_MTD_1_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_1_Sig_EE_ = ibook.book1D("Ele_eta_MTD_1_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_1_Sig_EE_ = ibook.book1D("Ele_phi_MTD_1_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Sig_EE",
+                     "Number of tracks in isolation cone around electron track after basic cuts with MTD SIM - 4 sigma "
+                     "significance - Signal Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4sigma_Sig_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Sig_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Sig_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
+                     "sigma significance - Signal Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 3 sigma significance - Signal Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3sigma_Sig_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Sig_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Sig_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
+                     "sigma significance - Signal Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Sig_EE",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 2 sigma significance - Signal Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2sigma_Sig_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Sig_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Sig_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
+                     "sigma significance - Signal Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_MTD_1_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_1_Sig_EE_ = ibook.book1D("Ele_eta_MTD_1_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_1_Sig_EE_ = ibook.book1D("Ele_phi_MTD_1_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_pt_gen_Sig_EE_ =
+        ibook.book1D("Ele_pT_gen_Sig_EE", "Electron pT genInfo - Signal Endcap;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_gen_Sig_EE_ =
+        ibook.book1D("Ele_eta_gen_Sig_EE", "Electron eta genInfo - Signal Endcap;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_gen_Sig_EE_ =
+        ibook.book1D("Ele_phi_gen_Sig_EE", "Electron phi genInfo - Signal Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_MTD_5_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_5_Sig_EE_ = ibook.book1D("Ele_eta_MTD_5_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_5_Sig_EE_ = ibook.book1D("Ele_phi_MTD_5_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_2_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_2_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_MTD_6_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_6_Sig_EE_ = ibook.book1D("Ele_eta_MTD_6_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_6_Sig_EE_ = ibook.book1D("Ele_phi_MTD_6_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_3_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_3_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_MTD_7_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_7_Sig_EE_ = ibook.book1D("Ele_eta_MTD_7_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_7_Sig_EE_ = ibook.book1D("Ele_phi_MTD_7_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_4_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_4_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_4sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_MTD_5_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_5_Sig_EE_ = ibook.book1D("Ele_eta_MTD_5_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_5_Sig_EE_ = ibook.book1D("Ele_phi_MTD_5_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_MTD_6_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_6_Sig_EE_ = ibook.book1D("Ele_eta_MTD_6_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_6_Sig_EE_ = ibook.book1D("Ele_phi_MTD_6_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_MTD_7_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_7_Sig_EE_ = ibook.book1D("Ele_eta_MTD_7_Sig_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_7_Sig_EE_ = ibook.book1D("Ele_phi_MTD_7_Sig_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_1_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_1_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_2_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_3_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_4_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_4_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_5_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_5_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_6_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_6_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_7_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_7_Sig_EE", "Electron pT MTD", 30, 10, 100);
+    meEle_pt_sim_MTD_1_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_1_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_2_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_2_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_3_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_3_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_4_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_4_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_5_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_5_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_6_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_6_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_7_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_7_Sig_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_pt_sim_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EE", "Electron pT MTD", 30, 10, 100);
+    meEle_pt_sim_MTD_4sigma_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_4sigma_Sig_EE",
+                     "Electron pT MTD SIM - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_3sigma_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_3sigma_Sig_EE",
+                     "Electron pT MTD SIM - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_2sigma_Sig_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_2sigma_Sig_EE",
+                     "Electron pT MTD SIM - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+  }
+
+  meEle_pt_MTD_4sigma_Sig_EE_ =
+      ibook.book1D("Ele_pT_MTD_4sigma_Sig_EE",
+                   "Electron pT MTD - 4 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Sig_EE",
+                                              "Electron eta MTD - 4 sigma significance - Signal Endcap;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_4sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Sig_EE",
+                                              "Electron phi MTD - 4 sigma significance - Signal Endcap;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+
+  meEle_pt_MTD_3sigma_Sig_EE_ =
+      ibook.book1D("Ele_pT_MTD_3sigma_Sig_EE",
+                   "Electron pT MTD - 3 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Sig_EE",
+                                              "Electron eta MTD - 3 sigma significance - Signal Endcap;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_3sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Sig_EE",
+                                              "Electron phi MTD - 3 sigma significance - Signal Endcap;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+
+  meEle_pt_MTD_2sigma_Sig_EE_ =
+      ibook.book1D("Ele_pT_MTD_2sigma_Sig_EE",
+                   "Electron pT MTD - 2 sigma significance - Signal Endcap;p_{T} (GeV);Counts",
+                   30,
+                   10,
+                   100);
+  meEle_eta_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Sig_EE",
+                                              "Electron eta MTD - 2 sigma significance - Signal Endcap;#eta;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
+  meEle_phi_MTD_2sigma_Sig_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Sig_EE",
+                                              "Electron phi MTD - 2 sigma significance - Signal Endcap;#phi;Counts",
+                                              128,
+                                              -3.2,
+                                              3.2);
 
   // background
-  meEleISO_Ntracks_Bkg_EB_ = ibook.book1D("Ele_Iso_Ntracks_Bkg_EB",
-                                          "Tracks in isolation cone around electron track after basic cuts",
-                                          20,
-                                          0,
-                                          20);  // hists for electrons
+  meEleISO_Ntracks_Bkg_EB_ = ibook.book1D(
+      "Ele_Iso_Ntracks_Bkg_EB",
+      "Number of tracks in isolation cone around electron track after basic cuts - Bkg Barrel;Number of tracks;Counts",
+      20,
+      0,
+      20);
   meEleISO_chIso_Bkg_EB_ = ibook.book1D(
-      "Ele_chIso_sum_Bkg_EB", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
-  meEleISO_rel_chIso_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts",
-                   1000,
-                   0,
-                   4);
+      "Ele_chIso_sum_Bkg_EB",
+      "Track pT sum in isolation cone around electron track after basic cuts - Bkg Barrel;p_{T} (GeV);Counts",
+      2000,
+      0,
+      20);
+  meEleISO_rel_chIso_Bkg_EB_ = ibook.book1D(
+      "Ele_rel_chIso_sum_Bkg_EB",
+      "Track relative pT sum in isolation cone around electron track after basic cuts - Bkg Barrel;Isolation;Counts",
+      1000,
+      0,
+      4);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_1_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_1_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_1_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_1_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_1_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_1_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_1_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_1_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_1_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_2_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_2_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_2_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_2_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_2_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+    meEleISO_Ntracks_gen_Bkg_EB_ = ibook.book1D("Ele_Iso_Ntracks_gen_Bkg_EB",
+                                                "Tracks in isolation cone around electron track after basic cuts using "
+                                                "genInfo - Bkg Barrel;Number of tracks;Counts",
+                                                20,
+                                                0,
+                                                20);
+    meEleISO_chIso_gen_Bkg_EB_ = ibook.book1D("Ele_chIso_sum_gen_Bkg_EB",
+                                              "Track pT sum in isolation cone around electron track after basic cuts "
+                                              "using genInfo - Bkg Barrel;p_{T} (GeV);Counts",
+                                              2000,
+                                              0,
+                                              20);
+    meEleISO_rel_chIso_gen_Bkg_EB_ = ibook.book1D("Ele_rel_chIso_sum_gen_Bkg_EB",
+                                                  "Track relative pT sum in isolation cone around electron track after "
+                                                  "basic cuts using genInfo - Bkg Barrel;Isolation;Counts",
+                                                  1000,
+                                                  0,
+                                                  4);
+    meEleISO_Ntracks_MTD_3_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_3_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_3_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_3_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_3_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_2_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_2_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_2_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_2_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_4_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_4_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_4_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_4_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_4_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_3_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_3_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_3_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_3_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_5_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_5_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_5_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_5_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_5_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_4_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_4_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_4_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_4_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_6_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_6_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_6_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_6_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_6_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_5_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_5_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_5_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_5_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_7_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_7_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_7_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_7_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_7_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_6_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_6_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_6_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_6_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_sim_1_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_1_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_1_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_1_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_7_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_7_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_7_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_7_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_sim_2_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_2_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_2_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
+    meEleISO_Ntracks_MTD_sim_3_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_3_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_3_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_4_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_4_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_4_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_5_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_5_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_5_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_5_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_6_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_6_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_6_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_6_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_7_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_7_Bkg_EB_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_7_Bkg_EB",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_7_Bkg_EB",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+  }
   meEleISO_Ntracks_MTD_4sigma_Bkg_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 4 sigma significance - "
+                   "Bkg Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_4sigma_Bkg_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 4 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 4 sigma significance - Bkg Barrel;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_3sigma_Bkg_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 3 sigma significance - "
+                   "Bkg Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_3sigma_Bkg_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 3 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 3 sigma significance - Bkg Barrel;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_2sigma_Bkg_EB_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 2 sigma significance - "
+                   "Bkg Barrel;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_2sigma_Bkg_EB_ =
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 2 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_1_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_1_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_2_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_3_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_4_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_5_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_5_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_6_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_6_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_7_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_7_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EB",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EB",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EB",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 2 sigma significance - Bkg Barrel;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEle_pt_tot_Bkg_EB_ =
-      ibook.book1D("Ele_pT_tot_Bkg_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
-  meEle_pt_noMTD_Bkg_EB_ = ibook.book1D("Ele_pT_noMTD_Bkg_EB", "Electron pT noMTD", 30, 10, 100);
+      ibook.book1D("Ele_pT_tot_Bkg_EB", "Electron pT tot - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
+  meEle_pt_noMTD_Bkg_EB_ =
+      ibook.book1D("Ele_pT_noMTD_Bkg_EB", "Electron pT noMTD - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_pt_sim_tot_Bkg_EB_ =
-      ibook.book1D("Ele_pT_sim_tot_Bkg_EB", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+      ibook.book1D("Ele_pT_sim_tot_Bkg_EB", "Electron pT tot - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Bkg_EB_ = ibook.book1D("Ele_eta_tot_Bkg_EB", "Electron eta tot", 128, -3.2, 3.2);
-  meEle_eta_noMTD_Bkg_EB_ = ibook.book1D("Ele_eta_noMTD_Bkg_EB", "Electron eta noMTD", 128, -3.2, 3.2);
+  meEle_eta_tot_Bkg_EB_ =
+      ibook.book1D("Ele_eta_tot_Bkg_EB", "Electron eta tot - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Bkg_EB_ =
+      ibook.book1D("Ele_eta_noMTD_Bkg_EB", "Electron eta noMTD - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
 
-  meEle_phi_tot_Bkg_EB_ = ibook.book1D("Ele_phi_tot_Bkg_EB", "Electron phi tot", 128, -3.2, 3.2);
-  meEle_phi_noMTD_Bkg_EB_ = ibook.book1D("Ele_phi_noMTD_Bkg_EB", "Electron phi noMTD", 128, -3.2, 3.2);
+  meEle_phi_tot_Bkg_EB_ =
+      ibook.book1D("Ele_phi_tot_Bkg_EB", "Electron phi tot - Bkg Barrel;#phi;#Counts", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Bkg_EB_ =
+      ibook.book1D("Ele_phi_noMTD_Bkg_EB", "Electron phi noMTD - Bkg Barrel;#phi;#Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_1_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_1_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 4 sigma significance - Bkg Barrel;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 4 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EB",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
+                     "sigma significance - Bkg Barrel;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 3 sigma significance - Bkg Barrel;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 3 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EB",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
+                     "sigma significance - Bkg Barrel;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EB",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 3 sigma significance - Bkg Barrel;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EB",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 2 sigma significance - Bkg Barrel;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EB",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
+                     "sigma significance - Bkg Barrel;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_1_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_1_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_pt_gen_Bkg_EB_ =
+        ibook.book1D("Ele_pT_gen_Bkg_EB", "Electron pT genInfo - Bkg Barrel;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_gen_Bkg_EB_ =
+        ibook.book1D("Ele_eta_gen_Bkg_EB", "Electron eta genInfo - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_gen_Bkg_EB_ =
+        ibook.book1D("Ele_phi_gen_Bkg_EB", "Electron phi genInfo - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_5_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_5_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_2_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_2_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_6_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_6_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_3_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_3_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_7_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_7_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_4_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_4_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_4sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_4sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_5_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_5_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_3sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_3sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_6_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_6_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_2sigma_Bkg_EB", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_2sigma_Bkg_EB", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_7_Bkg_EB_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EB", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_7_Bkg_EB_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EB", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_1_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_4_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_5_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_6_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_7_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+    meEle_pt_sim_MTD_1_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_2_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_3_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_4_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_5_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_6_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_7_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EB", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+  }
+  meEle_pt_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EB",
+                                             "Electron pT MTD - 4 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_4sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_eta_MTD_4sigma_Bkg_EB", "Electron eta MTD - 4 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_phi_MTD_4sigma_Bkg_EB", "Electron phi MTD - 4 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_4sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EB", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_MTD_3sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EB",
+                                             "Electron pT MTD - 3 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_3sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_eta_MTD_3sigma_Bkg_EB", "Electron eta MTD - 3 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_phi_MTD_3sigma_Bkg_EB", "Electron phi MTD - 3 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
 
-  meEleISO_Ntracks_Bkg_EE_ = ibook.book1D("Ele_Iso_Ntracks_Bkg_EE",
-                                          "Tracks in isolation cone around electron track after basic cuts",
-                                          20,
-                                          0,
-                                          20);  // hists for electrons
+  meEle_pt_MTD_2sigma_Bkg_EB_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EB",
+                                             "Electron pT MTD - 2 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_2sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_eta_MTD_2sigma_Bkg_EB", "Electron eta MTD - 2 sigma compatibility - Bkg Barrel;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Bkg_EB_ = ibook.book1D(
+      "Ele_phi_MTD_2sigma_Bkg_EB", "Electron phi MTD - 2 sigma compatibility - Bkg Barrel;#phi;Counts", 128, -3.2, 3.2);
+
+  meEleISO_Ntracks_Bkg_EE_ = ibook.book1D(
+      "Ele_Iso_Ntracks_Bkg_EE",
+      "Number of tracks in isolation cone around electron track after basic cuts - Bkg Endcap;Number of tracks;Counts",
+      20,
+      0,
+      20);
   meEleISO_chIso_Bkg_EE_ = ibook.book1D(
-      "Ele_chIso_sum_Bkg_EE", "Track pT sum in isolation cone around electron track after basic cuts", 2000, 0, 20);
-  meEleISO_rel_chIso_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts",
-                   1000,
-                   0,
-                   4);
+      "Ele_chIso_sum_Bkg_EE",
+      "Track pT sum in isolation cone around electron track after basic cuts - Bkg Endcap;p_{T} (GeV);Counts",
+      2000,
+      0,
+      20);
+  meEleISO_rel_chIso_Bkg_EE_ = ibook.book1D(
+      "Ele_rel_chIso_sum_Bkg_EE",
+      "Track relative pT sum in isolation cone around electron track after basic cuts - Bkg Endcap;Isolation;Counts",
+      1000,
+      0,
+      4);
+  if (optionalPlots_) {
+    meEle_pt_sim_MTD_4sigma_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EB",
+                     "Electron pT MTD SIM - 4 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_3sigma_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EB",
+                     "Electron pT MTD SIM - 3 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_2sigma_Bkg_EB_ =
+        ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EB",
+                     "Electron pT MTD SIM - 2 sigma compatibility - Bkg Barrel;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
 
-  meEleISO_Ntracks_MTD_1_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_1_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_1_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_1_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_1_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_1_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_1_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_1_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_1_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_1_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_1_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_2_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_2_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_2_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_2_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_2_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_2_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_2_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_2_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_2_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_2_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_2_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+    meEleISO_Ntracks_gen_Bkg_EE_ = ibook.book1D("Ele_Iso_Ntracks_gen_Bkg_EE",
+                                                "Tracks in isolation cone around electron track after basic cuts using "
+                                                "genInfo - Bkg Endcap;Number of tracks;Counts",
+                                                20,
+                                                0,
+                                                20);
+    meEleISO_chIso_gen_Bkg_EE_ = ibook.book1D("Ele_chIso_sum_gen_Bkg_EE",
+                                              "Track pT sum in isolation cone around electron track after basic cuts "
+                                              "using genInfo - Bkg Endcap;p_{T} (GeV);Counts",
+                                              2000,
+                                              0,
+                                              20);
+    meEleISO_rel_chIso_gen_Bkg_EE_ = ibook.book1D("Ele_rel_chIso_sum_gen_Bkg_EE",
+                                                  "Track relative pT sum in isolation cone around electron track after "
+                                                  "basic cuts using genInfo - Bkg Endcap;Isolation;Counts",
+                                                  1000,
+                                                  0,
+                                                  4);
 
-  meEleISO_Ntracks_MTD_3_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_3_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_3_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_3_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_3_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_3_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_3_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_3_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_3_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_3_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_3_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_4_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_4_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_4_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_4_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_4_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_4_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_4_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_4_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_4_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_4_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_4_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_5_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_5_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_5_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_5_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_5_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_5_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_5_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_5_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_5_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_5_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_5_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_6_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_6_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_6_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_6_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_6_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_6_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_6_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_6_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_6_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_6_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_6_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
-  meEleISO_Ntracks_MTD_7_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_7_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_7_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_7_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_7_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
+    meEleISO_Ntracks_MTD_7_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_7_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_7_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_7_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_7_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_7_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
 
+    meEleISO_Ntracks_MTD_sim_1_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_1_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_1_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_1_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_2_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_2_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_2_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_3_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_3_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_3_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_4_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_4_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_4_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_5_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_5_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_5_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_5_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_6_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_6_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_6_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_6_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+
+    meEleISO_Ntracks_MTD_sim_7_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic cuts with MTD;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_7_Bkg_EE_ = ibook.book1D(
+        "Ele_chIso_sum_MTD_sim_7_Bkg_EE",
+        "Track pT sum in isolation cone around electron track after basic cuts with MTD;p_{T} (GeV);Counts",
+        2000,
+        0,
+        20);
+    meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_ = ibook.book1D(
+        "Ele_rel_chIso_sum_MTD_sim_7_Bkg_EE",
+        "Track relative pT sum in isolation cone around electron track after basic cuts with MTD;Isolation;Counts",
+        1000,
+        0,
+        4);
+  }
   meEleISO_Ntracks_MTD_4sigma_Bkg_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_4sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 4 sigma compatibility - "
+                   "Bkg Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_4sigma_Bkg_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_4sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_4sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 4 sigma compatibility - Bkg Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_3sigma_Bkg_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_3sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 3 sigma compatibility - "
+                   "Bkg Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_3sigma_Bkg_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_3sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_3sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 3 sigma compatibility - Bkg Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEleISO_Ntracks_MTD_2sigma_Bkg_EE_ =
       ibook.book1D("Ele_Iso_Ntracks_MTD_2sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
+                   "Tracks in isolation cone around electron track after basic cuts with MTD - 2 sigma compatibility - "
+                   "Bkg Endcap;Number of tracks;Counts",
                    20,
                    0,
                    20);
   meEleISO_chIso_MTD_2sigma_Bkg_EE_ =
       ibook.book1D("Ele_chIso_sum_MTD_2sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track pT sum in isolation cone around electron track after basic "
+                   "cuts with MTD - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
                    2000,
                    0,
                    20);
   meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_ =
       ibook.book1D("Ele_rel_chIso_sum_MTD_2sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_1_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_1_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_1_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_1_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_1_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_2_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_3_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_4_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_5_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_5_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_5_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_5_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_5_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_6_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_6_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_6_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_6_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_6_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_7_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_7_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);  // hists for electrons
-  meEleISO_chIso_MTD_sim_7_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_7_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_7_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
-                   1000,
-                   0,
-                   4);
-
-  meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_ =
-      ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EE",
-                   "Tracks in isolation cone around electron track after basic cuts with MTD",
-                   20,
-                   0,
-                   20);
-  meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_ =
-      ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EE",
-                   "Track pT sum in isolation cone around electron track after basic cuts with MTD",
-                   2000,
-                   0,
-                   20);
-  meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_ =
-      ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EE",
-                   "Track relative pT sum in isolation cone around electron track after basic cuts with MTD",
+                   "Track relative pT sum in isolation cone around electron track "
+                   "after basic cuts with MTD - 2 sigma compatibility - Bkg Endcap;Isolation;Counts",
                    1000,
                    0,
                    4);
 
   meEle_pt_tot_Bkg_EE_ =
-      ibook.book1D("Ele_pT_tot_Bkg_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
-  meEle_pt_noMTD_Bkg_EE_ = ibook.book1D("Ele_pT_noMTD_Bkg_EE", "Electron pT noMTD", 30, 10, 100);
+      ibook.book1D("Ele_pT_tot_Bkg_EE", "Electron pT tot - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
+  meEle_pt_noMTD_Bkg_EE_ =
+      ibook.book1D("Ele_pT_noMTD_Bkg_EE", "Electron pT noMTD - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
   meEle_pt_sim_tot_Bkg_EE_ =
-      ibook.book1D("Ele_pT_sim_tot_Bkg_EE", "Electron pT tot", 30, 10, 100);  // hists for ele isto stuff start
+      ibook.book1D("Ele_pT_sim_tot_Bkg_EE", "Electron pT tot - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
 
-  meEle_eta_tot_Bkg_EE_ = ibook.book1D("Ele_eta_tot_Bkg_EE", "Electron eta tot", 128, -3.2, 3.2);
-  meEle_eta_noMTD_Bkg_EE_ = ibook.book1D("Ele_eta_noMTD_Bkg_EE", "Electron eta noMTD", 128, -3.2, 3.2);
+  meEle_eta_tot_Bkg_EE_ =
+      ibook.book1D("Ele_eta_tot_Bkg_EE", "Electron eta tot - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+  meEle_eta_noMTD_Bkg_EE_ =
+      ibook.book1D("Ele_eta_noMTD_Bkg_EE", "Electron eta noMTD - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
 
-  meEle_phi_tot_Bkg_EE_ = ibook.book1D("Ele_phi_tot_Bkg_EE", "Electron phi tot", 128, -3.2, 3.2);
-  meEle_phi_noMTD_Bkg_EE_ = ibook.book1D("Ele_phi_noMTD_Bkg_EE", "Electron phi noMTD", 128, -3.2, 3.2);
+  meEle_phi_tot_Bkg_EE_ =
+      ibook.book1D("Ele_phi_tot_Bkg_EE", "Electron phi tot - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+  meEle_phi_noMTD_Bkg_EE_ =
+      ibook.book1D("Ele_phi_noMTD_Bkg_EE", "Electron phi noMTD - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
+  if (optionalPlots_) {
+    meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_4sigma_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 4 sigma compatibility - Bkg Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_4sigma_Bkg_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_4sigma_Bkg_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 4 "
+                     "sigma compatibility - Bkg Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_1_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_1_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_3sigma_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 3 sigma compatibility - Bkg Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_3sigma_Bkg_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_3sigma_Bkg_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 3 "
+                     "sigma compatibility - Bkg Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_ =
+        ibook.book1D("Ele_Iso_Ntracks_MTD_sim_2sigma_Bkg_EE",
+                     "Tracks in isolation cone around electron track after basic "
+                     "cuts with MTD SIM - 2 sigma compatibility - Bkg Endcap;Number of tracks;Counts",
+                     20,
+                     0,
+                     20);
+    meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_ =
+        ibook.book1D("Ele_chIso_sum_MTD_sim_2sigma_Bkg_EE",
+                     "Track pT sum in isolation cone around electron track after "
+                     "basic cuts with MTD SIM - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                     2000,
+                     0,
+                     20);
+    meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_ =
+        ibook.book1D("Ele_rel_chIso_sum_MTD_sim_2sigma_Bkg_EE",
+                     "Track relative pT sum in isolation cone around electron track after basic cuts with MTD SIM - 2 "
+                     "sigma compatibility - Bkg Endcap;Isolation;Counts",
+                     1000,
+                     0,
+                     4);
 
-  meEle_pt_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_1_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_1_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_1_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_1_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_1_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
+    meEle_pt_gen_Bkg_EE_ =
+        ibook.book1D("Ele_pT_gen_Bkg_EE", "Electron pT genInfo - Bkg Endcap;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_gen_Bkg_EE_ =
+        ibook.book1D("Ele_eta_gen_Bkg_EE", "Electron eta genInfo - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_gen_Bkg_EE_ =
+        ibook.book1D("Ele_phi_gen_Bkg_EE", "Electron phi genInfo - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_2_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_2_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_5_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_5_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_3_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_3_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_6_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_6_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_4_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_4_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_7_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_7_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_5_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_5_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_5_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_5_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_5_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_4sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_4sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_6_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_6_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_6_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_6_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_6_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_3sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_3sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_7_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_eta_MTD_7_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_7_Bkg_EE", "Electron eta MTD;#eta;Counts", 128, -3.2, 3.2);
+    meEle_phi_MTD_7_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_7_Bkg_EE", "Electron phi MTD;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_eta_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_eta_MTD_2sigma_Bkg_EE", "Electron eta MTD", 128, -3.2, 3.2);
-  meEle_phi_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_phi_MTD_2sigma_Bkg_EE", "Electron phi MTD", 128, -3.2, 3.2);
+    meEle_pt_sim_MTD_1_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_2_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_3_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_4_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_5_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_6_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+    meEle_pt_sim_MTD_7_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EE", "Electron pT MTD;p_{T} (GeV);Counts", 30, 10, 100);
+  }
 
-  meEle_pt_sim_MTD_1_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_1_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_2_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_3_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_4_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_4_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_5_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_5_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_6_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_6_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_7_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_7_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_4sigma_Bkg_EE",
+                                             "Electron pT MTD - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_4sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_eta_MTD_4sigma_Bkg_EE", "Electron eta MTD - 4 sigma compatibility - Bkg Endcapi;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_4sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_phi_MTD_4sigma_Bkg_EE", "Electron phi MTD - 4 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_pt_sim_MTD_4sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
-  meEle_pt_sim_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EE", "Electron pT MTD", 30, 10, 100);
+  meEle_pt_MTD_3sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_3sigma_Bkg_EE",
+                                             "Electron pT MTD - 3 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_3sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_eta_MTD_3sigma_Bkg_EE", "Electron eta MTD - 3 sigma compatibility - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_3sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_phi_MTD_3sigma_Bkg_EE", "Electron phi MTD - 3 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_dt_general_pT_1 =
-      ibook.book1D("Iso_track_dt_general_pT_10_20", "Iso cone track dt distribution in pT bin 10-20 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_2 =
-      ibook.book1D("Iso_track_dt_general_pT_20_30", "Iso cone track dt distribution in pT bin 20-30 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_3 =
-      ibook.book1D("Iso_track_dt_general_pT_30_40", "Iso cone track dt distribution in pT bin 30-40 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_4 =
-      ibook.book1D("Iso_track_dt_general_pT_40_50", "Iso cone track dt distribution in pT bin 40-50 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_5 =
-      ibook.book1D("Iso_track_dt_general_pT_50_60", "Iso cone track dt distribution in pT bin 50-60 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_6 =
-      ibook.book1D("Iso_track_dt_general_pT_60_70", "Iso cone track dt distribution in pT bin 60-70 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_7 =
-      ibook.book1D("Iso_track_dt_general_pT_70_80", "Iso cone track dt distribution in pT bin 70-80 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_8 =
-      ibook.book1D("Iso_track_dt_general_pT_80_90", "Iso cone track dt distribution in pT bin 80-90 GeV ", 100, 0, 1);
-  meEle_dt_general_pT_9 =
-      ibook.book1D("Iso_track_dt_general_pT_90_100", "Iso cone track dt distribution in pT bin 90-100 GeV ", 100, 0, 1);
+  meEle_pt_MTD_2sigma_Bkg_EE_ = ibook.book1D("Ele_pT_MTD_2sigma_Bkg_EE",
+                                             "Electron pT MTD - 2 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                                             30,
+                                             10,
+                                             100);
+  meEle_eta_MTD_2sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_eta_MTD_2sigma_Bkg_EE", "Electron eta MTD - 2 sigma compatibility - Bkg Endcap;#eta;Counts", 128, -3.2, 3.2);
+  meEle_phi_MTD_2sigma_Bkg_EE_ = ibook.book1D(
+      "Ele_phi_MTD_2sigma_Bkg_EE", "Electron phi MTD - 2 sigma compatibility - Bkg Endcap;#phi;Counts", 128, -3.2, 3.2);
 
-  meEle_dtSignif_general_pT_1 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_10_20", "Iso cone track dt distribution in pT bin 10-20 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_2 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_20_30", "Iso cone track dt distribution in pT bin 20-30 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_3 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_30_40", "Iso cone track dt distribution in pT bin 30-40 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_4 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_40_50", "Iso cone track dt distribution in pT bin 40-50 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_5 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_50_60", "Iso cone track dt distribution in pT bin 50-60 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_6 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_60_70", "Iso cone track dt distribution in pT bin 60-70 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_7 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_70_80", "Iso cone track dt distribution in pT bin 70-80 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_8 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_80_90", "Iso cone track dt distribution in pT bin 80-90 GeV ", 1000, 0, 10);
-  meEle_dtSignif_general_pT_9 = ibook.book1D(
-      "Iso_track_dtSignif_general_pT_90_100", "Iso cone track dt distribution in pT bin 90-100 GeV ", 1000, 0, 10);
+  if (optionalPlots_) {
+    meEle_pt_sim_MTD_4sigma_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_4sigma_Bkg_EE",
+                     "Electron pT MTD SIM - 4 sigma compatibility - Bkg Endcap;p_{T} (GeV);Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_3sigma_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_3sigma_Bkg_EE",
+                     "Electron pT MTD SIM - 3 sigma compatibility - Bkg Endcap;#eta;Counts",
+                     30,
+                     10,
+                     100);
+    meEle_pt_sim_MTD_2sigma_Bkg_EE_ =
+        ibook.book1D("Ele_pT_sim_MTD_2sigma_Bkg_EE",
+                     "Electron pT MTD SIM - 2 sigma compatibility - Bkg Endcap;#phi;Counts",
+                     30,
+                     10,
+                     100);
+  }
 
-  meEle_dt_general_eta_1 =
-      ibook.book1D("Iso_track_dt_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ", 100, 0, 1);
-  meEle_dt_general_eta_2 =
-      ibook.book1D("Iso_track_dt_general_eta_05_10", "Iso cone track dt distribution in eta bin 0.5-1.0 ", 100, 0, 1);
-  meEle_dt_general_eta_3 =
-      ibook.book1D("Iso_track_dt_general_eta_10_15", "Iso cone track dt distribution in eta bin 1.0-1.5 ", 100, 0, 1);
-  meEle_dt_general_eta_4 =
-      ibook.book1D("Iso_track_dt_general_eta_15_20", "Iso cone track dt distribution in eta bin 1.5-2.0 ", 100, 0, 1);
-  meEle_dt_general_eta_5 =
-      ibook.book1D("Iso_track_dt_general_eta_20_24", "Iso cone track dt distribution in eta bin 2.0-2.4 ", 100, 0, 1);
+  meEle_dt_general_pT_1 = ibook.book1D("Iso_track_dt_general_pT_10_20",
+                                       "Iso cone track dt distribution in pT bin 10-20 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_2 = ibook.book1D("Iso_track_dt_general_pT_20_30",
+                                       "Iso cone track dt distribution in pT bin 20-30 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_3 = ibook.book1D("Iso_track_dt_general_pT_30_40",
+                                       "Iso cone track dt distribution in pT bin 30-40 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_4 = ibook.book1D("Iso_track_dt_general_pT_40_50",
+                                       "Iso cone track dt distribution in pT bin 40-50 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_5 = ibook.book1D("Iso_track_dt_general_pT_50_60",
+                                       "Iso cone track dt distribution in pT bin 50-60 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_6 = ibook.book1D("Iso_track_dt_general_pT_60_70",
+                                       "Iso cone track dt distribution in pT bin 60-70 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_7 = ibook.book1D("Iso_track_dt_general_pT_70_80",
+                                       "Iso cone track dt distribution in pT bin 70-80 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_8 = ibook.book1D("Iso_track_dt_general_pT_80_90",
+                                       "Iso cone track dt distribution in pT bin 80-90 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
+  meEle_dt_general_pT_9 = ibook.book1D("Iso_track_dt_general_pT_90_100",
+                                       "Iso cone track dt distribution in pT bin 90-100 GeV ;Time (ns);Counts",
+                                       100,
+                                       0,
+                                       1);
 
-  meEle_dtSignif_general_eta_1 = ibook.book1D(
-      "Iso_track_dtSignif_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ", 1000, 0, 10);
-  meEle_dtSignif_general_eta_2 = ibook.book1D(
-      "Iso_track_dtSignif_general_eta_05_10", "Iso cone track dt distribution in eta bin 0.5-1.0 ", 1000, 0, 10);
-  meEle_dtSignif_general_eta_3 = ibook.book1D(
-      "Iso_track_dtSignif_general_eta_10_15", "Iso cone track dt distribution in eta bin 1.0-1.5 ", 1000, 0, 10);
-  meEle_dtSignif_general_eta_4 = ibook.book1D(
-      "Iso_track_dtSignif_general_eta_15_20", "Iso cone track dt distribution in eta bin 1.5-2.0 ", 1000, 0, 10);
-  meEle_dtSignif_general_eta_5 = ibook.book1D(
-      "Iso_track_dtSignif_general_eta_20_24", "Iso cone track dt distribution in eta bin 2.0-2.4 ", 1000, 0, 10);
+  meEle_dtSignif_general_pT_1 = ibook.book1D("Iso_track_dtSignif_general_pT_10_20",
+                                             "Iso cone track dt distribution in pT bin 10-20 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_2 = ibook.book1D("Iso_track_dtSignif_general_pT_20_30",
+                                             "Iso cone track dt distribution in pT bin 20-30 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_3 = ibook.book1D("Iso_track_dtSignif_general_pT_30_40",
+                                             "Iso cone track dt distribution in pT bin 30-40 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_4 = ibook.book1D("Iso_track_dtSignif_general_pT_40_50",
+                                             "Iso cone track dt distribution in pT bin 40-50 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_5 = ibook.book1D("Iso_track_dtSignif_general_pT_50_60",
+                                             "Iso cone track dt distribution in pT bin 50-60 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_6 = ibook.book1D("Iso_track_dtSignif_general_pT_60_70",
+                                             "Iso cone track dt distribution in pT bin 60-70 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_7 = ibook.book1D("Iso_track_dtSignif_general_pT_70_80",
+                                             "Iso cone track dt distribution in pT bin 70-80 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_8 = ibook.book1D("Iso_track_dtSignif_general_pT_80_90",
+                                             "Iso cone track dt distribution in pT bin 80-90 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+  meEle_dtSignif_general_pT_9 = ibook.book1D("Iso_track_dtSignif_general_pT_90_100",
+                                             "Iso cone track dt distribution in pT bin 90-100 GeV ;Time (ns);Counts",
+                                             1000,
+                                             0,
+                                             10);
+
+  meEle_dt_general_eta_1 = ibook.book1D(
+      "Iso_track_dt_general_eta_0_05", "Iso cone track dt distribution in eta bin 0.0-0.5 ;Time (ns);Counts", 100, 0, 1);
+  meEle_dt_general_eta_2 = ibook.book1D("Iso_track_dt_general_eta_05_10",
+                                        "Iso cone track dt distribution in eta bin 0.5-1.0 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+  meEle_dt_general_eta_3 = ibook.book1D("Iso_track_dt_general_eta_10_15",
+                                        "Iso cone track dt distribution in eta bin 1.0-1.5 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+  meEle_dt_general_eta_4 = ibook.book1D("Iso_track_dt_general_eta_15_20",
+                                        "Iso cone track dt distribution in eta bin 1.5-2.0 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+  meEle_dt_general_eta_5 = ibook.book1D("Iso_track_dt_general_eta_20_24",
+                                        "Iso cone track dt distribution in eta bin 2.0-2.4 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+  meEle_dt_general_eta_6 = ibook.book1D("Iso_track_dt_general_eta_24_27",
+                                        "Iso cone track dt distribution in eta bin 2.4-2.7 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+  meEle_dt_general_eta_7 = ibook.book1D("Iso_track_dt_general_eta_27_30",
+                                        "Iso cone track dt distribution in eta bin 2.7-3.0 ;Time (ns);Counts",
+                                        100,
+                                        0,
+                                        1);
+
+  meEle_dtSignif_general_eta_1 = ibook.book1D("Iso_track_dtSignif_general_eta_0_05",
+                                              "Iso cone track dt distribution in eta bin 0.0-0.5 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_2 = ibook.book1D("Iso_track_dtSignif_general_eta_05_10",
+                                              "Iso cone track dt distribution in eta bin 0.5-1.0 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_3 = ibook.book1D("Iso_track_dtSignif_general_eta_10_15",
+                                              "Iso cone track dt distribution in eta bin 1.0-1.5 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_4 = ibook.book1D("Iso_track_dtSignif_general_eta_15_20",
+                                              "Iso cone track dt distribution in eta bin 1.5-2.0 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_5 = ibook.book1D("Iso_track_dtSignif_general_eta_20_24",
+                                              "Iso cone track dt distribution in eta bin 2.0-2.4 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_6 = ibook.book1D("Iso_track_dtSignif_general_eta_24_27",
+                                              "Iso cone track dt distribution in eta bin 2.4-2.7 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
+  meEle_dtSignif_general_eta_7 = ibook.book1D("Iso_track_dtSignif_general_eta_27_30",
+                                              "Iso cone track dt distribution in eta bin 2.7-3.0 ;Time (ns);Counts",
+                                              1000,
+                                              0,
+                                              10);
 
   // defining vectors for more efficient hist filling
   // Promt part
-  Ntracks_EB_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EB_,
-                         meEleISO_Ntracks_MTD_2_Sig_EB_,
-                         meEleISO_Ntracks_MTD_3_Sig_EB_,
-                         meEleISO_Ntracks_MTD_4_Sig_EB_,
-                         meEleISO_Ntracks_MTD_5_Sig_EB_,
-                         meEleISO_Ntracks_MTD_6_Sig_EB_,
-                         meEleISO_Ntracks_MTD_7_Sig_EB_};
-  ch_iso_EB_list_Sig = {meEleISO_chIso_MTD_1_Sig_EB_,
-                        meEleISO_chIso_MTD_2_Sig_EB_,
-                        meEleISO_chIso_MTD_3_Sig_EB_,
-                        meEleISO_chIso_MTD_4_Sig_EB_,
-                        meEleISO_chIso_MTD_5_Sig_EB_,
-                        meEleISO_chIso_MTD_6_Sig_EB_,
-                        meEleISO_chIso_MTD_7_Sig_EB_};
-  rel_ch_iso_EB_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_2_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_3_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_4_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_5_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_6_Sig_EB_,
-                            meEleISO_rel_chIso_MTD_7_Sig_EB_};
-
+  if (optionalPlots_) {
+    Ntracks_EB_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EB_,
+                           meEleISO_Ntracks_MTD_2_Sig_EB_,
+                           meEleISO_Ntracks_MTD_3_Sig_EB_,
+                           meEleISO_Ntracks_MTD_4_Sig_EB_,
+                           meEleISO_Ntracks_MTD_5_Sig_EB_,
+                           meEleISO_Ntracks_MTD_6_Sig_EB_,
+                           meEleISO_Ntracks_MTD_7_Sig_EB_};
+    ch_iso_EB_list_Sig = {meEleISO_chIso_MTD_1_Sig_EB_,
+                          meEleISO_chIso_MTD_2_Sig_EB_,
+                          meEleISO_chIso_MTD_3_Sig_EB_,
+                          meEleISO_chIso_MTD_4_Sig_EB_,
+                          meEleISO_chIso_MTD_5_Sig_EB_,
+                          meEleISO_chIso_MTD_6_Sig_EB_,
+                          meEleISO_chIso_MTD_7_Sig_EB_};
+    rel_ch_iso_EB_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_2_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_3_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_4_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_5_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_6_Sig_EB_,
+                              meEleISO_rel_chIso_MTD_7_Sig_EB_};
+  }
   Ntracks_EB_list_Significance_Sig = {
       meEleISO_Ntracks_MTD_4sigma_Sig_EB_, meEleISO_Ntracks_MTD_3sigma_Sig_EB_, meEleISO_Ntracks_MTD_2sigma_Sig_EB_};
   ch_iso_EB_list_Significance_Sig = {
@@ -3599,28 +4152,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                          meEleISO_rel_chIso_MTD_3sigma_Sig_EB_,
                                          meEleISO_rel_chIso_MTD_2sigma_Sig_EB_};
 
-  Ntracks_EE_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EE_,
-                         meEleISO_Ntracks_MTD_2_Sig_EE_,
-                         meEleISO_Ntracks_MTD_3_Sig_EE_,
-                         meEleISO_Ntracks_MTD_4_Sig_EE_,
-                         meEleISO_Ntracks_MTD_5_Sig_EE_,
-                         meEleISO_Ntracks_MTD_6_Sig_EE_,
-                         meEleISO_Ntracks_MTD_7_Sig_EE_};
-  ch_iso_EE_list_Sig = {meEleISO_chIso_MTD_1_Sig_EE_,
-                        meEleISO_chIso_MTD_2_Sig_EE_,
-                        meEleISO_chIso_MTD_3_Sig_EE_,
-                        meEleISO_chIso_MTD_4_Sig_EE_,
-                        meEleISO_chIso_MTD_5_Sig_EE_,
-                        meEleISO_chIso_MTD_6_Sig_EE_,
-                        meEleISO_chIso_MTD_7_Sig_EE_};
-  rel_ch_iso_EE_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_2_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_3_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_4_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_5_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_6_Sig_EE_,
-                            meEleISO_rel_chIso_MTD_7_Sig_EE_};
-
+  if (optionalPlots_) {
+    Ntracks_EE_list_Sig = {meEleISO_Ntracks_MTD_1_Sig_EE_,
+                           meEleISO_Ntracks_MTD_2_Sig_EE_,
+                           meEleISO_Ntracks_MTD_3_Sig_EE_,
+                           meEleISO_Ntracks_MTD_4_Sig_EE_,
+                           meEleISO_Ntracks_MTD_5_Sig_EE_,
+                           meEleISO_Ntracks_MTD_6_Sig_EE_,
+                           meEleISO_Ntracks_MTD_7_Sig_EE_};
+    ch_iso_EE_list_Sig = {meEleISO_chIso_MTD_1_Sig_EE_,
+                          meEleISO_chIso_MTD_2_Sig_EE_,
+                          meEleISO_chIso_MTD_3_Sig_EE_,
+                          meEleISO_chIso_MTD_4_Sig_EE_,
+                          meEleISO_chIso_MTD_5_Sig_EE_,
+                          meEleISO_chIso_MTD_6_Sig_EE_,
+                          meEleISO_chIso_MTD_7_Sig_EE_};
+    rel_ch_iso_EE_list_Sig = {meEleISO_rel_chIso_MTD_1_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_2_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_3_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_4_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_5_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_6_Sig_EE_,
+                              meEleISO_rel_chIso_MTD_7_Sig_EE_};
+  }
   Ntracks_EE_list_Significance_Sig = {
       meEleISO_Ntracks_MTD_4sigma_Sig_EE_, meEleISO_Ntracks_MTD_3sigma_Sig_EE_, meEleISO_Ntracks_MTD_2sigma_Sig_EE_};
   ch_iso_EE_list_Significance_Sig = {
@@ -3629,27 +4183,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                          meEleISO_rel_chIso_MTD_3sigma_Sig_EE_,
                                          meEleISO_rel_chIso_MTD_2sigma_Sig_EE_};
 
-  Ele_pT_MTD_EB_list_Sig = {meEle_pt_MTD_1_Sig_EB_,
-                            meEle_pt_MTD_2_Sig_EB_,
-                            meEle_pt_MTD_3_Sig_EB_,
-                            meEle_pt_MTD_4_Sig_EB_,
-                            meEle_pt_MTD_5_Sig_EB_,
-                            meEle_pt_MTD_6_Sig_EB_,
-                            meEle_pt_MTD_7_Sig_EB_};
-  Ele_eta_MTD_EB_list_Sig = {meEle_eta_MTD_1_Sig_EB_,
-                             meEle_eta_MTD_2_Sig_EB_,
-                             meEle_eta_MTD_3_Sig_EB_,
-                             meEle_eta_MTD_4_Sig_EB_,
-                             meEle_eta_MTD_5_Sig_EB_,
-                             meEle_eta_MTD_6_Sig_EB_,
-                             meEle_eta_MTD_7_Sig_EB_};
-  Ele_phi_MTD_EB_list_Sig = {meEle_phi_MTD_1_Sig_EB_,
-                             meEle_phi_MTD_2_Sig_EB_,
-                             meEle_phi_MTD_3_Sig_EB_,
-                             meEle_phi_MTD_4_Sig_EB_,
-                             meEle_phi_MTD_5_Sig_EB_,
-                             meEle_phi_MTD_6_Sig_EB_,
-                             meEle_phi_MTD_7_Sig_EB_};
+  if (optionalPlots_) {
+    Ele_pT_MTD_EB_list_Sig = {meEle_pt_MTD_1_Sig_EB_,
+                              meEle_pt_MTD_2_Sig_EB_,
+                              meEle_pt_MTD_3_Sig_EB_,
+                              meEle_pt_MTD_4_Sig_EB_,
+                              meEle_pt_MTD_5_Sig_EB_,
+                              meEle_pt_MTD_6_Sig_EB_,
+                              meEle_pt_MTD_7_Sig_EB_};
+    Ele_eta_MTD_EB_list_Sig = {meEle_eta_MTD_1_Sig_EB_,
+                               meEle_eta_MTD_2_Sig_EB_,
+                               meEle_eta_MTD_3_Sig_EB_,
+                               meEle_eta_MTD_4_Sig_EB_,
+                               meEle_eta_MTD_5_Sig_EB_,
+                               meEle_eta_MTD_6_Sig_EB_,
+                               meEle_eta_MTD_7_Sig_EB_};
+    Ele_phi_MTD_EB_list_Sig = {meEle_phi_MTD_1_Sig_EB_,
+                               meEle_phi_MTD_2_Sig_EB_,
+                               meEle_phi_MTD_3_Sig_EB_,
+                               meEle_phi_MTD_4_Sig_EB_,
+                               meEle_phi_MTD_5_Sig_EB_,
+                               meEle_phi_MTD_6_Sig_EB_,
+                               meEle_phi_MTD_7_Sig_EB_};
+  }
 
   Ele_pT_MTD_EB_list_Significance_Sig = {
       meEle_pt_MTD_4sigma_Sig_EB_, meEle_pt_MTD_3sigma_Sig_EB_, meEle_pt_MTD_2sigma_Sig_EB_};
@@ -3658,28 +4214,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   Ele_phi_MTD_EB_list_Significance_Sig = {
       meEle_phi_MTD_4sigma_Sig_EB_, meEle_phi_MTD_3sigma_Sig_EB_, meEle_phi_MTD_2sigma_Sig_EB_};
 
-  Ele_pT_MTD_EE_list_Sig = {meEle_pt_MTD_1_Sig_EE_,
-                            meEle_pt_MTD_2_Sig_EE_,
-                            meEle_pt_MTD_3_Sig_EE_,
-                            meEle_pt_MTD_4_Sig_EE_,
-                            meEle_pt_MTD_5_Sig_EE_,
-                            meEle_pt_MTD_6_Sig_EE_,
-                            meEle_pt_MTD_7_Sig_EE_};
-  Ele_eta_MTD_EE_list_Sig = {meEle_eta_MTD_1_Sig_EE_,
-                             meEle_eta_MTD_2_Sig_EE_,
-                             meEle_eta_MTD_3_Sig_EE_,
-                             meEle_eta_MTD_4_Sig_EE_,
-                             meEle_eta_MTD_5_Sig_EE_,
-                             meEle_eta_MTD_6_Sig_EE_,
-                             meEle_eta_MTD_7_Sig_EE_};
-  Ele_phi_MTD_EE_list_Sig = {meEle_phi_MTD_1_Sig_EE_,
-                             meEle_phi_MTD_2_Sig_EE_,
-                             meEle_phi_MTD_3_Sig_EE_,
-                             meEle_phi_MTD_4_Sig_EE_,
-                             meEle_phi_MTD_5_Sig_EE_,
-                             meEle_phi_MTD_6_Sig_EE_,
-                             meEle_phi_MTD_7_Sig_EE_};
-
+  if (optionalPlots_) {
+    Ele_pT_MTD_EE_list_Sig = {meEle_pt_MTD_1_Sig_EE_,
+                              meEle_pt_MTD_2_Sig_EE_,
+                              meEle_pt_MTD_3_Sig_EE_,
+                              meEle_pt_MTD_4_Sig_EE_,
+                              meEle_pt_MTD_5_Sig_EE_,
+                              meEle_pt_MTD_6_Sig_EE_,
+                              meEle_pt_MTD_7_Sig_EE_};
+    Ele_eta_MTD_EE_list_Sig = {meEle_eta_MTD_1_Sig_EE_,
+                               meEle_eta_MTD_2_Sig_EE_,
+                               meEle_eta_MTD_3_Sig_EE_,
+                               meEle_eta_MTD_4_Sig_EE_,
+                               meEle_eta_MTD_5_Sig_EE_,
+                               meEle_eta_MTD_6_Sig_EE_,
+                               meEle_eta_MTD_7_Sig_EE_};
+    Ele_phi_MTD_EE_list_Sig = {meEle_phi_MTD_1_Sig_EE_,
+                               meEle_phi_MTD_2_Sig_EE_,
+                               meEle_phi_MTD_3_Sig_EE_,
+                               meEle_phi_MTD_4_Sig_EE_,
+                               meEle_phi_MTD_5_Sig_EE_,
+                               meEle_phi_MTD_6_Sig_EE_,
+                               meEle_phi_MTD_7_Sig_EE_};
+  }
   Ele_pT_MTD_EE_list_Significance_Sig = {
       meEle_pt_MTD_4sigma_Sig_EE_, meEle_pt_MTD_3sigma_Sig_EE_, meEle_pt_MTD_2sigma_Sig_EE_};
   Ele_eta_MTD_EE_list_Significance_Sig = {
@@ -3688,116 +4245,117 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       meEle_phi_MTD_4sigma_Sig_EE_, meEle_phi_MTD_3sigma_Sig_EE_, meEle_phi_MTD_2sigma_Sig_EE_};
 
   // For SIM CASE
+  if (optionalPlots_) {
+    Ntracks_sim_EB_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_2_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_3_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_4_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_5_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_6_Sig_EB_,
+                               meEleISO_Ntracks_MTD_sim_7_Sig_EB_};
+    ch_iso_sim_EB_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_2_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_3_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_4_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_5_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_6_Sig_EB_,
+                              meEleISO_chIso_MTD_sim_7_Sig_EB_};
+    rel_ch_iso_sim_EB_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_2_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_3_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_4_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_5_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_6_Sig_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_7_Sig_EB_};
 
-  Ntracks_sim_EB_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_2_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_3_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_4_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_5_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_6_Sig_EB_,
-                             meEleISO_Ntracks_MTD_sim_7_Sig_EB_};
-  ch_iso_sim_EB_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_2_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_3_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_4_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_5_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_6_Sig_EB_,
-                            meEleISO_chIso_MTD_sim_7_Sig_EB_};
-  rel_ch_iso_sim_EB_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_2_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_3_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_4_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_5_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_6_Sig_EB_,
-                                meEleISO_rel_chIso_MTD_sim_7_Sig_EB_};
+    Ntracks_sim_EB_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_,
+                                            meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_,
+                                            meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_};
+    ch_iso_sim_EB_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EB_,
+                                           meEleISO_chIso_MTD_sim_3sigma_Sig_EB_,
+                                           meEleISO_chIso_MTD_sim_2sigma_Sig_EB_};
+    rel_ch_iso_sim_EB_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_,
+                                               meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_,
+                                               meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_};
 
-  Ntracks_sim_EB_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EB_,
-                                          meEleISO_Ntracks_MTD_sim_3sigma_Sig_EB_,
-                                          meEleISO_Ntracks_MTD_sim_2sigma_Sig_EB_};
-  ch_iso_sim_EB_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EB_,
-                                         meEleISO_chIso_MTD_sim_3sigma_Sig_EB_,
-                                         meEleISO_chIso_MTD_sim_2sigma_Sig_EB_};
-  rel_ch_iso_sim_EB_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EB_,
-                                             meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EB_,
-                                             meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EB_};
+    Ntracks_sim_EE_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_2_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_3_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_4_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_5_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_6_Sig_EE_,
+                               meEleISO_Ntracks_MTD_sim_7_Sig_EE_};
+    ch_iso_sim_EE_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_2_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_3_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_4_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_5_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_6_Sig_EE_,
+                              meEleISO_chIso_MTD_sim_7_Sig_EE_};
+    rel_ch_iso_sim_EE_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_2_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_3_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_4_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_5_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_6_Sig_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_7_Sig_EE_};
 
-  Ntracks_sim_EE_list_Sig = {meEleISO_Ntracks_MTD_sim_1_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_2_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_3_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_4_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_5_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_6_Sig_EE_,
-                             meEleISO_Ntracks_MTD_sim_7_Sig_EE_};
-  ch_iso_sim_EE_list_Sig = {meEleISO_chIso_MTD_sim_1_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_2_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_3_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_4_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_5_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_6_Sig_EE_,
-                            meEleISO_chIso_MTD_sim_7_Sig_EE_};
-  rel_ch_iso_sim_EE_list_Sig = {meEleISO_rel_chIso_MTD_sim_1_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_2_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_3_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_4_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_5_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_6_Sig_EE_,
-                                meEleISO_rel_chIso_MTD_sim_7_Sig_EE_};
+    Ntracks_sim_EE_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_,
+                                            meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_,
+                                            meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_};
+    ch_iso_sim_EE_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EE_,
+                                           meEleISO_chIso_MTD_sim_3sigma_Sig_EE_,
+                                           meEleISO_chIso_MTD_sim_2sigma_Sig_EE_};
+    rel_ch_iso_sim_EE_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_,
+                                               meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_,
+                                               meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_};
 
-  Ntracks_sim_EE_list_Significance_Sig = {meEleISO_Ntracks_MTD_sim_4sigma_Sig_EE_,
-                                          meEleISO_Ntracks_MTD_sim_3sigma_Sig_EE_,
-                                          meEleISO_Ntracks_MTD_sim_2sigma_Sig_EE_};
-  ch_iso_sim_EE_list_Significance_Sig = {meEleISO_chIso_MTD_sim_4sigma_Sig_EE_,
-                                         meEleISO_chIso_MTD_sim_3sigma_Sig_EE_,
-                                         meEleISO_chIso_MTD_sim_2sigma_Sig_EE_};
-  rel_ch_iso_sim_EE_list_Significance_Sig = {meEleISO_rel_chIso_MTD_sim_4sigma_Sig_EE_,
-                                             meEleISO_rel_chIso_MTD_sim_3sigma_Sig_EE_,
-                                             meEleISO_rel_chIso_MTD_sim_2sigma_Sig_EE_};
+    Ele_pT_sim_MTD_EB_list_Sig = {meEle_pt_sim_MTD_1_Sig_EB_,
+                                  meEle_pt_sim_MTD_2_Sig_EB_,
+                                  meEle_pt_sim_MTD_3_Sig_EB_,
+                                  meEle_pt_sim_MTD_4_Sig_EB_,
+                                  meEle_pt_sim_MTD_5_Sig_EB_,
+                                  meEle_pt_sim_MTD_6_Sig_EB_,
+                                  meEle_pt_sim_MTD_7_Sig_EB_};
 
-  Ele_pT_sim_MTD_EB_list_Sig = {meEle_pt_sim_MTD_1_Sig_EB_,
-                                meEle_pt_sim_MTD_2_Sig_EB_,
-                                meEle_pt_sim_MTD_3_Sig_EB_,
-                                meEle_pt_sim_MTD_4_Sig_EB_,
-                                meEle_pt_sim_MTD_5_Sig_EB_,
-                                meEle_pt_sim_MTD_6_Sig_EB_,
-                                meEle_pt_sim_MTD_7_Sig_EB_};
+    Ele_pT_sim_MTD_EB_list_Significance_Sig = {
+        meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_sim_MTD_2sigma_Sig_EB_};
 
-  Ele_pT_sim_MTD_EB_list_Significance_Sig = {
-      meEle_pt_sim_MTD_4sigma_Sig_EB_, meEle_pt_sim_MTD_3sigma_Sig_EB_, meEle_pt_sim_MTD_2sigma_Sig_EB_};
-
-  Ele_pT_sim_MTD_EE_list_Sig = {meEle_pt_sim_MTD_1_Sig_EE_,
-                                meEle_pt_sim_MTD_2_Sig_EE_,
-                                meEle_pt_sim_MTD_3_Sig_EE_,
-                                meEle_pt_sim_MTD_4_Sig_EE_,
-                                meEle_pt_sim_MTD_5_Sig_EE_,
-                                meEle_pt_sim_MTD_6_Sig_EE_,
-                                meEle_pt_sim_MTD_7_Sig_EE_};
-
-  Ele_pT_sim_MTD_EE_list_Significance_Sig = {
-      meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_sim_MTD_2sigma_Sig_EE_};
+    Ele_pT_sim_MTD_EE_list_Sig = {meEle_pt_sim_MTD_1_Sig_EE_,
+                                  meEle_pt_sim_MTD_2_Sig_EE_,
+                                  meEle_pt_sim_MTD_3_Sig_EE_,
+                                  meEle_pt_sim_MTD_4_Sig_EE_,
+                                  meEle_pt_sim_MTD_5_Sig_EE_,
+                                  meEle_pt_sim_MTD_6_Sig_EE_,
+                                  meEle_pt_sim_MTD_7_Sig_EE_};
+    Ele_pT_sim_MTD_EE_list_Significance_Sig = {
+        meEle_pt_sim_MTD_4sigma_Sig_EE_, meEle_pt_sim_MTD_3sigma_Sig_EE_, meEle_pt_sim_MTD_2sigma_Sig_EE_};
+  }
 
   // Non-promt part
-  Ntracks_EB_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_2_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_3_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_4_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_5_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_6_Bkg_EB_,
-                         meEleISO_Ntracks_MTD_7_Bkg_EB_};
-  ch_iso_EB_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EB_,
-                        meEleISO_chIso_MTD_2_Bkg_EB_,
-                        meEleISO_chIso_MTD_3_Bkg_EB_,
-                        meEleISO_chIso_MTD_4_Bkg_EB_,
-                        meEleISO_chIso_MTD_5_Bkg_EB_,
-                        meEleISO_chIso_MTD_6_Bkg_EB_,
-                        meEleISO_chIso_MTD_7_Bkg_EB_};
-  rel_ch_iso_EB_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_2_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_3_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_4_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_5_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_6_Bkg_EB_,
-                            meEleISO_rel_chIso_MTD_7_Bkg_EB_};
-
+  if (optionalPlots_) {
+    Ntracks_EB_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_2_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_3_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_4_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_5_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_6_Bkg_EB_,
+                           meEleISO_Ntracks_MTD_7_Bkg_EB_};
+    ch_iso_EB_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EB_,
+                          meEleISO_chIso_MTD_2_Bkg_EB_,
+                          meEleISO_chIso_MTD_3_Bkg_EB_,
+                          meEleISO_chIso_MTD_4_Bkg_EB_,
+                          meEleISO_chIso_MTD_5_Bkg_EB_,
+                          meEleISO_chIso_MTD_6_Bkg_EB_,
+                          meEleISO_chIso_MTD_7_Bkg_EB_};
+    rel_ch_iso_EB_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_2_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_3_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_4_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_5_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_6_Bkg_EB_,
+                              meEleISO_rel_chIso_MTD_7_Bkg_EB_};
+  }
   Ntracks_EB_list_Significance_Bkg = {
       meEleISO_Ntracks_MTD_4sigma_Bkg_EB_, meEleISO_Ntracks_MTD_3sigma_Bkg_EB_, meEleISO_Ntracks_MTD_2sigma_Bkg_EB_};
   ch_iso_EB_list_Significance_Bkg = {
@@ -3806,28 +4364,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                                          meEleISO_rel_chIso_MTD_3sigma_Bkg_EB_,
                                          meEleISO_rel_chIso_MTD_2sigma_Bkg_EB_};
 
-  Ntracks_EE_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_2_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_3_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_4_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_5_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_6_Bkg_EE_,
-                         meEleISO_Ntracks_MTD_7_Bkg_EE_};
-  ch_iso_EE_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EE_,
-                        meEleISO_chIso_MTD_2_Bkg_EE_,
-                        meEleISO_chIso_MTD_3_Bkg_EE_,
-                        meEleISO_chIso_MTD_4_Bkg_EE_,
-                        meEleISO_chIso_MTD_5_Bkg_EE_,
-                        meEleISO_chIso_MTD_6_Bkg_EE_,
-                        meEleISO_chIso_MTD_7_Bkg_EE_};
-  rel_ch_iso_EE_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_2_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_3_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_4_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_5_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_6_Bkg_EE_,
-                            meEleISO_rel_chIso_MTD_7_Bkg_EE_};
-
+  if (optionalPlots_) {
+    Ntracks_EE_list_Bkg = {meEleISO_Ntracks_MTD_1_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_2_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_3_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_4_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_5_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_6_Bkg_EE_,
+                           meEleISO_Ntracks_MTD_7_Bkg_EE_};
+    ch_iso_EE_list_Bkg = {meEleISO_chIso_MTD_1_Bkg_EE_,
+                          meEleISO_chIso_MTD_2_Bkg_EE_,
+                          meEleISO_chIso_MTD_3_Bkg_EE_,
+                          meEleISO_chIso_MTD_4_Bkg_EE_,
+                          meEleISO_chIso_MTD_5_Bkg_EE_,
+                          meEleISO_chIso_MTD_6_Bkg_EE_,
+                          meEleISO_chIso_MTD_7_Bkg_EE_};
+    rel_ch_iso_EE_list_Bkg = {meEleISO_rel_chIso_MTD_1_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_2_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_3_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_4_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_5_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_6_Bkg_EE_,
+                              meEleISO_rel_chIso_MTD_7_Bkg_EE_};
+  }
   Ntracks_EE_list_Significance_Bkg = {
       meEleISO_Ntracks_MTD_4sigma_Bkg_EE_, meEleISO_Ntracks_MTD_3sigma_Bkg_EE_, meEleISO_Ntracks_MTD_2sigma_Bkg_EE_};
   ch_iso_EE_list_Significance_Bkg = {
@@ -3835,29 +4394,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   rel_ch_iso_EE_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_4sigma_Bkg_EE_,
                                          meEleISO_rel_chIso_MTD_3sigma_Bkg_EE_,
                                          meEleISO_rel_chIso_MTD_2sigma_Bkg_EE_};
-
-  Ele_pT_MTD_EB_list_Bkg = {meEle_pt_MTD_1_Bkg_EB_,
-                            meEle_pt_MTD_2_Bkg_EB_,
-                            meEle_pt_MTD_3_Bkg_EB_,
-                            meEle_pt_MTD_4_Bkg_EB_,
-                            meEle_pt_MTD_5_Bkg_EB_,
-                            meEle_pt_MTD_6_Bkg_EB_,
-                            meEle_pt_MTD_7_Bkg_EB_};
-  Ele_eta_MTD_EB_list_Bkg = {meEle_eta_MTD_1_Bkg_EB_,
-                             meEle_eta_MTD_2_Bkg_EB_,
-                             meEle_eta_MTD_3_Bkg_EB_,
-                             meEle_eta_MTD_4_Bkg_EB_,
-                             meEle_eta_MTD_5_Bkg_EB_,
-                             meEle_eta_MTD_6_Bkg_EB_,
-                             meEle_eta_MTD_7_Bkg_EB_};
-  Ele_phi_MTD_EB_list_Bkg = {meEle_phi_MTD_1_Bkg_EB_,
-                             meEle_phi_MTD_2_Bkg_EB_,
-                             meEle_phi_MTD_3_Bkg_EB_,
-                             meEle_phi_MTD_4_Bkg_EB_,
-                             meEle_phi_MTD_5_Bkg_EB_,
-                             meEle_phi_MTD_6_Bkg_EB_,
-                             meEle_phi_MTD_7_Bkg_EB_};
-
+  if (optionalPlots_) {
+    Ele_pT_MTD_EB_list_Bkg = {meEle_pt_MTD_1_Bkg_EB_,
+                              meEle_pt_MTD_2_Bkg_EB_,
+                              meEle_pt_MTD_3_Bkg_EB_,
+                              meEle_pt_MTD_4_Bkg_EB_,
+                              meEle_pt_MTD_5_Bkg_EB_,
+                              meEle_pt_MTD_6_Bkg_EB_,
+                              meEle_pt_MTD_7_Bkg_EB_};
+    Ele_eta_MTD_EB_list_Bkg = {meEle_eta_MTD_1_Bkg_EB_,
+                               meEle_eta_MTD_2_Bkg_EB_,
+                               meEle_eta_MTD_3_Bkg_EB_,
+                               meEle_eta_MTD_4_Bkg_EB_,
+                               meEle_eta_MTD_5_Bkg_EB_,
+                               meEle_eta_MTD_6_Bkg_EB_,
+                               meEle_eta_MTD_7_Bkg_EB_};
+    Ele_phi_MTD_EB_list_Bkg = {meEle_phi_MTD_1_Bkg_EB_,
+                               meEle_phi_MTD_2_Bkg_EB_,
+                               meEle_phi_MTD_3_Bkg_EB_,
+                               meEle_phi_MTD_4_Bkg_EB_,
+                               meEle_phi_MTD_5_Bkg_EB_,
+                               meEle_phi_MTD_6_Bkg_EB_,
+                               meEle_phi_MTD_7_Bkg_EB_};
+  }
   Ele_pT_MTD_EB_list_Significance_Bkg = {
       meEle_pt_MTD_4sigma_Bkg_EB_, meEle_pt_MTD_3sigma_Bkg_EB_, meEle_pt_MTD_2sigma_Bkg_EB_};
   Ele_eta_MTD_EB_list_Significance_Bkg = {
@@ -3865,28 +4424,29 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   Ele_phi_MTD_EB_list_Significance_Bkg = {
       meEle_phi_MTD_4sigma_Bkg_EB_, meEle_phi_MTD_3sigma_Bkg_EB_, meEle_phi_MTD_2sigma_Bkg_EB_};
 
-  Ele_pT_MTD_EE_list_Bkg = {meEle_pt_MTD_1_Bkg_EE_,
-                            meEle_pt_MTD_2_Bkg_EE_,
-                            meEle_pt_MTD_3_Bkg_EE_,
-                            meEle_pt_MTD_4_Bkg_EE_,
-                            meEle_pt_MTD_5_Bkg_EE_,
-                            meEle_pt_MTD_6_Bkg_EE_,
-                            meEle_pt_MTD_7_Bkg_EE_};
-  Ele_eta_MTD_EE_list_Bkg = {meEle_eta_MTD_1_Bkg_EE_,
-                             meEle_eta_MTD_2_Bkg_EE_,
-                             meEle_eta_MTD_3_Bkg_EE_,
-                             meEle_eta_MTD_4_Bkg_EE_,
-                             meEle_eta_MTD_5_Bkg_EE_,
-                             meEle_eta_MTD_6_Bkg_EE_,
-                             meEle_eta_MTD_7_Bkg_EE_};
-  Ele_phi_MTD_EE_list_Bkg = {meEle_phi_MTD_1_Bkg_EE_,
-                             meEle_phi_MTD_2_Bkg_EE_,
-                             meEle_phi_MTD_3_Bkg_EE_,
-                             meEle_phi_MTD_4_Bkg_EE_,
-                             meEle_phi_MTD_5_Bkg_EE_,
-                             meEle_phi_MTD_6_Bkg_EE_,
-                             meEle_phi_MTD_7_Bkg_EE_};
-
+  if (optionalPlots_) {
+    Ele_pT_MTD_EE_list_Bkg = {meEle_pt_MTD_1_Bkg_EE_,
+                              meEle_pt_MTD_2_Bkg_EE_,
+                              meEle_pt_MTD_3_Bkg_EE_,
+                              meEle_pt_MTD_4_Bkg_EE_,
+                              meEle_pt_MTD_5_Bkg_EE_,
+                              meEle_pt_MTD_6_Bkg_EE_,
+                              meEle_pt_MTD_7_Bkg_EE_};
+    Ele_eta_MTD_EE_list_Bkg = {meEle_eta_MTD_1_Bkg_EE_,
+                               meEle_eta_MTD_2_Bkg_EE_,
+                               meEle_eta_MTD_3_Bkg_EE_,
+                               meEle_eta_MTD_4_Bkg_EE_,
+                               meEle_eta_MTD_5_Bkg_EE_,
+                               meEle_eta_MTD_6_Bkg_EE_,
+                               meEle_eta_MTD_7_Bkg_EE_};
+    Ele_phi_MTD_EE_list_Bkg = {meEle_phi_MTD_1_Bkg_EE_,
+                               meEle_phi_MTD_2_Bkg_EE_,
+                               meEle_phi_MTD_3_Bkg_EE_,
+                               meEle_phi_MTD_4_Bkg_EE_,
+                               meEle_phi_MTD_5_Bkg_EE_,
+                               meEle_phi_MTD_6_Bkg_EE_,
+                               meEle_phi_MTD_7_Bkg_EE_};
+  }
   Ele_pT_MTD_EE_list_Significance_Bkg = {
       meEle_pt_MTD_4sigma_Bkg_EE_, meEle_pt_MTD_3sigma_Bkg_EE_, meEle_pt_MTD_2sigma_Bkg_EE_};
   Ele_eta_MTD_EE_list_Significance_Bkg = {
@@ -3895,93 +4455,92 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       meEle_phi_MTD_4sigma_Bkg_EE_, meEle_phi_MTD_3sigma_Bkg_EE_, meEle_phi_MTD_2sigma_Bkg_EE_};
 
   // SIM CASE
+  if (optionalPlots_) {
+    Ntracks_sim_EB_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_2_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_3_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_4_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_5_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_6_Bkg_EB_,
+                               meEleISO_Ntracks_MTD_sim_7_Bkg_EB_};
+    ch_iso_sim_EB_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_2_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_3_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_4_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_5_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_6_Bkg_EB_,
+                              meEleISO_chIso_MTD_sim_7_Bkg_EB_};
+    rel_ch_iso_sim_EB_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_,
+                                  meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_};
+    Ntracks_sim_EB_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_,
+                                            meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_,
+                                            meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_};
+    ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_,
+                                           meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_,
+                                           meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_};
+    rel_ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_,
+                                               meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_,
+                                               meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_};
 
-  Ntracks_sim_EB_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_2_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_3_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_4_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_5_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_6_Bkg_EB_,
-                             meEleISO_Ntracks_MTD_sim_7_Bkg_EB_};
-  ch_iso_sim_EB_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_2_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_3_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_4_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_5_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_6_Bkg_EB_,
-                            meEleISO_chIso_MTD_sim_7_Bkg_EB_};
-  rel_ch_iso_sim_EB_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_2_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_3_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_4_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_5_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_6_Bkg_EB_,
-                                meEleISO_rel_chIso_MTD_sim_7_Bkg_EB_};
+    Ntracks_sim_EE_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_2_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_3_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_4_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_5_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_6_Bkg_EE_,
+                               meEleISO_Ntracks_MTD_sim_7_Bkg_EE_};
+    ch_iso_sim_EE_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_2_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_3_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_4_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_5_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_6_Bkg_EE_,
+                              meEleISO_chIso_MTD_sim_7_Bkg_EE_};
+    rel_ch_iso_sim_EE_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_,
+                                  meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_};
 
-  Ntracks_sim_EB_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EB_,
-                                          meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EB_,
-                                          meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EB_};
-  ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EB_,
-                                         meEleISO_chIso_MTD_sim_3sigma_Bkg_EB_,
-                                         meEleISO_chIso_MTD_sim_2sigma_Bkg_EB_};
-  rel_ch_iso_sim_EB_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EB_,
-                                             meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EB_,
-                                             meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EB_};
+    Ntracks_sim_EE_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_,
+                                            meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_,
+                                            meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_};
+    ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_,
+                                           meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_,
+                                           meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_};
+    rel_ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_,
+                                               meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_,
+                                               meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_};
 
-  Ntracks_sim_EE_list_Bkg = {meEleISO_Ntracks_MTD_sim_1_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_2_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_3_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_4_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_5_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_6_Bkg_EE_,
-                             meEleISO_Ntracks_MTD_sim_7_Bkg_EE_};
-  ch_iso_sim_EE_list_Bkg = {meEleISO_chIso_MTD_sim_1_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_2_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_3_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_4_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_5_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_6_Bkg_EE_,
-                            meEleISO_chIso_MTD_sim_7_Bkg_EE_};
-  rel_ch_iso_sim_EE_list_Bkg = {meEleISO_rel_chIso_MTD_sim_1_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_2_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_3_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_4_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_5_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_6_Bkg_EE_,
-                                meEleISO_rel_chIso_MTD_sim_7_Bkg_EE_};
+    Ele_pT_sim_MTD_EB_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EB_,
+                                  meEle_pt_sim_MTD_2_Bkg_EB_,
+                                  meEle_pt_sim_MTD_3_Bkg_EB_,
+                                  meEle_pt_sim_MTD_4_Bkg_EB_,
+                                  meEle_pt_sim_MTD_5_Bkg_EB_,
+                                  meEle_pt_sim_MTD_6_Bkg_EB_,
+                                  meEle_pt_sim_MTD_7_Bkg_EB_};
 
-  Ntracks_sim_EE_list_Significance_Bkg = {meEleISO_Ntracks_MTD_sim_4sigma_Bkg_EE_,
-                                          meEleISO_Ntracks_MTD_sim_3sigma_Bkg_EE_,
-                                          meEleISO_Ntracks_MTD_sim_2sigma_Bkg_EE_};
-  ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_chIso_MTD_sim_4sigma_Bkg_EE_,
-                                         meEleISO_chIso_MTD_sim_3sigma_Bkg_EE_,
-                                         meEleISO_chIso_MTD_sim_2sigma_Bkg_EE_};
-  rel_ch_iso_sim_EE_list_Significance_Bkg = {meEleISO_rel_chIso_MTD_sim_4sigma_Bkg_EE_,
-                                             meEleISO_rel_chIso_MTD_sim_3sigma_Bkg_EE_,
-                                             meEleISO_rel_chIso_MTD_sim_2sigma_Bkg_EE_};
+    Ele_pT_sim_MTD_EB_list_Significance_Bkg = {
+        meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_sim_MTD_2sigma_Bkg_EB_};
 
-  Ele_pT_sim_MTD_EB_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EB_,
-                                meEle_pt_sim_MTD_2_Bkg_EB_,
-                                meEle_pt_sim_MTD_3_Bkg_EB_,
-                                meEle_pt_sim_MTD_4_Bkg_EB_,
-                                meEle_pt_sim_MTD_5_Bkg_EB_,
-                                meEle_pt_sim_MTD_6_Bkg_EB_,
-                                meEle_pt_sim_MTD_7_Bkg_EB_};
+    Ele_pT_sim_MTD_EE_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EE_,
+                                  meEle_pt_sim_MTD_2_Bkg_EE_,
+                                  meEle_pt_sim_MTD_3_Bkg_EE_,
+                                  meEle_pt_sim_MTD_4_Bkg_EE_,
+                                  meEle_pt_sim_MTD_5_Bkg_EE_,
+                                  meEle_pt_sim_MTD_6_Bkg_EE_,
+                                  meEle_pt_sim_MTD_7_Bkg_EE_};
 
-  Ele_pT_sim_MTD_EB_list_Significance_Bkg = {
-      meEle_pt_sim_MTD_4sigma_Bkg_EB_, meEle_pt_sim_MTD_3sigma_Bkg_EB_, meEle_pt_sim_MTD_2sigma_Bkg_EB_};
-
-  Ele_pT_sim_MTD_EE_list_Bkg = {meEle_pt_sim_MTD_1_Bkg_EE_,
-                                meEle_pt_sim_MTD_2_Bkg_EE_,
-                                meEle_pt_sim_MTD_3_Bkg_EE_,
-                                meEle_pt_sim_MTD_4_Bkg_EE_,
-                                meEle_pt_sim_MTD_5_Bkg_EE_,
-                                meEle_pt_sim_MTD_6_Bkg_EE_,
-                                meEle_pt_sim_MTD_7_Bkg_EE_};
-
-  Ele_pT_sim_MTD_EE_list_Significance_Bkg = {
-      meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_sim_MTD_2sigma_Bkg_EE_};
-
+    Ele_pT_sim_MTD_EE_list_Significance_Bkg = {
+        meEle_pt_sim_MTD_4sigma_Bkg_EE_, meEle_pt_sim_MTD_3sigma_Bkg_EE_, meEle_pt_sim_MTD_2sigma_Bkg_EE_};
+  }
   // dt distribution hist vecotrs
 
   general_pT_list = {meEle_dt_general_pT_1,
@@ -4003,18 +4562,21 @@ void MtdEleIsoValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
                             meEle_dtSignif_general_pT_7,
                             meEle_dtSignif_general_pT_8,
                             meEle_dtSignif_general_pT_9};
-
   general_eta_list = {meEle_dt_general_eta_1,
                       meEle_dt_general_eta_2,
                       meEle_dt_general_eta_3,
                       meEle_dt_general_eta_4,
-                      meEle_dt_general_eta_5};
+                      meEle_dt_general_eta_5,
+                      meEle_dt_general_eta_6,
+                      meEle_dt_general_eta_7};
 
   general_eta_Signif_list = {meEle_dtSignif_general_eta_1,
                              meEle_dtSignif_general_eta_2,
                              meEle_dtSignif_general_eta_3,
                              meEle_dtSignif_general_eta_4,
-                             meEle_dtSignif_general_eta_5};
+                             meEle_dtSignif_general_eta_5,
+                             meEle_dtSignif_general_eta_6,
+                             meEle_dtSignif_general_eta_7};
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -4025,54 +4587,36 @@ void MtdEleIsoValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<std::string>("folder", "MTD/ElectronIso");
   desc.add<edm::InputTag>("inputTagG", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
-  desc.add<edm::InputTag>(
-      "inputTag_vtx",
-      edm::InputTag("offlinePrimaryVertices4D"));  //  "offlinePrimaryVertices4D" or "offlinePrimaryVertices" (3D case)
+  desc.add<edm::InputTag>("inputTag_vtx", edm::InputTag("offlinePrimaryVertices4D"));
   desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
-
-  desc.add<edm::InputTag>(
-      "inputEle_EB",
-      edm::InputTag("gedGsfElectrons"));  // Adding the elecollection, barrel ecal and track driven electrons
-  //desc.add<edm::InputTag>("inputEle", edm::InputTag("ecalDrivenGsfElectrons")); // barrel + endcap, but without track seeded electrons
-  desc.add<edm::InputTag>("inputEle_EE", edm::InputTag("ecalDrivenGsfElectronsHGC"));  // only endcap electrons
+  desc.add<edm::InputTag>("inputEle_EB", edm::InputTag("gedGsfElectrons"));
+  desc.add<edm::InputTag>("inputEle_EE", edm::InputTag("ecalDrivenGsfElectronsHGC"));
   desc.add<edm::InputTag>("inputGenP", edm::InputTag("genParticles"));
-  desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));                            // From Aurora
-  desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));  // From Aurora
-
-  desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
-  desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
-  desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
-  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("trackExtenderWithMTD:generalTracksigmat0"));
-  desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD:generalTrackassoc"))
-      ->setComment("Association between General and MTD Extended tracks");
-  desc.add<edm::InputTag>("pathLengthSrc", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
-  desc.add<edm::InputTag>("t0SafePID", edm::InputTag("tofPID:t0safe"));
-  desc.add<edm::InputTag>("sigmat0SafePID", edm::InputTag("tofPID:sigmat0safe"));
-  desc.add<edm::InputTag>("sigmat0PID", edm::InputTag("tofPID:sigmat0"));
+  desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
   desc.add<edm::InputTag>("t0PID", edm::InputTag("tofPID:t0"));
+  desc.add<edm::InputTag>("sigmat0PID", edm::InputTag("tofPID:sigmat0"));
   desc.add<edm::InputTag>("trackMVAQual", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
   desc.add<double>("trackMinimumPt", 1.0);  // [GeV]
   desc.add<double>("trackMinimumEta", 1.5);
   desc.add<double>("trackMaximumEta", 3.2);
   desc.add<double>("rel_iso_cut", 0.08);
-  //desc.add<std::vector<MonitorElement*>>("Ntracks_EB_list_Sig_test", {meEleISO_Ntracks_MTD_1_Sig_EB_,meEleISO_Ntracks_MTD_2_Sig_EB_,meEleISO_Ntracks_MTD_3_Sig_EB_,meEleISO_Ntracks_MTD_4_Sig_EB_,meEleISO_Ntracks_MTD_5_Sig_EB_,meEleISO_Ntracks_MTD_6_Sig_EB_,meEleISO_Ntracks_MTD_7_Sig_EB_}); // example that does not work...
   desc.add<bool>("optionTrackMatchToPV", false);
-  desc.add<bool>("option_dtToPV", false);
-  desc.add<bool>("option_dtToTrack", true);
+  desc.add<bool>("option_dtToTrack", true);  // default is dt with track, if false will do dt to vertex
   desc.add<bool>("option_dtDistributions", false);
+  desc.add<bool>("option_plots", false);
+  desc.add<double>("min_dR_cut", 0.01);
+  desc.add<double>("max_dR_cut", 0.3);
+  desc.add<double>("min_pt_cut_EB", 0.7);
+  desc.add<double>("min_pt_cut_EE", 0.4);
+  desc.add<double>("max_dz_cut_EB", 0.5);  // PARAM
+  desc.add<double>("max_dz_cut_EE", 0.5);  // PARAM
+  desc.add<double>("max_dz_vtx_cut", 0.5);
+  desc.add<double>("max_dxy_vtx_cut", 0.2);
+  desc.add<double>("min_strip_cut", 0.01);
+  desc.add<double>("min_track_mtd_mva_cut", 0.5);
 
   descriptions.add("mtdEleIsoValid", desc);
-}
-
-bool MtdEleIsoValidation::pdgCheck(int pdg) {
-  bool pass;
-  pdg = std::abs(pdg);
-  if (pdg == 11 || pdg == 15 || pdg == 23 || pdg == 24) {
-    pass = true;
-  } else {
-    pass = false;
-  }
-  return pass;
 }
 
 DEFINE_FWK_MODULE(MtdEleIsoValidation);

--- a/Validation/MtdValidation/python/MtdPostProcessor_cff.py
+++ b/Validation/MtdValidation/python/MtdPostProcessor_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Validation.MtdValidation.btlSimHitsPostProcessor_cfi import btlSimHitsPostProcessor
 from Validation.MtdValidation.btlLocalRecoPostProcessor_cfi import btlLocalRecoPostProcessor
 from Validation.MtdValidation.MtdTracksPostProcessor_cfi import MtdTracksPostProcessor
+from Validation.MtdValidation.MtdEleIsoPostProcessor_cfi import MtdEleIsoPostProcessor
 from Validation.MtdValidation.Primary4DVertexPostProcessor_cfi import Primary4DVertexPostProcessor
 
-mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + btlLocalRecoPostProcessor + MtdTracksPostProcessor + Primary4DVertexPostProcessor)
+mtdValidationPostProcessor = cms.Sequence(btlSimHitsPostProcessor + btlLocalRecoPostProcessor + MtdTracksPostProcessor + MtdEleIsoPostProcessor + Primary4DVertexPostProcessor)

--- a/Validation/MtdValidation/scripts/ROC_plotter.py
+++ b/Validation/MtdValidation/scripts/ROC_plotter.py
@@ -1,0 +1,319 @@
+import numpy as np
+import uproot as up
+import matplotlib.pyplot as plt
+from matplotlib.ticker import NullFormatter
+
+"""
+This is a sample code for ROC curve plotting (Feel free to change it to Your needs!)
+Code is ran from "Validation/MtdValidation/test" directory
+Before running the code initialize cmsenv
+Run the code by using python3 -> 'python3 ROC_ploter.py'
+Change the DQM File and ROC plot output directories accordingly to Your workspace
+
+"""
+
+
+print("All libraries has been read in!")
+
+directory_path = '/afs/cern.ch/user/n/nstrautn/CMSSW_13_1_0_pre4/src/Validation/MtdValidation/test/' # DQM file location directory
+ROC_plots_directory = '/afs/cern.ch/user/n/nstrautn/CMSSW_13_1_0_pre4/src/Validation/MtdValidation/test/ROC/' # ROC plots location directory
+
+class MTD_Ele_Iso: # Using class, so code would be a bit shorter
+    
+    def __init__(self,filename_Sig: str, filename_Bkg: str,dz_cut: str,dtSignif_cut: bool):
+
+        self.filename_sig = directory_path + filename_Sig
+        self.filename_bkg = directory_path + filename_Bkg
+
+        self.cut_type = dtSignif_cut # True if dt_significance is used, false if absolute dt cut is used.
+        self.dz_cut_description = dz_cut
+
+        self.Tree_Sig = up.open(self.filename_sig)["DQMData/Run 1/MTD/Run summary/ElectronIso;1"]
+        self.Tree_Bkg = up.open(self.filename_bkg)["DQMData/Run 1/MTD/Run summary/ElectronIso;1"]
+
+        self.Sig_hists = {} # Dictionary that will hold all Signal histograms
+        self.Bkg_hists = {} # Dictionary that will hold all Bakcground histograms
+
+        self.Sig_iso_eff = {} # Dictionary that will hold isolation efficiency values for all iso cut values in different timing cuts (Signal)
+        self.Bkg_iso_eff = {} # Dictionary that will hold isolation efficiency values for all iso cut values in different timing cuts (Bakcground)
+
+    def Read_hists(self): 
+        
+        self.Sig_hists['Sig_noMTD_EB']  = self.Tree_Sig['Ele_chIso_sum_Sig_EB;1'].to_numpy()
+        self.Sig_hists['Sig_noMTD_EE']  = self.Tree_Sig['Ele_chIso_sum_Sig_EE;1'].to_numpy()
+        self.Bkg_hists['Bkg_noMTD_EB']  = self.Tree_Bkg['Ele_chIso_sum_Bkg_EB;1'].to_numpy()
+        self.Bkg_hists['Bkg_noMTD_EE']  = self.Tree_Bkg['Ele_chIso_sum_Bkg_EE;1'].to_numpy()
+
+        if self.cut_type == True: # dt significance cut case
+            
+            self.Sig_hists['Sig_4sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_4sigma_Sig_EB;1'].to_numpy()
+            self.Sig_hists['Sig_3sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_3sigma_Sig_EB;1'].to_numpy()
+            self.Sig_hists['Sig_2sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_2sigma_Sig_EB;1'].to_numpy()
+            
+            self.Sig_hists['Sig_4sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_4sigma_Sig_EE;1'].to_numpy()
+            self.Sig_hists['Sig_3sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_3sigma_Sig_EE;1'].to_numpy()
+            self.Sig_hists['Sig_2sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_2sigma_Sig_EE;1'].to_numpy()
+            
+            self.Bkg_hists['Bkg_4sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_4sigma_Bkg_EB;1'].to_numpy()
+            self.Bkg_hists['Bkg_3sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3sigma_Bkg_EB;1'].to_numpy()
+            self.Bkg_hists['Bkg_2sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2sigma_Bkg_EB;1'].to_numpy()
+            
+            self.Bkg_hists['Bkg_4sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_4sigma_Bkg_EE;1'].to_numpy()
+            self.Bkg_hists['Bkg_3sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3sigma_Bkg_EE;1'].to_numpy()
+            self.Bkg_hists['Bkg_2sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2sigma_Bkg_EE;1'].to_numpy()
+
+        else: # absolute dt cut case #optional
+
+            # Can redifine how many of the 7 cuts defined in the EleIsoValidation code to plot. (Here they are numbered in the star position -> 'Ele_chIso_sum_MTD_*_Sig_EB;1')
+            # The cut values themselves are defined in the Validaton code, here we just plot the ROC curves.
+            
+            self.Sig_hists['Sig_cut1_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_1_Sig_EB;1'].to_numpy()
+            self.Sig_hists['Sig_cut2_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_2_Sig_EB;1'].to_numpy()
+            self.Sig_hists['Sig_cut3_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_3_Sig_EB;1'].to_numpy()
+            self.Sig_hists['Sig_cut5_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_5_Sig_EB;1'].to_numpy()
+            
+            self.Sig_hists['Sig_cut1_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_1_Sig_EE;1'].to_numpy()
+            self.Sig_hists['Sig_cut2_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_2_Sig_EE;1'].to_numpy()
+            self.Sig_hists['Sig_cut3_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_3_Sig_EE;1'].to_numpy()
+            self.Sig_hists['Sig_cut5_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_5_Sig_EE;1'].to_numpy()
+            
+            self.Bkg_hists['Bkg_cut1_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_1_Bkg_EB;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut2_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2_Bkg_EB;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut3_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3_Bkg_EB;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut5_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_5_Bkg_EB;1'].to_numpy()
+            
+            self.Bkg_hists['Bkg_cut1_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_1_Bkg_EE;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut2_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2_Bkg_EE;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut3_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3_Bkg_EE;1'].to_numpy()
+            self.Bkg_hists['Bkg_cut5_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_5_Bkg_EE;1'].to_numpy()
+
+    def Calculate_efficiencies(self): # Scan through ch_iso_sum bin values (iso cuts), to calculate the efficiency for full cut range.
+        
+        efficiency_Sig_noMTD_EB  , efficiency_Bkg_noMTD_EB ,  efficiency_Sig_noMTD_EE  , efficiency_Bkg_noMTD_EE  = [],[],[],[]
+
+        if self.cut_type == True:
+            
+            efficiency_Sig_4sigma_EB , efficiency_Bkg_4sigma_EB , efficiency_Sig_4sigma_EE , efficiency_Bkg_4sigma_EE = [],[],[],[]
+            efficiency_Sig_3sigma_EB , efficiency_Bkg_3sigma_EB , efficiency_Sig_3sigma_EE , efficiency_Bkg_3sigma_EE = [],[],[],[]
+            efficiency_Sig_2sigma_EB , efficiency_Bkg_2sigma_EB , efficiency_Sig_2sigma_EE , efficiency_Bkg_2sigma_EE = [],[],[],[]
+            
+            for i in range( len(self.Sig_hists['Sig_noMTD_EB'][0]) ):
+
+                efficiency_Sig_noMTD_EB.append( sum(self.Sig_hists['Sig_noMTD_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_noMTD_EB'][0]) )
+                efficiency_Sig_4sigma_EB.append( sum(self.Sig_hists['Sig_4sigma_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_4sigma_EB'][0]) )
+                efficiency_Sig_3sigma_EB.append( sum(self.Sig_hists['Sig_3sigma_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_3sigma_EB'][0]) )
+                efficiency_Sig_2sigma_EB.append( sum(self.Sig_hists['Sig_2sigma_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_2sigma_EB'][0]) )
+
+                efficiency_Bkg_noMTD_EB.append( sum(self.Bkg_hists['Bkg_noMTD_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_noMTD_EB'][0]) )
+                efficiency_Bkg_4sigma_EB.append( sum(self.Bkg_hists['Bkg_4sigma_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_4sigma_EB'][0]) )
+                efficiency_Bkg_3sigma_EB.append( sum(self.Bkg_hists['Bkg_3sigma_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_3sigma_EB'][0]) )
+                efficiency_Bkg_2sigma_EB.append( sum(self.Bkg_hists['Bkg_2sigma_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_2sigma_EB'][0]) )
+
+
+                efficiency_Sig_noMTD_EE.append( sum(self.Sig_hists['Sig_noMTD_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_noMTD_EE'][0]) )
+                efficiency_Sig_4sigma_EE.append( sum(self.Sig_hists['Sig_4sigma_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_4sigma_EE'][0]) )
+                efficiency_Sig_3sigma_EE.append( sum(self.Sig_hists['Sig_3sigma_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_3sigma_EE'][0]) )
+                efficiency_Sig_2sigma_EE.append( sum(self.Sig_hists['Sig_2sigma_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_2sigma_EE'][0]) )
+
+                efficiency_Bkg_noMTD_EE.append( sum(self.Bkg_hists['Bkg_noMTD_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_noMTD_EE'][0]) )
+                efficiency_Bkg_4sigma_EE.append( sum(self.Bkg_hists['Bkg_4sigma_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_4sigma_EE'][0]) )
+                efficiency_Bkg_3sigma_EE.append( sum(self.Bkg_hists['Bkg_3sigma_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_3sigma_EE'][0]) )
+                efficiency_Bkg_2sigma_EE.append( sum(self.Bkg_hists['Bkg_2sigma_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_2sigma_EE'][0]) )
+
+
+            self.Sig_iso_eff['Sig_noMTD_EB'] , self.Bkg_iso_eff['Bkg_noMTD_EB'] = efficiency_Sig_noMTD_EB , efficiency_Bkg_noMTD_EB
+            self.Sig_iso_eff['Sig_4sigma_EB'] , self.Bkg_iso_eff['Bkg_4sigma_EB'] = efficiency_Sig_4sigma_EB , efficiency_Bkg_4sigma_EB
+            self.Sig_iso_eff['Sig_3sigma_EB'] , self.Bkg_iso_eff['Bkg_3sigma_EB'] = efficiency_Sig_3sigma_EB , efficiency_Bkg_3sigma_EB
+            self.Sig_iso_eff['Sig_2sigma_EB'] , self.Bkg_iso_eff['Bkg_2sigma_EB'] = efficiency_Sig_2sigma_EB , efficiency_Bkg_2sigma_EB
+
+            self.Sig_iso_eff['Sig_noMTD_EE'] , self.Bkg_iso_eff['Bkg_noMTD_EE'] = efficiency_Sig_noMTD_EE , efficiency_Bkg_noMTD_EE
+            self.Sig_iso_eff['Sig_4sigma_EE'] , self.Bkg_iso_eff['Bkg_4sigma_EE'] = efficiency_Sig_4sigma_EE , efficiency_Bkg_4sigma_EE
+            self.Sig_iso_eff['Sig_3sigma_EE'] , self.Bkg_iso_eff['Bkg_3sigma_EE'] = efficiency_Sig_3sigma_EE , efficiency_Bkg_3sigma_EE
+            self.Sig_iso_eff['Sig_2sigma_EE'] , self.Bkg_iso_eff['Bkg_2sigma_EE'] = efficiency_Sig_2sigma_EE , efficiency_Bkg_2sigma_EE
+
+        else:
+            
+            efficiency_Sig_cut1_EB , efficiency_Bkg_cut1_EB , efficiency_Sig_cut1_EE , efficiency_Bkg_cut1_EE = [],[],[],[]
+            efficiency_Sig_cut2_EB , efficiency_Bkg_cut2_EB , efficiency_Sig_cut2_EE , efficiency_Bkg_cut2_EE = [],[],[],[]
+            efficiency_Sig_cut3_EB , efficiency_Bkg_cut3_EB , efficiency_Sig_cut3_EE , efficiency_Bkg_cut3_EE = [],[],[],[]
+            efficiency_Sig_cut5_EB , efficiency_Bkg_cut5_EB , efficiency_Sig_cut5_EE , efficiency_Bkg_cut5_EE = [],[],[],[]
+
+            for i in range( len(self.Sig_hists['Sig_noMTD_EB'][0]) ):
+
+                efficiency_Sig_noMTD_EB.append( sum(self.Sig_hists['Sig_noMTD_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_noMTD_EB'][0]) )
+                efficiency_Sig_cut1_EB.append( sum(self.Sig_hists['Sig_cut1_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_cut1_EB'][0]) )
+                efficiency_Sig_cut2_EB.append( sum(self.Sig_hists['Sig_cut2_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_cut2_EB'][0]) )
+                efficiency_Sig_cut3_EB.append( sum(self.Sig_hists['Sig_cut3_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_cut3_EB'][0]) )
+                efficiency_Sig_cut5_EB.append( sum(self.Sig_hists['Sig_cut5_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_cut5_EB'][0]) )
+
+                efficiency_Bkg_noMTD_EB.append( sum(self.Bkg_hists['Bkg_noMTD_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_noMTD_EB'][0]) )
+                efficiency_Bkg_cut1_EB.append( sum(self.Bkg_hists['Bkg_cut1_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut1_EB'][0]) )
+                efficiency_Bkg_cut2_EB.append( sum(self.Bkg_hists['Bkg_cut2_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut2_EB'][0]) )
+                efficiency_Bkg_cut3_EB.append( sum(self.Bkg_hists['Bkg_cut3_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut3_EB'][0]) )
+                efficiency_Bkg_cut5_EB.append( sum(self.Bkg_hists['Bkg_cut5_EB'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut5_EB'][0]) )
+
+
+                efficiency_Sig_noMTD_EE.append( sum(self.Sig_hists['Sig_noMTD_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_noMTD_EE'][0]) )
+                efficiency_Sig_cut1_EE.append( sum(self.Sig_hists['Sig_cut1_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_cut1_EE'][0]) )
+                efficiency_Sig_cut2_EE.append( sum(self.Sig_hists['Sig_cut2_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_cut2_EE'][0]) )
+                efficiency_Sig_cut3_EE.append( sum(self.Sig_hists['Sig_cut3_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_cut3_EE'][0]) )
+                efficiency_Sig_cut5_EE.append( sum(self.Sig_hists['Sig_cut5_EE'][0][0:i+1])/sum(self.Sig_hists['Sig_cut5_EE'][0]) )
+
+                efficiency_Bkg_noMTD_EE.append( sum(self.Bkg_hists['Bkg_noMTD_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_noMTD_EE'][0]) )
+                efficiency_Bkg_cut1_EE.append( sum(self.Bkg_hists['Bkg_cut1_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut1_EE'][0]) )
+                efficiency_Bkg_cut2_EE.append( sum(self.Bkg_hists['Bkg_cut2_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut2_EE'][0]) )
+                efficiency_Bkg_cut3_EE.append( sum(self.Bkg_hists['Bkg_cut3_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut3_EE'][0]) )
+                efficiency_Bkg_cut5_EE.append( sum(self.Bkg_hists['Bkg_cut5_EE'][0][0:i+1])/sum(self.Bkg_hists['Bkg_cut5_EE'][0]) )
+
+
+            self.Sig_iso_eff['Sig_noMTD_EB'] , self.Bkg_iso_eff['Bkg_noMTD_EB'] = efficiency_Sig_noMTD_EB , efficiency_Bkg_noMTD_EB
+            self.Sig_iso_eff['Sig_cut1_EB'] , self.Bkg_iso_eff['Bkg_cut1_EB'] = efficiency_Sig_cut1_EB , efficiency_Bkg_cut1_EB
+            self.Sig_iso_eff['Sig_cut2_EB'] , self.Bkg_iso_eff['Bkg_cut2_EB'] = efficiency_Sig_cut2_EB , efficiency_Bkg_cut2_EB
+            self.Sig_iso_eff['Sig_cut3_EB'] , self.Bkg_iso_eff['Bkg_cut3_EB'] = efficiency_Sig_cut3_EB , efficiency_Bkg_cut3_EB
+            self.Sig_iso_eff['Sig_cut5_EB'] , self.Bkg_iso_eff['Bkg_cut5_EB'] = efficiency_Sig_cut5_EB , efficiency_Bkg_cut5_EB
+
+            self.Sig_iso_eff['Sig_noMTD_EE'] , self.Bkg_iso_eff['Bkg_noMTD_EE'] = efficiency_Sig_noMTD_EE , efficiency_Bkg_noMTD_EE
+            self.Sig_iso_eff['Sig_cut1_EE'] , self.Bkg_iso_eff['Bkg_cut1_EE'] = efficiency_Sig_cut1_EE , efficiency_Bkg_cut1_EE
+            self.Sig_iso_eff['Sig_cut2_EE'] , self.Bkg_iso_eff['Bkg_cut2_EE'] = efficiency_Sig_cut2_EE , efficiency_Bkg_cut2_EE
+            self.Sig_iso_eff['Sig_cut3_EE'] , self.Bkg_iso_eff['Bkg_cut3_EE'] = efficiency_Sig_cut3_EE , efficiency_Bkg_cut3_EE
+            self.Sig_iso_eff['Sig_cut5_EE'] , self.Bkg_iso_eff['Bkg_cut5_EE'] = efficiency_Sig_cut5_EE , efficiency_Bkg_cut5_EE
+        
+    def Plot_ROC_curves(self,xmin,xmax,ymin,ymax,save: bool):
+
+        if self.cut_type == True:
+
+            plt.plot(self.Sig_iso_eff['Sig_noMTD_EB'],self.Bkg_iso_eff['Bkg_noMTD_EB'], label = 'noMTD')
+            plt.plot(self.Sig_iso_eff['Sig_4sigma_EB'],self.Bkg_iso_eff['Bkg_4sigma_EB'], label = '4sigma cut')
+            plt.plot(self.Sig_iso_eff['Sig_3sigma_EB'],self.Bkg_iso_eff['Bkg_3sigma_EB'], label = '3sigma cut')
+            plt.plot(self.Sig_iso_eff['Sig_2sigma_EB'],self.Bkg_iso_eff['Bkg_2sigma_EB'], label = '2sigma cut')
+            plt.legend(loc='best')
+            plt.ylim(ymin,ymax)
+            plt.xlim(xmin,xmax)
+            plt.grid()
+            plt.xlabel("Signal efficiency")
+            plt.ylabel("Background efficiency")
+            plt.title(f'ROC curves for BTL, {self.dz_cut_description}')
+            if(save):
+                plt.savefig(ROC_plots_directory+f'ROC_curve_BTL_dtsignif_{self.dz_cut_description}')
+            plt.show()
+
+            plt.plot(self.Sig_iso_eff['Sig_noMTD_EE'],self.Bkg_iso_eff['Bkg_noMTD_EE'], label = 'noMTD')
+            plt.plot(self.Sig_iso_eff['Sig_4sigma_EE'],self.Bkg_iso_eff['Bkg_4sigma_EE'], label = '4sigma cut')
+            plt.plot(self.Sig_iso_eff['Sig_3sigma_EE'],self.Bkg_iso_eff['Bkg_3sigma_EE'], label = '3sigma cut')
+            plt.plot(self.Sig_iso_eff['Sig_2sigma_EE'],self.Bkg_iso_eff['Bkg_2sigma_EE'], label = '2sigma cut')
+            plt.legend(loc='best')
+            plt.ylim(ymin,ymax)
+            plt.xlim(xmin,xmax)
+            plt.grid()
+            plt.xlabel("Signal efficiency")
+            plt.ylabel("Background efficiency")
+            plt.title(f'ROC curves for ETL, {self.dz_cut_description}')
+            if(save):
+                plt.savefig(ROC_plots_directory+f'ROC_curve_ETL_dtsignif_{self.dz_cut_description}')
+            plt.show()
+
+        else:
+            # Check the cut definitions in mtdEleIsoValidation.cc file (These are default ones)
+
+            plt.plot(self.Sig_iso_eff['Sig_noMTD_EB'],self.Bkg_iso_eff['Bkg_noMTD_EB'], label = 'noMTD')
+            plt.plot(self.Sig_iso_eff['Sig_cut1_EB'],self.Bkg_iso_eff['Bkg_cut1_EB'], label = 'cut1 - 300ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut2_EB'],self.Bkg_iso_eff['Bkg_cut2_EB'], label = 'cut2 - 270ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut3_EB'],self.Bkg_iso_eff['Bkg_cut3_EB'], label = 'cut3 - 240ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut5_EB'],self.Bkg_iso_eff['Bkg_cut5_EB'], label = 'cut5 - 180ps')
+            plt.legend(loc='best')
+            plt.ylim(ymin,ymax)
+            plt.xlim(xmin,xmax)
+            plt.grid()
+            plt.xlabel("Signal efficiency")
+            plt.ylabel("Background efficiency")
+            plt.title(f'ROC curves for BTL, {self.dz_cut_description}')
+            if(save):
+                plt.savefig(ROC_plots_directory+f'ROC_curve_BTL_abs_dt_{self.dz_cut_description}')
+            plt.show()
+
+            plt.plot(self.Sig_iso_eff['Sig_noMTD_EE'],self.Bkg_iso_eff['Bkg_noMTD_EE'], label = 'noMTD')
+            plt.plot(self.Sig_iso_eff['Sig_cut1_EE'],self.Bkg_iso_eff['Bkg_cut1_EE'], label = 'cut1 - 300ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut2_EE'],self.Bkg_iso_eff['Bkg_cut2_EE'], label = 'cut2 - 270ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut3_EE'],self.Bkg_iso_eff['Bkg_cut3_EE'], label = 'cut3 - 240ps')
+            plt.plot(self.Sig_iso_eff['Sig_cut5_EE'],self.Bkg_iso_eff['Bkg_cut5_EE'], label = 'cut5 - 180ps')
+            plt.legend(loc='best')
+            plt.ylim(ymin,ymax)
+            plt.xlim(xmin,xmax)
+            plt.grid()
+            plt.xlabel("Signal efficiency")
+            plt.ylabel("Background efficiency")
+            plt.title(f'ROC curves for ETL, {self.dz_cut_description}')
+            if(save):
+                plt.savefig(ROC_plots_directory+f'ROC_curve_ETL_abs_dt_{self.dz_cut_description}')
+            plt.show()
+
+
+
+def Plot_ROC_curves_vs_dz_noMTD(xmin,xmax,ymin,ymax,save:bool,*objects):
+
+    for i in objects:
+        plt.plot(i.Sig_iso_eff['Sig_noMTD_EB'],i.Bkg_iso_eff['Bkg_noMTD_EB'],label=f'noMTD {i.dz_cut_description}')
+    plt.legend(loc='best')
+    plt.ylim(ymin,ymax)
+    plt.xlim(xmin,xmax)
+    plt.grid()
+    plt.xlabel("Signal efficiency")
+    plt.ylabel("Background efficiency")
+    plt.title('ROC curves for BTL, no MTD case')
+    if(save):
+        plt.savefig(ROC_plots_directory+'ROC_curve_BTL_noMTD_dzCuts')
+    plt.show()
+
+    for i in objects:
+        plt.plot(i.Sig_iso_eff['Sig_noMTD_EE'],i.Bkg_iso_eff['Bkg_noMTD_EE'],label=f'noMTD {i.dz_cut_description}')
+    plt.legend(loc='best')
+    plt.ylim(ymin,ymax)
+    plt.xlim(xmin,xmax)
+    plt.grid()
+    plt.xlabel("Signal efficiency")
+    plt.ylabel("Background efficiency")
+    plt.title('ROC curves for ETL, no MTD case')
+    if(save):
+        plt.savefig(ROC_plots_directory+'ROC_curve_ETL_noMTD_dzCuts')
+    plt.show()
+
+
+
+
+# object.Sig_hists['Sig_noMTD_EB'][1] # -> Array of ch_iso_sum bin values. (cuts for iso efficiency)
+
+def main():
+    
+    #obj = MTD_Ele_Iso(Signal_DQM_file,Bakcground_DQM_file,dz_cut description,dt_significance_check(False if abs(dt) check))
+    dz010_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz010_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz010_v5.root','dz_1mm',True)
+    dz020_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz020_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz020_v5.root','dz_2mm',True)
+    dz030_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz030_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz030_v5.root','dz_3mm',True)
+    dz040_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz040_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz040_v5.root','dz_4mm',True)
+    dz050_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz050_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz050_v5.root','dz_5mm',True)
+
+    dz010_cut_obj.Read_hists()
+    dz020_cut_obj.Read_hists()
+    dz030_cut_obj.Read_hists()
+    dz040_cut_obj.Read_hists()
+    dz050_cut_obj.Read_hists()
+
+    dz010_cut_obj.Calculate_efficiencies()
+    dz020_cut_obj.Calculate_efficiencies()
+    dz030_cut_obj.Calculate_efficiencies()
+    dz040_cut_obj.Calculate_efficiencies()
+    dz050_cut_obj.Calculate_efficiencies()
+
+    # .Plot_ROC_curves(xmin,xmax,ymix,ymax,savePlot) -> Saves plot for BTL and ETL parts
+    dz010_cut_obj.Plot_ROC_curves(0.75,1.0,0.05,0.4,True)
+    dz020_cut_obj.Plot_ROC_curves(0.75,1.0,0.05,0.4,True)
+    dz030_cut_obj.Plot_ROC_curves(0.75,1.0,0.05,0.4,True)
+    dz040_cut_obj.Plot_ROC_curves(0.75,1.0,0.05,0.4,True)
+    dz050_cut_obj.Plot_ROC_curves(0.75,1.0,0.05,0.4,True)
+
+
+    # This function usually works, but sometimes??? it gives errors -> no idea why. (python version issue?)
+    Plot_ROC_curves_vs_dz_noMTD(0.75,1.0,0.05,0.4,True,dz010_cut_obj,dz020_cut_obj,dz030_cut_obj,dz040_cut_obj,dz050_cut_obj) 
+
+
+if __name__ == "__main__":
+   main()

--- a/Validation/MtdValidation/scripts/ROC_plotter.py
+++ b/Validation/MtdValidation/scripts/ROC_plotter.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import uproot as up
 import matplotlib.pyplot as plt
@@ -15,11 +16,11 @@ Change the DQM File and ROC plot output directories accordingly to Your workspac
 
 print("All libraries has been read in!")
 
-directory_path = '/afs/cern.ch/user/n/nstrautn/CMSSW_13_1_0_pre4/src/Validation/MtdValidation/test/' # DQM file location directory
-ROC_plots_directory = '/afs/cern.ch/user/n/nstrautn/CMSSW_13_1_0_pre4/src/Validation/MtdValidation/test/ROC/' # ROC plots location directory
+directory_path = os.getenv('PWD') # DQM file location directory, to be adjusted according need
+ROC_plots_directory = directory_path + '/ROC' # ROC plots location directory
 
 class MTD_Ele_Iso: # Using class, so code would be a bit shorter
-    
+
     def __init__(self,filename_Sig: str, filename_Bkg: str,dz_cut: str,dtSignif_cut: bool):
 
         self.filename_sig = directory_path + filename_Sig
@@ -37,27 +38,27 @@ class MTD_Ele_Iso: # Using class, so code would be a bit shorter
         self.Sig_iso_eff = {} # Dictionary that will hold isolation efficiency values for all iso cut values in different timing cuts (Signal)
         self.Bkg_iso_eff = {} # Dictionary that will hold isolation efficiency values for all iso cut values in different timing cuts (Bakcground)
 
-    def Read_hists(self): 
-        
+    def Read_hists(self):
+
         self.Sig_hists['Sig_noMTD_EB']  = self.Tree_Sig['Ele_chIso_sum_Sig_EB;1'].to_numpy()
         self.Sig_hists['Sig_noMTD_EE']  = self.Tree_Sig['Ele_chIso_sum_Sig_EE;1'].to_numpy()
         self.Bkg_hists['Bkg_noMTD_EB']  = self.Tree_Bkg['Ele_chIso_sum_Bkg_EB;1'].to_numpy()
         self.Bkg_hists['Bkg_noMTD_EE']  = self.Tree_Bkg['Ele_chIso_sum_Bkg_EE;1'].to_numpy()
 
         if self.cut_type == True: # dt significance cut case
-            
+
             self.Sig_hists['Sig_4sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_4sigma_Sig_EB;1'].to_numpy()
             self.Sig_hists['Sig_3sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_3sigma_Sig_EB;1'].to_numpy()
             self.Sig_hists['Sig_2sigma_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_2sigma_Sig_EB;1'].to_numpy()
-            
+
             self.Sig_hists['Sig_4sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_4sigma_Sig_EE;1'].to_numpy()
             self.Sig_hists['Sig_3sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_3sigma_Sig_EE;1'].to_numpy()
             self.Sig_hists['Sig_2sigma_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_2sigma_Sig_EE;1'].to_numpy()
-            
+
             self.Bkg_hists['Bkg_4sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_4sigma_Bkg_EB;1'].to_numpy()
             self.Bkg_hists['Bkg_3sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3sigma_Bkg_EB;1'].to_numpy()
             self.Bkg_hists['Bkg_2sigma_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2sigma_Bkg_EB;1'].to_numpy()
-            
+
             self.Bkg_hists['Bkg_4sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_4sigma_Bkg_EE;1'].to_numpy()
             self.Bkg_hists['Bkg_3sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3sigma_Bkg_EE;1'].to_numpy()
             self.Bkg_hists['Bkg_2sigma_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2sigma_Bkg_EE;1'].to_numpy()
@@ -66,37 +67,37 @@ class MTD_Ele_Iso: # Using class, so code would be a bit shorter
 
             # Can redifine how many of the 7 cuts defined in the EleIsoValidation code to plot. (Here they are numbered in the star position -> 'Ele_chIso_sum_MTD_*_Sig_EB;1')
             # The cut values themselves are defined in the Validaton code, here we just plot the ROC curves.
-            
+
             self.Sig_hists['Sig_cut1_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_1_Sig_EB;1'].to_numpy()
             self.Sig_hists['Sig_cut2_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_2_Sig_EB;1'].to_numpy()
             self.Sig_hists['Sig_cut3_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_3_Sig_EB;1'].to_numpy()
             self.Sig_hists['Sig_cut5_EB'] = self.Tree_Sig['Ele_chIso_sum_MTD_5_Sig_EB;1'].to_numpy()
-            
+
             self.Sig_hists['Sig_cut1_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_1_Sig_EE;1'].to_numpy()
             self.Sig_hists['Sig_cut2_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_2_Sig_EE;1'].to_numpy()
             self.Sig_hists['Sig_cut3_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_3_Sig_EE;1'].to_numpy()
             self.Sig_hists['Sig_cut5_EE'] = self.Tree_Sig['Ele_chIso_sum_MTD_5_Sig_EE;1'].to_numpy()
-            
+
             self.Bkg_hists['Bkg_cut1_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_1_Bkg_EB;1'].to_numpy()
             self.Bkg_hists['Bkg_cut2_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2_Bkg_EB;1'].to_numpy()
             self.Bkg_hists['Bkg_cut3_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3_Bkg_EB;1'].to_numpy()
             self.Bkg_hists['Bkg_cut5_EB'] = self.Tree_Bkg['Ele_chIso_sum_MTD_5_Bkg_EB;1'].to_numpy()
-            
+
             self.Bkg_hists['Bkg_cut1_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_1_Bkg_EE;1'].to_numpy()
             self.Bkg_hists['Bkg_cut2_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_2_Bkg_EE;1'].to_numpy()
             self.Bkg_hists['Bkg_cut3_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_3_Bkg_EE;1'].to_numpy()
             self.Bkg_hists['Bkg_cut5_EE'] = self.Tree_Bkg['Ele_chIso_sum_MTD_5_Bkg_EE;1'].to_numpy()
 
     def Calculate_efficiencies(self): # Scan through ch_iso_sum bin values (iso cuts), to calculate the efficiency for full cut range.
-        
+
         efficiency_Sig_noMTD_EB  , efficiency_Bkg_noMTD_EB ,  efficiency_Sig_noMTD_EE  , efficiency_Bkg_noMTD_EE  = [],[],[],[]
 
         if self.cut_type == True:
-            
+
             efficiency_Sig_4sigma_EB , efficiency_Bkg_4sigma_EB , efficiency_Sig_4sigma_EE , efficiency_Bkg_4sigma_EE = [],[],[],[]
             efficiency_Sig_3sigma_EB , efficiency_Bkg_3sigma_EB , efficiency_Sig_3sigma_EE , efficiency_Bkg_3sigma_EE = [],[],[],[]
             efficiency_Sig_2sigma_EB , efficiency_Bkg_2sigma_EB , efficiency_Sig_2sigma_EE , efficiency_Bkg_2sigma_EE = [],[],[],[]
-            
+
             for i in range( len(self.Sig_hists['Sig_noMTD_EB'][0]) ):
 
                 efficiency_Sig_noMTD_EB.append( sum(self.Sig_hists['Sig_noMTD_EB'][0][0:i+1])/sum(self.Sig_hists['Sig_noMTD_EB'][0]) )
@@ -132,7 +133,7 @@ class MTD_Ele_Iso: # Using class, so code would be a bit shorter
             self.Sig_iso_eff['Sig_2sigma_EE'] , self.Bkg_iso_eff['Bkg_2sigma_EE'] = efficiency_Sig_2sigma_EE , efficiency_Bkg_2sigma_EE
 
         else:
-            
+
             efficiency_Sig_cut1_EB , efficiency_Bkg_cut1_EB , efficiency_Sig_cut1_EE , efficiency_Bkg_cut1_EE = [],[],[],[]
             efficiency_Sig_cut2_EB , efficiency_Bkg_cut2_EB , efficiency_Sig_cut2_EE , efficiency_Bkg_cut2_EE = [],[],[],[]
             efficiency_Sig_cut3_EB , efficiency_Bkg_cut3_EB , efficiency_Sig_cut3_EE , efficiency_Bkg_cut3_EE = [],[],[],[]
@@ -177,7 +178,7 @@ class MTD_Ele_Iso: # Using class, so code would be a bit shorter
             self.Sig_iso_eff['Sig_cut2_EE'] , self.Bkg_iso_eff['Bkg_cut2_EE'] = efficiency_Sig_cut2_EE , efficiency_Bkg_cut2_EE
             self.Sig_iso_eff['Sig_cut3_EE'] , self.Bkg_iso_eff['Bkg_cut3_EE'] = efficiency_Sig_cut3_EE , efficiency_Bkg_cut3_EE
             self.Sig_iso_eff['Sig_cut5_EE'] , self.Bkg_iso_eff['Bkg_cut5_EE'] = efficiency_Sig_cut5_EE , efficiency_Bkg_cut5_EE
-        
+
     def Plot_ROC_curves(self,xmin,xmax,ymin,ymax,save: bool):
 
         if self.cut_type == True:
@@ -283,7 +284,7 @@ def Plot_ROC_curves_vs_dz_noMTD(xmin,xmax,ymin,ymax,save:bool,*objects):
 # object.Sig_hists['Sig_noMTD_EB'][1] # -> Array of ch_iso_sum bin values. (cuts for iso efficiency)
 
 def main():
-    
+
     #obj = MTD_Ele_Iso(Signal_DQM_file,Bakcground_DQM_file,dz_cut description,dt_significance_check(False if abs(dt) check))
     dz010_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz010_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz010_v5.root','dz_1mm',True)
     dz020_cut_obj = MTD_Ele_Iso('DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Sig_dz020_v5.root','DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_Bkg_dz020_v5.root','dz_2mm',True)

--- a/Validation/MtdValidation/test/mtdHarvesting_cfg.py
+++ b/Validation/MtdValidation/test/mtdHarvesting_cfg.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.Utilities.FileUtils as FileUtils
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process('mtdHarvesting',Phase2C17I13M9)
@@ -9,25 +8,17 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
-
-mylist = FileUtils.loadListFromFile('filenames_update.txt') # input file with file names from grid grid control output
-
 
 process.MessageLogger.cerr.FwkReport  = cms.untracked.PSet(
     reportEvery = cms.untracked.int32(-1),
 )
 
 # Input source
-# process.source = cms.Source("DQMRootSource",
-#     fileNames = cms.untracked.vstring('file:step3_inDQM.root')
-# )
-
-# input source, when using grid control - from file with filename list
 process.source = cms.Source("DQMRootSource",
-    fileNames = cms.untracked.vstring(*mylist)
+    fileNames = cms.untracked.vstring('file:step3_inDQM.root')
 )
 
 # Path and EndPath definitions

--- a/Validation/MtdValidation/test/mtdHarvesting_cfg.py
+++ b/Validation/MtdValidation/test/mtdHarvesting_cfg.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import FWCore.Utilities.FileUtils as FileUtils
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process('mtdHarvesting',Phase2C17I13M9)
@@ -13,13 +13,21 @@ process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
+mylist = FileUtils.loadListFromFile('filenames_update.txt') # input file with file names from grid grid control output
+
+
 process.MessageLogger.cerr.FwkReport  = cms.untracked.PSet(
     reportEvery = cms.untracked.int32(-1),
 )
 
 # Input source
+# process.source = cms.Source("DQMRootSource",
+#     fileNames = cms.untracked.vstring('file:step3_inDQM.root')
+# )
+
+# input source, when using grid control - from file with filename list
 process.source = cms.Source("DQMRootSource",
-    fileNames = cms.untracked.vstring('file:step3_inDQM.root')
+    fileNames = cms.untracked.vstring(*mylist)
 )
 
 # Path and EndPath definitions
@@ -32,9 +40,10 @@ process.dqmsave_step = cms.Path(process.DQMSaver)
 process.load("Validation.MtdValidation.btlSimHitsPostProcessor_cfi")
 process.load("Validation.MtdValidation.btlLocalRecoPostProcessor_cfi")
 process.load("Validation.MtdValidation.MtdTracksPostProcessor_cfi")
+process.load("Validation.MtdValidation.MtdEleIsoPostProcessor_cfi")
 process.load("Validation.MtdValidation.Primary4DVertexPostProcessor_cfi")
 
-process.harvesting = cms.Sequence(process.btlSimHitsPostProcessor + process.btlLocalRecoPostProcessor + process.MtdTracksPostProcessor + process.Primary4DVertexPostProcessor)
+process.harvesting = cms.Sequence(process.btlSimHitsPostProcessor + process.btlLocalRecoPostProcessor + process.MtdTracksPostProcessor + process.MtdEleIsoPostProcessor + process.Primary4DVertexPostProcessor)
 
 process.p = cms.Path( process.harvesting )
 

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -21,18 +21,27 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 #Setup FWK for multithreaded
-process.options.numberOfThreads = 4
+process.options.numberOfThreads = 4 # original
+#process.options.numberOfThreads = 1
 process.options.numberOfStreams = 0
 process.options.numberOfConcurrentLuminosityBlocks = 0
 process.options.eventSetup.numberOfConcurrentIOVs = 1
 
 process.MessageLogger.cerr.FwkReport  = cms.untracked.PSet(
-    reportEvery = cms.untracked.int32(100),
+    reportEvery = cms.untracked.int32(10),
 )
+
+# process.source = cms.Source("PoolSource",
+#     fileNames = cms.untracked.vstring(
+#         'file:step3.root'
+#     )
+# )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        'file:step3.root'
+        #'/store/relval/CMSSW_12_3_1/RelValZEE_14/GEN-SIM-RECO/PU_123X_mcRun4_realistic_v10_2026D88PU200-v1/2580000/004d34e5-d815-439e-b5b5-7bf4197bd02b.root'
+        '/store/relval/CMSSW_13_1_0_pre3/RelValZEE_14/GEN-SIM-RECO/PU_131X_mcRun4_realistic_v2_2026D95PU200-v1/00000/02e1c1df-11e7-4ba3-a827-3b5867a1d85a.root'
+        # '/store/relval/CMSSW_12_3_1/RelValZEE_14/GEN-SIM-RECO/PU_123X_mcRun4_realistic_v10_2026D88PU200-v1/2580000/7206d4e3-1b30-44a0-8835-596834030974.root'
     )
 )
 
@@ -53,6 +62,7 @@ etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid 
 
 # --- Global Validation
 process.load("Validation.MtdValidation.mtdTracksValid_cfi")
+process.load("Validation.MtdValidation.mtdEleIsoValid_cfi")
 process.load("Validation.MtdValidation.vertices4DValid_cfi")
 
 # process.btlDigiHitsValid.optionalPlots = True
@@ -62,7 +72,7 @@ process.load("Validation.MtdValidation.vertices4DValid_cfi")
 # process.mtdTracksValid.optionalPlots = True
 # process.vertices4DValid.optionalPlots = True
 
-process.validation = cms.Sequence(btlValidation + etlValidation + process.mtdTracksValid + process.vertices4DValid)
+process.validation = cms.Sequence(btlValidation + etlValidation + process.mtdTracksValid + process.mtdEleIsoValid + process.vertices4DValid)
 
 process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
     dataset = cms.untracked.PSet(

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -10,7 +10,7 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D95Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -21,8 +21,7 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 #Setup FWK for multithreaded
-process.options.numberOfThreads = 4 # original
-#process.options.numberOfThreads = 1
+process.options.numberOfThreads = 4
 process.options.numberOfStreams = 0
 process.options.numberOfConcurrentLuminosityBlocks = 0
 process.options.eventSetup.numberOfConcurrentIOVs = 1
@@ -31,17 +30,9 @@ process.MessageLogger.cerr.FwkReport  = cms.untracked.PSet(
     reportEvery = cms.untracked.int32(10),
 )
 
-# process.source = cms.Source("PoolSource",
-#     fileNames = cms.untracked.vstring(
-#         'file:step3.root'
-#     )
-# )
-
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        #'/store/relval/CMSSW_12_3_1/RelValZEE_14/GEN-SIM-RECO/PU_123X_mcRun4_realistic_v10_2026D88PU200-v1/2580000/004d34e5-d815-439e-b5b5-7bf4197bd02b.root'
-        '/store/relval/CMSSW_13_1_0_pre3/RelValZEE_14/GEN-SIM-RECO/PU_131X_mcRun4_realistic_v2_2026D95PU200-v1/00000/02e1c1df-11e7-4ba3-a827-3b5867a1d85a.root'
-        # '/store/relval/CMSSW_12_3_1/RelValZEE_14/GEN-SIM-RECO/PU_123X_mcRun4_realistic_v10_2026D88PU200-v1/2580000/7206d4e3-1b30-44a0-8835-596834030974.root'
+        'file:step3.root'
     )
 )
 


### PR DESCRIPTION
#### PR description:

This PR is based on the work of @pauris123 and @AuroraPerego, presented in https://indico.cern.ch/event/1293576/ , to monitor the impact of MTD timing information on electron isolation. A new Validation plugin is provided and added to the existing sequence. A basic minimal set of plots is selected for regular monitoring, while a more extensive analysis is optionally available for a full detailed study of ROC curves, documented in the presentations at the MTD meeting. 

The basic version, to run routinely in the validation part of RelVals, provides as memory occupancy:

```
17:46 cmsdev25 532> dqmMemoryStats.py -i DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root --summary -x -c 0 -u KiB -p 2 | grep MTD
682.16 KiB       MTD/ETL
248.97 KiB       MTD/BTL
47.10 KiB        MTD/Tracks
38.23 KiB        MTD/Vertices
34.57 KiB        MTD/ElectronIso <==============
```

#### PR validation:

Code compiles, runs and provides the desired plots.