### PR TITLE
New l1 track trigger stub window tune

### DIFF
--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -13,27 +13,50 @@ import FWCore.ParameterSet.Config as cms
 # This version was tested on CMSSW 10_0_0_pre1
 # 
 
+   # PU200 new modified tight tuning
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
-   zMatchingPS  = cms.bool(True),
-   zMatching2S  = cms.bool(True),
-   #Number of tilted rings per side in barrel layers (for tilted geom only)
-   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
-   # PU200 tight tuning, optimized for muons
-   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
-   TiltedBarrelCutSet = cms.VPSet(
-        cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
-   	),
-   EndcapCutSet = cms.VPSet(
-        cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
-        )
+       zMatchingPS  = cms.bool(True),
+       zMatching2S  = cms.bool(True),
+       NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.),
+       BarrelCut    = cms.vdouble(0, 2.0, 2.5, 3.5, 4.0, 5.5, 6.5),
+       TiltedBarrelCutSet = cms.VPSet(
+           cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
+           cms.PSet( TiltedCut = cms.vdouble( 0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5, 1.5, 1.5, 1.0, 1.0) ),
+           cms.PSet( TiltedCut = cms.vdouble( 0, 3.0, 3.0, 3.0, 3.0, 3.0, 2.5, 2.5, 3.0, 3.0, 2.5, 2.5, 2.5) ),
+           cms.PSet( TiltedCut = cms.vdouble(0, 4.0, 4.0, 4.0, 3.5, 3.5, 3.5, 3.0, 3.0, 2.5, 2.5, 2.5, 2.5) ),
+       ),
+       EndcapCutSet = cms.VPSet(
+           cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+           cms.PSet( EndcapCut = cms.vdouble(0, 1.0, 1.5, 1.5, 2.0, 2.0, 2.5, 2.5, 3.0, 4.0, 4.0, 2.5, 3.0, 3.5, 4.0, 5.0) ),
+           cms.PSet( EndcapCut = cms.vdouble(0, 0.5, 1.5, 1.5, 2.0, 2.0, 2.0, 2.5, 2.5, 3.0, 3.5, 2.0, 2.5, 3.0, 4.0, 4.0) ),
+           cms.PSet( EndcapCut = cms.vdouble(0, 1.5, 2.0, 2.0, 2.0, 2.0, 2.5, 3.0, 3.5, 2.5, 2.5, 3.0, 3.5) ),
+           cms.PSet( EndcapCut = cms.vdouble(0, 1.0, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 3.0, 2.0, 2.0, 3.0, 3.0) ),
+           cms.PSet( EndcapCut = cms.vdouble(0, 1.0, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.5, 3.0, 2.0, 2.0, 2.5) ),
+       )
+)
+   # PU200 tight tuning
+   #TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
+   #   zMatchingPS  = cms.bool(True),
+   #   zMatching2S  = cms.bool(True),
+   #   #Number of tilted rings per side in barrel layers (for tilted geom only)
+   #   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
+   #   # PU200 tight tuning, optimized for muons
+   #   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
+   #   TiltedBarrelCutSet = cms.VPSet(
+   #        cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
+   #        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
+   #        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
+   #        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
+   #   	),
+   #   EndcapCutSet = cms.VPSet(
+   #        cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
+   #        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
+   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
+   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
+   #        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
+   #        )
+   #
 
    # PU200 loose tuning, optimized for robustness (uncomment if you want to use it)
    #BarrelCut    = cms.vdouble( 0, 2.0, 3, 4.5, 6, 6.5, 7.0),
@@ -51,7 +74,7 @@ TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_of
    #     cms.PSet( EndcapCut = cms.vdouble( 0, 1., 2.5, 3.5, 6., 6.5, 6.5, 6.5, 6.5, 7, 7, 7, 7) ),
    #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3., 4.5, 6.5, 6.5, 7, 7, 7, 7, 7, 7) ),
    #     )
-)
+#)
 
 # CBC3 hit matching algorithm
 TTStubAlgorithm_cbc3_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_cbc3_Phase2TrackerDigi_",

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -3,14 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # First register all the hit matching algorithms, then specify preferred ones at end.
 
 # The stub windows used has been optimized for for PU200 events
-# We use by default the tight tuning
+# We use by default the new modified tight tuning
 #
-# Definition is presented here:
+# more details can be found in:
 #
-# https://indico.cern.ch/event/681577/#4-update-of-the-track-trigger
-#
-# This script is adapted to the very last Tilted Tracker geometry to date (tracker T5)
-# This version was tested on CMSSW 10_0_0_pre1
+# https://indico.cern.ch/event/1219718/contributions/5131439/attachments/2547947/4388175/Reza_15Nov2022.pdf
+# https://indico.cern.ch/event/1261747/contributions/5331753/attachments/2624385/4538593/Reza_13March2023.pdf
+# This script is adapted to the very last Tilted Tracker geometry (D76)
+# This version was tested on CMSSW_13_3_0_pre2
 # 
 
    # PU200 new modified tight tuning

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -34,47 +34,6 @@ TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_of
            cms.PSet( EndcapCut = cms.vdouble(0, 1.0, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.5, 3.0, 2.0, 2.0, 2.5) ),
        )
 )
-   # PU200 tight tuning
-   #TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",
-   #   zMatchingPS  = cms.bool(True),
-   #   zMatching2S  = cms.bool(True),
-   #   #Number of tilted rings per side in barrel layers (for tilted geom only)
-   #   NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
-   #   # PU200 tight tuning, optimized for muons
-   #   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
-   #   TiltedBarrelCutSet = cms.VPSet(
-   #        cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-   #        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
-   #        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
-   #        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
-   #   	),
-   #   EndcapCutSet = cms.VPSet(
-   #        cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
-   #        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
-   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
-   #        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
-   #        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
-   #        )
-   #
-
-   # PU200 loose tuning, optimized for robustness (uncomment if you want to use it)
-   #BarrelCut    = cms.vdouble( 0, 2.0, 3, 4.5, 6, 6.5, 7.0),
-   #TiltedBarrelCutSet = cms.VPSet(
-   #     cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3., 2.5, 3., 3., 2.5, 2.5, 2., 1.5, 1.5, 1, 1) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 4., 4, 4, 4, 4., 4., 4.5, 5, 4., 3.5, 3.5, 3) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 5, 5, 5, 5, 5, 5, 5.5, 5, 5, 5.5, 5.5, 5.5) ),
-   #	),
-   #EndcapCutSet = cms.VPSet(
-   #     cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1., 2.5, 2.5, 3.5, 5.5, 5.5, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 5, 6, 6, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 7, 7) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3., 4.5, 6., 6.5, 6.5, 6.5, 7, 7, 7, 7, 7) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1., 2.5, 3.5, 6., 6.5, 6.5, 6.5, 6.5, 7, 7, 7, 7) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3., 4.5, 6.5, 6.5, 7, 7, 7, 7, 7, 7) ),
-   #     )
-#)
 
 # CBC3 hit matching algorithm
 TTStubAlgorithm_cbc3_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_cbc3_Phase2TrackerDigi_",

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -2,16 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 # First register all the hit matching algorithms, then specify preferred ones at end.
 
-# The stub windows used has been optimized for for PU200 events
+# The stub windows used has been optimized for PU200 events
 # We use by default the new modified tight tuning
-#
-# more details can be found in:
-#
-# https://indico.cern.ch/event/1219718/contributions/5131439/attachments/2547947/4388175/Reza_15Nov2022.pdf
-# https://indico.cern.ch/event/1261747/contributions/5331753/attachments/2624385/4538593/Reza_13March2023.pdf
+# more details can be found in the following detector note: CMS DN-2020/005
+
 # This script is adapted to the very last Tilted Tracker geometry (D76)
 # This version was tested on CMSSW_13_3_0_pre2
-# 
 
    # PU200 new modified tight tuning
 TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_official_Phase2TrackerDigi_",


### PR DESCRIPTION
I have performed various studies related to the stub rate and stub reconstruction efficiencies. As a results I have made a new stub window tune. All details are documented in the following detector note (CMS DN-2020/005 -- The L1 Track Trigger Upgrade: Properties, Efficiencies, and Rates for Track Stubs)
the only updated file is the following: L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
 
