### PR TITLE
Avoid unnecessary Framework delays closing luminosity blocks (simple version)

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -2212,6 +2212,10 @@ namespace edm {
   }
 
   void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
+    if (streamLumiStatus_[iStreamIndex]->haveStartedNextLumiOrEndedRun()) {
+      streamEndLumiAsync(iTask, iStreamIndex);
+      return;
+    }
     auto group = iTask.group();
     sourceResourcesAcquirer_.serialQueueChain().push(*group, [this, iTask = std::move(iTask), iStreamIndex]() mutable {
       CMS_SA_ALLOW try {

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -87,8 +87,8 @@ namespace edm {
     EventProcessingState eventProcessingState() const { return eventProcessingState_; }
     void setEventProcessingState(EventProcessingState val) { eventProcessingState_ = val; }
 
-    bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_; }
-    void startNextLumiOrEndRun() { startedNextLumiOrEndedRun_ = true; }
+    bool haveStartedNextLumiOrEndedRun() const { return startedNextLumiOrEndedRun_.load(); }
+    void startNextLumiOrEndRun() { startedNextLumiOrEndedRun_.store(true); }
 
     bool didGlobalBeginSucceed() const { return globalBeginSucceeded_; }
     void globalBeginDidSucceed() { globalBeginSucceeded_ = true; }
@@ -107,7 +107,7 @@ namespace edm {
     edm::Timestamp endTime_{};
     std::atomic<char> endTimeSetStatus_{0};
     EventProcessingState eventProcessingState_{EventProcessingState::kProcessing};
-    bool startedNextLumiOrEndedRun_{false};  //read/write in m_sourceQueue
+    std::atomic<bool> startedNextLumiOrEndedRun_{false};
     bool globalBeginSucceeded_{false};
     bool cleaningUpAfterException_{false};
   };

--- a/FWCore/Integration/test/testLateLumiClosure_cfg.py
+++ b/FWCore/Integration/test/testLateLumiClosure_cfg.py
@@ -1,3 +1,20 @@
+# This test originally demonstrated a problem
+# reported online. The problem has since been
+# fixed by a modification in the function
+# EventProcessor::handleNextEventForStreamAsync.
+# I've left unmodified a description of the
+# problem below. It is still interesting to keep
+# this configuration around and running as it
+# still demonstrates the circumstances in a
+# way that none of the other tests replicate
+# and shows that the problem is fixed if one
+# examines the log output. Note that it is not
+# coded as a pass/fail test because the timing
+# could vary and we don't want a test that
+# occasionally fails. It might sometimes still
+# exhibit the problem behavior if for example
+# a thread hangs.
+
 # Demonstrates a problem first noticed online. Say there
 # are 3 lumis. The first and last lumis have events.
 # The middle one has no events. We are using


### PR DESCRIPTION
#### PR description:

This pull request fixes a problem related to luminosity blocks being closed later than necessary in some cases. It was noticed online in heavy ion runs. It should only be a problem online and not occur offline. The initial report and detailed description of the problem are in Issue https://github.com/cms-sw/cmssw/issues/42931. There are two items listed in the opening comment of that issue. This PR only addresses the first of those two items. "Lumisections that no longer receive events are closed late". It does not help with the second item.

The changes should not affect the behavior for the first stream that notices that a luminosity block has ended. Other streams though will notice the stream has ended and immediately call streamEndLumiAsync instead of waiting for it to be called by a task in the source serial queue. The delay is caused when that queue is blocked.

This PR should not affect the output of modules or anything else. It only affects the order in which things run. There are already many unit tests that verify the correct things are running and producing proper output. Those did not need modification. One unit test (see FWCore/Integration/test/testLateLumiClosure_cfg.py) is designed to demonstrate the problem. One can see the behavior in the log output of that test. Comparing the output with and without this PR shows that this PR fixes the problem. It is difficult to make this into a pass or fail type of test because timing can vary from one execution to the next. But I manually ran that test and verified that most of the time the problem is fixed by this PR (every time when I manually ran it). We usually do not want a unit test that occasionally fails. For example, behavior can be affected when the operating system pauses a thread due to contention issues.

(Note that this is my second try at this. The first version was too complex. This version is simpler, but there is a small imperfection in it. The following two lines of code in ```EventProcessor::handleNextEventForStreamAsync``` do not occur atomically.
```
    if (streamLumiStatus_[iStreamIndex]->haveStartedNextLumiOrEndedRun()) {
```
and
```
    sourceResourcesAcquirer_.serialQueueChain().push(*group, [this, iTask = std::move(iTask), iStreamIndex]() mutable {
```
When the condition is false and if in the very short time between them another stream ends the lumi, then reads the next lumi and progresses all the way to the point it is asking the input source what is next and that is waiting, the delayed lumi problem can still occur. After a few hours discussing this we decided the probability of this is small enough to ignore and also that the consequences of the delay occurring very rarely are not dire and so the simpler version is good enough. In the original version of the PR (see #43240), the code 100% avoids this problem. But there are about 10 extra lines of code with complicated synchronization. We decided the improvement that code provides was not worth the complexity. That code is still in GitHub though. If in the future the delay occurs often enough to cause problems, then we could still use it. This seems highly unlikely. It probably never occurs or if it does on rare occasions it is likely no one will notice.)

#### PR validation:

Existing Core unit tests pass. testLateLumiClosure_cfg.py exhibits the expected improvement in closing lumis
