### PR TITLE
Fix BeamSpotRcdRead_cfg and add unitTest

### DIFF
--- a/CondTools/BeamSpot/test/BeamSpotRcdRead_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotRcdRead_cfg.py
@@ -41,8 +41,10 @@ process.dbInput = cms.ESSource("PoolDBESSource",
 ####################################################################
 # Load and configure analyzer
 ####################################################################
-process.load("CondTools.BeamSpot.BeamSpotRcdRead_cfi")
-process.BeamSpotRead.rawFileName = 'reference_prompt_BeamSpotObjects_PCL_byLumi_v0_prompt.txt'
+from CondTools.BeamSpot.beamSpotRcdReader_cfi import beamSpotRcdReader
+process.BeamSpotRead = beamSpotRcdReader.clone(
+    rawFileName = 'reference_prompt_BeamSpotObjects_PCL_byLumi_v0_prompt.txt'
+)
 
 ####################################################################
 # Output file

--- a/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
@@ -39,6 +39,7 @@ cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True input
 
 printf "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdRead_cfg.py || die "Failure running BeamSpotRcdRead" $?
 
 printf "TESTING converting BeamSpotOnlineObjects from BeamSpotObjects ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineFromOfflineConverter_cfg.py unitTest=True startRun=325172 startLumi=458 || die "Failure running single-IOV BeamSpotOnlineFromOfflineConverter" $?


### PR DESCRIPTION
#### PR description:
- Fix the `CondTools/BeamSpot/test/BeamSpotRcdRead_cfg.py` script to correctly use the auto-generated cfi file
- Add unitTests to ensure this script doesn't get outdated (broken) in the future

#### PR validation:
Successfully ran:
```
scram b runtests_testReadWriteBeamSpotsFromDB
```

#### Backport:
Not a backport, no backport needed