### PR TITLE
Fix testCSCTriggerMapping test: avoid reading invalid data e.g empty line

### DIFF
--- a/CondFormats/CSCObjects/src/CSCTriggerMappingFromFile.cc
+++ b/CondFormats/CSCObjects/src/CSCTriggerMappingFromFile.cc
@@ -22,7 +22,8 @@ void CSCTriggerMappingFromFile::fill(void) {
       if (line[0] != commentFlag[0]) {
         int i1, i2, i3, i4, i5, i6, i7, i8, i9, i10;
         std::istringstream is(line);
-        is >> i1 >> i2 >> i3 >> i4 >> i5 >> i6 >> i7 >> i8 >> i9 >> i10;
+        if (!(is >> i1 >> i2 >> i3 >> i4 >> i5 >> i6 >> i7 >> i8 >> i9 >> i10))
+          continue;
         if (debugV())
           std::cout << i1 << " " << i2 << " " << i3 << " " << i4 << " " << i5 << " " << i6 << " " << i7 << " " << i8
                     << " " << i9 << " " << i10 << std::endl;


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/43031

The empty or invalid lines in the mapping files were causing unit test to fail for NON-LTO build. This test was reading the [following data](https://github.com/cms-sw/cmssw/blob/master/CondFormats/CSCObjects/test/csc_trigger_test_map.txt#L30-L33)
```
L30:      1       3       5       0       9       1       3       5       0       9
L31:# ================================================================================
L32:
L33:#Example of a more elaborate trigger schemes
```

As there was no check for empty lines (or invalid format lines) the test continued to process the L32 and has reused the `i1, i2, i3, i4, i5, i6, i7, i8, i9` read from the line `L30` and set `i10=0` . With some debug statements, the output from the tests was
```
LINE:      1       3       5       0       9       1       3       5       0       9
i1-10: 1 3 5 0 9 1 3 5 0 9
LINE: # ================================================================================
LINE:
i1-10: 1 3 5 0 9 1 3 5 0 0
```

Local tests shows that unit test works in NONLTO IBs with this fix