### PR TITLE
Add L1 Upgrade Workflow: 0.78

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -52,6 +52,7 @@ The offsets currently in use are:
 * 0.601: HLT as separate step
 * 0.7: trackingMkFit modifier
 * 0.701: DisplacedRegionalStep tracking iteration for Run-3
+* 0.78: Complete L1 workflow
 * 0.8: BPH Parking (Run-2)
 * 0.81: Running also HeavyFlavor DQM
 * 0.9: Vector hits

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1744,6 +1744,26 @@ upgradeWFs['HLTwDIGI75e33'] = UpgradeWorkflow_HLTwDIGI75e33(
     offset = 0.76,
 )
 
+class UpgradeWorkflow_L1Complete(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Digi' in step:
+            stepDict[stepName][k] = merge([{'-s': 'DIGI:pdigi_valid,L1,L1TrackTrigger,L1P2GT'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return '2026' in key
+
+upgradeWFs['L1Complete'] = UpgradeWorkflow_L1Complete(
+    steps = [
+        'Digi',
+        'DigiTrigger'
+    ],
+    PU = [
+        'Digi',
+        'DigiTrigger',
+    ],
+    suffix = '_L1Complete',
+    offset = 0.1001
+)
+
 class UpgradeWorkflow_Neutron(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'GenSim' in step:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1761,7 +1761,7 @@ upgradeWFs['L1Complete'] = UpgradeWorkflow_L1Complete(
         'DigiTrigger',
     ],
     suffix = '_L1Complete',
-    offset = 0.1001
+    offset = 0.78
 )
 
 class UpgradeWorkflow_Neutron(UpgradeWorkflow):

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1753,11 +1753,9 @@ class UpgradeWorkflow_L1Complete(UpgradeWorkflow):
 
 upgradeWFs['L1Complete'] = UpgradeWorkflow_L1Complete(
     steps = [
-        'Digi',
-        'DigiTrigger'
+        'DigiTrigger',
     ],
     PU = [
-        'Digi',
         'DigiTrigger',
     ],
     suffix = '_L1Complete',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1747,7 +1747,7 @@ upgradeWFs['HLTwDIGI75e33'] = UpgradeWorkflow_HLTwDIGI75e33(
 class UpgradeWorkflow_L1Complete(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         if 'Digi' in step:
-            stepDict[stepName][k] = merge([{'-s': 'DIGI:pdigi_valid,L1,L1TrackTrigger,L1P2GT'}, stepDict[step][k]])
+            stepDict[stepName][k] = merge([{'-s': 'DIGI:pdigi_valid,L1,L1TrackTrigger,L1P2GT,DIGI2RAW,HLT:@relval2026'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return '2026' in key
 


### PR DESCRIPTION
### PR description:

This PR creates an L1 workflow that includes the recently added Phase 2 L1 GT Emulator (and related `cmsDriver` step from https://github.com/cms-sw/cmssw/pull/43210) for testing of L1 upgrade sequences and PRs. The workflow should run a modified version of the `Digi` and `DigiTrigger` steps with the GT emulator inserted, and it should be available on 2026 workflows. @srimanob This should provide the L1 testing workflow we have been discussing, please let me know if you would like/were envisioning something else.

L1 would also like to explore whether this workflow, or a similar workflow idea can be used for validation of proposed to changes to L1, especially from the physics effects/menu effects perspective.

I don't know if this is the optimal solution for the testing that has been requested from L1, or if it will fully suit other L1 uses for it, so I would like some outside input on whether this is a good solution for being able to test the L1 steps going forward versus say, something like modifying the in place `Digi`/`DigiTrigger` steps, and having these L1 steps be in place "by default". Also, this runs redundant steps from the L1 point of view... Anything past step2 is not L1, so as far as testing L1 exclusively, seems like wasted work, but I am not sure how I might change that, or if it is within my ability to do so, let alone whether it is a good idea.

I don't know if there is a policy on naming/numbering these workflows. I didn't see anything relevant in the `README.md`, so I more or less chose `.1001` at random. If this needs to be changed, no issue, it is not used in anything else that we plan to commit at the moment.

@mcepeda & @artlbv I figure you might like to be informed about this, my hope is that eventually this can serve as the basis of a way to do more automatic L1 software validation and testing. Perhaps we can discuss this at some point.

### PR validation:

This PR has been tested by running two added workflows via the commands:
- `runTheMatrix.py --what upgrade -l 20834.1001` for an older and more used geometry
- `runTheMatrix.py --what upgrade -l 26834.1001` for a more recent geometry

Both workflows manage to run through step2, with the `Digi` or `DigiTrigger` steps, but, in full disclosure, step3 fails on the RAW2DIGI step, complaining about no FEDRawData collection.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and likely will not need backporting.