### PR TITLE
ECAL : DB PayloadInspector improvement

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstantsMC_PayloadInspector.cc
@@ -67,9 +67,9 @@ namespace {
           if (payload->barrelItems().empty())
             return false;
 
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibConstants_PayloadInspector.cc
@@ -64,9 +64,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalIntercalibErrors_PayloadInspector.cc
@@ -67,9 +67,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 0 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 0);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatiosRef_PayloadInspector.cc
@@ -64,9 +64,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAPDPNRatios_PayloadInspector.cc
@@ -62,9 +62,9 @@ namespace {
       for (auto const& iov : tag.iovs) {
         std::shared_ptr<EcalLaserAPDPNRatios> payload = Base::fetchPayload(std::get<1>(iov));
         if (payload.get()) {
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = 1; iphi < 361; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLaserAlphas_PayloadInspector.cc
@@ -63,9 +63,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPFRecHitThresholds_PayloadInspector.cc
@@ -66,9 +66,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 1 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 1);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -858,6 +858,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 200 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 200);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 
@@ -907,6 +910,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 200 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 200);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 
@@ -952,6 +958,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 200 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 200);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 
@@ -1153,6 +1162,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 2 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 2);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 
@@ -1201,6 +1213,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 1 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 1);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 
@@ -1245,6 +1260,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
+          // set to 0.5 for ieta 0 (no crystal)
+          for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
+            fillWithValue(iphi, 0, 0.5);
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);
 

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibConstants_PayloadInspector.cc
@@ -67,9 +67,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 0 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 0);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);

--- a/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalTimeCalibErrors_PayloadInspector.cc
@@ -67,9 +67,9 @@ namespace {
           // looping over the EB channels, via the dense-index, mapped into EBDetId's
           if (payload->barrelItems().empty())
             return false;
-          // set to -1 for ieta 0 (no crystal)
+          // set to 0 for ieta 0 (no crystal)
           for (int iphi = MIN_IPHI; iphi < MAX_IPHI + 1; iphi++)
-            fillWithValue(iphi, 0, -1);
+            fillWithValue(iphi, 0, 0);
 
           for (int cellid = EBDetId::MIN_HASH; cellid < EBDetId::kSizeForDenseIndexing; ++cellid) {
             uint32_t rawid = EBDetId::unhashIndex(cellid);


### PR DESCRIPTION
#### PR description:

ECAL : DB PayloadInspector improvement : the EB Maps show a line (at ieta=0) where NO crystals are present, but the default value chosen (-1 in general to distinguish this particular line) is too far from real values so the palette colors obtained is unusable.  New values at ieta=0 are closer to the real values, so that a color gradient will provide information.
In EcalPedestals_PayloadInspector, for the EBMean, a value of 200 near the reality has been chosen. For the EBRMS, 2 for G12, 1 for G1 and 0.5 for G1 are more adapted.


#### PR validation:

Tested in local with CondCore/Utilities/scripts/getPayloadData.py : Json file produced with values as expected at ieta=0

