### PR TITLE
Change Sonic to use ExternalFailure exception

### DIFF
--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -54,8 +54,8 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
     }
     //prepare an exception if exceeded
     else {
-      cms::Exception ex("SonicCallFailed");
-      ex << "call failed after max " << tries_ << " tries";
+      edm::Exception ex(edm::errors::ExternalFailure);
+      ex << "SonicCallFailed: call failed after max " << tries_ << " tries";
       eptr = make_exception_ptr(ex);
     }
   }


### PR DESCRIPTION
#### PR description:

Using the new exception type will make cmsRun return a more meaningful return value (which is what most code which launch cmsRun use to classify failures).

#### PR validation:

Code compiles.