### PR TITLE
faster edmConfigDump with --prune, also prunes unreferenced PSets

### DIFF
--- a/FWCore/ParameterSet/scripts/edmConfigDump
+++ b/FWCore/ParameterSet/scripts/edmConfigDump
@@ -23,12 +23,9 @@ parser.add_argument("configArgs",
 options = parser.parse_args()
 cmsProcess = processFromFile(options.filename, options.configArgs)
 
-if options.prune:
-    cmsProcess.prune(options.pruneVerbose)
-
 if options.output is not None:
     with open(options.output, "w") as f:
-        f.write(cmsProcess.dumpPython())
+        f.write(cmsProcess.dumpPython(prune=options.prune))
 else:
-    print(cmsProcess.dumpPython())
+    print(cmsProcess.dumpPython(prune=options.prune))
 


### PR DESCRIPTION
#### PR description:

`edmConfigDump` with `--prune` calls the `prune` method of the process object which is extremely slow and can even fail for some configurations because it uses `delattr` to remove unused attributes. Instead it should simply avoid printing the unused attributes to the final output.

Furthermore, it doesn't remove any PSets even though the data contained in most of them is already copied to the corresponding modules, adding thousands of lines of redundant data to the pruned config. Very few PSets are actually referenced by other PSets via `refToPSet_` and should be kept.

The main changes in this PR:
- The `prune` method of  `Process` was renamed to `_unusedAttributes`. Instead of calling `delattr`, it collects the unused attribute names into a list (to preserve order) and returns it. 
- `_unusedAttributes` also finds the names of all referenced PSets by recursively finding all `refToPSet_` attributes (elements of `__dict__` not starting with `'_'`) of objects and their children starting from the process object. All PSets that are not referenced are included in the returned list.
- A new `prune` method was added because it's used in some tests (in the same file). It simply calls `delattr` for every attribute returned by `_unusedAttributes`.
- `dumpPython` has a new boolean argument `prune`. If set to true, `_unusedAttributes` will be called and the resulting attributes will not be included in the output
- `edmConfigDump` doesn't call `prune` but sets the `prune` argument accordingly when calling `dumpPython`

#### PR validation:

Passes the tests in `FWCore/ParameterSet`