### PR TITLE
Phase 2 GTT TrackVertexAssociation Firmware limit

### DIFF
--- a/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
+++ b/L1Trigger/DemonstratorTools/interface/codecs/tracks.h
@@ -15,6 +15,22 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 namespace l1t::demo::codecs {
+  //function to get the gttLinkID from the TrackFindingProcessors
+  template <typename T>
+  unsigned int gttLinkID(T track) {
+    // use the sign bit of the tanL word to remove dependence on TTTrack eta member.
+    unsigned int etaSector = (track.getTrackWord()(TTTrack_TrackWord::TrackBitLocations::kTanlMSB,
+                                                   TTTrack_TrackWord::TrackBitLocations::kTanlMSB)
+                                  ? 0
+                                  : 1);
+    return etaSector + (2 * track.phiSector());
+  }
+
+  static inline std::pair<unsigned int, unsigned int> sectorsEtaPhiFromGTTLinkID(unsigned int id) {
+    unsigned int etaSector = (id % 2);
+    unsigned int phiSector = (static_cast<unsigned int>(id) - etaSector) / 2;
+    return std::pair<unsigned int, unsigned int>(etaSector, phiSector);
+  }
 
   // Return true if a track is contained within a collection
   bool trackInCollection(const edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>&,

--- a/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tracks.cc
@@ -24,7 +24,7 @@ namespace l1t::demo::codecs {
   std::array<std::vector<ap_uint<96>>, 18> getTrackWords(const edm::View<TTTrack<Ref_Phase2TrackerDigi_>>& tracks) {
     std::array<std::vector<ap_uint<96>>, 18> trackWords;
     for (const auto& track : tracks) {
-      trackWords.at((track.eta() >= 0 ? 1 : 0) + (2 * track.phiSector())).push_back(encodeTrack(track));
+      trackWords.at(gttLinkID(track)).push_back(encodeTrack(track));
     }
     return trackWords;
   }
@@ -39,10 +39,9 @@ namespace l1t::demo::codecs {
       edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> referenceTrackRef(referenceTracks, itrack);
 
       if (trackInCollection(referenceTrackRef, tracks)) {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector()))
-            .push_back(encodeTrack(referenceTrack));
+        trackWords.at(gttLinkID(referenceTrack)).push_back(encodeTrack(referenceTrack));
       } else {
-        trackWords.at((referenceTrack.eta() >= 0 ? 1 : 0) + (2 * referenceTrack.phiSector())).push_back(ap_uint<96>(0));
+        trackWords.at(gttLinkID(referenceTrack)).push_back(ap_uint<96>(0));
       }
     }
     return trackWords;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -164,8 +164,7 @@ private:
       }
     }
     bool operator()(const TTTrackType& t) {
-      //use same method as in L1Trigger/DemonstratorTools/src/codecs_tracks.cc method getTrackWords(...)
-      unsigned int gttLinkID = (t.eta() >= 0 ? 1 : 0) + (2 * t.phiSector());
+      unsigned int gttLinkID = l1t::demo::codecs::gttLinkID(t);
       //increment the counter of processed tracks
       processedTracksPerLink_.at(gttLinkID)++;
       //fwNTrackSetsTVA_ tracks may be processed in firmware, no more (<= used intentionally to match the off-by-one indexing versus LibHLS)
@@ -476,12 +475,12 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
   } //end loop over input converted tracks
 
   if (processSimulatedTracks_) {
-    linkLimitSel.print(); //FIXME
+    // linkLimitSel.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
   }
 
   if (processEmulatedTracks_) {
-    linkLimitSelEmu.print(); //FIXME
+    // linkLimitSelEmu.print(); //FIXME
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
     // test making the unconverted, fully-filled vertices
     for (unsigned int ive = 0; ive < nOutputVerticesEmulation; ive++) {

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -8,7 +8,6 @@ l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProd
   l1VerticesInputTag = cms.InputTag("l1tVertexFinder", "L1Vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
   outputCollectionName = cms.string("Level1TTTracksSelectedAssociated"),
-  outputVertexCollectionName = cms.string("L1VerticesUnconverted"),
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -1,12 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProducer',
+  l1TracksInputTag = cms.InputTag("l1tGTTInputProducer","Level1TTTracksConverted"),
   l1SelectedTracksInputTag = cms.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelected"),
   l1SelectedTracksEmulationInputTag = cms.InputTag("l1tTrackSelectionProducer", "Level1TTTracksSelectedEmulation"),
   # If no vertex collection is provided, then the DeltaZ cuts will not be run
   l1VerticesInputTag = cms.InputTag("l1tVertexFinder", "L1Vertices"),
   l1VerticesEmulationInputTag = cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
   outputCollectionName = cms.string("Level1TTTracksSelectedAssociated"),
+  outputVertexCollectionName = cms.string("L1VerticesUnconverted"),
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
@@ -16,10 +18,12 @@ l1tTrackVertexAssociationProducer = cms.EDProducer('L1TrackVertexAssociationProd
   useDisplacedTracksDeltaZOverride = cms.double(-1.0), # override the deltaZ cut value for displaced tracks
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
+  fwNTrackSetsTVA = cms.uint32(94), # firmware limit on number of GTT converted tracks considered for primary vertex association
   debug = cms.int32(0) # Verbosity levels: 0, 1, 2, 3, 4
 )
 
 l1tTrackVertexAssociationProducerExtended = l1tTrackVertexAssociationProducer.clone(
+  l1TracksInputTag = ("l1tGTTInputProducerExtended","Level1TTTracksExtendedConverted"),
   l1SelectedTracksInputTag = cms.InputTag("l1tTrackSelectionProducerExtended", "Level1TTTracksExtendedSelected"),
   l1SelectedTracksEmulationInputTag = cms.InputTag("l1tTrackSelectionProducerExtended", "Level1TTTracksExtendedSelectedEmulation"),
   outputCollectionName = cms.string("Level1TTTracksExtendedSelectedAssociated"),


### PR DESCRIPTION

#### PR description:

This PR implements matching of emulation to a firmware feature for the Global Track Trigger. For GTT, there are 18 optical links (9 phi sectors x 2 eta sectors) from the TrackFindingProcessors. Each link can send up to 104 tracks, but a limitation in the current firmware prevents all from being considered for association with the primary vertex: the limit is currently 94/104, and this limit is encoded in a configurable parameter in the l1tTrackVertexAssociation_cfi.py file. This has no impact on vertices (which are found using all (selected) tracks sent to GTT and strictly upstream of the TrackVertexAssociation), and in the cases of track-only objects, is expected to impact less than 1 in 10^6 ttbar (200PU) events (the original limit of 104 tracks per link was designed around such a figure of merit + an overhead, this PR decreases the overhead a small amount)

Bit-accurate outputs are maintained for board integration tests on 1008 events ttbar (200PU) events.

In anticipation of another PR, the code used to determine the link a track belongs to is encapsulated in a function in the codecs header, to be used commonly in the GTTFile{Reader,Writer} when updated.
#### PR validation:

This PR passed:
scram b
scram b code-checks
scram b code-format
Used to generate GTT test vectors for APx/Serenity on ~1000 events from TT (CMSSW_13_1) sample
Test vectors pass tests with corresponding update for TrackVertexAssociation in the LibHLS repo
runTheMatrix.py -l limited -i all --ibeos
#### Ports

This PR is a port from the cms-l1t-offline 13_3_0_pre3 integration branch, with commits squashed
https://github.com/cms-l1t-offline/cmssw/pull/1176
