### PR TITLE
Delete references to legacy module types in DQM.

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCOfflineClient.h
+++ b/DQM/CSCMonitorModule/plugins/CSCOfflineClient.h
@@ -28,7 +28,6 @@
 #include <set>
 
 /// DQM Framework stuff
-// #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 
 #include <DQMServices/Core/interface/DQMStore.h>

--- a/DQM/HcalTasks/plugins/OnlineDQMDigiAD_cmssw.cc
+++ b/DQM/HcalTasks/plugins/OnlineDQMDigiAD_cmssw.cc
@@ -10,7 +10,6 @@
 // #include "FWCore/Utilities/interface/Exception.h"
 // #include "FWCore/Utilities/interface/thread_safety_macros.h"
 // #include "FWCore/Framework/interface/Event.h"
-// #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"

--- a/DQM/Physics/src/EwkMuDQM.h
+++ b/DQM/Physics/src/EwkMuDQM.h
@@ -11,7 +11,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
-// #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQMOffline/L1Trigger/interface/L1TBeamConfiguration.h
+++ b/DQMOffline/L1Trigger/interface/L1TBeamConfiguration.h
@@ -28,7 +28,6 @@
 
 // User include files
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDAnalyzer.h"
 //#include "FWCore/Framework/interface/ESHandle.h"
 //#include "FWCore/Framework/interface/Event.h"
 //#include "FWCore/Framework/interface/LuminosityBlock.h"

--- a/DQMOffline/L1Trigger/interface/L1TLSBlock.h
+++ b/DQMOffline/L1Trigger/interface/L1TLSBlock.h
@@ -32,7 +32,6 @@
 
 // User include files
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDAnalyzer.h"
 //#include "FWCore/Framework/interface/ESHandle.h"
 //#include "FWCore/Framework/interface/Event.h"
 //#include "FWCore/Framework/interface/LuminosityBlock.h"


### PR DESCRIPTION
#### PR description:

Delete references to legacy modules types in DQM code (part of a minor campaign to delete all references in CMSSW to legacy module types). These files reference FWCore/Framework/interface/EDAnalyzer.h. This PR just removes lines that are already commented out.

#### PR validation:

Just cleanup deleting commented out lines. No new testing needed.