### PR TITLE
Remove try/catch clause in castor analyzer

### DIFF
--- a/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorLedAnalysis.cc
@@ -527,19 +527,17 @@ void CastorLedAnalysis::processLedEvent(const CastorDigiCollection& castor, cons
     evt_curr = m_nevtsample;
 
   // HF/Castor
-  try {
-    if (castor.empty())
-      throw (int)castor.size();
-    for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
-      const CastorDataFrame digi = (const CastorDataFrame)(*j);
-      _meol = castorHists.LEDTRENDS.find(digi.id());
-      if (_meol == castorHists.LEDTRENDS.end()) {
-        SetupLEDHists(2, digi.id(), castorHists.LEDTRENDS);
-      }
-      LedCastorHists(digi.id(), digi, castorHists.LEDTRENDS, cond);
+  if (castor.empty()) {
+    edm::LogError("CastorLedAnalysis") << "Event with " << (int)castor.size() << "Castor Digis passed." << std::endl;
+    return;
+  }
+  for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
+    const CastorDataFrame digi = (const CastorDataFrame)(*j);
+    _meol = castorHists.LEDTRENDS.find(digi.id());
+    if (_meol == castorHists.LEDTRENDS.end()) {
+      SetupLEDHists(2, digi.id(), castorHists.LEDTRENDS);
     }
-  } catch (int i) {
-    //    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
+    LedCastorHists(digi.id(), digi, castorHists.LEDTRENDS, cond);
   }
 
   // Call the function every m_nevtsample events

--- a/CalibCalorimetry/CastorCalib/src/CastorPedestalAnalysis.cc
+++ b/CalibCalorimetry/CastorCalib/src/CastorPedestalAnalysis.cc
@@ -105,32 +105,31 @@ void CastorPedestalAnalysis::processEvent(const CastorDigiCollection& castor, co
 
   m_shape = cond.getCastorShape();
   // HF
-  try {
-    if (castor.empty())
-      throw (int)castor.size();
-    for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
-      const CastorDataFrame digi = (const CastorDataFrame)(*j);
-      m_coder = cond.getCastorCoder(digi.id());
-      for (int i = m_startTS; i < digi.size() && i <= m_endTS; i++) {
-        for (int flag = 0; flag < 4; flag++) {
-          if (i + flag < digi.size() && i + flag <= m_endTS) {
-            per2CapsHists(flag, 2, digi.id(), digi.sample(i), digi.sample(i + flag), castorHists.PEDTRENDS, cond);
-          }
+  if (castor.empty()) {
+    edm::LogError("CastorLedAnalysis") << "Event with " << (int)castor.size() << "Castor Digis passed." << std::endl;
+    return;
+  }
+
+  for (CastorDigiCollection::const_iterator j = castor.begin(); j != castor.end(); ++j) {
+    const CastorDataFrame digi = (const CastorDataFrame)(*j);
+    m_coder = cond.getCastorCoder(digi.id());
+    for (int i = m_startTS; i < digi.size() && i <= m_endTS; i++) {
+      for (int flag = 0; flag < 4; flag++) {
+        if (i + flag < digi.size() && i + flag <= m_endTS) {
+          per2CapsHists(flag, 2, digi.id(), digi.sample(i), digi.sample(i + flag), castorHists.PEDTRENDS, cond);
         }
       }
-      if (m_startTS == 0 && m_endTS > 4) {
-        AllChanHists(digi.id(),
-                     digi.sample(0),
-                     digi.sample(1),
-                     digi.sample(2),
-                     digi.sample(3),
-                     digi.sample(4),
-                     digi.sample(5),
-                     castorHists.PEDTRENDS);
-      }
     }
-  } catch (int i) {
-    //    m_logFile << "Event with " << i<<" Castor Digis passed." << std::endl;
+    if (m_startTS == 0 && m_endTS > 4) {
+      AllChanHists(digi.id(),
+                   digi.sample(0),
+                   digi.sample(1),
+                   digi.sample(2),
+                   digi.sample(3),
+                   digi.sample(4),
+                   digi.sample(5),
+                   castorHists.PEDTRENDS);
+    }
   }
   // Call the function every m_nevtsample events
   if (m_nevtsample > 0) {


### PR DESCRIPTION
#### PR description:

Part of code cleaning campaign [slides](https://drive.google.com/file/d/1NupHuyuWHc2G6B70IKW2A30zeJ-lsOkA/view?usp=sharing) regarding the edm exception use guideline https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEdmExceptionUse . As the catch action clause in the original source has been commented, error message is directed to edm::LogError.

#### PR validation:

Tested locally with code-checks and code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.
