### PR TITLE
[CMSSW_13_3_X backport] Add Correct EGM Run3 electron NonIso MVA ID for EB

### DIFF
--- a/RecoEgamma/ElectronIdentification/data/ElectronIDVariablesRun3NonIso.txt
+++ b/RecoEgamma/ElectronIdentification/data/ElectronIDVariablesRun3NonIso.txt
@@ -1,0 +1,38 @@
+# File: ElectronIDVariablesRun3NonIso.txt
+#
+# This file is to be read by the MVAVariableHelper class. Lists all the
+# variables which appear in the xml files for the MVA based Electron IDs for Run2.
+# Variables are given line by line. The columns of each entry correspond to:
+#
+#     1. The name under which the variable appears in the weight files.
+#     2. How to get this variable from the electron with the cut parser (NO SPACES!)
+#        or if not available, how to get the variables elsewhere.
+#     3. The lower clip value for the variable to avoid crazy values. "None" if no clip.
+#     4. The upper clip value.
+#
+
+# This selection of ID variables is rather large and not intended to be used by a real ID,
+# but by an ntuplizer which dumps all possible ID variables.
+
+rho                                fixedGridRhoFastjetAll                                     None None
+ele_oldsigmaietaieta               full5x5_sigmaIetaIeta                                      None None
+ele_oldsigmaiphiiphi               full5x5_sigmaIphiIphi                                      None None
+ele_oldcircularity                 1.-full5x5_e1x5/full5x5_e5x5                                 -1.  2.
+ele_oldr9                          full5x5_r9                                                 None   5.
+ele_scletawidth                    superCluster.etaWidth                                      None None
+ele_sclphiwidth                    superCluster.phiWidth                                      None None
+ele_oldhe                          full5x5_hcalOverEcal                                       None None
+ele_kfhits                         closestCtfTrackNLayers                                     None None
+ele_kfchi2                         closestCtfTrackNormChi2                                    None  10.
+ele_gsfchi2                        gsfTrack.normalizedChi2                                    None 200.
+ele_fbrem                          fbrem                                                       -1. None
+ele_gsfhits                        gsfTrack.hitPattern.trackerLayersWithMeasurement           None None
+ele_expected_inner_hits            gsfTrack.hitPattern.numberOfLostHits('MISSING_INNER_HITS') None None
+ele_conversionVertexFitProbability convVtxFitProb                                             None None
+ele_ep                             eSuperClusterOverP                                         None  20.
+ele_eelepout                       eEleClusterOverPout                                        None  20.
+ele_IoEmIop                        1.0/ecalEnergy-1.0/trackMomentumAtVtx.R                    None None
+ele_deltaetain                     abs(deltaEtaSuperClusterTrackAtVtx)                       -0.06 0.06
+ele_deltaphiin                     abs(deltaPhiSuperClusterTrackAtVtx)                        -0.6  0.6
+ele_deltaetaseed                   abs(deltaEtaSeedClusterTrackAtCalo)                        -0.2  0.2
+ele_psEoverEraw                    superCluster.preshowerEnergy/superCluster.rawEnergy        None None

--- a/RecoEgamma/ElectronIdentification/python/FWLite.py
+++ b/RecoEgamma/ElectronIdentification/python/FWLite.py
@@ -86,7 +86,7 @@ class WorkingPoints(object):
 # Import information needed to construct the e/gamma MVAs
 
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_tools \
-        import EleMVA_6CategoriesCuts, mvaVariablesFile, mvaVariablesFileRun3, EleMVA_3CategoriesCuts
+        import EleMVA_6CategoriesCuts, mvaVariablesFile, mvaVariablesFileRun3, mvaVariablesFileRun3NonIso, EleMVA_3CategoriesCuts
 
 from RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Fall17_iso_V2_cff \
         import mvaWeightFiles as Fall17_iso_V2_weightFiles
@@ -120,7 +120,7 @@ electron_mvas = {
     "RunIIIWinter22IsoV1"   : ElectronMVAID("ElectronMVAEstimatorRun2","RunIIIWinter22IsoV1",
                                             EleMVA_6CategoriesCuts, RunIIIWinter22_iso_V1_weightFiles, mvaVariablesFileRun3),
     "RunIIIWinter22NoIsoV1" : ElectronMVAID("ElectronMVAEstimatorRun2","RunIIIWinter22NoIsoV1",
-                                            EleMVA_6CategoriesCuts, RunIIIWinter22_noIso_V1_weightFiles, mvaVariablesFileRun3),
+                                            EleMVA_6CategoriesCuts, RunIIIWinter22_noIso_V1_weightFiles, mvaVariablesFileRun3NonIso),
     "Fall17IsoV2"   : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17IsoV2",
                                     EleMVA_6CategoriesCuts, Fall17_iso_V2_weightFiles, mvaVariablesFile),
     "Fall17NoIsoV2" : ElectronMVAID("ElectronMVAEstimatorRun2","Fall17NoIsoV2",

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_RunIIIWinter22_noIso_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_RunIIIWinter22_noIso_V1_cff.py
@@ -9,7 +9,6 @@ mvaTag = "RunIIIWinter22NoIsoV1"
 
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Winter22NoIsoV1"
 
-
 mvaWeightFiles = cms.vstring(
      path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
      path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
@@ -21,11 +20,11 @@ mvaWeightFiles = cms.vstring(
 
 mvaEleID_RunIIIWinter22_noIso_V1_wp80_container = EleMVA_WP(
     idName = "mvaEleID-RunIIIWinter22-noIso-V1-wp80", mvaTag = mvaTag,
-    cutCategory0 = "0.99776583820026143", # EB1_5
-    cutCategory1 = "0.99399710641666705", # EB2_5
+    cutCategory0 = "0.9806578295496566", # EB1_5
+    cutCategory1 = "0.9413641904670094", # EB2_5
     cutCategory2 = "0.89762967983679642", # EE_5
-    cutCategory3 = "0.99997133733482069", # EB1_10
-    cutCategory4 = "0.99991566148661426", # EB2_10
+    cutCategory3 = "0.9997826058686308", # EB1_10
+    cutCategory4 = "0.9993177946586951", # EB2_10
     cutCategory5 = "0.99712023523348758", # EE_10
     )
 
@@ -33,11 +32,11 @@ mvaEleID_RunIIIWinter22_noIso_V1_wp80_container = EleMVA_WP(
 
 mvaEleID_RunIIIWinter22_noIso_V1_wp90_container = EleMVA_WP(
     idName = "mvaEleID-RunIIIWinter22-noIso-V1-wp90", mvaTag = mvaTag,
-    cutCategory0 = "0.9870981346957135", # EB1_5
-    cutCategory1 = "0.95756807831082225", # EB2_5
+    cutCategory0 = "0.8774784815007495", # EB1_5
+    cutCategory1 = "0.6755302215938275", # EB2_5
     cutCategory2 = "0.4195020250389494", # EE_5
-    cutCategory3 = "0.99981763428587134", # EB1_10
-    cutCategory4 = "0.99936974968805936", # EB2_10
+    cutCategory3 = "0.9981164732135666", # EB1_10
+    cutCategory4 = "0.9926206339419237", # EB2_10
     cutCategory5 = "0.96553633326857091", # EE_10
     )
 
@@ -52,7 +51,7 @@ mvaEleID_RunIIIWinter22_noIso_V1_producer_config = cms.PSet(
     nCategories         = cms.int32(6),
     categoryCuts        = cms.vstring(*EleMVA_6CategoriesCuts),
     weightFileNames     = mvaWeightFiles,
-    variableDefinition  = cms.string(mvaVariablesFileRun3)
+    variableDefinition  = cms.string(mvaVariablesFileRun3NonIso)
     )
 
 mvaEleID_RunIIIWinter22_noIso_V1_wp80 = configureVIDMVAEleID( mvaEleID_RunIIIWinter22_noIso_V1_wp80_container )

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_tools.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_tools.py
@@ -14,8 +14,9 @@ mvaClassName = "ElectronMVAEstimatorRun2"
 mvaProducerModuleLabel = "electronMVAValueMapProducer"
 
 # The files with the variable definitions
-mvaVariablesFile        = "RecoEgamma/ElectronIdentification/data/ElectronMVAEstimatorRun2Variables.txt"
-mvaVariablesFileRun3    = "RecoEgamma/ElectronIdentification/data/ElectronIDVariablesRun3.txt"
+mvaVariablesFile            = "RecoEgamma/ElectronIdentification/data/ElectronMVAEstimatorRun2Variables.txt"
+mvaVariablesFileRun3     = "RecoEgamma/ElectronIdentification/data/ElectronIDVariablesRun3.txt"
+mvaVariablesFileRun3NonIso  = "RecoEgamma/ElectronIdentification/data/ElectronIDVariablesRun3NonIso.txt"
 
 # =======================================
 # Define some commonly used category cuts


### PR DESCRIPTION
#### PR description:
Same as PR #43275


#### PR validation:
Same as PR #43275 

Please test this PR with https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/29

#### Backport
This PR is backport of PR #43275. Backport is required for the production of Mini and V13 Nano from CMSSW_13. 
