### PR TITLE
add verbose option to `BeamSpotRcdPrinter` and use it in the unit tests

### DIFF
--- a/CondTools/BeamSpot/test/BeamSpotRcdPrinter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotRcdPrinter_cfg.py
@@ -13,12 +13,18 @@ options.register('startIOV',
                  1406713458589700, # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.int, # string, int, or float
-                 "location of the input data")
+                 "starting IOV since")
 options.register('endIOV',
                  1406876667347162, # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.int, # string, int, or float
-                 "location of the input data")
+                 "ending IOV since")
+options.register('verbose',
+                 True, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "verbose output to screen")
+
 options.parseArguments()
 
 process.MessageLogger = cms.Service( "MessageLogger",
@@ -41,6 +47,7 @@ process.load("CondTools.BeamSpot.BeamSpotRcdPrinter_cfi")
 process.BeamSpotRcdPrinter.tagName  = options.inputTag
 process.BeamSpotRcdPrinter.startIOV = options.startIOV
 process.BeamSpotRcdPrinter.endIOV   = options.endIOV
+process.BeamSpotRcdPrinter.verbose  = options.verbose
 process.BeamSpotRcdPrinter.output   = "summary.txt"
 
 ### 2018 Prompt

--- a/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
+++ b/CondTools/BeamSpot/test/testReadWriteBeamSpotsFromDB.sh
@@ -38,7 +38,7 @@ printf "TESTING Reading BeamSpotOnlineHLTObjectsRcd DB object ...\n\n"
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineRecordsReader_cfg.py unitTest=True inputRecord=BeamSpotOnlineHLTObjectsRcd || die "Failure reading payload for BeamSpotOnlineHLTObjectsRcd" $?
 
 printf "TESTING reading BeamSpotObjectRcd DB object ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdPrinter_cfg.py || die "Failure running BeamSpotRcdPrinter" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdPrinter_cfg.py startIOV=1406713458589700 endIOV=1614147494085159 verbose=False || die "Failure running BeamSpotRcdPrinter" $?
 cmsRun ${SCRAM_TEST_PATH}/BeamSpotRcdRead_cfg.py || die "Failure running BeamSpotRcdRead" $?
 
 printf "TESTING converting BeamSpotOnlineObjects from BeamSpotObjects ...\n\n"


### PR DESCRIPTION
#### PR description:

Title says it all, in response to https://github.com/cms-sw/cmssw/pull/43265#issuecomment-1812379530

#### PR validation:

Run unit tests of the package  `scram b runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A