### PR TITLE
Pixel Alpaka Migration: Portable Product [II]

### DIFF
--- a/DataFormats/BeamSpot/BuildFile.xml
+++ b/DataFormats/BeamSpot/BuildFile.xml
@@ -1,10 +1,13 @@
+<use name="clhep"/>
+<use name="rootcore"/>
+<use name="rootsmatrix"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/Math"/>
-<use name="rootcore"/>
-<use name="rootsmatrix"/>
-<use name="clhep"/>
+<use name="DataFormats/Portable"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/BeamSpot/interface/BeamSpotHost.h
+++ b/DataFormats/BeamSpot/interface/BeamSpotHost.h
@@ -1,0 +1,10 @@
+#ifndef DataFormats_BeamSpot_interface_BeamSpotHost_h
+#define DataFormats_BeamSpot_interface_BeamSpotHost_h
+
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+
+// simplified representation of the beamspot data, in host memory
+using BeamSpotHost = PortableHostObject<BeamSpotPOD>;
+
+#endif  // DataFormats_BeamSpot_interface_BeamSpotHost_h

--- a/DataFormats/BeamSpot/interface/BeamSpotPOD.h
+++ b/DataFormats/BeamSpot/interface/BeamSpotPOD.h
@@ -1,19 +1,24 @@
 #ifndef DataFormats_BeamSpot_interface_BeamSpotPOD_h
 #define DataFormats_BeamSpot_interface_BeamSpotPOD_h
 
-// This struct is a transient-only, simplified representation of the beamspot
-// data used as the underlying type for data transfers and operations in
+// This struct is a simplified representation of the beamspot data
+// used as the underlying type for data transfers and operations in
 // heterogeneous code (e.g. in CUDA code).
 
 // The covariance matrix is not used in that code, so is left out here.
 
 // align to the CUDA L1 cache line size
 struct alignas(128) BeamSpotPOD {
-  float x, y, z;  // position
+  float x;  // position
+  float y;
+  float z;
   float sigmaZ;
-  float beamWidthX, beamWidthY;
-  float dxdz, dydz;
-  float emittanceX, emittanceY;
+  float beamWidthX;
+  float beamWidthY;
+  float dxdz;
+  float dydz;
+  float emittanceX;
+  float emittanceY;
   float betaStar;
 };
 

--- a/DataFormats/BeamSpot/interface/alpaka/BeamSpotDevice.h
+++ b/DataFormats/BeamSpot/interface/alpaka/BeamSpotDevice.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_BeamSpot_interface_alpaka_BeamSpotDevice_h
+#define DataFormats_BeamSpot_interface_alpaka_BeamSpotDevice_h
+
+#include "DataFormats/BeamSpot/interface/BeamSpotHost.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/Portable/interface/alpaka/PortableObject.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  // simplified representation of the beamspot data, in device global memory
+  using BeamSpotDevice = PortableObject<BeamSpotPOD>;
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+// check that the portable device collection for the host device is the same as the portable host collection
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(BeamSpotDevice, BeamSpotHost);
+
+#endif  // DataFormats_BeamSpot_interface_alpaka_BeamSpotDevice_h

--- a/DataFormats/BeamSpot/src/alpaka/classes_cuda.h
+++ b/DataFormats/BeamSpot/src/alpaka/classes_cuda.h
@@ -1,0 +1,4 @@
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpot/interface/alpaka/BeamSpotDevice.h"
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/BeamSpot/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/BeamSpot/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::BeamSpotDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::BeamSpotDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::BeamSpotDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/BeamSpot/src/alpaka/classes_rocm.h
+++ b/DataFormats/BeamSpot/src/alpaka/classes_rocm.h
@@ -1,0 +1,4 @@
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/BeamSpot/interface/alpaka/BeamSpotDevice.h"
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/BeamSpot/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/BeamSpot/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::BeamSpotDevice" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::BeamSpotDevice>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::BeamSpotDevice>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/BeamSpot/src/classes.cc
+++ b/DataFormats/BeamSpot/src/classes.cc
@@ -1,0 +1,4 @@
+#include "DataFormats/BeamSpot/interface/BeamSpotHost.h"
+#include "DataFormats/Portable/interface/PortableHostObjectReadRules.h"
+
+SET_PORTABLEHOSTOBJECT_READ_RULES(BeamSpotHost);

--- a/DataFormats/BeamSpot/src/classes.h
+++ b/DataFormats/BeamSpot/src/classes.h
@@ -1,3 +1,4 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotHost.h"
 #include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -5,6 +5,11 @@
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>
 
-  <class name="BeamSpotPOD" persistent="false"/>
-  <class name="edm::Wrapper<BeamSpotPOD>" persistent="false"/>
+  <class name="BeamSpotPOD" ClassVersion="3">
+   <version ClassVersion="3" checksum="280341519"/>
+  </class>
+  <class name="edm::Wrapper<BeamSpotPOD>"/>
+
+  <class name="BeamSpotHost"/>
+  <class name="edm::Wrapper<BeamSpotHost>"/>
 </lcgdict>

--- a/DataFormats/Portable/README.md
+++ b/DataFormats/Portable/README.md
@@ -1,10 +1,71 @@
+## Define portable data formats that wrap a simple C-style `struct` and can be persisted to ROOT files
+
+### `PortableHostObject<T>`
+
+`PortableHostObject<T>` is a class template that wraps a `struct` type `T` and an alpaka host buffer, that owns the
+memory where the `struct` is allocated. The content of the `struct` is persistent, while the buffer itself is transient.
+Specialisations of this template can be persisted, but requre special ROOT read rules to read the data into an alpaka
+memory buffer.
+
+The traditional way to declare these rules would be to add them to the `classes_def.xml` file. This method is described
+here for reference, but is deprecated. See below for a simpler method.
+For example, to declare the read rules for `portabletest::TestHostObject` based on the `portabletest::TestStruct` `struct`,
+one would add to the same `classes_def.xml` file where `portabletest::TestHostObject` is declared:
+```xml
+<read
+  sourceClass="portabletest::TestHostObject"
+  targetClass="portabletest::TestHostObject"
+  version="[1-]"
+  source="portabletest::TestStruct* product_;"
+  target="buffer_,product_"
+  embed="false">
+<![CDATA[
+  portabletest::TestHostObject::ROOTReadStreamer(newObj, *onfile.product_);
+]]>
+</read>
+```
+
+The recommended way to declare these rules is to create a `classes.cc` file along with `classes.h`, and use the
+`SET_PORTABLEHOSTOBJECT_READ_RULES` macro. For example, to declare the rules for `portabletest::TestHostObject` one
+would create the file `classes.cc` with the content:
+```c++
+#include "DataFormats/Portable/interface/PortableHostObjectReadRules.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
+
+SET_PORTABLEHOSTOBJECT_READ_RULES(portabletest::TestHostObject);
+```
+
+`PortableHostObject<T>` objects can also be read back in "bare ROOT" mode, without any dictionaries.
+They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
+This could make it possible to read them back with different portability solutions in the future.
+
+### `PortableDeviceObject<T, TDev>`
+
+`PortableDeviceObject<T, TDev>` is a class template that wraps a `struct` type `T` and an alpaka device buffer, that
+owns the memory where the `struct` is allocated.
+To avoid confusion and ODR-violations, the `PortableDeviceObject<T, TDev>` template cannot be used with the `Host`
+device type.
+Specialisations of this template are transient and cannot be persisted.
+
+### `ALPAKA_ACCELERATOR_NAMESPACE::PortableObject<T>`
+
+`ALPAKA_ACCELERATOR_NAMESPACE::PortableObject<T>` is a template alias that resolves to either
+`PortableHostObject<T>` or `PortableDeviceObject<T, ALPAKA_ACCELERATOR_NAMESPACE::Device>`, depending on the
+backend.
+
+### `PortableObject<T, TDev>`
+
+`PortableObject<T, TDev>` is an alias template that resolves to `ALPAKA_ACCELERATOR_NAMESPACE::PortableObject<T>`
+for the matching device.
+
+
 ## Define portable data formats that wrap SoA data structures and can be persisted to ROOT files
 
 ### `PortableHostCollection<T>`
 
 `PortableHostCollection<T>` is a class template that wraps a SoA type `T` and an alpaka host buffer, which owns the
 memory where the SoA is allocated. The content of the SoA is persistent, while the buffer itself is transient.
-Specialisations of this template can be persisted, but requre specil ROOT read rules to read the data into a single
+Specialisations of this template can be persisted, but requre special ROOT read rules to read the data into a single
 memory buffer.
 
 The original way to declare these rules, now deprecated, is to add them to the `classes_def.xml` file. For example,
@@ -24,8 +85,8 @@ would add to the same `classes_def.xml` file where `portabletest::TestHostCollec
 ```
 
 The new, recommended way to declare these rules is to create a `classes.cc` file along with `classes.h`, and use the
-`SET_PORTABLEHOSTCOLLECTION_READ_RULES`. For example, to declare the rules for `portabletest::TestHostCollection` one
-would create the file `classes.cc` with the content:
+`SET_PORTABLEHOSTCOLLECTION_READ_RULES` macro. For example, to declare the rules for `portabletest::TestHostCollection`
+one would create the file `classes.cc` with the content:
 ```c++
 #include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
@@ -33,8 +94,7 @@ would create the file `classes.cc` with the content:
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(portabletest::TestHostCollection);
 ```
 
-`PortableHostCollection<T>` can also be read back in "bare ROOT" mode, without any dictionaries.
-
+`PortableHostCollection<T>` collections can also be read back in "bare ROOT" mode, without any dictionaries.
 They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
 This could make it possible to read them back with different portability solutions in the future.
 
@@ -61,7 +121,8 @@ for the matching device.
 ## Notes
 
 Modules that are supposed to work with only host types (_e.g._ dealing with de/serialisation, data transfers, _etc._)
-should explicitly use the `PortableHostCollection<T>` types.
+should explicitly use the `PortableHostObject<T>` and `PortableHostCollection<T>` types.
 
 Modules that implement portable interfaces (_e.g._ producers) should use the generic types based on
+`ALPAKA_ACCELERATOR_NAMESPACE::PortableObject<T>` or `PortableObject<T, TDev>`, and
 `ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>` or `PortableCollection<T, TDev>`.

--- a/DataFormats/Portable/interface/PortableDeviceObject.h
+++ b/DataFormats/Portable/interface/PortableDeviceObject.h
@@ -1,0 +1,72 @@
+#ifndef DataFormats_Portable_interface_PortableDeviceObject_h
+#define DataFormats_Portable_interface_PortableDeviceObject_h
+
+#include <cassert>
+#include <optional>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+// generic object in device memory
+template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+class PortableDeviceObject {
+  static_assert(not std::is_same_v<TDev, alpaka_common::DevHost>,
+                "Use PortableHostObject<T> instead of PortableDeviceObject<T, DevHost>");
+
+public:
+  using Product = T;
+  using Buffer = cms::alpakatools::device_buffer<TDev, Product>;
+  using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, Product>;
+
+  PortableDeviceObject() = default;
+
+  PortableDeviceObject(TDev const& device)
+      // allocate global device memory
+      : buffer_{cms::alpakatools::make_device_buffer<Product>(device)} {
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % alignof(Product) == 0);
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  PortableDeviceObject(TQueue const& queue)
+      // allocate global device memory with queue-ordered semantic
+      : buffer_{cms::alpakatools::make_device_buffer<Product>(queue)} {
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % alignof(Product) == 0);
+  }
+
+  // non-copyable
+  PortableDeviceObject(PortableDeviceObject const&) = delete;
+  PortableDeviceObject& operator=(PortableDeviceObject const&) = delete;
+
+  // movable
+  PortableDeviceObject(PortableDeviceObject&&) = default;
+  PortableDeviceObject& operator=(PortableDeviceObject&&) = default;
+
+  // default destructor
+  ~PortableDeviceObject() = default;
+
+  // access the product
+  Product& value() { return *buffer_->data(); }
+  Product const& value() const { return *buffer_->data(); }
+
+  Product* data() { return buffer_->data(); }
+  Product const* data() const { return buffer_->data(); }
+
+  Product& operator*() { return *buffer_->data(); }
+  Product const& operator*() const { return *buffer_->data(); }
+
+  Product* operator->() { return buffer_->data(); }
+  Product const* operator->() const { return buffer_->data(); }
+
+  // access the buffer
+  Buffer buffer() { return *buffer_; }
+  ConstBuffer buffer() const { return *buffer_; }
+  ConstBuffer const_buffer() const { return *buffer_; }
+
+private:
+  std::optional<Buffer> buffer_;
+};
+
+#endif  // DataFormats_Portable_interface_PortableDeviceObject_h

--- a/DataFormats/Portable/interface/PortableHostObject.h
+++ b/DataFormats/Portable/interface/PortableHostObject.h
@@ -1,0 +1,81 @@
+#ifndef DataFormats_Portable_interface_PortableHostObject_h
+#define DataFormats_Portable_interface_PortableHostObject_h
+
+#include <cassert>
+#include <optional>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+// generic object in host memory
+template <typename T>
+class PortableHostObject {
+public:
+  using Product = T;
+  using Buffer = cms::alpakatools::host_buffer<Product>;
+  using ConstBuffer = cms::alpakatools::const_host_buffer<Product>;
+
+  PortableHostObject() = default;
+
+  PortableHostObject(alpaka_common::DevHost const& host)
+      // allocate pageable host memory
+      : buffer_{cms::alpakatools::make_host_buffer<Product>()}, product_{buffer_->data()} {
+    assert(reinterpret_cast<uintptr_t>(product_) % alignof(Product) == 0);
+  }
+
+  template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
+  PortableHostObject(TQueue const& queue)
+      // allocate pinned host memory associated to the given work queue, accessible by the queue's device
+      : buffer_{cms::alpakatools::make_host_buffer<Product>(queue)}, product_{buffer_->data()} {
+    assert(reinterpret_cast<uintptr_t>(product_) % alignof(Product) == 0);
+  }
+
+  // non-copyable
+  PortableHostObject(PortableHostObject const&) = delete;
+  PortableHostObject& operator=(PortableHostObject const&) = delete;
+
+  // movable
+  PortableHostObject(PortableHostObject&&) = default;
+  PortableHostObject& operator=(PortableHostObject&&) = default;
+
+  // default destructor
+  ~PortableHostObject() = default;
+
+  // access the product
+  Product& value() { return *product_; }
+  Product const& value() const { return *product_; }
+
+  Product* data() { return product_; }
+  Product const* data() const { return product_; }
+
+  Product& operator*() { return *product_; }
+  Product const& operator*() const { return *product_; }
+
+  Product* operator->() { return product_; }
+  Product const* operator->() const { return product_; }
+
+  // access the buffer
+  Buffer buffer() { return *buffer_; }
+  ConstBuffer buffer() const { return *buffer_; }
+  ConstBuffer const_buffer() const { return *buffer_; }
+
+  // part of the ROOT read streamer
+  static void ROOTReadStreamer(PortableHostObject* newObj, Product& product) {
+    // destroy the default-constructed object
+    newObj->~PortableHostObject();
+    // use the global "host" object returned by cms::alpakatools::host()
+    new (newObj) PortableHostObject(cms::alpakatools::host());
+    // copy the data from the on-file object to the new one
+    std::memcpy(newObj->product_, &product, sizeof(Product));
+  }
+
+private:
+  std::optional<Buffer> buffer_;  //!
+  Product* product_;
+};
+
+#endif  // DataFormats_Portable_interface_PortableHostObject_h

--- a/DataFormats/Portable/interface/PortableHostObjectReadRules.h
+++ b/DataFormats/Portable/interface/PortableHostObjectReadRules.h
@@ -1,0 +1,76 @@
+#ifndef DataFormats_Portable_interface_PortableHostObjectReadRules_h
+#define DataFormats_Portable_interface_PortableHostObjectReadRules_h
+
+#include <TGenericClassInfo.h>
+#include <TVirtualObject.h>
+
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "FWCore/Utilities/interface/concatenate.h"
+#include "FWCore/Utilities/interface/stringize.h"
+
+// read function for PortableHostObject, called for every event
+template <typename T>
+static void readPortableHostObject_v1(char *target, TVirtualObject *from_buffer) {
+  // extract the actual types
+  using Object = T;
+  using Product = typename Object::Product;
+
+  // valid only for PortableHostObject<T>
+  static_assert(std::is_same_v<Object, PortableHostObject<Product>>);
+
+  // proxy for the object being read from file
+  struct OnFile {
+    Product *product_;
+  };
+
+  // address in memory of the buffer containing the object being read from file
+  char *address = static_cast<char *>(from_buffer->GetObject());
+  // offset of the "product_" data member
+  static ptrdiff_t product_offset = from_buffer->GetClass()->GetDataMemberOffset("product_");
+  // pointer to the Product object being read from file
+  OnFile onfile = {*(Product **)(address + product_offset)};
+
+  // pointer to the Object object being constructed in memory
+  Object *newObj = (Object *)target;
+
+  // move the data from the on-file layout to the newly constructed object
+  Object::ROOTReadStreamer(newObj, *onfile.product_);
+}
+
+// put set_PortableHostObject_read_rules in the ROOT namespace to let it forward declare GenerateInitInstance
+namespace ROOT {
+
+  // set the read rules for PortableHostObject<T>;
+  // this is called only once, when the dictionary is loaded.
+  template <typename T>
+  static bool set_PortableHostObject_read_rules(std::string const &type) {
+    // forward declaration
+    TGenericClassInfo *GenerateInitInstance(T const *);
+
+    // build the read rules
+    std::vector<ROOT::Internal::TSchemaHelper> readrules(1);
+    ROOT::Internal::TSchemaHelper &rule = readrules[0];
+    rule.fTarget = "buffer_,product_";
+    rule.fSourceClass = type;
+    rule.fSource = type + "::Product* product_;";
+    rule.fCode = type + "::ROOTReadStreamer(newObj, *onfile.product_)";
+    rule.fVersion = "[1-]";
+    rule.fChecksum = "";
+    rule.fInclude = "";
+    rule.fEmbed = false;
+    rule.fFunctionPtr = reinterpret_cast<void *>(::readPortableHostObject_v1<T>);
+    rule.fAttributes = "";
+
+    // set the read rules
+    TGenericClassInfo *instance = GenerateInitInstance((T const *)nullptr);
+    instance->SetReadRules(readrules);
+
+    return true;
+  }
+}  // namespace ROOT
+
+#define SET_PORTABLEHOSTOBJECT_READ_RULES(OBJECT)                                                      \
+  static bool EDM_CONCATENATE(set_PortableHostObject_read_rules_done_at_, __LINE__) [[maybe_unused]] = \
+      ROOT::set_PortableHostObject_read_rules<OBJECT>(EDM_STRINGIZE(OBJECT))
+
+#endif  // DataFormats_Portable_interface_PortableHostObjectReadRules_h

--- a/DataFormats/Portable/interface/PortableObject.h
+++ b/DataFormats/Portable/interface/PortableObject.h
@@ -1,0 +1,20 @@
+#ifndef DataFormats_Portable_interface_PortableObject_h
+#define DataFormats_Portable_interface_PortableObject_h
+
+#include <type_traits>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+
+namespace traits {
+
+  // trait for a generic SoA-based product
+  template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+  class PortableObjectTrait;
+
+}  // namespace traits
+
+// type alias for a generic SoA-based product
+template <typename T, typename TDev, typename = std::enable_if_t<alpaka::isDevice<TDev>>>
+using PortableObject = typename traits::PortableObjectTrait<T, TDev>::ProductType;
+
+#endif  // DataFormats_Portable_interface_PortableObject_h

--- a/DataFormats/Portable/interface/alpaka/PortableCollection.h
+++ b/DataFormats/Portable/interface/alpaka/PortableCollection.h
@@ -1,7 +1,5 @@
-#ifndef DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h
-#define DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h
-
-#include <optional>
+#ifndef DataFormats_Portable_interface_alpaka_PortableCollection_h
+#define DataFormats_Portable_interface_alpaka_PortableCollection_h
 
 #include <alpaka/alpaka.hpp>
 
@@ -68,4 +66,4 @@ namespace cms::alpakatools {
   };
 }  // namespace cms::alpakatools
 
-#endif  // DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h
+#endif  // DataFormats_Portable_interface_alpaka_PortableCollection_h

--- a/DataFormats/Portable/interface/alpaka/PortableObject.h
+++ b/DataFormats/Portable/interface/alpaka/PortableObject.h
@@ -1,0 +1,69 @@
+#ifndef DataFormats_Portable_interface_alpaka_PortableObject_h
+#define DataFormats_Portable_interface_alpaka_PortableObject_h
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/Portable/interface/PortableObject.h"
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "DataFormats/Portable/interface/PortableDeviceObject.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/CopyToHost.h"
+
+// This header is not used by PortableObject, but is included here to automatically
+// provide its content to users of ALPAKA_ACCELERATOR_NAMESPACE::PortableObject.
+#include "HeterogeneousCore/AlpakaInterface/interface/AssertDeviceMatchesHostCollection.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+  // ... or any other CPU-based accelerators
+
+  // generic SoA-based product in host memory
+  template <typename T>
+  using PortableObject = ::PortableHostObject<T>;
+
+#else
+
+  // generic SoA-based product in device memory
+  template <typename T>
+  using PortableObject = ::PortableDeviceObject<T, Device>;
+
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace traits {
+
+  // specialise the trait for the device provided by the ALPAKA_ACCELERATOR_NAMESPACE
+  template <typename T>
+  class PortableObjectTrait<T, ALPAKA_ACCELERATOR_NAMESPACE::Device> {
+    using ProductType = ALPAKA_ACCELERATOR_NAMESPACE::PortableObject<T>;
+  };
+
+}  // namespace traits
+
+namespace cms::alpakatools {
+  template <typename TProduct, typename TDevice>
+  struct CopyToHost<PortableDeviceObject<TProduct, TDevice>> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue, PortableDeviceObject<TProduct, TDevice> const& srcData) {
+      PortableHostObject<TProduct> dstData(queue);
+      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      return dstData;
+    }
+  };
+
+  template <typename TProduct>
+  struct CopyToDevice<PortableHostObject<TProduct>> {
+    template <typename TQueue>
+    static auto copyAsync(TQueue& queue, PortableHostObject<TProduct> const& srcData) {
+      using TDevice = typename alpaka::trait::DevType<TQueue>::type;
+      PortableDeviceObject<TProduct, TDevice> dstData(queue);
+      alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
+      return dstData;
+    }
+  };
+}  // namespace cms::alpakatools
+
+#endif  // DataFormats_Portable_interface_alpaka_PortableObject_h

--- a/DataFormats/PortableTestObjects/interface/TestHostObject.h
+++ b/DataFormats/PortableTestObjects/interface/TestHostObject.h
@@ -1,0 +1,14 @@
+#ifndef DataFormats_PortableTestObjects_interface_TestHostObject_h
+#define DataFormats_PortableTestObjects_interface_TestHostObject_h
+
+#include "DataFormats/Portable/interface/PortableHostObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"
+
+namespace portabletest {
+
+  // struct with x, y, z, id fields in host memory
+  using TestHostObject = PortableHostObject<TestStruct>;
+
+}  // namespace portabletest
+
+#endif  // DataFormats_PortableTestObjects_interface_TestHostObject_h

--- a/DataFormats/PortableTestObjects/interface/TestStruct.h
+++ b/DataFormats/PortableTestObjects/interface/TestStruct.h
@@ -1,0 +1,18 @@
+#ifndef DataFormats_PortableTestObjects_interface_TestStruct_h
+#define DataFormats_PortableTestObjects_interface_TestStruct_h
+
+#include <cstdint>
+
+namespace portabletest {
+
+  // struct with x, y, z, id fields
+  struct TestStruct {
+    double x;
+    double y;
+    double z;
+    int32_t id;
+  };
+
+}  // namespace portabletest
+
+#endif  // DataFormats_PortableTestObjects_interface_TestStruct_h

--- a/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h
+++ b/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h
@@ -1,0 +1,27 @@
+#ifndef DataFormats_PortableTestObjects_interface_alpaka_TestDeviceObject_h
+#define DataFormats_PortableTestObjects_interface_alpaka_TestDeviceObject_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace portabletest {
+
+    // make the names from the top-level portabletest namespace visible for unqualified lookup
+    // inside the ALPAKA_ACCELERATOR_NAMESPACE::portabletest namespace
+    using namespace ::portabletest;
+
+    // struct with x, y, z, id fields in device global memory
+    using TestDeviceObject = PortableObject<TestStruct>;
+
+  }  // namespace portabletest
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+// check that the portable device collection for the host device is the same as the portable host collection
+ASSERT_DEVICE_MATCHES_HOST_COLLECTION(portabletest::TestDeviceObject, portabletest::TestHostObject);
+
+#endif  // DataFormats_PortableTestObjects_interface_alpaka_TestDeviceObject_h

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
@@ -1,4 +1,6 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
@@ -2,4 +2,8 @@
   <class name="alpaka_cuda_async::portabletest::TestDeviceCollection" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceCollection>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_cuda_async::portabletest::TestDeviceObject" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceObject>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::portabletest::TestDeviceObject>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_rocm.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_rocm.h
@@ -1,4 +1,6 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_rocm_def.xml
@@ -2,4 +2,8 @@
   <class name="alpaka_rocm_async::portabletest::TestDeviceCollection" persistent="false"/>
   <class name="edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceCollection>" persistent="false"/>
   <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceCollection>>" persistent="false"/>
+
+  <class name="alpaka_rocm_async::portabletest::TestDeviceObject" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceObject>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::portabletest::TestDeviceObject>>" persistent="false"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes.cc
+++ b/DataFormats/PortableTestObjects/src/classes.cc
@@ -1,4 +1,7 @@
 #include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
+#include "DataFormats/Portable/interface/PortableHostObjectReadRules.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
 
 SET_PORTABLEHOSTCOLLECTION_READ_RULES(portabletest::TestHostCollection);
+SET_PORTABLEHOSTOBJECT_READ_RULES(portabletest::TestHostObject);

--- a/DataFormats/PortableTestObjects/src/classes.h
+++ b/DataFormats/PortableTestObjects/src/classes.h
@@ -1,3 +1,5 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
 #include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/TestStruct.h"

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -3,4 +3,8 @@
   <class name="portabletest::TestSoA::View"/>
   <class name="portabletest::TestHostCollection"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
+
+  <class name="portabletest::TestStruct"/>
+  <class name="portabletest::TestHostObject"/>
+  <class name="edm::Wrapper<portabletest::TestHostObject>"/>
 </lcgdict>

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaObjectAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaObjectAnalyzer.cc
@@ -1,0 +1,78 @@
+#include <cassert>
+
+#include "DataFormats/PortableTestObjects/interface/TestHostObject.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+class TestAlpakaObjectAnalyzer : public edm::global::EDAnalyzer<> {
+public:
+  TestAlpakaObjectAnalyzer(edm::ParameterSet const& config)
+      : source_{config.getParameter<edm::InputTag>("source")}, token_{consumes(source_)} {
+    if (std::string const& eb = config.getParameter<std::string>("expectBackend"); not eb.empty()) {
+      expectBackend_ = cms::alpakatools::toBackend(eb);
+      backendToken_ = consumes(edm::InputTag(source_.label(), "backend", source_.process()));
+    }
+  }
+
+  void analyze(edm::StreamID sid, edm::Event const& event, edm::EventSetup const&) const override {
+    portabletest::TestHostObject const& product = event.get(token_);
+
+    auto const& value = product.value();
+    {
+      edm::LogInfo msg("TestAlpakaObjectAnalyzer");
+      msg << source_.encode() << ".data() at " << product.data() << '\n';
+      msg << source_.encode() << ".buffer().data() at " << product.buffer().data() << '\n';
+      msg << source_.encode() << ".value() = {\n";
+      msg << "  .x:  " << value.x << '\n';
+      msg << "  .y:  " << value.y << '\n';
+      msg << "  .z:  " << value.z << '\n';
+      msg << "  .id: " << value.id << '\n';
+      msg << "}\n";
+    }
+
+    // check that the product data is held in the product buffer
+    assert(product.buffer().data() == product.data());
+
+    // check that the product content is as expected
+    assert(value.x == 5.);
+    assert(value.y == 12.);
+    assert(value.z == 13.);
+    assert(value.id == 42);
+
+    // check that the backend is as expected
+    if (expectBackend_) {
+      auto backend = static_cast<cms::alpakatools::Backend>(event.get(backendToken_));
+      if (expectBackend_ != backend) {
+        throw cms::Exception("Assert") << "Expected input backend " << cms::alpakatools::toString(*expectBackend_)
+                                       << ", got " << cms::alpakatools::toString(backend);
+      }
+    }
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    desc.add<std::string>("expectBackend", "")
+        ->setComment(
+            "Expected backend of the input collection. Empty value means to not perform the check. Default: empty "
+            "string");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  const edm::InputTag source_;
+  const edm::EDGetTokenT<portabletest::TestHostObject> token_;
+  edm::EDGetTokenT<unsigned short> backendToken_;
+  std::optional<cms::alpakatools::Backend> expectBackend_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TestAlpakaObjectAnalyzer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -55,4 +55,31 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, collection.view(), collection->metadata().size(), xvalue);
   }
 
+  class TestAlgoStructKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  portabletest::TestDeviceObject::Product* data,
+                                  double x,
+                                  double y,
+                                  double z,
+                                  int32_t id) const {
+      // run on a single thread
+      if (once_per_grid(acc)) {
+        data->x = x;
+        data->y = y;
+        data->z = z;
+        data->id = id;
+      }
+    }
+  };
+
+  void TestAlgo::fillObject(
+      Queue& queue, portabletest::TestDeviceObject& object, double x, double y, double z, int32_t id) const {
+    // run on a single thread
+    auto workDiv = make_workdiv<Acc1D>(1, 1);
+
+    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoStructKernel{}, object.data(), x, y, z, id);
+  }
+
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
@@ -2,6 +2,7 @@
 #define HeterogeneousCore_AlpakaTest_plugins_alpaka_TestAlgo_h
 
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceObject.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -9,6 +10,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlgo {
   public:
     void fill(Queue& queue, portabletest::TestDeviceCollection& collection, double xvalue = 0.) const;
+    void fillObject(
+        Queue& queue, portabletest::TestDeviceObject& object, double x, double y, double z, int32_t id) const;
   };
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/test/reader.py
+++ b/HeterogeneousCore/AlpakaTest/test/reader.py
@@ -7,11 +7,16 @@ process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring('file:test.root')
 )
 
-# enable logging for the TestAlpakaAnalyzer
+# enable logging for the analysers
 process.MessageLogger.TestAlpakaAnalyzer = cms.untracked.PSet()
+process.MessageLogger.TestAlpakaObjectAnalyzer = cms.untracked.PSet()
 
-# analyse the first product
+# analyse the first set of products
 process.testAnalyzer = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('testProducer')
+)
+
+process.testObjectAnalyzer = cms.EDAnalyzer('TestAlpakaObjectAnalyzer',
     source = cms.InputTag('testProducer')
 )
 
@@ -21,8 +26,13 @@ process.testAnalyzerSerial = cms.EDAnalyzer('TestAlpakaAnalyzer',
     expectBackend = cms.string('SerialSync')
 )
 
-process.cuda_path = cms.Path(process.testAnalyzer)
+process.testObjectAnalyzerSerial = cms.EDAnalyzer('TestAlpakaObjectAnalyzer',
+    source = cms.InputTag('testProducerSerial'),
+    expectBackend = cms.string('SerialSync')
+)
 
-process.serial_path = cms.Path(process.testAnalyzerSerial)
+process.device_path = cms.Path(process.testAnalyzer + process.testObjectAnalyzer)
+
+process.serial_path = cms.Path(process.testAnalyzerSerial + process.testObjectAnalyzerSerial)
 
 process.maxEvents.input = 10


### PR DESCRIPTION
#### PR description:

This PR stems from #41117 and it's the 2nd of a series of smaller PRs:  

- https://github.com/cms-sw/cmssw/pull/41282
- https://github.com/cms-sw/cmssw/pull/43295
- https://github.com/cms-sw/cmssw/pull/41285
- https://github.com/cms-sw/cmssw/pull/41286
- https://github.com/cms-sw/cmssw/pull/41287
- https://github.com/cms-sw/cmssw/pull/41288
- https://github.com/cms-sw/cmssw/pull/43294

It includes the `PortableProduct` object and a couple of tests.
 
Keeping track of the comments in https://github.com/PixelTracksAlpaka/cmssw/issues/40.