### PR TITLE
Allow Alpaka ESProducer to produce a 'null' data product

### DIFF
--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerNull.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaESProducerNull.cc
@@ -1,0 +1,41 @@
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestData.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/ESTestData.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class demonstrates an ESProducer that
+   * - produces a null in a host produce function
+   * - produces a null in a device produce function
+   */
+  class TestAlpakaESProducerNull : public ESProducer {
+  public:
+    TestAlpakaESProducerNull(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
+      setWhatProduced(this, &TestAlpakaESProducerNull::produceHost);
+      setWhatProduced(this, &TestAlpakaESProducerNull::produceDevice);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+    std::optional<AlpakaESTestDataAHost> produceHost(AlpakaESTestRecordA const& iRecord) { return {}; }
+
+    std::unique_ptr<AlpakaESTestDataCDevice> produceDevice(device::Record<AlpakaESTestRecordD> const& iRecord) {
+      return {};
+    }
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(TestAlpakaESProducerNull);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerNullES.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerNullES.cc
@@ -1,0 +1,74 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/AlpakaESTestRecords.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/AlpakaESTestData.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class tests various ways of a device ESProduct being missing
+   */
+  class TestAlpakaGlobalProducerNullES : public global::EDProducer<> {
+  public:
+    TestAlpakaGlobalProducerNullES(edm::ParameterSet const& config)
+        : esTokenA_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"))),
+          esTokenC_(esConsumes(config.getParameter<edm::ESInputTag>("eventSetupSource"))),
+          esTokenCNotExist_(esConsumes(edm::ESInputTag("", "doesNotExist"))) {}
+
+    void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
+      bool threw = false;
+      try {
+        [[maybe_unused]] auto handleA = iSetup.getHandle(esTokenA_);
+      } catch (cms::Exception& e) {
+        threw = true;
+      }
+      if (not threw) {
+        throw cms::Exception("Assert") << "Getting AlpakaESTestDataADevice ESProduct did not throw";
+      }
+
+      threw = false;
+      try {
+        [[maybe_unused]] auto const& prodC = iSetup.getData(esTokenC_);
+      } catch (cms::Exception& e) {
+        threw = true;
+      }
+      if (not threw) {
+        throw cms::Exception("Assert") << "Getting AlpakaESTestDataCDevice ESProduct did not throw";
+      }
+
+      auto handleC = iSetup.getHandle(esTokenCNotExist_);
+      if (handleC.isValid()) {
+        throw cms::Exception("Assert") << "Getting non-existing AlpakaESTestDataCDevice succeeded, should have failed";
+      }
+      threw = false;
+      try {
+        [[maybe_unused]] auto const& prodC = *handleC;
+      } catch (cms::Exception& e) {
+        threw = true;
+      }
+      if (not threw) {
+        throw cms::Exception("Assert")
+            << "De-referencing ESHandle of non-existentAlpakaESTestDataADevice did not throw";
+      }
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add("eventSetupSource", edm::ESInputTag{});
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const device::ESGetToken<AlpakaESTestDataADevice, AlpakaESTestRecordA> esTokenA_;
+    const device::ESGetToken<AlpakaESTestDataCDevice, AlpakaESTestRecordA> esTokenC_;
+    const device::ESGetToken<AlpakaESTestDataCDevice, AlpakaESTestRecordA> esTokenCNotExist_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducerNullES);

--- a/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
+++ b/HeterogeneousCore/AlpakaTest/test/testAlpakaModules_cfg.py
@@ -54,6 +54,9 @@ process.alpakaESProducerD = cms.ESProducer("TestAlpakaESProducerD@alpaka",
     srcA = cms.ESInputTag("", "appendedLabel"),
     srcB = cms.ESInputTag("", "explicitLabel"),
 )
+process.alpakaESProducerNull = cms.ESProducer("TestAlpakaESProducerNull@alpaka",
+    appendToDataLabel = cms.string("null"),
+)
 
 process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
 
@@ -111,12 +114,16 @@ process.alpakaStreamSynchronizingConsumer = cms.EDAnalyzer("TestAlpakaAnalyzer",
     expectSize = cms.int32(10),
     expectBackend = cms.string("SerialSync")
 )
+process.alpakaNullESConsumer = cms.EDProducer("TestAlpakaGlobalProducerNullES@alpaka",
+    eventSetupSource = cms.ESInputTag("", "null")
+)
 
 if args.processAcceleratorBackend != "":
     process.ProcessAcceleratorAlpaka.setBackend(args.processAcceleratorBackend)
 if args.moduleBackend != "":
-    for name in ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD",
-                 "GlobalProducer", "StreamProducer", "StreamInstanceProducer", "StreamSynchronizingProducer"]:
+    for name in ["ESProducerA", "ESProducerB", "ESProducerC", "ESProducerD", "ESProducerNull",
+                 "GlobalProducer", "StreamProducer", "StreamInstanceProducer", "StreamSynchronizingProducer",
+                 "NullESConsumer"]:
         mod = getattr(process, "alpaka"+name)
         mod.alpaka = cms.untracked.PSet(backend = cms.untracked.string(args.moduleBackend))
 if args.expectBackend == "cuda_async":
@@ -157,7 +164,8 @@ process.p = cms.Path(
     process.alpakaGlobalConsumer+
     process.alpakaStreamConsumer+
     process.alpakaStreamInstanceConsumer+
-    process.alpakaStreamSynchronizingConsumer,
+    process.alpakaStreamSynchronizingConsumer+
+    process.alpakaNullESConsumer,
     process.t
 )
 process.ep = cms.EndPath(process.output)


### PR DESCRIPTION
#### PR description:

To be consistent with the ESProducers in general. The 'null' case is for an ESProducer to signal an error such that an exception is thrown when a consumer tries to get the data (even with `getHandle()`).

Resolves https://github.com/makortel/framework/issues/636

#### PR validation:

Unit tests run.