### PR TITLE
[G4VECGEOM] Replace deprecated method

### DIFF
--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -72,7 +72,7 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
 
 void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {
   fastStep.KillPrimaryTrack();
-  fastStep.SetPrimaryTrackPathLength(0.0);
+  fastStep.ProposePrimaryTrackPathLength(0.0);
   auto track = fastTrack.GetPrimaryTrack();
   G4double energy = track->GetKineticEnergy() * scaleFactor;
 


### PR DESCRIPTION
#### PR description:

Fix the following warning:
```
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/src/RunManagerMTWorker.cc
CMSSW_CPU_TYPE= /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DEIGEN_DONT_PARALLELIZE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DGNU_GCC -DG4V9 -DGNU_GCC -DG4V9 -DDD4HEP_USE_GEANT4_UNITS=1 -DCMSSW_GIT_HASH='CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/dd4hep/v01-26x-2840511565c2d48388765f90579bcad9/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.1.ref10-f00041eee0e53c2b6746cb68a0af4502/include/Geant4 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.1.ref10-f00041eee0e53c2b6746cb68a0af4502/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/boost/1.80.0-826a207b8543c52970cb1f72d50f068c/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/clhep/2.4.7.1-5bfe601b6d65215d210a10fe9d6d7478/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/expat/2.4.8-b093687a482bf386f8f8c236c5b2efa2/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gsl/2.6-f316a321a173f181b66df52be79d894b/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc/2.06.10-db64552c0ab28562be049cf5c3d31c99/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/heppdt/3.04.01-f5ef5efe94631f515873259333eaaa07/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.26.11-1ef575234f3b954353280f3578660947/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2021.9.0-e755918dac6a30ec36eff63ac4f7ddec/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/vecgeom/v1.2.1-35adfe5c99700701c19371de9114c36a/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/vecgeom/v1.2.1-35adfe5c99700701c19371de9114c36a/include/VecGeom -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xerces-c/3.1.3-c7b88eaa36d0408120f3c29826a04bf6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/eigen/3bb6a48d8c171cf20b5f8e48bfb4e424fbd4f79e-36a69a0d7b82bf7496dcc3ff29886d0d/include/eigen3 -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fmt/8.0.1-54e94b39f5cf29341bb9c4765764e1ca/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/g4hepem/20230309-f4a2af9b034d54fdf67fdf0914c84de8/include/G4HepEm -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/hepmc3/3.2.5-7606a946f19ead73b3e143d4ce0e3e49/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/OpenBLAS/0.3.15-15504a5c800a9ecbbc2befbb991bead5/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tinyxml2/6.2.0-d17873b4d6a42a43226cf689f82ec1ef/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -ftls-model=global-dynamic -pthread -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  -MMD -MF tmp/el8_amd64_gcc12/src/SimG4Core/Application/src/SimG4CoreApplication/RunManagerMTWorker.cc.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/src/RunManagerMTWorker.cc -o tmp/el8_amd64_gcc12/src/SimG4Core/Application/src/SimG4CoreApplication/RunManagerMTWorker.cc.o
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/src/LowEnergyFastSimModel.cc: In member function 'virtual void LowEnergyFastSimModel::DoIt(const G4FastTrack&, G4FastStep&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/src/LowEnergyFastSimModel.cc:75:37: warning: 'void G4FastStep::SetPrimaryTrackPathLength(G4double)' is deprecated: use ProposePrimaryTrackPathLength instead [-Wdeprecated-declarations]
    75 |   fastStep.SetPrimaryTrackPathLength(0.0);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.1.ref10-f00041eee0e53c2b6746cb68a0af4502/include/Geant4/G4FastStep.hh:351,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.1.ref10-f00041eee0e53c2b6746cb68a0af4502/include/Geant4/G4VFastSimulationModel.hh:44,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/interface/LowEnergyFastSimModel.h:8,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/801fdb4835407ac807095887336e08c7/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/src/SimG4Core/Application/src/LowEnergyFastSimModel.cc:4:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/geant4/11.1.ref10-f00041eee0e53c2b6746cb68a0af4502/include/Geant4/G4FastStep.icc:61:13: note: declared here
   61 | inline void G4FastStep::SetPrimaryTrackPathLength(G4double pathLength)
      |    
```
[full log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_G4VECGEOM_X_2023-11-15-2300/SimG4Core/Application)

#### PR validation:

Bot tests
