### PR TITLE
[CalibFormats] Remove explicit copy-assignment operator 

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelHdwAddress.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelHdwAddress.h
@@ -46,8 +46,6 @@ namespace pos {
 
     friend std::ostream& pos::operator<<(std::ostream& s, const PixelHdwAddress& pixelroc);
 
-    const PixelHdwAddress& operator=(const PixelHdwAddress& aROC);
-
     bool operator()(const PixelHdwAddress& roc1, const PixelHdwAddress& roc2) const;
 
     // Checks for equality of all parts except the ROC numbers and portaddress.

--- a/CalibFormats/SiPixelObjects/interface/PixelModuleName.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelModuleName.h
@@ -72,7 +72,7 @@ namespace pos {
     }
     int module() const {
       assert((id_ & 0x80000000) != 0);
-      return ((id_)&0x3) + 1;
+      return ((id_) & 0x3) + 1;
     }
 
     friend std::ostream& operator<<(std::ostream& s, const PixelModuleName& pixelroc);

--- a/CalibFormats/SiPixelObjects/interface/PixelModuleName.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelModuleName.h
@@ -77,8 +77,6 @@ namespace pos {
 
     friend std::ostream& operator<<(std::ostream& s, const PixelModuleName& pixelroc);
 
-    const PixelModuleName& operator=(const PixelModuleName& aROC);
-
     const bool operator<(const PixelModuleName& aROC) const { return id_ < aROC.id_; }
 
     const bool operator==(const PixelModuleName& aModule) const { return id_ == aModule.id_; }

--- a/CalibFormats/SiPixelObjects/interface/PixelROCName.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelROCName.h
@@ -77,8 +77,6 @@ namespace pos {
 
     friend std::ostream& pos::operator<<(std::ostream& s, const PixelROCName& pixelroc);
 
-    const PixelROCName& operator=(const PixelROCName& aROC);
-
     const bool operator<(const PixelROCName& aROC) const { return id_ < aROC.id_; }
 
     const bool operator==(const PixelROCName& aROC) const { return id_ == aROC.id_; }

--- a/CalibFormats/SiPixelObjects/src/PixelHdwAddress.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelHdwAddress.cc
@@ -63,21 +63,6 @@ std::ostream& pos::operator<<(std::ostream& s, const PixelHdwAddress& pixelroc) 
 }
 
 //====================================================================================
-const PixelHdwAddress& PixelHdwAddress::operator=(const PixelHdwAddress& aROC) {
-  fecnumber_ = aROC.fecnumber_;
-  mfec_ = aROC.mfec_;
-  mfecchannel_ = aROC.mfecchannel_;
-  portaddress_ = aROC.portaddress_;
-  hubaddress_ = aROC.hubaddress_;
-  rocid_ = aROC.rocid_;
-  fednumber_ = aROC.fednumber_;
-  fedchannel_ = aROC.fedchannel_;
-  fedrocnumber_ = aROC.fedrocnumber_;
-
-  return *this;
-}
-
-//====================================================================================
 // Added by Dario
 void PixelHdwAddress::setAddress(std::string what, int value) {
   std::string mthn = "[PixelHdwAddress::setAddress()]\t\t\t    ";

--- a/CalibFormats/SiPixelObjects/src/PixelModuleName.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelModuleName.cc
@@ -245,9 +245,3 @@ ostream& pos::operator<<(ostream& s, const PixelModuleName& pixelroc) {
 
   return s;
 }
-
-const PixelModuleName& PixelModuleName::operator=(const PixelModuleName& aROC) {
-  id_ = aROC.id_;
-
-  return *this;
-}

--- a/CalibFormats/SiPixelObjects/src/PixelROCName.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelROCName.cc
@@ -286,9 +286,3 @@ std::ostream& pos::operator<<(std::ostream& s, const PixelROCName& pixelroc) {
 
   return s;
 }
-
-const PixelROCName& PixelROCName::operator=(const PixelROCName& aROC) {
-  id_ = aROC.id_;
-
-  return *this;
-}


### PR DESCRIPTION
#### PR description:

Remove explicitly-defined trivial copy-assignment operator ([rule-of-three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) violation). 

#### PR validation:

Bot tests
