### PR TITLE
Add era modifier for Run3 and HcalPFCuts withTopo to event record

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -15,7 +15,8 @@ from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
 
 Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018, run2_HLTconditions_2018]),
-                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal)
+                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal, hcalPfCutsFromDB)
 

--- a/Configuration/Eras/python/Modifier_hcalPfCutsFromDB_cff.py
+++ b/Configuration/Eras/python/Modifier_hcalPfCutsFromDB_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+hcalPfCutsFromDB = cms.Modifier()


### PR DESCRIPTION
#### PR description:

This PR addresses the technical baseline changes needed by #43025 and #43164: the addition of an Era Modifier, its implementation into Era_Run3, and mostly the addition of HcalPFCuts to the event record.

#### PR validation:

runTheMatrix.py -l 10824.0
runTheMatrix.py -l 10024.0
