### PR TITLE
[13_3_X] Adapt PF code to read Hcal thresholds from GT

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -15,7 +15,8 @@ from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTconditions_2018
 from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
 
 Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018, run2_egamma_2018, run2_HLTconditions_2018]),
-                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal)
+                         run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2022, dd4hep, run3_RPC, run3_ecal, hcalPfCutsFromDB)
 

--- a/Configuration/Eras/python/Modifier_hcalPfCutsFromDB_cff.py
+++ b/Configuration/Eras/python/Modifier_hcalPfCutsFromDB_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+hcalPfCutsFromDB =  cms.Modifier()

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedL1Seeded_cfi.py
@@ -111,6 +111,7 @@ hltParticleFlowClusterECALUncorrectedL1Seeded = cms.EDProducer("PFClusterProduce
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitECALL1Seeded"),
+    usePFThresholdsFromDB = cms.bool(False), 
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedL1Seeded_cfi.py
@@ -111,7 +111,7 @@ hltParticleFlowClusterECALUncorrectedL1Seeded = cms.EDProducer("PFClusterProduce
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitECALL1Seeded"),
-    usePFThresholdsFromDB = cms.bool(False), 
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE 
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedUnseeded_cfi.py
@@ -111,6 +111,7 @@ hltParticleFlowClusterECALUncorrectedUnseeded = cms.EDProducer("PFClusterProduce
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitECALUnseeded"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterECALUncorrectedUnseeded_cfi.py
@@ -111,7 +111,7 @@ hltParticleFlowClusterECALUncorrectedUnseeded = cms.EDProducer("PFClusterProduce
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitECALUnseeded"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
@@ -134,6 +134,7 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitHBHE"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
@@ -10,7 +10,8 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
             cms.PSet(
                 depths = cms.vint32(1, 2, 3, 4),
                 detector = cms.string('HCAL_BARREL1'),
-                gatheringThreshold = cms.vdouble(0.8, 1.2, 1.2, 1.2),
+                #Run3 thresholds. Will be overwritten with valid aging customisation
+                gatheringThreshold = cms.vdouble(0.1, 0.2, 0.3, 0.3),
                 gatheringThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
             ),
             cms.PSet(
@@ -39,7 +40,8 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
                 cms.PSet(
                     depths = cms.vint32(1, 2, 3, 4),
                     detector = cms.string('HCAL_BARREL1'),
-                    logWeightDenominator = cms.vdouble(0.8, 1.2, 1.2, 1.2)
+                    #Run3 thresholds. Will be overwritten with valid aging customisation
+                    logWeightDenominator = cms.vdouble(0.1, 0.2, 0.3, 0.3)
                 ),
                 cms.PSet(
                     depths = cms.vint32(
@@ -70,7 +72,8 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
                 cms.PSet(
                     depths = cms.vint32(1, 2, 3, 4),
                     detector = cms.string('HCAL_BARREL1'),
-                    logWeightDenominator = cms.vdouble(0.8, 1.2, 1.2, 1.2)
+                    #Run3 thresholds. Will be overwritten with valid aging customisation
+                    logWeightDenominator = cms.vdouble(0.1, 0.2, 0.3, 0.3)
                 ),
                 cms.PSet(
                     depths = cms.vint32(
@@ -92,7 +95,8 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
             cms.PSet(
                 depths = cms.vint32(1, 2, 3, 4),
                 detector = cms.string('HCAL_BARREL1'),
-                recHitEnergyNorm = cms.vdouble(0.8, 1.2, 1.2, 1.2)
+                #Run3 thresholds. Will be overwritten with valid aging customisation
+                recHitEnergyNorm = cms.vdouble(0.1, 0.2, 0.3, 0.3)
             ),
             cms.PSet(
                 depths = cms.vint32(
@@ -143,7 +147,8 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
             cms.PSet(
                 depths = cms.vint32(1, 2, 3, 4),
                 detector = cms.string('HCAL_BARREL1'),
-                seedingThreshold = cms.vdouble(1.0, 1.5, 1.5, 1.5),
+                #Run3 thresholds. Will be overwritten with valid aging customisation
+                seedingThreshold = cms.vdouble(0.125, 0.250, 0.350, 0.350),
                 seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0)
             ),
             cms.PSet(

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHBHE_cfi.py
@@ -134,7 +134,7 @@ hltParticleFlowClusterHBHE = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("hltParticleFlowRecHitHBHE"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(True),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 hltParticleFlowClusterHCAL = cms.EDProducer("PFMultiDepthClusterProducer",
     clustersSource = cms.InputTag("hltParticleFlowClusterHBHE"),
-    usePFThresholdsFromDB = cms.bool(False), 
+    usePFThresholdsFromDB = cms.bool(True), 
     energyCorrector = cms.PSet(
 
     ),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
@@ -14,7 +14,8 @@ hltParticleFlowClusterHCAL = cms.EDProducer("PFMultiDepthClusterProducer",
                 cms.PSet(
                     depths = cms.vint32(1, 2, 3, 4),
                     detector = cms.string('HCAL_BARREL1'),
-                    logWeightDenominator = cms.vdouble(0.8, 1.2, 1.2, 1.2)
+                    #Run3 thresholds. Will be overwritten with valid aging customisation
+                    logWeightDenominator = cms.vdouble(0.1, 0.2, 0.3, 0.3)
                 ),
                 cms.PSet(
                     depths = cms.vint32(

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowClusterHCAL_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 hltParticleFlowClusterHCAL = cms.EDProducer("PFMultiDepthClusterProducer",
     clustersSource = cms.InputTag("hltParticleFlowClusterHBHE"),
+    usePFThresholdsFromDB = cms.bool(False), 
     energyCorrector = cms.PSet(
 
     ),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
@@ -13,7 +13,8 @@ hltParticleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                     cms.PSet(
                         depth = cms.vint32(1, 2, 3, 4),
                         detectorEnum = cms.int32(1),
-                        threshold = cms.vdouble(0.8, 1.2, 1.2, 1.2)
+                        #Run3 thresholds. Will be overwritten with valid aging customisation 
+                        threshold = cms.vdouble(0.1, 0.2, 0.3, 0.3) 
                     ),
                     cms.PSet(
                         depth = cms.vint32(

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
@@ -27,7 +27,8 @@ hltParticleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                         )
                     )
                 ),
-                name = cms.string('PFRecHitQTestHCALThresholdVsDepth')
+                name = cms.string('PFRecHitQTestHCALThresholdVsDepth'),
+                usePFThresholdsFromDB = cms.bool(False)
             ),
             cms.PSet(
                 cleaningThresholds = cms.vdouble(0.0),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowRecHitHBHE_cfi.py
@@ -28,7 +28,7 @@ hltParticleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                     )
                 ),
                 name = cms.string('PFRecHitQTestHCALThresholdVsDepth'),
-                usePFThresholdsFromDB = cms.bool(False)
+                usePFThresholdsFromDB = cms.bool(True)
             ),
             cms.PSet(
                 cleaningThresholds = cms.vdouble(0.0),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterECALUncorrected_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterECALUncorrected_cfi.py
@@ -111,7 +111,7 @@ particleFlowClusterECALUncorrected = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterECALUncorrected_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterECALUncorrected_cfi.py
@@ -111,6 +111,7 @@ particleFlowClusterECALUncorrected = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(cms.PSet(
         RecHitFlagsToBeExcluded = cms.vstring(),
         algoName = cms.string('FlagsCleanerECAL')

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHF_cfi.py
@@ -58,6 +58,7 @@ particleFlowClusterHF = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHF"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHF_cfi.py
@@ -58,7 +58,7 @@ particleFlowClusterHF = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHF"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLL1Seeded_cfi.py
@@ -25,7 +25,7 @@ particleFlowClusterHGCalFromTICLL1Seeded = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGCL1Seeded"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLL1Seeded_cfi.py
@@ -25,6 +25,7 @@ particleFlowClusterHGCalFromTICLL1Seeded = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGCL1Seeded"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLUnseeded_cfi.py
@@ -25,7 +25,7 @@ particleFlowClusterHGCalFromTICLUnseeded = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCalFromTICLUnseeded_cfi.py
@@ -25,6 +25,7 @@ particleFlowClusterHGCalFromTICLUnseeded = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
@@ -25,7 +25,7 @@ particleFlowClusterHGCal = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
-    usePFThresholdsFromDB = cms.bool(False),
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
@@ -25,6 +25,7 @@ particleFlowClusterHGCal = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
+    usePFThresholdsFromDB = cms.bool(False),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('PassThruSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHO_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHO_cfi.py
@@ -58,6 +58,7 @@ particleFlowClusterHO = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHO"),
+    usePFThresholdsFromDB = cms.bool(False), 
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHO_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHO_cfi.py
@@ -58,7 +58,7 @@ particleFlowClusterHO = cms.EDProducer("PFClusterProducer",
     ),
     recHitCleaners = cms.VPSet(),
     recHitsSource = cms.InputTag("particleFlowRecHitHO"),
-    usePFThresholdsFromDB = cms.bool(False), 
+    usePFThresholdsFromDB = cms.bool(False), # this needs to be True only for HBHE
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
         algoName = cms.string('LocalMaximumSeedFinder'),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowRecHitHF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowRecHitHF_cfi.py
@@ -32,7 +32,7 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
                     threshold = cms.vdouble(1.2, 1.8)
                 )),
                 name = cms.string('PFRecHitQTestHCALThresholdVsDepth'),
-                usePFThresholdsFromDB = cms.bool(False)
+                usePFThresholdsFromDB = cms.bool(False) # this needs to be True only for HBHE
             )
         ),
         src = cms.InputTag("hfreco"),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowRecHitHF_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowRecHitHF_cfi.py
@@ -31,7 +31,8 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
                     detectorEnum = cms.int32(4),
                     threshold = cms.vdouble(1.2, 1.8)
                 )),
-                name = cms.string('PFRecHitQTestHCALThresholdVsDepth')
+                name = cms.string('PFRecHitQTestHCALThresholdVsDepth'),
+                usePFThresholdsFromDB = cms.bool(False)
             )
         ),
         src = cms.InputTag("hfreco"),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -262,6 +262,22 @@ def customizeHLTfor42943(process):
 
     return process
 
+def customizeHLTfor43025(process):
+
+    for producer in producers_by_type(process, "PFClusterProducer"):
+        producer.usePFThresholdsFromDB = cms.bool(True)
+
+    for producer in producers_by_type(process, "PFMultiDepthClusterProducer"):
+        producer.usePFThresholdsFromDB = cms.bool(True)
+
+    for producer in producers_by_type(process, "PFRecHitProducer"):
+        if producer.producers[0].name.value() == 'PFHBHERecHitCreator':
+            producer.producers[0].qualityTests[0].usePFThresholdsFromDB = cms.bool(True)        
+        if producer.producers[0].name.value() == 'PFHFRecHitCreator':
+            producer.producers[0].qualityTests[1].usePFThresholdsFromDB = cms.bool(False)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -272,5 +288,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customizeHLTfor42497(process)
     process = customizeHLTfor42943(process)
-
+    process = customizeHLTfor43025(process)
+    
     return process

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -11,6 +11,9 @@
 #include "CondFormats/HcalObjects/interface/HcalRecoParams.h"
 #include "CondFormats/DataRecord/interface/HcalRecoParamsRcd.h"
 
+#include "CondFormats/HcalObjects/interface/HcalPFCuts.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
@@ -26,6 +29,7 @@ class HcalChannelPropertiesEP : public edm::ESProducer {
 public:
   typedef std::unique_ptr<HcalRecoParams> ReturnType1;
   typedef std::unique_ptr<HcalChannelPropertiesVec> ReturnType2;
+  typedef std::unique_ptr<HcalPFCuts> ReturnType3;
 
   inline HcalChannelPropertiesEP(const edm::ParameterSet&) {
     auto cc1 = setWhatProduced(this, &HcalChannelPropertiesEP::produce1);
@@ -39,13 +43,16 @@ public:
     sevToken_ = cc2.consumes();
     qualToken_ = cc2.consumes(qTag);
     geomToken_ = cc2.consumes();
+
+    edm::es::Label productLabel("withTopo");
+    auto cc3 = setWhatProduced(this, &HcalChannelPropertiesEP::produce3, productLabel);
+    topoToken3_ = cc3.consumes();
+    pfcutsToken_ = cc3.consumes();
   }
 
   inline ~HcalChannelPropertiesEP() override {}
 
   ReturnType1 produce1(const HcalChannelPropertiesAuxRecord& rcd) {
-    using namespace edm;
-
     const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken_);
     const HcalRecoParams& params = rcd.getRecord<HcalRecoParamsRcd>().get(paramsToken_);
 
@@ -61,8 +68,7 @@ public:
     // This means that we are sometimes going to rebuild the
     // whole table on the lumi block boundaries instead of
     // just updating the list of bad channels.
-    using namespace edm;
-
+    //
     // Retrieve various event setup records and data products
     const HcalDbRecord& dbRecord = rcd.getRecord<HcalDbRecord>();
     const HcalDbService& cond = dbRecord.get(condToken_);
@@ -118,18 +124,28 @@ public:
     return prod;
   }
 
+  ReturnType3 produce3(const HcalPFCutsRcd& rcd) {
+    const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken3_);
+    const HcalPFCuts& cuts = rcd.get(pfcutsToken_);
+
+    ReturnType3 prod = std::make_unique<HcalPFCuts>(cuts);
+    prod->setTopo(&htopo);
+    return prod;
+  }
+
   HcalChannelPropertiesEP() = delete;
   HcalChannelPropertiesEP(const HcalChannelPropertiesEP&) = delete;
   HcalChannelPropertiesEP& operator=(const HcalChannelPropertiesEP&) = delete;
 
 private:
   edm::ESGetToken<HcalDbService, HcalDbRecord> condToken_;
-  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_, topoToken3_;
   edm::ESGetToken<HcalRecoParams, HcalRecoParamsRcd> paramsToken_;
   edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> sevToken_;
   edm::ESGetToken<HcalChannelQuality, HcalChannelQualityRcd> qualToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
   edm::ESGetToken<HcalRecoParams, HcalChannelPropertiesAuxRecord> myParamsToken_;
+  edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> pfcutsToken_;
 };
 
 DEFINE_FWK_EVENTSETUP_MODULE(HcalChannelPropertiesEP);

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -125,7 +125,7 @@ public:
   }
 
   ReturnType3 produce3(const HcalPFCutsRcd& rcd) {
-    const HcalTopology& htopo = rcd.getRecord<HcalRecNumberingRecord>().get(topoToken3_);
+    const HcalTopology& htopo = rcd.get(topoToken3_);
     const HcalPFCuts& cuts = rcd.get(pfcutsToken_);
 
     ReturnType3 prod = std::make_unique<HcalPFCuts>(cuts);

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -92,7 +92,7 @@ public:
                              const std::vector<bool>& mask,   // mask flags
                              const std::vector<bool>& seeds,  // seed flags
                              reco::PFClusterCollection&,      //output
-                             HcalPFCuts*) = 0;
+                             const HcalPFCuts*) = 0;
 
   std::ostream& operator<<(std::ostream& o) const {
     o << "InitialClusteringStep with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -8,6 +8,8 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <string>
 #include <iostream>
@@ -87,9 +89,10 @@ public:
   virtual void updateEvent(const edm::Event&) {}
 
   virtual void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-                             const std::vector<bool>& mask,    // mask flags
-                             const std::vector<bool>& seeds,   // seed flags
-                             reco::PFClusterCollection&) = 0;  //output
+                             const std::vector<bool>& mask,   // mask flags
+                             const std::vector<bool>& seeds,  // seed flags
+                             reco::PFClusterCollection&,      //output
+                             HcalPFCuts*) = 0;
 
   std::ostream& operator<<(std::ostream& o) const {
     o << "InitialClusteringStep with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -5,6 +5,8 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <string>
 
@@ -27,9 +29,9 @@ public:
   virtual void update(const edm::EventSetup&) {}
 
   // here we transform one PFCluster to use the new position calculation
-  virtual void calculateAndSetPosition(reco::PFCluster&) = 0;
+  virtual void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) = 0;
   // here you call a loop inside to transform the whole vector
-  virtual void calculateAndSetPositions(reco::PFClusterCollection&) = 0;
+  virtual void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) = 0;
 
   const std::string& name() const { return _algoName; }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -29,9 +29,9 @@ public:
   virtual void update(const edm::EventSetup&) {}
 
   // here we transform one PFCluster to use the new position calculation
-  virtual void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) = 0;
+  virtual void calculateAndSetPosition(reco::PFCluster&, const HcalPFCuts*) = 0;
   // here you call a loop inside to transform the whole vector
-  virtual void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) = 0;
+  virtual void calculateAndSetPositions(reco::PFClusterCollection&, const HcalPFCuts*) = 0;
 
   const std::string& name() const { return _algoName; }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -7,6 +7,8 @@
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <string>
 #include <iostream>
@@ -41,7 +43,8 @@ public:
 
   virtual void buildClusters(const reco::PFClusterCollection& topos,
                              const std::vector<bool>& seedable,
-                             reco::PFClusterCollection& outclus) = 0;
+                             reco::PFClusterCollection& outclus,
+                             HcalPFCuts*) = 0;
 
   std::ostream& operator<<(std::ostream& o) const {
     o << "PFClusterBuilder with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -44,7 +44,7 @@ public:
   virtual void buildClusters(const reco::PFClusterCollection& topos,
                              const std::vector<bool>& seedable,
                              reco::PFClusterCollection& outclus,
-                             HcalPFCuts*) = 0;
+                             const HcalPFCuts*) = 0;
 
   std::ostream& operator<<(std::ostream& o) const {
     o << "PFClusterBuilder with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -264,8 +264,7 @@ public:
         psets_(iConfig.getParameter<std::vector<edm::ParameterSet>>("cuts")),
         cutsFromDB(iConfig.getParameter<bool>("usePFThresholdsFromDB")) {
     if (cutsFromDB) {
-      htopoToken_ = cc.esConsumes<HcalTopology, HcalRecNumberingRecord>();
-      hcalCutsToken_ = cc.esConsumes<HcalPFCuts, HcalPFCutsRcd>();
+      hcalCutsToken_ = cc.esConsumes<HcalPFCuts, HcalPFCutsRcd>(edm::ESInputTag("", "withTopo"));
     }
     for (auto& pset : psets_) {
       depths_.push_back(pset.getParameter<std::vector<int>>("depth"));
@@ -279,7 +278,6 @@ public:
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
     if (cutsFromDB) {
-      htopo = &iSetup.getData(htopoToken_);
       hcalCuts = &iSetup.getData(hcalCutsToken_);
     }
   }
@@ -305,7 +303,6 @@ protected:
   std::vector<std::vector<int>> depths_;
   std::vector<std::vector<double>> thresholds_;
   std::vector<int> detector_;
-  const HcalTopology* htopo;
   const HcalPFCuts* hcalCuts;
 
   bool test(unsigned aDETID, double energy, double time, bool& clean) {
@@ -314,7 +311,6 @@ protected:
     if (cutsFromDB) {
       std::unique_ptr<HcalPFCuts> paramPF_;
       paramPF_ = std::make_unique<HcalPFCuts>(*hcalCuts);
-      paramPF_->setTopo(htopo);
       item = paramPF_->getValues(detid.rawId());
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -10,6 +10,8 @@
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "DataFormats/METReco/interface/HcalPhase1FlagLabels.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <iostream>
 
@@ -258,7 +260,13 @@ public:
   PFRecHitQTestHCALThresholdVsDepth() {}
 
   PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig, edm::ConsumesCollector& cc)
-      : PFRecHitQTestBase(iConfig, cc), psets_(iConfig.getParameter<std::vector<edm::ParameterSet>>("cuts")) {
+      : PFRecHitQTestBase(iConfig, cc),
+        psets_(iConfig.getParameter<std::vector<edm::ParameterSet>>("cuts")),
+        cutsFromDB(iConfig.getParameter<bool>("usePFThresholdsFromDB")) {
+    if (cutsFromDB) {
+      htopoToken_ = cc.esConsumes<HcalTopology, HcalRecNumberingRecord>();
+      hcalCutsToken_ = cc.esConsumes<HcalPFCuts, HcalPFCutsRcd>();
+    }
     for (auto& pset : psets_) {
       depths_.push_back(pset.getParameter<std::vector<int>>("depth"));
       thresholds_.push_back(pset.getParameter<std::vector<double>>("threshold"));
@@ -269,7 +277,12 @@ public:
     }
   }
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    if (cutsFromDB) {
+      htopo = &iSetup.getData(htopoToken_);
+      hcalCuts = &iSetup.getData(hcalCutsToken_);
+    }
+  }
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
   bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
@@ -292,16 +305,26 @@ protected:
   std::vector<std::vector<int>> depths_;
   std::vector<std::vector<double>> thresholds_;
   std::vector<int> detector_;
+  const HcalTopology* htopo;
+  const HcalPFCuts* hcalCuts;
 
   bool test(unsigned aDETID, double energy, double time, bool& clean) {
     HcalDetId detid(aDETID);
+    const HcalPFCut* item = nullptr;
+    if (cutsFromDB) {
+      std::unique_ptr<HcalPFCuts> paramPF_;
+      paramPF_ = std::make_unique<HcalPFCuts>(*hcalCuts);
+      paramPF_->setTopo(htopo);
+      item = paramPF_->getValues(detid.rawId());
+    }
 
     for (unsigned int d = 0; d < detector_.size(); ++d) {
       if (detid.subdet() != detector_[d])
         continue;
       for (unsigned int i = 0; i < thresholds_[d].size(); ++i) {
         if (detid.depth() == depths_[d][i]) {
-          if (energy < thresholds_[d][i]) {
+          float thres = cutsFromDB ? item->noiseThreshold() : thresholds_[d][i];
+          if (energy < thres) {
             clean = false;
             return false;
           }
@@ -311,6 +334,11 @@ protected:
     }
     return true;
   }
+
+private:
+  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
+  edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
+  bool cutsFromDB;
 };
 
 //

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -278,7 +278,7 @@ public:
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
     if (cutsFromDB) {
-      hcalCuts = &iSetup.getData(hcalCutsToken_);
+      paramPF = &iSetup.getData(hcalCutsToken_);
     }
   }
 
@@ -303,15 +303,13 @@ protected:
   std::vector<std::vector<int>> depths_;
   std::vector<std::vector<double>> thresholds_;
   std::vector<int> detector_;
-  const HcalPFCuts* hcalCuts;
+  HcalPFCuts const* paramPF = nullptr;
 
   bool test(unsigned aDETID, double energy, double time, bool& clean) {
     HcalDetId detid(aDETID);
     const HcalPFCut* item = nullptr;
     if (cutsFromDB) {
-      std::unique_ptr<HcalPFCuts> paramPF_;
-      paramPF_ = std::make_unique<HcalPFCuts>(*hcalCuts);
-      item = paramPF_->getValues(detid.rawId());
+      item = paramPF->getValues(detid.rawId());
     }
 
     for (unsigned int d = 0; d < detector_.size(); ++d) {

--- a/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
@@ -5,6 +5,8 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class SeedFinderBase {
 public:
@@ -15,7 +17,8 @@ public:
 
   virtual void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                          const std::vector<bool>& mask,
-                         std::vector<bool>& seedable) = 0;
+                         std::vector<bool>& seedable,
+                         HcalPFCuts*) = 0;
 
   const std::string& name() const { return _algoName; }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
@@ -18,7 +18,7 @@ public:
   virtual void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                          const std::vector<bool>& mask,
                          std::vector<bool>& seedable,
-                         HcalPFCuts*) = 0;
+                         const HcalPFCuts*) = 0;
 
   const std::string& name() const { return _algoName; }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.cc
@@ -1,5 +1,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class Basic2DClusterForEachSeed : public InitialClusteringStepBase {
 public:
@@ -10,7 +12,8 @@ public:
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
                      const std::vector<bool>&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection&) override;
+                     reco::PFClusterCollection&,
+                     HcalPFCuts*) override;
 };
 
 DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DClusterForEachSeed, "Basic2DClusterForEachSeed");
@@ -18,7 +21,8 @@ DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DClusterForEachSeed, "Basi
 void Basic2DClusterForEachSeed::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                               const std::vector<bool>& rechitMask,
                                               const std::vector<bool>& seedable,
-                                              reco::PFClusterCollection& output) {
+                                              reco::PFClusterCollection& output,
+                                              HcalPFCuts*) {
   auto const& hits = *input;
 
   // loop over seeds and make clusters

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DClusterForEachSeed.cc
@@ -13,7 +13,7 @@ public:
                      const std::vector<bool>&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection&,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 };
 
 DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DClusterForEachSeed, "Basic2DClusterForEachSeed");
@@ -22,7 +22,7 @@ void Basic2DClusterForEachSeed::buildClusters(const edm::Handle<reco::PFRecHitCo
                                               const std::vector<bool>& rechitMask,
                                               const std::vector<bool>& seedable,
                                               reco::PFClusterCollection& output,
-                                              HcalPFCuts*) {
+                                              const HcalPFCuts*) {
   auto const& hits = *input;
 
   // loop over seeds and make clusters

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -34,7 +34,7 @@ public:
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection& outclus,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   const unsigned _maxIterations;
@@ -51,7 +51,7 @@ private:
   void seedPFClustersFromTopo(const reco::PFCluster&,
                               const std::vector<bool>&,
                               reco::PFClusterCollection&,
-                              HcalPFCuts*) const;
+                              const HcalPFCuts*) const;
 
   void growPFClusters(const reco::PFCluster&,
                       const std::vector<bool>&,
@@ -59,7 +59,7 @@ private:
                       const unsigned iter,
                       double dist,
                       reco::PFClusterCollection&,
-                      HcalPFCuts*) const;
+                      const HcalPFCuts*) const;
 
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
@@ -141,7 +141,7 @@ Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::Parame
 void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollection& input,
                                                    const std::vector<bool>& seedable,
                                                    reco::PFClusterCollection& output,
-                                                   HcalPFCuts* hcalCuts) {
+                                                   const HcalPFCuts* hcalCuts) {
   reco::PFClusterCollection clustersInTopo;
   for (const auto& topocluster : input) {
     clustersInTopo.clear();
@@ -172,7 +172,7 @@ void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollecti
 void Basic2DGenericPFlowClusterizer::seedPFClustersFromTopo(const reco::PFCluster& topo,
                                                             const std::vector<bool>& seedable,
                                                             reco::PFClusterCollection& initialPFClusters,
-                                                            HcalPFCuts* hcalCuts) const {
+                                                            const HcalPFCuts* hcalCuts) const {
   const auto& recHitFractions = topo.recHitFractions();
   for (const auto& rhf : recHitFractions) {
     if (!seedable[rhf.recHitRef().key()])
@@ -195,7 +195,7 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
                                                     const unsigned iter,
                                                     double diff,
                                                     reco::PFClusterCollection& clusters,
-                                                    HcalPFCuts* hcalCuts) const {
+                                                    const HcalPFCuts* hcalCuts) const {
   if (iter >= _maxIterations) {
     LOGDRESSED("Basic2DGenericPFlowClusterizer:growAndStabilizePFClusters")
         << "reached " << _maxIterations << " iterations, terminated position "

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -4,6 +4,8 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include "Math/GenVector/VectorUtil.h"
 #include "vdt/vdtMath.h"
@@ -31,7 +33,8 @@ public:
 
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection& outclus) override;
+                     reco::PFClusterCollection& outclus,
+                     HcalPFCuts*) override;
 
 private:
   const unsigned _maxIterations;
@@ -45,14 +48,18 @@ private:
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
 
-  void seedPFClustersFromTopo(const reco::PFCluster&, const std::vector<bool>&, reco::PFClusterCollection&) const;
+  void seedPFClustersFromTopo(const reco::PFCluster&,
+                              const std::vector<bool>&,
+                              reco::PFClusterCollection&,
+                              HcalPFCuts*) const;
 
   void growPFClusters(const reco::PFCluster&,
                       const std::vector<bool>&,
                       const unsigned toleranceScaling,
                       const unsigned iter,
                       double dist,
-                      reco::PFClusterCollection&) const;
+                      reco::PFClusterCollection&,
+                      HcalPFCuts*) const;
 
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
@@ -133,13 +140,14 @@ Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::Parame
 
 void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollection& input,
                                                    const std::vector<bool>& seedable,
-                                                   reco::PFClusterCollection& output) {
+                                                   reco::PFClusterCollection& output,
+                                                   HcalPFCuts* hcalCuts) {
   reco::PFClusterCollection clustersInTopo;
   for (const auto& topocluster : input) {
     clustersInTopo.clear();
-    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo);
+    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo, hcalCuts);
     const unsigned tolScal = std::pow(std::max(1.0, clustersInTopo.size() - 1.0), 2.0);
-    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo);
+    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo, hcalCuts);
     // step added by Josh Bendavid, removes low-fraction clusters
     // did not impact position resolution with fraction cut of 1e-7
     // decreases the size of each pf cluster considerably
@@ -147,12 +155,12 @@ void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollecti
     // recalculate the positions of the pruned clusters
     if (_convergencePosCalc) {
       // if defined, use the special position calculation for convergence tests
-      _convergencePosCalc->calculateAndSetPositions(clustersInTopo);
+      _convergencePosCalc->calculateAndSetPositions(clustersInTopo, hcalCuts);
     } else {
       if (clustersInTopo.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
+        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back(), hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPositions(clustersInTopo);
+        _positionCalc->calculateAndSetPositions(clustersInTopo, hcalCuts);
       }
     }
     for (auto& clusterout : clustersInTopo) {
@@ -163,7 +171,8 @@ void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollecti
 
 void Basic2DGenericPFlowClusterizer::seedPFClustersFromTopo(const reco::PFCluster& topo,
                                                             const std::vector<bool>& seedable,
-                                                            reco::PFClusterCollection& initialPFClusters) const {
+                                                            reco::PFClusterCollection& initialPFClusters,
+                                                            HcalPFCuts* hcalCuts) const {
   const auto& recHitFractions = topo.recHitFractions();
   for (const auto& rhf : recHitFractions) {
     if (!seedable[rhf.recHitRef().key()])
@@ -173,9 +182,9 @@ void Basic2DGenericPFlowClusterizer::seedPFClustersFromTopo(const reco::PFCluste
     current.addRecHitFraction(rhf);
     current.setSeed(rhf.recHitRef()->detId());
     if (_convergencePosCalc) {
-      _convergencePosCalc->calculateAndSetPosition(current);
+      _convergencePosCalc->calculateAndSetPosition(current, hcalCuts);
     } else {
-      _positionCalc->calculateAndSetPosition(current);
+      _positionCalc->calculateAndSetPosition(current, hcalCuts);
     }
   }
 }
@@ -185,7 +194,8 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
                                                     const unsigned toleranceScaling,
                                                     const unsigned iter,
                                                     double diff,
-                                                    reco::PFClusterCollection& clusters) const {
+                                                    reco::PFClusterCollection& clusters,
+                                                    HcalPFCuts* hcalCuts) const {
   if (iter >= _maxIterations) {
     LOGDRESSED("Basic2DGenericPFlowClusterizer:growAndStabilizePFClusters")
         << "reached " << _maxIterations << " iterations, terminated position "
@@ -200,9 +210,9 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
     clus_prev_pos.emplace_back(repp.rho(), repp.eta(), repp.phi());
     if (_convergencePosCalc) {
       if (clusters.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(cluster);
+        _allCellsPosCalc->calculateAndSetPosition(cluster, hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPosition(cluster);
+        _positionCalc->calculateAndSetPosition(cluster, hcalCuts);
       }
     }
     cluster.resetHitsAndFractions();
@@ -227,11 +237,18 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
 
     for (unsigned int j = 0; j < recHitEnergyNormDepthPair.second.size(); ++j) {
       int depth = recHitEnergyNormDepthPair.first[j];
-
       if ((cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth() == depth) ||
           (cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth() == depth) ||
           (cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1))
         recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
+    }
+
+    if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in PFClusterProducer.cc
+      if ((cell_layer == PFLayer::HCAL_BARREL1) || (cell_layer == PFLayer::HCAL_ENDCAP)) {
+        HcalDetId thisId = refhit->detId();
+        const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+        recHitEnergyNorm = item->noiseThreshold();
+      }
     }
 
     // add rechits to clusters, calculating fraction based on distance
@@ -283,12 +300,12 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
   double diff2 = 0.0;
   for (unsigned i = 0; i < clusters.size(); ++i) {
     if (_convergencePosCalc) {
-      _convergencePosCalc->calculateAndSetPosition(clusters[i]);
+      _convergencePosCalc->calculateAndSetPosition(clusters[i], hcalCuts);
     } else {
       if (clusters.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(clusters[i]);
+        _allCellsPosCalc->calculateAndSetPosition(clusters[i], hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPosition(clusters[i]);
+        _positionCalc->calculateAndSetPosition(clusters[i], hcalCuts);
       }
     }
     const double delta2 = reco::deltaR2(clusters[i].positionREP(), clus_prev_pos[i]);
@@ -299,7 +316,7 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
   dist2.clear();
   frac.clear();
   clus_prev_pos.clear();  // avoid badness
-  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters);
+  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters, hcalCuts);
 }
 
 void Basic2DGenericPFlowClusterizer::prunePFClusters(reco::PFClusterCollection& clusters) const {

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -235,19 +235,18 @@ void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
     double recHitEnergyNorm = 0.;
     auto const& recHitEnergyNormDepthPair = _recHitEnergyNorms.find(cell_layer)->second;
 
-    for (unsigned int j = 0; j < recHitEnergyNormDepthPair.second.size(); ++j) {
-      int depth = recHitEnergyNormDepthPair.first[j];
-      if ((cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth() == depth) ||
-          (cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth() == depth) ||
-          (cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1))
-        recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
-    }
-
-    if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in PFClusterProducer.cc
-      if ((cell_layer == PFLayer::HCAL_BARREL1) || (cell_layer == PFLayer::HCAL_ENDCAP)) {
-        HcalDetId thisId = refhit->detId();
-        const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
-        recHitEnergyNorm = item->noiseThreshold();
+    if (hcalCuts != nullptr &&  // this means, cutsFromDB is set to True in PFClusterProducer.cc
+        (cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP)) {
+      HcalDetId thisId = refhit->detId();
+      const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+      recHitEnergyNorm = item->noiseThreshold();
+    } else {
+      for (unsigned int j = 0; j < recHitEnergyNormDepthPair.second.size(); ++j) {
+        int depth = recHitEnergyNormDepthPair.first[j];
+        if ((cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth() == depth) ||
+            (cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth() == depth) ||
+            (cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1))
+          recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -229,22 +229,22 @@ void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFClus
       int cell_layer = (int)refhit.layer();
       float threshold = 0;
 
-      for (unsigned int j = 0; j < (std::get<2>(_logWeightDenom)).size(); ++j) {
-        // barrel is detecor type1
-        int detectorEnum = std::get<0>(_logWeightDenom)[j];
-        int depth = std::get<1>(_logWeightDenom)[j];
+      if (hcalCuts != nullptr &&  // this means, cutsFromDB is set to True in the producer code
+          (cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_ENDCAP)) {
+        HcalDetId thisId = refhit.detId();
+        const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+        threshold = 1. / (item->noiseThreshold());
 
-        if ((cell_layer == PFLayer::HCAL_BARREL1 && detectorEnum == 1 && refhit.depth() == depth) ||
-            (cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum == 2 && refhit.depth() == depth) || detectorEnum == 0) {
-          threshold = std::get<2>(_logWeightDenom)[j];
-        }
-      }
-
-      if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in the producer code
-        if ((cell_layer == PFLayer::HCAL_BARREL1) || (cell_layer == PFLayer::HCAL_ENDCAP)) {
-          HcalDetId thisId = refhit.detId();
-          const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
-          threshold = 1. / (item->noiseThreshold());
+      } else {
+        for (unsigned int j = 0; j < (std::get<2>(_logWeightDenom)).size(); ++j) {
+          // barrel is detecor type1
+          int detectorEnum = std::get<0>(_logWeightDenom)[j];
+          int depth = std::get<1>(_logWeightDenom)[j];
+          if ((cell_layer == PFLayer::HCAL_BARREL1 && detectorEnum == 1 && refhit.depth() == depth) ||
+              (cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum == 2 && refhit.depth() == depth) ||
+              detectorEnum == 0) {
+            threshold = std::get<2>(_logWeightDenom)[j];
+          }
         }
       }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -94,8 +94,8 @@ public:
   Basic2DGenericPFlowPositionCalc(const Basic2DGenericPFlowPositionCalc&) = delete;
   Basic2DGenericPFlowPositionCalc& operator=(const Basic2DGenericPFlowPositionCalc&) = delete;
 
-  void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) override;
-  void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) override;
+  void calculateAndSetPosition(reco::PFCluster&, const HcalPFCuts*) override;
+  void calculateAndSetPositions(reco::PFClusterCollection&, const HcalPFCuts*) override;
 
 private:
   const int _posCalcNCrystals;
@@ -105,7 +105,7 @@ private:
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcBarrel;
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcEndcap;
 
-  void calculateAndSetPositionActual(reco::PFCluster&, HcalPFCuts*) const;
+  void calculateAndSetPositionActual(reco::PFCluster&, const HcalPFCuts*) const;
 };
 
 DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, Basic2DGenericPFlowPositionCalc, "Basic2DGenericPFlowPositionCalc");
@@ -117,19 +117,19 @@ namespace {
   }
 }  // namespace
 
-void Basic2DGenericPFlowPositionCalc::calculateAndSetPosition(reco::PFCluster& cluster, HcalPFCuts* hcalCuts) {
+void Basic2DGenericPFlowPositionCalc::calculateAndSetPosition(reco::PFCluster& cluster, const HcalPFCuts* hcalCuts) {
   calculateAndSetPositionActual(cluster, hcalCuts);
 }
 
 void Basic2DGenericPFlowPositionCalc::calculateAndSetPositions(reco::PFClusterCollection& clusters,
-                                                               HcalPFCuts* hcalCuts) {
+                                                               const HcalPFCuts* hcalCuts) {
   for (reco::PFCluster& cluster : clusters) {
     calculateAndSetPositionActual(cluster, hcalCuts);
   }
 }
 
 void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFCluster& cluster,
-                                                                    HcalPFCuts* hcalCuts) const {
+                                                                    const HcalPFCuts* hcalCuts) const {
   if (!cluster.seed()) {
     throw cms::Exception("ClusterWithNoSeed") << " Found a cluster with no seed: " << cluster;
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -1,6 +1,8 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class Basic2DGenericTopoClusterizer : public InitialClusteringStepBase {
   typedef Basic2DGenericTopoClusterizer B2DGT;
@@ -15,7 +17,8 @@ public:
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
                      const std::vector<bool>&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection&) override;
+                     reco::PFClusterCollection&,
+                     HcalPFCuts*) override;
 
 private:
   const bool _useCornerCells;
@@ -23,7 +26,8 @@ private:
                         const std::vector<bool>&,  // masked rechits
                         unsigned int,              //present rechit
                         std::vector<bool>&,        // hit usage state
-                        reco::PFCluster&);         // the topocluster
+                        reco::PFCluster&,          // the topocluster
+                        HcalPFCuts*);
 };
 
 DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DGenericTopoClusterizer, "Basic2DGenericTopoClusterizer");
@@ -43,7 +47,8 @@ DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DGenericTopoClusterizer, "
 void Basic2DGenericTopoClusterizer::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                                   const std::vector<bool>& rechitMask,
                                                   const std::vector<bool>& seedable,
-                                                  reco::PFClusterCollection& output) {
+                                                  reco::PFClusterCollection& output,
+                                                  HcalPFCuts* hcalCuts) {
   auto const& hits = *input;
   std::vector<bool> used(hits.size(), false);
   std::vector<unsigned int> seeds;
@@ -64,7 +69,7 @@ void Basic2DGenericTopoClusterizer::buildClusters(const edm::Handle<reco::PFRecH
     if (!rechitMask[seed] || !seedable[seed] || used[seed])
       continue;
     temp.reset();
-    buildTopoCluster(input, rechitMask, seed, used, temp);
+    buildTopoCluster(input, rechitMask, seed, used, temp, hcalCuts);
     if (!temp.recHitFractions().empty())
       output.push_back(temp);
   }
@@ -74,7 +79,8 @@ void Basic2DGenericTopoClusterizer::buildTopoCluster(const edm::Handle<reco::PFR
                                                      const std::vector<bool>& rechitMask,
                                                      unsigned int kcell,
                                                      std::vector<bool>& used,
-                                                     reco::PFCluster& topocluster) {
+                                                     reco::PFCluster& topocluster,
+                                                     HcalPFCuts* hcalCuts) {
   auto const& cell = (*input)[kcell];
   int cell_layer = (int)cell.layer();
   if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(cell.positionREP().eta()) > 0.34) {
@@ -93,6 +99,14 @@ void Basic2DGenericTopoClusterizer::buildTopoCluster(const edm::Handle<reco::PFR
         (cell_layer != PFLayer::HCAL_BARREL1 && cell_layer != PFLayer::HCAL_ENDCAP)) {
       thresholdE = std::get<1>(thresholds)[j];
       thresholdPT2 = std::get<2>(thresholds)[j];
+    }
+  }
+
+  if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in PFClusterProducer.cc
+    if ((cell_layer == PFLayer::HCAL_BARREL1) || (cell_layer == PFLayer::HCAL_ENDCAP)) {
+      HcalDetId thisId = cell.detId();
+      const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+      thresholdE = item->noiseThreshold();
     }
   }
 
@@ -118,6 +132,6 @@ void Basic2DGenericTopoClusterizer::buildTopoCluster(const edm::Handle<reco::PFR
           << " Reasons : " << used[nb] << " (used) " << !rechitMask[nb] << " (masked)." << std::endl;
       continue;
     }
-    buildTopoCluster(input, rechitMask, nb, used, topocluster);
+    buildTopoCluster(input, rechitMask, nb, used, topocluster, hcalCuts);
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -18,7 +18,7 @@ public:
                      const std::vector<bool>&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection&,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   const bool _useCornerCells;
@@ -27,7 +27,7 @@ private:
                         unsigned int,              //present rechit
                         std::vector<bool>&,        // hit usage state
                         reco::PFCluster&,          // the topocluster
-                        HcalPFCuts*);
+                        const HcalPFCuts*);
 };
 
 DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DGenericTopoClusterizer, "Basic2DGenericTopoClusterizer");
@@ -48,7 +48,7 @@ void Basic2DGenericTopoClusterizer::buildClusters(const edm::Handle<reco::PFRecH
                                                   const std::vector<bool>& rechitMask,
                                                   const std::vector<bool>& seedable,
                                                   reco::PFClusterCollection& output,
-                                                  HcalPFCuts* hcalCuts) {
+                                                  const HcalPFCuts* hcalCuts) {
   auto const& hits = *input;
   std::vector<bool> used(hits.size(), false);
   std::vector<unsigned int> seeds;
@@ -80,7 +80,7 @@ void Basic2DGenericTopoClusterizer::buildTopoCluster(const edm::Handle<reco::PFR
                                                      unsigned int kcell,
                                                      std::vector<bool>& used,
                                                      reco::PFCluster& topocluster,
-                                                     HcalPFCuts* hcalCuts) {
+                                                     const HcalPFCuts* hcalCuts) {
   auto const& cell = (*input)[kcell];
   int cell_layer = (int)cell.layer();
   if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(cell.positionREP().eta()) > 0.34) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -12,7 +12,8 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
 #include "TPrincipal.h"
@@ -26,8 +27,8 @@ public:
   Cluster3DPCACalculator(const Cluster3DPCACalculator&) = delete;
   Cluster3DPCACalculator& operator=(const Cluster3DPCACalculator&) = delete;
 
-  void calculateAndSetPosition(reco::PFCluster&) override;
-  void calculateAndSetPositions(reco::PFClusterCollection&) override;
+  void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) override;
+  void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) override;
 
 private:
   const bool updateTiming_;
@@ -40,12 +41,12 @@ private:
 
 DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, Cluster3DPCACalculator, "Cluster3DPCACalculator");
 
-void Cluster3DPCACalculator::calculateAndSetPosition(reco::PFCluster& cluster) {
+void Cluster3DPCACalculator::calculateAndSetPosition(reco::PFCluster& cluster, HcalPFCuts* cuts) {
   pca_ = std::make_unique<TPrincipal>(3, "D");
   calculateAndSetPositionActual(cluster);
 }
 
-void Cluster3DPCACalculator::calculateAndSetPositions(reco::PFClusterCollection& clusters) {
+void Cluster3DPCACalculator::calculateAndSetPositions(reco::PFClusterCollection& clusters, HcalPFCuts* cuts) {
   for (reco::PFCluster& cluster : clusters) {
     pca_ = std::make_unique<TPrincipal>(3, "D");
     calculateAndSetPositionActual(cluster);

--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -27,8 +27,8 @@ public:
   Cluster3DPCACalculator(const Cluster3DPCACalculator&) = delete;
   Cluster3DPCACalculator& operator=(const Cluster3DPCACalculator&) = delete;
 
-  void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) override;
-  void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) override;
+  void calculateAndSetPosition(reco::PFCluster&, const HcalPFCuts*) override;
+  void calculateAndSetPositions(reco::PFClusterCollection&, const HcalPFCuts*) override;
 
 private:
   const bool updateTiming_;
@@ -41,12 +41,12 @@ private:
 
 DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, Cluster3DPCACalculator, "Cluster3DPCACalculator");
 
-void Cluster3DPCACalculator::calculateAndSetPosition(reco::PFCluster& cluster, HcalPFCuts* cuts) {
+void Cluster3DPCACalculator::calculateAndSetPosition(reco::PFCluster& cluster, const HcalPFCuts* cuts) {
   pca_ = std::make_unique<TPrincipal>(3, "D");
   calculateAndSetPositionActual(cluster);
 }
 
-void Cluster3DPCACalculator::calculateAndSetPositions(reco::PFClusterCollection& clusters, HcalPFCuts* cuts) {
+void Cluster3DPCACalculator::calculateAndSetPositions(reco::PFClusterCollection& clusters, const HcalPFCuts* cuts) {
   for (reco::PFCluster& cluster : clusters) {
     pca_ = std::make_unique<TPrincipal>(3, "D");
     calculateAndSetPositionActual(cluster);

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
@@ -48,8 +48,8 @@ public:
 
   void update(const edm::EventSetup& es) override;
 
-  void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) override;
-  void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) override;
+  void calculateAndSetPosition(reco::PFCluster&, const HcalPFCuts*) override;
+  void calculateAndSetPositions(reco::PFClusterCollection&, const HcalPFCuts*) override;
 
 private:
   const double _param_T0_EB;
@@ -92,11 +92,11 @@ void ECAL2DPositionCalcWithDepthCorr::update(const edm::EventSetup& es) {
   }
 }
 
-void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPosition(reco::PFCluster& cluster, HcalPFCuts*) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPosition(reco::PFCluster& cluster, const HcalPFCuts*) {
   calculateAndSetPositionActual(cluster);
 }
 
-void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositions(reco::PFClusterCollection& clusters, HcalPFCuts*) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositions(reco::PFClusterCollection& clusters, const HcalPFCuts*) {
   for (reco::PFCluster& cluster : clusters) {
     calculateAndSetPositionActual(cluster);
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
@@ -48,8 +48,8 @@ public:
 
   void update(const edm::EventSetup& es) override;
 
-  void calculateAndSetPosition(reco::PFCluster&) override;
-  void calculateAndSetPositions(reco::PFClusterCollection&) override;
+  void calculateAndSetPosition(reco::PFCluster&, HcalPFCuts*) override;
+  void calculateAndSetPositions(reco::PFClusterCollection&, HcalPFCuts*) override;
 
 private:
   const double _param_T0_EB;
@@ -92,11 +92,11 @@ void ECAL2DPositionCalcWithDepthCorr::update(const edm::EventSetup& es) {
   }
 }
 
-void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPosition(reco::PFCluster& cluster) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPosition(reco::PFCluster& cluster, HcalPFCuts*) {
   calculateAndSetPositionActual(cluster);
 }
 
-void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositions(reco::PFClusterCollection& clusters) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositions(reco::PFClusterCollection& clusters, HcalPFCuts*) {
   for (reco::PFCluster& cluster : clusters) {
     calculateAndSetPositionActual(cluster);
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -20,7 +20,7 @@ public:
   void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                  const std::vector<bool>& mask,
                  std::vector<bool>& seedable,
-                 HcalPFCuts*) override;
+                 const HcalPFCuts*) override;
 
 private:
   const int _nNeighbours;
@@ -96,7 +96,7 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
 void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                                        const std::vector<bool>& mask,
                                        std::vector<bool>& seedable,
-                                       HcalPFCuts* hcalCuts) {
+                                       const HcalPFCuts* hcalCuts) {
   auto nhits = input->size();
   initDynArray(bool, nhits, usable, true);
   //need to run over energy sorted rechits

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -2,6 +2,8 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <algorithm>
 #include <cfloat>
@@ -17,7 +19,8 @@ public:
 
   void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                  const std::vector<bool>& mask,
-                 std::vector<bool>& seedable) override;
+                 std::vector<bool>& seedable,
+                 HcalPFCuts*) override;
 
 private:
   const int _nNeighbours;
@@ -57,7 +60,6 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
   const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("thresholdsByDetector");
   for (const auto& pset : thresholds) {
     const std::string& det = pset.getParameter<std::string>("detector");
-
     std::vector<int> depths;
     std::vector<double> thresh_E;
     std::vector<double> thresh_pT;
@@ -93,7 +95,8 @@ LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
 // the starting state of seedable is all false!
 void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                                        const std::vector<bool>& mask,
-                                       std::vector<bool>& seedable) {
+                                       std::vector<bool>& seedable,
+                                       HcalPFCuts* hcalCuts) {
   auto nhits = input->size();
   initDynArray(bool, nhits, usable, true);
   //need to run over energy sorted rechits
@@ -123,6 +126,14 @@ void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollectio
           (seedlayer != PFLayer::HCAL_BARREL1 && seedlayer != PFLayer::HCAL_ENDCAP)) {
         thresholdE = std::get<1>(thresholds)[j];
         thresholdPT2 = std::get<2>(thresholds)[j];
+      }
+    }
+
+    if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in PFClusterProducer.cc
+      if ((seedlayer == PFLayer::HCAL_BARREL1) || (seedlayer == PFLayer::HCAL_ENDCAP)) {
+        HcalDetId thisId = maybeseed.detId();
+        const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+        thresholdE = item->seedThreshold();
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -31,7 +31,7 @@ public:
                      const std::vector<bool>&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection&,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   bool filterByTracksterPID_;
@@ -58,7 +58,7 @@ void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHit
                                                 const std::vector<bool>& rechitMask,
                                                 const std::vector<bool>& seedable,
                                                 reco::PFClusterCollection& output,
-                                                HcalPFCuts*) {
+                                                const HcalPFCuts*) {
   auto const& hits = *input;
 
   const auto& tracksters = *trackstersH_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalTrackster.cc
@@ -4,6 +4,8 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class PFClusterFromHGCalTrackster : public InitialClusteringStepBase {
 public:
@@ -28,7 +30,8 @@ public:
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
                      const std::vector<bool>&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection&) override;
+                     reco::PFClusterCollection&,
+                     HcalPFCuts*) override;
 
 private:
   bool filterByTracksterPID_;
@@ -54,7 +57,8 @@ void PFClusterFromHGCalTrackster::updateEvent(const edm::Event& ev) {
 void PFClusterFromHGCalTrackster::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                                 const std::vector<bool>& rechitMask,
                                                 const std::vector<bool>& seedable,
-                                                reco::PFClusterCollection& output) {
+                                                reco::PFClusterCollection& output,
+                                                HcalPFCuts*) {
   auto const& hits = *input;
 
   const auto& tracksters = *trackstersH_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -21,7 +21,6 @@ public:
   ~PFClusterProducer() override = default;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  void endRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -29,7 +28,7 @@ private:
   edm::EDGetTokenT<reco::PFRecHitCollection> _rechitsLabel;
   edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
   bool cutsFromDB;
-  HcalPFCuts* paramPF;
+  HcalPFCuts const* paramPF = nullptr;
 
   // options
   const bool _prodInitClusters;
@@ -119,12 +118,7 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
 
 void PFClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   if (cutsFromDB) {
-    const HcalPFCuts& hcalCuts = es.getData(hcalCutsToken_);
-    std::unique_ptr<HcalPFCuts> paramPF_;
-    paramPF_ = std::make_unique<HcalPFCuts>(hcalCuts);
-    paramPF = paramPF_.release();
-  } else {  // if (cutsFromDB) condition ends
-    paramPF = nullptr;
+    paramPF = &es.getData(hcalCutsToken_);
   }
   _initialClustering->update(es);
   if (_pfClusterBuilder)
@@ -186,5 +180,3 @@ void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     e.put(std::move(initialClusters), "initialClusters");
   e.put(std::move(pfClusters));
 }
-
-void PFClusterProducer::endRun(const edm::Run& run, const edm::EventSetup& es) { delete paramPF; }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -11,7 +11,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
 #include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
 #include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
-#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 #include <memory>
 
@@ -31,7 +30,6 @@ public:
 private:
   // inputs
   edm::EDGetTokenT<reco::PFClusterCollection> _clustersLabel;
-  edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> htopoToken_;
   edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
   // options
   // the actual algorithm
@@ -63,8 +61,7 @@ PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet
   edm::ConsumesCollector&& cc = consumesCollector();
 
   if (cutsFromDB) {
-    htopoToken_ = esConsumes<HcalTopology, HcalRecNumberingRecord, edm::Transition::BeginRun>();
-    hcalCutsToken_ = esConsumes<HcalPFCuts, HcalPFCutsRcd, edm::Transition::BeginRun>();
+    hcalCutsToken_ = esConsumes<HcalPFCuts, HcalPFCutsRcd, edm::Transition::BeginRun>(edm::ESInputTag("", "withTopo"));
   }
 
   if (!pfcConf.empty()) {
@@ -83,12 +80,10 @@ PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet
 
 void PFMultiDepthClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   if (cutsFromDB) {
-    const HcalTopology& htopo = es.getData(htopoToken_);
     const HcalPFCuts& hcalCuts = es.getData(hcalCutsToken_);
 
     std::unique_ptr<HcalPFCuts> paramPF_;
     paramPF_ = std::make_unique<HcalPFCuts>(hcalCuts);
-    paramPF_->setTopo(&htopo);
     paramPF = paramPF_.release();
   } else {
     paramPF = nullptr;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -24,7 +24,6 @@ public:
   ~PFMultiDepthClusterProducer() override = default;
 
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  void endRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -36,7 +35,7 @@ private:
   std::unique_ptr<PFClusterBuilderBase> _pfClusterBuilder;
   std::unique_ptr<PFClusterEnergyCorrectorBase> _energyCorrector;
   bool cutsFromDB;
-  HcalPFCuts* paramPF;
+  HcalPFCuts const* paramPF = nullptr;
 };
 
 DEFINE_FWK_MODULE(PFMultiDepthClusterProducer);
@@ -80,13 +79,7 @@ PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet
 
 void PFMultiDepthClusterProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
   if (cutsFromDB) {
-    const HcalPFCuts& hcalCuts = es.getData(hcalCutsToken_);
-
-    std::unique_ptr<HcalPFCuts> paramPF_;
-    paramPF_ = std::make_unique<HcalPFCuts>(hcalCuts);
-    paramPF = paramPF_.release();
-  } else {
-    paramPF = nullptr;
+    paramPF = &es.getData(hcalCutsToken_);
   }
   _pfClusterBuilder->update(es);
 }
@@ -108,5 +101,3 @@ void PFMultiDepthClusterProducer::produce(edm::Event& e, const edm::EventSetup& 
   }
   e.put(std::move(pfClusters));
 }
-
-void PFMultiDepthClusterProducer::endRun(const edm::Run& run, const edm::EventSetup& es) { delete paramPF; }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -28,7 +28,7 @@ public:
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection& outclus,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
@@ -93,7 +93,7 @@ PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, 
 void PFMultiDepthClusterizer::buildClusters(const reco::PFClusterCollection& input,
                                             const std::vector<bool>& seedable,
                                             reco::PFClusterCollection& output,
-                                            HcalPFCuts* hcalCuts) {
+                                            const HcalPFCuts* hcalCuts) {
   std::vector<double> etaRMS2(input.size(), 0.0);
   std::vector<double> phiRMS2(input.size(), 0.0);
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -6,7 +6,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Math/GenVector/VectorUtil.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
-
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 #include "vdt/vdtMath.h"
 
 #include <iterator>
@@ -26,7 +27,8 @@ public:
 
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection& outclus) override;
+                     reco::PFClusterCollection& outclus,
+                     HcalPFCuts*) override;
 
 private:
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
@@ -90,7 +92,8 @@ PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf, 
 
 void PFMultiDepthClusterizer::buildClusters(const reco::PFClusterCollection& input,
                                             const std::vector<bool>& seedable,
-                                            reco::PFClusterCollection& output) {
+                                            reco::PFClusterCollection& output,
+                                            HcalPFCuts* hcalCuts) {
   std::vector<double> etaRMS2(input.size(), 0.0);
   std::vector<double> phiRMS2(input.size(), 0.0);
 
@@ -133,7 +136,7 @@ void PFMultiDepthClusterizer::buildClusters(const reco::PFClusterCollection& inp
     reco::PFCluster cluster = input[i];
     mask[i] = true;
     expandCluster(cluster, i, mask, input, prunedLinks);
-    _allCellsPosCalc->calculateAndSetPosition(cluster);
+    _allCellsPosCalc->calculateAndSetPosition(cluster, hcalCuts);
     output.push_back(cluster);
     //    printf("Added linked cluster with energy =%f\n",cluster.energy());
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -5,6 +5,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include "Math/GenVector/VectorUtil.h"
 #include "TMath.h"
@@ -33,7 +35,8 @@ public:
 
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection& outclus) override;
+                     reco::PFClusterCollection& outclus,
+                     HcalPFCuts*) override;
 
 private:
   const unsigned _maxIterations;
@@ -55,14 +58,18 @@ private:
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcBarrel;
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcEndcap;
 
-  void seedPFClustersFromTopo(const reco::PFCluster&, const std::vector<bool>&, reco::PFClusterCollection&) const;
+  void seedPFClustersFromTopo(const reco::PFCluster&,
+                              const std::vector<bool>&,
+                              reco::PFClusterCollection&,
+                              HcalPFCuts*) const;
 
   void growPFClusters(const reco::PFCluster&,
                       const std::vector<bool>&,
                       const unsigned toleranceScaling,
                       const unsigned iter,
                       double dist,
-                      reco::PFClusterCollection&) const;
+                      reco::PFClusterCollection&,
+                      HcalPFCuts* hcalCuts) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
   void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
   double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, int cell_layer, double prev_timeres2) const;
@@ -146,13 +153,14 @@ PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& 
 
 void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& input,
                                                const std::vector<bool>& seedable,
-                                               reco::PFClusterCollection& output) {
+                                               reco::PFClusterCollection& output,
+                                               HcalPFCuts* hcalCuts) {
   reco::PFClusterCollection clustersInTopo;
   for (const auto& topocluster : input) {
     clustersInTopo.clear();
-    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo);
+    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo, hcalCuts);
     const unsigned tolScal = std::pow(std::max(1.0, clustersInTopo.size() - 1.0), 2.0);
-    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo);
+    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo, hcalCuts);
     // step added by Josh Bendavid, removes low-fraction clusters
     // did not impact position resolution with fraction cut of 1e-7
     // decreases the size of each pf cluster considerably
@@ -160,12 +168,12 @@ void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& 
     // recalculate the positions of the pruned clusters
     if (_convergencePosCalc) {
       // if defined, use the special position calculation for convergence tests
-      _convergencePosCalc->calculateAndSetPositions(clustersInTopo);
+      _convergencePosCalc->calculateAndSetPositions(clustersInTopo, hcalCuts);
     } else {
       if (clustersInTopo.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
+        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back(), hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPositions(clustersInTopo);
+        _positionCalc->calculateAndSetPositions(clustersInTopo, hcalCuts);
       }
     }
     for (auto& clusterout : clustersInTopo) {
@@ -176,7 +184,8 @@ void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& 
 
 void PFlow2DClusterizerWithTime::seedPFClustersFromTopo(const reco::PFCluster& topo,
                                                         const std::vector<bool>& seedable,
-                                                        reco::PFClusterCollection& initialPFClusters) const {
+                                                        reco::PFClusterCollection& initialPFClusters,
+                                                        HcalPFCuts* hcalCuts) const {
   const auto& recHitFractions = topo.recHitFractions();
   for (const auto& rhf : recHitFractions) {
     if (!seedable[rhf.recHitRef().key()])
@@ -186,9 +195,9 @@ void PFlow2DClusterizerWithTime::seedPFClustersFromTopo(const reco::PFCluster& t
     current.addRecHitFraction(rhf);
     current.setSeed(rhf.recHitRef()->detId());
     if (_convergencePosCalc) {
-      _convergencePosCalc->calculateAndSetPosition(current);
+      _convergencePosCalc->calculateAndSetPosition(current, hcalCuts);
     } else {
-      _positionCalc->calculateAndSetPosition(current);
+      _positionCalc->calculateAndSetPosition(current, hcalCuts);
     }
   }
 }
@@ -198,7 +207,8 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
                                                 const unsigned toleranceScaling,
                                                 const unsigned iter,
                                                 double diff,
-                                                reco::PFClusterCollection& clusters) const {
+                                                reco::PFClusterCollection& clusters,
+                                                HcalPFCuts* hcalCuts) const {
   if (iter >= _maxIterations) {
     LOGDRESSED("PFlow2DClusterizerWithTime:growAndStabilizePFClusters")
         << "reached " << _maxIterations << " iterations, terminated position "
@@ -216,9 +226,9 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
     clus_prev_pos.emplace_back(repp.rho(), repp.eta(), repp.phi());
     if (_convergencePosCalc) {
       if (clusters.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(cluster);
+        _allCellsPosCalc->calculateAndSetPosition(cluster, hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPosition(cluster);
+        _positionCalc->calculateAndSetPosition(cluster, hcalCuts);
       }
     }
     double resCluster2;
@@ -243,7 +253,15 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
     if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(refhit->positionREP().eta()) > 0.34) {
       cell_layer *= 100;
     }
-    const double recHitEnergyNorm = _recHitEnergyNorms.find(cell_layer)->second;
+    double recHitEnergyNorm = _recHitEnergyNorms.find(cell_layer)->second;
+    if (hcalCuts != nullptr) {  // this means, cutsFromDB is set to True in the producer code
+      if ((cell_layer == PFLayer::HCAL_BARREL1) || (cell_layer == PFLayer::HCAL_ENDCAP)) {
+        HcalDetId thisId = refhit->detId();
+        const HcalPFCut* item = hcalCuts->getValues(thisId.rawId());
+        recHitEnergyNorm = item->noiseThreshold();
+      }
+    }
+
     math::XYZPoint topocellpos_xyz(refhit->position());
     dist2.clear();
     frac.clear();
@@ -307,12 +325,12 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
   double diff2 = 0.0;
   for (unsigned i = 0; i < clusters.size(); ++i) {
     if (_convergencePosCalc) {
-      _convergencePosCalc->calculateAndSetPosition(clusters[i]);
+      _convergencePosCalc->calculateAndSetPosition(clusters[i], hcalCuts);
     } else {
       if (clusters.size() == 1 && _allCellsPosCalc) {
-        _allCellsPosCalc->calculateAndSetPosition(clusters[i]);
+        _allCellsPosCalc->calculateAndSetPosition(clusters[i], hcalCuts);
       } else {
-        _positionCalc->calculateAndSetPosition(clusters[i]);
+        _positionCalc->calculateAndSetPosition(clusters[i], hcalCuts);
       }
     }
     const double delta2 = reco::deltaR2(clusters[i].positionREP(), clus_prev_pos[i]);
@@ -326,7 +344,7 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
   clus_chi2.clear();
   clus_chi2_nhits.clear();
   clus_prev_timeres2.clear();
-  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters);
+  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters, hcalCuts);
 }
 
 void PFlow2DClusterizerWithTime::prunePFClusters(reco::PFClusterCollection& clusters) const {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -36,7 +36,7 @@ public:
   void buildClusters(const reco::PFClusterCollection&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection& outclus,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   const unsigned _maxIterations;
@@ -61,7 +61,7 @@ private:
   void seedPFClustersFromTopo(const reco::PFCluster&,
                               const std::vector<bool>&,
                               reco::PFClusterCollection&,
-                              HcalPFCuts*) const;
+                              const HcalPFCuts*) const;
 
   void growPFClusters(const reco::PFCluster&,
                       const std::vector<bool>&,
@@ -69,7 +69,7 @@ private:
                       const unsigned iter,
                       double dist,
                       reco::PFClusterCollection&,
-                      HcalPFCuts* hcalCuts) const;
+                      const HcalPFCuts* hcalCuts) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
   void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
   double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, int cell_layer, double prev_timeres2) const;
@@ -154,7 +154,7 @@ PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& 
 void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& input,
                                                const std::vector<bool>& seedable,
                                                reco::PFClusterCollection& output,
-                                               HcalPFCuts* hcalCuts) {
+                                               const HcalPFCuts* hcalCuts) {
   reco::PFClusterCollection clustersInTopo;
   for (const auto& topocluster : input) {
     clustersInTopo.clear();
@@ -185,7 +185,7 @@ void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& 
 void PFlow2DClusterizerWithTime::seedPFClustersFromTopo(const reco::PFCluster& topo,
                                                         const std::vector<bool>& seedable,
                                                         reco::PFClusterCollection& initialPFClusters,
-                                                        HcalPFCuts* hcalCuts) const {
+                                                        const HcalPFCuts* hcalCuts) const {
   const auto& recHitFractions = topo.recHitFractions();
   for (const auto& rhf : recHitFractions) {
     if (!seedable[rhf.recHitRef().key()])
@@ -208,7 +208,7 @@ void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
                                                 const unsigned iter,
                                                 double diff,
                                                 reco::PFClusterCollection& clusters,
-                                                HcalPFCuts* hcalCuts) const {
+                                                const HcalPFCuts* hcalCuts) const {
   if (iter >= _maxIterations) {
     LOGDRESSED("PFlow2DClusterizerWithTime:growAndStabilizePFClusters")
         << "reached " << _maxIterations << " iterations, terminated position "

--- a/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
@@ -10,7 +10,8 @@ public:
 
   void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                  const std::vector<bool>& mask,
-                 std::vector<bool>& seedable) override;
+                 std::vector<bool>& seedable,
+                 HcalPFCuts*) override;
 
 private:
 };
@@ -22,6 +23,7 @@ PassThruSeedFinder::PassThruSeedFinder(const edm::ParameterSet& conf) : SeedFind
 // the starting state of seedable is all false!
 void PassThruSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                                    const std::vector<bool>& mask,
-                                   std::vector<bool>& seedable) {
+                                   std::vector<bool>& seedable,
+                                   HcalPFCuts*) {
   seedable = std::vector<bool>(input->size(), true);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
@@ -11,7 +11,7 @@ public:
   void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                  const std::vector<bool>& mask,
                  std::vector<bool>& seedable,
-                 HcalPFCuts*) override;
+                 const HcalPFCuts*) override;
 
 private:
 };
@@ -24,6 +24,6 @@ PassThruSeedFinder::PassThruSeedFinder(const edm::ParameterSet& conf) : SeedFind
 void PassThruSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
                                    const std::vector<bool>& mask,
                                    std::vector<bool>& seedable,
-                                   HcalPFCuts*) {
+                                   const HcalPFCuts*) {
   seedable = std::vector<bool>(input->size(), true);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
@@ -26,7 +26,7 @@ public:
                      const std::vector<bool>&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection&,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   edm::EDGetTokenT<SimClusterCollection> _simClusterToken;
@@ -53,7 +53,7 @@ void GenericSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitColl
                                             const std::vector<bool>& rechitMask,
                                             const std::vector<bool>& seedable,
                                             reco::PFClusterCollection& output,
-                                            HcalPFCuts* hcalCuts) {
+                                            const HcalPFCuts* hcalCuts) {
   const SimClusterCollection& simClusters = *_simClusterH;
   auto const& hits = *input;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.cc
@@ -5,6 +5,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class GenericSimClusterMapper : public InitialClusteringStepBase {
   typedef GenericSimClusterMapper B2DGT;
@@ -23,7 +25,8 @@ public:
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
                      const std::vector<bool>&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection&) override;
+                     reco::PFClusterCollection&,
+                     HcalPFCuts*) override;
 
 private:
   edm::EDGetTokenT<SimClusterCollection> _simClusterToken;
@@ -49,7 +52,8 @@ void GenericSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(
 void GenericSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                             const std::vector<bool>& rechitMask,
                                             const std::vector<bool>& seedable,
-                                            reco::PFClusterCollection& output) {
+                                            reco::PFClusterCollection& output,
+                                            HcalPFCuts* hcalCuts) {
   const SimClusterCollection& simClusters = *_simClusterH;
   auto const& hits = *input;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -51,7 +51,7 @@ public:
                      const std::vector<bool>&,
                      const std::vector<bool>&,
                      reco::PFClusterCollection&,
-                     HcalPFCuts*) override;
+                     const HcalPFCuts*) override;
 
 private:
   hgcal::RecHitTools rhtools_;
@@ -111,7 +111,7 @@ void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCo
                                               const std::vector<bool>& rechitMask,
                                               const std::vector<bool>& seedable,
                                               reco::PFClusterCollection& output,
-                                              HcalPFCuts* hcalCuts) {
+                                              const HcalPFCuts* hcalCuts) {
   const SimClusterCollection& simClusters = *simClusterH_;
   auto const& hits = *input;
   RealisticHitToClusterAssociator realisticAssociator;

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -16,6 +16,8 @@
 #include "RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 #include <unordered_map>
 
@@ -48,7 +50,8 @@ public:
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
                      const std::vector<bool>&,
                      const std::vector<bool>&,
-                     reco::PFClusterCollection&) override;
+                     reco::PFClusterCollection&,
+                     HcalPFCuts*) override;
 
 private:
   hgcal::RecHitTools rhtools_;
@@ -107,7 +110,8 @@ void RealisticSimClusterMapper::update(const edm::EventSetup& es) { rhtools_.set
 void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
                                               const std::vector<bool>& rechitMask,
                                               const std::vector<bool>& seedable,
-                                              reco::PFClusterCollection& output) {
+                                              reco::PFClusterCollection& output,
+                                              HcalPFCuts* hcalCuts) {
   const SimClusterCollection& simClusters = *simClusterH_;
   auto const& hits = *input;
   RealisticHitToClusterAssociator realisticAssociator;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -60,7 +60,7 @@ _localMaxSeeds_ECAL = cms.PSet(
               seedingThresholdPt = cms.double(0.0)
               )
     ),
-    nNeighbours = cms.int32(8)
+    nNeighbours = cms.int32(8),
 )
 
 # topo clusterizer
@@ -131,6 +131,7 @@ _pfClusterizer_ECAL = cms.PSet(
 particleFlowClusterECALUncorrected = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitECAL"),
+    usePFThresholdsFromDB = cms.bool(False), 
     recHitCleaners = cms.VPSet(),
     #seedCleaners = cms.VPSet(_seedsFlagsCleaner_ECAL,_seedCleaner_ECAL),
     seedCleaners = cms.VPSet(_seedsFlagsCleaner_ECAL),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -166,7 +166,6 @@ particleFlowClusterHBHEOnly = particleFlowClusterHBHE.clone(
 )
 
 #--- Use DB conditions for cuts&seeds for Run3 and phase2
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-(phase2_common | run3_common).toModify( particleFlowClusterHBHE,
-                                     usePFThresholdsFromDB = True)
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
+hcalPfCutsFromDB.toModify( particleFlowClusterHBHE,
+                           usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -19,6 +19,7 @@ _seedingThresholdsHBphase1_2023 = cms.vdouble(0.6, 0.5, 0.5, 0.5)
 particleFlowClusterHBHE = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHBHE"),
+    usePFThresholdsFromDB = cms.bool(False),
     recHitCleaners = cms.VPSet(),
     seedCleaners = cms.VPSet(),
     seedFinder = cms.PSet(
@@ -35,7 +36,7 @@ particleFlowClusterHBHE = cms.EDProducer(
                         seedingThresholdPt = cms.vdouble(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                         )
               ),
-        nNeighbours = cms.int32(4)
+        nNeighbours = cms.int32(4),
     ),
     initialClusteringStep = cms.PSet(
         algoName = cms.string("Basic2DGenericTopoClusterizer"),    
@@ -163,3 +164,9 @@ run3_egamma_2023.toModify(particleFlowClusterHBHE,
 particleFlowClusterHBHEOnly = particleFlowClusterHBHE.clone(
     recHitsSource = "particleFlowRecHitHBHEOnly"
 )
+
+#--- Use DB conditions for cuts&seeds solely for Run3
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(~phase2_common & run3_common).toModify( particleFlowClusterHBHE,
+                                     usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -165,8 +165,8 @@ particleFlowClusterHBHEOnly = particleFlowClusterHBHE.clone(
     recHitsSource = "particleFlowRecHitHBHEOnly"
 )
 
-#--- Use DB conditions for cuts&seeds solely for Run3
+#--- Use DB conditions for cuts&seeds for Run3 and phase2
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-(~phase2_common & run3_common).toModify( particleFlowClusterHBHE,
+(phase2_common | run3_common).toModify( particleFlowClusterHBHE,
                                      usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -67,8 +67,8 @@ particleFlowClusterHCALOnly = particleFlowClusterHCAL.clone(
     clustersSource = "particleFlowClusterHBHEOnly"
 )
 
-#--- Use DB conditions for cuts&seeds solely for Run3
+#--- Use DB conditions for cuts&seeds for Run3 and Phase2
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-(~phase2_common & run3_common).toModify( particleFlowClusterHCAL,
+(phase2_common | run3_common).toModify( particleFlowClusterHCAL,
                                      usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -9,6 +9,7 @@ _thresholdsHBphase1_2023 = cms.vdouble(0.4, 0.3, 0.3, 0.3)
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
        clustersSource = cms.InputTag("particleFlowClusterHBHE"),
+       usePFThresholdsFromDB = cms.bool(False),
        pfClusterBuilder =cms.PSet(
            algoName = cms.string("PFMultiDepthClusterizer"),
            nSigmaEta = cms.double(2.),
@@ -65,3 +66,9 @@ run3_egamma_2023.toModify(particleFlowClusterHCAL,
 particleFlowClusterHCALOnly = particleFlowClusterHCAL.clone(
     clustersSource = "particleFlowClusterHBHEOnly"
 )
+
+#--- Use DB conditions for cuts&seeds solely for Run3
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+(~phase2_common & run3_common).toModify( particleFlowClusterHCAL,
+                                     usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -68,7 +68,6 @@ particleFlowClusterHCALOnly = particleFlowClusterHCAL.clone(
 )
 
 #--- Use DB conditions for cuts&seeds for Run3 and Phase2
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-(phase2_common | run3_common).toModify( particleFlowClusterHCAL,
-                                     usePFThresholdsFromDB = True)
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
+hcalPfCutsFromDB.toModify( particleFlowClusterHCAL,
+                           usePFThresholdsFromDB = True)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
@@ -45,7 +45,7 @@ _localMaxSeeds_HF = cms.PSet(
               )
 
     ),
-    nNeighbours = cms.int32(0)
+    nNeighbours = cms.int32(0),
 )
 
 #topo clusters
@@ -104,6 +104,7 @@ _pfClusterizer_HF = cms.PSet(
 particleFlowClusterHF = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHF"),
+    usePFThresholdsFromDB = cms.bool(False),
     recHitCleaners = cms.VPSet(),
     seedCleaners = cms.VPSet(),
     seedFinder = _localMaxSeeds_HF,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGC_cfi.py
@@ -60,6 +60,7 @@ _hgcalTracksterMapper_HGCal = cms.PSet(
 particleFlowClusterHGCal = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHGC"),
+    usePFThresholdsFromDB = cms.bool(False),
     recHitCleaners = cms.VPSet(),
     seedCleaners   = cms.VPSet(),
     seedFinder = _passThruSeeds_HGCal,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
@@ -19,7 +19,7 @@ _localMaxSeeds_HO = cms.PSet(
               seedingThresholdPt = cms.double(0.0)
               )
     ),
-    nNeighbours = cms.int32(4)
+    nNeighbours = cms.int32(4),
 )
 
 #topo clusters
@@ -77,6 +77,7 @@ _pfClusterizer_HO = cms.PSet(
 particleFlowClusterHO = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitHO"),
+    usePFThresholdsFromDB = cms.bool(False),
     recHitCleaners = cms.VPSet(),
     seedCleaners  = cms.VPSet(),
     seedFinder = _localMaxSeeds_HO,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
@@ -18,7 +18,7 @@ _localMaxSeeds_PS = cms.PSet(
               seedingThresholdPt = cms.double(0.0)
               )
     ),
-    nNeighbours = cms.int32(4)
+    nNeighbours = cms.int32(4),
 )
 
 #topo clusters
@@ -71,6 +71,7 @@ _pfClusterizer_PS = cms.PSet(
 particleFlowClusterPS = cms.EDProducer(
     "PFClusterProducer",
     recHitsSource = cms.InputTag("particleFlowRecHitPS"),
+    usePFThresholdsFromDB = cms.bool(False),
     recHitCleaners = cms.VPSet(),
     seedCleaners = cms.VPSet(),
     seedFinder = _localMaxSeeds_PS,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -63,10 +63,8 @@ run3_egamma_2023.toModify(particleFlowRecHitHBHE,
 )
 
 #--- Use DB conditions for cuts&seeds for Run3 and Phase2
-from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-
-(phase2_common | run3_common).toModify( particleFlowRecHitHBHE,
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
+hcalPfCutsFromDB.toModify( particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(usePFThresholdsFromDB = True) } ) },
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -62,11 +62,11 @@ run3_egamma_2023.toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1_2023) } ) } ) },
 )
 
-#--- Use DB conditions for cuts&seeds solely for Run3
+#--- Use DB conditions for cuts&seeds for Run3 and Phase2
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 
-(~phase2_common & run3_common).toModify( particleFlowRecHitHBHE,
+(phase2_common | run3_common).toModify( particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(usePFThresholdsFromDB = True) } ) },
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -19,6 +19,7 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
              qualityTests = cms.VPSet(
                   cms.PSet(
                   name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),
+                  usePFThresholdsFromDB = cms.bool(False),
                   cuts = cms.VPSet(
                         cms.PSet(
                             depth=cms.vint32(1, 2, 3, 4),
@@ -59,6 +60,14 @@ run3_HB.toModify(particleFlowRecHitHBHE,
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
 run3_egamma_2023.toModify(particleFlowRecHitHBHE,
     producers = {0 : dict(qualityTests = {0 : dict(cuts = {0 : dict(threshold = _thresholdsHBphase1_2023) } ) } ) },
+)
+
+#--- Use DB conditions for cuts&seeds solely for Run3
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+
+(~phase2_common & run3_common).toModify( particleFlowRecHitHBHE,
+    producers = {0 : dict(qualityTests = {0 : dict(usePFThresholdsFromDB = True) } ) },
 )
 
 # HCALonly WF

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHF_cfi.py
@@ -27,6 +27,7 @@ particleFlowRecHitHF = cms.EDProducer("PFRecHitProducer",
                   ),
                   cms.PSet(
                       name = cms.string("PFRecHitQTestHCALThresholdVsDepth"),
+                      usePFThresholdsFromDB = cms.bool(False),
                       cuts = cms.VPSet(
                              cms.PSet(
                                  depth = cms.vint32(1,2),


### PR DESCRIPTION
Verbatim backport of https://github.com/cms-sw/cmssw/pull/43025

Technical PR. No change in physics should be there; except: 
- some changes in Phase2 HLT, the cause of which is understood -> https://github.com/cms-sw/cmssw/pull/43025#issuecomment-1814590349 ). 
- some non-reproducibility issues https://github.com/cms-sw/cmssw/issues/43293

This PR allows HCal thresholds to be read from GT, so that during data-taking the thresholds can be updated more easily, w/o the overhead of needing a new CMSSW release every time there is a threshold update.

If this can enter 13_3_X then a proper validation with high-stat will be possible, which can be useful to gain more confidence before using it for 2024 data-taking.