### PR TITLE
Remove explicit copy-constructor from TotemTimingDigi

### DIFF
--- a/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingDigi.h
@@ -25,9 +25,7 @@ public:
                   const uint16_t cellInfo,
                   const std::vector<uint8_t>& samples,
                   const TotemTimingEventInfo& totemTimingEventInfo);
-  TotemTimingDigi(const TotemTimingDigi& digi);
   TotemTimingDigi();
-  ~TotemTimingDigi(){};
 
   /// Digis are equal if they have all the same values, NOT checking the samples!
   bool operator==(const TotemTimingDigi& digi) const;

--- a/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
+++ b/DataFormats/CTPPSDigi/interface/TotemTimingEventInfo.h
@@ -26,9 +26,7 @@ public:
                        const uint8_t numberOfSamples,
                        const uint8_t offsetOfSamples,
                        const uint8_t pllInfo);
-  TotemTimingEventInfo(const TotemTimingEventInfo& eventInfo);
   TotemTimingEventInfo();
-  ~TotemTimingEventInfo(){};
 
   /// Digis are equal if they have all the same values, NOT checking the samples!
   bool operator==(const TotemTimingEventInfo& eventInfo) const;

--- a/DataFormats/CTPPSDigi/src/TotemTimingDigi.cc
+++ b/DataFormats/CTPPSDigi/src/TotemTimingDigi.cc
@@ -22,15 +22,6 @@ TotemTimingDigi::TotemTimingDigi(const uint8_t hwId,
       samples_(samples),
       totemTimingEventInfo_(totemTimingEventInfo) {}
 
-TotemTimingDigi::TotemTimingDigi(const TotemTimingDigi& digi)
-    : hwId_(digi.hwId_),
-      fpgaTimestamp_(digi.fpgaTimestamp_),
-      timestampA_(digi.timestampA_),
-      timestampB_(digi.timestampB_),
-      cellInfo_(digi.cellInfo_),
-      samples_(digi.samples_),
-      totemTimingEventInfo_(digi.totemTimingEventInfo_) {}
-
 TotemTimingDigi::TotemTimingDigi() : hwId_(0), fpgaTimestamp_(0), timestampA_(0), timestampB_(0), cellInfo_(0) {}
 
 // Comparison

--- a/DataFormats/CTPPSDigi/src/TotemTimingEventInfo.cc
+++ b/DataFormats/CTPPSDigi/src/TotemTimingEventInfo.cc
@@ -27,18 +27,6 @@ TotemTimingEventInfo::TotemTimingEventInfo(const uint8_t hwId,
       offsetOfSamples_(offsetOfSamples),
       pllInfo_(pllInfo) {}
 
-TotemTimingEventInfo::TotemTimingEventInfo(const TotemTimingEventInfo& eventInfo)
-    : hwId_(eventInfo.hwId_),
-      l1ATimestamp_(eventInfo.l1ATimestamp_),
-      bunchNumber_(eventInfo.bunchNumber_),
-      orbitNumber_(eventInfo.orbitNumber_),
-      eventNumber_(eventInfo.eventNumber_),
-      channelMap_(eventInfo.channelMap_),
-      l1ALatency_(eventInfo.l1ALatency_),
-      numberOfSamples_(eventInfo.numberOfSamples_),
-      offsetOfSamples_(eventInfo.offsetOfSamples_),
-      pllInfo_(eventInfo.pllInfo_) {}
-
 TotemTimingEventInfo::TotemTimingEventInfo()
     : hwId_(0),
       l1ATimestamp_(0),


### PR DESCRIPTION
#### PR description:

Implicit copy-constructors are deprecated, and not necessary in most cases. This PR removes unnnecessary copy-assignment operators and destructors in favor of auto-generated ones.

#### PR validation:

Bot tests
