### PR TITLE
[XPOG][RECO] Fix DEVEL warnings on deprecated copy-constructors

### DIFF
--- a/DataFormats/PatCandidates/interface/PFIsolation.h
+++ b/DataFormats/PatCandidates/interface/PFIsolation.h
@@ -15,16 +15,6 @@ namespace pat {
 
     PFIsolation(float ch, float nh, float ph, float pu) : chiso_(ch), nhiso_(nh), phiso_(ph), puiso_(pu) {}
 
-    ~PFIsolation() {}
-
-    PFIsolation& operator=(const PFIsolation& iso) {
-      chiso_ = iso.chiso_;
-      nhiso_ = iso.nhiso_;
-      phiso_ = iso.phiso_;
-      puiso_ = iso.puiso_;
-      return *this;
-    }
-
     float chargedHadronIso() const { return chiso_; }
     float neutralHadronIso() const { return nhiso_; }
     float photonIso() const { return phiso_; }


### PR DESCRIPTION
This PR solves the compiler warnings on module `DataFormats/PatCandidates` on deprecated implicit copy-constructors shown in DEVEL IBs:
```
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/225a463d1231a8a4c99dd9e7e0b20bde/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-15-2300/src/DataFormats/PatCandidates/interface/Electron.h:26:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/225a463d1231a8a4c99dd9e7e0b20bde/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-15-2300/src/DataFormats/PatCandidates/interface/Lepton.h: In copy constructor 'pat::Lepton<reco::GsfElectron>::Lepton(const pat::Lepton<reco::GsfElectron>&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/225a463d1231a8a4c99dd9e7e0b20bde/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-15-2300/src/DataFormats/PatCandidates/interface/Lepton.h:29:9: warning: implicitly-declared 'constexpr pat::PFIsolation::PFIsolation(const pat::PFIsolation&)' is deprecated [-Wdeprecated-copy]
    29 |   class Lepton : public PATObject<LeptonType> {
      |         ^~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/225a463d1231a8a4c99dd9e7e0b20bde/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-15-2300/src/DataFormats/PatCandidates/interface/Lepton.h:24:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/225a463d1231a8a4c99dd9e7e0b20bde/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-15-2300/src/DataFormats/PatCandidates/interface/PFIsolation.h:20:18: note: because 'pat::PFIsolation' has user-provided 'pat::PFIsolation& pat::PFIsolation::operator=(const pat::PFIsolation&)'
   20 |     PFIsolation& operator=(const PFIsolation& iso) {
      |                  ^~~~~~~~
/da
```
This PR removes the unnnecessary copy-assignment operator and destructor in favor of the auto-generated ones.