### PR TITLE
cleanup classlib string List/Format usage

### DIFF
--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -41,12 +41,10 @@
 #include <vector>
 #include <map>
 #include <tuple>
+#include <filesystem>
 
 #include "TString.h"
 #include "TList.h"
-
-#include "classlib/utils/StringList.h"
-#include "classlib/utils/StringOps.h"
 
 class EDMtoMEConverter : public edm::one::EDProducer<edm::one::WatchRuns,
                                                      edm::one::WatchLuminosityBlocks,
@@ -476,17 +474,12 @@ void EDMtoMEConverter::getData(DQMStore::IBooker &iBooker, DQMStore::IGetter &iG
       if (verbosity > 0)
         std::cout << pathname << std::endl;
 
-      std::string dir;
-
       // deconstruct path from fullpath
-      StringList fulldir = StringOps::split(pathname, "/");
-      std::string name = *(fulldir.end() - 1);
-
-      for (unsigned j = 0; j < fulldir.size() - 1; ++j) {
-        dir += fulldir[j];
-        if (j != fulldir.size() - 2)
-          dir += "/";
-      }
+      std::filesystem::path fulldir(pathname);
+      std::string name = fulldir.filename();
+      std::string dir = fulldir.parent_path();
+      if (dir == "/")
+        dir = "";
 
       // define new monitor element
       adjustScope(iBooker, iGetFrom, reScope);

--- a/DQMServices/Core/BuildFile.xml
+++ b/DQMServices/Core/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="protobuf"/>
 <use name="roothistmatrix"/>
 <use name="tbb"/>
+<use name="fmt"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/DQMServices/Core/interface/DQMNet.h
+++ b/DQMServices/Core/interface/DQMNet.h
@@ -4,7 +4,6 @@
 #include "classlib/iobase/Socket.h"
 #include "classlib/iobase/IOSelector.h"
 #include "classlib/iobase/Pipe.h"
-#include "classlib/utils/Signal.h"
 #include "classlib/utils/Error.h"
 #include "classlib/utils/Time.h"
 #include <pthread.h>

--- a/DQMServices/Core/src/DQMNet.cc
+++ b/DQMServices/Core/src/DQMNet.cc
@@ -1,14 +1,10 @@
 #include "DQMServices/Core/interface/DQMNet.h"
 #include "classlib/iobase/InetServerSocket.h"
 #include "classlib/iobase/LocalServerSocket.h"
-#include "classlib/iobase/Filename.h"
 #include "classlib/sysapi/InetSocket.h"  // for completing InetAddress
-#include "classlib/utils/TimeInfo.h"
-#include "classlib/utils/StringList.h"
-#include "classlib/utils/StringFormat.h"
-#include "classlib/utils/StringOps.h"
 #include "classlib/utils/SystemError.h"
 #include "classlib/utils/Regexp.h"
+#include <fmt/format.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/wait.h>
@@ -832,8 +828,8 @@ bool DQMNet::onPeerConnect(IOSelectEvent *ev) {
   if (auto *inet = dynamic_cast<InetSocket *>(s)) {
     InetAddress peeraddr = inet->peername();
     InetAddress myaddr = inet->sockname();
-    p->peeraddr = StringFormat("%1:%2").arg(peeraddr.hostname()).arg(peeraddr.port()).value();
-    localaddr = StringFormat("%1:%2").arg(myaddr.hostname()).arg(myaddr.port()).value();
+    p->peeraddr = fmt::format("{}:{}", peeraddr.hostname(), peeraddr.port());
+    localaddr = fmt::format("{}:{}", myaddr.hostname(), myaddr.port());
   } else if (auto *local = dynamic_cast<LocalSocket *>(s)) {
     p->peeraddr = local->peername().path();
     localaddr = local->sockname().path();
@@ -1130,7 +1126,7 @@ void DQMNet::run() {
 
           InetAddress peeraddr = ((InetSocket *)s)->peername();
           InetAddress myaddr = ((InetSocket *)s)->sockname();
-          p->peeraddr = StringFormat("%1:%2").arg(peeraddr.hostname()).arg(peeraddr.port()).value();
+          p->peeraddr = fmt::format("{}:{}", peeraddr.hostname(), peeraddr.port());
           p->mask = IORead | IOWrite | IOUrgent;
           p->update = ap->update;
           p->automatic = ap;

--- a/DQMServices/Core/src/DQMService.cc
+++ b/DQMServices/Core/src/DQMService.cc
@@ -4,7 +4,6 @@
 #include "DQMServices/Core/interface/DQMScope.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "classlib/utils/Error.h"
 #include <mutex>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
`classlib` cleanup
- Remove `lat::StringList, lat::StringFormat` usage
- Remove unused include statements