### PR TITLE
[14_0_X SIM] Replace deprecated method

### DIFF
--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -28,7 +28,7 @@ LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* reg
   fPositron = G4Positron::Positron();
   fMaterial = nullptr;
   auto table = G4Material::GetMaterialTable();
-  for (auto& mat : *table) {
+  for (auto const & mat : *table) {
     G4String nam = mat->GetName();
     size_t n = nam.size();
     if (n > 4) {
@@ -72,7 +72,7 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
 
 void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {
   fastStep.KillPrimaryTrack();
-  fastStep.SetPrimaryTrackPathLength(0.0);
+  fastStep.ProposePrimaryTrackPathLength(0.0);
   auto track = fastTrack.GetPrimaryTrack();
   G4double energy = track->GetKineticEnergy() * scaleFactor;
 

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -28,7 +28,7 @@ LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* reg
   fPositron = G4Positron::Positron();
   fMaterial = nullptr;
   auto table = G4Material::GetMaterialTable();
-  for (auto const & mat : *table) {
+  for (auto const& mat : *table) {
     G4String nam = mat->GetName();
     size_t n = nam.size();
     if (n > 4) {


### PR DESCRIPTION
#### PR description:
This PR substitute #43299. It is needed in order to use in future new Geant4 versions. Existing WFs should not be affected.

#### PR validation:
only compilation should be checked.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: will be useful to backport to 13_3_X.

