### PR TITLE
Do not use `size() - 1` in `HLTL1TMatchedJetsVBFFilter` [`13_2_X`]

### DIFF
--- a/HLTrigger/JetMET/plugins/HLTL1TMatchedJetsVBFFilter.h
+++ b/HLTrigger/JetMET/plugins/HLTL1TMatchedJetsVBFFilter.h
@@ -171,7 +171,7 @@ void HLTL1TMatchedJetsVBFFilter<T>::fillJetIndices(std::vector<unsigned int>& ou
   int i2 = -1;
   double m2jj_max = -1;
 
-  for (unsigned int i = 0; i < jetIndices.size() - 1; i++) {
+  for (unsigned int i = 0; i < jetIndices.size(); i++) {
     auto const& jet1 = jets[jetIndices[i]];
 
     for (unsigned int j = i + 1; j < jetIndices.size(); j++) {


### PR DESCRIPTION
backport of #43324

From the description of #43324:

>This PR fixes a bug introduced by me in https://github.com/cms-sw/cmssw/pull/42543, spotted by @mmusich (see https://github.com/cms-sw/cmssw/pull/43300#issuecomment-1817465701). This bug led to failures in a few RelVals [*] after the integration of https://github.com/cms-sw/cmssw/pull/43300 (first HLT menus using the buggy plugin).
>
>The issue is that in
>https://github.com/cms-sw/cmssw/blob/9e9d289e9d02ac5302347670783e608f8d12179e/HLTrigger/JetMET/plugins/HLTL1TMatchedJetsVBFFilter.h#L174
>`jetIndices.size() - 1` is converted to `unsigned int`, so it becomes `(uint) -1` (i.e. `4294967295`), which is unintended.
>
>In this particular case, it is sufficient to remove the `-1` in the loop range: this removes the bug, and does not change the overall behaviour of the plugin. (The extra cost of the additional iteration when `size > 0` is mostly likely minuscule.)
>
>To be backported down to `13_2_X` (where the buggy plugin was introduced).
>
>Merely technical. No changes expected.
>
>[*] RelVals with seg-faults in `CMSSW_14_0_X_2023-11-17-2300` and `CMSSW_13_3_X_2023-11-17-2300`
>```
>141.001,141.008,141.008505,141.008511,141.008521,141.11,141.112
>```
>These RelVals did not fail in `CMSSW_13_2_X_2023-11-17-2300`, because in that cycle the same RelVals use the frozen HLT menu "2023-v1.2" (which has not changed recently, and does not use the buggy plugin).

#### PR validation:

None beyond the check done for #43324.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#43324

Bugfix of a plugin used at HLT.
