### PR TITLE
Fix tracer log viewer issue with callID

### DIFF
--- a/FWCore/Services/scripts/edmTracerCompactLogViewer.py
+++ b/FWCore/Services/scripts/edmTracerCompactLogViewer.py
@@ -661,7 +661,7 @@ class ESModuleTransitionParser(object):
         container = container[index]
         #find slot containing the pre
         for slot in container:
-            if slot[-1]["mod"] == -1*self.moduleID and slot[-1]['callID'] == self.callID:
+            if slot[-1]["mod"] == -1*self.moduleID and slot[-1].get('callID',0) == self.callID:
                 slot[-1]["finish"]=self.time*kMicroToSec
                 del slot[-1]['callID']
                 return


### PR DESCRIPTION
#### PR description:

The callID is a temporary key so need to be able to handle case where it has been removed.

#### PR validation:

This fixed a problem I saw when running the script on a high thread count job using the HDF5 conditions reader.