### PR TITLE
Migrate calotower code to use HCAL thresholds from GT

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -146,7 +146,10 @@ calotowermaker = cms.EDProducer("CaloTowersCreator",
     AllowMissingInputs = cms.bool(False),
 	
 # specify hcal upgrade phase - 0, 1, 2	
-	HcalPhase = cms.int32(0)
+    HcalPhase = cms.int32(0),
+
+# Read HBHE thresholds from Global Tag
+    usePFThresholdsFromDB = cms.bool(False)
     
 )
 
@@ -175,3 +178,8 @@ run3_HB.toModify(calotowermaker,
     HBThreshold2 = 0.2,
     HBThreshold = 0.3,
 )
+
+#--- Use DB conditions for HBHE thresholds for Run3 and phase2
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
+hcalPfCutsFromDB.toModify( calotowermaker,
+                           usePFThresholdsFromDB = True)

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.h
@@ -26,6 +26,10 @@
 #include <tuple>
 
 #include <map>
+
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
+
 class CaloTowerTopology;
 class HcalTopology;
 class CaloGeometry;
@@ -158,6 +162,7 @@ public:
                    const HcalTopology* htopo,
                    const CaloGeometry* geo);
 
+  void setThresFromDB(const HcalPFCuts* cuts);
   // pass the containers of channels status from the event record (stored in DB)
   // these are called in  CaloTowersCreator
   void setHcalChStatusFromDB(const HcalChannelQuality* s) { theHcalChStatus = s; }
@@ -317,6 +322,7 @@ private:
   double theHOEScale;
   double theHF1EScale;
   double theHF2EScale;
+  const HcalPFCuts* hcalCuts;
   const CaloTowerTopology* theTowerTopology;
   const HcalTopology* theHcalTopology;
   const CaloGeometry* theGeometry;

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -6,7 +6,6 @@
 // Now we allow for the creation of towers from
 // rejected hists as well: requested by the MET group
 // for studies of the effect of noise clean up.
-
 #include "CaloTowersCreationAlgo.h"
 #include "EScales.h"
 
@@ -25,12 +24,15 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 
 class CaloTowersCreator : public edm::stream::EDProducer<> {
 public:
   explicit CaloTowersCreator(const edm::ParameterSet& ps);
   ~CaloTowersCreator() override {}
   void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   double EBEScale, EEEScale, HBEScale, HESEScale;
   double HEDEScale, HOEScale, HF1EScale, HF2EScale;
@@ -84,6 +86,10 @@ private:
   edm::ESWatcher<IdealGeometryRecord> caloTowerConstituentsWatcher_;
   edm::ESWatcher<EcalSeverityLevelAlgoRcd> ecalSevLevelWatcher_;
   EScales eScales_;
+
+  edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
+  bool cutsFromDB;
+  HcalPFCuts const* paramPF = nullptr;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -148,6 +154,7 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
             conf.getParameter<double>("MomEBDepth"),
             conf.getParameter<double>("MomEEDepth"),
             conf.getParameter<int>("HcalPhase")),
+      //conf.getParameter<bool>("usePFThresholdsFromDB")),
 
       ecalLabels_(conf.getParameter<std::vector<edm::InputTag> >("ecalInputs")),
       allowMissingInputs_(conf.getParameter<bool>("AllowMissingInputs")),
@@ -165,7 +172,8 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
           conf.getParameter<unsigned int>("HcalAcceptSeverityLevelForRejectedHit")),
 
       useRejectedRecoveredHcalHits_(conf.getParameter<bool>("UseRejectedRecoveredHcalHits")),
-      useRejectedRecoveredEcalHits_(conf.getParameter<bool>("UseRejectedRecoveredEcalHits"))
+      useRejectedRecoveredEcalHits_(conf.getParameter<bool>("UseRejectedRecoveredEcalHits")),
+      cutsFromDB(conf.getParameter<bool>("usePFThresholdsFromDB"))
 
 {
   algo_.setMissingHcalRescaleFactorForEcal(conf.getParameter<double>("missingHcalRescaleFactorForEcal"));
@@ -183,6 +191,9 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
   tok_hcalSevComputer_ = esConsumes<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd>();
   tok_ecalSevAlgo_ = esConsumes<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd>();
 
+  if (cutsFromDB) {
+    hcalCutsToken_ = esConsumes<HcalPFCuts, HcalPFCutsRcd, edm::Transition::BeginRun>(edm::ESInputTag("", "withTopo"));
+  }
   const unsigned nLabels = ecalLabels_.size();
   for (unsigned i = 0; i != nLabels; i++)
     toks_ecal_.push_back(consumes<EcalRecHitCollection>(ecalLabels_[i]));
@@ -215,6 +226,13 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
   std::cout << "VI Producer " << (useRejectedHitsOnly_ ? "use rejectOnly " : " ")
             << (allowMissingInputs_ ? "allowMissing " : " ") << nLabels << ' ' << severitynames.size() << std::endl;
 #endif
+}
+
+void CaloTowersCreator::beginRun(const edm::Run& run, const edm::EventSetup& es) {
+  if (cutsFromDB) {
+    paramPF = &es.getData(hcalCutsToken_);
+  }
+  algo_.setThresFromDB(paramPF);
 }
 
 void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
@@ -452,6 +470,7 @@ void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<unsigned int>("HcalAcceptSeverityLevelForRejectedHit", 9999);
   desc.add<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers", {});
   desc.add<int>("HcalPhase", 0);
+  desc.add<bool>("usePFThresholdsFromDB", true);
 
   descriptions.addDefault(desc);
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -154,7 +154,6 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
             conf.getParameter<double>("MomEBDepth"),
             conf.getParameter<double>("MomEEDepth"),
             conf.getParameter<int>("HcalPhase")),
-      //conf.getParameter<bool>("usePFThresholdsFromDB")),
 
       ecalLabels_(conf.getParameter<std::vector<edm::InputTag> >("ecalInputs")),
       allowMissingInputs_(conf.getParameter<bool>("AllowMissingInputs")),


### PR DESCRIPTION
#### PR description:

While our final aim is to fully deprecate calotowers, there is no clear ETA for that. Several POGs still use calotowers, specially at HLT. So, to ensure that correct HCAL thresholds are used in making calotowers,  the safest way is to use the thresholds from GT.
That is what is done in this PR. Related github issue: https://github.com/cms-sw/cmssw/issues/43312 

This is a technical PR. In principle there should not be any change in physics. But I expect there will be some changes. 

For Phase2 HLT, there might be some changes seen in PR tests, because the thresholds from DB and thresholds written here would not match:
https://github.com/cms-sw/cmssw/blob/40d9d46f15f482f8fa72892ffc76f5bce8d618ce/HLTrigger/Configuration/python/HLT_75e33/modules/caloTowerForTrk_cfi.py#L23-L25
https://github.com/cms-sw/cmssw/blob/40d9d46f15f482f8fa72892ffc76f5bce8d618ce/HLTrigger/Configuration/python/HLT_75e33/modules/towerMaker_cfi.py#L23-L25

In offline reco also, some changes can be seen in barrel for Run3, because the correct thresholds present in DB and thresholds written here does not seem to match:
https://github.com/cms-sw/cmssw/blob/e9b40ab5975f05832f3e6a9fcaffa1cbd3315fbb/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py#L173-L176

#### PR validation:

Checked with `12434.0_TTbar_14TeV+2023`

FYI @missirol  @cms-sw/hlt-l2  @cms-sw/alca-l2 @cms-sw/hcal-dpg-l2 