### PR TITLE
Run3-alca248 Extend one more momentum bin to be studied in the calibration using isolated charged hadrons

### DIFF
--- a/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibMonitor.C
@@ -293,7 +293,7 @@ public:
   void correctEnergy(double &ener, const Long64_t &entry);
 
 private:
-  static const unsigned int npbin = 6, kp50 = 3;
+  static const unsigned int npbin = 7, kp50 = 3;
   CalibCorrFactor *corrFactor_;
   CalibCorr *cFactor_;
   CalibSelectRBX *cSelect_;
@@ -593,7 +593,7 @@ void CalibMonitor::Init(TChain *tree, const char *comFileName, const char *outFi
       ++nbins;
     }
   }
-  int ipbin[npbin] = {10, 20, 30, 40, 60, 100};
+  int ipbin[npbin] = {10, 20, 30, 40, 60, 100, 500};
   for (unsigned int i = 0; i < npbin; ++i)
     ps_.push_back((double)(ipbin[i]));
   int npvtx[6] = {0, 7, 10, 13, 16, 100};

--- a/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
+++ b/Calibration/HcalCalibAlgos/macros/CalibPlotProperties.C
@@ -152,13 +152,13 @@ void unpackDetId(unsigned int, int &, int &, int &, int &, int &);
 #include "CalibCorr.C"
 
 namespace CalibPlots {
-  static const int npbin = 4;
+  static const int npbin = 5;
   static const int netabin = 4;
   static const int ndepth = 7;
   static const int ntitles = 5;
   static const int npbin0 = (npbin + 1);
   int getP(int k) {
-    const int ipbin[npbin0] = {20, 30, 40, 60, 100};
+    const int ipbin[npbin0] = {20, 30, 40, 60, 100, 500};
     return ((k >= 0 && k < npbin0) ? ipbin[k] : 0);
   }
   double getMomentum(int k) { return (double)(getP(k)); }


### PR DESCRIPTION
#### PR description:

Extend one more momentum bin to be studied in the calibration using isolated charged hadrons

#### PR validation:

Use the macros to study depth dependence as a function of energy

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

nothing special