### PR TITLE
DisplacedRegionalStep track DNN

### DIFF
--- a/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/trackSelectionTf_cfi.py
@@ -7,5 +7,9 @@ trackSelectionTfPLess = _tfGraphDefProducer.clone(
     ComponentName = "trackSelectionTfPLess",
     FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFitPixelLessOnly_Run3_12_5_0_pre5.pb"
 )
+trackSelectionTfDisplacedRegional = _tfGraphDefProducer.clone(
+    ComponentName = "trackSelectionTfDisplacedRegional",
+    FileName = "RecoTracker/FinalTrackSelectors/data/TrackTfClassifier/MkFitDisplacedRegionalOnly_Run3_12_5_0_pre5.pb"
+)
 
 

--- a/RecoTracker/IterativeTracking/python/DisplacedRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DisplacedRegionalStep_cff.py
@@ -453,6 +453,7 @@ from RecoTracker.FinalTrackSelectors.trackTfClassifier_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_cfi import *
 from RecoTracker.FinalTrackSelectors.trackSelectionTf_CKF_cfi import *
 trackdnn.toReplaceWith(displacedRegionalStep, trackTfClassifier.clone(
+     mva         = dict(tfDnnLabel  = 'trackSelectionTfDisplacedRegional'),
      src         = 'displacedRegionalStepTracks',
      qualityCuts = qualityCutDictionary.DisplacedRegionalStep.value()
 ))


### PR DESCRIPTION
#### PR description:

This PR changes the track DNN used by the DisplacedRegionalStep to a model trained on tracks from this iteration. Details for this training can be found in the following presentation:
https://indico.cern.ch/event/1345175/#12-displaced-regional-tracking

See accompanying PR in cms-data/RecoTracker-FinalTrackSelectors#13.

#### PR validation:

The tracking-only RECO has been run with these changes in CMSSW_14_0_X_2023-11-12-2300, with fake rates and efficiencies in the above talk.