### PR TITLE
Remove explicit assignment operator from edm::View

### DIFF
--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -46,9 +46,11 @@ namespace edm {
     std::unique_ptr<ViewBase> clone() const;
 
   protected:
-    ViewBase();
-    ViewBase(ViewBase const&);
-    ViewBase& operator=(ViewBase const&);
+    ViewBase() = default;
+    ViewBase(ViewBase const&) = default;
+    ViewBase(ViewBase&&) = default;
+    ViewBase& operator=(ViewBase const&) = default;
+    ViewBase& operator=(ViewBase&&) = default;
     virtual std::unique_ptr<ViewBase> doClone() const = 0;
     void swap(ViewBase&) {}  // Nothing to swap
   };
@@ -101,11 +103,7 @@ namespace edm {
     // infrastructure code.
     View(std::vector<void const*> const& pointers, FillViewHelperVector const& helpers, EDProductGetter const* getter);
 
-    ~View() override;
-
     void swap(View& other);
-
-    View& operator=(View const& rhs);
 
     size_type capacity() const;
 
@@ -190,9 +188,6 @@ namespace edm {
       }
     }
   }
-
-  template <typename T>
-  View<T>::~View() {}
 
   template <typename T>
   inline void View<T>::swap(View& other) {
@@ -292,13 +287,6 @@ namespace edm {
   template <typename T>
   std::unique_ptr<ViewBase> View<T>::doClone() const {
     return std::unique_ptr<ViewBase>{new View(*this)};
-  }
-
-  template <typename T>
-  inline View<T>& View<T>::operator=(View<T> const& rhs) {
-    View<T> temp(rhs);
-    this->swap(temp);
-    return *this;
   }
 
   template <typename T>

--- a/DataFormats/Common/src/View.cc
+++ b/DataFormats/Common/src/View.cc
@@ -18,8 +18,4 @@ namespace edm {
     return p;
   }
 
-  ViewBase::ViewBase() {}
-
-  ViewBase::ViewBase(ViewBase const&) {}
-
 }  // namespace edm

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -206,6 +206,9 @@ void testPtr::constructTest() {
     Ptr<Dummy> copyPtr(dummy2Ptr);
     CPPUNIT_ASSERT(dummy2Ptr.key() == copyPtr.key());
     CPPUNIT_ASSERT(dummy2Ptr.get() == static_cast<const Dummy*>(dummy2Ptr.get()));
+
+    Ptr<Dummy> movePtr(std::move(copyPtr));
+    CPPUNIT_ASSERT(dummy2Ptr.key() == movePtr.key());
   }
 }
 

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -173,6 +173,10 @@ void testRefToBaseProd::constructTest() {
 
     CPPUNIT_ASSERT(dummyPtr2.id() == pid);
     compareTo(dummyPtr2, dummyContainer);
+
+    RefToBaseProd<Dummy> dummyPtr3(std::move(dummyPtr2));
+    CPPUNIT_ASSERT(dummyPtr3.id() == pid);
+    compareTo(dummyPtr3, dummyContainer);
   }
 }
 


### PR DESCRIPTION
#### PR description:

Rely on implicitly declared copy/move constructor/assignment for `edm::View`. Declare all these explicitly (even if defaulted) for the `edm::ViewBase` though, to have them `protected`.

Resolves https://github.com/cms-sw/cmssw/issues/43314
Resolves https://github.com/makortel/framework/issues/726

#### PR validation:

`DataFormats/Common` unit tests pass.