### PR TITLE
update `totemT2NewDigi_reco_cfg.py` to get DAQ mapping from conditions DB

### DIFF
--- a/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
@@ -10,10 +10,9 @@ process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["Totem"]
 
 process.load('Configuration.EventContent.EventContent_cff')
-#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-
-#from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
 
 #dummy = cms.untracked.FileInPath('RecoPPS/Local/data/run364983_ls0001_streamA_StorageManager.dat'),
 
@@ -29,16 +28,13 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 # raw-to-digi conversion
-process.load('CalibPPS.ESProducers.totemT2DAQMapping_cff')
 process.load('EventFilter.CTPPSRawToDigi.totemT2Digis_cfi')
 process.totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
-process.totemDAQMappingESSourceXML.verbosity = 1
 process.totemT2Digis.RawUnpacking.verbosity = 1
 process.totemT2Digis.RawToDigi.verbosity = 3
 process.totemT2Digis.RawToDigi.useOlderT2TestFile = True
 process.totemT2Digis.RawToDigi.printUnknownFrameSummary = True
 process.totemT2Digis.RawToDigi.printErrorSummary = True
-process.totemDAQMappingESSourceXML.multipleChannelsPerPayload = True
 
 # rechits production
 #process.load('Geometry.ForwardCommonData.totemT22021V2XML_cfi')


### PR DESCRIPTION
#### PR description:

Silences [unit tests failures in IB](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_0_X_2023-11-20-2300/unitTestLogs/RecoPPS/Local#/54), necessary after merge of https://github.com/cms-sw/cmssw/pull/42711

#### PR validation:

`scram b runtests` in the affected package now runs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A