### PR TITLE
Fixes needed for UB/ASANXX builds

### DIFF
--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -15,7 +15,7 @@
 </bin>
 
 <bin name="testExpressionEvaluator" file="testExpressionEvaluator.cc,testRunner.cpp">
-  <ifrelease name="_ASAN_">
+  <ifrelease name="ASAN">
     <flags NO_TEST_PREFIX="1"/>
   </ifrelease>
   <use name="Geometry/CommonDetUnit"/>
@@ -32,7 +32,7 @@
 </bin>
 
 <bin file="ExpressionEvaluatorUnitTest.cpp">
-  <ifrelease name="_ASAN_">
+  <ifrelease name="ASAN">
     <flags NO_TEST_PREFIX="1"/>
   </ifrelease>
   <flags CXXFLAGS="-fopenmp"/>

--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -1,4 +1,4 @@
-<ifrelease name="_UBSAN_">
+<ifrelease name="UBSAN">
   <flags REM_CXXFLAGS="-fno-omit-frame-pointer -fsanitize=undefined"/>
 </ifrelease>
 <use name="boost_serialization"/>

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -18,7 +18,7 @@
 <test name="TestFWCoreServicesDriver_zombiekiller"    command="test_zombiekiller.sh"/>
 <test name="TestFWCoreServicesDriver_cpu"             command="test_cpu.sh"/>
 
-<ifrelease name="!_ASAN_">
+<ifrelease name="!ASAN">
   <test name="TestFWCoreServicesDriver_resource"        command="test_resource.sh"/>
 </ifrelease>
 

--- a/FWCore/Services/test/test_resource_succeed_cfg.py
+++ b/FWCore/Services/test/test_resource_succeed_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import os
 
-mem_limit = 1.0 if not '_UBSAN_X' in os.getenv('CMSSW_VERSION', '') else 1.5
+mem_limit = 1.0 if not 'UBSAN' in os.getenv('CMSSW_VERSION', '') else 1.5
 
 process = cms.Process("TEST")
 

--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -3,7 +3,7 @@
   <use name="catch2"/>
 </bin>
 
-<ifrelease name="!_ASAN_">
+<ifrelease name="!ASAN">
   <bin file="test_proxies.cc" name="testAllocMonitorPreload">
     <use name="PerfTools/AllocMonitor"/>
     <use name="PerfTools/AllocMonitorPreload"/>

--- a/Utilities/ReleaseScripts/test/BuildFile.xml
+++ b/Utilities/ReleaseScripts/test/BuildFile.xml
@@ -2,7 +2,7 @@
 <test name="test-clang-tidy" command="test-clang-tidy.sh">
   <use name="llvm"/>
 </test>
-<ifrelease name="!_ASAN_">
+<ifrelease name="!ASAN">
   <test name="TestValgrind" command="test-valgrind.sh">
     <flags PRE_TEST="test-valgrind-memleak"/>
     <use name="valgrind"/>


### PR DESCRIPTION
For ASAN/UBSAN tests, only check for `ASAN` or `UBSAN` in release name. This is needed for special IBs where we have ASAN/UBSAN enable along with some other flavor e.g ASANR630/UBSANR630 for root 6.30 based builds.