### PR TITLE
 Update `hash_name` function for RelMon utilities

### DIFF
--- a/Utilities/RelMon/python/directories2html.py
+++ b/Utilities/RelMon/python/directories2html.py
@@ -23,6 +23,8 @@ from ROOT import TCanvas,gStyle,TH1F,TGaxis,gPad,kRed
 sys.argv=theargv
 
 import os
+import hashlib
+
 if "RELMON_SA" in os.environ:
   from .dirstructure import Comparison,Directory
   from .definitions import *
@@ -32,7 +34,6 @@ else:
   from Utilities.RelMon.definitions import *
   from Utilities.RelMon.utils import unpickler
   
-  import hashlib
 #-------------------------------------------------------------------------------
 
 def encode_obj_url(url):
@@ -933,8 +934,9 @@ def make_summary_table(indir,aggregation_rules,aggregation_rules_twiki, hashing_
 
 #-----------UPDATES------
 def hash_name(file_name, flag):
-    #print "     HashFILE name: "+file_name
     if flag: #if hashing flag is ON then return
+        if (3,0,0) <= sys.version_info:
+            return hashlib.md5(file_name.encode('utf-8')).hexdigest()[:10]
         return hashlib.md5(file_name).hexdigest()[:10] #md5 hashed file name with length 10
     else:
         return file_name #return standart name


### PR DESCRIPTION
#### PR description:

Fixes a compatibility bug between Python 2 and 3 for RelMon HTML report generation. If the parameter `--hash_name` is set when using `ValidationMatrix.py`, the scripts fails because it is required to encode the parameter `file_name` to be hashed as `bytes`. `str` is not longer supported. 

#### PR validation:

Some manual tests:

1. Isolate the updated function (`hash_name`) into another script and use it to hash some strings calling the script using the Python 2.7 and Python 3.11 interpreters.
2. Generate a dummy comparison report with the following .root file: [DQM_V0001_R000000001__RelValBuMixing_14__CMSSW_12_4_0-124X_mcRun3_2022_realistic_v5-v1__DQMIO.root](https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_12_4_x/DQM_V0001_R000000001__RelValBuMixing_14__CMSSW_12_4_0-124X_mcRun3_2022_realistic_v5-v1__DQMIO.root), via:

`ValidationMatrix.py -R DQM_V0001_R000000001__RelValBuMixing_14__CMSSW_12_4_0-124X_mcRun3_2022_realistic_v5-v1__DQMIO.root -T DQM_V0001_R000000001__RelValBuMixing_14__CMSSW_12_4_0-124X_mcRun3_2022_realistic_v5-v1__DQMIO.root -o Test_Report --hash_name --standalone`