### PR TITLE
Added callID to ESModuleCallingContext

### DIFF
--- a/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
+++ b/CondCore/CondHDF5ESSource/plugins/HDF5ProductResolver.cc
@@ -78,8 +78,10 @@ void HDF5ProductResolver::prefetchAsyncImpl(edm::WaitingTaskHolder iTask,
       [this, iov = iRecord.validityInterval(), iParent, &iRecord](auto& iGroup, auto iActivity) {
         queue_->push(iGroup, [this, &iGroup, act = std::move(iActivity), iov, iParent, &iRecord] {
           CMS_SA_ALLOW try {
-            edm::ESModuleCallingContext context(
-                providerDescription(), edm::ESModuleCallingContext::State::kRunning, iParent);
+            edm::ESModuleCallingContext context(providerDescription(),
+                                                reinterpret_cast<std::uintptr_t>(this),
+                                                edm::ESModuleCallingContext::State::kRunning,
+                                                iParent);
             iRecord.activityRegistry()->preESModuleSignal_.emit(iRecord.key(), context);
             struct EndGuard {
               EndGuard(edm::eventsetup::EventSetupRecordImpl const& iRecord,

--- a/FWCore/Framework/interface/CallbackBase.h
+++ b/FWCore/Framework/interface/CallbackBase.h
@@ -70,7 +70,7 @@ namespace edm {
       CallbackBase(T* iProd, std::shared_ptr<TProduceFunc> iProduceFunc, unsigned int iID, const TDecorator& iDec)
           : proxyData_{},
             producer_(iProd),
-            callingContext_(&iProd->description()),
+            callingContext_(&iProd->description(), iID),
             produceFunction_(std::move(iProduceFunc)),
             id_(iID),
             wasCalledForThisRecord_(false),

--- a/FWCore/Framework/src/ESSourceProductResolverBase.cc
+++ b/FWCore/Framework/src/ESSourceProductResolverBase.cc
@@ -38,7 +38,8 @@ void edm::eventsetup::ESSourceProductResolverBase::doPrefetchAndSignals(
     edm::eventsetup::EventSetupRecordImpl const& iRecord,
     edm::eventsetup::DataKey const& iKey,
     edm::ESParentContext const& iParent) {
-  edm::ESModuleCallingContext context(providerDescription(), ESModuleCallingContext::State::kRunning, iParent);
+  edm::ESModuleCallingContext context(
+      providerDescription(), reinterpret_cast<std::uintptr_t>(this), ESModuleCallingContext::State::kRunning, iParent);
   iRecord.activityRegistry()->preESModuleSignal_.emit(iRecord.key(), context);
   struct EndGuard {
     EndGuard(EventSetupRecordImpl const& iRecord, ESModuleCallingContext const& iContext)

--- a/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ESModuleCallingContext.h
@@ -17,6 +17,7 @@ Services as an argument to their callback functions.
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include <iosfwd>
+#include <cstdint>
 
 namespace edm {
 
@@ -34,9 +35,10 @@ namespace edm {
       kInvalid
     };
 
-    ESModuleCallingContext(edm::eventsetup::ComponentDescription const* moduleDescription);
+    ESModuleCallingContext(edm::eventsetup::ComponentDescription const* moduleDescription, std::uintptr_t id);
 
     ESModuleCallingContext(edm::eventsetup::ComponentDescription const* moduleDescription,
+                           std::uintptr_t id,
                            State state,
                            ESParentContext const& parent);
 
@@ -47,6 +49,10 @@ namespace edm {
     edm::eventsetup::ComponentDescription const* componentDescription() const { return componentDescription_; }
     State state() const { return state_; }
     Type type() const { return parent_.type(); }
+    /** Returns a unique id for this module to differentiate possibly concurrent calls to the module.
+	    The value returned may be large so not appropriate for an index lookup.
+	*/
+    std::uintptr_t callID() const { return id_; }
     ESParentContext const& parent() const { return parent_; }
     ModuleCallingContext const* moduleCallingContext() const { return parent_.moduleCallingContext(); }
     ESModuleCallingContext const* esmoduleCallingContext() const { return parent_.esmoduleCallingContext(); }
@@ -62,6 +68,7 @@ namespace edm {
   private:
     edm::eventsetup::ComponentDescription const* componentDescription_;
     ESParentContext parent_;
+    std::uintptr_t id_;
     State state_;
   };
 }  // namespace edm

--- a/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ESModuleCallingContext.cc
@@ -7,13 +7,15 @@
 
 namespace edm {
 
-  ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription)
-      : componentDescription_(componentDescription), parent_(), state_(State::kInvalid) {}
+  ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription,
+                                                 std::uintptr_t id)
+      : componentDescription_(componentDescription), parent_(), id_(id), state_(State::kInvalid) {}
 
   ESModuleCallingContext::ESModuleCallingContext(edm::eventsetup::ComponentDescription const* componentDescription,
+                                                 std::uintptr_t id,
                                                  State state,
                                                  ESParentContext const& parent)
-      : componentDescription_(componentDescription), parent_(parent), state_(state) {}
+      : componentDescription_(componentDescription), parent_(parent), id_(id), state_(state) {}
 
   void ESModuleCallingContext::setContext(State state, ESParentContext const& parent) {
     state_ = state;

--- a/FWCore/Services/plugins/tracer_setupFile.cc
+++ b/FWCore/Services/plugins/tracer_setupFile.cc
@@ -223,7 +223,7 @@ namespace {
                                     phaseID,
                                     iContext.componentDescription()->id_ + 1,
                                     recordIndex,
-                                    reinterpret_cast<std::uintptr_t>(&iContext),
+                                    iContext.callID(),
                                     requestingModuleID,
                                     t);
       logFile_->write(std::move(msg));


### PR DESCRIPTION
#### PR description:

The callID can be used to differentiate concurrent calls to the same module.

#### PR validation:

Code compiles.