### PR TITLE
[mkFit] Apply material effects after error propagation

### DIFF
--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -552,8 +552,7 @@ namespace mkfit {
     MPlexLL temp;
     MultHelixProp(errorProp, outErr, temp);
     MultHelixPropTransp(errorProp, temp, outErr);
-    // MultHelixPropFull(errorProp, outErr, temp);
-    // MultHelixPropTranspFull(errorProp, temp, outErr);
+    // can replace with: MultHelixPropFull(errorProp, outErr, temp); MultHelixPropTranspFull(errorProp, temp, outErr);
 
     if (pflags.apply_material) {
       MPlexQF hitsRl;
@@ -679,13 +678,11 @@ namespace mkfit {
     }
 #endif
 
-     // Matriplex version of:
-     // result.errors = ROOT::Math::Similarity(errorProp, outErr);
-     MPlexLL temp;
-     MultHelixPropEndcap(errorProp, outErr, temp);
-     MultHelixPropTranspEndcap(errorProp, temp, outErr);
-     // MultHelixPropFull(errorProp, outErr, temp);
-     // MultHelixPropTranspFull(errorProp, temp, outErr);
+    // Matriplex version of: result.errors = ROOT::Math::Similarity(errorProp, outErr);
+    MPlexLL temp;
+    MultHelixPropEndcap(errorProp, outErr, temp);
+    MultHelixPropTranspEndcap(errorProp, temp, outErr);
+    // can replace with: MultHelixPropFull(errorProp, outErr, temp); MultHelixPropTranspFull(errorProp, temp, outErr);
 
     if (pflags.apply_material) {
       MPlexQF hitsRl;

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -548,6 +548,13 @@ namespace mkfit {
     }
 #endif
 
+    // MultHelixProp can be optimized for CCS coordinates, see GenMPlexOps.pl
+    MPlexLL temp;
+    MultHelixProp(errorProp, outErr, temp);
+    MultHelixPropTransp(errorProp, temp, outErr);
+    // MultHelixPropFull(errorProp, outErr, temp);
+    // MultHelixPropTranspFull(errorProp, temp, outErr);
+
     if (pflags.apply_material) {
       MPlexQF hitsRl;
       MPlexQF hitsXi;
@@ -580,13 +587,6 @@ namespace mkfit {
     }
 
     squashPhiMPlex(outPar, N_proc);  // ensure phi is between |pi|
-
-    // MultHelixProp can be optimized for CCS coordinates, see GenMPlexOps.pl
-    MPlexLL temp;
-    MultHelixProp(errorProp, outErr, temp);
-    MultHelixPropTransp(errorProp, temp, outErr);
-    // MultHelixPropFull(errorProp, outErr, temp);
-    // MultHelixPropTranspFull(errorProp, temp, outErr);
 
     // Matriplex version of:
     // result.errors = ROOT::Math::Similarity(errorProp, outErr);
@@ -679,6 +679,14 @@ namespace mkfit {
     }
 #endif
 
+     // Matriplex version of:
+     // result.errors = ROOT::Math::Similarity(errorProp, outErr);
+     MPlexLL temp;
+     MultHelixPropEndcap(errorProp, outErr, temp);
+     MultHelixPropTranspEndcap(errorProp, temp, outErr);
+     // MultHelixPropFull(errorProp, outErr, temp);
+     // MultHelixPropTranspFull(errorProp, temp, outErr);
+
     if (pflags.apply_material) {
       MPlexQF hitsRl;
       MPlexQF hitsXi;
@@ -735,14 +743,6 @@ namespace mkfit {
     }
 
     squashPhiMPlex(outPar, N_proc);  // ensure phi is between |pi|
-
-    // Matriplex version of:
-    // result.errors = ROOT::Math::Similarity(errorProp, outErr);
-    MPlexLL temp;
-    MultHelixPropEndcap(errorProp, outErr, temp);
-    MultHelixPropTranspEndcap(errorProp, temp, outErr);
-    // MultHelixPropFull(errorProp, outErr, temp);
-    // MultHelixPropTranspFull(errorProp, temp, outErr);
 
     // PROP-FAIL-ENABLE To keep physics changes minimal, we always restore the
     // state to input when propagation fails -- as was the default before.


### PR DESCRIPTION
#### PR description:

A minor update after PR #43146 to swap the order of the material effects and the propagation to the next layer.
This is implementation is the correct one and will be kept for the next developments.
The effects on the physics performance are small, but beneficial

#### PR validation:

MTV validation before (blue) and after (red) at this [link](http://uaf-10.t2.ucsd.edu/~legianni/plots_testPR43146_andfurther_PR/)

In particular for the ootb plots the perfomances are similar or better

eg. all tracks vs pT

![image](https://github.com/cms-sw/cmssw/assets/7805577/cb72da5e-29e9-4e8f-8500-a6b8501ec23b)


or high purity tracks vs pT

![image](https://github.com/cms-sw/cmssw/assets/7805577/f23c84f7-514e-489c-802d-49e48fd95810)

@slava77 
