### PR TITLE
add `L1TUtmTriggerMenu_PayloadInspector` and related unit tests

### DIFF
--- a/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
+++ b/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
@@ -1,0 +1,213 @@
+#ifndef CondCore_L1TPlugins_L1TUtmTriggerMenuPayloadInspectorHelper_H
+#define CondCore_L1TPlugins_L1TUtmTriggerMenuPayloadInspectorHelper_H
+
+#include "TH1.h"
+#include "TH2.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+#include "TLatex.h"
+#include "TLine.h"
+
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+
+namespace L1TUtmTriggerMenuInspectorHelper {
+
+  using l1tUtmAlgoMap = std::map<std::string, L1TUtmAlgorithm>;
+  using l1tUtmConditionMap = std::map<std::string, L1TUtmCondition>;
+
+  class L1UtmTriggerMenuInfo {
+  public:
+    // constructor
+    L1UtmTriggerMenuInfo(const L1TUtmTriggerMenu* l1utmMenu) { m_map = l1utmMenu->getAlgorithmMap(); }
+
+    // destructor
+    ~L1UtmTriggerMenuInfo() = default;
+
+  public:
+    const std::vector<std::string> listOfAlgos() const {
+      std::vector<std::string> output;
+      std::transform(m_map.begin(),
+                     m_map.end(),
+                     std::back_inserter(output),
+                     [](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
+                       return pair.first;  // Extracting the string key using lambda
+                     });
+      return output;
+    }
+
+    //___________________________________________________________________
+    const std::vector<std::string> listOfCommonAlgos(const L1TUtmTriggerMenu* other) const {
+      const auto& otherMap = other->getAlgorithmMap();
+
+      std::vector<std::string> commonKeys;
+
+      // Lambda function to find common keys and store them in commonKeys vector
+      std::for_each(
+          m_map.begin(), m_map.end(), [&commonKeys, &otherMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
+            const std::string& key = pair.first;
+
+            // Check if the key exists in map2
+            if (otherMap.find(key) != otherMap.end()) {
+              commonKeys.push_back(key);
+            }
+          });
+      return commonKeys;
+    }
+
+    //___________________________________________________________________
+    const std::vector<std::string> onlyInThis(const L1TUtmTriggerMenu* other) const {
+      const auto& otherMap = other->getAlgorithmMap();
+
+      std::vector<std::string> stringsOnlyInFirstMap;
+
+      // Lambda function to extract only the strings present in m_map but not in otherMap
+      std::for_each(m_map.begin(),
+                    m_map.end(),
+                    [&stringsOnlyInFirstMap, &otherMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
+                      const std::string& key = pair.first;
+                      // Check if the key exists in otherMap
+                      if (otherMap.find(key) == otherMap.end()) {
+                        stringsOnlyInFirstMap.push_back(key);  // Add key to the vector
+                      }
+                    });
+
+      return stringsOnlyInFirstMap;
+    }
+
+    //___________________________________________________________________
+    const std::vector<std::string> onlyInOther(const L1TUtmTriggerMenu* other) const {
+      const auto& otherMap = other->getAlgorithmMap();
+
+      std::vector<std::string> stringsOnlyInSecondMap;
+
+      // Lambda function capturing 'this' to access the member variable 'm_map'
+      std::for_each(otherMap.begin(),
+                    otherMap.end(),
+                    [this, &stringsOnlyInSecondMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
+                      const std::string& key = pair.first;
+
+                      // Check if the key exists in m_map
+                      if (this->m_map.find(key) == this->m_map.end()) {
+                        stringsOnlyInSecondMap.push_back(key);  // Add key to the vector
+                      }
+                    });
+
+      return stringsOnlyInSecondMap;
+    }
+
+  private:
+    l1tUtmAlgoMap m_map;
+  };
+
+  class L1TUtmTriggerMenuDisplay {
+  public:
+    L1TUtmTriggerMenuDisplay(const L1TUtmTriggerMenu* thisMenu, std::string theTag, std::string theIOV)
+        : m_info(thisMenu), m_tagName(theTag), m_IOVsinceDisplay(theIOV) {}
+    ~L1TUtmTriggerMenuDisplay() = default;
+
+    void setImageFileName(const std::string& theFileName) {
+      m_imageFileName = theFileName;
+      return;
+    }
+
+    //___________________________________________________________________
+    void plotDiffWithOtherMenu(const L1TUtmTriggerMenu* other, std::string theRefTag, std::string theRefIOV) {
+      const auto& vec_only_in_this = m_info.onlyInThis(other);
+      const auto& vec_only_in_other = m_info.onlyInOther(other);
+
+      // preparations for plotting
+      // starting table at y=1.0 (top of the canvas)
+      // first column is at 0.03, second column at 0.22 NDC
+      unsigned int mapsize = vec_only_in_this.size() + vec_only_in_other.size();
+      float pitch = 1. / (mapsize * 1.1);
+      float y, x1, x2;
+      std::vector<float> y_x1, y_x2, y_line;
+      std::vector<std::string> s_x1, s_x2, s_x3;
+      y = 1.0;
+      x1 = 0.02;
+      x2 = x1 + 0.45;
+      y -= pitch;
+
+      // title for plot
+      y_x1.push_back(y);
+      s_x1.push_back("#scale[1.1]{Key}");
+      y_x2.push_back(y);
+      s_x2.push_back("#scale[1.1]{Target tag / IOV: #color[2]{" + m_tagName + "} / " + m_IOVsinceDisplay + "}");
+
+      y -= pitch;
+      y_x1.push_back(y);
+      s_x1.push_back("");
+      y_x2.push_back(y);
+      s_x2.push_back("#scale[1.1]{Refer  tag / IOV: #color[4]{" + theRefTag + "} / " + theRefIOV + "}");
+
+      y -= pitch / 2.;
+      y_line.push_back(y);
+
+      // First, check if there are records in reference which are not in target
+      for (const auto& ref : vec_only_in_other) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(ref);
+        y_x2.push_back(y);
+        s_x2.push_back("#color[4]{#bf{Only in reference, not in target.}}");
+        y_line.push_back(y - (pitch / 2.));
+      }
+
+      // Second, check if there are records in target which are not in reference
+      for (const auto& tar : vec_only_in_this) {
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back(tar);
+        y_x2.push_back(y);
+        s_x2.push_back("#color[2]{#bf{Only in target, not in reference.}}");
+        y_line.push_back(y - (pitch / 2.));
+      }
+
+      // Finally, print text to TCanvas
+      TCanvas canvas("L1TUtmMenuData", "L1TUtmMenuData", 2000, std::max(y_x1.size(), y_x2.size()) * 40);
+      TLatex l;
+      // Draw the columns titles
+      l.SetTextAlign(12);
+
+      float newpitch = 1 / (std::max(y_x1.size(), y_x2.size()) * 1.1);
+      float factor = newpitch / pitch;
+      l.SetTextSize(newpitch - 0.002);
+      canvas.cd();
+      for (unsigned int i = 0; i < y_x1.size(); i++) {
+        l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]) * factor, s_x1[i].c_str());
+      }
+
+      for (unsigned int i = 0; i < y_x2.size(); i++) {
+        l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]) * factor, s_x2[i].c_str());
+      }
+
+      canvas.cd();
+      canvas.Update();
+
+      // Draw horizontal lines separating records
+      TLine lines[y_line.size()];
+      unsigned int iL = 0;
+      for (const auto& line : y_line) {
+        lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line) * factor, gPad->GetUxmax(), 1 - (1 - line) * factor);
+        lines[iL].SetLineWidth(1);
+        lines[iL].SetLineStyle(9);
+        lines[iL].SetLineColor(2);
+        lines[iL].Draw("same");
+        iL++;
+      }
+
+      std::string fileName("L1UtmMenuData_Compare.png");
+      if (!m_imageFileName.empty())
+        fileName = m_imageFileName;
+      canvas.SaveAs(fileName.c_str());
+    }
+
+  private:
+    L1UtmTriggerMenuInfo m_info;    //!< map of the record / metadata associations
+    std::string m_tagName;          //!< tag name
+    std::string m_IOVsinceDisplay;  //!< iov since
+    std::string m_imageFileName;    //!< image file name
+  };
+}  // namespace L1TUtmTriggerMenuInspectorHelper
+
+#endif

--- a/CondCore/L1TPlugins/plugins/BuildFile.xml
+++ b/CondCore/L1TPlugins/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<library file="L1TUtmTriggerMenu_PayloadInspector.cc" name="L1TUtmTriggerMenu_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="CondFormats/L1TObjects"/>
+</library>

--- a/CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc
+++ b/CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc
@@ -1,0 +1,172 @@
+/*!
+  \file L1UtmTriggerMenu_PayloadInspector
+  \Payload Inspector Plugin for L1UtmTriggerMenu payloads
+  \author M. Musich
+  \version $Revision: 1.0 $
+  \date $Date: 2023/11/15 14:49:00 $
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+
+// the data format of the condition to be inspected
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h"
+
+#include <memory>
+#include <sstream>
+#include <iostream>
+
+// include ROOT
+#include "TH2F.h"
+#include "TLegend.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TGraph.h"
+#include "TStyle.h"
+#include "TLatex.h"
+#include "TPave.h"
+#include "TPaveStats.h"
+
+namespace {
+
+  using namespace cond::payloadInspector;
+
+  class L1TUtmTriggerMenuDisplayAlgos : public PlotImage<L1TUtmTriggerMenu, SINGLE_IOV> {
+  public:
+    L1TUtmTriggerMenuDisplayAlgos() : PlotImage<L1TUtmTriggerMenu, SINGLE_IOV>("L1TUtmTriggerMenu plot") {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      std::string IOVsince = std::to_string(std::get<0>(iov));
+      auto tagname = tag.name;
+      std::shared_ptr<L1TUtmTriggerMenu> payload = fetchPayload(std::get<1>(iov));
+      if (payload.get()) {
+        /// Create a canvas
+        const auto& theMap = payload->getAlgorithmMap();
+
+        unsigned int mapsize = theMap.size();
+        float pitch = 1. / (mapsize);
+
+        float y, x1, x2;
+        std::vector<float> y_x1, y_x2, y_line;
+        std::vector<std::string> s_x1, s_x2, s_x3;
+
+        // starting table at y=1.0 (top of the canvas)
+        // first column is at 0.02, second column at 0.32 NDC
+        y = 1.0;
+        x1 = 0.02;
+        x2 = x1 + 0.15;
+
+        y -= pitch;
+        y_x1.push_back(y);
+        s_x1.push_back("#scale[1.2]{Algo Name}");
+        y_x2.push_back(y);
+        s_x2.push_back("#scale[1.2]{tag: " + tag.name + " in IOV: " + IOVsince + "}");
+
+        y -= pitch / 2.;
+        y_line.push_back(y);
+
+        for (const auto& [name, algo] : theMap) {
+          y -= pitch;
+          y_x1.push_back(y);
+          s_x1.push_back("''");
+
+          y_x2.push_back(y);
+          s_x2.push_back("#color[2]{" + name + "}");
+          y_line.push_back(y - (pitch / 2.));
+        }
+
+        TCanvas canvas("L1TriggerAlgos", "L1TriggerAlgos", 2000, mapsize * 40);
+        TLatex l;
+        // Draw the columns titles
+        l.SetTextAlign(12);
+        l.SetTextSize(pitch * 10);
+        canvas.cd();
+        for (unsigned int i = 0; i < y_x1.size(); i++) {
+          l.DrawLatexNDC(x1, 1 - (1 - y_x1[i]), s_x1[i].c_str());
+        }
+
+        for (unsigned int i = 0; i < y_x2.size(); i++) {
+          l.DrawLatexNDC(x2, 1 - (1 - y_x2[i]), s_x2[i].c_str());
+        }
+
+        canvas.cd();
+        canvas.Update();
+
+        TLine lines[y_line.size()];
+        unsigned int iL = 0;
+        for (const auto& line : y_line) {
+          lines[iL] = TLine(gPad->GetUxmin(), 1 - (1 - line), gPad->GetUxmax(), 1 - (1 - line));
+          lines[iL].SetLineWidth(1);
+          lines[iL].SetLineStyle(9);
+          lines[iL].SetLineColor(2);
+          lines[iL].Draw("same");
+          iL++;
+        }
+
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+      }  // payload
+      return true;
+    }  // fill
+  };
+
+  template <IOVMultiplicity nIOVs, int ntags>
+  class L1TUtmTriggerMenu_CompareAlgosBase : public PlotImage<L1TUtmTriggerMenu, nIOVs, ntags> {
+  public:
+    L1TUtmTriggerMenu_CompareAlgosBase()
+        : PlotImage<L1TUtmTriggerMenu, nIOVs, ntags>("L1TUtmTriggerMenu comparison of contents") {}
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto f_tagname = PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        l_tagname = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<L1TUtmTriggerMenu> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<L1TUtmTriggerMenu> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      // In case of only one tag, use f_tagname for both target and reference
+      std::string tmpTagName = l_tagname;
+      if (tmpTagName.empty())
+        tmpTagName = f_tagname;
+
+      L1TUtmTriggerMenuInspectorHelper::L1TUtmTriggerMenuDisplay thePlot(last_payload.get(), tmpTagName, lastIOVsince);
+      thePlot.setImageFileName(this->m_imageFileName);
+      thePlot.plotDiffWithOtherMenu(first_payload.get(), f_tagname, firstIOVsince);
+
+      return true;
+    }
+  };
+
+  using L1TUtmTriggerMenu_CompareAlgos = L1TUtmTriggerMenu_CompareAlgosBase<MULTI_IOV, 1>;
+  using L1TUtmTriggerMenu_CompareAlgosTwoTags = L1TUtmTriggerMenu_CompareAlgosBase<SINGLE_IOV, 2>;
+
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(L1TUtmTriggerMenu) {
+  PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenuDisplayAlgos);
+  PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareAlgos);
+  PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareAlgosTwoTags);
+}

--- a/CondCore/L1TPlugins/test/BuildFile.xml
+++ b/CondCore/L1TPlugins/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="CondCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<bin file="testL1TObjectsPayloadInspector.cpp" name="testL1TObjectsPayloadInspector">
+</bin>

--- a/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
+++ b/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  // L1TUtmTriggerMenu
+  std::string tag = "L1Menu_CollisionsHeavyIons2023_v1_1_5_xml";
+  cond::Time_t start = static_cast<unsigned long long>(1);
+  cond::Time_t end = static_cast<unsigned long long>(1);
+
+  edm::LogPrint("testL1TObjectsPayloadInspector") << "## Exercising L1UtmTriggerMenu tests" << std::endl;
+
+  L1TUtmTriggerMenuDisplayAlgos test1;
+  test1.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test1.data() << std::endl;
+
+  tag = "L1TUtmTriggerMenu_Stage2v0_hlt";
+  start = static_cast<unsigned long long>(375649);
+  end = static_cast<unsigned long long>(375650);
+
+  L1TUtmTriggerMenu_CompareAlgos test2;
+  test2.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test2.data() << std::endl;
+
+  tag = "L1Menu_CollisionsHeavyIons2023_v1_1_4_xml";
+  std::string tag2 = "L1Menu_CollisionsHeavyIons2023_v1_1_5_xml";
+  start = static_cast<unsigned long long>(1);
+  end = static_cast<unsigned long long>(1);
+
+  L1TUtmTriggerMenu_CompareAlgosTwoTags test3;
+  test3.process(connectionString, PI::mk_input(tag, start, end, tag2, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test3.data() << std::endl;
+
+  tag = "L1TGlobalPrescalesVetos_passThrough_mc";
+  edm::LogPrint("testL1TObjectsPayloadInspector") << "## Exercising  L1TGlobalPrescalesVetos tests" << std::endl;
+
+  Py_Finalize();
+}

--- a/CondCore/L1TPlugins/test/testL1TPI.sh
+++ b/CondCore/L1TPlugins/test/testL1TPI.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+mkdir -p $W_DIR/results
+
+if [ -f *.png ]; then
+    rm *.png
+fi
+
+# Run get payload data script
+
+####################
+# Test L1UtmTriggerMenu
+####################
+getPayloadData.py \
+    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
+    --plot plot_L1TUtmTriggerMenuDisplayAlgos \
+    --tag L1Menu_CollisionsHeavyIons2023_v1_1_5_xml \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TUtmTriggerMenuPlot.png
+
+####################
+# Test L1UtmTriggerMenu comparison (two IOVs, same tag)
+####################
+getPayloadData.py \
+    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
+    --plot plot_L1TUtmTriggerMenu_CompareAlgos \
+    --tag L1TUtmTriggerMenu_Stage2v0_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "375649", "end_iov": "375650"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_Compare.png
+
+####################
+# Test L1UtmTriggerMenu comparison (two tags)
+####################
+getPayloadData.py \
+    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
+    --plot plot_L1TUtmTriggerMenu_CompareAlgosTwoTags \
+    --tag L1Menu_CollisionsHeavyIons2023_v1_1_4_xml \
+    --tagtwo L1Menu_CollisionsHeavyIons2023_v1_1_5_xml \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareTwoTags.png


### PR DESCRIPTION
#### PR description:

Title says it all, add a payload inspector for the `L1TUtmTriggerMenu` conditions format used to store the L1 menu for Run-3 data-taking. It supports both display of the supported algos and plots of the differences in algo both between two tags and between 2 IOVs of the same tag.

#### PR validation:

The unit tests introduced in this PR `scram b runtests_testL1TObjectsPayloadInspector` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A