### PR TITLE
[13_2_X SIM] Allowed MT mode for RHStopTracer of R-hadron simulation

### DIFF
--- a/SimG4Core/CustomPhysics/interface/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/interface/RHStopTracer.h
@@ -22,7 +22,7 @@ class RHStopTracer : public SimProducer,
                      public Observer<const EndOfTrack *> {
 public:
   RHStopTracer(edm::ParameterSet const &p);
-  ~RHStopTracer() override;
+  ~RHStopTracer() override = default;
   void update(const BeginOfRun *) override;
   void update(const BeginOfEvent *) override;
   void update(const BeginOfTrack *) override;

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -36,12 +36,11 @@ RHStopTracer::RHStopTracer(edm::ParameterSet const& p) {
 
   mTraceEnergy *= CLHEP::GeV;
   rePartName = mTraceParticleName;
+  setMT(true);
 
-  edm::LogInfo("SimG4CoreCustomPhysics") << "RHStopTracer::RHStopTracer " << mTraceParticleName
-                                         << " Eth(GeV)= " << mTraceEnergy;
+  edm::LogVerbatim("SimG4CoreCustomPhysics")
+      << "RHStopTracer::RHStopTracer " << mTraceParticleName << " Eth(GeV)= " << mTraceEnergy;
 }
-
-RHStopTracer::~RHStopTracer() {}
 
 void RHStopTracer::update(const BeginOfRun* fRun) {
   LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> begin of the run " << (*fRun)()->GetRunID();


### PR DESCRIPTION
#### PR description:

See https://github.com/cms-sw/cmssw/pull/43273

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/43273