### PR TITLE
DAQ - add per-tbb-thread microstate (14_0_X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitor.h
+++ b/EventFilter/Utilities/interface/FastMonitor.h
@@ -77,13 +77,12 @@ namespace jsoncollector {
     std::string getCSVString(int sid = -1);
 
     //fastpath file output
-    void outputCSV(std::string const& path, std::string const& csvString);
+    void outputCSV(std::string const& path, std::vector<std::string> const& csvString);
 
     //provide merged variable back to user
     JsonMonitorable* getMergedIntJForLumi(std::string const& name, unsigned int forLumi);
 
     // merges and outputs everything collected for the given stream to JSON file
-    bool outputFullJSONs(std::string const& pathstem, std::string const& ext, unsigned int lumi, bool output = true);
     bool outputFullJSON(std::string const& path, unsigned int lumi, bool output = true);
 
     //discard what was collected for a lumisection

--- a/EventFilter/Utilities/interface/SourceCommon.h
+++ b/EventFilter/Utilities/interface/SourceCommon.h
@@ -1,0 +1,25 @@
+#ifndef EventFilter_Utilities_SourceCommon_h
+#define EventFilter_Utilities_SourceCommon_h
+
+/*
+ * This header will host common definitions used by FedRawDataInputSource and DAQSource
+ * */
+
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+
+class IdleSourceSentry {
+public:
+  IdleSourceSentry(evf::FastMonitoringService* fms) : fms_(fms) {
+    if (fms_)
+      fms_->setTMicrostate(evf::FastMonState::mIdleSource);
+  }
+  ~IdleSourceSentry() {
+    if (fms_)
+      fms_->setTMicrostate(evf::FastMonState::mIdle);
+  }
+
+private:
+  evf::FastMonitoringService* fms_;
+};
+
+#endif

--- a/EventFilter/Utilities/plugins/microstatedef.jsd
+++ b/EventFilter/Utilities/plugins/microstatedef.jsd
@@ -5,7 +5,7 @@
          "operation" : "histo"
       },
       {
-         "name" : "Ministate",
+         "name" : "tMicrostate",
          "operation" : "histo"
       },
       {

--- a/EventFilter/Utilities/plugins/microstatedeffast.jsd
+++ b/EventFilter/Utilities/plugins/microstatedeffast.jsd
@@ -5,7 +5,7 @@
          "operation" : "histo"
       },
       {
-         "name" : "Ministate",
+         "name" : "tMicrostate",
          "operation" : "histo"
       },
       {

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -29,6 +29,21 @@
 
 using namespace evf::FastMonState;
 
+class IdleSourceSentry {
+public:
+  IdleSourceSentry(evf::FastMonitoringService* fms) : fms_(fms) {
+    if (fms_)
+      fms_->setTMicrostate(mIdleSource);
+  }
+  ~IdleSourceSentry() {
+    if (fms_)
+      fms_->setTMicrostate(mIdle);
+  }
+
+private:
+  evf::FastMonitoringService* fms_;
+};
+
 DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),
       dataModeConfig_(pset.getUntrackedParameter<std::string>("dataMode")),
@@ -373,11 +388,14 @@ evf::EvFDaqDirector::FileStatus DAQSource::getNextDataBlock() {
   if (!currentFile_.get()) {
     evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
     setMonState(inWaitInput);
-    if (!fileQueue_.try_pop(currentFile_)) {
-      //sleep until wakeup (only in single-buffer mode) or timeout
-      std::unique_lock<std::mutex> lkw(mWakeup_);
-      if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout || !currentFile_.get())
-        return evf::EvFDaqDirector::noFile;
+    {
+      IdleSourceSentry ids(fms_);
+      if (!fileQueue_.try_pop(currentFile_)) {
+        //sleep until wakeup (only in single-buffer mode) or timeout
+        std::unique_lock<std::mutex> lkw(mWakeup_);
+        if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout || !currentFile_.get())
+          return evf::EvFDaqDirector::noFile;
+      }
     }
     status = currentFile_->status_;
     if (status == evf::EvFDaqDirector::runEnded) {
@@ -468,10 +486,13 @@ evf::EvFDaqDirector::FileStatus DAQSource::getNextDataBlock() {
   //multibuffer mode
   //wait for the current chunk to become added to the vector
   setMonState(inWaitChunk);
-  while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
-    usleep(10000);
-    if (setExceptionState_)
-      threadError();
+  {
+    IdleSourceSentry ids(fms_);
+    while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
+      usleep(10000);
+      if (setExceptionState_)
+        threadError();
+    }
   }
   setMonState(inChunkReceived);
 
@@ -508,13 +529,14 @@ evf::EvFDaqDirector::FileStatus DAQSource::getNextDataBlock() {
     currentFile_->rewindChunk(dataMode_->headerSize());
 
     setMonState(inWaitChunk);
-
-    //do the copy to the beginning of the starting chunk. move pointers for next event in the next chunk
-    chunkEnd = currentFile_->advance(dataPosition, dataMode_->headerSize() + msgSize);
-    assert(chunkEnd);
-    //mark to release old chunk
-    chunkIsFree_ = true;
-
+    {
+      IdleSourceSentry ids(fms_);
+      //do the copy to the beginning of the starting chunk. move pointers for next event in the next chunk
+      chunkEnd = currentFile_->advance(dataPosition, dataMode_->headerSize() + msgSize);
+      assert(chunkEnd);
+      //mark to release old chunk
+      chunkIsFree_ = true;
+    }
     setMonState(inChunkReceived);
     //header and payload is moved, update view
     dataMode_->makeDataBlockView(

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 
-#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/SourceCommon.h"
 #include "EventFilter/Utilities/interface/DataPointDefinition.h"
 #include "EventFilter/Utilities/interface/FFFNamingSchema.h"
 #include "EventFilter/Utilities/interface/crc32c.h"
@@ -28,21 +28,6 @@
 #include "EventFilter/Utilities/interface/reader.h"
 
 using namespace evf::FastMonState;
-
-class IdleSourceSentry {
-public:
-  IdleSourceSentry(evf::FastMonitoringService* fms) : fms_(fms) {
-    if (fms_)
-      fms_->setTMicrostate(mIdleSource);
-  }
-  ~IdleSourceSentry() {
-    if (fms_)
-      fms_->setTMicrostate(mIdle);
-  }
-
-private:
-  evf::FastMonitoringService* fms_;
-};
 
 DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),

--- a/EventFilter/Utilities/src/FastMonitor.cc
+++ b/EventFilter/Utilities/src/FastMonitor.cc
@@ -225,11 +225,12 @@ std::string FastMonitor::getCSVString(int sid) {
   return ss.str();
 }
 
-void FastMonitor::outputCSV(std::string const& path, std::string const& csvString) {
+void FastMonitor::outputCSV(std::string const& path, std::vector<std::string> const& csvs) {
   std::ofstream outputFile;
   outputFile.open(path.c_str(), std::fstream::out | std::fstream::trunc);
   outputFile << defPathFast_ << std::endl;
-  outputFile << csvString << std::endl;
+  for (const auto& csvString : csvs)
+    outputFile << csvString << std::endl;
   outputFile.close();
 }
 
@@ -238,31 +239,6 @@ JsonMonitorable* FastMonitor::getMergedIntJForLumi(std::string const& name, unsi
   auto it = dpNameMap_.find(name);
   assert(it != dpNameMap_.end());
   return dataPoints_[it->second]->mergeAndRetrieveValue(forLumi);
-}
-
-bool FastMonitor::outputFullJSONs(std::string const& pathstem, std::string const& ext, unsigned int lumi, bool output) {
-  LogDebug("FastMonitor") << "SNAP updates -: " << recentSnaps_ << " (by timer: " << recentSnapsTimer_
-                          << ") in lumisection ";
-
-  recentSnaps_ = recentSnapsTimer_ = 0;
-  for (unsigned int i = 0; i < nStreams_; i++) {
-    //merge even if no output
-    Json::Value serializeRoot;
-    for (unsigned int j = 0; j < jsonDpIndex_.size(); j++) {
-      dataPoints_[jsonDpIndex_[j]]->mergeAndSerialize(serializeRoot, lumi, true, i);
-    }
-    if (!output)
-      continue;
-    //get extension
-    std::stringstream tidext;
-    tidext << "_tid" << i;
-    std::string path = pathstem + tidext.str() + ext;
-
-    Json::StyledWriter writer;
-    std::string&& result = writer.write(serializeRoot);
-    FileIO::writeStringToFile(path, result);
-  }
-  return output;
 }
 
 bool FastMonitor::outputFullJSON(std::string const& path, unsigned int lumi, bool output) {

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -48,6 +48,21 @@
 
 using namespace evf::FastMonState;
 
+class IdleSourceSentry {
+public:
+  IdleSourceSentry(evf::FastMonitoringService* fms) : fms_(fms) {
+    if (fms_)
+      fms_->setTMicrostate(mIdleSource);
+  }
+  ~IdleSourceSentry() {
+    if (fms_)
+      fms_->setTMicrostate(mIdle);
+  }
+
+private:
+  evf::FastMonitoringService* fms_;
+};
+
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),
       defPath_(pset.getUntrackedParameter<std::string>("buDefPath", "")),
@@ -362,11 +377,14 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
   if (!currentFile_.get()) {
     evf::EvFDaqDirector::FileStatus status = evf::EvFDaqDirector::noFile;
     setMonState(inWaitInput);
-    if (!fileQueue_.try_pop(currentFile_)) {
-      //sleep until wakeup (only in single-buffer mode) or timeout
-      std::unique_lock<std::mutex> lkw(mWakeup_);
-      if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout || !currentFile_.get())
-        return evf::EvFDaqDirector::noFile;
+    {
+      IdleSourceSentry ids(fms_);
+      if (!fileQueue_.try_pop(currentFile_)) {
+        //sleep until wakeup (only in single-buffer mode) or timeout
+        std::unique_lock<std::mutex> lkw(mWakeup_);
+        if (cvWakeup_.wait_for(lkw, std::chrono::milliseconds(100)) == std::cv_status::timeout || !currentFile_.get())
+          return evf::EvFDaqDirector::noFile;
+      }
     }
     status = currentFile_->status_;
     if (status == evf::EvFDaqDirector::runEnded) {
@@ -469,10 +487,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
   if (singleBufferMode_) {
     //should already be there
     setMonState(inWaitChunk);
-    while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
-      usleep(10000);
-      if (currentFile_->parent_->exceptionState() || setExceptionState_)
-        currentFile_->parent_->threadError();
+    {
+      IdleSourceSentry ids(fms_);
+      while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
+        usleep(10000);
+        if (currentFile_->parent_->exceptionState() || setExceptionState_)
+          currentFile_->parent_->threadError();
+      }
     }
     setMonState(inChunkReceived);
 
@@ -528,10 +549,13 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
   else {
     //wait for the current chunk to become added to the vector
     setMonState(inWaitChunk);
-    while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
-      usleep(10000);
-      if (setExceptionState_)
-        threadError();
+    {
+      IdleSourceSentry ids(fms_);
+      while (!currentFile_->waitForChunk(currentFile_->currentChunk_)) {
+        usleep(10000);
+        if (setExceptionState_)
+          threadError();
+      }
     }
     setMonState(inChunkReceived);
 
@@ -575,9 +599,10 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
         //copy event to a chunk start and move pointers
 
         setMonState(inWaitChunk);
-
-        chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_] + msgSize);
-
+        {
+          IdleSourceSentry ids(fms_);
+          chunkEnd = currentFile_->advance(dataPosition, FRDHeaderVersionSize[detectedFRDversion_] + msgSize);
+        }
         setMonState(inChunkReceived);
 
         assert(chunkEnd);

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -32,7 +32,7 @@
 
 #include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
 
-#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/SourceCommon.h"
 #include "EventFilter/Utilities/interface/DataPointDefinition.h"
 #include "EventFilter/Utilities/interface/FFFNamingSchema.h"
 
@@ -47,21 +47,6 @@
 #include "EventFilter/Utilities/interface/reader.h"
 
 using namespace evf::FastMonState;
-
-class IdleSourceSentry {
-public:
-  IdleSourceSentry(evf::FastMonitoringService* fms) : fms_(fms) {
-    if (fms_)
-      fms_->setTMicrostate(mIdleSource);
-  }
-  ~IdleSourceSentry() {
-    if (fms_)
-      fms_->setTMicrostate(mIdle);
-  }
-
-private:
-  evf::FastMonitoringService* fms_;
-};
 
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm::InputSourceDescription const& desc)
     : edm::RawInputSource(pset, desc),

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -30,7 +30,7 @@ options.register ('fffBaseDir',
                   "FFF base directory")
 
 options.register ('numThreads',
-                  2, # default value
+                  3, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW threads")

--- a/EventFilter/Utilities/test/start_multiLS_FU.py
+++ b/EventFilter/Utilities/test/start_multiLS_FU.py
@@ -30,7 +30,7 @@ options.register ('fffBaseDir',
                   "FFF base directory")
 
 options.register ('numThreads',
-                  2, # default value
+                  3, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW threads")

--- a/EventFilter/Utilities/test/unittest_FU.py
+++ b/EventFilter/Utilities/test/unittest_FU.py
@@ -30,7 +30,7 @@ options.register ('fffBaseDir',
                   "FFF base directory")
 
 options.register ('numThreads',
-                  2, # default value
+                  3, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW threads")

--- a/EventFilter/Utilities/test/unittest_FU_daqsource.py
+++ b/EventFilter/Utilities/test/unittest_FU_daqsource.py
@@ -36,7 +36,7 @@ options.register ('fffBaseDir',
                   "FFF base directory")
 
 options.register ('numThreads',
-                  2, # default value
+                  3, # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,          # string, int, or float
                   "Number of CMSSW threads")


### PR DESCRIPTION
#### PR description:
Per-tbb-thread microstate sampling, more accurate with module-level multithreading (unscheduled execution).
Also changes acquire sampling.
Unused functionality (ministates, slow json file etc.) removed.

Includes also TBB concurrency tracking which is based on flagging which thread is running and which isn't scheduled. In that case Idle state is reflagged as Fwk (except if input source is waiting for input). This will cover time spend outside modules by threads from the pool.

#### PR validation:

Unit tests pass.
Tested in DAQ3VAL system.
Microstate screenshot:
<img width="797" alt="image_thread_us" src="https://github.com/cms-sw/cmssw/assets/5859622/f0a00bf2-81c8-4b11-94bb-5b1f57e3c396">
