### PR TITLE
Fix usage of deprecated methods returning TIterator (replace with range loops or begin/end)

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -329,9 +329,7 @@ string TagProbeFitter::calculateEfficiency(string dirName,
   } else {
     // disactive not needed branches
     inputTree->SetBranchStatus("*", false);
-    TIterator* iter = dataVars.createIterator();
-    TObject* obj(nullptr);
-    while ((obj = iter->Next()))
+    for (TObject* obj: dataVars)
       inputTree->SetBranchStatus(obj->GetName(), true);
   }
 
@@ -480,8 +478,8 @@ string TagProbeFitter::calculateEfficiency(string dirName,
     if (data_bin->numEntries() > 0) {
       //set the values of binnedVariables to the mean value in this data bin
       RooArgSet meanOfVariables;
-      RooLinkedListIter vit = binnedVariables.iterator();
-      for (RooRealVar* v = (RooRealVar*)vit.Next(); v != nullptr; v = (RooRealVar*)vit.Next()) {
+      for (const RooAbsArg* vv: binnedVariables) {
+        const RooRealVar* v = dynamic_cast<const RooRealVar*>(vv);
         meanOfVariables.addClone(*v);
         double mean = w->data("data")->mean(*v);
         RooBinning binning((RooBinning&)v->getBinning());
@@ -788,8 +786,7 @@ void TagProbeFitter::saveFitPlot(RooWorkspace* w) {
   RooAbsPdf& pdf = *w->pdf("simPdf");
   std::unique_ptr<RooArgSet> obs(pdf.getObservables(*dataAll));
   RooRealVar* mass = nullptr;
-  RooLinkedListIter it = obs->iterator();
-  for (RooAbsArg* v = (RooAbsArg*)it.Next(); v != nullptr; v = (RooAbsArg*)it.Next()) {
+  for (RooAbsArg* v: *obs) {
     if (!v->InheritsFrom("RooRealVar"))
       continue;
     mass = (RooRealVar*)v;
@@ -867,8 +864,7 @@ void TagProbeFitter::saveDistributionsPlot(RooWorkspace* w) {
 
   const RooArgSet* vars = dataAll->get();
   vector<RooRealVar*> reals;
-  RooLinkedListIter it = vars->iterator();
-  for (RooAbsArg* v = (RooAbsArg*)it.Next(); v != nullptr; v = (RooAbsArg*)it.Next()) {
+  for (RooAbsArg* v: *vars) {
     if (!v->InheritsFrom("RooRealVar"))
       continue;
     reals.push_back((RooRealVar*)v);
@@ -909,15 +905,15 @@ void TagProbeFitter::saveEfficiencyPlots(RooDataSet& eff,
                                          const TString& effName,
                                          RooArgSet& binnedVariables,
                                          RooArgSet& mappedCategories) {
-  RooLinkedListIter v1it = binnedVariables.iterator();
   bool isOnePoint =
       (eff.numEntries() == 1);  // for datasets with > 1 entry, we don't make plots for variables with just one bin
-  for (RooRealVar* v1 = (RooRealVar*)v1it.Next(); v1 != nullptr; v1 = (RooRealVar*)v1it.Next()) {
+  for (auto it1 = binnedVariables.begin(); it1 != binnedVariables.end(); it1++) {
+    RooRealVar* v1 = dynamic_cast<RooRealVar*>(*it1);
     RooArgSet binCategories1D;
     if (v1->numBins() == 1 && !isOnePoint)
       continue;
-    RooLinkedListIter v2it = binnedVariables.iterator();
-    for (RooRealVar* v2 = (RooRealVar*)v2it.Next(); v2 != nullptr; v2 = (RooRealVar*)v2it.Next()) {
+    for (auto it2 = binnedVariables.begin(); it2 != binnedVariables.end(); it2++) {
+      RooRealVar* v2 = dynamic_cast<RooRealVar*>(*it2);
       if (v2 == v1)
         continue;
       if (v2->numBins() == 1 && !isOnePoint)
@@ -926,8 +922,8 @@ void TagProbeFitter::saveEfficiencyPlots(RooDataSet& eff,
           RooBinningCategory(TString(v2->GetName()) + "_bins", TString(v2->GetName()) + "_bins", *v2));
 
       RooArgSet binCategories2D;
-      RooLinkedListIter v3it = binnedVariables.iterator();
-      for (RooRealVar* v3 = (RooRealVar*)v3it.Next(); v3 != nullptr; v3 = (RooRealVar*)v3it.Next()) {
+      for (auto it3 = binnedVariables.begin(); it3 != binnedVariables.end(); it3++) {
+        RooRealVar* v3 = dynamic_cast<RooRealVar*>(*it3);
         if (v3 == v1 || v3 == v2)
           continue;
         binCategories2D.addClone(

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -329,7 +329,7 @@ string TagProbeFitter::calculateEfficiency(string dirName,
   } else {
     // disactive not needed branches
     inputTree->SetBranchStatus("*", false);
-    for (TObject* obj: dataVars)
+    for (TObject* obj : dataVars)
       inputTree->SetBranchStatus(obj->GetName(), true);
   }
 
@@ -478,7 +478,7 @@ string TagProbeFitter::calculateEfficiency(string dirName,
     if (data_bin->numEntries() > 0) {
       //set the values of binnedVariables to the mean value in this data bin
       RooArgSet meanOfVariables;
-      for (const RooAbsArg* vv: binnedVariables) {
+      for (const RooAbsArg* vv : binnedVariables) {
         const RooRealVar* v = dynamic_cast<const RooRealVar*>(vv);
         meanOfVariables.addClone(*v);
         double mean = w->data("data")->mean(*v);
@@ -786,7 +786,7 @@ void TagProbeFitter::saveFitPlot(RooWorkspace* w) {
   RooAbsPdf& pdf = *w->pdf("simPdf");
   std::unique_ptr<RooArgSet> obs(pdf.getObservables(*dataAll));
   RooRealVar* mass = nullptr;
-  for (RooAbsArg* v: *obs) {
+  for (RooAbsArg* v : *obs) {
     if (!v->InheritsFrom("RooRealVar"))
       continue;
     mass = (RooRealVar*)v;
@@ -864,7 +864,7 @@ void TagProbeFitter::saveDistributionsPlot(RooWorkspace* w) {
 
   const RooArgSet* vars = dataAll->get();
   vector<RooRealVar*> reals;
-  for (RooAbsArg* v: *vars) {
+  for (RooAbsArg* v : *vars) {
     if (!v->InheritsFrom("RooRealVar"))
       continue;
     reals.push_back((RooRealVar*)v);

--- a/PhysicsTools/Utilities/src/SideBandSubtraction.cc
+++ b/PhysicsTools/Utilities/src/SideBandSubtraction.cc
@@ -98,15 +98,14 @@ int SideBandSubtract::doSubtraction(RooRealVar* variable,
   //out how to do this in one shot to avoid a loop
   //O(N_vars*N_events)...
 
-  TIterator* iter = (TIterator*)Data->get()->createIterator();
-  RooAbsArg* var = nullptr;
   RooRealVar* sep_var = nullptr;
-  while ((var = (RooAbsArg*)iter->Next())) {
+  for (const auto& var : *Data->get()) {
     if ((string)var->GetName() == (string)SeparationVariable->GetName()) {
       sep_var = (RooRealVar*)var;
       break;
     }
   }
+
   for (int i = 0; i < Data->numEntries(); i++) {
     Data->get(i);
     Double_t value = variable->getVal();
@@ -431,9 +430,7 @@ int SideBandSubtract::doGlobalFit() {
 
   //need to grab sbs objects after each global fit, because they get reset
   resetSBSProducts();
-  TIterator* iter = (TIterator*)Data->get()->createIterator();
-  RooAbsArg* variable;
-  while ((variable = (RooAbsArg*)iter->Next())) {
+  for (const auto& variable: *Data->get()) {
     for (unsigned int i = 0; i < BaseHistos.size(); i++) {
       if ((string)variable->GetName() != (string)SeparationVariable->GetName() &&
           (string)variable->GetName() == (string)BaseHistos[i]->GetName())
@@ -441,11 +438,6 @@ int SideBandSubtract::doGlobalFit() {
     }
   }
 
-  //  clean up our memory...
-  if (variable)
-    delete variable;
-  if (iter)
-    delete iter;
   return 0;
 }
 void SideBandSubtract::doFastSubtraction(TH1F& Total, TH1F& Result, SbsRegion& leftRegion, SbsRegion& rightRegion) {

--- a/PhysicsTools/Utilities/src/SideBandSubtraction.cc
+++ b/PhysicsTools/Utilities/src/SideBandSubtraction.cc
@@ -430,7 +430,7 @@ int SideBandSubtract::doGlobalFit() {
 
   //need to grab sbs objects after each global fit, because they get reset
   resetSBSProducts();
-  for (const auto& variable: *Data->get()) {
+  for (const auto& variable : *Data->get()) {
     for (unsigned int i = 0; i < BaseHistos.size(); i++) {
       if ((string)variable->GetName() != (string)SeparationVariable->GetName() &&
           (string)variable->GetName() == (string)BaseHistos[i]->GetName())


### PR DESCRIPTION
#### PR description:

This PR fixes warnings observed in ROOT6_X IBs:[1](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_ROOT6_X_2023-11-22-2300/PhysicsTools/TagAndProbe), [2](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_ROOT6_X_2023-11-22-2300/PhysicsTools/Utilities):

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc: In member function 'std::string TagProbeFitter::calculateEfficiency(std::string, const std::vector<std::__cxx11::basic_string<char> >&, const std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::map<std::__cxx11::basic_string<char>, std::vector<double> >&, std::map<std::__cxx11::basic_string<char>, std::vector<std::__cxx11::basic_string<char> > >&, std::vector<std::__cxx11::basic_string<char> >&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:332:46: warning: 'TIterator* RooAbsCollection::createIterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   332 |     TIterator* iter = dataVars.createIterator();
      |                       ~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooArgSet.h:19,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooWorkspace.h:20,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/interface/TagProbeFitter.h:7,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:1:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:227:21: note: declared here
  227 |   inline TIterator* createIterator(bool dir = kIterForward) const
      |                     ^~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:483:55: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   483 |       RooLinkedListIter vit = binnedVariables.iterator();
      |                               ~~~~~~~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc: In member function 'void TagProbeFitter::saveFitPlot(RooWorkspace*)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:791:39: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   791 |   RooLinkedListIter it = obs->iterator();
      |                          ~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc: In member function 'void TagProbeFitter::saveDistributionsPlot(RooWorkspace*)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:870:40: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   870 |   RooLinkedListIter it = vars->iterator();
      |                          ~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc: In member function 'void TagProbeFitter::saveEfficiencyPlots(RooDataSet&, const TString&, RooArgSet&, RooArgSet&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:912:52: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   912 |   RooLinkedListIter v1it = binnedVariables.iterator();
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:919:54: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   919 |     RooLinkedListIter v2it = binnedVariables.iterator();
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:929:56: warning: 'RooLinkedListIter RooAbsCollection::iterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   929 |       RooLinkedListIter v3it = binnedVariables.iterator();
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:235:21: note: declared here
  235 |   RooLinkedListIter iterator(bool dir = kIterForward) const
      |                     ^~~~~~~~
```

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/src/SideBandSubtraction.cc: In member function 'int SideBandSubtract::doSubtraction(RooRealVar*, Double_t, Int_t)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/src/SideBandSubtraction.cc:101:60: warning: 'TIterator* RooAbsCollection::createIterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   101 |   TIterator* iter = (TIterator*)Data->get()->createIterator();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooArgSet.h:19,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsReal.h:22,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsRealLValue.h:24,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooRealVar.h:19,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/interface/SideBandSubtraction.h:5,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/src/SideBandSubtraction.cc:13:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:227:21: note: declared here
  227 |   inline TIterator* createIterator(bool dir = kIterForward) const
      |                     ^~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/src/SideBandSubtraction.cc: In member function 'int SideBandSubtract::doGlobalFit()':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/69cb71416398349c2ccc9f39dc38e469/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_ROOT6_X_2023-11-22-2300/src/PhysicsTools/Utilities/src/SideBandSubtraction.cc:434:60: warning: 'TIterator* RooAbsCollection::createIterator(bool) const' is deprecated: will be removed in ROOT v6.34: begin(), end() and range-based for loops. [-Wdeprecated-declarations]
   434 |   TIterator* iter = (TIterator*)Data->get()->createIterator();
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-00fbbfcc467ea63cb3d71a5375f62eb9/include/RooAbsCollection.h:227:21: note: declared here
  227 |   inline TIterator* createIterator(bool dir = kIterForward) const
      |                     ^~~~~~~~~~~~~~
```
#### PR validation:

Bot tests
