### PR TITLE
CondDBESSource.cc added dump method to JSON file

### DIFF
--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -93,6 +93,8 @@ public:
 
   typedef enum { NOREFRESH, REFRESH_ALWAYS, REFRESH_OPEN_IOVS, REFRESH_EACH_RUN, RECONNECT_EACH_RUN } RefreshPolicy;
 
+  std::string m_jsonDumpFilename;
+
   explicit CondDBESSource(const edm::ParameterSet&);
   ~CondDBESSource() override;
 
@@ -164,5 +166,7 @@ private:
                                const std::vector<std::string>& roottagList,
                                std::map<std::string, cond::GTEntry_t>& replacement,
                                cond::GTMetadata_t& gtMetadata);
+
+  void printStatistics(const Stats& stats) const;
 };
 #endif


### PR DESCRIPTION
#### PR description:
The purpose of this PR is to improve the CondDBESSource.cc dump method.
Records and their consumption will be output to a JSON file rather than a log file or console due to the fact that they are usually too long for visual analysis.
This is more convenient for further use, for example, generating [сonsumption tables](https://twiki.cern.ch/twiki/bin/view/CMS/AlCaDBHLT2023) a log parsing script was previously used to fill it out

Previously, this issue was raised in the following [PR ](https://github.com/cms-sw/cmssw/pull/39901) but was not approved

Taking into account the [comment](https://github.com/cms-sw/cmssw/pull/43374#issuecomment-1824678266), I left the old dump method but added the option to upload JSON specifying the file name via the command: 
`process.GlobalTag.JsonDumpFileName =cms.untracked.string("CondDBESSource.json")`
The command above starts the creation of a JSON dump file if the file name or path to it is specified.

#### PR validation:
The generated .json file should have the same contents as the previous version of dumpstat after running.

`cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi  --conditions auto:phase1_2023_realistic_postBPix -n 5 --era Run3_2023 --geometry DB:Extended -s GEN --fileout output_step1_GEN.root --beamspot Realistic25ns13p6TeVEarly2023Collision  --customise_commands='process.GlobalTag.DumpStat =cms.untracked.bool(True) \n process.GlobalTag.JsonDumpFileName =cms.untracked.string("CondDBESSource.json")'|& tee output_step1_GEN.log`
OR (without dump into .log)
`cmsDriver.py TTbar_13TeV_TuneCUETP8M1_cfi  --conditions auto:phase1_2023_realistic_postBPix -n 5 --era Run3_2023 --geometry DB:Extended -s GEN --fileout output_step1_GEN.root --beamspot Realistic25ns13p6TeVEarly2023Collision  --customise_commands='process.GlobalTag.JsonDumpFileName =cms.untracked.string("CondDBESSource.json")'|& tee output_step1_GEN.log`
Not a backport

