### PR TITLE
[ALCA] Remove explicit assignment operator in favor of the compiler-generated one

### DIFF
--- a/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
+++ b/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h
@@ -59,9 +59,6 @@ protected:
   LocalError localError_;
 
 private:
-  // should not have assignment operator (?)
-  BeamSpotTransientTrackingRecHit &operator=(const BeamSpotTransientTrackingRecHit &t) { return *(this); }
-
   // hide the clone method for ReferenceCounted. Warning: this method is still
   // accessible via the bas class TrackingRecHit interface!
   BeamSpotTransientTrackingRecHit *clone() const override { return new BeamSpotTransientTrackingRecHit(*this); }


### PR DESCRIPTION
Hello,

This PR fixes the following warning present in DEVEL IBs:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3856d1287bf767d6ebb3a52d56c4458c/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-22-2300/src/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h: In member function 'virtual BeamSpotTransientTrackingRecHit* BeamSpotTransientTrackingRecHit::clone() const':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3856d1287bf767d6ebb3a52d56c4458c/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-22-2300/src/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h:67:109: warning: implicitly-declared 'BeamSpotTransientTrackingRecHit::BeamSpotTransientTrackingRecHit(const BeamSpotTransientTrackingRecHit&)' is deprecated [-Wdeprecated-copy]
    67 |   BeamSpotTransientTrackingRecHit *clone() const override { return new BeamSpotTransientTrackingRecHit(*this); }
      |                                                                                                             ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/3856d1287bf767d6ebb3a52d56c4458c/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-22-2300/src/Alignment/ReferenceTrajectories/interface/BeamSpotTransientTrackingRecHit.h:63:36: note: because 'BeamSpotTransientTrackingRecHit' has user-provided 'BeamSpotTransientTrackingRecHit& BeamSpotTransientTrackingRecHit::operator=(const BeamSpotTransientTrackingRecHit&)'
   63 |   BeamSpotTransientTrackingRecHit &operator=(const BeamSpotTransientTrackingRecHit &t) { return *(this); }
      |   
```
Tested locally.

Thanks,
Andrea