### PR TITLE
[SIMULATION] Fix DEVEL warnings on deprecated copy-constructors

### DIFF
--- a/DataFormats/MuonDetId/interface/DTBtiId.h
+++ b/DataFormats/MuonDetId/interface/DTBtiId.h
@@ -45,9 +45,6 @@ public:
   DTBtiId(const int wheel_id, const int station_id, const int sector_id, const int superlayer_id, const int bti_id)
       : _suplId(wheel_id, station_id, sector_id, superlayer_id), _bti(bti_id) {}
 
-  ///  Constructor
-  DTBtiId(const DTBtiId& btiId) : _suplId(btiId._suplId), _bti(btiId._bti) {}
-
   /// Destructor
   virtual ~DTBtiId() {}
 

--- a/DataFormats/MuonDetId/interface/DTChamberId.h
+++ b/DataFormats/MuonDetId/interface/DTChamberId.h
@@ -30,11 +30,6 @@ public:
   /// exception is thrown.
   DTChamberId(int wheel, int station, int sector);
 
-  /// Copy Constructor.
-  /// Any bits outside the DTChamberId fields are zeroed; apart for
-  /// this, no check is done on the vaildity of the values.
-  DTChamberId(const DTChamberId& chId);
-
   /// Return the wheel number
   int wheel() const { return int((id_ >> wheelStartBit_) & wheelMask_) + minWheelId - 1; }
 

--- a/DataFormats/MuonDetId/interface/DTLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTLayerId.h
@@ -27,11 +27,6 @@ public:
   /// exception is thrown.
   DTLayerId(int wheel, int station, int sector, int superlayer, int layer);
 
-  /// Copy Constructor.
-  /// Any bits outside the DTLayerId fields are zeroed; apart for
-  /// this, no check is done on the vaildity of the values.
-  DTLayerId(const DTLayerId& layerId);
-
   /// Constructor from a camberId and SL and layer numbers
   DTLayerId(const DTChamberId& chId, int superlayer, int layer);
 

--- a/DataFormats/MuonDetId/interface/DTSuperLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTSuperLayerId.h
@@ -27,11 +27,6 @@ public:
   /// exception is thrown.
   DTSuperLayerId(int wheel, int station, int sector, int superlayer);
 
-  /// Copy Constructor.
-  /// Any bits outside the DTChamberId fields are zeroed; apart for
-  /// this, no check is done on the vaildity of the values.
-  DTSuperLayerId(const DTSuperLayerId& slId);
-
   /// Constructor from a DTChamberId and SL number.
   DTSuperLayerId(const DTChamberId& chId, int superlayer);
 

--- a/DataFormats/MuonDetId/interface/DTTracoId.h
+++ b/DataFormats/MuonDetId/interface/DTTracoId.h
@@ -43,9 +43,6 @@ public:
   DTTracoId(const int wheel_id, const int station_id, const int sector_id, const int traco_id)
       : _statId(wheel_id, station_id, sector_id), _traco(traco_id) {}
 
-  ///  Constructor
-  DTTracoId(const DTTracoId& tracoId) : _statId(tracoId._statId), _traco(tracoId._traco) {}
-
   /// Destructor
   virtual ~DTTracoId() {}
 

--- a/DataFormats/MuonDetId/interface/DTWireId.h
+++ b/DataFormats/MuonDetId/interface/DTWireId.h
@@ -26,9 +26,6 @@ public:
   /// exception is thrown.
   DTWireId(int wheel, int station, int sector, int superlayer, int layer, int wire);
 
-  /// Copy Constructor.
-  DTWireId(const DTWireId& wireId);
-
   /// Constructor from a CamberId and SL, layer and wire numbers
   DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire);
 

--- a/DataFormats/MuonDetId/src/DTChamberId.cc
+++ b/DataFormats/MuonDetId/src/DTChamberId.cc
@@ -34,10 +34,6 @@ DTChamberId::DTChamberId(int wheel, int station, int sector) : DetId(DetId::Muon
          (sector & sectorMask_) << sectorStartBit_;
 }
 
-DTChamberId::DTChamberId(const DTChamberId& chId)
-    // The mask is required for proper slicing, i.e. if chId is actually a derived class.
-    : DetId(chId.rawId() & chamberIdMask_) {}
-
 void DTChamberId::checkMuonId() {
   if (det() != DetId::Muon || subdetId() != MuonSubdetId::DT) {
     throw cms::Exception("InvalidDetId") << "DTChamberId ctor:"

--- a/DataFormats/MuonDetId/src/DTLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTLayerId.cc
@@ -18,13 +18,6 @@ DTLayerId::DTLayerId(uint32_t id) {
   checkMuonId();
 }
 
-// Copy Constructor.
-DTLayerId::DTLayerId(const DTLayerId& layerId) : DTSuperLayerId() {
-  // The mask is required for proper slicing, i.e. if layerId is
-  // actually a derived class.
-  id_ = (layerId.rawId() & layerIdMask_);
-}
-
 // Constructor from a camberId and SL and layer numbers
 DTLayerId::DTLayerId(const DTChamberId& chId, int superlayer, int layer) : DTSuperLayerId(chId, superlayer) {
   if (layer < minLayerId || layer > maxLayerId) {

--- a/DataFormats/MuonDetId/src/DTSuperLayerId.cc
+++ b/DataFormats/MuonDetId/src/DTSuperLayerId.cc
@@ -26,13 +26,6 @@ DTSuperLayerId::DTSuperLayerId(int wheel, int station, int sector, int superlaye
   id_ |= (superlayer & slMask_) << slayerStartBit_;
 }
 
-// Copy Constructor.
-DTSuperLayerId::DTSuperLayerId(const DTSuperLayerId& slId) : DTChamberId() {
-  // The mask is required for proper slicing, i.e. if slId is
-  // actually a derived class.
-  id_ = (slId.rawId() & slIdMask_);
-}
-
 // Constructor from a camberId and SL number
 DTSuperLayerId::DTSuperLayerId(const DTChamberId& chId, int superlayer) : DTChamberId(chId) {
   if (superlayer < minSuperLayerId || superlayer > maxSuperLayerId) {

--- a/DataFormats/MuonDetId/src/DTWireId.cc
+++ b/DataFormats/MuonDetId/src/DTWireId.cc
@@ -28,9 +28,6 @@ DTWireId::DTWireId(int wheel, int station, int sector, int superlayer, int layer
   id_ |= (wire & wireMask_) << wireStartBit_;
 }
 
-// Copy Constructor.
-DTWireId::DTWireId(const DTWireId& wireId) : DTLayerId() { id_ = wireId.rawId(); }
-
 // Constructor from a CamberId and SL, layer and wire numbers
 DTWireId::DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire) : DTLayerId(chId, superlayer, layer) {
   if (wire < minWireId || wire > maxWireId) {


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on the `DataFormats/MuonDetId` module.

Thanks,
Andrea