### PR TITLE
Monitoring of tau decay products in NanoDQM

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -870,7 +870,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
         TauProd = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
-                Count1D('_size', 40, -0.5, 5.5, 'tau decay products')
+                Count1D('_size', 40, -0.5, 5.5, 'tau decay products'),
                 Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
                 Plot1D('eta', 'eta', 20, -5, 5, 'eta'),

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -867,6 +867,17 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('probDM11PNet', 'probDM11PNet', 20, 0, 1, 'normalised probablity of decayMode 11, 3h+1pi0 (PNet 2023)'),
             )
         ),
+        TauProd = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Count1D('_size', 40, -0.5, 5.5, 'tau decay products')
+                Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
+                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+                Plot1D('eta', 'eta', 20, -5, 5, 'eta'),
+                Plot1D('pdgId', 'pdgId', 200, -10250, 10250, 'PDG code assigned by the event reconstruction (not by MC truth)'),
+                NoPlot('status'),
+            )
+        ),        
         TkMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(


### PR DESCRIPTION
#### PR description:

This PR builds on top of  https://github.com/cms-sw/cmssw/pull/42987,  such that the tau decay products can be monitored by NanoDQM.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backports for this PR are planned for CMSSW versions 13_2_X, 13_3_X.


