### PR TITLE
Tau decay products in NanoDQM

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -838,7 +838,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
         TauProd = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
-                Count1D('_size', 40, -0.5, 5.5, 'tau decay products')
+                Count1D('_size', 40, -0.5, 5.5, 'tau decay products'),
                 Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
                 Plot1D('eta', 'eta', 20, -5, 5, 'eta'),

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -835,6 +835,17 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('probDM11PNet', 'probDM11PNet', 20, 0, 1, 'normalised probablity of decayMode 11, 3h+1pi0 (PNet 2023)'),
             )
         ),
+        TauProd = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Count1D('_size', 40, -0.5, 5.5, 'tau decay products')
+                Plot1D('pt', 'pt', 20, 0, 200, 'pt'),
+                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+                Plot1D('eta', 'eta', 20, -5, 5, 'eta'),
+                Plot1D('pdgId', 'pdgId', 200, -10250, 10250, 'PDG code assigned by the event reconstruction (not by MC truth)'),
+                NoPlot('status'),
+            )
+        ),        
         TkMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -152,6 +152,23 @@ run3_nanoAOD_124.toModify(
                  from_raw=True, wp_thrs=WORKING_POINTS_v2p5["jet"])
 )
 
+tauSignalCands = cms.EDProducer("PATTauSignalCandidatesProducer",
+    src = tauTable.src,
+    storeLostTracks = cms.bool(True)
+)
+
+tauSignalCandsTable = simpleCandidateFlatTableProducer.clone(
+    src = cms.InputTag("tauSignalCands"),
+    cut = cms.string("pt > 0."),
+    name = cms.string("TauProd"),
+    doc = cms.string("tau signal candidates"),
+    variables = cms.PSet(
+        P3Vars,
+        pdgId = Var("pdgId", int, doc="PDG code assigned by the event reconstruction (not by MC truth)"),
+        tauIdx = Var("status", "int16", doc="index of the mother tau"),
+        #trkPt = Var("?daughter(0).hasTrackDetails()?daughter(0).bestTrack().pt():0", float, precision=-1, doc="pt of associated track"), #MB: better to store ratio over cand pt?
+    )
+)
 
 tauGenJetsForNano = tauGenJets.clone(
     GenParticles = "finalGenParticles",
@@ -220,6 +237,8 @@ tauMCTable = cms.EDProducer("CandMCMatchTableProducer",
 
 tauTask = cms.Task(finalTaus)
 tauTablesTask = cms.Task(tauTable)
+tauSignalCandsTask = cms.Task(tauSignalCands,tauSignalCandsTable)
+tauTablesTask.add(tauSignalCandsTask)
 
 genTauTask = cms.Task(tauGenJetsForNano,tauGenJetsSelectorAllHadronsForNano,genVisTaus,genVisTauTable)
 tauMCTask = cms.Task(genTauTask,tausMCMatchLepTauForTable,tausMCMatchHadTauForTable,tauMCTable)

--- a/PhysicsTools/PatAlgos/plugins/PATTauSignalCandidatesProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauSignalCandidatesProducer.cc
@@ -1,0 +1,75 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"  //MB: can use CompositePtrCandidate, but dictionaries not defined
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+class PATTauSignalCandidatesProducer : public edm::stream::EDProducer<> {
+public:
+  explicit PATTauSignalCandidatesProducer(const edm::ParameterSet&);
+  ~PATTauSignalCandidatesProducer() override{};
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
+  //--- configuration parameters
+  edm::EDGetTokenT<pat::TauCollection> tausToken_;
+  const bool storeLostTracks_;
+};
+
+PATTauSignalCandidatesProducer::PATTauSignalCandidatesProducer(const edm::ParameterSet& cfg)
+    : tausToken_(consumes<pat::TauCollection>(cfg.getParameter<edm::InputTag>("src"))),
+      storeLostTracks_(cfg.getParameter<bool>("storeLostTracks")) {
+  produces<std::vector<reco::VertexCompositePtrCandidate>>();
+}
+
+void PATTauSignalCandidatesProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  // Get the vector of taus
+  edm::Handle<pat::TauCollection> inputTaus;
+  evt.getByToken(tausToken_, inputTaus);
+
+  auto outputCands = std::make_unique<std::vector<reco::VertexCompositePtrCandidate>>();
+  outputCands->reserve(inputTaus->size() * 3);  //avarage number of tau signal cands
+  for (size_t iTau = 0; iTau < inputTaus->size(); ++iTau) {
+    for (const auto& cand : (*inputTaus)[iTau].signalCands()) {
+      reco::VertexCompositePtrCandidate outCand(*cand);
+      outCand.setStatus(iTau);  //trick to store index of the mother tau to be used in NanoAOD
+      outCand.addDaughter(cand);
+      outputCands->push_back(outCand);
+    }
+    if (storeLostTracks_) {
+      for (const auto& cand : (*inputTaus)[iTau].signalLostTracks()) {
+        reco::VertexCompositePtrCandidate outCand(*cand);
+        outCand.setStatus(iTau);  //trick to store index of the mother tau to be used in NanoAOD
+        auto pdgId = cand->pdgId();
+        outCand.setPdgId(
+            pdgId + 10000 * ((pdgId >= 0) -
+                             (pdgId < 0)));  // increase abs(pdgId) by 10000 to distingish from "true" signal candidates
+        outCand.addDaughter(cand);
+        outputCands->push_back(outCand);
+      }
+    }
+  }
+
+  evt.put(std::move(outputCands));
+}
+
+void PATTauSignalCandidatesProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // patTauDecayCandidatesProducer
+  edm::ParameterSetDescription desc;
+
+  desc.add<edm::InputTag>("src", edm::InputTag("slimmedTaus"));
+  desc.add<bool>("storeLostTracks", true)
+      ->setComment("If true, lostTracks will be stored together with other candidates with pdgId=+-10211");
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(PATTauSignalCandidatesProducer);


### PR DESCRIPTION
#### PR description:

This PR adds tau decay product information in NanoAOD. A collection of tau decay products is created on the fly and then stored in a new NanoAOD table. Additional information stored is as follows for each candidate in the table:

- 3-momenta
- PDG ID
- Index of its mother tau

Size tests have been conducted to assess the size increase on NanoAOD. These tests have been conducted using two RelVal samples:

- TTBar (/w PU)
- ZTT

The cumulative contribution of the tau decay products in NanoAOD is expected to be around 1.3 % (TTBar) and 2% (ZTT). Breakdowns are available [here](https://cernbox.cern.ch/s/7ImmLYlChHIIS41).

This PR also allows the tau decay products to be monitored by NanoDQM.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of PRs https://github.com/cms-sw/cmssw/pull/42987 & https://github.com/cms-sw/cmssw/pull/43382
