### PR TITLE
(Backport) Adding L1 unprefirable event info and Final OR decision in BX-1/-2

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -377,7 +377,7 @@ l1PreFiringEventWeightTable = globalVariablesTableProducer.clone(
 l1bits=cms.EDProducer("L1TriggerResultsConverter",
                        src=cms.InputTag("gtStage2Digis"),
                        legacyL1=cms.bool(False),
-                       storeUnprefireableBit=cms.bool(True),
+                       storeUnprefireableBits=cms.bool(True),
                        src_ext=cms.InputTag("simGtExtUnprefireable"))
 
 triggerObjectTablesTask = cms.Task( unpackedPatTrigger,triggerObjectTable,l1bits)


### PR DESCRIPTION
#### PR description:

This PR adds four booleans to NANOAOD (`L1_UnprefireableEvent_TriggerRules`, `L1_UnprefireableEvent_FirstBxInTrain`, `L1_FinalOR_BXmin1`, `L1_FinalOR_BXmin2`) related to L1T prefiring studies. 
This is a backport of https://github.com/cms-sw/cmssw/pull/43306/ and https://github.com/cms-sw/cmssw/pull/43150 
