### PR TITLE
Fix deprecated-copy warnings in L1Trigger/L1CaloTrigger

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -434,22 +434,10 @@ namespace p2eg {
 
   class towerHCAL {
   private:
-    ap_uint<10> et;
-    ap_uint<6> fb;
+    ap_uint<10> et = 0;
+    ap_uint<6> fb = 0;
 
   public:
-    // constructor
-    towerHCAL() {
-      et = 0;
-      fb = 0;
-    };
-
-    // copy constructor
-    towerHCAL(const towerHCAL& other) {
-      et = other.et;
-      fb = other.fb;
-    };
-
     // set members
     inline void zeroOut() {
       et = 0;
@@ -484,6 +472,12 @@ namespace p2eg {
           towersHCAL[i][j] = other.towersHCAL[i][j];
         }
       };
+    };
+
+    // overload operator= to use copy constructor
+    towers3x4 operator=(const towers3x4& other) {
+      const towers3x4& newRegion(other);
+      return newRegion;
     };
 
     // set members
@@ -597,22 +591,9 @@ namespace p2eg {
   */
   class crystalMax {
   public:
-    ap_uint<10> energy;
-    uint8_t phiMax;
-    uint8_t etaMax;
-
-    crystalMax() {
-      energy = 0;
-      phiMax = 0;
-      etaMax = 0;
-    }
-
-    crystalMax& operator=(const crystalMax& rhs) {
-      energy = rhs.energy;
-      phiMax = rhs.phiMax;
-      etaMax = rhs.etaMax;
-      return *this;
-    }
+    ap_uint<10> energy = 0;
+    uint8_t phiMax = 0;
+    uint8_t etaMax = 0;
   };
 
   class ecaltp_t {
@@ -686,14 +667,9 @@ namespace p2eg {
 
   class tower_t {
   public:
-    ap_uint<16> data;
+    ap_uint<16> data = 0;
 
-    tower_t() { data = 0; }
-    tower_t& operator=(const tower_t& rhs) {
-      data = rhs.data;
-      return *this;
-    }
-
+    tower_t() = default;
     tower_t(ap_uint<12> et, ap_uint<4> hoe) { data = (et) | (((ap_uint<16>)hoe) << 12); }
 
     ap_uint<12> et() { return (data & 0xFFF); }
@@ -765,34 +741,13 @@ namespace p2eg {
 
   class clusterInfo {
   public:
-    ap_uint<10> seedEnergy;
-    ap_uint<15> energy;
-    ap_uint<15> et5x5;
-    ap_uint<15> et2x5;
-    ap_uint<5> phiMax;
-    ap_uint<5> etaMax;
-    ap_uint<2> brems;
-
-    clusterInfo() {
-      seedEnergy = 0;
-      energy = 0;
-      et5x5 = 0;
-      et2x5 = 0;
-      phiMax = 0;
-      etaMax = 0;
-      brems = 0;
-    }
-
-    clusterInfo& operator=(const clusterInfo& rhs) {
-      seedEnergy = rhs.seedEnergy;
-      energy = rhs.energy;
-      et5x5 = rhs.et5x5;
-      et2x5 = rhs.et2x5;
-      phiMax = rhs.phiMax;
-      etaMax = rhs.etaMax;
-      brems = rhs.brems;
-      return *this;
-    }
+    ap_uint<10> seedEnergy = 0;
+    ap_uint<15> energy = 0;
+    ap_uint<15> et5x5 = 0;
+    ap_uint<15> et2x5 = 0;
+    ap_uint<5> phiMax = 0;
+    ap_uint<5> etaMax = 0;
+    ap_uint<2> brems = 0;
   };
 
   //--------------------------------------------------------//
@@ -851,20 +806,6 @@ namespace p2eg {
       is_looseTkss = cluster_is_looseTkss;
       is_iso = cluster_is_iso;
       is_looseTkiso = cluster_is_looseTkiso;
-    }
-
-    Cluster& operator=(const Cluster& rhs) {
-      data = rhs.data;
-      regionIdx = rhs.regionIdx;
-      calib = rhs.calib;
-      brems = rhs.brems;
-      et5x5 = rhs.et5x5;
-      et2x5 = rhs.et2x5;
-      is_ss = rhs.is_ss;
-      is_looseTkss = rhs.is_looseTkss;
-      is_iso = rhs.is_iso;
-      is_looseTkiso = rhs.is_looseTkiso;
-      return *this;
     }
 
     void setRegionIdx(int regIdx) { regionIdx = regIdx; }  // Newly added


### PR DESCRIPTION
#### PR description:

Fix `deprecated-copy` warnings ([rule-of-three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) violation) in L1Trigger/L1CaloTrigger:

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::towers3x4::towers3x4(const p2eg::towers3x4&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:484:51: warning: implicitly-declared 'p2eg::towerHCAL& p2eg::towerHCAL::operator=(const p2eg::towerHCAL&)' is deprecated [-Wdeprecated-copy]
   484 |           towersHCAL[i][j] = other.towersHCAL[i][j];
      |                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:448:5: note: because 'p2eg::towerHCAL' has user-provided 'p2eg::towerHCAL::towerHCAL(const p2eg::towerHCAL&)'
  448 |     towerHCAL(const towerHCAL& other) {
      |     ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::card::card(const p2eg::card&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:537:49: warning: implicitly-declared 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)' is deprecated [-Wdeprecated-copy]
   537 |         card3x4Towers[i] = other.card3x4Towers[i];
      |                                                 ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:480:5: note: because 'p2eg::towers3x4' has user-provided 'p2eg::towers3x4::towers3x4(const p2eg::towers3x4&)'
  480 |     towers3x4(const towers3x4& other) {
      |     ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In member function 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:470:9: warning: implicitly-declared 'p2eg::towerHCAL& p2eg::towerHCAL::operator=(const p2eg::towerHCAL&)' is deprecated [-Wdeprecated-copy]
   470 |   class towers3x4 {
      |         ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:448:5: note: because 'p2eg::towerHCAL' has user-provided 'p2eg::towerHCAL::towerHCAL(const p2eg::towerHCAL&)'
  448 |     towerHCAL(const towerHCAL& other) {
      |     ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::card::card(const p2eg::card&)':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:537:49: note: synthesized method 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)' first required here
  537 |         card3x4Towers[i] = other.card3x4Towers[i];
      |                                                 ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:55:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::crystalMax p2eg::getPeakBin15N(etaStripPeak_t)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1007:10: warning: implicitly-declared 'p2eg::crystalMax::crystalMax(const p2eg::crystalMax&)' is deprecated [-Wdeprecated-copy]
  1007 |   return x;
      |          ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:610:17: note: because 'p2eg::crystalMax' has user-provided 'p2eg::crystalMax& p2eg::crystalMax::operator=(const p2eg::crystalMax&)'
  610 |     crystalMax& operator=(const crystalMax& rhs) {
      |                 ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getClusterPosition(ecalRegion_t)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1091:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1091 |   return cluster;
      |          ^~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:786:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  786 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::Cluster p2eg::packCluster(ap_uint<15>&, ap_uint<5>&, ap_uint<5>&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1112:10: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1112 |   return pack;
      |          ^~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getBremsValuesPos(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1231:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1231 |   return cluster_tmp;
      |          ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:786:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  786 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getBremsValuesNeg(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1306:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1306 |   return cluster_tmp;
      |          ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:786:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  786 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getClusterValues(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1410:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1410 |   return cluster_tmp;
      |          ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:786:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  786 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::Cluster p2eg::getClusterFromRegion3x4(crystal (*)[20])':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1467:10: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1467 |   return returnCluster;
      |          ^~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>&, int, int, int)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1493:40: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1493 |       p2eg::Cluster c1 = cluster_list[i];
      |                                        ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1494:40: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1494 |       p2eg::Cluster c2 = cluster_list[j];
      |                                        ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc: In member function 'virtual void Phase2L1CaloEGammaEmulator::produce(edm::Event&, const edm::EventSetup&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:384:51: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
   384 |         p2eg::Cluster cExtra = cluster_list[cc][kk];
      |                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:525:67: warning: implicitly-declared 'p2eg::tower_t::tower_t(const p2eg::tower_t&)' is deprecated [-Wdeprecated-copy]
   525 |           p2eg::tower_t t0_ecal = towerECALCard[iTower][iLink][rcc];
      |                                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:692:14: note: because 'p2eg::tower_t' has user-provided 'p2eg::tower_t& p2eg::tower_t::operator=(const p2eg::tower_t&)'
  692 |     tower_t& operator=(const tower_t& rhs) {
      |              ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:526:67: warning: implicitly-declared 'p2eg::tower_t::tower_t(const p2eg::tower_t&)' is deprecated [-Wdeprecated-copy]
   526 |           p2eg::tower_t t0_hcal = towerHCALCard[iTower][iLink][rcc];
      |                                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:692:14: note: because 'p2eg::tower_t' has user-provided 'p2eg::tower_t& p2eg::tower_t::operator=(const p2eg::tower_t&)'
  692 |     tower_t& operator=(const tower_t& rhs) {
      |              ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:546:61: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
   546 |         p2eg::Cluster c0 = cluster_list_merged[rcc][iCluster];
      |                                                             ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:856:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  856 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
```

#### PR validation:

Bot tests
