### PR TITLE
CTPPS update Run3 Direct Simulation to use old LHCInfo after LHCInfo update

### DIFF
--- a/CalibPPS/ESProducers/plugins/CTPPSBeamParametersFromLHCInfoESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSBeamParametersFromLHCInfoESSource.cc
@@ -13,7 +13,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+#include "CondTools/RunInfo/interface/LHCInfoCombined.h"
 #include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
 
 #include "CondFormats/RunInfo/interface/LHCInfo.h"
@@ -31,7 +31,10 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  const edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> lhcInfoPerLSToken_;
+  edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> lhcInfoPerFillToken_;
+  const bool useNewLHCInfo_;
 
   CTPPSBeamParameters defaultParameters_;
 };
@@ -39,8 +42,12 @@ private:
 //----------------------------------------------------------------------------------------------------
 
 CTPPSBeamParametersFromLHCInfoESSource::CTPPSBeamParametersFromLHCInfoESSource(const edm::ParameterSet& iConfig)
-    : lhcInfoToken_(
-          setWhatProduced(this).consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))) {
+    : useNewLHCInfo_(iConfig.getParameter<bool>("useNewLHCInfo")) {
+  auto cc = setWhatProduced(this);
+  lhcInfoToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")));
+  lhcInfoPerLSToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerLSLabel")));
+  lhcInfoPerFillToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerFillLabel")));
+
   defaultParameters_.setBeamDivergenceX45(iConfig.getParameter<double>("beamDivX45"));
   defaultParameters_.setBeamDivergenceY45(iConfig.getParameter<double>("beamDivX56"));
   defaultParameters_.setBeamDivergenceX56(iConfig.getParameter<double>("beamDivY45"));
@@ -62,13 +69,16 @@ CTPPSBeamParametersFromLHCInfoESSource::CTPPSBeamParametersFromLHCInfoESSource(c
 
 std::unique_ptr<CTPPSBeamParameters> CTPPSBeamParametersFromLHCInfoESSource::produce(
     const CTPPSBeamParametersRcd& iRecord) {
-  LHCInfo const& lhcInfo = iRecord.get(lhcInfoToken_);
+  auto lhcInfoCombined =
+      LHCInfoCombined::createLHCInfoCombined<CTPPSBeamParametersRcd,
+                                             edm::mpl::Vector<LHCInfoRcd, LHCInfoPerFillRcd, LHCInfoPerLSRcd>>(
+          iRecord, lhcInfoPerLSToken_, lhcInfoPerFillToken_, lhcInfoToken_, useNewLHCInfo_);
 
   auto bp = std::make_unique<CTPPSBeamParameters>(defaultParameters_);
 
-  const auto beamMom = lhcInfo.energy();
-  const auto betaStar = lhcInfo.betaStar() * 1E2;      // conversion m --> cm
-  const auto xangle = lhcInfo.crossingAngle() * 1E-6;  // conversion mu rad --> rad
+  const auto beamMom = lhcInfoCombined.energy;
+  const auto betaStar = lhcInfoCombined.betaStarX * 1E2;       // conversion m --> cm
+  const auto xangle = lhcInfoCombined.crossingAngle() * 1E-6;  // conversion mu rad --> rad
 
   bp->setBeamMom45(beamMom);
   bp->setBeamMom56(beamMom);
@@ -92,6 +102,9 @@ void CTPPSBeamParametersFromLHCInfoESSource::fillDescriptions(edm::Configuration
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("lhcInfoLabel", "");
+  desc.add<std::string>("lhcInfoPerLSLabel", "");
+  desc.add<std::string>("lhcInfoPerFillLabel", "");
+  desc.add<bool>("useNewLHCInfo", false);
 
   // beam divergence (rad)
   desc.add<double>("beamDivX45", 0.1);

--- a/CalibPPS/ESProducers/python/ctppsBeamParametersFromLHCInfoESSource_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsBeamParametersFromLHCInfoESSource_cff.py
@@ -1,0 +1,7 @@
+from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(ctppsBeamParametersFromLHCInfoESSource, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsBeamParametersFromLHCInfoESSource, useNewLHCInfo = False)

--- a/CalibPPS/ESProducers/python/ctppsInterpolatedOpticalFunctionsESSource_cff.py
+++ b/CalibPPS/ESProducers/python/ctppsInterpolatedOpticalFunctionsESSource_cff.py
@@ -1,3 +1,7 @@
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cfi import *
+
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(ctppsInterpolatedOpticalFunctionsESSource, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsInterpolatedOpticalFunctionsESSource, useNewLHCInfo = False)

--- a/CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h
+++ b/CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h
@@ -8,10 +8,13 @@
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 
 #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+#include "CondFormats/DataRecord/interface/LHCInfoPerFillRcd.h"
+#include "CondFormats/DataRecord/interface/LHCInfoPerLSRcd.h"
 
 #include "FWCore/Utilities/interface/mplVector.h"
 
-class CTPPSBeamParametersRcd
-    : public edm::eventsetup::DependentRecordImplementation<CTPPSBeamParametersRcd, edm::mpl::Vector<LHCInfoRcd>> {};
+class CTPPSBeamParametersRcd : public edm::eventsetup::DependentRecordImplementation<
+                                   CTPPSBeamParametersRcd,
+                                   edm::mpl::Vector<LHCInfoRcd, LHCInfoPerFillRcd, LHCInfoPerLSRcd>> {};
 
 #endif

--- a/CondTools/RunInfo/interface/LHCInfoCombined.h
+++ b/CondTools/RunInfo/interface/LHCInfoCombined.h
@@ -43,7 +43,7 @@ public:
   void setFromPerLS(const LHCInfoPerLS& infoPerLS);
   void setFromPerFill(const LHCInfoPerFill& infoPerFill);
 
-  float crossingAngle();
+  float crossingAngle() const;
   static constexpr float crossingAngleInvalid = -1.;
   bool isCrossingAngleInvalid();
 

--- a/CondTools/RunInfo/src/LHCInfoCombined.cc
+++ b/CondTools/RunInfo/src/LHCInfoCombined.cc
@@ -43,7 +43,7 @@ void LHCInfoCombined::setFromPerFill(const LHCInfoPerFill& infoPerFill) {
   fillNumber = infoPerFill.fillNumber();
 }
 
-float LHCInfoCombined::crossingAngle() {
+float LHCInfoCombined::crossingAngle() const {
   if (crossingAngleX == 0. && crossingAngleY == 0.) {
     return crossingAngleInvalid;
   }

--- a/Configuration/Eras/python/Modifier_ctpps_directSim_cff.py
+++ b/Configuration/Eras/python/Modifier_ctpps_directSim_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+ctpps_directSim =  cms.Modifier()

--- a/Configuration/ProcessModifiers/python/Era_Run3_CTPPS_directSim_cff.py
+++ b/Configuration/ProcessModifiers/python/Era_Run3_CTPPS_directSim_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+
+Run3_CTPPS_directSim = cms.ModifierChain(Run3,ctpps_directSim)

--- a/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
+++ b/RecoPPS/ProtonReconstruction/python/ctppsProtons_cff.py
@@ -15,3 +15,6 @@ ctppsProtons.default_time = -999.
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(ctppsProtons, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsProtons, useNewLHCInfo = False)

--- a/SimPPS/DirectSimProducer/python/ppsDirectProtonSimulation_cff.py
+++ b/SimPPS/DirectSimProducer/python/ppsDirectProtonSimulation_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import ctppsBeamParametersFromLHCInfoESSource as _esLHCinfo
+from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cff import ctppsBeamParametersFromLHCInfoESSource as _esLHCinfo
 from SimPPS.DirectSimProducer.ppsDirectProtonSimulation_cfi import ppsDirectProtonSimulation as _dirProtonSim
 from IOMC.EventVertexGenerators.beamDivergenceVtxGenerator_cfi import beamDivergenceVtxGenerator as _vtxGen
 

--- a/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
+++ b/SimTransport/PPSProtonTransport/python/PPSTransportESSources_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # beam optics
 from CondCore.CondDB.CondDB_cfi import *
-from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cfi import *
+from CalibPPS.ESProducers.ctppsBeamParametersFromLHCInfoESSource_cff import *
 from CalibPPS.ESProducers.ctppsInterpolatedOpticalFunctionsESSource_cff import *
 ctppsInterpolatedOpticalFunctionsESSource.lhcInfoLabel = ""
 

--- a/Validation/CTPPS/plugins/CTPPSHepMCDistributionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSHepMCDistributionPlotter.cc
@@ -15,8 +15,7 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
-#include "CondFormats/RunInfo/interface/LHCInfo.h"
-#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+#include "CondTools/RunInfo/interface/LHCInfoCombined.h"
 
 #include "TFile.h"
 #include "TH1D.h"
@@ -29,13 +28,20 @@ class CTPPSHepMCDistributionPlotter : public edm::one::EDAnalyzer<> {
 public:
   explicit CTPPSHepMCDistributionPlotter(const edm::ParameterSet &);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endJob() override;
 
-  edm::EDGetTokenT<edm::HepMCProduct> tokenHepMC_;
-  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoESToken_;
-  std::string outputFile_;
+  const edm::EDGetTokenT<edm::HepMCProduct> tokenHepMC_;
+
+  const edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  const edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> lhcInfoPerLSToken_;
+  const edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> lhcInfoPerFillToken_;
+  const bool useNewLHCInfo_;
+
+  const std::string outputFile_;
 
   std::unique_ptr<TH1D> h_vtx_x_, h_vtx_y_, h_vtx_z_, h_vtx_t_;
   std::unique_ptr<TH1D> h_xi_, h_th_x_, h_th_y_;
@@ -51,7 +57,12 @@ using namespace HepMC;
 
 CTPPSHepMCDistributionPlotter::CTPPSHepMCDistributionPlotter(const edm::ParameterSet &iConfig)
     : tokenHepMC_(consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("tagHepMC"))),
-      lhcInfoESToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))),
+
+      lhcInfoToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))),
+      lhcInfoPerLSToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerLSLabel")))),
+      lhcInfoPerFillToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerFillLabel")))),
+      useNewLHCInfo_(iConfig.getParameter<bool>("useNewLHCInfo")),
+
       outputFile_(iConfig.getParameter<string>("outputFile")),
 
       h_vtx_x_(new TH1D("h_vtx_x", ";vtx_x   (mm)", 100, 0., 0.)),
@@ -65,9 +76,22 @@ CTPPSHepMCDistributionPlotter::CTPPSHepMCDistributionPlotter(const edm::Paramete
 
 //----------------------------------------------------------------------------------------------------
 
+void CTPPSHepMCDistributionPlotter::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("lhcInfoLabel", "")->setComment("label of the LHCInfo record");
+  desc.add<std::string>("lhcInfoPerLSLabel", "")->setComment("label of the LHCInfoPerLS record");
+  desc.add<std::string>("lhcInfoPerFillLabel", "")->setComment("label of the LHCInfoPerFill record");
+  desc.add<bool>("useNewLHCInfo", false)->setComment("flag whether to use new LHCInfoPer* records or old LHCInfo");
+
+  desc.add<std::string>("outputFile", "")->setComment("output file");
+
+  descriptions.add("ctppsHepMCDistributionPlotter", desc);
+}
+
 void CTPPSHepMCDistributionPlotter::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get conditions
-  const auto &lhcInfo = iSetup.getData(lhcInfoESToken_);
+  LHCInfoCombined lhcInfoCombined(iSetup, lhcInfoPerLSToken_, lhcInfoPerFillToken_, lhcInfoToken_, useNewLHCInfo_);
 
   // get input
   edm::Handle<edm::HepMCProduct> hHepMC;
@@ -98,7 +122,7 @@ void CTPPSHepMCDistributionPlotter::analyze(const edm::Event &iEvent, const edm:
       continue;
 
     const auto &mom = part->momentum();
-    const double p_nom = lhcInfo.energy();
+    const double p_nom = lhcInfoCombined.energy;
 
     if (mom.rho() / p_nom < 0.7)
       continue;

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionEfficiencyEstimatorData.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionEfficiencyEstimatorData.cc
@@ -12,8 +12,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
-#include "CondFormats/RunInfo/interface/LHCInfo.h"
-#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+#include "CondTools/RunInfo/interface/LHCInfoCombined.h"
 #include "CondFormats/DataRecord/interface/CTPPSInterpolatedOpticsRcd.h"
 #include "CondFormats/PPSObjects/interface/LHCInterpolatedOpticalFunctionsSetCollection.h"
 #include "CondFormats/DataRecord/interface/PPSAssociationCutsRcd.h"
@@ -53,7 +52,10 @@ private:
   edm::EDGetTokenT<CTPPSLocalTrackLiteCollection> tokenTracks_;
   edm::EDGetTokenT<reco::ForwardProtonCollection> tokenRecoProtonsMultiRP_;
 
-  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoESToken_;
+  const edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  const edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> lhcInfoPerLSToken_;
+  const edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> lhcInfoPerFillToken_;
+  const bool useNewLHCInfo_;
   edm::ESGetToken<LHCInterpolatedOpticalFunctionsSetCollection, CTPPSInterpolatedOpticsRcd> opticsESToken_;
   edm::ESGetToken<PPSAssociationCuts, PPSAssociationCutsRcd> ppsAssociationCutsToken_;
 
@@ -243,7 +245,11 @@ CTPPSProtonReconstructionEfficiencyEstimatorData::CTPPSProtonReconstructionEffic
       tokenRecoProtonsMultiRP_(
           consumes<reco::ForwardProtonCollection>(iConfig.getParameter<InputTag>("tagRecoProtonsMultiRP"))),
 
-      lhcInfoESToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))),
+      lhcInfoToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))),
+      lhcInfoPerLSToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerLSLabel")))),
+      lhcInfoPerFillToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerFillLabel")))),
+      useNewLHCInfo_(iConfig.getParameter<bool>("useNewLHCInfo")),
+
       opticsESToken_(esConsumes(ESInputTag("", iConfig.getParameter<std::string>("opticsLabel")))),
       ppsAssociationCutsToken_(
           esConsumes(ESInputTag("", iConfig.getParameter<std::string>("ppsAssociationCutsLabel")))),
@@ -283,7 +289,10 @@ void CTPPSProtonReconstructionEfficiencyEstimatorData::fillDescriptions(edm::Con
   desc.add<edm::InputTag>("tagTracks", edm::InputTag())->setComment("input tag for local lite tracks");
   desc.add<edm::InputTag>("tagRecoProtonsMultiRP", edm::InputTag())->setComment("input tag for multi-RP reco protons");
 
-  desc.add<string>("lhcInfoLabel", "")->setComment("label of LHCInfo data");
+  desc.add<std::string>("lhcInfoLabel", "")->setComment("label of the LHCInfo record");
+  desc.add<std::string>("lhcInfoPerLSLabel", "")->setComment("label of the LHCInfoPerLS record");
+  desc.add<std::string>("lhcInfoPerFillLabel", "")->setComment("label of the LHCInfoPerFill record");
+  desc.add<bool>("useNewLHCInfo", false)->setComment("flag whether to use new LHCInfoPer* records or old LHCInfo");
   desc.add<string>("opticsLabel", "")->setComment("label of optics data");
   desc.add<string>("ppsAssociationCutsLabel", "")->setComment("label of PPSAssociationCuts data");
 
@@ -321,7 +330,8 @@ void CTPPSProtonReconstructionEfficiencyEstimatorData::analyze(const edm::Event 
   std::ostringstream os;
 
   // get conditions
-  const auto &lhcInfo = iSetup.getData(lhcInfoESToken_);
+  const LHCInfoCombined lhcInfoCombined(
+      iSetup, lhcInfoPerLSToken_, lhcInfoPerFillToken_, lhcInfoToken_, useNewLHCInfo_);
   const auto &opticalFunctions = iSetup.getData(opticsESToken_);
   const auto &ppsAssociationCuts = iSetup.getData(ppsAssociationCutsToken_);
 
@@ -660,8 +670,10 @@ void CTPPSProtonReconstructionEfficiencyEstimatorData::analyze(const edm::Event 
         evp.idx_N = i;
         evp.idx_F = j;
 
-        evp.x_cut = ass_cut.isSatisfied(ass_cut.qX, tr_i.x(), tr_i.y(), lhcInfo.crossingAngle(), tr_i.x() - tr_j.x());
-        evp.y_cut = ass_cut.isSatisfied(ass_cut.qY, tr_i.x(), tr_i.y(), lhcInfo.crossingAngle(), tr_i.y() - tr_j.y());
+        evp.x_cut =
+            ass_cut.isSatisfied(ass_cut.qX, tr_i.x(), tr_i.y(), lhcInfoCombined.crossingAngle(), tr_i.x() - tr_j.x());
+        evp.y_cut =
+            ass_cut.isSatisfied(ass_cut.qY, tr_i.x(), tr_i.y(), lhcInfoCombined.crossingAngle(), tr_i.y() - tr_j.y());
 
         evp.match = evp.x_cut && evp.y_cut;
 

--- a/Validation/CTPPS/python/ctppsHepMCDistributionPlotter_cff.py
+++ b/Validation/CTPPS/python/ctppsHepMCDistributionPlotter_cff.py
@@ -1,0 +1,8 @@
+from Validation.CTPPS.CTPPSHepMCDistributionPlotter_cfi import *
+
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(CTPPSHepMCDistributionPlotter, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(CTPPSHepMCDistributionPlotter, useNewLHCInfo = False)

--- a/Validation/CTPPS/python/ctppsLHCInfoPlotter_cff.py
+++ b/Validation/CTPPS/python/ctppsLHCInfoPlotter_cff.py
@@ -1,3 +1,7 @@
 from Validation.CTPPS.ctppsLHCInfoPlotter_cfi import *
+
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(ctppsLHCInfoPlotter, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsLHCInfoPlotter, useNewLHCInfo = False)

--- a/Validation/CTPPS/python/ctppsProtonReconstructionEfficiencyEstimatorData_cff.py
+++ b/Validation/CTPPS/python/ctppsProtonReconstructionEfficiencyEstimatorData_cff.py
@@ -1,0 +1,7 @@
+from Validation.CTPPS.ctppsProtonReconstructionEfficiencyEstimatorData_cfi import *
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(ctppsProtonReconstructionEfficiencyEstimatorData, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsProtonReconstructionEfficiencyEstimatorData, useNewLHCInfo = False)

--- a/Validation/CTPPS/python/ctppsProtonReconstructionEfficiencyEstimatorMC_cff.py
+++ b/Validation/CTPPS/python/ctppsProtonReconstructionEfficiencyEstimatorMC_cff.py
@@ -1,0 +1,7 @@
+from Validation.CTPPS.ctppsProtonReconstructionEfficiencyEstimatorMC_cfi import *
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(ctppsProtonReconstructionEfficiencyEstimatorMC, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsProtonReconstructionEfficiencyEstimatorMC, useNewLHCInfo = False)

--- a/Validation/CTPPS/python/ctppsProtonReconstructionSimulationValidator_cff.py
+++ b/Validation/CTPPS/python/ctppsProtonReconstructionSimulationValidator_cff.py
@@ -1,0 +1,7 @@
+from Validation.CTPPS.ctppsProtonReconstructionSimulationValidator_cfi import *
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(ctppsProtonReconstructionSimulationValidator, useNewLHCInfo = True)
+
+from Configuration.Eras.Modifier_ctpps_directSim_cff import ctpps_directSim
+ctpps_directSim.toModify(ctppsProtonReconstructionSimulationValidator, useNewLHCInfo = False)

--- a/Validation/CTPPS/test/simu/run_multiple
+++ b/Validation/CTPPS/test/simu/run_multiple
@@ -20,7 +20,8 @@ pids=""
 function RunOne()
 {
 	local config="$1"
-	local era="$2"
+	local era_mod_path="$2"
+	local era="$3"
 
 	local cfg="simu_${config}_cfg.py"
 	local log="simu_${config}.log"
@@ -29,6 +30,7 @@ function RunOne()
 	local out_protons="simu_${config}_protons.root"
 
 	cat "$inputDir/template_cfg.py" | sed "\
+			s|\$ERA_MOD_PATH|$era_mod_path|;\
 			s|\$ERA|$era|;\
 			s|\$CONFIG|$config|;\
 			s|\$N_EVENTS|$n_events|;\
@@ -43,13 +45,13 @@ function RunOne()
 
 #----------------------------------------------------------------------------------------------------
 
-RunOne "2016" "Run2_2016"
+RunOne "2016" "Configuration.Eras" "Run2_2016"
 
-RunOne "2017" "Run2_2017"
+RunOne "2017" "Configuration.Eras" "Run2_2017"
 
-RunOne "2018" "Run2_2018"
+RunOne "2018" "Configuration.Eras" "Run2_2018"
 
-RunOne "2022" "Run3"
+RunOne "2022" "Configuration.ProcessModifiers" "Run3_CTPPS_directSim"
 
 rc=0
 for pid in $pids

--- a/Validation/CTPPS/test/simu/template_cfg.py
+++ b/Validation/CTPPS/test/simu/template_cfg.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_$ERA_cff import *
+from $ERA_MOD_PATH.Era_$ERA_cff import *
 process = cms.Process('CTPPSTest', $ERA)
 
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
@@ -32,15 +32,8 @@ process.PoolDBESSource = cms.ESSource("PoolDBESSource",
     process.CondDB,
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('CTPPSPixelAnalysisMaskRcd'),
-        tag = cms.string("CTPPSPixelAnalysisMask_Run3_v1_hlt")),
-        cms.PSet(
-        record = cms.string('LHCInfoPerLSRcd'),
-        tag = cms.string("LHCInfoPerLS_endFill_Run3_mc_v1")),
-        cms.PSet(
-        record = cms.string('LHCInfoPerFillRcd'),
-        tag = cms.string("LHCInfoPerFill_endFill_Run3_mc_v1")),
-        )
-)
+        tag = cms.string("CTPPSPixelAnalysisMask_Run3_v1_hlt"))
+        ))
 
 # random seeds
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",


### PR DESCRIPTION
#### PR description:

A followup PR to https://github.com/cms-sw/cmssw/pull/42515 and a draft https://github.com/cms-sw/cmssw/pull/42890, this PR updates `Direct Simulation` to be able to use both old `LHCInfo` and new `LHCInfoPer*` records for possible future updates. 
Moreover it introduces a new Process Modifier `Run3_CTPPS_directSim` to be used when `Direct Simulation` is ran in Run3. This is needed because this simulation uses old `LHCInfo` no matter the run number. (In every other case modules ran in Run3 should be looking for new `LHCInfoPer*` records)


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

To validate please run Validation/CTPPS/test/simu/run_multiple

