### PR TITLE
Fix deprecated-copy warning in L1GtVhdlTemplateFile

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h
@@ -37,10 +37,6 @@ public:
   L1GtVhdlTemplateFile();
   /// constructor with filename
   L1GtVhdlTemplateFile(const std::string &filename);
-  /// copy constructor
-  L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs);
-  /// destructor
-  ~L1GtVhdlTemplateFile();
   /// replaces searchString with replaceString at it's first occurance in string
   static const bool findAndReplaceString(std::string &paramString,
                                          const std::string &searchString,

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlTemplateFile.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlTemplateFile.cc
@@ -34,18 +34,6 @@ L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const std::string &filename) {
     std::cout << "Error while opening file: " << filename << std::endl;
 }
 
-//copy constructor
-L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs) {
-  lines_ = rhs.lines_;
-  intern_ = rhs.intern_;
-  parameterMap_ = rhs.parameterMap_;
-}
-
-// destructor
-L1GtVhdlTemplateFile::~L1GtVhdlTemplateFile() {
-  // empty
-}
-
 const bool L1GtVhdlTemplateFile::findAndReplaceString(std::string &paramString,
                                                       const std::string &searchString,
                                                       const std::string &replaceString) {


### PR DESCRIPTION
#### PR description:

Fix deprecated-copy warnings ([rule-of-three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) violation) in L1TriggerConfig/L1GtConfigProducers:

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc: In member function 'L1GtVhdlTemplateFile L1GtVhdlWriterCore::openVhdlFileWithCommonHeader(const std::string&, const std::string&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc:892:20: warning: implicitly-declared 'L1GtVhdlTemplateFile& L1GtVhdlTemplateFile::operator=(const L1GtVhdlTemplateFile&)' is deprecated [-Wdeprecated-copy]
   892 |   commonHeaderCp = commonHeader_;
      |                    ^~~~~~~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriterCore.h:28,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc:16:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h:41:3: note: because 'L1GtVhdlTemplateFile' has user-provided 'L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile&)'
   41 |   L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs);
      |   ^~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc: In member function 'void L1GtVhdlWriterCore::writeMuonSetupVhdl(std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&, const std::string&, short unsigned int&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc:929:67: warning: implicitly-declared 'L1GtVhdlTemplateFile& L1GtVhdlTemplateFile::operator=(const L1GtVhdlTemplateFile&)' is deprecated [-Wdeprecated-copy]
   929 |   muonTemplate = openVhdlFileWithCommonHeader(filename, outputFile);
      |                                                                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h:41:3: note: because 'L1GtVhdlTemplateFile' has user-provided 'L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile&)'
   41 |   L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs);
      |   ^~~~~~~~~~~~~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc:946:28: warning: implicitly-declared 'L1GtVhdlTemplateFile& L1GtVhdlTemplateFile::operator=(const L1GtVhdlTemplateFile&)' is deprecated [-Wdeprecated-copy]
   946 |     internalTemplateCopy = internalTemplate;
      |                            ^~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h:41:3: note: because 'L1GtVhdlTemplateFile' has user-provided 'L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile&)'
   41 |   L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs);
      |   ^~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc: In member function 'void L1GtVhdlWriterCore::writeEtmSetup(std::string&, const int&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc:1078:63: warning: implicitly-declared 'L1GtVhdlTemplateFile& L1GtVhdlTemplateFile::operator=(const L1GtVhdlTemplateFile&)' is deprecated [-Wdeprecated-copy]
  1078 |   myTemplate = openVhdlFileWithCommonHeader(filename, filename);
      |                                                               ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlTemplateFile.h:41:3: note: because 'L1GtVhdlTemplateFile' has user-provided 'L1GtVhdlTemplateFile::L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile&)'
   41 |   L1GtVhdlTemplateFile(const L1GtVhdlTemplateFile &rhs);
      |   ^~~~~~~~~~~~~~~~~~~~
```

#### PR validation:

Bot tests