### PR TITLE
Fix deprecated-copy warnings in MagneticField/ParametrizedEngine

### DIFF
--- a/MagneticField/ParametrizedEngine/src/rz_harm_poly.h
+++ b/MagneticField/ParametrizedEngine/src/rz_harm_poly.h
@@ -17,7 +17,6 @@ namespace magfieldparam {
     double SinPhi;
 
     trig_pair() : CosPhi(1.), SinPhi(0.) {}
-    trig_pair(const trig_pair &tp) : CosPhi(tp.CosPhi), SinPhi(tp.SinPhi) {}
     trig_pair(const double C, const double S) : CosPhi(C), SinPhi(S) {}
     trig_pair(const double phi) : CosPhi(cos(phi)), SinPhi(sin(phi)) {}
 


### PR DESCRIPTION
#### PR description:

Fix deprecated-copy warnings ([rule-of-three](https://en.wikipedia.org/wiki/Rule_of_three_(C%2B%2B_programming)) violation) in MagneticField/ParametrizedEngine:

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc: In static member function 'static void magfieldparam::rz_harm_poly::SetTrigArrSize(unsigned int)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc:108:32: warning: implicitly-declared 'constexpr magfieldparam::trig_pair& magfieldparam::trig_pair::operator=(const magfieldparam::trig_pair&)' is deprecated [-Wdeprecated-copy]
   108 |   (*TrigArr) = trig_pair(1., 0.);
      |                                ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc:2:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.h:20:5: note: because 'magfieldparam::trig_pair' has user-provided 'magfieldparam::trig_pair::trig_pair(const magfieldparam::trig_pair&)'
   20 |     trig_pair(const trig_pair &tp) : CosPhi(tp.CosPhi), SinPhi(tp.SinPhi) {}
      |     ^~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc: In static member function 'static void magfieldparam::rz_harm_poly::FillTrigArr(double)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc:119:16: warning: implicitly-declared 'constexpr magfieldparam::trig_pair& magfieldparam::trig_pair::operator=(const magfieldparam::trig_pair&)' is deprecated [-Wdeprecated-copy]
   119 |   TrigArr[1] = tp;
      |                ^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.h:20:5: note: because 'magfieldparam::trig_pair' has user-provided 'magfieldparam::trig_pair::trig_pair(const magfieldparam::trig_pair&)'
   20 |     trig_pair(const trig_pair &tp) : CosPhi(tp.CosPhi), SinPhi(tp.SinPhi) {}
      |     ^~~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.cc:121:41: warning: implicitly-declared 'constexpr magfieldparam::trig_pair& magfieldparam::trig_pair::operator=(const magfieldparam::trig_pair&)' is deprecated [-Wdeprecated-copy]
   121 |     TrigArr[jp] = TrigArr[jp - 1].Add(tp);
      |                                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/MagneticField/ParametrizedEngine/src/rz_harm_poly.h:20:5: note: because 'magfieldparam::trig_pair' has user-provided 'magfieldparam::trig_pair::trig_pair(const magfieldparam::trig_pair&)'
   20 |     trig_pair(const trig_pair &tp) : CosPhi(tp.CosPhi), SinPhi(tp.SinPhi) {}
      |     ^~~~~~~~~
```

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
