### PR TITLE
Fix deprecated-copy warnings in MkFitCore

### DIFF
--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -393,8 +393,6 @@ namespace mkfit {
     Track(int charge, const SVector3& position, const SVector3& momentum, const SMatrixSym66& errors, float chi2)
         : TrackBase(charge, position, momentum, errors, chi2) {}
 
-    Track(const Track& t) : TrackBase(t), hitsOnTrk_(t.hitsOnTrk_) {}
-
     // This function is very inefficient, use only for debug and validation!
     HitVec hitsVector(const std::vector<HitVec>& globalHitVec) const {
       HitVec hitsVec;

--- a/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
@@ -56,11 +56,6 @@ namespace Matriplex {
     T& operator()(idx_t n, idx_t i, idx_t j) { return fArray[(i * D2 + j) * N + n]; }
     const T& operator()(idx_t n, idx_t i, idx_t j) const { return fArray[(i * D2 + j) * N + n]; }
 
-    Matriplex& operator=(const Matriplex& m) {
-      memcpy(fArray, m.fArray, sizeof(T) * kTotSize);
-      return *this;
-    }
-
     Matriplex& operator=(T t) {
       for (idx_t i = 0; i < kTotSize; ++i)
         fArray[i] = t;


### PR DESCRIPTION
#### PR description:

Fix deprecated-copy warnings in MkFitCore:
<details>
  <summary>Build log</summary>
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc: In function 'void mkfit::kalmanOperation(int, const MPlexLS&, const MPlexLV&, const MPlexHS&, const MPlexHV&, MPlexLS&, MPlexLV&, MPlexQF&, int)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:923:26: warning: implicitly-declared 'constexpr Matriplex::MatriplexSym<float, 6, 4>::MatriplexSym(const Matriplex::MatriplexSym<float, 6, 4>&)' is deprecated [-Wdeprecated-copy]
   923 |       MPlexLS psErrLoc = psErr;
      |                          ^~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matrix.h:27,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h:5,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:1:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h:76:19: note: because 'Matriplex::MatriplexSym<float, 6, 4>' has user-provided 'Matriplex::MatriplexSym<T, D, N>& Matriplex::MatriplexSym<T, D, N>::operator=(const Matriplex::MatriplexSym<T, D, N>&) [with T = float; int D = 6; int N = 4]'
   76 |     MatriplexSym& operator=(const MatriplexSym& m) {
      |                   ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc: In function 'void mkfit::kalmanOperationPlane(int, const MPlexLS&, const MPlexLV&, const MPlexHS&, const MPlexHV&, const MPlexHV&, const MPlexHV&, MPlexLS&, MPlexLV&, MPlexQF&, int)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc:1248:26: warning: implicitly-declared 'constexpr Matriplex::MatriplexSym<float, 6, 4>::MatriplexSym(const Matriplex::MatriplexSym<float, 6, 4>&)' is deprecated [-Wdeprecated-copy]
  1248 |       MPlexLS psErrLoc = psErr;
      |                          ^~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h:76:19: note: because 'Matriplex::MatriplexSym<float, 6, 4>' has user-provided 'Matriplex::MatriplexSym<T, D, N>& Matriplex::MatriplexSym<T, D, N>::operator=(const Matriplex::MatriplexSym<T, D, N>&) [with T = float; int D = 6; int N = 4]'
   76 |     MatriplexSym& operator=(const MatriplexSym& m) {
      |                   ^~~~~~~~
>> Compiling  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/radix_sort.cc
CMSSW_CPU_TYPE= /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DCMSSW_GIT_HASH='CMSSW_14_0_DEVEL_X_2023-11-26-2300' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_14_0_DEVEL_X_2023-11-26-2300' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.26.11-1ef575234f3b954353280f3578660947/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2021.9.0-e755918dac6a30ec36eff63ac4f7ddec/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/cms/vdt/0.4.3-5a80085534117eaccb28e669c6da4b6f/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/json/3.10.2-a6d86565b09ec3d0e02bf7b52c31bbfc/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Ofast -fno-reciprocal-math -mrecip=none -DBOOST_DISABLE_ASSERTS -fopenmp-simd -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr  -fPIC  -MMD -MF tmp/el8_amd64_gcc12/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/radix_sort.cc.d /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/radix_sort.cc -o tmp/el8_amd64_gcc12/src/RecoTracker/MkFitCore/src/RecoTrackerMkFitCore/radix_sort.cc.o
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:1:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h: In constructor 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(const mkfit::MPlexLV&, const mkfit::mini_propagators::MPI&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:64:97: warning: implicitly-declared 'constexpr Matriplex::Matriplex<int, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<int, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    64 |         : InitialStatePlex(StatePlex(par), chg, par.ReduceFixedIJ(3, 0), par.ReduceFixedIJ(5, 0)) {}
      |                                                                                                 ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h:5,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matrix.h:27,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:6:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<int, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = int; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:66:39: note:   initializing argument 2 of 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(mkfit::mini_propagators::StatePlex, mkfit::mini_propagators::MPI, mkfit::mini_propagators::MPF, mkfit::mini_propagators::MPF, float)'
   66 |     InitialStatePlex(StatePlex s, MPI charge, MPF ipt, MPF tht, float bf = Config::Bfield)
      |                                   ~~~~^~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h: In constructor 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(mkfit::mini_propagators::StatePlex, mkfit::mini_propagators::MPI, mkfit::mini_propagators::MPF, mkfit::mini_propagators::MPF, float)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:67:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    67 |         : StatePlex(s), inv_pt(ipt), theta(tht) {
      |                         ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:67:38: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    67 |         : StatePlex(s), inv_pt(ipt), theta(tht) {
      |                                      ^~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc: In function 'mkfit::mini_propagators::MPF mkfit::mini_propagators::fast_atan2(const MPF&, const MPF&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:114:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   114 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc: In function 'mkfit::mini_propagators::MPF mkfit::mini_propagators::fast_tan(const MPF&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:122:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   122 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc: In member function 'int mkfit::mini_propagators::InitialStatePlex::propagate_to_r(mkfit::mini_propagators::PropAlgo_e, const mkfit::mini_propagators::MPF&, mkfit::mini_propagators::StatePlex&, bool, int) const':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:186:24: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   186 |           MPF o_px = c.px;  // copy before overwriting
      |                        ^~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::Matriplex<T, 1, 1, N> Matriplex::Matriplex<T, D1, D2, N>::ReduceFixedIJ(Matriplex::idx_t, Matriplex::idx_t) const [with T = float; int D1 = 6; int D2 = 1; int N = 4; Matriplex::idx_t = int]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:64:66:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:309:14: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   309 |       return t;
      |              ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator/(T, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:135:49:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:401:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   401 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator/(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:139:47:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:343:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   343 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:345:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   345 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator*(T, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:155:33:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:394:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   394 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator*(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:155:41:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:336:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   336 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:338:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   338 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::hypot(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:166:36:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:419:24: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   419 |     return t.hypot(a, b);
      |                        ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator-(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:167:25:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:329:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   329 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:331:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   331 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator+(T, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:168:62:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:380:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   380 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator-(T, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:183:52:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:387:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   387 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator+(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.cc:184:56:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:322:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   322 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:324:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   324 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkBuilder.cc: In lambda function:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkBuilder.cc:445:23: warning: implicitly-declared 'mkfit::Track& mkfit::Track::operator=(const mkfit::Track&)' is deprecated [-Wdeprecated-copy]
   445 |       m_tracks[pos] = seed;
      |                       ^~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/interface/TrackStructures.h:6,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/interface/MkBuilder.h:6,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkBuilder.cc:7:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/interface/Track.h:396:5: note: because 'mkfit::Track' has user-provided 'mkfit::Track::Track(const mkfit::Track&)'
  396 |     Track(const Track& t) : TrackBase(t), hitsOnTrk_(t.hitsOnTrk_) {}
      |     ^~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:9:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h: In constructor 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(const mkfit::MPlexLV&, const mkfit::mini_propagators::MPI&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:64:97: warning: implicitly-declared 'constexpr Matriplex::Matriplex<int, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<int, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    64 |         : InitialStatePlex(StatePlex(par), chg, par.ReduceFixedIJ(3, 0), par.ReduceFixedIJ(5, 0)) {}
      |                                                                                                 ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h:5,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matrix.h:27,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkBase.h:4,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.h:4,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:1:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<int, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = int; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:66:39: note:   initializing argument 2 of 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(mkfit::mini_propagators::StatePlex, mkfit::mini_propagators::MPI, mkfit::mini_propagators::MPF, mkfit::mini_propagators::MPF, float)'
   66 |     InitialStatePlex(StatePlex s, MPI charge, MPF ipt, MPF tht, float bf = Config::Bfield)
      |                                   ~~~~^~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h: In constructor 'mkfit::mini_propagators::InitialStatePlex::InitialStatePlex(mkfit::mini_propagators::StatePlex, mkfit::mini_propagators::MPI, mkfit::mini_propagators::MPF, mkfit::mini_propagators::MPF, float)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:67:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    67 |         : StatePlex(s), inv_pt(ipt), theta(tht) {
      |                         ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:67:38: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
    67 |         : StatePlex(s), inv_pt(ipt), theta(tht) {
      |                                      ^~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc: In member function 'void mkfit::MkFinder::findCandidates(const mkfit::LayerOfHits&, std::vector<std::vector<mkfit::TrackCand, std::allocator<mkfit::TrackCand> > >&, int, int, const mkfit::FindingFoos&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:1343:26: warning: implicitly-declared 'constexpr Matriplex::Matriplex<int, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<int, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
  1343 |         MPlexQI tmpChg = m_Chg;
      |                          ^~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<int, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = int; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::Matriplex<T, 1, 1, N> Matriplex::Matriplex<T, D1, D2, N>::ReduceFixedIJ(Matriplex::idx_t, Matriplex::idx_t) const [with T = float; int D1 = 6; int D2 = 1; int N = 4; Matriplex::idx_t = int]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MiniPropagators.h:64:66:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:309:14: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   309 |       return t;
      |              ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator-(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:810:29:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:329:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   329 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:331:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   331 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator+(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:811:32:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:322:25: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   322 |     MPlex<T, D1, D2, N> t = a;
      |                         ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:324:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   324 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::operator*(T, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:811:36:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:394:12: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   394 |     return t;
      |            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h: In instantiation of 'Matriplex::MPlex<T, D1, D2, N> Matriplex::hypot(MPlex<T, D1, D2, N>&, MPlex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4; MPlex<T, D1, D2, N> = Matriplex<float, 1, 1, 4>]':
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/MkFinder.cc:828:46:   required from here
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:419:24: warning: implicitly-declared 'constexpr Matriplex::Matriplex<float, 1, 1, 4>::Matriplex(const Matriplex::Matriplex<float, 1, 1, 4>&)' is deprecated [-Wdeprecated-copy]
   419 |     return t.hypot(a, b);
      |                        ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/36ee15c53d3074956fb6548fe912a5bd/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-26-2300/src/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h:59:16: note: because 'Matriplex::Matriplex<float, 1, 1, 4>' has user-provided 'Matriplex::Matriplex<T, D1, D2, N>& Matriplex::Matriplex<T, D1, D2, N>::operator=(const Matriplex::Matriplex<T, D1, D2, N>&) [with T = float; int D1 = 1; int D2 = 1; int N = 4]'
   59 |     Matriplex& operator=(const Matriplex& m) {
      |                ^~~~~~~~
```
</details>
#### PR validation:

Bot tests
