### PR TITLE
[14_0_X SIM] Update FTFP_BERT_EMN physics

### DIFF
--- a/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h
+++ b/SimG4Core/PhysicsLists/interface/CMSEmStandardPhysicsXS.h
@@ -30,6 +30,7 @@ private:
   G4double fSafetyFactor;
   G4double fLambdaLimit;
   G4MscStepLimitType fStepLimitType;
+  bool fG4HepEmActive;
 };
 
 #endif

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMN.cc
@@ -8,6 +8,7 @@
 #include "G4IonPhysics.hh"
 #include "G4StoppingPhysics.hh"
 #include "G4HadronElasticPhysics.hh"
+#include "G4HadronicParameters.hh"
 
 FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) {
   int ver = p.getUntrackedParameter<int>("Verbosity", 0);
@@ -28,12 +29,25 @@ FTFPCMS_BERT_EMN::FTFPCMS_BERT_EMN(const edm::ParameterSet& p) : PhysicsList(p) 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
     RegisterPhysics(gn);
+    bool mu = p.getParameter<bool>("G4MuonPairProductionByMuon");
+    gn->MuonToMuMu(mu);
+    edm::LogVerbatim("PhysicsList") << " Muon pair production by muons: " << mu;
   }
 
   // Decays
   this->RegisterPhysics(new G4DecayPhysics(ver));
 
   if (hadPhys) {
+    bool ngen = p.getParameter<bool>("G4NeutronGeneralProcess");
+    bool bc = p.getParameter<bool>("G4BCHadronicProcess");
+    bool hn = p.getParameter<bool>("G4LightHyperNucleiTracking");
+    auto param = G4HadronicParameters::Instance();
+    param->SetEnableNeutronGeneralProcess(ngen);
+    param->SetEnableBCParticles(bc);
+    param->SetEnableHyperNuclei(hn);
+    edm::LogVerbatim("PhysicsList") << " Eneble neutron general process: " << ngen
+                                    << "\n Enable b- and c- hadron physics: " << bc
+                                    << "\n Enable light hyper-nuclei physics: " << hn;
     // Hadron Elastic scattering
     RegisterPhysics(new G4HadronElasticPhysics(ver));
 

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -4,13 +4,13 @@
 
 #include "G4SystemOfUnits.hh"
 #include "G4ParticleDefinition.hh"
+#include "G4LossTableManager.hh"
 #include "G4EmParameters.hh"
 #include "G4EmBuilder.hh"
 
 #include "G4ComptonScattering.hh"
 #include "G4GammaConversion.hh"
 #include "G4PhotoElectricEffect.hh"
-#include "G4LivermorePhotoElectricModel.hh"
 
 #include "G4MscStepLimitType.hh"
 
@@ -37,14 +37,12 @@
 #include "G4PhysicsListHelper.hh"
 #include "G4BuilderType.hh"
 #include "G4GammaGeneralProcess.hh"
-#include "G4LossTableManager.hh"
 
 #include "G4ProcessManager.hh"
 #include "G4TransportationWithMsc.hh"
 
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
-#include <string>
 
 CMSEmStandardPhysics::CMSEmStandardPhysics(G4int ver, const edm::ParameterSet& p)
     : G4VPhysicsConstructor("CMSEmStandard_emm") {
@@ -136,8 +134,6 @@ void CMSEmStandardPhysics::ConstructProcess() {
   // e-
   particle = G4Electron::Electron();
 
-  G4eIonisation* eioni = new G4eIonisation();
-
   G4UrbanMscModel* msc1 = new G4UrbanMscModel();
   G4WentzelVIModel* msc2 = new G4WentzelVIModel();
   msc1->SetHighEnergyLimit(highEnergyLimit);
@@ -203,13 +199,12 @@ void CMSEmStandardPhysics::ConstructProcess() {
   ssm->SetLowEnergyLimit(highEnergyLimit);
   ssm->SetActivationLowEnergyLimit(highEnergyLimit);
 
-  ph->RegisterProcess(eioni, particle);
+  ph->RegisterProcess(new G4eIonisation(), particle);
   ph->RegisterProcess(new G4eBremsstrahlung(), particle);
   ph->RegisterProcess(ss, particle);
 
   // e+
   particle = G4Positron::Positron();
-  eioni = new G4eIonisation();
 
   msc1 = new G4UrbanMscModel();
   msc2 = new G4WentzelVIModel();
@@ -274,7 +269,7 @@ void CMSEmStandardPhysics::ConstructProcess() {
   ssm->SetLowEnergyLimit(highEnergyLimit);
   ssm->SetActivationLowEnergyLimit(highEnergyLimit);
 
-  ph->RegisterProcess(eioni, particle);
+  ph->RegisterProcess(new G4eIonisation(), particle);
   ph->RegisterProcess(new G4eBremsstrahlung(), particle);
   ph->RegisterProcess(new G4eplusAnnihilation(), particle);
   ph->RegisterProcess(ss, particle);


### PR DESCRIPTION
#### PR description:
Geant4 Physics List FTFP_BERT_EMN is designed in order to provide more accurate simulation of Phase-2 CMS. In this PR this Physics List is updated to be coherent with CMS default FTFP_BERT_EMM. G4HepEm option is added. This PR should not affect any WF.

Estimated CPU speed-up for Phase-2 with FTFP_BERT_EMN physics 10-20% depending on WF.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

