### PR TITLE
[CORE] [DEVEL] Fix warnings on deprecated copy-constructors

### DIFF
--- a/Utilities/General/test/test_precomputed_value_sort.cpp
+++ b/Utilities/General/test/test_precomputed_value_sort.cpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <iostream>
 #include <cmath>
+#include <cassert>
 
 using namespace std;
 
@@ -66,6 +67,30 @@ int main() {
   v1.push_back(Point(-5.12, 0.321));
   v1.push_back(Point(-5.12, -0.321));
 
+  vector<float> r;
+  r.reserve(v1.size());
+  vector<float> phi;
+  phi.reserve(v1.size());
+  for (vector<Point>::iterator i = v1.begin(); i != v1.end(); ++i) {
+    r.push_back(i->r());
+    phi.push_back(i->phi());
+  }
+  std::sort(r.begin(), r.end());
+  std::sort(phi.begin(), phi.end());
+
+  cout << endl;
+  cout << "Sorted R's:" << endl;
+  for (size_t i = 0; i < r.size(); i++) {
+    cout << r[i] << endl;
+  }
+
+  cout << endl;
+  cout << "Sorted Phi's:" << endl;
+  for (size_t i = 0; i < phi.size(); i++) {
+    cout << phi[i] << endl;
+  }
+  cout << endl;
+
   // A vector of pointer to Points
   vector<Point*> v2;
   for (vector<Point>::iterator i = v1.begin(); i != v1.end(); ++i) {
@@ -84,30 +109,45 @@ int main() {
   cout << "Sorted with ExtractR1 : " << endl;
   copy(v1.begin(), v1.end(), ostream_iterator<Point>(cout, "\n"));
   cout << endl;
+  for (size_t i = 0; i < r.size(); i++) {
+    assert(v1[i].r() == r[i]);
+  }
 
   // Sort v2
   cout << "Sorted with ExtractR2: " << endl;
   precomputed_value_sort(v2.begin(), v2.end(), extractR2);
   copy(v2.begin(), v2.end(), ostream_iterator<Point*>(cout, "\n"));
   cout << endl;
+  for (size_t i = 0; i < r.size(); i++) {
+    assert(v2[i]->r() == r[i]);
+  }
 
   // Sort v3 using a BinaryPredicate
   cout << "Sort with LessR: " << endl;
   precomputed_value_sort(v3.begin(), v3.end(), extractR2, lessR);
   copy(v3.begin(), v3.end(), ostream_iterator<Point*>(cout, "\n"));
   cout << endl;
+  for (size_t i = 0; i < r.size(); i++) {
+    assert(v3[i]->r() == r[i]);
+  }
 
-  // Sort v3 using phi
+  // Sort v2 using phi
   cout << "Sort with ExtractPhi2: " << endl;
-  precomputed_value_sort(v3.begin(), v3.end(), extractPhi2);
-  copy(v3.begin(), v3.end(), ostream_iterator<Point*>(cout, "\n"));
+  precomputed_value_sort(v2.begin(), v2.end(), extractPhi2);
+  copy(v2.begin(), v2.end(), ostream_iterator<Point*>(cout, "\n"));
   cout << endl;
+  for (size_t i = 0; i < phi.size(); i++) {
+    assert(v2[i]->phi() == phi[i]);
+  }
 
   // Sort v3 using a BinaryPredicate
   cout << "Sort with LessDPhi: " << endl;
   precomputed_value_sort(v3.begin(), v3.end(), extractPhi2, lessDPhi);
   copy(v3.begin(), v3.end(), ostream_iterator<Point*>(cout, "\n"));
   cout << endl;
+  for (size_t i = 0; i < phi.size(); i++) {
+    assert(v3[i]->phi() == phi[i]);
+  }
 
   return 0;
 }

--- a/Utilities/General/test/test_precomputed_value_sort.cpp
+++ b/Utilities/General/test/test_precomputed_value_sort.cpp
@@ -23,7 +23,6 @@ private:
 class Point {
 public:
   Point(float x = 0, float y = 0);
-  Point(const Point& p);
   float r() const { return sqrt(X * X + Y * Y); }
   Phi phi() const { return Phi(atan2(Y, X)); }
   float X, Y;
@@ -36,8 +35,6 @@ ostream& operator<<(ostream& o, const Point& p) {
 ostream& operator<<(ostream& o, const Point* p) { return o << *p; }
 
 Point::Point(float x, float y) : X(x), Y(y) { cout << "New Point" << *this << endl; }
-
-Point::Point(const Point& p) : X(p.X), Y(p.Y) { cout << "New Point (copy)" << *this << endl; }
 
 // A trivial operation on Point
 float extractR1(const Point& p) { return p.r(); }


### PR DESCRIPTION
Fixes deprecated warnings for DEVEL IBs.
Updated `test_precomputed_value_sort` to actually compare the results and fail in case of unexpected results.