### PR TITLE
[ALCA] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/CalibCalorimetry/EcalPedestalOffsets/interface/TSinglePedEntry.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/TSinglePedEntry.h
@@ -12,13 +12,6 @@
 
 class TSinglePedEntry {
 public:
-  //! ctor
-  TSinglePedEntry();
-  //! copy ctor
-  TSinglePedEntry(const TSinglePedEntry &orig);
-  //! dtor
-  ~TSinglePedEntry();
-
   //! add a single value
   void insert(const int &pedestal);
   //! get the average of the inserted values

--- a/CalibCalorimetry/EcalPedestalOffsets/src/TSinglePedEntry.cc
+++ b/CalibCalorimetry/EcalPedestalOffsets/src/TSinglePedEntry.cc
@@ -3,18 +3,6 @@
 #include <cmath>
 #include <iostream>
 
-TSinglePedEntry::TSinglePedEntry() : m_pedestalSqSum(0), m_pedestalSum(0), m_entries(0) {
-  //  std::cout << "[TSinglePedEntry][ctor]" << std::endl ;
-}
-
-TSinglePedEntry::~TSinglePedEntry() {}
-
-TSinglePedEntry::TSinglePedEntry(const TSinglePedEntry &orig) {
-  m_pedestalSqSum = orig.m_pedestalSqSum;
-  m_pedestalSum = orig.m_pedestalSum;
-  m_entries = orig.m_entries;
-}
-
 void TSinglePedEntry::insert(const int &pedestal) {
   m_pedestalSqSum += pedestal * pedestal;
   m_pedestalSum += pedestal;

--- a/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
@@ -27,13 +27,13 @@ public:
   SiStripHashedDetId(const std::vector<DetId> &);
 
   /** Copy constructor. */
-  SiStripHashedDetId(const SiStripHashedDetId &);
+  SiStripHashedDetId(const SiStripHashedDetId &) = default;
 
   /** Public default constructor. */
-  SiStripHashedDetId();
+  SiStripHashedDetId() = default;
 
   /** Default destructor. */
-  ~SiStripHashedDetId();
+  ~SiStripHashedDetId() = default;
 
   // ---------- typedefs ----------
 

--- a/CalibFormats/SiStripObjects/src/SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripHashedDetId.cc
@@ -33,30 +33,6 @@ SiStripHashedDetId::SiStripHashedDetId(const std::vector<DetId> &det_ids) : detI
 
 // -----------------------------------------------------------------------------
 //
-SiStripHashedDetId::SiStripHashedDetId(const SiStripHashedDetId &input) : detIds_(), id_(0), iter_(detIds_.begin()) {
-  LogTrace(mlCabling_) << "[SiStripHashedDetId::" << __func__ << "]"
-                       << " Constructing object...";
-  detIds_.reserve(input.end() - input.begin());
-  std::copy(input.begin(), input.end(), detIds_.begin());
-}
-
-// -----------------------------------------------------------------------------
-//
-SiStripHashedDetId::SiStripHashedDetId() : detIds_(), id_(0), iter_(detIds_.begin()) {
-  LogTrace(mlCabling_) << "[SiStripHashedDetId::" << __func__ << "]"
-                       << " Constructing object...";
-}
-
-// -----------------------------------------------------------------------------
-//
-SiStripHashedDetId::~SiStripHashedDetId() {
-  LogTrace(mlCabling_) << "[SiStripHashedDetId::" << __func__ << "]"
-                       << " Destructing object...";
-  detIds_.clear();
-}
-
-// -----------------------------------------------------------------------------
-//
 void SiStripHashedDetId::init(const std::vector<uint32_t> &raw_ids) {
   detIds_.clear();
   detIds_.reserve(16000);


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on some ALCA modules.

Thanks,
Andrea