### PR TITLE
[DQM] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_HistoDef.h
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_HistoDef.h
@@ -73,6 +73,11 @@ namespace cscdqm {
     HistoDef(const HistoId p_id) : id(p_id) {}
 
     /**
+       * @brief  Copy constructor
+       */
+    HistoDef(const HistoDef&) = default;
+
+    /**
        * @brief  Base virtual destructor
        */
     virtual ~HistoDef() {}

--- a/DQM/HcalCommon/interface/ContainerXXX.h
+++ b/DQM/HcalCommon/interface/ContainerXXX.h
@@ -22,6 +22,7 @@ namespace hcaldqm {
     ContainerXXX() {}
     ContainerXXX(hashfunctions::HashType ht) : _hashmap(ht) {}
     ContainerXXX(ContainerXXX const &x);
+    ContainerXXX& operator=(const ContainerXXX& other) = default;
     virtual ~ContainerXXX() { _cmap.clear(); }
 
     //  initialize, booking. booking is done from Electronicsmap.

--- a/DQM/HcalCommon/interface/ContainerXXX.h
+++ b/DQM/HcalCommon/interface/ContainerXXX.h
@@ -22,7 +22,7 @@ namespace hcaldqm {
     ContainerXXX() {}
     ContainerXXX(hashfunctions::HashType ht) : _hashmap(ht) {}
     ContainerXXX(ContainerXXX const &x);
-    ContainerXXX& operator=(const ContainerXXX& other) = default;
+    ContainerXXX &operator=(const ContainerXXX &other) = default;
     virtual ~ContainerXXX() { _cmap.clear(); }
 
     //  initialize, booking. booking is done from Electronicsmap.

--- a/DQM/TrackerRemapper/interface/mat4.h
+++ b/DQM/TrackerRemapper/interface/mat4.h
@@ -46,6 +46,8 @@ public:
       data[i] = mat[i];
   }
 
+  mat4& operator=(const mat4& mat) = default;
+
   mat4& operator&(const mat4& mat) {
     if (this != &mat) {
       for (unsigned i = 0; i < 12; ++i)


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on some DQM modules.

Thanks,
Andrea