### PR TITLE
[ALCA][DB] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -28,7 +28,6 @@ namespace PhysicsTools {
 
     class BitSet {
     public:
-
       std::vector<unsigned char> store;
       unsigned int bitsInLast;
 

--- a/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
+++ b/CondFormats/PhysicsToolsObjects/interface/MVAComputer.h
@@ -28,12 +28,6 @@ namespace PhysicsTools {
 
     class BitSet {
     public:
-      // help that poor ROOT to copy bitsets... (workaround)
-      BitSet &operator=(const BitSet &other) {
-        store = other.store;
-        bitsInLast = other.bitsInLast;
-        return *this;
-      }
 
       std::vector<unsigned char> store;
       unsigned int bitsInLast;

--- a/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
@@ -56,10 +56,6 @@ public:
   typedef Container InputVector;
 
   SiStripBadStrip(){};
-  SiStripBadStrip(const SiStripBadStrip& orig) {
-    v_badstrips = orig.v_badstrips;
-    indexes = orig.indexes;
-  }
   virtual ~SiStripBadStrip(){};
 
   bool put(const uint32_t& detID, const InputVector& vect) { return put(detID, Range(vect.begin(), vect.end())); }

--- a/CondFormats/SiStripObjects/interface/SiStripNoises.h
+++ b/CondFormats/SiStripObjects/interface/SiStripNoises.h
@@ -49,7 +49,6 @@ public:
   typedef Registry::const_iterator RegistryIterator;
   typedef std::vector<uint16_t> InputVector;
 
-  SiStripNoises(const SiStripNoises&);
   SiStripNoises() {}
   ~SiStripNoises() {}
 

--- a/CondFormats/SiStripObjects/src/SiStripNoises.cc
+++ b/CondFormats/SiStripObjects/src/SiStripNoises.cc
@@ -6,13 +6,6 @@
 #include <iomanip>
 #include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
 
-SiStripNoises::SiStripNoises(const SiStripNoises& input) {
-  v_noises.clear();
-  indexes.clear();
-  v_noises.insert(v_noises.end(), input.v_noises.begin(), input.v_noises.end());
-  indexes.insert(indexes.end(), input.indexes.begin(), input.indexes.end());
-}
-
 bool SiStripNoises::put(const uint32_t& DetId, const InputVector& input) {
   std::vector<unsigned char> Vo_CHAR;
   encode(input, Vo_CHAR);


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on some ALCA-DB modules.

Thanks,
Andrea