### PR TITLE
[RECONSTRUCTION] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/CommonTools/Utils/interface/PdgIdSelector.h
+++ b/CommonTools/Utils/interface/PdgIdSelector.h
@@ -17,6 +17,7 @@ struct PdgIdSelector {
     end_ = pdgId_.end();
   }
   PdgIdSelector(const PdgIdSelector& o) : pdgId_(o.pdgId_), begin_(pdgId_.begin()), end_(pdgId_.end()) {}
+  PdgIdSelector& operator=(const PdgIdSelector& o) = default;
   PdgIdSelector& operator==(const PdgIdSelector& o) {
     *this = o;
     return *this;

--- a/CommonTools/Utils/interface/StatusSelector.h
+++ b/CommonTools/Utils/interface/StatusSelector.h
@@ -17,6 +17,7 @@ struct StatusSelector {
     end_ = status_.end();
   }
   StatusSelector(const StatusSelector& o) : status_(o.status_), begin_(status_.begin()), end_(status_.end()) {}
+  StatusSelector& operator=(const StatusSelector& o) = default;
   StatusSelector& operator==(const StatusSelector& o) {
     *this = o;
     return *this;


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on `CommonTools/Utils` module. In this case, the approach is to define the assignment operator to fulfill the rule of three.

Thanks,
Andrea