### PR TITLE
[L1][DQM] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TMuonDQMOffline.h
@@ -188,6 +188,7 @@ class MuonGmtPair {
 public:
   MuonGmtPair(const reco::Muon* muon, const l1t::Muon* regMu, const PropagateToMuon& propagator, bool useAtVtxCoord);
   MuonGmtPair(const MuonGmtPair& muonGmtPair);
+  MuonGmtPair& operator=(const MuonGmtPair& muonGmtPair) = default;
   ~MuonGmtPair(){};
 
   double dR();

--- a/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TPhase2MuonOffline.h
@@ -137,6 +137,7 @@ class GenMuonGMTPair {
 public:
   GenMuonGMTPair(const reco::GenParticle* mu, const l1t::L1Candidate* gmtmu);
   GenMuonGMTPair(const GenMuonGMTPair& muongmtPair);
+  GenMuonGMTPair& operator=(const GenMuonGMTPair& muongmtPair) = default;
   ~GenMuonGMTPair(){};
 
   float dR2();

--- a/DQMOffline/L1Trigger/interface/L1TTauOffline.h
+++ b/DQMOffline/L1Trigger/interface/L1TTauOffline.h
@@ -56,7 +56,7 @@ public:
       : m_tau(tau), m_regTau(regTau), m_eta(999.), m_phi_bar(999.), m_phi_end(999.){};
 
   TauL1TPair(const TauL1TPair& tauL1tPair);
-
+  TauL1TPair& operator=(const TauL1TPair& tauL1tPair) = default;
   ~TauL1TPair(){};
 
   double dR();


### PR DESCRIPTION
Hello,

This PR solves the DEVEL warnings on deprecated copy-constructors present in the IBs on the `DQMOffline/L1Trigger` module.

Thanks,
Andrea
