### PR TITLE
[SIMULATION] Fix DEVEL warnings on assignment operator implicitly defined

### DIFF
--- a/DataFormats/MuonDetId/interface/DTBtiId.h
+++ b/DataFormats/MuonDetId/interface/DTBtiId.h
@@ -48,6 +48,9 @@ public:
   ///  Constructor
   DTBtiId(const DTBtiId& btiId) : _suplId(btiId._suplId), _bti(btiId._bti) {}
 
+  // Assignment Operator
+  DTBtiId& operator=(const DTBtiId& btiId) = default;
+
   /// Destructor
   virtual ~DTBtiId() {}
 

--- a/DataFormats/MuonDetId/interface/DTChamberId.h
+++ b/DataFormats/MuonDetId/interface/DTChamberId.h
@@ -35,6 +35,9 @@ public:
   /// this, no check is done on the vaildity of the values.
   DTChamberId(const DTChamberId& chId);
 
+  /// Assignment Operator.
+  DTChamberId& operator=(const DTChamberId& chId) = default;
+
   /// Return the wheel number
   int wheel() const { return int((id_ >> wheelStartBit_) & wheelMask_) + minWheelId - 1; }
 

--- a/DataFormats/MuonDetId/interface/DTLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTLayerId.h
@@ -32,6 +32,9 @@ public:
   /// this, no check is done on the vaildity of the values.
   DTLayerId(const DTLayerId& layerId);
 
+  /// Assignment Operator.
+  DTLayerId& operator=(const DTLayerId& layerId) = default;
+
   /// Constructor from a camberId and SL and layer numbers
   DTLayerId(const DTChamberId& chId, int superlayer, int layer);
 

--- a/DataFormats/MuonDetId/interface/DTSuperLayerId.h
+++ b/DataFormats/MuonDetId/interface/DTSuperLayerId.h
@@ -32,6 +32,9 @@ public:
   /// this, no check is done on the vaildity of the values.
   DTSuperLayerId(const DTSuperLayerId& slId);
 
+  /// Assignment Operator.
+  DTSuperLayerId& operator=(const DTSuperLayerId& slId) = default;
+
   /// Constructor from a DTChamberId and SL number.
   DTSuperLayerId(const DTChamberId& chId, int superlayer);
 

--- a/DataFormats/MuonDetId/interface/DTTracoId.h
+++ b/DataFormats/MuonDetId/interface/DTTracoId.h
@@ -46,6 +46,9 @@ public:
   ///  Constructor
   DTTracoId(const DTTracoId& tracoId) : _statId(tracoId._statId), _traco(tracoId._traco) {}
 
+  // Assignment Operator
+  DTTracoId& operator=(const DTTracoId& tracoId) = default;
+
   /// Destructor
   virtual ~DTTracoId() {}
 

--- a/DataFormats/MuonDetId/interface/DTWireId.h
+++ b/DataFormats/MuonDetId/interface/DTWireId.h
@@ -29,6 +29,9 @@ public:
   /// Copy Constructor.
   DTWireId(const DTWireId& wireId);
 
+  /// Assignment Operator.
+  DTWireId& operator=(const DTWireId& wireId) = default;
+
   /// Constructor from a CamberId and SL, layer and wire numbers
   DTWireId(const DTChamberId& chId, int superlayer, int layer, int wire);
 


### PR DESCRIPTION
Hello,

This PR defines assignment operators to fix DEVEL warnings on assignment operator implicitly defined:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82f6b430b79423c634bfd066ffbab3c6/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-27-2300/src/DataFormats/MuonDetId/test/testDTDetIds.cc: In member function 'void testDTDetIds::testMemberOperators()':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82f6b430b79423c634bfd066ffbab3c6/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-27-2300/src/DataFormats/MuonDetId/test/testDTDetIds.cc:298:14: warning: implicitly-declared 'constexpr DTChamberId& DTChamberId::operator=(const DTChamberId&)' is deprecated [-Wdeprecated-copy]
   298 |   chamber2 = chamber1;
      |              ^~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82f6b430b79423c634bfd066ffbab3c6/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-27-2300/src/DataFormats/MuonDetId/test/testDTDetIds.cc:12:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/82f6b430b79423c634bfd066ffbab3c6/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-27-2300/src/DataFormats/MuonDetId/interface/DTChamberId.h:36:3: note: because 'DTChamberId' has user-provided 'DTChamberId::DTChamberId(const DTChamberId&)'
   36 |   DTChamberId(const DTChamberId& chId);
      |   ^~~~~~~~~~~
```
They are present in the IBs on the `DataFormats/MuonDetId` module. It is a different approach for https://github.com/cms-sw/cmssw/pull/43381 where unit test `testMuonDetId` failed due to assignment errors.
Thanks,
Andrea
