### PR TITLE
[13.3.X] remove HLT tracking and vertexing validation harvesting from phase-2 exclusion modifier 

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidationHarvest_cff.py
@@ -42,9 +42,7 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 # Temporary Phase-2 configuration
 # Exclude everything except JetMET for now
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([postProcessorHLTtrackingSequence,
-                                                                                 postProcessorHLTvertexing,
-                                                                                 HLTMuonPostVal,
+phase2_common.toReplaceWith(hltpostvalidation, hltpostvalidation.copyAndExclude([HLTMuonPostVal,
                                                                                  HLTTauPostVal,
                                                                                  EgammaPostVal,
                                                                                  postProcessorHLTgsfTrackingSequence,


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43330

#### PR description:

Title says it all, address https://github.com/cms-sw/cmssw/issues/39362#issuecomment-1818476705

#### PR validation:

`runTheMatrix.py -l 24834.0 -t 4 -j 8 --ibeos` runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/43330 to 13.3.X
