### PR TITLE
[ALCA] Fix copy-constructor warnings reported in DEVEL IBs

### DIFF
--- a/CalibCalorimetry/EcalPedestalOffsets/interface/TSinglePedEntry.h
+++ b/CalibCalorimetry/EcalPedestalOffsets/interface/TSinglePedEntry.h
@@ -15,12 +15,14 @@ public:
   //! ctor
   TSinglePedEntry();
   //! copy ctor
-  TSinglePedEntry(const TSinglePedEntry &orig);
+  TSinglePedEntry(const TSinglePedEntry& orig);
+  //! assignment op
+  TSinglePedEntry& operator=(const TSinglePedEntry& orig) = default;
   //! dtor
   ~TSinglePedEntry();
 
   //! add a single value
-  void insert(const int &pedestal);
+  void insert(const int& pedestal);
   //! get the average of the inserted values
   double average() const;
   //! get the RMS of the inserted values

--- a/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
@@ -29,6 +29,9 @@ public:
   /** Copy constructor. */
   SiStripHashedDetId(const SiStripHashedDetId &);
 
+  /** Assignment operator. */
+  SiStripHashedDetId &operator=(const SiStripHashedDetId &) = default;
+
   /** Public default constructor. */
   SiStripHashedDetId();
 


### PR DESCRIPTION
Hello,

This PR follows up on the discussion started at https://github.com/cms-sw/cmssw/pull/43408.
I am defining the missing assignment operators to fulfill the rule of three (see https://github.com/cms-sw/cmssw/pull/43408#issuecomment-1829333134) to avoid missing initializations (see https://github.com/cms-sw/cmssw/pull/43408#discussion_r1407565529)

Thanks!