### PR TITLE
[GEM] Update for GEM pulse stretching simulation and minor bug fix

### DIFF
--- a/CondFormats/GEMObjects/interface/GEMChMap.h
+++ b/CondFormats/GEMObjects/interface/GEMChMap.h
@@ -46,7 +46,13 @@ public:
   struct chamDC {
     uint32_t detId;
     int chamberType;
-    bool operator<(const chamDC& r) const { return detId < r.detId; }
+    bool operator<(const chamDC& r) const {
+      if (detId == r.detId) {
+        return chamberType < r.chamberType;
+      } else {
+        return detId < r.detId;
+      }
+    }
 
     COND_SERIALIZABLE;
   };

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -39,13 +39,13 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  int event_type_;
-  int minBunch_;
-  int maxBunch_;
-  edm::EDGetTokenT<GEMDigiCollection> digi_token;
+  const int event_type_;
+  const int minBunch_;
+  const int maxBunch_;
+  const edm::EDGetTokenT<GEMDigiCollection> digiToken_;
   edm::ESGetToken<GEMChMap, GEMChMapRcd> gemChMapToken_;
-  bool useDBEMap_;
-  bool simulatePulseStretching_;
+  const bool useDBEMap_;
+  const bool simulatePulseStretching_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -55,7 +55,7 @@ GEMDigiToRawModule::GEMDigiToRawModule(const edm::ParameterSet& pset)
     : event_type_(pset.getParameter<int>("eventType")),
       minBunch_(pset.getParameter<int>("minBunch")),
       maxBunch_(pset.getParameter<int>("maxBunch")),
-      digi_token(consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("gemDigi"))),
+      digiToken_(consumes<GEMDigiCollection>(pset.getParameter<edm::InputTag>("gemDigi"))),
       useDBEMap_(pset.getParameter<bool>("useDBEMap")),
       simulatePulseStretching_(pset.getParameter<bool>("simulatePulseStretching")) {
   produces<FEDRawDataCollection>();
@@ -95,7 +95,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
   auto fedRawDataCol = std::make_unique<FEDRawDataCollection>();
 
   edm::Handle<GEMDigiCollection> gemDigis;
-  iEvent.getByToken(digi_token, gemDigis);
+  iEvent.getByToken(digiToken_, gemDigis);
   if (!gemDigis.isValid()) {
     iEvent.put(std::move(fedRawDataCol));
     return;

--- a/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/gemPacker_cfi.py
@@ -6,6 +6,6 @@ from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
-run2_GEM_2017.toModify(gemPacker, useDBEMap = True)
-run3_GEM.toModify(gemPacker, useDBEMap = True)
-phase2_GEM.toModify(gemPacker, useDBEMap = False)
+run2_GEM_2017.toModify(gemPacker, useDBEMap = True, simulatePulseStretching = False)
+run3_GEM.toModify(gemPacker, useDBEMap = True, simulatePulseStretching = True)
+phase2_GEM.toModify(gemPacker, useDBEMap = False, simulatePulseStretching = False)

--- a/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
+++ b/SimMuon/GEMDigitizer/plugins/GEMDigiProducer.cc
@@ -84,7 +84,7 @@ void GEMDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<std::string>("mixLabel", "mix");
 
   desc.add<double>("signalPropagationSpeed", 0.66);
-  desc.add<double>("timeResolution", 5.);
+  desc.add<double>("timeResolution", 18.);
   desc.add<double>("timeJitter", 1.0);
   desc.add<double>("averageShapingTime", 50.0);
   desc.add<double>("averageEfficiency", 0.98);
@@ -104,7 +104,6 @@ void GEMDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<bool>("simulateElectronBkg", true);
   // flase == simulate only neutral bkg
   desc.add<bool>("simulateIntrinsicNoise", false);
-  desc.add<bool>("bx0filter", false);
 
   desc.add<double>("instLumi", 7.5);
   // in units of 1E34 cm^-2 s^-1. Internally the background is parmetrized from FLUKA+GEANT result at 5E+34 (PU 140). We are adding a 1.5 factor for PU 200

--- a/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
+++ b/SimMuon/GEMDigitizer/python/muonGEMDigis_cfi.py
@@ -7,10 +7,10 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(simMuonGEMDigis, mixLabel = "mixData")
 
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
-run2_common.toModify( simMuonGEMDigis, instLumi = 1.5, bx0filter = True)
+run2_common.toModify( simMuonGEMDigis, instLumi = 1.5)
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify( simMuonGEMDigis, instLumi = 2.0, bx0filter = True)
+run3_common.toModify( simMuonGEMDigis, instLumi = 2.0)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify( simMuonGEMDigis, instLumi = 5, bx0filter = False)
+phase2_common.toModify( simMuonGEMDigis, instLumi = 5)

--- a/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSignalModel.cc
@@ -20,7 +20,6 @@ GEMSignalModel::GEMSignalModel(const edm::ParameterSet& config)
       timeResolution_(config.getParameter<double>("timeResolution")),
       timeJitter_(config.getParameter<double>("timeJitter")),
       signalPropagationSpeed_(config.getParameter<double>("signalPropagationSpeed")),
-      bx0filter_(config.getParameter<bool>("bx0filter")),
       resolutionX_(config.getParameter<double>("resolutionX")),
       cspeed(geant_units::operators::convertMmToCm(CLHEP::c_light)),
       // average energy required to remove an electron due to ionization for an Ar/CO2 gas mixture (in the ratio of 70/30) is 28.1 eV
@@ -38,8 +37,6 @@ void GEMSignalModel::simulate(const GEMEtaPartition* roll,
     if (hit.energyLoss() < energyMinCut)
       continue;
     const int bx(getSimHitBx(&hit, engine));
-    if (bx != 0 and bx0filter_)
-      continue;
     const std::vector<std::pair<int, int> >& cluster(simulateClustering(top, &hit, bx, engine));
     for (const auto& digi : cluster) {
       detectorHitMap_.emplace(digi, &hit);


### PR DESCRIPTION
#### PR description:

##### Update on GEM digitization simulation
* Changing the time resolution of `GEMDigi` for the trigger primitive study
* Removing `bx0filter` for the GEM digitization simulation
* Adding pulse stretching simulation on the GEM packer (8bx time window for Run3)
* We are expecting some changes on the GEM related objects because we extended 25 ns time window to 200 ns time window on Run 3 & Run 2 scenario

##### Bug Fix
* Add missing comparator for `GEMChMap::ChamDC`

#### PR validation:

* The code format has applied with `scram build code-format` and tested with `scram build code-checks`
* The branch has tested with the following commands to check if it works in Run3 or Phase 2 scenarios
```
runTheMatrix.py -l 12450.0
runTheMatrix.py -l 26850.0
```