### PR TITLE
[13.3.X] fix HLT track collection for SiStrip at HLT monitoring

### DIFF
--- a/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py
@@ -215,26 +215,24 @@ hltESPFittingSmootherIT = cms.ESProducer( "KFFittingSmootherESProducer",
   RejectTracks = cms.bool( True )
 )
 
-
-
 from DQMOffline.Trigger.SiStrip_OfflineMonitoring_cff import *
-hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBWithTrackAngle')
-hltTrackRefitterForSiStripMonitorTrack.Propagator              = cms.string('hltESPRungeKuttaTrackerPropagator')
-hltTrackRefitterForSiStripMonitorTrack.Fitter                  = cms.string('hltESPFittingSmootherIT')
-hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = cms.InputTag('hltMeasurementTrackerEvent')
-hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = cms.string('navigationSchoolESProducer')
-hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltTracksMerged") # hltIter2Merged
+hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = 'hltESPTTRHBWithTrackAngle'
+hltTrackRefitterForSiStripMonitorTrack.Propagator              = 'hltESPRungeKuttaTrackerPropagator'
+hltTrackRefitterForSiStripMonitorTrack.Fitter                  = 'hltESPFittingSmootherIT'
+hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = 'hltMeasurementTrackerEvent'
+hltTrackRefitterForSiStripMonitorTrack.NavigationSchool        = 'navigationSchoolESProducer'
+hltTrackRefitterForSiStripMonitorTrack.src                     = 'hltMergedTracks' # hltIter2Merged
 
-HLTSiStripMonitorTrack.TopFolderName = cms.string('HLT/SiStrip')
+HLTSiStripMonitorTrack.TopFolderName = 'HLT/SiStrip'
 HLTSiStripMonitorTrack.TrackProducer = 'hltTrackRefitterForSiStripMonitorTrack'
 HLTSiStripMonitorTrack.TrackLabel    = ''
-HLTSiStripMonitorTrack.Cluster_src   = cms.InputTag('hltSiStripRawToClustersFacility')
-HLTSiStripMonitorTrack.AlgoName      = cms.string("HLT")
-HLTSiStripMonitorTrack.Trend_On      = cms.bool(True)
-HLTSiStripMonitorTrack.Mod_On        = cms.bool(False)
-HLTSiStripMonitorTrack.OffHisto_On   = cms.bool(True)
-HLTSiStripMonitorTrack.HistoFlag_On  = cms.bool(False)
-HLTSiStripMonitorTrack.TkHistoMap_On = cms.bool(False)
+HLTSiStripMonitorTrack.Cluster_src   = 'hltSiStripRawToClustersFacility'
+HLTSiStripMonitorTrack.AlgoName      = 'HLT'
+HLTSiStripMonitorTrack.Trend_On      = True
+HLTSiStripMonitorTrack.Mod_On        = False
+HLTSiStripMonitorTrack.OffHisto_On   = True
+HLTSiStripMonitorTrack.HistoFlag_On  = False
+HLTSiStripMonitorTrack.TkHistoMap_On = False
 
 HLTSiStripMonitorClusterAPVgainCalibration = HLTSiStripMonitorCluster.clone()
 from DQM.TrackingMonitorSource.pset4GenericTriggerEventFlag_cfi import *

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -12,7 +12,7 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 trackingMonitoringHLTsequence = cms.Sequence(
     pixelTracksMonitoringHLT # hltPixel tracks monitoring
     * iter2MergedTracksMonitoringHLT # hltIter2Merged tracks monitoring    
-    * iterHLTTracksMonitoringHLT # hltTracksMerged tracks monitoring
+    * iterHLTTracksMonitoringHLT # hltMergedTracks tracks monitoring
 )
 
 egmTrackingMonitorHLTsequence = cms.Sequence(


### PR DESCRIPTION
backport of #43385

#### PR description:

I casually noticed that in online DQM HLT on-track SiStrip quantities are empty (see e.g. [here](https://cmsweb.cern.ch/dqm/online-playback/start?runnr=0;dataset=/Global/Online/ALL;sampletype=live;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=HLT/SiStrip/MechanicalView/TOB;focus=HLT/SiStrip/MechanicalView/TOB/Summary_ClusterCharge_OnTrack__TOB;zoom=yes;)), while reviewing the TSG ticket [CMSHLT-2766](https://its.cern.ch/jira/browse/CMSHLT-2766).
I think this is due to the fact that in the configuration file an not-existent track collection (`hltTracksMerged` instead of `hltMergedTracks`) is passed to the track refitter:

https://github.com/cms-sw/cmssw/blob/c4e98e96b39f8ac58da0b14d9b63db2f554a09e0/DQM/HLTEvF/python/HLTSiStripMonitoring_cff.py#L226

I fix this here, while also removing where possible redundant cms type specifications

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #43385