### PR TITLE
fix primary vertex source for HLT tracking monitoring for Phase-2 / HIon

### DIFF
--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -29,11 +29,13 @@ pixelTracksMonitoringHLT = trackingMonHLT.clone(
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 pp_on_PbPb_run3.toModify(pixelTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltPixelTracksPPOnAA',
                          allTrackProducer = 'hltPixelTracksPPOnAA')
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(pixelTracksMonitoringHLT,
+                        primaryVertex    = 'hltPhase2PixelVertices',
                         TrackProducer    = 'hltPhase2PixelTracks',
                         allTrackProducer = 'hltPhase2PixelTracks')
 
@@ -107,12 +109,14 @@ iterHLTTracksMonitoringHLT = trackingMonHLT.clone(
 )
 
 pp_on_PbPb_run3.toModify(iterHLTTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltMergedTracksPPOnAA',
                          allTrackProducer = 'hltMergedTracksPPOnAA')
 
 phase2_tracker.toModify(iterHLTTracksMonitoringHLT,
-                        TrackProducer    = cms.InputTag("generalTracks","","HLT"),
-                        allTrackProducer = cms.InputTag("generalTracks","","HLT"))
+                        primaryVertex    = 'hltPhase2PixelVertices',
+                        TrackProducer    = 'generalTracks::HLT',
+                        allTrackProducer = 'generalTracks::HLT')
 
 iter3TracksMonitoringHLT = trackingMonHLT.clone(
     FolderName       = 'HLT/Tracking/iter3Merged',
@@ -157,6 +161,7 @@ doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
 )
 
 pp_on_PbPb_run3.toModify(doubletRecoveryHPTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA',
                          allTrackProducer = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA')
 


### PR DESCRIPTION
#### PR description:

In the process of the alca validation [CMSALCA-240](https://its.cern.ch/jira/browse/CMSALCA-240) it was noticed that the track IP wrt PV plots are empty (e.g. https://tinyurl.com/yru69pww). 
This is due to a leftover customization that was forgotten at https://github.com/cms-sw/cmssw/pull/43141. 
Coincidentally I notice that also the Phase-2 customization introduced back then in https://github.com/cms-sw/cmssw/pull/42783 was not taking the different name of the pixel PV collection.
Both are fixed here. I profit of the PR to drop the cms type specification as generally required.

#### PR validation:

Run successfully `runTheMatrix.py -l 142.0,24834.0 -t 4 -j 8 --ibeos` and checked that the empty plots are now filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but could be backported (at least to 13.3.X)