### PR TITLE
Build CaloParticles and introduce LC associations in the barrel for Phase2

### DIFF
--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -85,8 +85,8 @@ private:
   const edm::EDGetTokenT<std::vector<SimCluster>> simclusters_token_;
   const edm::EDGetTokenT<std::vector<CaloParticle>> caloparticles_token_;
 
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimClusterToReco_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollection> associatorMapCaloParticleToReco_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionWithSimClusters> associatorMapSimClusterToReco_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollection> associatorMapCaloParticleToReco_token_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geom_token_;
   hgcal::RecHitTools rhtools_;
   const float fractionCut_;

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -103,16 +103,16 @@ private:
   const edm::EDGetTokenT<std::vector<ticl::Trackster>> simTracksters_CP_token_;
   const edm::EDGetTokenT<std::vector<ticl::Trackster>> simTracksters_PU_token_;
   const edm::EDGetTokenT<std::vector<TICLCandidate>> simTICLCandidate_token_;
-  const edm::EDGetTokenT<hgcal::RecoToSimCollectionSimTracksters> tsRecoToSimSC_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionSimTracksters> tsSimToRecoSC_token_;
-  const edm::EDGetTokenT<hgcal::RecoToSimCollectionSimTracksters> tsRecoToSimCP_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionSimTracksters> tsSimToRecoCP_token_;
-  const edm::EDGetTokenT<hgcal::RecoToSimCollectionSimTracksters> MergeRecoToSimSC_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionSimTracksters> MergeSimToRecoSC_token_;
-  const edm::EDGetTokenT<hgcal::RecoToSimCollectionSimTracksters> MergeRecoToSimCP_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionSimTracksters> MergeSimToRecoCP_token_;
-  const edm::EDGetTokenT<hgcal::RecoToSimCollectionSimTracksters> MergeRecoToSimPU_token_;
-  const edm::EDGetTokenT<hgcal::SimToRecoCollectionSimTracksters> MergeSimToRecoPU_token_;
+  const edm::EDGetTokenT<ticl::RecoToSimCollectionSimTracksters> tsRecoToSimSC_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionSimTracksters> tsSimToRecoSC_token_;
+  const edm::EDGetTokenT<ticl::RecoToSimCollectionSimTracksters> tsRecoToSimCP_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionSimTracksters> tsSimToRecoCP_token_;
+  const edm::EDGetTokenT<ticl::RecoToSimCollectionSimTracksters> MergeRecoToSimSC_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionSimTracksters> MergeSimToRecoSC_token_;
+  const edm::EDGetTokenT<ticl::RecoToSimCollectionSimTracksters> MergeRecoToSimCP_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionSimTracksters> MergeSimToRecoCP_token_;
+  const edm::EDGetTokenT<ticl::RecoToSimCollectionSimTracksters> MergeRecoToSimPU_token_;
+  const edm::EDGetTokenT<ticl::SimToRecoCollectionSimTracksters> MergeSimToRecoPU_token_;
   const edm::EDGetTokenT<std::vector<SimCluster>> simclusters_token_;
   const edm::EDGetTokenT<std::vector<CaloParticle>> caloparticles_token_;
 
@@ -739,24 +739,24 @@ TICLDumper::TICLDumper(const edm::ParameterSet& ps)
       simTICLCandidate_token_(
           consumes<std::vector<TICLCandidate>>(ps.getParameter<edm::InputTag>("simTICLCandidates"))),
       tsRecoToSimSC_token_(
-          consumes<hgcal::RecoToSimCollectionSimTracksters>(ps.getParameter<edm::InputTag>("recoToSimAssociatorSC"))),
+          consumes<ticl::RecoToSimCollectionSimTracksters>(ps.getParameter<edm::InputTag>("recoToSimAssociatorSC"))),
       tsSimToRecoSC_token_(
-          consumes<hgcal::SimToRecoCollectionSimTracksters>(ps.getParameter<edm::InputTag>("simToRecoAssociatorSC"))),
+          consumes<ticl::SimToRecoCollectionSimTracksters>(ps.getParameter<edm::InputTag>("simToRecoAssociatorSC"))),
       tsRecoToSimCP_token_(
-          consumes<hgcal::RecoToSimCollectionSimTracksters>(ps.getParameter<edm::InputTag>("recoToSimAssociatorCP"))),
+          consumes<ticl::RecoToSimCollectionSimTracksters>(ps.getParameter<edm::InputTag>("recoToSimAssociatorCP"))),
       tsSimToRecoCP_token_(
-          consumes<hgcal::SimToRecoCollectionSimTracksters>(ps.getParameter<edm::InputTag>("simToRecoAssociatorCP"))),
-      MergeRecoToSimSC_token_(consumes<hgcal::RecoToSimCollectionSimTracksters>(
+          consumes<ticl::SimToRecoCollectionSimTracksters>(ps.getParameter<edm::InputTag>("simToRecoAssociatorCP"))),
+      MergeRecoToSimSC_token_(consumes<ticl::RecoToSimCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergerecoToSimAssociatorSC"))),
-      MergeSimToRecoSC_token_(consumes<hgcal::SimToRecoCollectionSimTracksters>(
+      MergeSimToRecoSC_token_(consumes<ticl::SimToRecoCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergesimToRecoAssociatorSC"))),
-      MergeRecoToSimCP_token_(consumes<hgcal::RecoToSimCollectionSimTracksters>(
+      MergeRecoToSimCP_token_(consumes<ticl::RecoToSimCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergerecoToSimAssociatorCP"))),
-      MergeSimToRecoCP_token_(consumes<hgcal::SimToRecoCollectionSimTracksters>(
+      MergeSimToRecoCP_token_(consumes<ticl::SimToRecoCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergesimToRecoAssociatorCP"))),
-      MergeRecoToSimPU_token_(consumes<hgcal::RecoToSimCollectionSimTracksters>(
+      MergeRecoToSimPU_token_(consumes<ticl::RecoToSimCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergerecoToSimAssociatorPU"))),
-      MergeSimToRecoPU_token_(consumes<hgcal::SimToRecoCollectionSimTracksters>(
+      MergeSimToRecoPU_token_(consumes<ticl::SimToRecoCollectionSimTracksters>(
           ps.getParameter<edm::InputTag>("MergesimToRecoAssociatorPU"))),
       simclusters_token_(consumes(ps.getParameter<edm::InputTag>("simclusters"))),
       caloparticles_token_(consumes(ps.getParameter<edm::InputTag>("caloparticles"))),
@@ -1198,51 +1198,51 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
   const auto& simTICLCandidates = *simTICLCandidates_h;
 
   // trackster reco to sim SC
-  edm::Handle<hgcal::RecoToSimCollectionSimTracksters> tsRecoToSimSC_h;
+  edm::Handle<ticl::RecoToSimCollectionSimTracksters> tsRecoToSimSC_h;
   event.getByToken(tsRecoToSimSC_token_, tsRecoToSimSC_h);
   auto const& tsRecoSimSCMap = *tsRecoToSimSC_h;
 
   // sim simTrackster SC to reco trackster
-  edm::Handle<hgcal::SimToRecoCollectionSimTracksters> tsSimToRecoSC_h;
+  edm::Handle<ticl::SimToRecoCollectionSimTracksters> tsSimToRecoSC_h;
   event.getByToken(tsSimToRecoSC_token_, tsSimToRecoSC_h);
   auto const& tsSimToRecoSCMap = *tsSimToRecoSC_h;
 
   // trackster reco to sim CP
-  edm::Handle<hgcal::RecoToSimCollectionSimTracksters> tsRecoToSimCP_h;
+  edm::Handle<ticl::RecoToSimCollectionSimTracksters> tsRecoToSimCP_h;
   event.getByToken(tsRecoToSimCP_token_, tsRecoToSimCP_h);
   auto const& tsRecoSimCPMap = *tsRecoToSimCP_h;
 
   // sim simTrackster CP to reco trackster
-  edm::Handle<hgcal::SimToRecoCollectionSimTracksters> tsSimToRecoCP_h;
+  edm::Handle<ticl::SimToRecoCollectionSimTracksters> tsSimToRecoCP_h;
   event.getByToken(tsSimToRecoCP_token_, tsSimToRecoCP_h);
   auto const& tsSimToRecoCPMap = *tsSimToRecoCP_h;
 
-  edm::Handle<hgcal::RecoToSimCollectionSimTracksters> mergetsRecoToSimSC_h;
+  edm::Handle<ticl::RecoToSimCollectionSimTracksters> mergetsRecoToSimSC_h;
   event.getByToken(MergeRecoToSimSC_token_, mergetsRecoToSimSC_h);
   auto const& MergetsRecoSimSCMap = *mergetsRecoToSimSC_h;
 
   // sim simTrackster SC to reco trackster
-  edm::Handle<hgcal::SimToRecoCollectionSimTracksters> mergetsSimToRecoSC_h;
+  edm::Handle<ticl::SimToRecoCollectionSimTracksters> mergetsSimToRecoSC_h;
   event.getByToken(MergeSimToRecoSC_token_, mergetsSimToRecoSC_h);
   auto const& MergetsSimToRecoSCMap = *mergetsSimToRecoSC_h;
 
   // trackster reco to sim CP
-  edm::Handle<hgcal::RecoToSimCollectionSimTracksters> mergetsRecoToSimCP_h;
+  edm::Handle<ticl::RecoToSimCollectionSimTracksters> mergetsRecoToSimCP_h;
   event.getByToken(MergeRecoToSimCP_token_, mergetsRecoToSimCP_h);
   auto const& MergetsRecoSimCPMap = *mergetsRecoToSimCP_h;
 
   // sim simTrackster CP to reco trackster
-  edm::Handle<hgcal::SimToRecoCollectionSimTracksters> mergetsSimToRecoCP_h;
+  edm::Handle<ticl::SimToRecoCollectionSimTracksters> mergetsSimToRecoCP_h;
   event.getByToken(MergeSimToRecoCP_token_, mergetsSimToRecoCP_h);
   auto const& MergetsSimToRecoCPMap = *mergetsSimToRecoCP_h;
 
   // trackster reco to sim PU
-  edm::Handle<hgcal::RecoToSimCollectionSimTracksters> mergetsRecoToSimPU_h;
+  edm::Handle<ticl::RecoToSimCollectionSimTracksters> mergetsRecoToSimPU_h;
   event.getByToken(MergeRecoToSimPU_token_, mergetsRecoToSimPU_h);
   auto const& MergetsRecoSimPUMap = *mergetsRecoToSimPU_h;
 
   // sim simTrackster PU to reco trackster
-  edm::Handle<hgcal::SimToRecoCollectionSimTracksters> mergetsSimToRecoPU_h;
+  edm::Handle<ticl::SimToRecoCollectionSimTracksters> mergetsSimToRecoPU_h;
   event.getByToken(MergeSimToRecoPU_token_, mergetsSimToRecoPU_h);
   auto const& MergetsSimToRecoPUMap = *mergetsSimToRecoPU_h;
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreImpl.cc
@@ -1,0 +1,280 @@
+#include "BarrelLCToCPAssociatorByEnergyScoreImpl.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+
+#include "SimCalorimetry/HGCalAssociatorProducers/interface/AssociatorTools.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+
+BarrelLCToCPAssociatorByEnergyScoreImpl::BarrelLCToCPAssociatorByEnergyScoreImpl(
+    edm::EDProductGetter const& productGetter,
+    bool hardScatterOnly,
+    const std::unordered_map<DetId, const reco::PFRecHit*>* hitMap)
+    : hardScatterOnly_(hardScatterOnly), hitMap_(hitMap), productGetter_(&productGetter) {
+  layers_ = 6;
+}
+
+ticl::association BarrelLCToCPAssociatorByEnergyScoreImpl::makeConnections(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
+  const auto& clusters = *cCCH.product();
+  const auto& caloParticles = *cPCH.product();
+  auto nLayerClusters = clusters.size();
+
+  std::vector<size_t> cPIndices;
+  removeCPFromPU(caloParticles, cPIndices, hardScatterOnly_);
+  auto nCaloParticles = cPIndices.size();
+
+  ticl::caloParticleToLayerCluster cPOnLayer;
+  cPOnLayer.resize(nCaloParticles);
+  for (unsigned int i = 0; i < nCaloParticles; ++i) {
+    cPOnLayer[i].resize(layers_);
+    for (unsigned int j = 0; j < layers_; ++j) {
+      cPOnLayer[i][j].caloParticleId = i;
+      cPOnLayer[i][j].energy = 0.f;
+      cPOnLayer[i][j].hits_and_fractions.clear();
+    }
+  }
+
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToCaloParticleId_Map;
+  for (const auto& cpId : cPIndices) {
+    const SimClusterRefVector& simClusterRefVector = caloParticles[cpId].simClusters();
+    for (const auto& it_sc : simClusterRefVector) {
+      const SimCluster& simCluster = (*(it_sc));
+      const auto& hits_and_fractions = simCluster.hits_and_fractions();
+      for (const auto& it_haf : hits_and_fractions) {
+        const auto hitid = (it_haf.first);
+        DetId hitId(hitid);
+        int cpLayerId = 0;
+        if (hitId.det() == DetId::Hcal)
+          cpLayerId = (HcalDetId(hitid)).depth();
+        else if (hitId.subdetId() == HcalSubdetector::HcalOuter)
+          cpLayerId = (HcalDetId(hitid)).depth() + 1;
+        const auto itcheck = hitMap_->find(hitid);
+        if (itcheck != hitMap_->end()) {
+          auto hit_find_it = detIdToCaloParticleId_Map.find(hitid);
+          if (hit_find_it == detIdToCaloParticleId_Map.end()) {
+            detIdToCaloParticleId_Map[hitid] = std::vector<ticl::detIdInfoInCluster>();
+            detIdToCaloParticleId_Map[hitid].emplace_back(cpId, it_haf.second);
+          } else {
+            auto findHitIt = std::find(detIdToCaloParticleId_Map[hitid].begin(),
+                                       detIdToCaloParticleId_Map[hitid].end(),
+                                       ticl::detIdInfoInCluster{cpId, it_haf.second});
+            if (findHitIt != detIdToCaloParticleId_Map[hitid].end()) {
+              findHitIt->fraction += it_haf.second;
+            } else {
+              detIdToCaloParticleId_Map[hitid].emplace_back(cpId, it_haf.second);
+            }
+          }
+          const reco::PFRecHit* hit = itcheck->second;
+          cPOnLayer[cpId][cpLayerId].energy += it_haf.second * hit->energy();
+          auto& haf = cPOnLayer[cpId][cpLayerId].hits_and_fractions;
+          auto found = std::find_if(
+              std::begin(haf), std::end(haf), [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
+          if (found != haf.end()) {
+            found->second += it_haf.second;
+          } else {
+            cPOnLayer[cpId][cpLayerId].hits_and_fractions.emplace_back(hitid, it_haf.second);
+          }
+        }
+      }
+    }
+  }
+
+#ifdef EDM_ML_DEBUG
+  LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "cPOnLayer INFO" << std::endl;
+  for (size_t cp = 0; cp < cPOnLayer.size(); ++cp) {
+    LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "For CaloParticle Idx: " << cp << " we have: " << std::endl;
+    for (size_t cpp = 0; cpp < cPOnLayer[cp].size(); ++cpp) {
+      LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "  On Layer: " << cpp << " we have:" << std::endl;
+      LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl")
+          << "    CaloParticleIdx: " << cPOnLayer[cp][cpp].caloParticleId << std::endl;
+      LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl")
+          << "    Energy:          " << cPOnLayer[cp][cpp].energy << std::endl;
+      double tot_energy = 0.;
+      for (auto const& haf : cPOnLayer[cp][cpp].hits_and_fractions) {
+        LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl")
+            << "      Hits/fraction/energy: " << (uint32_t)haf.first << "/" << haf.second << "/"
+            << haf.second * hitMap_->at(haf.first)->energy() << std::endl;
+        tot_energy += haf.second * hitMap_->at(haf.first)->energy();
+      }
+      LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "    Tot Sum haf: " << tot_energy << std::endl;
+      for (auto const& lc : cPOnLayer[cp][cpp].layerClusterIdToEnergyAndScore) {
+        LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "      lcIdx/energy/score: " << lc.first << "/"
+                                                            << lc.second.first << "/" << lc.second.second << std::endl;
+      }
+    }
+  }
+
+  LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl") << "detIdToCaloParticleId_Map INFO" << std::endl;
+  for (auto const& cp : detIdToCaloParticleId_Map) {
+    LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl")
+        << "For detId: " << (uint32_t)cp.first
+        << " we have found the following connections with CaloParticles:" << std::endl;
+    for (auto const& cpp : cp.second) {
+      LogDebug("BarrelLCToCPAssociatorByEnergyScoreImpl")
+          << "  CaloParticle Id: " << cpp.clusterId << " with fraction: " << cpp.fraction
+          << " and energy: " << cpp.fraction * hitMap_->at(cp.first)->energy() << std::endl;
+    }
+  }
+#endif
+
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  ticl::layerClusterToCaloParticle cpsInLayerCluster;
+  cpsInLayerCluster.resize(nLayerClusters);
+
+  for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
+    const std::vector<std::pair<DetId, float>>& hits_and_fractions = clusters[lcId].hitsAndFractions();
+    unsigned int numberOfHitInLC = hits_and_fractions.size();
+    const auto firstHitDetId = hits_and_fractions[0].first;
+    int lcLayerId = 0;
+    if (firstHitDetId.det() == DetId::Hcal)
+      lcLayerId = (HcalDetId(firstHitDetId)).depth();
+    else if (firstHitDetId.subdetId() == HcalSubdetector::HcalOuter)
+      lcLayerId = (HcalDetId(firstHitDetId)).depth() + 1;
+
+    for (unsigned int hitId = 0; hitId < numberOfHitInLC; ++hitId) {
+      const auto rh_detid = hits_and_fractions[hitId].first;
+      const auto rhFraction = hits_and_fractions[hitId].second;
+
+      auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
+      if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
+        detIdToLayerClusterId_Map[rh_detid] = std::vector<ticl::detIdInfoInCluster>();
+      }
+      detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
+
+      auto hit_find_in_CP = detIdToCaloParticleId_Map.find(rh_detid);
+
+      if (hit_find_in_CP != detIdToCaloParticleId_Map.end()) {
+        const auto itcheck = hitMap_->find(rh_detid);
+        const reco::PFRecHit* hit = itcheck->second;
+        for (auto& h : hit_find_in_CP->second) {
+          cPOnLayer[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[lcId].first += h.fraction * hit->energy();
+          cpsInLayerCluster[lcId].emplace_back(h.clusterId, 0.f);
+        }
+      }
+    }
+  }
+
+  for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
+    std::sort(cpsInLayerCluster[lcId].begin(), cpsInLayerCluster[lcId].end());
+    auto last = std::unique(cpsInLayerCluster[lcId].begin(), cpsInLayerCluster[lcId].end());
+    cpsInLayerCluster[lcId].erase(last, cpsInLayerCluster[lcId].end());
+    const auto& hits_and_fractions = clusters[lcId].hitsAndFractions();
+    unsigned int numberOfHitsInLC = hits_and_fractions.size();
+
+    if (clusters[lcId].energy() == 0. && !cpsInLayerCluster[lcId].empty()) {
+      for (auto& cpPair : cpsInLayerCluster[lcId]) {
+        cpPair.second = 1.;
+      }
+      continue;
+    }
+
+    float invLayerClusterEnergyWeight = 0.f;
+    for (auto const& haf : hits_and_fractions) {
+      invLayerClusterEnergyWeight +=
+          (haf.second * hitMap_->at(haf.first)->energy()) * (haf.second * hitMap_->at(haf.first)->energy());
+    }
+    invLayerClusterEnergyWeight = 1.f / invLayerClusterEnergyWeight;
+    for (unsigned int i = 0; i < numberOfHitsInLC; ++i) {
+      DetId rh_detid = hits_and_fractions[i].first;
+      float rhFraction = hits_and_fractions[i].second;
+
+      bool hitWithNoCP = (detIdToCaloParticleId_Map.find(rh_detid) == detIdToCaloParticleId_Map.end());
+
+      auto itcheck = hitMap_->find(rh_detid);
+      const reco::PFRecHit* hit = itcheck->second;
+      float hitEnergyWeight = hit->energy() * hit->energy();
+
+      for (auto& cpPair : cpsInLayerCluster[lcId]) {
+        float cpFraction = 0.f;
+        if (!hitWithNoCP) {
+          auto findHitIt = std::find(detIdToCaloParticleId_Map[rh_detid].begin(),
+                                     detIdToCaloParticleId_Map[rh_detid].end(),
+                                     ticl::detIdInfoInCluster{cpPair.first, 0.f});
+          if (findHitIt != detIdToCaloParticleId_Map[rh_detid].end())
+            cpFraction = findHitIt->fraction;
+        }
+        cpPair.second += std::min(std::pow(rhFraction - cpFraction, 2), std::pow(rhFraction, 2)) * hitEnergyWeight *
+                         invLayerClusterEnergyWeight;
+      }
+    }
+  }
+
+  for (const auto& cpId : cPIndices) {
+    for (unsigned int layerId = 0; layerId < layers_; ++layerId) {
+      unsigned int CPNumberOfHits = cPOnLayer[cpId][layerId].hits_and_fractions.size();
+      if (CPNumberOfHits == 0)
+        continue;
+      float invCPEnergyWeight = 0.;
+      for (auto const& haf : cPOnLayer[cpId][layerId].hits_and_fractions) {
+        invCPEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
+      }
+      invCPEnergyWeight = 1.f / invCPEnergyWeight;
+      for (unsigned int i = 0; i < CPNumberOfHits; ++i) {
+        auto& cp_hitDetId = cPOnLayer[cpId][layerId].hits_and_fractions[i].first;
+        auto& cpFraction = cPOnLayer[cpId][layerId].hits_and_fractions[i].second;
+
+        bool hitWithNoLC = false;
+        if (cpFraction == 0.f)
+          continue;
+        auto hit_find_in_LC = detIdToLayerClusterId_Map.find(cp_hitDetId);
+        if (hit_find_in_LC == detIdToLayerClusterId_Map.end())
+          hitWithNoLC = true;
+        auto itcheck = hitMap_->find(cp_hitDetId);
+        const reco::PFRecHit* hit = itcheck->second;
+        float hitEnergyWeight = hit->energy() * hit->energy();
+        for (auto& lcPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+          unsigned int layerClusterId = lcPair.first;
+          float lcFraction = 0.f;
+
+          if (!hitWithNoLC) {
+            auto findHitIt = std::find(detIdToLayerClusterId_Map[cp_hitDetId].begin(),
+                                       detIdToLayerClusterId_Map[cp_hitDetId].end(),
+                                       ticl::detIdInfoInCluster{layerClusterId, 0.f});
+            if (findHitIt != detIdToLayerClusterId_Map[cp_hitDetId].end())
+              lcFraction = findHitIt->fraction;
+          }
+          lcPair.second.second += std::min(std::pow(lcFraction - cpFraction, 2), std::pow(cpFraction, 2)) *
+                                  hitEnergyWeight * invCPEnergyWeight;
+        }
+      }
+    }
+  }
+  return {cpsInLayerCluster, cPOnLayer};
+}
+
+ticl::RecoToSimCollection BarrelLCToCPAssociatorByEnergyScoreImpl::associateRecoToSim(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
+  ticl::RecoToSimCollection returnValue(productGetter_);
+  const auto& links = makeConnections(cCCH, cPCH);
+
+  const auto& cpsInLayerCluster = std::get<0>(links);
+  for (size_t lcId = 0; lcId < cpsInLayerCluster.size(); ++lcId) {
+    for (const auto& cpPair : cpsInLayerCluster[lcId]) {
+      returnValue.insert(edm::Ref<reco::CaloClusterCollection>(cCCH, lcId),
+                         std::make_pair(edm::Ref<CaloParticleCollection>(cPCH, cpPair.first), cpPair.second));
+    }
+  }
+  return returnValue;
+}
+
+ticl::SimToRecoCollection BarrelLCToCPAssociatorByEnergyScoreImpl::associateSimToReco(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
+  ticl::SimToRecoCollection returnValue(productGetter_);
+  const auto& links = makeConnections(cCCH, cPCH);
+
+  const auto& cPOnLayer = std::get<1>(links);
+  for (size_t cpId = 0; cpId < cPOnLayer.size(); ++cpId) {
+    for (size_t layerId = 0; layerId < cPOnLayer[cpId].size(); ++layerId) {
+      for (const auto& lcPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+        returnValue.insert(edm::Ref<CaloParticleCollection>(cPCH, cpId),
+                           std::make_pair(edm::Ref<reco::CaloClusterCollection>(cCCH, lcPair.first),
+                                          std::make_pair(lcPair.second.first, lcPair.second.second)));
+      }
+    }
+  }
+  return returnValue;
+}

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreImpl.h
@@ -1,0 +1,57 @@
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+namespace ticl {
+  struct detIdInfoInCluster {
+    bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
+    long unsigned int clusterId;
+    float fraction;
+    detIdInfoInCluster(long unsigned int cId, float fr) {
+      clusterId = cId;
+      fraction = fr;
+    }
+  };
+
+  struct caloParticleOnLayer {
+    unsigned int caloParticleId;
+    float energy = 0;
+    std::vector<std::pair<DetId, float>> hits_and_fractions;
+    std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
+  };
+
+  typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToCaloParticle;
+  typedef std::vector<std::vector<ticl::caloParticleOnLayer>> caloParticleToLayerCluster;
+  typedef std::tuple<layerClusterToCaloParticle, caloParticleToLayerCluster> association;
+}  //namespace ticl
+
+class BarrelLCToCPAssociatorByEnergyScoreImpl : public ticl::LayerClusterToCaloParticleAssociatorBaseImpl {
+public:
+  explicit BarrelLCToCPAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
+                                                   bool,
+                                                   const std::unordered_map<DetId, const reco::PFRecHit *> *);
+
+  ticl::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                               const edm::Handle<CaloParticleCollection> &cPCH) const override;
+
+  ticl::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                               const edm::Handle<CaloParticleCollection> &cPCH) const override;
+
+private:
+  const bool hardScatterOnly_;
+  const std::unordered_map<DetId, const reco::PFRecHit *> *hitMap_;
+  unsigned layers_;
+  edm::EDProductGetter const *productGetter_;
+  ticl::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                    const edm::Handle<CaloParticleCollection> &cPCH) const;
+};

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorByEnergyScoreProducer.cc
@@ -1,0 +1,54 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
+#include "BarrelLCToCPAssociatorByEnergyScoreImpl.h"
+
+class BarrelLCToCPAssociatorByEnergyScoreProducer : public edm::global::EDProducer<> {
+public:
+  explicit BarrelLCToCPAssociatorByEnergyScoreProducer(const edm::ParameterSet &);
+  ~BarrelLCToCPAssociatorByEnergyScoreProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  edm::EDGetTokenT<std::unordered_map<DetId, const reco::PFRecHit *>> hitMap_;
+  const bool hardScatterOnly_;
+};
+
+BarrelLCToCPAssociatorByEnergyScoreProducer::BarrelLCToCPAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
+    : hitMap_(consumes<std::unordered_map<DetId, const reco::PFRecHit *>>(ps.getParameter<edm::InputTag>("hitMapTag"))),
+      hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")) {
+  produces<ticl::LayerClusterToCaloParticleAssociator>();
+}
+
+BarrelLCToCPAssociatorByEnergyScoreProducer::~BarrelLCToCPAssociatorByEnergyScoreProducer() {}
+
+void BarrelLCToCPAssociatorByEnergyScoreProducer::produce(edm::StreamID,
+                                                          edm::Event &iEvent,
+                                                          const edm::EventSetup &es) const {
+  const auto hitMap = &iEvent.get(hitMap_);
+
+  auto impl =
+      std::make_unique<BarrelLCToCPAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_, hitMap);
+  auto toPut = std::make_unique<ticl::LayerClusterToCaloParticleAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void BarrelLCToCPAssociatorByEnergyScoreProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("hitMapTag", edm::InputTag("barrelRecHitMapProducer"));
+  desc.add<bool>("hardScatterOnly", true);
+
+  cfg.add("barrelLayerClusterAssociatorByEnergyScore", desc);
+}
+
+DEFINE_FWK_MODULE(BarrelLCToCPAssociatorByEnergyScoreProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToCPAssociatorEDProducer.cc
@@ -1,0 +1,78 @@
+#include <memory>
+#include <string>
+
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+class BarrelLCToCPAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit BarrelLCToCPAssociatorEDProducer(const edm::ParameterSet &);
+  ~BarrelLCToCPAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
+  edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
+  edm::EDGetTokenT<ticl::LayerClusterToCaloParticleAssociator> associatorToken_;
+};
+
+BarrelLCToCPAssociatorEDProducer::BarrelLCToCPAssociatorEDProducer(const edm::ParameterSet &pset) {
+  produces<ticl::SimToRecoCollection>();
+  produces<ticl::RecoToSimCollection>();
+
+  CPCollectionToken_ = consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"));
+  LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"));
+  associatorToken_ =
+      consumes<ticl::LayerClusterToCaloParticleAssociator>(pset.getParameter<edm::InputTag>("associator"));
+}
+
+BarrelLCToCPAssociatorEDProducer::~BarrelLCToCPAssociatorEDProducer() {}
+
+void BarrelLCToCPAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<ticl::LayerClusterToCaloParticleAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  Handle<CaloParticleCollection> CPCollection;
+  iEvent.getByToken(CPCollectionToken_, CPCollection);
+
+  Handle<reco::CaloClusterCollection> LCCollection;
+  iEvent.getByToken(LCCollectionToken_, LCCollection);
+
+  // associate LC and CP
+  LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
+  ticl::RecoToSimCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, CPCollection);
+
+  LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
+  ticl::SimToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, CPCollection);
+
+  auto rts = std::make_unique<ticl::RecoToSimCollection>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollection>(simRecColl);
+
+  iEvent.put(std::move(rts));
+  iEvent.put(std::move(str));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(BarrelLCToCPAssociatorEDProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreImpl.cc
@@ -1,0 +1,228 @@
+#include "BarrelLCToSCAssociatorByEnergyScoreImpl.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+BarrelLCToSCAssociatorByEnergyScoreImpl::BarrelLCToSCAssociatorByEnergyScoreImpl(
+    edm::EDProductGetter const& productGetter,
+    bool hardScatterOnly,
+    const std::unordered_map<DetId, const reco::PFRecHit*>* hitMap)
+    : hardScatterOnly_(hardScatterOnly), hitMap_(hitMap), productGetter_(&productGetter) {
+  layers_ = 6;
+}
+
+ticl::association BarrelLCToSCAssociatorByEnergyScoreImpl::makeConnections(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
+  const auto& clusters = *cCCH.product();
+  const auto& simClusters = *sCCH.product();
+  auto nLayerClusters = clusters.size();
+  auto nSimClusters = simClusters.size();
+  std::vector<size_t> sCIndices;
+  for (unsigned int scId = 0; scId < nSimClusters; ++scId) {
+    if (hardScatterOnly_ && (simClusters[scId].g4Tracks()[0].eventId().event() != 0 or
+                             simClusters[scId].g4Tracks()[0].eventId().bunchCrossing() != 0)) {
+      continue;
+    }
+    sCIndices.emplace_back(scId);
+  }
+  nSimClusters = sCIndices.size();
+  ticl::simClusterToLayerCluster lcsInSimCluster;
+  lcsInSimCluster.resize(nSimClusters);
+
+  for (unsigned int i = 0; i < nSimClusters; ++i) {
+    lcsInSimCluster[i].resize(layers_);
+    for (unsigned int j = 0; j < layers_; ++j) {
+      lcsInSimCluster[i][j].simClusterId = i;
+      lcsInSimCluster[i][j].energy = 0.f;
+      lcsInSimCluster[i][j].hits_and_fractions.clear();
+    }
+  }
+
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToSimClusterId_Map;
+  for (const auto& scId : sCIndices) {
+    const auto& hits_and_fractions = simClusters[scId].hits_and_fractions();
+    for (const auto& it_haf : hits_and_fractions) {
+      const auto hitid = (it_haf.first);
+      auto scLayerId = 0;
+      if ((DetId(hitid)).det() == DetId::Hcal) {
+        scLayerId = (HcalDetId(hitid)).depth();
+        if ((DetId(hitid)).subdetId() == HcalSubdetector::HcalOuter)
+          scLayerId += 1;
+      }
+      const auto itcheck = hitMap_->find(hitid);
+      if (itcheck != hitMap_->end()) {
+        auto hit_find_it = detIdToSimClusterId_Map.find(hitid);
+        if (hit_find_it == detIdToSimClusterId_Map.end()) {
+          detIdToSimClusterId_Map[hitid] = std::vector<ticl::detIdInfoInCluster>();
+        }
+        detIdToSimClusterId_Map[hitid].emplace_back(scId, it_haf.second);
+
+        const reco::PFRecHit* hit = itcheck->second;
+        lcsInSimCluster[scId][scLayerId].energy += it_haf.second * hit->energy();
+        lcsInSimCluster[scId][scLayerId].hits_and_fractions.emplace_back(hitid, it_haf.second);
+      }
+    }
+  }
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  ticl::layerClusterToSimCluster scsInLayerCluster;
+  scsInLayerCluster.resize(nLayerClusters);
+
+  for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
+    const std::vector<std::pair<DetId, float>>& hits_and_fractions = clusters[lcId].hitsAndFractions();
+    unsigned int numberOfHitsInLC = hits_and_fractions.size();
+    const auto firstHitDetId = hits_and_fractions[0].first;
+    int lcLayerId = 0;
+    if (DetId(firstHitDetId).det() == DetId::Hcal) {
+      lcLayerId = (HcalDetId(firstHitDetId)).depth();
+      if ((DetId(firstHitDetId)).subdetId() == HcalSubdetector::HcalOuter)
+        lcLayerId += 1;
+    }
+
+    for (unsigned int hitId = 0; hitId < numberOfHitsInLC; ++hitId) {
+      const auto rh_detid = hits_and_fractions[hitId].first;
+      const auto rhFraction = hits_and_fractions[hitId].second;
+
+      auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
+      if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
+        detIdToLayerClusterId_Map[rh_detid] = std::vector<ticl::detIdInfoInCluster>();
+      }
+      detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
+
+      auto hit_find_in_SC = detIdToSimClusterId_Map.find(rh_detid);
+
+      if (hit_find_in_SC != detIdToSimClusterId_Map.end()) {
+        const auto itcheck = hitMap_->find(rh_detid);
+        const reco::PFRecHit* hit = itcheck->second;
+
+        for (auto& h : hit_find_in_SC->second) {
+          lcsInSimCluster[h.clusterId][lcLayerId].layerClusterIdToEnergyAndScore[lcId].first +=
+              h.fraction * hit->energy();
+          scsInLayerCluster[lcId].emplace_back(h.clusterId, 0.f);
+        }
+      }
+    }
+  }
+
+  for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
+    std::sort(scsInLayerCluster[lcId].begin(), scsInLayerCluster[lcId].end());
+    auto last = std::unique(scsInLayerCluster[lcId].begin(), scsInLayerCluster[lcId].end());
+    scsInLayerCluster[lcId].erase(last, scsInLayerCluster[lcId].end());
+    const auto& hits_and_fractions = clusters[lcId].hitsAndFractions();
+    unsigned int numberOfHitsInLC = hits_and_fractions.size();
+
+    if (clusters[lcId].energy() == 0. && !scsInLayerCluster[lcId].empty()) {
+      for (auto& scPair : scsInLayerCluster[lcId]) {
+        scPair.second = 1;
+      }
+      continue;
+    }
+
+    float invLayerClusterEnergyWeight = 0.f;
+    for (auto const& haf : hits_and_fractions) {
+      invLayerClusterEnergyWeight +=
+          (haf.second * hitMap_->at(haf.first)->energy()) * (haf.second * hitMap_->at(haf.first)->energy());
+    }
+    invLayerClusterEnergyWeight = 1.f / invLayerClusterEnergyWeight;
+    for (unsigned int i = 0; i < numberOfHitsInLC; ++i) {
+      DetId rh_detid = hits_and_fractions[i].first;
+      float rhFraction = hits_and_fractions[i].second;
+
+      bool hitWithSC = (detIdToSimClusterId_Map.find(rh_detid) != detIdToSimClusterId_Map.end());
+
+      auto itcheck = hitMap_->find(rh_detid);
+      const reco::PFRecHit* hit = itcheck->second;
+      float hitEnergyWeight = hit->energy() * hit->energy();
+
+      for (auto& scPair : scsInLayerCluster[lcId]) {
+        float scFraction = 0.f;
+        if (hitWithSC) {
+          auto findHitIt = std::find(detIdToSimClusterId_Map[rh_detid].begin(),
+                                     detIdToSimClusterId_Map[rh_detid].end(),
+                                     ticl::detIdInfoInCluster{scPair.first, 0.f});
+          if (findHitIt != detIdToSimClusterId_Map[rh_detid].end())
+            scFraction = findHitIt->fraction;
+        }
+        scPair.second += std::min(std::pow(rhFraction - scFraction, 2), std::pow(rhFraction, 2)) * hitEnergyWeight *
+                         invLayerClusterEnergyWeight;
+      }
+    }
+  }
+  for (const auto& scId : sCIndices) {
+    for (unsigned int layerId = 0; layerId < layers_; ++layerId) {
+      unsigned int SCNumberOfHits = lcsInSimCluster[scId][layerId].hits_and_fractions.size();
+      if (SCNumberOfHits == 0)
+        continue;
+      float invSCEnergyWeight = 0.f;
+      for (auto const& haf : lcsInSimCluster[scId][layerId].hits_and_fractions) {
+        invSCEnergyWeight += std::pow(haf.second * hitMap_->at(haf.first)->energy(), 2);
+      }
+      invSCEnergyWeight = 1.f / invSCEnergyWeight;
+      for (unsigned int i = 0; i < SCNumberOfHits; ++i) {
+        auto& sc_hitDetId = lcsInSimCluster[scId][layerId].hits_and_fractions[i].first;
+        auto& scFraction = lcsInSimCluster[scId][layerId].hits_and_fractions[i].second;
+
+        bool hitWithLC = false;
+        if (scFraction == 0.f)
+          continue;
+        auto hit_find_in_LC = detIdToLayerClusterId_Map.find(sc_hitDetId);
+        if (hit_find_in_LC != detIdToLayerClusterId_Map.end())
+          hitWithLC = true;
+        auto itcheck = hitMap_->find(sc_hitDetId);
+        const reco::PFRecHit* hit = itcheck->second;
+        float hitEnergyWeight = hit->energy() * hit->energy();
+        for (auto& lcPair : lcsInSimCluster[scId][layerId].layerClusterIdToEnergyAndScore) {
+          unsigned int layerClusterId = lcPair.first;
+          float lcFraction = 0.f;
+
+          if (hitWithLC) {
+            auto findHitIt = std::find(detIdToLayerClusterId_Map[sc_hitDetId].begin(),
+                                       detIdToLayerClusterId_Map[sc_hitDetId].end(),
+                                       ticl::detIdInfoInCluster{layerClusterId, 0.f});
+            if (findHitIt != detIdToLayerClusterId_Map[sc_hitDetId].end())
+              lcFraction = findHitIt->fraction;
+          }
+          lcPair.second.second += std::min(std::pow(lcFraction - scFraction, 2), std::pow(scFraction, 2)) *
+                                  hitEnergyWeight * invSCEnergyWeight;
+        }
+      }
+    }
+  }
+  return {scsInLayerCluster, lcsInSimCluster};
+}
+
+ticl::RecoToSimCollectionWithSimClusters BarrelLCToSCAssociatorByEnergyScoreImpl::associateRecoToSim(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
+  ticl::RecoToSimCollectionWithSimClusters returnValue(productGetter_);
+  const auto& links = makeConnections(cCCH, sCCH);
+
+  const auto& scsInLayerCluster = std::get<0>(links);
+  for (size_t lcId = 0; lcId < scsInLayerCluster.size(); ++lcId) {
+    for (const auto& scPair : scsInLayerCluster[lcId]) {
+      returnValue.insert(edm::Ref<reco::CaloClusterCollection>(cCCH, lcId),
+                         std::make_pair(edm::Ref<SimClusterCollection>(sCCH, scPair.first), scPair.second));
+      returnValue.insert(edm::Ref<reco::CaloClusterCollection>(cCCH, lcId),
+                         std::make_pair(edm::Ref<SimClusterCollection>(sCCH, scPair.first), scPair.second));
+    }
+  }
+  return returnValue;
+}
+
+ticl::SimToRecoCollectionWithSimClusters BarrelLCToSCAssociatorByEnergyScoreImpl::associateSimToReco(
+    const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
+  ticl::SimToRecoCollectionWithSimClusters returnValue(productGetter_);
+  const auto& links = makeConnections(cCCH, sCCH);
+
+  const auto& lcsInSimCluster = std::get<1>(links);
+  for (size_t scId = 0; scId < lcsInSimCluster.size(); ++scId) {
+    for (size_t layerId = 0; layerId < lcsInSimCluster[scId].size(); ++layerId) {
+      for (const auto& lcPair : lcsInSimCluster[scId][layerId].layerClusterIdToEnergyAndScore) {
+        returnValue.insert(edm::Ref<SimClusterCollection>(sCCH, scId),
+                           std::make_pair(edm::Ref<reco::CaloClusterCollection>(cCCH, lcPair.first),
+                                          std::make_pair(lcPair.second.first, lcPair.second.second)));
+      }
+    }
+  }
+  return returnValue;
+}

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreImpl.h
@@ -1,0 +1,63 @@
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <memory>  // shared_ptr
+
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+namespace ticl {
+  struct detIdInfoInCluster {
+    bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
+    long unsigned int clusterId;
+    float fraction;
+    detIdInfoInCluster(long unsigned int cId, float fr) {
+      clusterId = cId;
+      fraction = fr;
+    }
+  };
+
+  struct simClusterOnCLayer {
+    unsigned int simClusterId;
+    float energy = 0;
+    std::vector<std::pair<DetId, float>> hits_and_fractions;
+    std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
+  };
+
+  typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
+  typedef std::vector<std::vector<ticl::simClusterOnCLayer>> simClusterToLayerCluster;
+  typedef std::tuple<layerClusterToSimCluster, simClusterToLayerCluster> association;
+}  // namespace ticl
+
+class BarrelLCToSCAssociatorByEnergyScoreImpl : public ticl::LayerClusterToSimClusterAssociatorBaseImpl {
+public:
+  explicit BarrelLCToSCAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
+                                                   bool,
+                                                   const std::unordered_map<DetId, const reco::PFRecHit *> *);
+
+  ticl::RecoToSimCollectionWithSimClusters associateRecoToSim(
+      const edm::Handle<reco::CaloClusterCollection> &cCH,
+      const edm::Handle<SimClusterCollection> &sCCH) const override;
+
+  ticl::SimToRecoCollectionWithSimClusters associateSimToReco(
+      const edm::Handle<reco::CaloClusterCollection> &cCH,
+      const edm::Handle<SimClusterCollection> &sCCH) const override;
+
+private:
+  const bool hardScatterOnly_;
+  const std::unordered_map<DetId, const reco::PFRecHit *> *hitMap_;
+  unsigned layers_;
+  edm::EDProductGetter const *productGetter_;
+  ticl::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                    const edm::Handle<SimClusterCollection> &sCCH) const;
+};

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorByEnergyScoreProducer.cc
@@ -1,0 +1,58 @@
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+#include "BarrelLCToSCAssociatorByEnergyScoreImpl.h"
+
+class BarrelLCToSCAssociatorByEnergyScoreProducer : public edm::global::EDProducer<> {
+public:
+  explicit BarrelLCToSCAssociatorByEnergyScoreProducer(const edm::ParameterSet &);
+  ~BarrelLCToSCAssociatorByEnergyScoreProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  edm::EDGetTokenT<std::unordered_map<DetId, const reco::PFRecHit *>> hitMap_;
+  const bool hardScatterOnly_;
+};
+
+BarrelLCToSCAssociatorByEnergyScoreProducer::BarrelLCToSCAssociatorByEnergyScoreProducer(const edm::ParameterSet &ps)
+    : hitMap_(consumes<std::unordered_map<DetId, const reco::PFRecHit *>>(ps.getParameter<edm::InputTag>("hitMapTag"))),
+      hardScatterOnly_(ps.getParameter<bool>("hardScatterOnly")) {
+  // Register the product
+  produces<ticl::LayerClusterToSimClusterAssociator>();
+}
+
+BarrelLCToSCAssociatorByEnergyScoreProducer::~BarrelLCToSCAssociatorByEnergyScoreProducer() {}
+
+void BarrelLCToSCAssociatorByEnergyScoreProducer::produce(edm::StreamID,
+                                                          edm::Event &iEvent,
+                                                          const edm::EventSetup &es) const {
+  const auto hitMap = &iEvent.get(hitMap_);
+
+  auto impl =
+      std::make_unique<BarrelLCToSCAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_, hitMap);
+  auto toPut = std::make_unique<ticl::LayerClusterToSimClusterAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void BarrelLCToSCAssociatorByEnergyScoreProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("hitMapTag", edm::InputTag("barrelRecHitMapProducer"));
+  desc.add<bool>("hardScatterOnly", true);
+
+  cfg.add("barrelSimClusterAssociatorByEnergyScore", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BarrelLCToSCAssociatorByEnergyScoreProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/BarrelLCToSCAssociatorEDProducer.cc
@@ -1,0 +1,64 @@
+#include <memory>
+#include <string>
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+class BarrelLCToSCAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit BarrelLCToSCAssociatorEDProducer(const edm::ParameterSet &);
+  ~BarrelLCToSCAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
+  edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
+  edm::EDGetTokenT<ticl::LayerClusterToSimClusterAssociator> associatorToken_;
+};
+
+BarrelLCToSCAssociatorEDProducer::BarrelLCToSCAssociatorEDProducer(const edm::ParameterSet &pset) {
+  produces<ticl::SimToRecoCollectionWithSimClusters>();
+  produces<ticl::RecoToSimCollectionWithSimClusters>();
+
+  SCCollectionToken_ = consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"));
+  LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lcl"));
+  associatorToken_ = consumes<ticl::LayerClusterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+}
+
+BarrelLCToSCAssociatorEDProducer::~BarrelLCToSCAssociatorEDProducer() {}
+
+void BarrelLCToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<ticl::LayerClusterToSimClusterAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  Handle<SimClusterCollection> SCCollection;
+  iEvent.getByToken(SCCollectionToken_, SCCollection);
+
+  Handle<reco::CaloClusterCollection> LCCollection;
+  iEvent.getByToken(LCCollectionToken_, LCCollection);
+
+  ticl::RecoToSimCollectionWithSimClusters recSimColl = theAssociator->associateRecoToSim(LCCollection, SCCollection);
+  ticl::SimToRecoCollectionWithSimClusters simRecColl = theAssociator->associateSimToReco(LCCollection, SCCollection);
+
+  auto rts = std::make_unique<ticl::RecoToSimCollectionWithSimClusters>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollectionWithSimClusters>(simRecColl);
+
+  iEvent.put(std::move(rts));
+  iEvent.put(std::move(str));
+}
+
+DEFINE_FWK_MODULE(BarrelLCToSCAssociatorEDProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -18,7 +18,7 @@ LCToCPAssociatorByEnergyScoreImpl::LCToCPAssociatorByEnergyScoreImpl(
   layers_ = recHitTools_->lastLayerBH();
 }
 
-hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
+ticl::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
   // Get collections
   const auto& clusters = *cCCH.product();
@@ -34,7 +34,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   // among other the information to compute the CaloParticle-To-LayerCluster score. It is one of the two objects that
   // build the output of the makeConnections function.
   // cPOnLayer[cpId][layerId]
-  hgcal::caloParticleToLayerCluster cPOnLayer;
+  ticl::caloParticleToLayerCluster cPOnLayer;
   cPOnLayer.resize(nCaloParticles);
   for (unsigned int i = 0; i < nCaloParticles; ++i) {
     cPOnLayer[i].resize(layers_ * 2);
@@ -51,7 +51,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   // contributed to that hit by storing the CaloParticle id and the fraction of the hit. Observe here
   // that all the different contributions of the same CaloParticle to a single hit (coming from their
   // internal SimClusters) are merged into a single entry with the fractions properly summed.
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToCaloParticleId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToCaloParticleId_Map;
   for (const auto& cpId : cPIndices) {
     const SimClusterRefVector& simClusterRefVector = caloParticles[cpId].simClusters();
     for (const auto& it_sc : simClusterRefVector) {
@@ -65,12 +65,12 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
         if (itcheck != hitMap_->end()) {
           auto hit_find_it = detIdToCaloParticleId_Map.find(hitid);
           if (hit_find_it == detIdToCaloParticleId_Map.end()) {
-            detIdToCaloParticleId_Map[hitid] = std::vector<hgcal::detIdInfoInCluster>();
+            detIdToCaloParticleId_Map[hitid] = std::vector<ticl::detIdInfoInCluster>();
             detIdToCaloParticleId_Map[hitid].emplace_back(cpId, it_haf.second);
           } else {
             auto findHitIt = std::find(detIdToCaloParticleId_Map[hitid].begin(),
                                        detIdToCaloParticleId_Map[hitid].end(),
-                                       hgcal::detIdInfoInCluster{cpId, it_haf.second});
+                                       ticl::detIdInfoInCluster{cpId, it_haf.second});
             if (findHitIt != detIdToCaloParticleId_Map[hitid].end()) {
               findHitIt->fraction += it_haf.second;
             } else {
@@ -137,12 +137,12 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
 #endif
 
   // Fill detIdToLayerClusterId_Map and cpsInLayerCluster; update cPOnLayer
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToLayerClusterId_Map;
   // this contains the ids of the caloparticles contributing with at least one
   // hit to the layer cluster and the reconstruction error. To be returned
   // since this contains the information to compute the
   // LayerCluster-To-CaloParticle score.
-  hgcal::layerClusterToCaloParticle cpsInLayerCluster;
+  ticl::layerClusterToCaloParticle cpsInLayerCluster;
   cpsInLayerCluster.resize(nLayerClusters);
 
   for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
@@ -155,10 +155,9 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     for (unsigned int hitId = 0; hitId < numberOfHitsInLC; hitId++) {
       const auto rh_detid = hits_and_fractions[hitId].first;
       const auto rhFraction = hits_and_fractions[hitId].second;
-
       auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
       if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
-        detIdToLayerClusterId_Map[rh_detid] = std::vector<hgcal::detIdInfoInCluster>();
+        detIdToLayerClusterId_Map[rh_detid] = std::vector<ticl::detIdInfoInCluster>();
       }
       detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
 
@@ -358,7 +357,6 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     for (unsigned int i = 0; i < numberOfHitsInLC; ++i) {
       DetId rh_detid = hits_and_fractions[i].first;
       float rhFraction = hits_and_fractions[i].second;
-
       bool hitWithNoCP = (detIdToCaloParticleId_Map.find(rh_detid) == detIdToCaloParticleId_Map.end());
 
       auto itcheck = hitMap_->find(rh_detid);
@@ -370,7 +368,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
         if (!hitWithNoCP) {
           auto findHitIt = std::find(detIdToCaloParticleId_Map[rh_detid].begin(),
                                      detIdToCaloParticleId_Map[rh_detid].end(),
-                                     hgcal::detIdInfoInCluster{cpPair.first, 0.f});
+                                     ticl::detIdInfoInCluster{cpPair.first, 0.f});
           if (findHitIt != detIdToCaloParticleId_Map[rh_detid].end())
             cpFraction = findHitIt->fraction;
         }
@@ -425,7 +423,6 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
       for (unsigned int i = 0; i < CPNumberOfHits; ++i) {
         auto& cp_hitDetId = cPOnLayer[cpId][layerId].hits_and_fractions[i].first;
         auto& cpFraction = cPOnLayer[cpId][layerId].hits_and_fractions[i].second;
-
         bool hitWithNoLC = false;
         if (cpFraction == 0.f)
           continue;  //hopefully this should never happen
@@ -442,7 +439,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
           if (!hitWithNoLC) {
             auto findHitIt = std::find(detIdToLayerClusterId_Map[cp_hitDetId].begin(),
                                        detIdToLayerClusterId_Map[cp_hitDetId].end(),
-                                       hgcal::detIdInfoInCluster{layerClusterId, 0.f});
+                                       ticl::detIdInfoInCluster{layerClusterId, 0.f});
             if (findHitIt != detIdToLayerClusterId_Map[cp_hitDetId].end())
               lcFraction = findHitIt->fraction;
           }
@@ -476,9 +473,9 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
   return {cpsInLayerCluster, cPOnLayer};
 }
 
-hgcal::RecoToSimCollection LCToCPAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimCollection LCToCPAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
-  hgcal::RecoToSimCollection returnValue(productGetter_);
+  ticl::RecoToSimCollection returnValue(productGetter_);
   const auto& links = makeConnections(cCCH, cPCH);
 
   const auto& cpsInLayerCluster = std::get<0>(links);
@@ -496,9 +493,9 @@ hgcal::RecoToSimCollection LCToCPAssociatorByEnergyScoreImpl::associateRecoToSim
   return returnValue;
 }
 
-hgcal::SimToRecoCollection LCToCPAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimToRecoCollection LCToCPAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<CaloParticleCollection>& cPCH) const {
-  hgcal::SimToRecoCollection returnValue(productGetter_);
+  ticl::SimToRecoCollection returnValue(productGetter_);
   const auto& links = makeConnections(cCCH, cPCH);
   const auto& cPOnLayer = std::get<1>(links);
   for (size_t cpId = 0; cpId < cPOnLayer.size(); ++cpId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.h
@@ -14,7 +14,7 @@ namespace edm {
   class EDProductGetter;
 }
 
-namespace hgcal {
+namespace ticl {
   // This structure is used both for LayerClusters and CaloParticles storing their id and the fraction of a hit
   // that belongs to the LayerCluster or CaloParticle. The meaning of the operator is extremely important since
   // this struct will be used inside maps and other containers and when searching for one particular occurence
@@ -55,25 +55,25 @@ namespace hgcal {
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToCaloParticle;
   // This is used to save the caloParticleOnLayer structure for all CaloParticles in each layer.
   // It is not exactly what is returned outside, but out of its entries, the output object is build.
-  typedef std::vector<std::vector<hgcal::caloParticleOnLayer>> caloParticleToLayerCluster;
+  typedef std::vector<std::vector<ticl::caloParticleOnLayer>> caloParticleToLayerCluster;
   //This is the output of the makeConnections function that contain all the work with CP2LC and LC2CP
   //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to
   //provide the final product.
   typedef std::tuple<layerClusterToCaloParticle, caloParticleToLayerCluster> association;
-}  // namespace hgcal
+}  // namespace ticl
 
-class LCToCPAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToCaloParticleAssociatorBaseImpl {
+class LCToCPAssociatorByEnergyScoreImpl : public ticl::LayerClusterToCaloParticleAssociatorBaseImpl {
 public:
   explicit LCToCPAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
                                              bool,
                                              std::shared_ptr<hgcal::RecHitTools>,
                                              const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<CaloParticleCollection> &cPCH) const override;
+  ticl::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                               const edm::Handle<CaloParticleCollection> &cPCH) const override;
 
-  hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                const edm::Handle<CaloParticleCollection> &cPCH) const override;
+  ticl::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                               const edm::Handle<CaloParticleCollection> &cPCH) const override;
 
 private:
   const bool hardScatterOnly_;
@@ -81,6 +81,6 @@ private:
   const std::unordered_map<DetId, const HGCRecHit *> *hitMap_;
   unsigned layers_;
   edm::EDProductGetter const *productGetter_;
-  hgcal::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                     const edm::Handle<CaloParticleCollection> &cPCH) const;
+  ticl::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                    const edm::Handle<CaloParticleCollection> &cPCH) const;
 };

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreProducer.cc
@@ -36,7 +36,7 @@ LCToCPAssociatorByEnergyScoreProducer::LCToCPAssociatorByEnergyScoreProducer(con
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::LayerClusterToCaloParticleAssociator>();
+  produces<ticl::LayerClusterToCaloParticleAssociator>();
 }
 
 LCToCPAssociatorByEnergyScoreProducer::~LCToCPAssociatorByEnergyScoreProducer() {}
@@ -51,7 +51,7 @@ void LCToCPAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   auto impl =
       std::make_unique<LCToCPAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
-  auto toPut = std::make_unique<hgcal::LayerClusterToCaloParticleAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::LayerClusterToCaloParticleAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorEDProducer.cc
@@ -40,17 +40,17 @@ private:
 
   edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
   edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
-  edm::EDGetTokenT<hgcal::LayerClusterToCaloParticleAssociator> associatorToken_;
+  edm::EDGetTokenT<ticl::LayerClusterToCaloParticleAssociator> associatorToken_;
 };
 
 LCToCPAssociatorEDProducer::LCToCPAssociatorEDProducer(const edm::ParameterSet &pset) {
-  produces<hgcal::SimToRecoCollection>();
-  produces<hgcal::RecoToSimCollection>();
+  produces<ticl::SimToRecoCollection>();
+  produces<ticl::RecoToSimCollection>();
 
   CPCollectionToken_ = consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"));
   LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"));
   associatorToken_ =
-      consumes<hgcal::LayerClusterToCaloParticleAssociator>(pset.getParameter<edm::InputTag>("associator"));
+      consumes<ticl::LayerClusterToCaloParticleAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
 LCToCPAssociatorEDProducer::~LCToCPAssociatorEDProducer() {}
@@ -63,7 +63,7 @@ LCToCPAssociatorEDProducer::~LCToCPAssociatorEDProducer() {}
 void LCToCPAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::LayerClusterToCaloParticleAssociator> theAssociator;
+  edm::Handle<ticl::LayerClusterToCaloParticleAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<CaloParticleCollection> CPCollection;
@@ -74,13 +74,13 @@ void LCToCPAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
 
   // associate LC and CP
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, CPCollection);
+  ticl::RecoToSimCollection recSimColl = theAssociator->associateRecoToSim(LCCollection, CPCollection);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, CPCollection);
+  ticl::SimToRecoCollection simRecColl = theAssociator->associateSimToReco(LCCollection, CPCollection);
 
-  auto rts = std::make_unique<hgcal::RecoToSimCollection>(recSimColl);
-  auto str = std::make_unique<hgcal::SimToRecoCollection>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimCollection>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollection>(simRecColl);
 
   iEvent.put(std::move(rts));
   iEvent.put(std::move(str));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -12,7 +12,7 @@ LCToSCAssociatorByEnergyScoreImpl::LCToSCAssociatorByEnergyScoreImpl(
   layers_ = recHitTools_->lastLayerBH();
 }
 
-hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
+ticl::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
   // Get collections
   const auto& clusters = *cCCH.product();
@@ -39,7 +39,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   // among other the information to compute the SimCluster-To-LayerCluster score. It is one of the two objects that
   // build the output of the makeConnections function.
   // lcsInSimCluster[scId][layerId]
-  hgcal::simClusterToLayerCluster lcsInSimCluster;
+  ticl::simClusterToLayerCluster lcsInSimCluster;
   lcsInSimCluster.resize(nSimClusters);
   for (unsigned int i = 0; i < nSimClusters; ++i) {
     lcsInSimCluster[i].resize(layers_ * 2);
@@ -55,7 +55,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   // contributed to that hit by storing the SimCluster id and the fraction of the hit. Observe here
   // that in contrast to the CaloParticle case there is no merging and summing of the fractions, which
   // in the CaloParticle's case was necessary due to the multiple SimClusters of a single CaloParticle.
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToSimClusterId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToSimClusterId_Map;
   for (const auto& scId : sCIndices) {
     const auto& hits_and_fractions = simClusters[scId].hits_and_fractions();
     for (const auto& it_haf : hits_and_fractions) {
@@ -67,7 +67,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
       if (itcheck != hitMap_->end()) {
         auto hit_find_it = detIdToSimClusterId_Map.find(hitid);
         if (hit_find_it == detIdToSimClusterId_Map.end()) {
-          detIdToSimClusterId_Map[hitid] = std::vector<hgcal::detIdInfoInCluster>();
+          detIdToSimClusterId_Map[hitid] = std::vector<ticl::detIdInfoInCluster>();
         }
         detIdToSimClusterId_Map[hitid].emplace_back(scId, it_haf.second);
 
@@ -125,12 +125,12 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   // Fill detIdToLayerClusterId_Map and scsInLayerCluster; update lcsInSimCluster
   // The detIdToLayerClusterId_Map is used to connect a hit Detid (key) with all the LayerClusters that
   // contributed to that hit by storing the LayerCluster id and the fraction of the corresponding hit.
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToLayerClusterId_Map;
   // scsInLayerCluster together with lcsInSimCluster are the two objects that are used to build the
   // output of the makeConnections function. scsInLayerCluster connects a LayerCluster with
   // all the SimClusters that share at least one cell with the LayerCluster and for each pair (LC,SC)
   // it stores the score.
-  hgcal::layerClusterToSimCluster scsInLayerCluster;  //[lcId][scId]->(score)
+  ticl::layerClusterToSimCluster scsInLayerCluster;  //[lcId][scId]->(score)
   scsInLayerCluster.resize(nLayerClusters);
 
   for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
@@ -146,7 +146,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
 
       auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
       if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
-        detIdToLayerClusterId_Map[rh_detid] = std::vector<hgcal::detIdInfoInCluster>();
+        detIdToLayerClusterId_Map[rh_detid] = std::vector<ticl::detIdInfoInCluster>();
       }
       detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
 
@@ -377,7 +377,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
         if (hitWithSC) {
           auto findHitIt = std::find(detIdToSimClusterId_Map[rh_detid].begin(),
                                      detIdToSimClusterId_Map[rh_detid].end(),
-                                     hgcal::detIdInfoInCluster{scPair.first, 0.f});
+                                     ticl::detIdInfoInCluster{scPair.first, 0.f});
           if (findHitIt != detIdToSimClusterId_Map[rh_detid].end())
             scFraction = findHitIt->fraction;
         }
@@ -461,7 +461,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
           if (hitWithLC) {
             auto findHitIt = std::find(detIdToLayerClusterId_Map[sc_hitDetId].begin(),
                                        detIdToLayerClusterId_Map[sc_hitDetId].end(),
-                                       hgcal::detIdInfoInCluster{layerClusterId, 0.f});
+                                       ticl::detIdInfoInCluster{layerClusterId, 0.f});
             if (findHitIt != detIdToLayerClusterId_Map[sc_hitDetId].end())
               lcFraction = findHitIt->fraction;
           }
@@ -496,9 +496,9 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
   return {scsInLayerCluster, lcsInSimCluster};
 }
 
-hgcal::RecoToSimCollectionWithSimClusters LCToSCAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimCollectionWithSimClusters LCToSCAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
-  hgcal::RecoToSimCollectionWithSimClusters returnValue(productGetter_);
+  ticl::RecoToSimCollectionWithSimClusters returnValue(productGetter_);
   const auto& links = makeConnections(cCCH, sCCH);
 
   const auto& scsInLayerCluster = std::get<0>(links);
@@ -516,9 +516,9 @@ hgcal::RecoToSimCollectionWithSimClusters LCToSCAssociatorByEnergyScoreImpl::ass
   return returnValue;
 }
 
-hgcal::SimToRecoCollectionWithSimClusters LCToSCAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimToRecoCollectionWithSimClusters LCToSCAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<reco::CaloClusterCollection>& cCCH, const edm::Handle<SimClusterCollection>& sCCH) const {
-  hgcal::SimToRecoCollectionWithSimClusters returnValue(productGetter_);
+  ticl::SimToRecoCollectionWithSimClusters returnValue(productGetter_);
   const auto& links = makeConnections(cCCH, sCCH);
   const auto& lcsInSimCluster = std::get<1>(links);
   for (size_t scId = 0; scId < lcsInSimCluster.size(); ++scId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.h
@@ -14,7 +14,7 @@ namespace edm {
   class EDProductGetter;
 }
 
-namespace hgcal {
+namespace ticl {
   // This structure is used both for LayerClusters and SimClusters storing their id and the fraction of a hit
   // that belongs to the LayerCluster or SimCluster. The meaning of the operator is extremely important since
   // this struct will be used inside maps and other containers and when searching for one particular occurence
@@ -52,25 +52,25 @@ namespace hgcal {
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> layerClusterToSimCluster;
   // This is used to save the simClusterOnLayer structure for all simClusters in each layer.
   // It is not exactly what is returned outside, but out of its entries, the output object is build.
-  typedef std::vector<std::vector<hgcal::simClusterOnCLayer>> simClusterToLayerCluster;
+  typedef std::vector<std::vector<ticl::simClusterOnCLayer>> simClusterToLayerCluster;
   //This is the output of the makeConnections function that contain all the work with SC2LC and LC2SC
   //association. It will be read by the relevant associateSimToReco and associateRecoToSim functions to
   //provide the final product.
   typedef std::tuple<layerClusterToSimCluster, simClusterToLayerCluster> association;
-}  // namespace hgcal
+}  // namespace ticl
 
-class LCToSCAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToSimClusterAssociatorBaseImpl {
+class LCToSCAssociatorByEnergyScoreImpl : public ticl::LayerClusterToSimClusterAssociatorBaseImpl {
 public:
   explicit LCToSCAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
                                              bool,
                                              std::shared_ptr<hgcal::RecHitTools>,
                                              const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::RecoToSimCollectionWithSimClusters associateRecoToSim(
+  ticl::RecoToSimCollectionWithSimClusters associateRecoToSim(
       const edm::Handle<reco::CaloClusterCollection> &cCH,
       const edm::Handle<SimClusterCollection> &sCCH) const override;
 
-  hgcal::SimToRecoCollectionWithSimClusters associateSimToReco(
+  ticl::SimToRecoCollectionWithSimClusters associateSimToReco(
       const edm::Handle<reco::CaloClusterCollection> &cCH,
       const edm::Handle<SimClusterCollection> &sCCH) const override;
 
@@ -80,6 +80,6 @@ private:
   const std::unordered_map<DetId, const HGCRecHit *> *hitMap_;
   unsigned layers_;
   edm::EDProductGetter const *productGetter_;
-  hgcal::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                     const edm::Handle<SimClusterCollection> &sCCH) const;
+  ticl::association makeConnections(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                    const edm::Handle<SimClusterCollection> &sCCH) const;
 };

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreProducer.cc
@@ -36,7 +36,7 @@ LCToSCAssociatorByEnergyScoreProducer::LCToSCAssociatorByEnergyScoreProducer(con
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::LayerClusterToSimClusterAssociator>();
+  produces<ticl::LayerClusterToSimClusterAssociator>();
 }
 
 LCToSCAssociatorByEnergyScoreProducer::~LCToSCAssociatorByEnergyScoreProducer() {}
@@ -51,7 +51,7 @@ void LCToSCAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   auto impl =
       std::make_unique<LCToSCAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
-  auto toPut = std::make_unique<hgcal::LayerClusterToSimClusterAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::LayerClusterToSimClusterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorEDProducer.cc
@@ -39,17 +39,16 @@ private:
 
   edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
   edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
-  edm::EDGetTokenT<hgcal::LayerClusterToSimClusterAssociator> associatorToken_;
+  edm::EDGetTokenT<ticl::LayerClusterToSimClusterAssociator> associatorToken_;
 };
 
 LCToSCAssociatorEDProducer::LCToSCAssociatorEDProducer(const edm::ParameterSet &pset) {
-  produces<hgcal::SimToRecoCollectionWithSimClusters>();
-  produces<hgcal::RecoToSimCollectionWithSimClusters>();
+  produces<ticl::SimToRecoCollectionWithSimClusters>();
+  produces<ticl::RecoToSimCollectionWithSimClusters>();
 
   SCCollectionToken_ = consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"));
   LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lcl"));
-  associatorToken_ =
-      consumes<hgcal::LayerClusterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+  associatorToken_ = consumes<ticl::LayerClusterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
 LCToSCAssociatorEDProducer::~LCToSCAssociatorEDProducer() {}
@@ -62,7 +61,7 @@ LCToSCAssociatorEDProducer::~LCToSCAssociatorEDProducer() {}
 void LCToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::LayerClusterToSimClusterAssociator> theAssociator;
+  edm::Handle<ticl::LayerClusterToSimClusterAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<SimClusterCollection> SCCollection;
@@ -73,13 +72,13 @@ void LCToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
 
   // associate LC and SC
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimCollectionWithSimClusters recSimColl = theAssociator->associateRecoToSim(LCCollection, SCCollection);
+  ticl::RecoToSimCollectionWithSimClusters recSimColl = theAssociator->associateRecoToSim(LCCollection, SCCollection);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimToRecoCollectionWithSimClusters simRecColl = theAssociator->associateSimToReco(LCCollection, SCCollection);
+  ticl::SimToRecoCollectionWithSimClusters simRecColl = theAssociator->associateSimToReco(LCCollection, SCCollection);
 
-  auto rts = std::make_unique<hgcal::RecoToSimCollectionWithSimClusters>(recSimColl);
-  auto str = std::make_unique<hgcal::SimToRecoCollectionWithSimClusters>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimCollectionWithSimClusters>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollectionWithSimClusters>(simRecColl);
 
   iEvent.put(std::move(rts));
   iEvent.put(std::move(str));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.cc
@@ -10,14 +10,14 @@
 LCToSimTSAssociatorByEnergyScoreImpl::LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const& productGetter)
     : productGetter_(&productGetter) {}
 
-hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<reco::CaloClusterCollection>& cCCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH,
     const edm::Handle<CaloParticleCollection>& cPCH,
-    const hgcal::RecoToSimCollection& lCToCPs,
+    const ticl::RecoToSimCollection& lCToCPs,
     const edm::Handle<SimClusterCollection>& sCCH,
-    const hgcal::RecoToSimCollectionWithSimClusters& lCToSCs) const {
-  hgcal::RecoToSimTracksterCollection returnValue(productGetter_);
+    const ticl::RecoToSimCollectionWithSimClusters& lCToSCs) const {
+  ticl::RecoToSimTracksterCollection returnValue(productGetter_);
 
   const auto simTracksters = *sTCH.product();
 
@@ -89,14 +89,14 @@ hgcal::RecoToSimTracksterCollection LCToSimTSAssociatorByEnergyScoreImpl::associ
   return returnValue;
 }
 
-hgcal::SimTracksterToRecoCollection LCToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimTracksterToRecoCollection LCToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<reco::CaloClusterCollection>& cCCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH,
     const edm::Handle<CaloParticleCollection>& cPCH,
-    const hgcal::SimToRecoCollection& cPToLCs,
+    const ticl::SimToRecoCollection& cPToLCs,
     const edm::Handle<SimClusterCollection>& sCCH,
-    const hgcal::SimToRecoCollectionWithSimClusters& sCToLCs) const {
-  hgcal::SimTracksterToRecoCollection returnValue(productGetter_);
+    const ticl::SimToRecoCollectionWithSimClusters& sCToLCs) const {
+  ticl::SimTracksterToRecoCollection returnValue(productGetter_);
 
   const auto simTracksters = *sTCH.product();
   for (size_t tsId = 0; tsId < simTracksters.size(); ++tsId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreImpl.h
@@ -19,25 +19,25 @@ namespace edm {
   class EDProductGetter;
 }
 
-class LCToSimTSAssociatorByEnergyScoreImpl : public hgcal::LayerClusterToSimTracksterAssociatorBaseImpl {
+class LCToSimTSAssociatorByEnergyScoreImpl : public ticl::LayerClusterToSimTracksterAssociatorBaseImpl {
 public:
   explicit LCToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &);
 
-  hgcal::RecoToSimTracksterCollection associateRecoToSim(
+  ticl::RecoToSimTracksterCollection associateRecoToSim(
       const edm::Handle<reco::CaloClusterCollection> &cCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
-      const hgcal::RecoToSimCollection &lCToCPs,
+      const ticl::RecoToSimCollection &lCToCPs,
       const edm::Handle<SimClusterCollection> &sCCH,
-      const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
+      const ticl::RecoToSimCollectionWithSimClusters &lCToSCs) const override;
 
-  hgcal::SimTracksterToRecoCollection associateSimToReco(
+  ticl::SimTracksterToRecoCollection associateSimToReco(
       const edm::Handle<reco::CaloClusterCollection> &cCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
-      const hgcal::SimToRecoCollection &cPToLCs,
+      const ticl::SimToRecoCollection &cPToLCs,
       const edm::Handle<SimClusterCollection> &sCCH,
-      const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const override;
+      const ticl::SimToRecoCollectionWithSimClusters &sCToLCs) const override;
 
 private:
   edm::EDProductGetter const *productGetter_;

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorByEnergyScoreProducer.cc
@@ -32,7 +32,7 @@ LCToSimTSAssociatorByEnergyScoreProducer::LCToSimTSAssociatorByEnergyScoreProduc
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::LayerClusterToSimTracksterAssociator>();
+  produces<ticl::LayerClusterToSimTracksterAssociator>();
 }
 
 LCToSimTSAssociatorByEnergyScoreProducer::~LCToSimTSAssociatorByEnergyScoreProducer() {}
@@ -44,7 +44,7 @@ void LCToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
   rhtools_->setGeometry(*geom);
 
   auto impl = std::make_unique<LCToSimTSAssociatorByEnergyScoreImpl>(iEvent.productGetter());
-  auto toPut = std::make_unique<hgcal::LayerClusterToSimTracksterAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::LayerClusterToSimTracksterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSimTSAssociatorEDProducer.cc
@@ -40,34 +40,34 @@ private:
 
   edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
   edm::EDGetTokenT<ticl::TracksterCollection> SimTSCollectionToken_;
-  edm::EDGetTokenT<hgcal::LayerClusterToSimTracksterAssociator> associatorToken_;
+  edm::EDGetTokenT<ticl::LayerClusterToSimTracksterAssociator> associatorToken_;
 
   edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
   edm::InputTag associatorCP_;
-  edm::EDGetTokenT<hgcal::RecoToSimCollection> associationMapLCToCPToken_;
-  edm::EDGetTokenT<hgcal::SimToRecoCollection> associationMapCPToLCToken_;
+  edm::EDGetTokenT<ticl::RecoToSimCollection> associationMapLCToCPToken_;
+  edm::EDGetTokenT<ticl::SimToRecoCollection> associationMapCPToLCToken_;
 
   edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
   edm::InputTag associatorSC_;
-  edm::EDGetTokenT<hgcal::RecoToSimCollectionWithSimClusters> associationMapLCToSCToken_;
-  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associationMapSCToLCToken_;
+  edm::EDGetTokenT<ticl::RecoToSimCollectionWithSimClusters> associationMapLCToSCToken_;
+  edm::EDGetTokenT<ticl::SimToRecoCollectionWithSimClusters> associationMapSCToLCToken_;
 };
 
 LCToSimTSAssociatorEDProducer::LCToSimTSAssociatorEDProducer(const edm::ParameterSet &pset)
     : LCCollectionToken_(consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lc"))),
       SimTSCollectionToken_(consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"))),
       associatorToken_(
-          consumes<hgcal::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
+          consumes<ticl::LayerClusterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"))),
       CPCollectionToken_(consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"))),
       associatorCP_(pset.getParameter<edm::InputTag>("associator_cp")),
-      associationMapLCToCPToken_(consumes<hgcal::RecoToSimCollection>(associatorCP_)),
-      associationMapCPToLCToken_(consumes<hgcal::SimToRecoCollection>(associatorCP_)),
+      associationMapLCToCPToken_(consumes<ticl::RecoToSimCollection>(associatorCP_)),
+      associationMapCPToLCToken_(consumes<ticl::SimToRecoCollection>(associatorCP_)),
       SCCollectionToken_(consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"))),
       associatorSC_(pset.getParameter<edm::InputTag>("associator_sc")),
-      associationMapLCToSCToken_(consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSC_)),
-      associationMapSCToLCToken_(consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorSC_)) {
-  produces<hgcal::SimTracksterToRecoCollection>();
-  produces<hgcal::RecoToSimTracksterCollection>();
+      associationMapLCToSCToken_(consumes<ticl::RecoToSimCollectionWithSimClusters>(associatorSC_)),
+      associationMapSCToLCToken_(consumes<ticl::SimToRecoCollectionWithSimClusters>(associatorSC_)) {
+  produces<ticl::SimTracksterToRecoCollection>();
+  produces<ticl::RecoToSimTracksterCollection>();
 }
 
 LCToSimTSAssociatorEDProducer::~LCToSimTSAssociatorEDProducer() {}
@@ -80,7 +80,7 @@ LCToSimTSAssociatorEDProducer::~LCToSimTSAssociatorEDProducer() {}
 void LCToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::LayerClusterToSimTracksterAssociator> theAssociator;
+  edm::Handle<ticl::LayerClusterToSimTracksterAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<reco::CaloClusterCollection> LCCollection;
@@ -101,15 +101,15 @@ void LCToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, c
 
   // associate LC and SimTS
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(
+  ticl::RecoToSimTracksterCollection recSimColl = theAssociator->associateRecoToSim(
       LCCollection, SimTSCollection, CPCollection, LCToCPsColl, SCCollection, LCToSCsColl);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(
+  ticl::SimTracksterToRecoCollection simRecColl = theAssociator->associateSimToReco(
       LCCollection, SimTSCollection, CPCollection, CPToLCsColl, SCCollection, SCToLCsColl);
 
-  auto rts = std::make_unique<hgcal::RecoToSimTracksterCollection>(recSimColl);
-  auto str = std::make_unique<hgcal::SimTracksterToRecoCollection>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimTracksterCollection>(recSimColl);
+  auto str = std::make_unique<ticl::SimTracksterToRecoCollection>(simRecColl);
 
   iEvent.put(std::move(rts));
   iEvent.put(std::move(str));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.cc
@@ -12,7 +12,7 @@ TSToSCAssociatorByEnergyScoreImpl::TSToSCAssociatorByEnergyScoreImpl(
   layers_ = recHitTools_->lastLayerBH();
 }
 
-hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
+ticl::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH) const {
@@ -41,7 +41,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
   // Initialize tssInSimCluster. To be returned outside, since it contains the
   // information to compute the SimCluster-To-Trackster score.
   // tssInSimCluster[scId]:
-  hgcal::simClusterToTrackster tssInSimCluster;
+  ticl::simClusterToTrackster tssInSimCluster;
   tssInSimCluster.resize(nSimClusters);
   for (unsigned int i = 0; i < nSimClusters; ++i) {
     tssInSimCluster[i].simClusterId = i;
@@ -50,7 +50,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
   }
 
   // Fill detIdToSimClusterId_Map and update tssInSimCluster
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToSimClusterId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToSimClusterId_Map;
   for (const auto& scId : sCIndices) {
     const auto& hits_and_fractions = simClusters[scId].hits_and_fractions();
     for (const auto& it_haf : hits_and_fractions) {
@@ -59,7 +59,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
       if (itcheck != hitMap_->end()) {
         const auto hit_find_it = detIdToSimClusterId_Map.find(hitid);
         if (hit_find_it == detIdToSimClusterId_Map.end()) {
-          detIdToSimClusterId_Map[hitid] = std::vector<hgcal::detIdInfoInCluster>();
+          detIdToSimClusterId_Map[hitid] = std::vector<ticl::detIdInfoInCluster>();
         }
         detIdToSimClusterId_Map[hitid].emplace_back(scId, it_haf.second);
 
@@ -107,11 +107,11 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
 #endif
 
   // Fill detIdToLayerClusterId_Map and scsInTrackster; update tssInSimCluster
-  std::unordered_map<DetId, std::vector<hgcal::detIdInfoInCluster>> detIdToLayerClusterId_Map;
+  std::unordered_map<DetId, std::vector<ticl::detIdInfoInCluster>> detIdToLayerClusterId_Map;
   // this contains the ids of the simclusters contributing with at least one
   // hit to the Trackster. To be returned since this contains the information
   // to compute the Trackster-To-SimCluster score.
-  hgcal::tracksterToSimCluster scsInTrackster;  //[tsId][scId]->(energy,score)
+  ticl::tracksterToSimCluster scsInTrackster;  //[tsId][scId]->(energy,score)
   scsInTrackster.resize(nTracksters);
 
   for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
@@ -128,7 +128,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
 
         const auto hit_find_in_LC = detIdToLayerClusterId_Map.find(rh_detid);
         if (hit_find_in_LC == detIdToLayerClusterId_Map.end()) {
-          detIdToLayerClusterId_Map[rh_detid] = std::vector<hgcal::detIdInfoInCluster>();
+          detIdToLayerClusterId_Map[rh_detid] = std::vector<ticl::detIdInfoInCluster>();
         }
         detIdToLayerClusterId_Map[rh_detid].emplace_back(lcId, rhFraction);
 
@@ -359,7 +359,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
           if (hitWithSC) {
             const auto findHitIt = std::find(detIdToSimClusterId_Map[rh_detid].begin(),
                                              detIdToSimClusterId_Map[rh_detid].end(),
-                                             hgcal::detIdInfoInCluster{scPair.first, 0.f});
+                                             ticl::detIdInfoInCluster{scPair.first, 0.f});
             if (findHitIt != detIdToSimClusterId_Map[rh_detid].end())
               scFraction = findHitIt->fraction;
           }
@@ -447,7 +447,7 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
           if (hitWithLC) {
             const auto findHitIt = std::find(detIdToLayerClusterId_Map[sc_hitDetId].begin(),
                                              detIdToLayerClusterId_Map[sc_hitDetId].end(),
-                                             hgcal::detIdInfoInCluster{lcId, 0.f});
+                                             ticl::detIdInfoInCluster{lcId, 0.f});
             if (findHitIt != detIdToLayerClusterId_Map[sc_hitDetId].end())
               tsFraction = findHitIt->fraction * lcFractionInTs;
           }
@@ -480,11 +480,11 @@ hgcal::association TSToSCAssociatorByEnergyScoreImpl::makeConnections(
   return {scsInTrackster, tssInSimCluster};
 }
 
-hgcal::RecoToSimCollectionTracksters TSToSCAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimCollectionTracksters TSToSCAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH) const {
-  hgcal::RecoToSimCollectionTracksters returnValue(productGetter_);
+  ticl::RecoToSimCollectionTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sCCH);
 
   const auto& scsInTrackster = std::get<0>(links);
@@ -502,11 +502,11 @@ hgcal::RecoToSimCollectionTracksters TSToSCAssociatorByEnergyScoreImpl::associat
   return returnValue;
 }
 
-hgcal::SimToRecoCollectionTracksters TSToSCAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimToRecoCollectionTracksters TSToSCAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH) const {
-  hgcal::SimToRecoCollectionTracksters returnValue(productGetter_);
+  ticl::SimToRecoCollectionTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sCCH);
   const auto& tssInSimCluster = std::get<1>(links);
   for (size_t scId = 0; scId < tssInSimCluster.size(); ++scId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreImpl.h
@@ -14,7 +14,7 @@ namespace edm {
   class EDProductGetter;
 }
 
-namespace hgcal {
+namespace ticl {
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
     long unsigned int clusterId;
@@ -33,24 +33,24 @@ namespace hgcal {
   };
 
   typedef std::vector<std::vector<std::pair<unsigned int, float>>> tracksterToSimCluster;
-  typedef std::vector<hgcal::simClusterOnBLayer> simClusterToTrackster;
+  typedef std::vector<ticl::simClusterOnBLayer> simClusterToTrackster;
   typedef std::tuple<tracksterToSimCluster, simClusterToTrackster> association;
-}  // namespace hgcal
+}  // namespace ticl
 
-class TSToSCAssociatorByEnergyScoreImpl : public hgcal::TracksterToSimClusterAssociatorBaseImpl {
+class TSToSCAssociatorByEnergyScoreImpl : public ticl::TracksterToSimClusterAssociatorBaseImpl {
 public:
   explicit TSToSCAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
                                              bool,
                                              std::shared_ptr<hgcal::RecHitTools>,
                                              const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::RecoToSimCollectionTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                          const edm::Handle<SimClusterCollection> &sCCH) const override;
+  ticl::RecoToSimCollectionTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                         const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                         const edm::Handle<SimClusterCollection> &sCCH) const override;
 
-  hgcal::SimToRecoCollectionTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                          const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                          const edm::Handle<SimClusterCollection> &sCCH) const override;
+  ticl::SimToRecoCollectionTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                         const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                         const edm::Handle<SimClusterCollection> &sCCH) const override;
 
 private:
   const bool hardScatterOnly_;
@@ -58,7 +58,7 @@ private:
   const std::unordered_map<DetId, const HGCRecHit *> *hitMap_;
   unsigned layers_;
   edm::EDProductGetter const *productGetter_;
-  hgcal::association makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                     const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                     const edm::Handle<SimClusterCollection> &sCCH) const;
+  ticl::association makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                    const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                    const edm::Handle<SimClusterCollection> &sCCH) const;
 };

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorByEnergyScoreProducer.cc
@@ -36,7 +36,7 @@ TSToSCAssociatorByEnergyScoreProducer::TSToSCAssociatorByEnergyScoreProducer(con
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::TracksterToSimClusterAssociator>();
+  produces<ticl::TracksterToSimClusterAssociator>();
 }
 
 TSToSCAssociatorByEnergyScoreProducer::~TSToSCAssociatorByEnergyScoreProducer() {}
@@ -51,7 +51,7 @@ void TSToSCAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   auto impl =
       std::make_unique<TSToSCAssociatorByEnergyScoreImpl>(iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
-  auto toPut = std::make_unique<hgcal::TracksterToSimClusterAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::TracksterToSimClusterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSCAssociatorEDProducer.cc
@@ -40,17 +40,17 @@ private:
   edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
   edm::EDGetTokenT<ticl::TracksterCollection> TSCollectionToken_;
   edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
-  edm::EDGetTokenT<hgcal::TracksterToSimClusterAssociator> associatorToken_;
+  edm::EDGetTokenT<ticl::TracksterToSimClusterAssociator> associatorToken_;
 };
 
 TSToSCAssociatorEDProducer::TSToSCAssociatorEDProducer(const edm::ParameterSet &pset) {
-  produces<hgcal::SimToRecoCollectionTracksters>();
-  produces<hgcal::RecoToSimCollectionTracksters>();
+  produces<ticl::SimToRecoCollectionTracksters>();
+  produces<ticl::RecoToSimCollectionTracksters>();
 
   SCCollectionToken_ = consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"));
   TSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_tst"));
   LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lcl"));
-  associatorToken_ = consumes<hgcal::TracksterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+  associatorToken_ = consumes<ticl::TracksterToSimClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
 TSToSCAssociatorEDProducer::~TSToSCAssociatorEDProducer() {}
@@ -63,7 +63,7 @@ TSToSCAssociatorEDProducer::~TSToSCAssociatorEDProducer() {}
 void TSToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::TracksterToSimClusterAssociator> theAssociator;
+  edm::Handle<ticl::TracksterToSimClusterAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<SimClusterCollection> SCCollection;
@@ -77,15 +77,15 @@ void TSToSCAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, cons
 
   // associate TS and SC
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimCollectionTracksters recSimColl =
+  ticl::RecoToSimCollectionTracksters recSimColl =
       theAssociator->associateRecoToSim(TSCollection, LCCollection, SCCollection);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimToRecoCollectionTracksters simRecColl =
+  ticl::SimToRecoCollectionTracksters simRecColl =
       theAssociator->associateSimToReco(TSCollection, LCCollection, SCCollection);
 
-  auto rts = std::make_unique<hgcal::RecoToSimCollectionTracksters>(recSimColl);
-  auto str = std::make_unique<hgcal::SimToRecoCollectionTracksters>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimCollectionTracksters>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollectionTracksters>(simRecColl);
 
   iEvent.put(std::move(rts));
   iEvent.put(std::move(str));

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.cc
@@ -11,7 +11,7 @@ TSToSimTSAssociatorByEnergyScoreImpl::TSToSimTSAssociatorByEnergyScoreImpl(
   layers_ = recHitTools_->lastLayerBH();
 }
 
-hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
+ticl::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH) const {
@@ -38,7 +38,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   // among other the information to compute the SimTrackster-To-Trackster score. It is one of the two objects that
   // build the output of the makeConnections function.
   // tssInSimTrackster[stId]
-  hgcal::simTracksterToTrackster tssInSimTrackster;
+  ticl::simTracksterToTrackster tssInSimTrackster;
   tssInSimTrackster.resize(nSimTracksters);
   for (unsigned int i = 0; i < nSimTracksters; ++i) {
     tssInSimTrackster[i].simTracksterId = i;
@@ -50,7 +50,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   // The lcToSimTracksterId_Map is used to connect a LayerCluster, via its id (key), with all the SimTracksters that
   // contributed to that LayerCluster by storing the SimTrackster id and the fraction of the LayerCluster's energy
   // in which the SimTrackster contributed.
-  std::unordered_map<int, std::vector<hgcal::lcInfoInTrackster>> lcToSimTracksterId_Map;
+  std::unordered_map<int, std::vector<ticl::lcInfoInTrackster>> lcToSimTracksterId_Map;
   for (const auto& stId : sTIndices) {
     const auto& lcs = simTracksters[stId].vertices();
     int lcInSimTst = 0;
@@ -59,7 +59,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
 
       const auto lc_find_it = lcToSimTracksterId_Map.find(lcId);
       if (lc_find_it == lcToSimTracksterId_Map.end()) {
-        lcToSimTracksterId_Map[lcId] = std::vector<hgcal::lcInfoInTrackster>();
+        lcToSimTracksterId_Map[lcId] = std::vector<ticl::lcInfoInTrackster>();
       }
       lcToSimTracksterId_Map[lcId].emplace_back(stId, fraction);
 
@@ -108,7 +108,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   // this contains the ids of the simTracksters contributing with at least one
   // hit to the Trackster. To be returned since this contains the information
   // to compute the Trackster-To-SimTrackster score.
-  hgcal::tracksterToSimTrackster stsInTrackster;  // tsId->(stId,score)
+  ticl::tracksterToSimTrackster stsInTrackster;  // tsId->(stId,score)
   stsInTrackster.resize(nTracksters);
 
   for (unsigned int tsId = 0; tsId < nTracksters; ++tsId) {
@@ -328,7 +328,7 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
         if (lcWithST) {
           const auto findLCIt = std::find(lcToSimTracksterId_Map[lcId].begin(),
                                           lcToSimTracksterId_Map[lcId].end(),
-                                          hgcal::lcInfoInTrackster{stPair.first, 0.f});
+                                          ticl::lcInfoInTrackster{stPair.first, 0.f});
           if (findLCIt != lcToSimTracksterId_Map[lcId].end()) {
             stFraction = findLCIt->fraction;
           }
@@ -434,11 +434,11 @@ hgcal::association TSToSimTSAssociatorByEnergyScoreImpl::makeConnections(
   return {stsInTrackster, tssInSimTrackster};
 }
 
-hgcal::RecoToSimCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH) const {
-  hgcal::RecoToSimCollectionSimTracksters returnValue(productGetter_);
+  ticl::RecoToSimCollectionSimTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sTCH);
 
   const auto& stsInTrackster = std::get<0>(links);
@@ -457,11 +457,11 @@ hgcal::RecoToSimCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::as
   return returnValue;
 }
 
-hgcal::SimToRecoCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimToRecoCollectionSimTracksters TSToSimTSAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH) const {
-  hgcal::SimToRecoCollectionSimTracksters returnValue(productGetter_);
+  ticl::SimToRecoCollectionSimTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sTCH);
   const auto& tssInSimTrackster = std::get<1>(links);
   for (size_t stId = 0; stId < tssInSimTrackster.size(); ++stId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreImpl.h
@@ -14,7 +14,7 @@ namespace edm {
   class EDProductGetter;
 }
 
-namespace hgcal {
+namespace ticl {
   // This structure is used for SimTracksters storing its id and the energy fraction of
   // a LayerCluster that is related to that SimTrackster. Be careful not to be confused by the fact that
   // similar structs are used in other HGCAL associators where the fraction is a hit's fraction.
@@ -59,23 +59,23 @@ namespace hgcal {
   typedef std::vector<std::vector<std::pair<unsigned int, std::pair<float, float>>>> tracksterToSimTrackster;
   // This is used to save the simTracksterOnLayer structure for all simTracksters.
   // It is not exactly what is returned outside, but out of its entries, the output object is build.
-  typedef std::vector<hgcal::simTracksterOnLayer> simTracksterToTrackster;
+  typedef std::vector<ticl::simTracksterOnLayer> simTracksterToTrackster;
   typedef std::tuple<tracksterToSimTrackster, simTracksterToTrackster> association;
-}  // namespace hgcal
+}  // namespace ticl
 
-class TSToSimTSAssociatorByEnergyScoreImpl : public hgcal::TracksterToSimTracksterAssociatorBaseImpl {
+class TSToSimTSAssociatorByEnergyScoreImpl : public ticl::TracksterToSimTracksterAssociatorBaseImpl {
 public:
   explicit TSToSimTSAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
                                                 bool,
                                                 std::shared_ptr<hgcal::RecHitTools>,
                                                 const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+  ticl::RecoToSimCollectionSimTracksters associateRecoToSim(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
 
-  hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+  ticl::SimToRecoCollectionSimTracksters associateSimToReco(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
@@ -86,7 +86,7 @@ private:
   const std::unordered_map<DetId, const HGCRecHit *> *hitMap_;
   unsigned layers_;
   edm::EDProductGetter const *productGetter_;
-  hgcal::association makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                     const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                     const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+  ticl::association makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                    const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                    const edm::Handle<ticl::TracksterCollection> &sTCH) const;
 };

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorByEnergyScoreProducer.cc
@@ -36,7 +36,7 @@ TSToSimTSAssociatorByEnergyScoreProducer::TSToSimTSAssociatorByEnergyScoreProduc
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::TracksterToSimTracksterAssociator>();
+  produces<ticl::TracksterToSimTracksterAssociator>();
 }
 
 TSToSimTSAssociatorByEnergyScoreProducer::~TSToSimTSAssociatorByEnergyScoreProducer() {}
@@ -51,7 +51,7 @@ void TSToSimTSAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   auto impl = std::make_unique<TSToSimTSAssociatorByEnergyScoreImpl>(
       iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
-  auto toPut = std::make_unique<hgcal::TracksterToSimTracksterAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::TracksterToSimTracksterAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSAssociatorEDProducer.cc
@@ -40,17 +40,17 @@ private:
   edm::EDGetTokenT<ticl::TracksterCollection> TSCollectionToken_;
   edm::EDGetTokenT<ticl::TracksterCollection> SimTSCollectionToken_;
   edm::EDGetTokenT<reco::CaloClusterCollection> LCCollectionToken_;
-  edm::EDGetTokenT<hgcal::TracksterToSimTracksterAssociator> associatorToken_;
+  edm::EDGetTokenT<ticl::TracksterToSimTracksterAssociator> associatorToken_;
 };
 
 TSToSimTSAssociatorEDProducer::TSToSimTSAssociatorEDProducer(const edm::ParameterSet &pset) {
-  produces<hgcal::SimToRecoCollectionSimTracksters>("simToReco");
-  produces<hgcal::RecoToSimCollectionSimTracksters>("recoToSim");
+  produces<ticl::SimToRecoCollectionSimTracksters>("simToReco");
+  produces<ticl::RecoToSimCollectionSimTracksters>("recoToSim");
 
   TSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_tst"));
   SimTSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"));
   LCCollectionToken_ = consumes<reco::CaloClusterCollection>(pset.getParameter<edm::InputTag>("label_lcl"));
-  associatorToken_ = consumes<hgcal::TracksterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+  associatorToken_ = consumes<ticl::TracksterToSimTracksterAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
 TSToSimTSAssociatorEDProducer::~TSToSimTSAssociatorEDProducer() {}
@@ -63,7 +63,7 @@ TSToSimTSAssociatorEDProducer::~TSToSimTSAssociatorEDProducer() {}
 void TSToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::TracksterToSimTracksterAssociator> theAssociator;
+  edm::Handle<ticl::TracksterToSimTracksterAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<ticl::TracksterCollection> TSCollection;
@@ -77,15 +77,15 @@ void TSToSimTSAssociatorEDProducer::produce(edm::StreamID, edm::Event &iEvent, c
 
   // associate TS and SimTS
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
-  hgcal::RecoToSimCollectionSimTracksters recSimColl =
+  ticl::RecoToSimCollectionSimTracksters recSimColl =
       theAssociator->associateRecoToSim(TSCollection, LCCollection, SimTSCollection);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimToRecoCollectionSimTracksters simRecColl =
+  ticl::SimToRecoCollectionSimTracksters simRecColl =
       theAssociator->associateSimToReco(TSCollection, LCCollection, SimTSCollection);
 
-  auto rts = std::make_unique<hgcal::RecoToSimCollectionSimTracksters>(recSimColl);
-  auto str = std::make_unique<hgcal::SimToRecoCollectionSimTracksters>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimCollectionSimTracksters>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollectionSimTracksters>(simRecColl);
 
   iEvent.put(std::move(rts), "recoToSim");
   iEvent.put(std::move(str), "simToReco");

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.cc
@@ -13,7 +13,7 @@ TSToSimTSHitLCAssociatorByEnergyScoreImpl::TSToSimTSHitLCAssociatorByEnergyScore
   layers_ = recHitTools_->lastLayerBH();
 }
 
-hgcal::association_t TSToSimTSHitLCAssociatorByEnergyScoreImpl::makeConnections(
+ticl::association_t TSToSimTSHitLCAssociatorByEnergyScoreImpl::makeConnections(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH,
@@ -34,8 +34,8 @@ hgcal::association_t TSToSimTSHitLCAssociatorByEnergyScoreImpl::makeConnections(
   std::unordered_map<DetId, std::vector<std::pair<int, float>>> detIdCaloParticleId_Map;
   std::unordered_map<DetId, std::vector<std::pair<int, float>>> detIdToRecoTSId_Map;
 
-  hgcal::sharedEnergyAndScore_t recoToSim_sharedEnergyAndScore;
-  hgcal::sharedEnergyAndScore_t simToReco_sharedEnergyAndScore;
+  ticl::sharedEnergyAndScore_t recoToSim_sharedEnergyAndScore;
+  ticl::sharedEnergyAndScore_t simToReco_sharedEnergyAndScore;
 
   recoToSim_sharedEnergyAndScore.resize(nTracksters);
   simToReco_sharedEnergyAndScore.resize(nSimTracksters);
@@ -206,13 +206,13 @@ hgcal::association_t TSToSimTSHitLCAssociatorByEnergyScoreImpl::makeConnections(
   return {recoToSim_sharedEnergyAndScore, simToReco_sharedEnergyAndScore};
 }
 
-hgcal::RecoToSimCollectionSimTracksters TSToSimTSHitLCAssociatorByEnergyScoreImpl::associateRecoToSim(
+ticl::RecoToSimCollectionSimTracksters TSToSimTSHitLCAssociatorByEnergyScoreImpl::associateRecoToSim(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH,
     const edm::Handle<CaloParticleCollection>& cPCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH) const {
-  hgcal::RecoToSimCollectionSimTracksters returnValue(productGetter_);
+  ticl::RecoToSimCollectionSimTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sCCH, cPCH, sTCH);
   const auto& recoToSim_sharedEnergyAndScore = std::get<0>(links);
   for (std::size_t tsId = 0; tsId < recoToSim_sharedEnergyAndScore.size(); ++tsId) {
@@ -234,13 +234,13 @@ hgcal::RecoToSimCollectionSimTracksters TSToSimTSHitLCAssociatorByEnergyScoreImp
   return returnValue;
 }
 
-hgcal::SimToRecoCollectionSimTracksters TSToSimTSHitLCAssociatorByEnergyScoreImpl::associateSimToReco(
+ticl::SimToRecoCollectionSimTracksters TSToSimTSHitLCAssociatorByEnergyScoreImpl::associateSimToReco(
     const edm::Handle<ticl::TracksterCollection>& tCH,
     const edm::Handle<reco::CaloClusterCollection>& lCCH,
     const edm::Handle<SimClusterCollection>& sCCH,
     const edm::Handle<CaloParticleCollection>& cPCH,
     const edm::Handle<ticl::TracksterCollection>& sTCH) const {
-  hgcal::SimToRecoCollectionSimTracksters returnValue(productGetter_);
+  ticl::SimToRecoCollectionSimTracksters returnValue(productGetter_);
   const auto& links = makeConnections(tCH, lCCH, sCCH, cPCH, sTCH);
   const auto& simToReco_sharedEnergyAndScore = std::get<1>(links);
   for (std::size_t simTsId = 0; simTsId < simToReco_sharedEnergyAndScore.size(); ++simTsId) {

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.h
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreImpl.h
@@ -14,7 +14,7 @@ namespace edm {
   class EDProductGetter;
 }
 
-namespace hgcal {
+namespace ticl {
 
   struct detIdInfoInCluster {
     bool operator==(const detIdInfoInCluster &o) const { return clusterId == o.clusterId; };
@@ -40,29 +40,29 @@ namespace hgcal {
   // the SimTracksters (via their ids (stIds)) that share at least one LayerCluster. In that pair
   // it stores the score (tsId->(stId,score)). Keep in mind that the association is not unique, since there could be
   // several instances of the same SimTrackster from several related SimClusters that each contributed to the same Trackster.
-}  // namespace hgcal
+}  // namespace ticl
 
-class TSToSimTSHitLCAssociatorByEnergyScoreImpl : public hgcal::TracksterToSimTracksterHitLCAssociatorBaseImpl {
+class TSToSimTSHitLCAssociatorByEnergyScoreImpl : public ticl::TracksterToSimTracksterHitLCAssociatorBaseImpl {
 public:
   explicit TSToSimTSHitLCAssociatorByEnergyScoreImpl(edm::EDProductGetter const &,
                                                      bool,
                                                      std::shared_ptr<hgcal::RecHitTools>,
                                                      const std::unordered_map<DetId, const HGCRecHit *> *);
 
-  hgcal::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                       const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                       const edm::Handle<SimClusterCollection> &sCCH,
-                                       const edm::Handle<CaloParticleCollection> &cPCH,
-                                       const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+  ticl::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                      const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                      const edm::Handle<SimClusterCollection> &sCCH,
+                                      const edm::Handle<CaloParticleCollection> &cPCH,
+                                      const edm::Handle<ticl::TracksterCollection> &sTCH) const;
 
-  hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+  ticl::RecoToSimCollectionSimTracksters associateRecoToSim(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const override;
 
-  hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+  ticl::SimToRecoCollectionSimTracksters associateSimToReco(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH,

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorByEnergyScoreProducer.cc
@@ -36,7 +36,7 @@ TSToSimTSHitLCAssociatorByEnergyScoreProducer::TSToSimTSHitLCAssociatorByEnergyS
   rhtools_.reset(new hgcal::RecHitTools());
 
   // Register the product
-  produces<hgcal::TracksterToSimTracksterHitLCAssociator>();
+  produces<ticl::TracksterToSimTracksterHitLCAssociator>();
 }
 
 TSToSimTSHitLCAssociatorByEnergyScoreProducer::~TSToSimTSHitLCAssociatorByEnergyScoreProducer() {}
@@ -51,7 +51,7 @@ void TSToSimTSHitLCAssociatorByEnergyScoreProducer::produce(edm::StreamID,
 
   auto impl = std::make_unique<TSToSimTSHitLCAssociatorByEnergyScoreImpl>(
       iEvent.productGetter(), hardScatterOnly_, rhtools_, hitMap);
-  auto toPut = std::make_unique<hgcal::TracksterToSimTracksterHitLCAssociator>(std::move(impl));
+  auto toPut = std::make_unique<ticl::TracksterToSimTracksterHitLCAssociator>(std::move(impl));
   iEvent.put(std::move(toPut));
 }
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorEDProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/TSToSimTSHitLCAssociatorEDProducer.cc
@@ -41,13 +41,13 @@ private:
   edm::EDGetTokenT<SimClusterCollection> SCCollectionToken_;
   edm::EDGetTokenT<CaloParticleCollection> CPCollectionToken_;
   edm::EDGetTokenT<std::map<uint, std::vector<uint>>> simTrackstersMap_;
-  hgcal::validationType valType_;
-  edm::EDGetTokenT<hgcal::TracksterToSimTracksterHitLCAssociator> associatorToken_;
+  ticl::validationType valType_;
+  edm::EDGetTokenT<ticl::TracksterToSimTracksterHitLCAssociator> associatorToken_;
 };
 
 TSToSimTSHitLCAssociatorEDProducer::TSToSimTSHitLCAssociatorEDProducer(const edm::ParameterSet &pset) {
-  produces<hgcal::SimToRecoCollectionSimTracksters>("simToReco");
-  produces<hgcal::RecoToSimCollectionSimTracksters>("recoToSim");
+  produces<ticl::SimToRecoCollectionSimTracksters>("simToReco");
+  produces<ticl::RecoToSimCollectionSimTracksters>("recoToSim");
 
   TSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_tst"));
   SimTSCollectionToken_ = consumes<ticl::TracksterCollection>(pset.getParameter<edm::InputTag>("label_simTst"));
@@ -55,7 +55,7 @@ TSToSimTSHitLCAssociatorEDProducer::TSToSimTSHitLCAssociatorEDProducer(const edm
   SCCollectionToken_ = consumes<SimClusterCollection>(pset.getParameter<edm::InputTag>("label_scl"));
   CPCollectionToken_ = consumes<CaloParticleCollection>(pset.getParameter<edm::InputTag>("label_cp"));
   associatorToken_ =
-      consumes<hgcal::TracksterToSimTracksterHitLCAssociator>(pset.getParameter<edm::InputTag>("associator"));
+      consumes<ticl::TracksterToSimTracksterHitLCAssociator>(pset.getParameter<edm::InputTag>("associator"));
 }
 
 TSToSimTSHitLCAssociatorEDProducer::~TSToSimTSHitLCAssociatorEDProducer() {}
@@ -65,7 +65,7 @@ void TSToSimTSHitLCAssociatorEDProducer::produce(edm::StreamID,
                                                  const edm::EventSetup &iSetup) const {
   using namespace edm;
 
-  edm::Handle<hgcal::TracksterToSimTracksterHitLCAssociator> theAssociator;
+  edm::Handle<ticl::TracksterToSimTracksterHitLCAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
 
   Handle<ticl::TracksterCollection> TSCollection;
@@ -86,15 +86,15 @@ void TSToSimTSHitLCAssociatorEDProducer::produce(edm::StreamID,
   // associate TS and SimTS
   LogTrace("AssociatorValidator") << "Calling associateRecoToSim method\n";
 
-  hgcal::RecoToSimCollectionSimTracksters recSimColl =
+  ticl::RecoToSimCollectionSimTracksters recSimColl =
       theAssociator->associateRecoToSim(TSCollection, LCCollection, SCCollection, CPCollection, SimTSCollection);
 
   LogTrace("AssociatorValidator") << "Calling associateSimToReco method\n";
-  hgcal::SimToRecoCollectionSimTracksters simRecColl =
+  ticl::SimToRecoCollectionSimTracksters simRecColl =
       theAssociator->associateSimToReco(TSCollection, LCCollection, SCCollection, CPCollection, SimTSCollection);
 
-  auto rts = std::make_unique<hgcal::RecoToSimCollectionSimTracksters>(recSimColl);
-  auto str = std::make_unique<hgcal::SimToRecoCollectionSimTracksters>(simRecColl);
+  auto rts = std::make_unique<ticl::RecoToSimCollectionSimTracksters>(recSimColl);
+  auto str = std::make_unique<ticl::SimToRecoCollectionSimTracksters>(simRecColl);
 
   iEvent.put(std::move(rts), "recoToSim");
   iEvent.put(std::move(str), "simToReco");

--- a/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h
@@ -11,11 +11,11 @@
 
 // forward declarations
 
-namespace hgcal {
+namespace ticl {
 
   class LayerClusterToCaloParticleAssociator {
   public:
-    LayerClusterToCaloParticleAssociator(std::unique_ptr<hgcal::LayerClusterToCaloParticleAssociatorBaseImpl>);
+    LayerClusterToCaloParticleAssociator(std::unique_ptr<ticl::LayerClusterToCaloParticleAssociatorBaseImpl>);
     LayerClusterToCaloParticleAssociator() = default;
     LayerClusterToCaloParticleAssociator(LayerClusterToCaloParticleAssociator &&) = default;
     LayerClusterToCaloParticleAssociator &operator=(LayerClusterToCaloParticleAssociator &&) = default;
@@ -27,14 +27,14 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to CaloParticles
-    hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<CaloParticleCollection> &cPCH) const {
+    ticl::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                 const edm::Handle<CaloParticleCollection> &cPCH) const {
       return m_impl->associateRecoToSim(cCCH, cPCH);
     };
 
     /// Associate a CaloParticle to LayerClusters
-    hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                  const edm::Handle<CaloParticleCollection> &cPCH) const {
+    ticl::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                 const edm::Handle<CaloParticleCollection> &cPCH) const {
       return m_impl->associateSimToReco(cCCH, cPCH);
     }
 
@@ -42,6 +42,6 @@ namespace hgcal {
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToCaloParticleAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h
@@ -16,7 +16,7 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 
-namespace hgcal {
+namespace ticl {
 
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<CaloParticleCollection, reco::CaloClusterCollection, std::pair<float, float>>>
@@ -33,13 +33,13 @@ namespace hgcal {
     virtual ~LayerClusterToCaloParticleAssociatorBaseImpl();
 
     /// Associate a LayerCluster to CaloParticles
-    virtual hgcal::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<CaloParticleCollection> &cPCH) const;
+    virtual ticl::RecoToSimCollection associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                         const edm::Handle<CaloParticleCollection> &cPCH) const;
 
     /// Associate a CaloParticle to LayerClusters
-    virtual hgcal::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
-                                                          const edm::Handle<CaloParticleCollection> &cPCH) const;
+    virtual ticl::SimToRecoCollection associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCH,
+                                                         const edm::Handle<CaloParticleCollection> &cPCH) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h
@@ -11,11 +11,11 @@
 
 // forward declarations
 
-namespace hgcal {
+namespace ticl {
 
   class LayerClusterToSimClusterAssociator {
   public:
-    LayerClusterToSimClusterAssociator(std::unique_ptr<hgcal::LayerClusterToSimClusterAssociatorBaseImpl>);
+    LayerClusterToSimClusterAssociator(std::unique_ptr<ticl::LayerClusterToSimClusterAssociatorBaseImpl>);
     LayerClusterToSimClusterAssociator() = default;
     LayerClusterToSimClusterAssociator(LayerClusterToSimClusterAssociator &&) = default;
     LayerClusterToSimClusterAssociator &operator=(LayerClusterToSimClusterAssociator &&) = default;
@@ -26,14 +26,14 @@ namespace hgcal {
         delete;  // stop default
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to SimClusters
-    hgcal::RecoToSimCollectionWithSimClusters associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                                 const edm::Handle<SimClusterCollection> &sCCH) const {
+    ticl::RecoToSimCollectionWithSimClusters associateRecoToSim(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                                const edm::Handle<SimClusterCollection> &sCCH) const {
       return m_impl->associateRecoToSim(cCCH, sCCH);
     };
 
     /// Associate a SimCluster to LayerClusters
-    hgcal::SimToRecoCollectionWithSimClusters associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
-                                                                 const edm::Handle<SimClusterCollection> &sCCH) const {
+    ticl::SimToRecoCollectionWithSimClusters associateSimToReco(const edm::Handle<reco::CaloClusterCollection> &cCCH,
+                                                                const edm::Handle<SimClusterCollection> &sCCH) const {
       return m_impl->associateSimToReco(cCCH, sCCH);
     }
 
@@ -41,6 +41,6 @@ namespace hgcal {
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToSimClusterAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociatorBaseImpl.h
@@ -16,7 +16,7 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
-namespace hgcal {
+namespace ticl {
 
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<SimClusterCollection, reco::CaloClusterCollection, std::pair<float, float>>>
@@ -32,13 +32,13 @@ namespace hgcal {
     virtual ~LayerClusterToSimClusterAssociatorBaseImpl();
 
     /// Associate a LayerCluster to SimClusters
-    virtual hgcal::RecoToSimCollectionWithSimClusters associateRecoToSim(
+    virtual ticl::RecoToSimCollectionWithSimClusters associateRecoToSim(
         const edm::Handle<reco::CaloClusterCollection> &cCH, const edm::Handle<SimClusterCollection> &sCCH) const;
 
     /// Associate a SimCluster to LayerClusters
-    virtual hgcal::SimToRecoCollectionWithSimClusters associateSimToReco(
+    virtual ticl::SimToRecoCollectionWithSimClusters associateSimToReco(
         const edm::Handle<reco::CaloClusterCollection> &cCH, const edm::Handle<SimClusterCollection> &sCCH) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h
@@ -11,11 +11,11 @@
 
 // forward declarations
 
-namespace hgcal {
+namespace ticl {
 
   class LayerClusterToSimTracksterAssociator {
   public:
-    LayerClusterToSimTracksterAssociator(std::unique_ptr<hgcal::LayerClusterToSimTracksterAssociatorBaseImpl>);
+    LayerClusterToSimTracksterAssociator(std::unique_ptr<ticl::LayerClusterToSimTracksterAssociatorBaseImpl>);
     LayerClusterToSimTracksterAssociator() = default;
     LayerClusterToSimTracksterAssociator(LayerClusterToSimTracksterAssociator &&) = default;
     LayerClusterToSimTracksterAssociator &operator=(LayerClusterToSimTracksterAssociator &&) = default;
@@ -27,24 +27,24 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a LayerCluster to SimTracksters
-    hgcal::RecoToSimTracksterCollection associateRecoToSim(
+    ticl::RecoToSimTracksterCollection associateRecoToSim(
         const edm::Handle<reco::CaloClusterCollection> &cCCH,
         const edm::Handle<ticl::TracksterCollection> &stCH,
         const edm::Handle<CaloParticleCollection> &cPCH,
-        const hgcal::RecoToSimCollection &lCToCPs,
+        const ticl::RecoToSimCollection &lCToCPs,
         const edm::Handle<SimClusterCollection> &sCCH,
-        const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+        const ticl::RecoToSimCollectionWithSimClusters &lCToSCs) const {
       return m_impl->associateRecoToSim(cCCH, stCH, cPCH, lCToCPs, sCCH, lCToSCs);
     };
 
     /// Associate a SimTrackster to LayerClusters
-    hgcal::SimTracksterToRecoCollection associateSimToReco(
+    ticl::SimTracksterToRecoCollection associateSimToReco(
         const edm::Handle<reco::CaloClusterCollection> &cCCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH,
         const edm::Handle<CaloParticleCollection> &cPCH,
-        const hgcal::SimToRecoCollection &cpToLCs,
+        const ticl::SimToRecoCollection &cpToLCs,
         const edm::Handle<SimClusterCollection> &sCCH,
-        const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+        const ticl::SimToRecoCollectionWithSimClusters &sCToLCs) const {
       return m_impl->associateSimToReco(cCCH, sTCH, cPCH, cpToLCs, sCCH, sCToLCs);
     }
 
@@ -52,6 +52,6 @@ namespace hgcal {
     // ---------- member data --------------------------------
     std::unique_ptr<LayerClusterToSimTracksterAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h
@@ -20,7 +20,7 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 #include "LayerClusterToSimClusterAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
 
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, reco::CaloClusterCollection, std::pair<float, float>>>
@@ -37,23 +37,23 @@ namespace hgcal {
     virtual ~LayerClusterToSimTracksterAssociatorBaseImpl();
 
     /// Associate a LayerCluster to SimTracksters
-    virtual hgcal::RecoToSimTracksterCollection associateRecoToSim(
+    virtual ticl::RecoToSimTracksterCollection associateRecoToSim(
         const edm::Handle<reco::CaloClusterCollection> &cCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH,
         const edm::Handle<CaloParticleCollection> &cPCH,
-        const hgcal::RecoToSimCollection &lCToCPs,
+        const ticl::RecoToSimCollection &lCToCPs,
         const edm::Handle<SimClusterCollection> &sCCH,
-        const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const;
+        const ticl::RecoToSimCollectionWithSimClusters &lCToSCs) const;
 
     /// Associate a SimTrackster to LayerClusters
-    virtual hgcal::SimTracksterToRecoCollection associateSimToReco(
+    virtual ticl::SimTracksterToRecoCollection associateSimToReco(
         const edm::Handle<reco::CaloClusterCollection> &cCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH,
         const edm::Handle<CaloParticleCollection> &cPCH,
-        const hgcal::SimToRecoCollection &cPToLCs,
+        const ticl::SimToRecoCollection &cPToLCs,
         const edm::Handle<SimClusterCollection> &sCCH,
-        const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const;
+        const ticl::SimToRecoCollectionWithSimClusters &sCToLCs) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h
@@ -11,11 +11,11 @@
 
 // forward declarations
 
-namespace hgcal {
+namespace ticl {
 
   class TracksterToSimClusterAssociator {
   public:
-    TracksterToSimClusterAssociator(std::unique_ptr<hgcal::TracksterToSimClusterAssociatorBaseImpl>);
+    TracksterToSimClusterAssociator(std::unique_ptr<ticl::TracksterToSimClusterAssociatorBaseImpl>);
     TracksterToSimClusterAssociator() = default;
     TracksterToSimClusterAssociator(TracksterToSimClusterAssociator &&) = default;
     TracksterToSimClusterAssociator &operator=(TracksterToSimClusterAssociator &&) = default;
@@ -26,16 +26,16 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a Trackster to SimClusters
-    hgcal::RecoToSimCollectionTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                            const edm::Handle<SimClusterCollection> &sCCH) const {
+    ticl::RecoToSimCollectionTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                           const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                           const edm::Handle<SimClusterCollection> &sCCH) const {
       return m_impl->associateRecoToSim(tCH, lCCH, sCCH);
     };
 
     /// Associate a SimCluster to Tracksters
-    hgcal::SimToRecoCollectionTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                                            const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                                            const edm::Handle<SimClusterCollection> &sCCH) const {
+    ticl::SimToRecoCollectionTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                           const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                           const edm::Handle<SimClusterCollection> &sCCH) const {
       return m_impl->associateSimToReco(tCH, lCCH, sCCH);
     }
 
@@ -43,6 +43,6 @@ namespace hgcal {
     // ---------- member data --------------------------------
     std::unique_ptr<TracksterToSimClusterAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimClusterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimClusterAssociatorBaseImpl.h
@@ -17,7 +17,7 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
-namespace hgcal {
+namespace ticl {
 
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<SimClusterCollection, ticl::TracksterCollection, std::pair<float, float>>>
@@ -33,17 +33,15 @@ namespace hgcal {
     virtual ~TracksterToSimClusterAssociatorBaseImpl();
 
     /// Associate a Trackster to SimClusters
-    virtual hgcal::RecoToSimCollectionTracksters associateRecoToSim(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<SimClusterCollection> &sCCH) const;
+    virtual ticl::RecoToSimCollectionTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                                   const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                                   const edm::Handle<SimClusterCollection> &sCCH) const;
 
     /// Associate a SimCluster to Tracksters
-    virtual hgcal::SimToRecoCollectionTracksters associateSimToReco(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<SimClusterCollection> &sCCH) const;
+    virtual ticl::SimToRecoCollectionTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                                   const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                                   const edm::Handle<SimClusterCollection> &sCCH) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h
@@ -11,11 +11,11 @@
 
 // forward declarations
 
-namespace hgcal {
+namespace ticl {
 
   class TracksterToSimTracksterAssociator {
   public:
-    TracksterToSimTracksterAssociator(std::unique_ptr<hgcal::TracksterToSimTracksterAssociatorBaseImpl>);
+    TracksterToSimTracksterAssociator(std::unique_ptr<ticl::TracksterToSimTracksterAssociatorBaseImpl>);
     TracksterToSimTracksterAssociator() = default;
     TracksterToSimTracksterAssociator(TracksterToSimTracksterAssociator &&) = default;
     TracksterToSimTracksterAssociator &operator=(TracksterToSimTracksterAssociator &&) = default;
@@ -27,18 +27,16 @@ namespace hgcal {
 
     // ---------- const member functions ---------------------
     /// Associate a Trackster to SimClusters
-    hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    ticl::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                              const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                              const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateRecoToSim(tCH, lCCH, sTCH);
     };
 
     /// Associate a SimCluster to Tracksters
-    hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    ticl::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                              const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                              const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateSimToReco(tCH, lCCH, sTCH);
     }
 
@@ -46,6 +44,6 @@ namespace hgcal {
     // ---------- member data --------------------------------
     std::unique_ptr<TracksterToSimTracksterAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h
@@ -17,7 +17,7 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
-namespace hgcal {
+namespace ticl {
 
   typedef edm::AssociationMap<
       edm::OneToManyWithQualityGeneric<ticl::TracksterCollection, ticl::TracksterCollection, std::pair<float, float>>>
@@ -34,17 +34,17 @@ namespace hgcal {
     virtual ~TracksterToSimTracksterAssociatorBaseImpl();
 
     /// Associate a Trackster to SimClusters
-    virtual hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+    virtual ticl::RecoToSimCollectionSimTracksters associateRecoToSim(
         const edm::Handle<ticl::TracksterCollection> &tCH,
         const edm::Handle<reco::CaloClusterCollection> &lCCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH) const;
 
     /// Associate a SimCluster to Tracksters
-    virtual hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+    virtual ticl::SimToRecoCollectionSimTracksters associateSimToReco(
         const edm::Handle<ticl::TracksterCollection> &tCH,
         const edm::Handle<reco::CaloClusterCollection> &lCCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociator.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociator.h
@@ -9,11 +9,11 @@
 
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
 
   class TracksterToSimTracksterHitLCAssociator {
   public:
-    TracksterToSimTracksterHitLCAssociator(std::unique_ptr<hgcal::TracksterToSimTracksterHitLCAssociatorBaseImpl>);
+    TracksterToSimTracksterHitLCAssociator(std::unique_ptr<ticl::TracksterToSimTracksterHitLCAssociatorBaseImpl>);
     TracksterToSimTracksterHitLCAssociator() = default;
     TracksterToSimTracksterHitLCAssociator(TracksterToSimTracksterHitLCAssociator &&) = default;
     TracksterToSimTracksterHitLCAssociator &operator=(TracksterToSimTracksterHitLCAssociator &&) = default;
@@ -22,36 +22,34 @@ namespace hgcal {
 
     ~TracksterToSimTracksterHitLCAssociator() = default;
 
-    hgcal::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                         const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                         const edm::Handle<SimClusterCollection> &sCCH,
-                                         const edm::Handle<CaloParticleCollection> &cPCH,
-                                         const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    ticl::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                        const edm::Handle<SimClusterCollection> &sCCH,
+                                        const edm::Handle<CaloParticleCollection> &cPCH,
+                                        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->makeConnections(tCH, lCCH, sCCH, cPCH, sTCH);
     }
     /// Associate a Trackster to SimClusters
-    hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<SimClusterCollection> &sCCH,
-        const edm::Handle<CaloParticleCollection> &cPCH,
-        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    ticl::RecoToSimCollectionSimTracksters associateRecoToSim(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                              const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                              const edm::Handle<SimClusterCollection> &sCCH,
+                                                              const edm::Handle<CaloParticleCollection> &cPCH,
+                                                              const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateRecoToSim(tCH, lCCH, sCCH, cPCH, sTCH);
     };
 
     /// Associate a SimCluster to Tracksters
-    hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
-        const edm::Handle<ticl::TracksterCollection> &tCH,
-        const edm::Handle<reco::CaloClusterCollection> &lCCH,
-        const edm::Handle<SimClusterCollection> &sCCH,
-        const edm::Handle<CaloParticleCollection> &cPCH,
-        const edm::Handle<ticl::TracksterCollection> &sTCH) const {
+    ticl::SimToRecoCollectionSimTracksters associateSimToReco(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                                              const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                                              const edm::Handle<SimClusterCollection> &sCCH,
+                                                              const edm::Handle<CaloParticleCollection> &cPCH,
+                                                              const edm::Handle<ticl::TracksterCollection> &sTCH) const {
       return m_impl->associateSimToReco(tCH, lCCH, sCCH, cPCH, sTCH);
     }
 
   private:
     std::unique_ptr<TracksterToSimTracksterHitLCAssociatorBaseImpl> m_impl;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h
@@ -10,7 +10,7 @@
 typedef std::vector<SimCluster> SimClusterCollection;
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
 
-namespace hgcal {
+namespace ticl {
 
   enum validationType { Linking = 0, PatternRecognition, PatternRecognition_CP };
 
@@ -31,14 +31,14 @@ namespace hgcal {
     /// Destructor
     virtual ~TracksterToSimTracksterHitLCAssociatorBaseImpl();
 
-    hgcal::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
-                                         const edm::Handle<reco::CaloClusterCollection> &lCCH,
-                                         const edm::Handle<SimClusterCollection> &sCCH,
-                                         const edm::Handle<CaloParticleCollection> &cPCH,
-                                         const edm::Handle<ticl::TracksterCollection> &sTCH) const;
+    ticl::association_t makeConnections(const edm::Handle<ticl::TracksterCollection> &tCH,
+                                        const edm::Handle<reco::CaloClusterCollection> &lCCH,
+                                        const edm::Handle<SimClusterCollection> &sCCH,
+                                        const edm::Handle<CaloParticleCollection> &cPCH,
+                                        const edm::Handle<ticl::TracksterCollection> &sTCH) const;
 
     /// Associate a Trackster to SimClusters
-    virtual hgcal::RecoToSimCollectionSimTracksters associateRecoToSim(
+    virtual ticl::RecoToSimCollectionSimTracksters associateRecoToSim(
         const edm::Handle<ticl::TracksterCollection> &tCH,
         const edm::Handle<reco::CaloClusterCollection> &lCCH,
         const edm::Handle<SimClusterCollection> &sCCH,
@@ -46,13 +46,13 @@ namespace hgcal {
         const edm::Handle<ticl::TracksterCollection> &sTCH) const;
 
     /// Associate a SimCluster to Tracksters
-    virtual hgcal::SimToRecoCollectionSimTracksters associateSimToReco(
+    virtual ticl::SimToRecoCollectionSimTracksters associateSimToReco(
         const edm::Handle<ticl::TracksterCollection> &tCH,
         const edm::Handle<reco::CaloClusterCollection> &lCCH,
         const edm::Handle<SimClusterCollection> &sCCH,
         const edm::Handle<CaloParticleCollection> &cPCH,
         const edm::Handle<ticl::TracksterCollection> &sTCH) const;
   };
-}  // namespace hgcal
+}  // namespace ticl
 
 #endif

--- a/SimDataFormats/Associations/src/LayerClusterToCaloParticleAssociator.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToCaloParticleAssociator.cc
@@ -2,6 +2,6 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociator.h"
 
-hgcal::LayerClusterToCaloParticleAssociator::LayerClusterToCaloParticleAssociator(
-    std::unique_ptr<hgcal::LayerClusterToCaloParticleAssociatorBaseImpl> ptr)
+ticl::LayerClusterToCaloParticleAssociator::LayerClusterToCaloParticleAssociator(
+    std::unique_ptr<ticl::LayerClusterToCaloParticleAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/LayerClusterToCaloParticleAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToCaloParticleAssociatorBaseImpl.cc
@@ -2,18 +2,18 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToCaloParticleAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   LayerClusterToCaloParticleAssociatorBaseImpl::LayerClusterToCaloParticleAssociatorBaseImpl(){};
   LayerClusterToCaloParticleAssociatorBaseImpl::~LayerClusterToCaloParticleAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimCollection LayerClusterToCaloParticleAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimCollection LayerClusterToCaloParticleAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<CaloParticleCollection> &cPCH) const {
-    return hgcal::RecoToSimCollection();
+    return ticl::RecoToSimCollection();
   }
 
-  hgcal::SimToRecoCollection LayerClusterToCaloParticleAssociatorBaseImpl::associateSimToReco(
+  ticl::SimToRecoCollection LayerClusterToCaloParticleAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<CaloParticleCollection> &cPCH) const {
-    return hgcal::SimToRecoCollection();
+    return ticl::SimToRecoCollection();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/LayerClusterToSimClusterAssociator.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimClusterAssociator.cc
@@ -2,6 +2,6 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociator.h"
 
-hgcal::LayerClusterToSimClusterAssociator::LayerClusterToSimClusterAssociator(
-    std::unique_ptr<hgcal::LayerClusterToSimClusterAssociatorBaseImpl> ptr)
+ticl::LayerClusterToSimClusterAssociator::LayerClusterToSimClusterAssociator(
+    std::unique_ptr<ticl::LayerClusterToSimClusterAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/LayerClusterToSimClusterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimClusterAssociatorBaseImpl.cc
@@ -2,18 +2,18 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimClusterAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   LayerClusterToSimClusterAssociatorBaseImpl::LayerClusterToSimClusterAssociatorBaseImpl(){};
   LayerClusterToSimClusterAssociatorBaseImpl::~LayerClusterToSimClusterAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimCollectionWithSimClusters LayerClusterToSimClusterAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimCollectionWithSimClusters LayerClusterToSimClusterAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<SimClusterCollection> &sCCH) const {
-    return hgcal::RecoToSimCollectionWithSimClusters();
+    return ticl::RecoToSimCollectionWithSimClusters();
   }
 
-  hgcal::SimToRecoCollectionWithSimClusters LayerClusterToSimClusterAssociatorBaseImpl::associateSimToReco(
+  ticl::SimToRecoCollectionWithSimClusters LayerClusterToSimClusterAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<reco::CaloClusterCollection> &cCCH, const edm::Handle<SimClusterCollection> &sCCH) const {
-    return hgcal::SimToRecoCollectionWithSimClusters();
+    return ticl::SimToRecoCollectionWithSimClusters();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociator.cc
@@ -2,6 +2,6 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
 
-hgcal::LayerClusterToSimTracksterAssociator::LayerClusterToSimTracksterAssociator(
-    std::unique_ptr<hgcal::LayerClusterToSimTracksterAssociatorBaseImpl> ptr)
+ticl::LayerClusterToSimTracksterAssociator::LayerClusterToSimTracksterAssociator(
+    std::unique_ptr<ticl::LayerClusterToSimTracksterAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/LayerClusterToSimTracksterAssociatorBaseImpl.cc
@@ -2,28 +2,28 @@
 
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   LayerClusterToSimTracksterAssociatorBaseImpl::LayerClusterToSimTracksterAssociatorBaseImpl(){};
   LayerClusterToSimTracksterAssociatorBaseImpl::~LayerClusterToSimTracksterAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimTracksterCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimTracksterCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<reco::CaloClusterCollection> &cCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
-      const hgcal::RecoToSimCollection &lCToCPs,
+      const ticl::RecoToSimCollection &lCToCPs,
       const edm::Handle<SimClusterCollection> &sCCH,
-      const hgcal::RecoToSimCollectionWithSimClusters &lCToSCs) const {
-    return hgcal::RecoToSimTracksterCollection();
+      const ticl::RecoToSimCollectionWithSimClusters &lCToSCs) const {
+    return ticl::RecoToSimTracksterCollection();
   }
 
-  hgcal::SimTracksterToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
+  ticl::SimTracksterToRecoCollection LayerClusterToSimTracksterAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<reco::CaloClusterCollection> &cCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
-      const hgcal::SimToRecoCollection &cPToLCs,
+      const ticl::SimToRecoCollection &cPToLCs,
       const edm::Handle<SimClusterCollection> &sCCH,
-      const hgcal::SimToRecoCollectionWithSimClusters &sCToLCs) const {
-    return hgcal::SimTracksterToRecoCollection();
+      const ticl::SimToRecoCollectionWithSimClusters &sCToLCs) const {
+    return ticl::SimTracksterToRecoCollection();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/TracksterToSimClusterAssociator.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimClusterAssociator.cc
@@ -2,6 +2,6 @@
 
 #include "SimDataFormats/Associations/interface/TracksterToSimClusterAssociator.h"
 
-hgcal::TracksterToSimClusterAssociator::TracksterToSimClusterAssociator(
-    std::unique_ptr<hgcal::TracksterToSimClusterAssociatorBaseImpl> ptr)
+ticl::TracksterToSimClusterAssociator::TracksterToSimClusterAssociator(
+    std::unique_ptr<ticl::TracksterToSimClusterAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/TracksterToSimClusterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimClusterAssociatorBaseImpl.cc
@@ -2,22 +2,22 @@
 
 #include "SimDataFormats/Associations/interface/TracksterToSimClusterAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   TracksterToSimClusterAssociatorBaseImpl::TracksterToSimClusterAssociatorBaseImpl(){};
   TracksterToSimClusterAssociatorBaseImpl::~TracksterToSimClusterAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimCollectionTracksters TracksterToSimClusterAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimCollectionTracksters TracksterToSimClusterAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH) const {
-    return hgcal::RecoToSimCollectionTracksters();
+    return ticl::RecoToSimCollectionTracksters();
   }
 
-  hgcal::SimToRecoCollectionTracksters TracksterToSimClusterAssociatorBaseImpl::associateSimToReco(
+  ticl::SimToRecoCollectionTracksters TracksterToSimClusterAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH) const {
-    return hgcal::SimToRecoCollectionTracksters();
+    return ticl::SimToRecoCollectionTracksters();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterAssociator.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterAssociator.cc
@@ -2,6 +2,6 @@
 
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociator.h"
 
-hgcal::TracksterToSimTracksterAssociator::TracksterToSimTracksterAssociator(
-    std::unique_ptr<hgcal::TracksterToSimTracksterAssociatorBaseImpl> ptr)
+ticl::TracksterToSimTracksterAssociator::TracksterToSimTracksterAssociator(
+    std::unique_ptr<ticl::TracksterToSimTracksterAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterAssociatorBaseImpl.cc
@@ -2,22 +2,22 @@
 
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   TracksterToSimTracksterAssociatorBaseImpl::TracksterToSimTracksterAssociatorBaseImpl(){};
   TracksterToSimTracksterAssociatorBaseImpl::~TracksterToSimTracksterAssociatorBaseImpl(){};
 
-  hgcal::RecoToSimCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-    return hgcal::RecoToSimCollectionSimTracksters();
+    return ticl::RecoToSimCollectionSimTracksters();
   }
 
-  hgcal::SimToRecoCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateSimToReco(
+  ticl::SimToRecoCollectionSimTracksters TracksterToSimTracksterAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-    return hgcal::SimToRecoCollectionSimTracksters();
+    return ticl::SimToRecoCollectionSimTracksters();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterHitLCAssociator.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterHitLCAssociator.cc
@@ -1,5 +1,5 @@
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociator.h"
 
-hgcal::TracksterToSimTracksterHitLCAssociator::TracksterToSimTracksterHitLCAssociator(
-    std::unique_ptr<hgcal::TracksterToSimTracksterHitLCAssociatorBaseImpl> ptr)
+ticl::TracksterToSimTracksterHitLCAssociator::TracksterToSimTracksterHitLCAssociator(
+    std::unique_ptr<ticl::TracksterToSimTracksterHitLCAssociatorBaseImpl> ptr)
     : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/TracksterToSimTracksterHitLCAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TracksterToSimTracksterHitLCAssociatorBaseImpl.cc
@@ -1,34 +1,34 @@
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociatorBaseImpl.h"
 
-namespace hgcal {
+namespace ticl {
   TracksterToSimTracksterHitLCAssociatorBaseImpl::TracksterToSimTracksterHitLCAssociatorBaseImpl(){};
   TracksterToSimTracksterHitLCAssociatorBaseImpl::~TracksterToSimTracksterHitLCAssociatorBaseImpl(){};
 
-  hgcal::association_t TracksterToSimTracksterHitLCAssociatorBaseImpl::makeConnections(
+  ticl::association_t TracksterToSimTracksterHitLCAssociatorBaseImpl::makeConnections(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-    return hgcal::association_t();
+    return ticl::association_t();
   }
 
-  hgcal::RecoToSimCollectionSimTracksters TracksterToSimTracksterHitLCAssociatorBaseImpl::associateRecoToSim(
+  ticl::RecoToSimCollectionSimTracksters TracksterToSimTracksterHitLCAssociatorBaseImpl::associateRecoToSim(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-    return hgcal::RecoToSimCollectionSimTracksters();
+    return ticl::RecoToSimCollectionSimTracksters();
   }
 
-  hgcal::SimToRecoCollectionSimTracksters TracksterToSimTracksterHitLCAssociatorBaseImpl::associateSimToReco(
+  ticl::SimToRecoCollectionSimTracksters TracksterToSimTracksterHitLCAssociatorBaseImpl::associateSimToReco(
       const edm::Handle<ticl::TracksterCollection> &tCH,
       const edm::Handle<reco::CaloClusterCollection> &lCCH,
       const edm::Handle<SimClusterCollection> &sCCH,
       const edm::Handle<CaloParticleCollection> &cPCH,
       const edm::Handle<ticl::TracksterCollection> &sTCH) const {
-    return hgcal::SimToRecoCollectionSimTracksters();
+    return ticl::SimToRecoCollectionSimTracksters();
   }
 
-}  // namespace hgcal
+}  // namespace ticl

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -25,19 +25,19 @@ namespace SimDataFormats_Associations {
 
     edm::Wrapper<reco::VertexToTrackingVertexAssociator> dummy4;
 
-    edm::Wrapper<hgcal::LayerClusterToCaloParticleAssociator> dummy5;
+    edm::Wrapper<ticl::LayerClusterToCaloParticleAssociator> dummy5;
 
-    edm::Wrapper<hgcal::LayerClusterToSimClusterAssociator> dummy6;
+    edm::Wrapper<ticl::LayerClusterToSimClusterAssociator> dummy6;
 
-    edm::Wrapper<hgcal::TracksterToSimClusterAssociator> dummy7;
+    edm::Wrapper<ticl::TracksterToSimClusterAssociator> dummy7;
 
     edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator> dummy8;
 
-    edm::Wrapper<hgcal::TracksterToSimTracksterAssociator> dummy9;
+    edm::Wrapper<ticl::TracksterToSimTracksterAssociator> dummy9;
 
-    edm::Wrapper<hgcal::TracksterToSimTracksterHitLCAssociator> dummy10;
+    edm::Wrapper<ticl::TracksterToSimTracksterHitLCAssociator> dummy10;
 
-    edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator> dummy11;
+    edm::Wrapper<ticl::LayerClusterToSimTracksterAssociator> dummy11;
 
     reco::VertexSimToRecoCollection vstrc;
     reco::VertexSimToRecoCollection::const_iterator vstrci;

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -9,26 +9,26 @@
   <class name="reco::VertexToTrackingVertexAssociator" persistent="false"/>
   <class name="edm::Wrapper<reco::VertexToTrackingVertexAssociator>" persistent="false"/>
 
-  <class name="hgcal::LayerClusterToCaloParticleAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::LayerClusterToCaloParticleAssociator>" persistent="false"/>
+  <class name="ticl::LayerClusterToCaloParticleAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::LayerClusterToCaloParticleAssociator>" persistent="false"/>
 
-  <class name="hgcal::LayerClusterToSimClusterAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::LayerClusterToSimClusterAssociator>" persistent="false"/>
+  <class name="ticl::LayerClusterToSimClusterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::LayerClusterToSimClusterAssociator>" persistent="false"/>
 
-  <class name="hgcal::TracksterToSimClusterAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::TracksterToSimClusterAssociator>" persistent="false"/>
+  <class name="ticl::TracksterToSimClusterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::TracksterToSimClusterAssociator>" persistent="false"/>
 
   <class name="hgcal::MultiClusterToCaloParticleAssociator" persistent="false"/>
   <class name="edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator>" persistent="false"/>
 
-  <class name="hgcal::TracksterToSimTracksterAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::TracksterToSimTracksterAssociator>" persistent="false"/>
+  <class name="ticl::TracksterToSimTracksterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::TracksterToSimTracksterAssociator>" persistent="false"/>
 
-  <class name="hgcal::TracksterToSimTracksterHitLCAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::TracksterToSimTracksterHitLCAssociator>" persistent="false"/>
+  <class name="ticl::TracksterToSimTracksterHitLCAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::TracksterToSimTracksterHitLCAssociator>" persistent="false"/>
 
-  <class name="hgcal::LayerClusterToSimTracksterAssociator" persistent="false"/>
-  <class name="edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator>" persistent="false"/>
+  <class name="ticl::LayerClusterToSimTracksterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<ticl::LayerClusterToSimTracksterAssociator>" persistent="false"/>
 
 
   <class name="reco::VertexSimToRecoCollection" >
@@ -41,14 +41,14 @@
   <class name="edm::Wrapper<reco::VertexRecoToSimCollection>" />
 
 
-  <class name="hgcal::SimToRecoCollection" >
+  <class name="ticl::SimToRecoCollection" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::SimToRecoCollection>" />
-  <class name="hgcal::RecoToSimCollection" >
+  <class name="edm::Wrapper<ticl::SimToRecoCollection>" />
+  <class name="ticl::RecoToSimCollection" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::RecoToSimCollection>" />
+  <class name="edm::Wrapper<ticl::RecoToSimCollection>" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<CaloParticle> >,edm::RefProd<vector<reco::CaloCluster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<CaloParticle> > >" />
@@ -56,28 +56,28 @@
   <class name="vector<pair<unsigned int,pair<float,float> > >" />
 
 
-  <class name="hgcal::SimToRecoCollectionWithSimClusters" >
+  <class name="ticl::SimToRecoCollectionWithSimClusters" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::SimToRecoCollectionWithSimClusters>" />
-  <class name="hgcal::RecoToSimCollectionWithSimClusters" >
+  <class name="edm::Wrapper<ticl::SimToRecoCollectionWithSimClusters>" />
+  <class name="ticl::RecoToSimCollectionWithSimClusters" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::RecoToSimCollectionWithSimClusters>" />
+  <class name="edm::Wrapper<ticl::RecoToSimCollectionWithSimClusters>" />
 
   <class name="edm::RefProd<vector<ticl::Trackster> >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >, edm::RefProd<vector<ticl::Trackster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >, edm::RefProd<vector<SimCluster> > >" />
 
 
-  <class name="hgcal::SimToRecoCollectionTracksters" >
+  <class name="ticl::SimToRecoCollectionTracksters" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::SimToRecoCollectionTracksters>" />
-  <class name="hgcal::RecoToSimCollectionTracksters" >
+  <class name="edm::Wrapper<ticl::SimToRecoCollectionTracksters>" />
+  <class name="ticl::RecoToSimCollectionTracksters" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::RecoToSimCollectionTracksters>" />
+  <class name="edm::Wrapper<ticl::RecoToSimCollectionTracksters>" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<SimCluster> >,edm::RefProd<vector<reco::CaloCluster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<SimCluster> > >" />
@@ -111,26 +111,26 @@
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::HGCalMultiCluster> >,edm::RefProd<vector<CaloParticle> > >" />
 
 
-  <class name="hgcal::SimToRecoCollectionSimTracksters" >
+  <class name="ticl::SimToRecoCollectionSimTracksters" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::SimToRecoCollectionSimTracksters>" />
-  <class name="hgcal::RecoToSimCollectionSimTracksters" >
+  <class name="edm::Wrapper<ticl::SimToRecoCollectionSimTracksters>" />
+  <class name="ticl::RecoToSimCollectionSimTracksters" >
     <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::RecoToSimCollectionSimTracksters>" />
+  <class name="edm::Wrapper<ticl::RecoToSimCollectionSimTracksters>" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<ticl::Trackster> > >" />
 
 
-  <class name="hgcal::SimTracksterToRecoCollection" >
+  <class name="ticl::SimTracksterToRecoCollection" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::SimTracksterToRecoCollection>" />
-  <class name="hgcal::RecoToSimTracksterCollection" >
+  <class name="edm::Wrapper<ticl::SimTracksterToRecoCollection>" />
+  <class name="ticl::RecoToSimTracksterCollection" >
    <field name="transientMap_" transient="true"/>
   </class>
-  <class name="edm::Wrapper<hgcal::RecoToSimTracksterCollection>" />
+  <class name="edm::Wrapper<ticl::RecoToSimTracksterCollection>" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<reco::CaloCluster> >,edm::RefProd<vector<ticl::Trackster> > >" />
   <class name="edm::helpers::KeyVal<edm::RefProd<vector<ticl::Trackster> >,edm::RefProd<vector<reco::CaloCluster> > >" />

--- a/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/caloTruthProducer_cfi.py
@@ -18,12 +18,6 @@ caloParticles = cms.PSet(
                 cms.InputTag('g4SimHits','HGCHitsHEfront'),
                 cms.InputTag('g4SimHits','HGCHitsHEback')
             ),
-#            hcal = cms.VInputTag(cms.InputTag('g4SimHits','HcalHits')),
-#            ecal = cms.VInputTag(
-#                cms.InputTag('g4SimHits','EcalHitsEE'),
-#                cms.InputTag('g4SimHits','EcalHitsEB'),
-#                cms.InputTag('g4SimHits','EcalHitsES')
-#            )
 	),
 	simTrackCollection = cms.InputTag('g4SimHits'),
 	simVertexCollection = cms.InputTag('g4SimHits'),
@@ -59,3 +53,20 @@ run3_ecalclustering.toModify(
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(caloParticles, cms.PSet()) # don't allow this to run in fastsim
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(
+    caloParticles, 
+    simHitCollections = cms.PSet(
+        hgc = cms.VInputTag(
+            cms.InputTag('g4SimHits', 'HGCHitsEE'),
+            cms.InputTag('g4SimHits', 'HGCHitsHEfront'),
+            cms.InputTag('g4SimHits', 'HGCHitsHEback'),
+        ),
+        hcal = cms.VInputTag(cms.InputTag('g4SimHits', 'HcalHits')),
+        ecal = cms.VInputTag(
+            cms.InputTag('g4SimHits', 'EcalHitsEB')
+        )
+    )
+)
+
+        

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -89,10 +89,10 @@ protected:
   edm::EDGetTokenT<std::vector<SimVertex>> simVertices_;
   std::vector<edm::EDGetTokenT<std::vector<float>>> clustersMaskTokens_;
   edm::EDGetTokenT<std::unordered_map<DetId, const HGCRecHit*>> hitMap_;
-  edm::EDGetTokenT<hgcal::RecoToSimCollection> associatorMapRtS;
-  edm::EDGetTokenT<hgcal::SimToRecoCollection> associatorMapStR;
-  edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimtR;
-  edm::EDGetTokenT<hgcal::RecoToSimCollectionWithSimClusters> associatorMapRtSim;
+  edm::EDGetTokenT<ticl::RecoToSimCollection> associatorMapRtS;
+  edm::EDGetTokenT<ticl::SimToRecoCollection> associatorMapStR;
+  edm::EDGetTokenT<ticl::SimToRecoCollectionWithSimClusters> associatorMapSimtR;
+  edm::EDGetTokenT<ticl::RecoToSimCollectionWithSimClusters> associatorMapRtSim;
   std::unique_ptr<HGVHistoProducerAlgo> histoProducerAlgo_;
 
 private:

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -271,8 +271,8 @@ public:
                                       std::vector<size_t> const& cPSelectedIndices,
                                       std::unordered_map<DetId, const HGCRecHit*> const&,
                                       unsigned int layers,
-                                      const hgcal::RecoToSimCollection& recSimColl,
-                                      const hgcal::SimToRecoCollection& simRecColl) const;
+                                      const ticl::RecoToSimCollection& recSimColl,
+                                      const ticl::SimToRecoCollection& simRecColl) const;
   void layerClusters_to_SimClusters(const Histograms& histograms,
                                     const int count,
                                     edm::Handle<reco::CaloClusterCollection> clusterHandle,
@@ -283,8 +283,8 @@ public:
                                     const std::vector<float>& mask,
                                     std::unordered_map<DetId, const HGCRecHit*> const&,
                                     unsigned int layers,
-                                    const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
-                                    const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
+                                    const ticl::RecoToSimCollectionWithSimClusters& recSimColl,
+                                    const ticl::SimToRecoCollectionWithSimClusters& simRecColl) const;
   void tracksters_to_SimTracksters(const Histograms& histograms,
                                    const int count,
                                    const ticl::TracksterCollection& Tracksters,
@@ -319,8 +319,8 @@ public:
                                    std::map<double, double> cummatbudg,
                                    unsigned int layers,
                                    std::vector<int> thicknesses,
-                                   const hgcal::RecoToSimCollection& recSimColl,
-                                   const hgcal::SimToRecoCollection& simRecColl) const;
+                                   const ticl::RecoToSimCollection& recSimColl,
+                                   const ticl::SimToRecoCollection& simRecColl) const;
   void fill_simCluster_histos(const Histograms& histograms,
                               std::vector<SimCluster> const& simClusters,
                               unsigned int layers,
@@ -335,8 +335,8 @@ public:
                                          const std::vector<float>& mask,
                                          std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
                                          unsigned int layers,
-                                         const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
-                                         const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
+                                         const ticl::RecoToSimCollectionWithSimClusters& recSimColl,
+                                         const ticl::SimToRecoCollectionWithSimClusters& simRecColl) const;
   void fill_cluster_histos(const Histograms& histograms, const int count, const reco::CaloCluster& cluster) const;
   void fill_trackster_histos(const Histograms& histograms,
                              const int count,

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -44,8 +44,8 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
     clustersMaskTokens_.push_back(consumes<std::vector<float>>(itag));
   }
 
-  associatorMapSimtR = consumes<hgcal::SimToRecoCollectionWithSimClusters>(associatorSim_);
-  associatorMapRtSim = consumes<hgcal::RecoToSimCollectionWithSimClusters>(associatorSim_);
+  associatorMapSimtR = consumes<ticl::SimToRecoCollectionWithSimClusters>(associatorSim_);
+  associatorMapRtSim = consumes<ticl::RecoToSimCollectionWithSimClusters>(associatorSim_);
 
   simTrackstersMap_ = consumes<std::map<uint, std::vector<uint>>>(edm::InputTag("ticlSimTracksters"));
 
@@ -62,8 +62,8 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
   simTracksters_ = consumes<ticl::TracksterCollection>(label_simTS);
   simTracksters_fromCPs_ = consumes<ticl::TracksterCollection>(label_simTSFromCP);
 
-  associatorMapRtS = consumes<hgcal::RecoToSimCollection>(associator_);
-  associatorMapStR = consumes<hgcal::SimToRecoCollection>(associator_);
+  associatorMapRtS = consumes<ticl::RecoToSimCollection>(associator_);
+  associatorMapStR = consumes<ticl::SimToRecoCollection>(associator_);
 
   cpSelector = CaloParticleSelector(pset.getParameter<double>("ptMinCP"),
                                     pset.getParameter<double>("ptMaxCP"),
@@ -280,10 +280,10 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   tools_->setGeometry(*geom);
   histoProducerAlgo_->setRecHitTools(tools_);
 
-  edm::Handle<hgcal::SimToRecoCollection> simtorecoCollectionH;
+  edm::Handle<ticl::SimToRecoCollection> simtorecoCollectionH;
   event.getByToken(associatorMapStR, simtorecoCollectionH);
   auto simRecColl = *simtorecoCollectionH;
-  edm::Handle<hgcal::RecoToSimCollection> recotosimCollectionH;
+  edm::Handle<ticl::RecoToSimCollection> recotosimCollectionH;
   event.getByToken(associatorMapRtS, recotosimCollectionH);
   auto recSimColl = *recotosimCollectionH;
 
@@ -346,10 +346,10 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
     for (unsigned int ws = 0; ws < label_clustersmask.size(); ws++) {
       const auto& inputClusterMask = event.get(clustersMaskTokens_[ws]);
 
-      edm::Handle<hgcal::SimToRecoCollectionWithSimClusters> simtorecoCollectionH;
+      edm::Handle<ticl::SimToRecoCollectionWithSimClusters> simtorecoCollectionH;
       event.getByToken(associatorMapSimtR, simtorecoCollectionH);
       auto simRecColl = *simtorecoCollectionH;
-      edm::Handle<hgcal::RecoToSimCollectionWithSimClusters> recotosimCollectionH;
+      edm::Handle<ticl::RecoToSimCollectionWithSimClusters> recotosimCollectionH;
       event.getByToken(associatorMapRtSim, recotosimCollectionH);
       auto recSimColl = *recotosimCollectionH;
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1705,8 +1705,8 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterAssociation_hist
     const std::vector<float>& mask,
     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
     unsigned int layers,
-    const hgcal::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
-    const hgcal::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
+    const ticl::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
+    const ticl::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
   //Each event to be treated as two events: an event in +ve endcap,
   //plus another event in -ve endcap. In this spirit there will be
   //a layer variable (layerid) that maps the layers in :
@@ -1745,8 +1745,8 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
                                                           std::vector<size_t> const& cPSelectedIndices,
                                                           std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
                                                           unsigned int layers,
-                                                          const hgcal::RecoToSimCollection& cpsInLayerClusterMap,
-                                                          const hgcal::SimToRecoCollection& cPOnLayerMap) const {
+                                                          const ticl::RecoToSimCollection& cpsInLayerClusterMap,
+                                                          const ticl::SimToRecoCollection& cPOnLayerMap) const {
   const auto nLayerClusters = clusters.size();
 
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdToCaloParticleId_Map;
@@ -2005,8 +2005,8 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     const std::vector<float>& mask,
     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
     unsigned int layers,
-    const hgcal::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
-    const hgcal::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
+    const ticl::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
+    const ticl::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
   // Here fill the plots to compute the different metrics linked to
   // reco-level, namely fake-rate and merge-rate. In this loop should *not*
   // restrict only to the selected SimClusters.
@@ -2185,8 +2185,8 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
                                                        std::map<double, double> cummatbudg,
                                                        unsigned int layers,
                                                        std::vector<int> thicknesses,
-                                                       const hgcal::RecoToSimCollection& cpsInLayerClusterMap,
-                                                       const hgcal::SimToRecoCollection& cPOnLayerMap) const {
+                                                       const ticl::RecoToSimCollection& cpsInLayerClusterMap,
+                                                       const ticl::SimToRecoCollection& cPOnLayerMap) const {
   //Each event to be treated as two events: an event in +ve endcap,
   //plus another event in -ve endcap. In this spirit there will be
   //a layer variable (layerid) that maps the layers in :

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1612,49 +1612,47 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simCluster_histos(const Hi
     for (const auto& hAndF : sc.hits_and_fractions()) {
       const DetId sh_detid = hAndF.first;
 
-      //The layer the cluster belongs to. As mentioned in the mapping above, it takes into account -z and +z.
-      int layerid =
-          recHitTools_->getLayerWithOffset(sh_detid) + layers * ((recHitTools_->zside(sh_detid) + 1) >> 1) - 1;
-      //zside that the current cluster belongs to.
-      int zside = recHitTools_->zside(sh_detid);
+      if (sh_detid.det() == DetId::Forward || sh_detid.det() == DetId::HGCalEE || sh_detid.det() == DetId::HGCalHSi ||
+          sh_detid.det() == DetId::HGCalHSc) {
+        //The layer the cluster belongs to. As mentioned in the mapping above, it takes into account -z and +z.
+        int layerid =
+            recHitTools_->getLayerWithOffset(sh_detid) + layers * ((recHitTools_->zside(sh_detid) + 1) >> 1) - 1;
+        //zside that the current cluster belongs to.
+        int zside = recHitTools_->zside(sh_detid);
 
-      //add the simCluster to the relevant layer. A SimCluster may give contribution to several layers.
-      if (occurenceSCinlayer[layerid] == 0) {
-        tnscpl[layerid]++;
+        //add the simCluster to the relevant layer. A SimCluster may give contribution to several layers.
+        if (occurenceSCinlayer[layerid] == 0) {
+          tnscpl[layerid]++;
+        }
+        occurenceSCinlayer[layerid]++;
+
+        if (sh_detid.det() == DetId::HGCalHSc)
+          thickness = -1;
+        else
+          thickness = recHitTools_->getSiThickness(sh_detid);
+
+        if ((thickness == 120.) && (zside > 0.)) {
+          nthhits120p++;
+        } else if ((thickness == 120.) && (zside < 0.)) {
+          nthhits120m++;
+        } else if ((thickness == 200.) && (zside > 0.)) {
+          nthhits200p++;
+        } else if ((thickness == 200.) && (zside < 0.)) {
+          nthhits200m++;
+        } else if ((thickness == 300.) && (zside > 0.)) {
+          nthhits300p++;
+        } else if ((thickness == 300.) && (zside < 0.)) {
+          nthhits300m++;
+        } else if ((thickness == -1) && (zside > 0.)) {
+          nthhitsscintp++;
+        } else if ((thickness == -1) && (zside < 0.)) {
+          nthhitsscintm++;
+        } else {  //assert(0);
+          LogDebug("HGCalValidator")
+              << " You are running a geometry that contains thicknesses different than the normal ones. "
+              << "\n";
+        }
       }
-      occurenceSCinlayer[layerid]++;
-
-      if (sh_detid.det() == DetId::Forward || sh_detid.det() == DetId::HGCalEE || sh_detid.det() == DetId::HGCalHSi) {
-        thickness = recHitTools_->getSiThickness(sh_detid);
-      } else if (sh_detid.det() == DetId::HGCalHSc) {
-        thickness = -1;
-      } else {
-        LogDebug("HGCalValidator") << "These are HGCal simClusters, you shouldn't be here !!! " << layerid << "\n";
-        continue;
-      }
-
-      if ((thickness == 120.) && (zside > 0.)) {
-        nthhits120p++;
-      } else if ((thickness == 120.) && (zside < 0.)) {
-        nthhits120m++;
-      } else if ((thickness == 200.) && (zside > 0.)) {
-        nthhits200p++;
-      } else if ((thickness == 200.) && (zside < 0.)) {
-        nthhits200m++;
-      } else if ((thickness == 300.) && (zside > 0.)) {
-        nthhits300p++;
-      } else if ((thickness == 300.) && (zside < 0.)) {
-        nthhits300m++;
-      } else if ((thickness == -1) && (zside > 0.)) {
-        nthhitsscintp++;
-      } else if ((thickness == -1) && (zside < 0.)) {
-        nthhitsscintm++;
-      } else {  //assert(0);
-        LogDebug("HGCalValidator")
-            << " You are running a geometry that contains thicknesses different than the normal ones. "
-            << "\n";
-      }
-
     }  //end of loop through hits
 
     //Check for simultaneously having hits of different kind. Checking at least two combinations is sufficient.
@@ -1674,7 +1672,6 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simCluster_histos(const Hi
       //This is a cluster with hits of one kind
       tnscpthminus[std::to_string((int)thickness)]++;
     }
-
   }  //end of loop through SimClusters of the event
 
   //Per layer : Loop 0->99


### PR DESCRIPTION
#### PR description:

This PR enables the creation of CaloParticles in both ECAL and HCAL for Phase2. In addition, LayerCluster to CaloParticle and LayerCluster to SimCluster associations (described [here](https://hgcal.web.cern.ch/Validation/LayerClusterValidation/) and used in [`SimCalorimetry/HGCalAssociatorProducers`](https://github.com/brusale/cmssw/tree/master/SimCalorimetry/HGCalAssociatorProducers/plugins)) are introduced for the barrel region. Also, `namespace hgcal` has been changed into `namespace ticl`.

#### PR validation:

Tested on workflows `23234.0`, `24896.0` and `24900.0`.

@felicepantaleo @rovere @thomreis @valsdav @bmarzocc @hatakeyamak 
