### PR TITLE
[HGCAL trigger] Update ECON-T BestChoice NData

### DIFF
--- a/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
+++ b/L1Trigger/L1THGCal/python/l1tHGCalConcentratorProducer_cfi.py
@@ -52,8 +52,10 @@ bestchoice_ndata_centralized = [
         ]
 
 
+# Values taken from ECON-T working document v9 (March 2022)
+# https://edms.cern.ch/file/2206779/1/ECON-T_specification_working_doc_v9_2mar2022.pdf
 bestchoice_ndata_decentralized = [
-        1, 3, 6, 9, 14, 18, 23, 27, 32, 37, 41, 46, 0, 0, 0, 0,
+        1, 4, 6, 9, 14, 18, 23, 28, 32, 37, 41, 46, 48, 0, 0, 0,
         0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0,
         0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0,
         0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0,


### PR DESCRIPTION
#### PR description:
- Update configuration of the number of trigger cells sent from the ECON-T with the BestChoice algorithm, as a function of the number of connected elinks
- Following [ECON-T specifications document](https://edms.cern.ch/file/2206779/1/ECON-T_specification_working_doc_v9_2mar2022.pdf)
- To be noted that the BestChoice algorithm is not used in default sequences; therefore no changes are expected.

Associated internal PRs and reviews:
- hgc-tpg#45

#### PR validation:
Tested D86, D92, D94 workflows
```
runTheMatrix.py -w upgrade -l 20034.0 --maxSteps=2 & # D86
runTheMatrix.py -w upgrade -l 22434.0 --maxSteps=2 & # D92
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 & # D94
```
