### PR TITLE
add trackingParabolicMf for iterative tracking starting from phase-1

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -10,6 +10,7 @@ from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
+from Configuration.ProcessModifiers.trackingParabolicMf_cff import trackingParabolicMf
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
@@ -27,5 +28,5 @@ from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
 Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, ctpps_2016]),
                               phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-                              trackingPhase1, trackdnn, trackingMkFitProd, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
+                              trackingPhase1, trackdnn, trackingMkFitProd, trackingParabolicMf, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 


### PR DESCRIPTION
This is essentially a technical PR for physics with a small speedup improvement in tracking.

Initially this change was already made in LS1 in 7X release cycle (!), but got lost due to automated git forward ports.

More details are available in  #41557

Special BPH validation was done via https://its.cern.ch/jira/browse/PDMVRELVALS-192

