### PR TITLE
Removed std::auto_ptr from Herwig7Interface

### DIFF
--- a/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
+++ b/GeneratorInterface/Herwig7Interface/interface/Herwig7Interface.h
@@ -52,11 +52,11 @@ protected:
   bool initGenerator();
   void flushRandomNumberGenerator();
 
-  static std::auto_ptr<HepMC::GenEvent> convert(const ThePEG::EventPtr &event);
+  static std::unique_ptr<HepMC::GenEvent> convert(const ThePEG::EventPtr &event);
 
   static double pthat(const ThePEG::EventPtr &event);
 
-  std::auto_ptr<HepMC::IO_BaseClass> iobc_;
+  std::unique_ptr<HepMC::IO_BaseClass> iobc_;
 
   // HerwigUi contains settings piped to Herwig7
   std::shared_ptr<Herwig::HerwigUIProvider> HwUI_;

--- a/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
+++ b/GeneratorInterface/Herwig7Interface/src/Herwig7Interface.cc
@@ -4,13 +4,12 @@
  *  Dominik Beutel dominik.beutel@cern.ch
  */
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <cstdlib>
-#include <memory>
 #include <cmath>
 #include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
 
 #include <algorithm>
 
@@ -57,7 +56,7 @@ Herwig7Interface::Herwig7Interface(const edm::ParameterSet &pset)
   // Write events in hepmc ascii format for debugging purposes
   string dumpEvents = pset.getUntrackedParameter<string>("dumpEvents", "");
   if (!dumpEvents.empty()) {
-    iobc_.reset(new HepMC::IO_GenEvent(dumpEvents, ios::out));
+    iobc_ = std::make_unique<HepMC::IO_GenEvent>(dumpEvents, ios::out);
     edm::LogInfo("ThePEGSource") << "Event logging switched on (=> " << dumpEvents << ")";
   }
   // Clear dumpConfig target
@@ -223,8 +222,8 @@ void Herwig7Interface::flushRandomNumberGenerator() {
       */
 }
 
-auto_ptr<HepMC::GenEvent> Herwig7Interface::convert(const ThePEG::EventPtr &event) {
-  return std::auto_ptr<HepMC::GenEvent>(ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
+unique_ptr<HepMC::GenEvent> Herwig7Interface::convert(const ThePEG::EventPtr &event) {
+  return std::unique_ptr<HepMC::GenEvent>(ThePEG::HepMCConverter<HepMC::GenEvent>::convert(*event));
 }
 
 double Herwig7Interface::pthat(const ThePEG::EventPtr &event) {


### PR DESCRIPTION
#### PR description:

Replaced with std::unique_ptr.
This is part of a campaign to remove std::auto_ptr from CMSSW.

#### PR validation:

Code compiles.