### PR TITLE
Added ActivityRegistry signals for EDProducer transforms

### DIFF
--- a/FWCore/Framework/interface/EventForTransformer.h
+++ b/FWCore/Framework/interface/EventForTransformer.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Common/interface/WrapperBase.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
@@ -24,19 +25,20 @@
 namespace edm {
 
   class EventPrincipal;
-  class ModuleCallingContext;
 
   class EventForTransformer {
   public:
-    EventForTransformer(EventPrincipal const&, ModuleCallingContext const*);
+    EventForTransformer(EventPrincipal const&, ModuleCallingContext);
 
     BasicHandle get(edm::TypeID const& iTypeID, ProductResolverIndex iIndex) const;
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, BasicHandle const& iGetHandle);
 
+    ModuleCallingContext const& moduleCallingContext() const { return mcc_; }
+
   private:
     EventPrincipal const& eventPrincipal_;
-    ModuleCallingContext const* mcc_;
+    ModuleCallingContext mcc_;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/TransformerBase.h
+++ b/FWCore/Framework/interface/TransformerBase.h
@@ -28,6 +28,7 @@ namespace edm {
   class ModuleDescription;
   class WaitingTaskWithArenaHolder;
   class WaitingTaskHolder;
+  class ActivityRegistry;
 
   class TransformerBase {
   public:
@@ -48,6 +49,7 @@ namespace edm {
     ProductResolverIndex prefetchImp(std::size_t iIndex) const { return transformInfo_.get<kResolverIndex>(iIndex); }
     void transformImpAsync(WaitingTaskHolder iTask,
                            std::size_t iIndex,
+                           edm::ActivityRegistry* iAct,
                            ProducerBase const& iBase,
                            edm::EventForTransformer&) const;
 

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -83,7 +83,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
@@ -162,6 +162,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -86,7 +86,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
@@ -165,6 +165,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -50,6 +50,7 @@ namespace edm {
 
   class WaitingTaskWithArenaHolder;
   class ServiceWeakToken;
+  class ActivityRegistry;
 
   namespace global {
     namespace impl {
@@ -519,8 +520,9 @@ namespace edm {
         void transformAsync_(WaitingTaskHolder iTask,
                              std::size_t iIndex,
                              edm::EventForTransformer& iEvent,
+                             edm::ActivityRegistry* iAct,
                              ServiceWeakToken const& iToken) const final {
-          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, *this, iEvent);
+          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, iAct, *this, iEvent);
         }
         void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
           if (iBranchType == InEvent) {

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -83,7 +83,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
 
       //For now this is a placeholder
@@ -163,6 +163,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -86,7 +86,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
@@ -166,6 +166,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -47,6 +47,7 @@
 // forward declarations
 namespace edm {
   class ServiceWeakToken;
+  class ActivityRegistry;
 
   namespace limited {
     namespace impl {
@@ -507,8 +508,9 @@ namespace edm {
         void transformAsync_(WaitingTaskHolder iTask,
                              std::size_t iIndex,
                              edm::EventForTransformer& iEvent,
+                             edm::ActivityRegistry* iAct,
                              ServiceWeakToken const& iToken) const final {
-          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, *this, iEvent);
+          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, iAct, *this, iEvent);
         }
         void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
           if (iBranchType == InEvent) {

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -80,7 +80,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
@@ -139,6 +139,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -85,7 +85,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocRuns(unsigned int);
@@ -139,6 +139,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       virtual void clearInputProcessBlockCaches();

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -50,6 +50,7 @@ namespace edm {
   class SharedResourcesAcquirer;
   class WaitingTaskHolder;
   class ServiceWeakToken;
+  class ActivityRegistry;
 
   namespace one {
     namespace impl {
@@ -399,8 +400,9 @@ namespace edm {
         void transformAsync_(WaitingTaskHolder iTask,
                              std::size_t iIndex,
                              edm::EventForTransformer& iEvent,
+                             edm::ActivityRegistry* iAct,
                              ServiceWeakToken const& iToken) const final {
-          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, *this, iEvent);
+          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, iAct, *this, iEvent);
         }
         void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
           if (iBranchType == InEvent) {

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -80,6 +80,7 @@ namespace edm {
       virtual void transformAsync_(WaitingTaskHolder iTask,
                                    std::size_t iIndex,
                                    edm::EventForTransformer& iEvent,
+                                   edm::ActivityRegistry* iAct,
                                    ServiceWeakToken const& iToken) const;
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) { moduleDescriptionPtr_ = iDesc; }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -134,7 +134,7 @@ namespace edm {
                             size_t iTransformIndex,
                             EventPrincipal const& iEvent,
                             ActivityRegistry*,
-                            ModuleCallingContext const*,
+                            ModuleCallingContext,
                             ServiceWeakToken const&);
 
     protected:

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -353,8 +353,9 @@ namespace edm {
         void transformAsync_(WaitingTaskHolder iTask,
                              std::size_t iIndex,
                              edm::EventForTransformer& iEvent,
+                             edm::ActivityRegistry* iAct,
                              ServiceWeakToken const& iToken) const final {
-          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, *this, iEvent);
+          return TransformerBase::transformImpAsync(std::move(iTask), iIndex, iAct, *this, iEvent);
         }
         void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
           if (iBranchType == InEvent) {

--- a/FWCore/Framework/src/EventForTransformer.cc
+++ b/FWCore/Framework/src/EventForTransformer.cc
@@ -11,12 +11,12 @@
 
 namespace edm {
 
-  EventForTransformer::EventForTransformer(EventPrincipal const& ep, ModuleCallingContext const* moduleCallingContext)
+  EventForTransformer::EventForTransformer(EventPrincipal const& ep, ModuleCallingContext moduleCallingContext)
       : eventPrincipal_{ep}, mcc_{moduleCallingContext} {}
 
   BasicHandle EventForTransformer::get(edm::TypeID const& iTypeID, ProductResolverIndex iIndex) const {
     bool amb = false;
-    return eventPrincipal_.getByToken(PRODUCT_TYPE, iTypeID, iIndex, false, amb, nullptr, mcc_);
+    return eventPrincipal_.getByToken(PRODUCT_TYPE, iTypeID, iIndex, false, amb, nullptr, &mcc_);
   }
 
   void EventForTransformer::put(ProductResolverIndex index,

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -566,7 +566,8 @@ namespace edm {
 
       //This gives a lifetime greater than this call
       ParentContext parent(mcc);
-      mcc_ = ModuleCallingContext(worker_->description(), ModuleCallingContext::State::kPrefetching, parent, nullptr);
+      mcc_ = ModuleCallingContext(
+          worker_->description(), index_, ModuleCallingContext::State::kPrefetching, parent, nullptr);
 
       EventTransitionInfo const& info = aux_->eventTransitionInfo();
       worker_->doTransformAsync(WaitingTaskHolder(*waitTask.group(), t),

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -252,8 +252,8 @@ namespace edm {
       ServiceRegistry::Operate guard(weakToken.lock());
 
       ModuleCallingContext mcc(
-          &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
-      module_->doTransformAsync(iTask, iTransformIndex, iEvent, activityRegistry(), &mcc, weakToken);
+          &module_->moduleDescription(), iTransformIndex, ModuleCallingContext::State::kRunning, iParent, nullptr);
+      module_->doTransformAsync(iTask, iTransformIndex, iEvent, activityRegistry(), mcc, weakToken);
     } catch (...) {
       iTask.doneWaiting(std::current_exception());
       return;

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -87,11 +87,11 @@ namespace edm {
     void EDFilterBase::doTransformAsync(WaitingTaskHolder iTask,
                                         size_t iTransformIndex,
                                         EventPrincipal const& iEvent,
-                                        ActivityRegistry*,
-                                        ModuleCallingContext const* iMCC,
+                                        ActivityRegistry* iAct,
+                                        ModuleCallingContext iMCC,
                                         ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -99,6 +99,7 @@ namespace edm {
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,
                                        edm::EventForTransformer& iEvent,
+                                       edm::ActivityRegistry* iAct,
                                        ServiceWeakToken const& iToken) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -93,11 +93,11 @@ namespace edm {
     void EDProducerBase::doTransformAsync(WaitingTaskHolder iTask,
                                           size_t iTransformIndex,
                                           EventPrincipal const& iEvent,
-                                          ActivityRegistry*,
-                                          ModuleCallingContext const* iMCC,
+                                          ActivityRegistry* iAct,
+                                          ModuleCallingContext iMCC,
                                           ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -105,6 +105,7 @@ namespace edm {
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,
                                          edm::EventForTransformer& iEvent,
+                                         edm::ActivityRegistry* iAct,
                                          ServiceWeakToken const& iToken) const {}
 
     void EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -71,11 +71,11 @@ namespace edm {
     void EDFilterBase::doTransformAsync(WaitingTaskHolder iTask,
                                         size_t iTransformIndex,
                                         EventPrincipal const& iEvent,
-                                        ActivityRegistry*,
-                                        ModuleCallingContext const* iMCC,
+                                        ActivityRegistry* iAct,
+                                        ModuleCallingContext iMCC,
                                         ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -83,6 +83,7 @@ namespace edm {
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,
                                        edm::EventForTransformer& iEvent,
+                                       edm::ActivityRegistry* iAct,
                                        ServiceWeakToken const& iToken) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -71,11 +71,11 @@ namespace edm {
     void EDProducerBase::doTransformAsync(WaitingTaskHolder iTask,
                                           size_t iTransformIndex,
                                           EventPrincipal const& iEvent,
-                                          ActivityRegistry*,
-                                          ModuleCallingContext const* iMCC,
+                                          ActivityRegistry* iAct,
+                                          ModuleCallingContext iMCC,
                                           ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -83,6 +83,7 @@ namespace edm {
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,
                                          edm::EventForTransformer& iEvent,
+                                         edm::ActivityRegistry* iAct,
                                          ServiceWeakToken const& iToken) const {}
 
     void EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -83,11 +83,11 @@ namespace edm {
     void EDFilterBase::doTransformAsync(WaitingTaskHolder iTask,
                                         size_t iTransformIndex,
                                         EventPrincipal const& iEvent,
-                                        ActivityRegistry*,
-                                        ModuleCallingContext const* iMCC,
+                                        ActivityRegistry* iAct,
+                                        ModuleCallingContext iMCC,
                                         ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -95,6 +95,7 @@ namespace edm {
     void EDFilterBase::transformAsync_(WaitingTaskHolder iTask,
                                        std::size_t iIndex,
                                        edm::EventForTransformer& iEvent,
+                                       edm::ActivityRegistry* iAct,
                                        ServiceWeakToken const& iToken) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -74,11 +74,11 @@ namespace edm {
     void EDProducerBase::doTransformAsync(WaitingTaskHolder iTask,
                                           size_t iTransformIndex,
                                           EventPrincipal const& iEvent,
-                                          ActivityRegistry*,
-                                          ModuleCallingContext const* iMCC,
+                                          ActivityRegistry* iAct,
+                                          ModuleCallingContext iMCC,
                                           ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      transformAsync_(iTask, iTransformIndex, ev, iToken);
+      transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
@@ -86,6 +86,7 @@ namespace edm {
     void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                          std::size_t iIndex,
                                          edm::EventForTransformer& iEvent,
+                                         edm::ActivityRegistry* iAct,
                                          ServiceWeakToken const& iToken) const {}
 
     void EDProducerBase::doBeginJob() {

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -46,11 +46,11 @@ namespace edm {
     void ProducingModuleAdaptorBase<edm::stream::EDProducerBase>::doTransformAsync(WaitingTaskHolder iTask,
                                                                                    size_t iTransformIndex,
                                                                                    EventPrincipal const& iEvent,
-                                                                                   ActivityRegistry*,
-                                                                                   ModuleCallingContext const* iMCC,
+                                                                                   ActivityRegistry* iAct,
+                                                                                   ModuleCallingContext iMCC,
                                                                                    ServiceWeakToken const& iToken) {
       EventForTransformer ev(iEvent, iMCC);
-      m_streamModules[iEvent.streamID()]->transformAsync_(iTask, iTransformIndex, ev, iToken);
+      m_streamModules[iEvent.streamID()]->transformAsync_(iTask, iTransformIndex, ev, iAct, iToken);
     }
 
     //

--- a/FWCore/Framework/src/stream/EDProducerBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerBase.cc
@@ -74,6 +74,7 @@ edm::ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex)
 void EDProducerBase::transformAsync_(WaitingTaskHolder iTask,
                                      std::size_t iIndex,
                                      edm::EventForTransformer& iEvent,
+                                     edm::ActivityRegistry* iAct,
                                      ServiceWeakToken const& iToken) const {}
 
 void EDProducerBase::prevalidate(ConfigurationDescriptions& iConfig) { edmodule_mightGet_config(iConfig); }

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -196,7 +196,7 @@ namespace edm {
                                                          size_t iTransformIndex,
                                                          EventPrincipal const& iEvent,
                                                          ActivityRegistry*,
-                                                         ModuleCallingContext const* iMCC,
+                                                         ModuleCallingContext iMCC,
                                                          ServiceWeakToken const&) {}
 
     template <typename T>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -78,6 +78,7 @@
 
   <test name="testFWCoreIntegrationTransform" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py"/>
   <test name="testFWCoreIntegrationTransform_async" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --async_"/>
+  <test name="testFWCoreIntegrationTransform_async_tracer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --async_ --addTracer 2>&amp;1 | fgrep 'transform in event' | wc | awk '{print $1}' | fgrep 24"/>
   <test name="testFWCoreIntegrationTransform_onPath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --onPath"/>
   <test name="testFWCoreIntegrationTransform_onPath_async" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --onPath --async_"/>
   <test name="testFWCoreIntegrationTransform_noTransform" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --noTransform"/>

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -763,6 +763,54 @@ namespace edm {
     }
     AR_WATCH_USING_METHOD_2(watchPostModuleEventAcquire)
 
+    /// signal is emitted before the module starts a transform during the Event and before prefetching for the transform has started
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleTransformPrefetching;
+    PreModuleTransformPrefetching preModuleTransformPrefetchingSignal_;
+    void watchPreModuleTransformPrefetching(PreModuleTransformPrefetching::slot_type const& iSlot) {
+      preModuleTransformPrefetchingSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleTransformPrefetching)
+
+    /// signal is emitted before the module starts a transform during the Event and after prefetching for the transform has finished
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleTransformPrefetching;
+    PostModuleTransformPrefetching postModuleTransformPrefetchingSignal_;
+    void watchPostModuleTransformPrefetching(PostModuleTransformPrefetching::slot_type const& iSlot) {
+      postModuleTransformPrefetchingSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleTransformPrefetching)
+
+    /// signal is emitted before the module starts a transform during the Event
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleTransform;
+    PreModuleTransform preModuleTransformSignal_;
+    void watchPreModuleTransform(PreModuleTransform::slot_type const& iSlot) {
+      preModuleTransformSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleTransform)
+
+    /// signal is emitted after the module finished a transform during  the Event
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleTransform;
+    PostModuleTransform postModuleTransformSignal_;
+    void watchPostModuleTransform(PostModuleTransform::slot_type const& iSlot) {
+      postModuleTransformSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleTransform)
+
+    /// signal is emitted before the module starts the acquire method for a transform during the Event
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleTransformAcquiring;
+    PreModuleTransformAcquiring preModuleTransformAcquiringSignal_;
+    void watchPreModuleTransformAcquiring(PreModuleTransformAcquiring::slot_type const& iSlot) {
+      preModuleTransformAcquiringSignal_.connect(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPreModuleTransformAcquiring)
+
+    /// signal is emitted after the module finishes the acquire method for a transform during the Event
+    typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleTransformAcquiring;
+    PostModuleTransformAcquiring postModuleTransformAcquiringSignal_;
+    void watchPostModuleTransformAcquiring(PostModuleTransformAcquiring::slot_type const& iSlot) {
+      postModuleTransformAcquiringSignal_.connect_front(iSlot);
+    }
+    AR_WATCH_USING_METHOD_2(watchPostModuleTransformAcquiring)
+
     /// signal is emitted after the module starts processing the Event and before a delayed get has started
     typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEventDelayedGet;
     PreModuleEventDelayedGet preModuleEventDelayedGetSignal_;

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -17,6 +17,7 @@ Services as an argument to their callback functions.
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 
 #include <iosfwd>
+#include <cstdint>
 
 namespace cms {
   class Exception;
@@ -42,6 +43,7 @@ namespace edm {
     ModuleCallingContext(ModuleDescription const* moduleDescription);
 
     ModuleCallingContext(ModuleDescription const* moduleDescription,
+                         std::uintptr_t id,
                          State state,
                          ParentContext const& parent,
                          ModuleCallingContext const* previousOnThread);
@@ -53,6 +55,11 @@ namespace edm {
     ModuleDescription const* moduleDescription() const { return moduleDescription_; }
     State state() const { return state_; }
     Type type() const { return parent_.type(); }
+    /** Returns a unique id for this module to differentiate possibly concurrent calls to the module.
+        The value returned may be large so not appropriate for an index lookup.
+        A value of 0 denotes a call to produce, analyze or filter. Other values denote a transform.
+    */
+    std::uintptr_t callID() const { return id_; }
     ParentContext const& parent() const { return parent_; }
     ModuleCallingContext const* moduleCallingContext() const { return parent_.moduleCallingContext(); }
     PlaceInPathContext const* placeInPathContext() const { return parent_.placeInPathContext(); }
@@ -81,6 +88,7 @@ namespace edm {
     ModuleCallingContext const* previousModuleOnThread_;
     ModuleDescription const* moduleDescription_;
     ParentContext parent_;
+    std::uintptr_t id_;
     State state_;
   };
 

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -249,6 +249,15 @@ namespace edm {
     preModuleEventAcquireSignal_.connect(std::cref(iOther.preModuleEventAcquireSignal_));
     postModuleEventAcquireSignal_.connect(std::cref(iOther.postModuleEventAcquireSignal_));
 
+    preModuleTransformPrefetchingSignal_.connect(std::cref(iOther.preModuleTransformPrefetchingSignal_));
+    postModuleTransformPrefetchingSignal_.connect(std::cref(iOther.postModuleTransformPrefetchingSignal_));
+
+    preModuleTransformSignal_.connect(std::cref(iOther.preModuleTransformSignal_));
+    postModuleTransformSignal_.connect(std::cref(iOther.postModuleTransformSignal_));
+
+    preModuleTransformAcquiringSignal_.connect(std::cref(iOther.preModuleTransformAcquiringSignal_));
+    postModuleTransformAcquiringSignal_.connect(std::cref(iOther.postModuleTransformAcquiringSignal_));
+
     preModuleEventDelayedGetSignal_.connect(std::cref(iOther.preModuleEventDelayedGetSignal_));
     postModuleEventDelayedGetSignal_.connect(std::cref(iOther.postModuleEventDelayedGetSignal_));
 
@@ -485,6 +494,15 @@ namespace edm {
 
     copySlotsToFrom(preModuleEventAcquireSignal_, iOther.preModuleEventAcquireSignal_);
     copySlotsToFromReverse(postModuleEventAcquireSignal_, iOther.postModuleEventAcquireSignal_);
+
+    copySlotsToFrom(preModuleTransformPrefetchingSignal_, iOther.preModuleTransformPrefetchingSignal_);
+    copySlotsToFromReverse(postModuleTransformPrefetchingSignal_, iOther.postModuleTransformPrefetchingSignal_);
+
+    copySlotsToFrom(preModuleTransformSignal_, iOther.preModuleTransformSignal_);
+    copySlotsToFromReverse(postModuleTransformSignal_, iOther.postModuleTransformSignal_);
+
+    copySlotsToFrom(preModuleTransformAcquiringSignal_, iOther.preModuleTransformAcquiringSignal_);
+    copySlotsToFromReverse(postModuleTransformAcquiringSignal_, iOther.postModuleTransformAcquiringSignal_);
 
     copySlotsToFrom(preModuleEventDelayedGetSignal_, iOther.preModuleEventDelayedGetSignal_);
     copySlotsToFromReverse(postModuleEventDelayedGetSignal_, iOther.postModuleEventDelayedGetSignal_);

--- a/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
@@ -12,15 +12,21 @@
 namespace edm {
 
   ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription)
-      : previousModuleOnThread_(nullptr), moduleDescription_(moduleDescription), parent_(), state_(State::kInvalid) {}
+      : previousModuleOnThread_(nullptr),
+        moduleDescription_(moduleDescription),
+        parent_(),
+        id_(0),
+        state_(State::kInvalid) {}
 
   ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription,
+                                             std::uintptr_t id,
                                              State state,
                                              ParentContext const& parent,
                                              ModuleCallingContext const* previousOnThread)
       : previousModuleOnThread_(previousOnThread),
         moduleDescription_(moduleDescription),
         parent_(parent),
+        id_(id),
         state_(state) {}
 
   void ModuleCallingContext::setContext(State state,

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -161,6 +161,12 @@ namespace edm {
       void postModuleEventDelayedGet(StreamContext const&, ModuleCallingContext const&);
       void preEventReadFromSource(StreamContext const&, ModuleCallingContext const&);
       void postEventReadFromSource(StreamContext const&, ModuleCallingContext const&);
+      void preModuleTransformPrefetching(StreamContext const&, ModuleCallingContext const&);
+      void postModuleTransformPrefetching(StreamContext const&, ModuleCallingContext const&);
+      void preModuleTransform(StreamContext const&, ModuleCallingContext const&);
+      void postModuleTransform(StreamContext const&, ModuleCallingContext const&);
+      void preModuleTransformAcquiring(StreamContext const&, ModuleCallingContext const&);
+      void postModuleTransformAcquiring(StreamContext const&, ModuleCallingContext const&);
 
       void preModuleStreamPrefetching(StreamContext const&, ModuleCallingContext const&);
       void postModuleStreamPrefetching(StreamContext const&, ModuleCallingContext const&);
@@ -359,6 +365,12 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
   iRegistry.watchPostModuleEventDelayedGet(this, &Tracer::postModuleEventDelayedGet);
   iRegistry.watchPreEventReadFromSource(this, &Tracer::preEventReadFromSource);
   iRegistry.watchPostEventReadFromSource(this, &Tracer::postEventReadFromSource);
+  iRegistry.watchPreModuleTransformPrefetching(this, &Tracer::preModuleTransformPrefetching);
+  iRegistry.watchPostModuleTransformPrefetching(this, &Tracer::postModuleTransformPrefetching);
+  iRegistry.watchPreModuleTransform(this, &Tracer::preModuleTransform);
+  iRegistry.watchPostModuleTransform(this, &Tracer::postModuleTransform);
+  iRegistry.watchPreModuleTransformAcquiring(this, &Tracer::preModuleTransformAcquiring);
+  iRegistry.watchPostModuleTransformAcquiring(this, &Tracer::postModuleTransformAcquiring);
 
   iRegistry.watchPreModuleStreamPrefetching(this, &Tracer::preModuleStreamPrefetching);
   iRegistry.watchPostModuleStreamPrefetching(this, &Tracer::postModuleStreamPrefetching);
@@ -1228,6 +1240,93 @@ void Tracer::postEventReadFromSource(StreamContext const& sc, ModuleCallingConte
       << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
 }
 
+void Tracer::preModuleTransformPrefetching(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: prefetching before transform in event for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+  if (dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
+}
+
+void Tracer::postModuleTransformPrefetching(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: prefetching before transform in event for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+  if (dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
+}
+
+void Tracer::preModuleTransform(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: transform in event for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+  if (dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
+}
+
+void Tracer::postModuleTransform(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: transform in event for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+  if (dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
+}
+
+void Tracer::preModuleTransformAcquiring(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " starting: acquiring before transform in event for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+}
+
+void Tracer::postModuleTransformAcquiring(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  LogAbsolute out("Tracer");
+  out << TimeStamper(printTimestamps_);
+  unsigned int nIndents = mcc.depth() + 4;
+  for (unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: acquiring before transform in event acquire for module: stream = " << sc.streamID() << " label = '"
+      << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id()
+      << " callID = " << mcc.callID();
+}
 void Tracer::preModuleStreamPrefetching(StreamContext const& sc, ModuleCallingContext const& mcc) {
   LogAbsolute out("Tracer");
   out << TimeStamper(printTimestamps_);


### PR DESCRIPTION
#### PR description:

If an EDProducer registers transform callbacks, the ActivityRegistry will not emit signals for
- prefetching data needed for the transform
- calling of any asynchronous pre-transform task
- calling of the transform task The Tracer service was updated to use the new signals.

#### PR validation:

Code compiles. Framework unit tests pass.