### PR TITLE
[13.2.X] fix primary vertex source for HLT tracking monitoring for HIon

### DIFF
--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -29,6 +29,7 @@ pixelTracksMonitoringHLT = trackingMonHLT.clone(
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 pp_on_PbPb_run3.toModify(pixelTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltPixelTracksPPOnAA',
                          allTrackProducer = 'hltPixelTracksPPOnAA')
 
@@ -102,6 +103,7 @@ iterHLTTracksMonitoringHLT = trackingMonHLT.clone(
 )
 
 pp_on_PbPb_run3.toModify(iterHLTTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltMergedTracksPPOnAA',
                          allTrackProducer = 'hltMergedTracksPPOnAA')
 
@@ -148,6 +150,7 @@ doubletRecoveryHPTracksMonitoringHLT = trackingMonHLT.clone(
 )
 
 pp_on_PbPb_run3.toModify(doubletRecoveryHPTracksMonitoringHLT,
+                         primaryVertex    = 'hltPixelVerticesPPOnAA',
                          TrackProducer    = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA',
                          allTrackProducer = 'hltDoubletRecoveryPFlowTrackSelectionHighPurityPPOnAA')
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43427

#### PR description:

In the process of the alca validation [CMSALCA-240](https://its.cern.ch/jira/browse/CMSALCA-240) it was noticed that the track IP wrt PV plots are empty (e.g. https://tinyurl.com/yru69pww). 
This is due to a leftover customization that was forgotten at https://github.com/cms-sw/cmssw/pull/43141. 

#### PR validation:

Run successfully `runTheMatrix.py -l 142.0 -t 4 -j 8 --ibeos` and checked that the empty plots are now filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Partial backport of https://github.com/cms-sw/cmssw/pull/43427