### PR TITLE
Run3-gex175 Remove std::cout in favour of edm::LogVerbatim in Fireworks/Geometry

### DIFF
--- a/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
@@ -138,7 +138,8 @@ TGeoMgrFromDdd::ReturnType TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRec
     gGeoIdentity = new TGeoIdentity("Identity");
   }
 
-  edm::LogVerbatim("TGeoMgrFromDdd") << "about to initialize the DDCompactView walker with a root node " << viewH->root() << std::endl;
+  edm::LogVerbatim("TGeoMgrFromDdd") << "about to initialize the DDCompactView walker with a root node "
+                                     << viewH->root() << std::endl;
 
   auto walker = viewH->walker();
   auto info = walker.current();
@@ -171,7 +172,8 @@ TGeoMgrFromDdd::ReturnType TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRec
     if (m_verbose) {
       edm::LogVerbatim("TGeoMgrFromDdd") << "parentStack of size " << parentStack.size();
       auto num = (info.second != nullptr) ? info.second->copyno() : 0;
-      edm::LogVerbatim("TGeoMgrFromDdd") << info.first.name() << " " << num << " " << DDSolidShapesName::name(info.first.solid().shape());
+      edm::LogVerbatim("TGeoMgrFromDdd") << info.first.name() << " " << num << " "
+                                         << DDSolidShapesName::name(info.first.solid().shape());
     }
 
     std::string name = m_fullname ? info.first.name().fullname() : info.first.name().name();

--- a/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
@@ -138,8 +138,7 @@ TGeoMgrFromDdd::ReturnType TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRec
     gGeoIdentity = new TGeoIdentity("Identity");
   }
 
-  std::cout << "about to initialize the DDCompactView walker"
-            << " with a root node " << viewH->root() << std::endl;
+  edm::LogVerbatim("TGeoMgrFromDdd") << "about to initialize the DDCompactView walker with a root node " << viewH->root() << std::endl;
 
   auto walker = viewH->walker();
   auto info = walker.current();
@@ -170,10 +169,9 @@ TGeoMgrFromDdd::ReturnType TGeoMgrFromDdd::produce(const DisplayGeomRecord& iRec
     auto info = walker.current();
 
     if (m_verbose) {
-      std::cout << "parentStack of size " << parentStack.size() << std::endl;
+      edm::LogVerbatim("TGeoMgrFromDdd") << "parentStack of size " << parentStack.size();
       auto num = (info.second != nullptr) ? info.second->copyno() : 0;
-      std::cout << info.first.name() << " " << num << " " << DDSolidShapesName::name(info.first.solid().shape())
-                << std::endl;
+      edm::LogVerbatim("TGeoMgrFromDdd") << info.first.name() << " " << num << " " << DDSolidShapesName::name(info.first.solid().shape());
     }
 
     std::string name = m_fullname ? info.first.name().fullname() : info.first.name().name();
@@ -614,7 +612,7 @@ TGeoVolume* TGeoMgrFromDdd::createVolume(const std::string& iName, const DDSolid
 
 TGeoMaterial* TGeoMgrFromDdd::createMaterial(const DDMaterial& iMaterial) {
   std::string mat_name = m_fullname ? iMaterial.name().fullname() : iMaterial.name().name();
-  edm::LogVerbatim("TGeoMgrFromDdd") << "createMateriale with name: " << mat_name;
+  edm::LogVerbatim("TGeoMgrFromDdd") << "createMaterial with name: " << mat_name;
   TGeoMaterial* mat = nameToMaterial_[mat_name];
 
   if (mat == nullptr) {


### PR DESCRIPTION
#### PR description:

Remove std::cout in favour of edm::LogVerbatim in Fireworks/Geometry

#### PR validation:

Tested by dumping the geometry of HFNose  and visualising that using Fireworks

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special