### PR TITLE
Removing unnecessary try/catch clauses in Hcal{Led,Pedestal}Analysis.cc

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalLedAnalysis.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalLedAnalysis.h
@@ -83,7 +83,6 @@ private:
   std::string m_outputFileText;
   std::string m_outputFileX;
   std::ofstream m_outFile;
-  std::ofstream m_logFile;
   std::ofstream m_outputFileXML;
 
   int m_startTS;

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPedestalAnalysis.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPedestalAnalysis.h
@@ -107,7 +107,7 @@ private:
   std::string m_outputFileROOT;
   std::string m_outputFileMean;
   std::string m_outputFileWidth;
-  std::ofstream m_logFile;
+
   int m_startTS;
   int m_endTS;
   int m_nevtsample;


### PR DESCRIPTION
#### PR description:

Part of code cleaning campaign [slides](https://drive.google.com/file/d/1NupHuyuWHc2G6B70IKW2A30zeJ-lsOkA/view?usp=sharing) regarding the edm exception use guideline https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEdmExceptionUse . As the catch action clause in the original source has been commented, error message is directed to edm::LogError.

#### PR validation:

Tested locally with code-checks and code-format.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport.