### PR TITLE
BackPort of "Update ecalMultiFitUncalibRecHit_cfi.py' PR #43152

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -78,10 +78,12 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
 from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
 run3_ecal.toModify(ecalMultiFitUncalibRecHit,
     algoPSet = dict(timealgo = 'crossCorrelationMethod',
-        outOfTimeThresholdGain12pEB = 2.5,
-        outOfTimeThresholdGain12mEB = 2.5,
-        outOfTimeThresholdGain61pEB = 2.5,
-        outOfTimeThresholdGain61mEB = 2.5,
+        EBtimeNconst = 25.5,
+        EBtimeConstantTerm = 0.85,
+        outOfTimeThresholdGain12pEB = 3.0,
+        outOfTimeThresholdGain12mEB = 3.0,
+        outOfTimeThresholdGain61pEB = 3.0,
+        outOfTimeThresholdGain61mEB = 3.0,
         timeCalibTag = cms.ESInputTag('', 'CC'),
         timeOffsetTag = cms.ESInputTag('', 'CC')
     )


### PR DESCRIPTION
Updating CC parameters to improve agreement with previous object reco using ratio timing algorithm setting for rechit kOOT flag.

PR description:
This BackPort modifies the outOfTimeThresholdGain’s to 3.0 and added EBtimeNconst = 25.5 & EBtimeConstantTerm = 0.85 for CC timing algorithm in 13_1_X.

PR validation:
This PR only changes config values and does not touch code. The affect on object reco of these config changes has been studied.
