### PR TITLE
Allow an InputSource to declare a run/lumi is the last to be merged

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -330,7 +330,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  edm::InputSource::ItemType getNextItemType() override;
+  edm::InputSource::ItemTypeInfo getNextItemType() override;
 
   std::shared_ptr<edm::FileBlock> readFile_() override;
   std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
@@ -440,7 +440,7 @@ DQMRootSource::DQMRootSource(edm::ParameterSet const& iPSet, const edm::InputSou
           {"LUMI", MonitorElementData::Scope::LUMI},
           {"RUN", MonitorElementData::Scope::RUN},
           {"JOB", MonitorElementData::Scope::JOB}}[iPSet.getUntrackedParameter<std::string>("reScope", "JOB")]),
-      m_nextItemType(edm::InputSource::IsFile),
+      m_nextItemType(edm::InputSource::ItemType::IsFile),
       m_treeReaders(kNIndicies, std::shared_ptr<TreeReaderBase>()),
       m_currentIndex(0),
       m_openFiles(std::vector<OpenFileInfo>()),
@@ -448,7 +448,7 @@ DQMRootSource::DQMRootSource(edm::ParameterSet const& iPSet, const edm::InputSou
   edm::sortAndRemoveOverlaps(m_lumisToProcess);
 
   if (m_catalog.fileNames(0).empty()) {
-    m_nextItemType = edm::InputSource::IsStop;
+    m_nextItemType = edm::InputSource::ItemType::IsStop;
   } else {
     m_treeReaders[kIntIndex].reset(new TreeSimpleReader<Long64_t>(MonitorElementData::Kind::INT, m_rescope));
     m_treeReaders[kFloatIndex].reset(new TreeSimpleReader<double>(MonitorElementData::Kind::REAL, m_rescope));
@@ -483,7 +483,7 @@ DQMRootSource::~DQMRootSource() {
 // member functions
 //
 
-edm::InputSource::ItemType DQMRootSource::getNextItemType() { return m_nextItemType; }
+edm::InputSource::ItemTypeInfo DQMRootSource::getNextItemType() { return m_nextItemType; }
 
 // We will read the metadata of all files and fill m_fileMetadatas vector
 std::shared_ptr<edm::FileBlock> DQMRootSource::readFile_() {
@@ -630,9 +630,9 @@ std::shared_ptr<edm::FileBlock> DQMRootSource::readFile_() {
 
   // Stop if there's nothing to process. Otherwise start the run.
   if (m_fileMetadatas.empty())
-    m_nextItemType = edm::InputSource::IsStop;
+    m_nextItemType = edm::InputSource::ItemType::IsStop;
   else
-    m_nextItemType = edm::InputSource::IsRun;
+    m_nextItemType = edm::InputSource::ItemType::IsRun;
 
   // We have to return something but not sure why
   return std::make_shared<edm::FileBlock>();
@@ -728,18 +728,18 @@ bool DQMRootSource::isRunOrLumiTransition() const {
 
 void DQMRootSource::readNextItemType() {
   if (m_currentIndex == 0) {
-    m_nextItemType = edm::InputSource::IsRun;
+    m_nextItemType = edm::InputSource::ItemType::IsRun;
   } else if (m_currentIndex > m_fileMetadatas.size() - 1) {
     // We reached the end
-    m_nextItemType = edm::InputSource::IsStop;
+    m_nextItemType = edm::InputSource::ItemType::IsStop;
   } else {
     FileMetadata previousMetadata = m_fileMetadatas[m_currentIndex - 1];
     FileMetadata metadata = m_fileMetadatas[m_currentIndex];
 
     if (previousMetadata.m_run != metadata.m_run) {
-      m_nextItemType = edm::InputSource::IsRun;
+      m_nextItemType = edm::InputSource::ItemType::IsRun;
     } else if (previousMetadata.m_lumi != metadata.m_lumi) {
-      m_nextItemType = edm::InputSource::IsLumi;
+      m_nextItemType = edm::InputSource::ItemType::IsLumi;
     }
   }
 }

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.cc
@@ -38,7 +38,7 @@ DQMProtobufReader::DQMProtobufReader(edm::ParameterSet const& pset, edm::InputSo
   produces<DQMToken, edm::Transition::BeginLuminosityBlock>("DQMGenerationRecoLumi");
 }
 
-edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
+edm::InputSource::ItemTypeInfo DQMProtobufReader::getNextItemType() {
   typedef DQMFileIterator::State State;
   typedef DQMFileIterator::LumiEntry LumiEntry;
 
@@ -49,23 +49,23 @@ edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
 
     if (edm::shutdown_flag.load()) {
       fiterator_.logFileAction("Shutdown flag was set, shutting down.");
-      return InputSource::IsStop;
+      return InputSource::ItemType::IsStop;
     }
 
     // check for end of run file and force quit
     if (flagEndOfRunKills_ && (fiterator_.state() != State::OPEN)) {
-      return InputSource::IsStop;
+      return InputSource::ItemType::IsStop;
     }
 
     // check for end of run and quit if everything has been processed.
     // this is the clean exit
     if ((!fiterator_.lumiReady()) && (fiterator_.state() == State::EOR)) {
-      return InputSource::IsStop;
+      return InputSource::ItemType::IsStop;
     }
 
     // skip to the next file if we have no files openned yet
     if (fiterator_.lumiReady()) {
-      return InputSource::IsLumi;
+      return InputSource::ItemType::IsLumi;
     }
 
     fiterator_.delay();
@@ -73,7 +73,7 @@ edm::InputSource::ItemType DQMProtobufReader::getNextItemType() {
     // IsSynchronize state
     //
     // comment out in order to block at this level
-    // return InputSource::IsSynchronize;
+    // return InputSource::ItemType::IsSynchronize;
   }
 
   // this is unreachable

--- a/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMProtobufReader.h
@@ -21,7 +21,7 @@ namespace dqmservices {
 
   private:
     void load(DQMStore* store, std::string filename);
-    edm::InputSource::ItemType getNextItemType() override;
+    edm::InputSource::ItemTypeInfo getNextItemType() override;
     std::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override;
     std::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     void readRun_(edm::RunPrincipal& rpCache) override;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -185,8 +185,9 @@ namespace edm {
     // The following functions are used by the code implementing
     // transition handling.
 
-    InputSource::ItemType nextTransitionType();
-    InputSource::ItemType lastTransitionType() const { return lastSourceTransition_; }
+    InputSource::ItemTypeInfo nextTransitionType();
+    InputSource::ItemTypeInfo lastTransitionType() const { return lastSourceTransition_; }
+    void nextTransitionTypeAsync(std::shared_ptr<RunProcessingStatus> iRunStatus, WaitingTaskHolder nextTask);
 
     void readFile();
     bool fileBlockValid() { return fb_.get() != nullptr; }
@@ -294,6 +295,10 @@ namespace edm {
     void throwAboutModulesRequiringLuminosityBlockSynchronization() const;
     void warnAboutModulesRequiringRunSynchronization() const;
     void warnAboutLegacyModules() const;
+
+    bool needToCallNext() const { return needToCallNext_; }
+    void setNeedToCallNext(bool val) { needToCallNext_ = val; }
+
     //------------------------------------------------------------------
     //
     // Data members below.
@@ -311,7 +316,7 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     ServiceToken serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
-    InputSource::ItemType lastSourceTransition_ = InputSource::IsInvalid;
+    InputSource::ItemTypeInfo lastSourceTransition_;
     edm::propagate_const<std::unique_ptr<ModuleTypeResolverMaker const>> moduleTypeResolverMaker_;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
@@ -369,7 +374,7 @@ namespace edm {
 
     bool printDependencies_ = false;
     bool deleteNonConsumedUnscheduledModules_ = true;
-    bool firstItemAfterLumiMerge_ = true;
+    bool needToCallNext_ = true;
   };  // class EventProcessor
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -101,17 +101,17 @@ public:
 
   edm::InputSource::ItemType processFiles(EventProcessor& iEP) {
     bool finished = false;
-    auto nextTransition = iEP.nextTransitionType();
-    if (nextTransition != edm::InputSource::IsFile)
+    edm::InputSource::ItemType nextTransition = iEP.nextTransitionType();
+    if (nextTransition != edm::InputSource::ItemType::IsFile)
       return nextTransition;
     do {
       switch (nextTransition) {
-        case edm::InputSource::IsFile: {
+        case edm::InputSource::ItemType::IsFile: {
           processFile(iEP);
           nextTransition = iEP.nextTransitionType();
           break;
         }
-        case edm::InputSource::IsRun: {
+        case edm::InputSource::ItemType::IsRun: {
           nextTransition = runs_.processRuns(iEP);
           break;
         }

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -48,7 +48,7 @@ namespace edm {
     token t;
     if (not(input_ >> t)) {
       reachedEndOfInput_ = true;
-      return lastTransition_ = InputSource::IsStop;
+      return lastTransition_ = InputSource::ItemType::IsStop;
     }
 
     char ch = t.id;
@@ -57,11 +57,11 @@ namespace edm {
     if (ch == 'r') {
       output_ << "    *** nextItemType: Run " << t.value << " ***\n";
       nextRun_ = static_cast<RunNumber_t>(t.value);
-      return lastTransition_ = InputSource::IsRun;
+      return lastTransition_ = InputSource::ItemType::IsRun;
     } else if (ch == 'l') {
       output_ << "    *** nextItemType: Lumi " << t.value << " ***\n";
       nextLumi_ = static_cast<LuminosityBlockNumber_t>(t.value);
-      return lastTransition_ = InputSource::IsLumi;
+      return lastTransition_ = InputSource::ItemType::IsLumi;
     } else if (ch == 'e') {
       output_ << "    *** nextItemType: Event ***\n";
       // a special value for test purposes only
@@ -71,7 +71,7 @@ namespace edm {
       } else {
         shouldWeStop_ = false;
       }
-      return lastTransition_ = InputSource::IsEvent;
+      return lastTransition_ = InputSource::ItemType::IsEvent;
     } else if (ch == 'f') {
       output_ << "    *** nextItemType: File " << t.value << " ***\n";
       // a special value for test purposes only
@@ -79,7 +79,7 @@ namespace edm {
         shouldWeCloseOutput_ = false;
       else
         shouldWeCloseOutput_ = true;
-      return lastTransition_ = InputSource::IsFile;
+      return lastTransition_ = InputSource::ItemType::IsFile;
     } else if (ch == 's') {
       output_ << "    *** nextItemType: Stop " << t.value << " ***\n";
       // a special value for test purposes only
@@ -87,17 +87,17 @@ namespace edm {
         shouldWeEndLoop_ = false;
       else
         shouldWeEndLoop_ = true;
-      return lastTransition_ = InputSource::IsStop;
+      return lastTransition_ = InputSource::ItemType::IsStop;
     } else if (ch == 'x') {
       output_ << "    *** nextItemType: Restart " << t.value << " ***\n";
       shouldWeEndLoop_ = t.value;
-      return lastTransition_ = InputSource::IsStop;
+      return lastTransition_ = InputSource::ItemType::IsStop;
     } else if (ch == 't') {
       output_ << "    *** nextItemType: Throw " << t.value << " ***\n";
       shouldThrow_ = true;
       return nextTransitionType();
     }
-    return lastTransition_ = InputSource::IsInvalid;
+    return lastTransition_ = InputSource::ItemType::IsInvalid;
   }
 
   InputSource::ItemType MockEventProcessor::lastTransitionType() const { return lastTransition_; }
@@ -112,9 +112,9 @@ namespace edm {
       }
       readAndProcessEvent();
       if (shouldWeStop()) {
-        return InputSource::IsEvent;
+        return InputSource::ItemType::IsEvent;
       }
-    } while (nextTransitionType() == InputSource::IsEvent);
+    } while (nextTransitionType() == InputSource::ItemType::IsEvent);
 
     return lastTransitionType();
   }
@@ -137,7 +137,7 @@ namespace edm {
 
         fp.normalEnd();
 
-        if (trans != InputSource::IsStop) {
+        if (trans != InputSource::ItemType::IsStop) {
           //problem with the source
           doErrorStuff();
           break;
@@ -188,15 +188,15 @@ namespace edm {
 
   InputSource::ItemType MockEventProcessor::processRuns() {
     bool finished = false;
-    auto nextTransition = edm::InputSource::IsRun;
+    auto nextTransition = edm::InputSource::ItemType::IsRun;
     do {
       switch (nextTransition) {
-        case edm::InputSource::IsRun: {
+        case edm::InputSource::ItemType::IsRun: {
           processRun();
           nextTransition = nextTransitionType();
           break;
         }
-        case edm::InputSource::IsLumi: {
+        case edm::InputSource::ItemType::IsLumi: {
           nextTransition = processLumis();
           break;
         }
@@ -225,10 +225,10 @@ namespace edm {
   InputSource::ItemType MockEventProcessor::processLumis() {
     if (lumiStatus_ and currentLumiNumber_ == nextLumi_) {
       readAndMergeLumi();
-      if (nextTransitionType() == InputSource::IsEvent) {
+      if (nextTransitionType() == InputSource::ItemType::IsEvent) {
         readAndProcessEvents();
         if (shouldWeStop()) {
-          return edm::InputSource::IsStop;
+          return edm::InputSource::ItemType::IsStop;
         }
       }
     } else {
@@ -239,10 +239,10 @@ namespace edm {
       throwIfNeeded();
       didGlobalBeginLumiSucceed_ = true;
       //Need to do event processing here
-      if (nextTransitionType() == InputSource::IsEvent) {
+      if (nextTransitionType() == InputSource::ItemType::IsEvent) {
         readAndProcessEvents();
         if (shouldWeStop()) {
-          return edm::InputSource::IsStop;
+          return edm::InputSource::ItemType::IsStop;
         }
       }
     }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -118,7 +118,7 @@ namespace edm {
     bool lumiStatus_ = false;
     LuminosityBlockNumber_t currentLumiNumber_ = 0;
     bool didGlobalBeginLumiSucceed_ = false;
-    InputSource::ItemType lastTransition_ = InputSource::IsInvalid;
+    InputSource::ItemType lastTransition_ = InputSource::ItemType::IsInvalid;
 
     bool currentRun_ = false;
     RunNumber_t currentRunNumber_ = 0;

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -80,9 +80,6 @@ ModuleCallingContext state = Running
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
@@ -109,6 +106,9 @@ ModuleCallingContext state = Running
     ProcessContext: TEST cf65ff121f7d0ed0d094247b80407269
 
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -48,15 +48,15 @@
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000

--- a/FWCore/Integration/plugins/PutOrMergeTestSource.cc
+++ b/FWCore/Integration/plugins/PutOrMergeTestSource.cc
@@ -30,7 +30,7 @@ namespace edmtest {
     void registerProducts() final;
 
   private:
-    ItemType getNextItemType() final;
+    ItemTypeInfo getNextItemType() final;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() final;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() final;
     std::shared_ptr<FileBlock> readFile_() final;
@@ -109,21 +109,21 @@ void PutOrMergeTestSource::registerProducts() {
   productRegistryUpdate().copyProduct(thingWithEqualDesc_);
 }
 
-InputSource::ItemType PutOrMergeTestSource::getNextItemType() {
+InputSource::ItemTypeInfo PutOrMergeTestSource::getNextItemType() {
   switch (stage_) {
     case 0: {
-      return IsFile;
+      return ItemType::IsFile;
     }
     case 1: {
-      return IsRun;
+      return ItemType::IsRun;
     }
     case 2: {
-      return IsRun;
+      return ItemType::IsRun;
     }
     default:
-      return IsStop;
+      return ItemType::IsStop;
   }
-  return IsInvalid;
+  return ItemType::IsInvalid;
 }
 
 std::shared_ptr<RunAuxiliary> PutOrMergeTestSource::readRunAuxiliary_() {

--- a/FWCore/Integration/test/inputSourceTest.sh
+++ b/FWCore/Integration/test/inputSourceTest.sh
@@ -5,3 +5,20 @@ function die { echo $1: status $2 ;  exit $2; }
 cmsRun ${SCRAM_TEST_PATH}/inputSourceTest_cfg.py || die 'Failed in inputSourceTest_cfg.py' $?
 
 cmsRun ${SCRAM_TEST_PATH}/testLateLumiClosure_cfg.py || die 'Failed in testLateLumiClosure_cfg.py' $?
+
+# The following demonstrates declaring the last run or lumi entry to be merged eliminates the delay
+# before globalBeginRun and globalBeginLumi while waiting for the next thing to arrive
+# to know that the last entry to be merged has already arrived. (Note the previous test is very similar
+# and shows the delay, running without enableDeclareLast will also demonstrate it).
+
+cmsRun ${SCRAM_TEST_PATH}/testDeclareLastEntryForMerge_cfg.py --enableDeclareLast --multipleEntriesForRun 2 --multipleEntriesForLumi 4 || die 'Failed in testDeclareLastEntryForMerge_cfg.py' $?
+
+# The next two cmsRun processes should throw an exception (intentional)
+# These two tests show the Framework will detect a buggy InputSource that
+# declares something last that is NOT last.
+
+cmsRun ${SCRAM_TEST_PATH}/testDeclareLastEntryForMerge_cfg.py --enableDeclareAllLast --multipleEntriesForRun 1 && die 'Failed in testDeclareLastEntryForMerge_cfg.py, last run source bug not detected' 1
+
+cmsRun ${SCRAM_TEST_PATH}/testDeclareLastEntryForMerge_cfg.py --enableDeclareAllLast --multipleEntriesForLumi 2 && die 'Failed in testDeclareLastEntryForMerge_cfg.py, last lumi source bug not detected' 1
+
+exit 0

--- a/FWCore/Integration/test/testDeclareLastEntryForMerge_cfg.py
+++ b/FWCore/Integration/test/testDeclareLastEntryForMerge_cfg.py
@@ -1,0 +1,57 @@
+
+import FWCore.ParameterSet.Config as cms
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test InputSource Declaring last run or lumi entry for merge')
+
+parser.add_argument("--enableDeclareLast", action="store_true", help="Declare last entry for merge")
+parser.add_argument("--enableDeclareAllLast", action="store_true", help="Declare all entries as last for merge (force intentional source bug)")
+parser.add_argument("--multipleEntriesForRun", type=int)
+parser.add_argument("--multipleEntriesForLumi", type=int)
+
+args = parser.parse_args()
+
+process = cms.Process("PROD")
+
+process.options = dict(
+    numberOfThreads = 2,
+    numberOfStreams = 2,
+    numberOfConcurrentRuns = 1,
+    numberOfConcurrentLuminosityBlocks = 2
+)
+
+process.Tracer = cms.Service("Tracer",
+    printTimestamps = cms.untracked.bool(True)
+)
+
+process.source = cms.Source("SourceWithWaits",
+    timePerLumi = cms.untracked.double(1),
+    sleepAfterStartOfRun = cms.untracked.double(0.25),
+    eventsPerLumi = cms.untracked.vuint32(4,0,5,4,0,5),
+    lumisPerRun = cms.untracked.uint32(3),
+    declareLast = cms.untracked.bool(False),
+    declareAllLast = cms.untracked.bool(False),
+    multipleEntriesForLumi = cms.untracked.uint32(0),
+    multipleEntriesForRun = cms.untracked.uint32(0)
+)
+
+if args.enableDeclareLast:
+    process.source.declareLast = True
+
+if args.enableDeclareAllLast:
+    process.source.declareAllLast = True
+
+if args.multipleEntriesForLumi is not None:
+    process.source.multipleEntriesForLumi = args.multipleEntriesForLumi
+
+if args.multipleEntriesForRun is not None:
+    process.source.multipleEntriesForRun = args.multipleEntriesForRun
+
+process.sleepingProducer = cms.EDProducer("timestudy::SleepingProducer",
+    ivalue = cms.int32(1),
+    consumes = cms.VInputTag(),
+    eventTimes = cms.vdouble(0.1, 0.1, 0.6, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+)
+
+process.p = cms.Path(process.sleepingProducer)

--- a/FWCore/Integration/test/testLateLumiClosure_cfg.py
+++ b/FWCore/Integration/test/testLateLumiClosure_cfg.py
@@ -56,7 +56,8 @@ process.Tracer = cms.Service("Tracer",
 )
 
 process.source = cms.Source("SourceWithWaits",
-    timePerLumi = cms.untracked.uint32(1),
+    timePerLumi = cms.untracked.double(1),
+    sleepAfterStartOfRun = cms.untracked.double(0.25),
     eventsPerLumi = cms.untracked.vuint32(4,0,5),
     lumisPerRun = cms.untracked.uint32(100)
 )

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -319,9 +319,6 @@ GlobalContext: transition = BeginRun
     ProcessContext: COPY 6f4335e86de793448be83fe14f12dcb7
     parent ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -378,6 +375,9 @@ StreamContext: StreamID = 0 transition = BeginRun
     ProcessContext: COPY 6f4335e86de793448be83fe14f12dcb7
     parent ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -132,9 +132,6 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -173,6 +170,9 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -343,7 +343,6 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 1 : time = 1
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
@@ -362,6 +361,7 @@
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
@@ -2742,9 +2742,6 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 2 : time = 55000001
-++++ queuing: EventSetup synchronization run: 2 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 2 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
@@ -2763,6 +2760,9 @@
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ queuing: EventSetup synchronization run: 2 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 2 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
@@ -5141,9 +5141,6 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 3 : time = 105000001
-++++ queuing: EventSetup synchronization run: 3 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 3 lumi: 1 event: 0
-++++ post: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
@@ -5162,6 +5159,9 @@
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ queuing: EventSetup synchronization run: 3 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 3 lumi: 1 event: 0
+++++ post: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001

--- a/FWCore/Modules/src/TestSource.cc
+++ b/FWCore/Modules/src/TestSource.cc
@@ -15,7 +15,7 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    ItemType getNextItemType() final;
+    ItemTypeInfo getNextItemType() final;
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() final;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() final;
     void readEvent_(EventPrincipal& eventPrincipal) final;
@@ -36,32 +36,32 @@ namespace edm {
 
   TestSource::ItemType TestSource::stringToType(const std::string& iTrans) {
     if (iTrans == "IsStop") {
-      return IsStop;
+      return ItemType::IsStop;
     }
     if (iTrans == "IsFile") {
-      return IsFile;
+      return ItemType::IsFile;
     }
     if (iTrans == "IsRun") {
-      return IsRun;
+      return ItemType::IsRun;
     }
     if (iTrans == "IsLumi") {
-      return IsLumi;
+      return ItemType::IsLumi;
     }
     if (iTrans == "IsEvent") {
-      return IsEvent;
+      return ItemType::IsEvent;
     }
     if (iTrans == "IsSynchronize") {
-      return IsSynchronize;
+      return ItemType::IsSynchronize;
     }
 
     throw edm::Exception(errors::Configuration) << "Unknown transition type \'" << iTrans << "\'";
 
-    return IsInvalid;
+    return ItemType::IsInvalid;
   }
 
-  TestSource::ItemType TestSource::getNextItemType() {
+  TestSource::ItemTypeInfo TestSource::getNextItemType() {
     if (m_nextTransition == m_transitions.end()) {
-      return IsStop;
+      return ItemType::IsStop;
     }
     auto trans = m_nextTransition->first;
     ++m_nextTransition;

--- a/FWCore/Sources/interface/IDGeneratorSourceBase.h
+++ b/FWCore/Sources/interface/IDGeneratorSourceBase.h
@@ -66,7 +66,7 @@ namespace edm {
     }
 
   private:
-    typename BASE::ItemType getNextItemType() final;
+    typename BASE::ItemTypeInfo getNextItemType() final;
     virtual void initialize(EventID& id, TimeValue_t& time, TimeValue_t& interval);
     virtual bool setRunAndEventInfo(EventID& id, TimeValue_t& time, EventAuxiliary::ExperimentType& etype) = 0;
     virtual bool noFiles() const;

--- a/FWCore/Sources/interface/RawInputSource.h
+++ b/FWCore/Sources/interface/RawInputSource.h
@@ -35,7 +35,7 @@ namespace edm {
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void reset_();
     void rewind_() override;
-    ItemType getNextItemType() override;
+    ItemTypeInfo getNextItemType() override;
     void closeFile_() final;
     std::shared_ptr<FileBlock> readFile_() final;
     virtual void genuineCloseFile() {}

--- a/FWCore/Sources/src/IDGeneratorSourceBase.cc
+++ b/FWCore/Sources/src/IDGeneratorSourceBase.cc
@@ -133,18 +133,18 @@ namespace edm {
   }
 
   template <typename BASE>
-  typename BASE::ItemType IDGeneratorSourceBase<BASE>::getNextItemType() {
-    if (BASE::state() == BASE::IsInvalid) {
-      return noFiles() ? BASE::IsStop : BASE::IsFile;
+  typename BASE::ItemTypeInfo IDGeneratorSourceBase<BASE>::getNextItemType() {
+    if (BASE::state() == BASE::ItemType::IsInvalid) {
+      return noFiles() ? BASE::ItemType::IsStop : BASE::ItemType::IsFile;
     }
     if (BASE::newRun()) {
-      return BASE::IsRun;
+      return BASE::ItemType::IsRun;
     }
     if (BASE::newLumi()) {
-      return BASE::IsLumi;
+      return BASE::ItemType::IsLumi;
     }
     if (BASE::eventCached()) {
-      return BASE::IsEvent;
+      return BASE::ItemType::IsEvent;
     }
     EventID oldEventID = eventID_;
     advanceToNext(eventID_, presentTime_);
@@ -154,7 +154,7 @@ namespace edm {
     size_t index = fileIndex();
     bool another = setRunAndEventInfo(eventID_, presentTime_, eType_);
     if (!another) {
-      return BASE::IsStop;
+      return BASE::ItemType::IsStop;
     }
     bool newFile = (fileIndex() > index);
     BASE::setEventCached();
@@ -162,15 +162,15 @@ namespace edm {
       // New Run
       BASE::setNewRun();
       BASE::setNewLumi();
-      return newFile ? BASE::IsFile : BASE::IsRun;
+      return newFile ? BASE::ItemType::IsFile : BASE::ItemType::IsRun;
     }
     // Same Run
     if (BASE::newLumi() || eventID_.luminosityBlock() != oldEventID.luminosityBlock()) {
       // New Lumi
       BASE::setNewLumi();
-      return newFile ? BASE::IsFile : BASE::IsLumi;
+      return newFile ? BASE::ItemType::IsFile : BASE::ItemType::IsLumi;
     }
-    return newFile ? BASE::IsFile : BASE::IsEvent;
+    return newFile ? BASE::ItemType::IsFile : BASE::ItemType::IsEvent;
   }
 
   template <typename BASE>

--- a/FWCore/Sources/src/RawInputSource.cc
+++ b/FWCore/Sources/src/RawInputSource.cc
@@ -53,18 +53,18 @@ namespace edm {
     eventPrincipal.fillEventPrincipal(eventAuxiliary, history);
   }
 
-  InputSource::ItemType RawInputSource::getNextItemType() {
-    if (state() == IsInvalid) {
-      return IsFile;
+  InputSource::ItemTypeInfo RawInputSource::getNextItemType() {
+    if (state() == ItemType::IsInvalid) {
+      return ItemType::IsFile;
     }
     if (newRun() && runAuxiliary()) {
-      return IsRun;
+      return ItemType::IsRun;
     }
     if (newLumi() && luminosityBlockAuxiliary()) {
-      return IsLumi;
+      return ItemType::IsLumi;
     }
     if (eventCached()) {
-      return IsEvent;
+      return ItemType::IsEvent;
     }
     if (inputFileTransitionsEachEvent_) {
       // The following two lines are here because after a source
@@ -76,22 +76,22 @@ namespace edm {
     }
     Next another = checkNext();
     if (another == Next::kStop) {
-      return IsStop;
+      return ItemType::IsStop;
     } else if (another == Next::kEvent and inputFileTransitionsEachEvent_) {
       fakeInputFileTransition_ = true;
-      return IsFile;
+      return ItemType::IsFile;
     } else if (another == Next::kFile) {
       setNewRun();
       setNewLumi();
       resetEventCached();
-      return IsFile;
+      return ItemType::IsFile;
     }
     if (newRun()) {
-      return IsRun;
+      return ItemType::IsRun;
     } else if (newLumi()) {
-      return IsLumi;
+      return ItemType::IsLumi;
     }
-    return IsEvent;
+    return ItemType::IsEvent;
   }
 
   void RawInputSource::reset_() {

--- a/IOPool/Input/src/OneLumiPoolSource.cc
+++ b/IOPool/Input/src/OneLumiPoolSource.cc
@@ -15,7 +15,7 @@ namespace edm {
     explicit OneLumiPoolSource(ParameterSet const& pset, InputSourceDescription const& desc);
 
   private:
-    ItemType getNextItemType() override;
+    ItemTypeInfo getNextItemType() override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
 
     void readEvent_(EventPrincipal& eventPrincipal) override {
@@ -37,9 +37,9 @@ namespace edm {
     return ret;
   }
 
-  InputSource::ItemType OneLumiPoolSource::getNextItemType() {
+  InputSource::ItemTypeInfo OneLumiPoolSource::getNextItemType() {
     auto type = PoolSource::getNextItemType();
-    if (type == IsLumi) {
+    if (type == ItemType::IsLumi) {
       if (seenFirstLumi_) {
         do {
           edm::HistoryAppender historyAppender;
@@ -50,7 +50,7 @@ namespace edm {
           LuminosityBlockPrincipal temp(prodReg, procConfig, &historyAppender, 0);
           readLuminosityBlock_(temp);
           type = PoolSource::getNextItemType();
-        } while (type == IsLumi);
+        } while (type == ItemType::IsLumi);
       } else {
         seenFirstLumi_ = true;
       }

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -260,15 +260,15 @@ namespace edm {
     return true;
   }
 
-  InputSource::ItemType PoolSource::getNextItemType() {
+  InputSource::ItemTypeInfo PoolSource::getNextItemType() {
     RunNumber_t run = IndexIntoFile::invalidRun;
     LuminosityBlockNumber_t lumi = IndexIntoFile::invalidLumi;
     EventNumber_t event = IndexIntoFile::invalidEvent;
     InputSource::ItemType itemType = primaryFileSequence_->getNextItemType(run, lumi, event);
-    if (secondaryFileSequence_ && (IsSynchronize != state())) {
-      if (itemType == IsRun || itemType == IsLumi || itemType == IsEvent) {
+    if (secondaryFileSequence_ && (ItemType::IsSynchronize != state())) {
+      if (itemType == ItemType::IsRun || itemType == ItemType::IsLumi || itemType == ItemType::IsEvent) {
         if (!secondaryFileSequence_->containedInCurrentFile(run, lumi, event)) {
-          return IsSynchronize;
+          return ItemType::IsSynchronize;
         }
       }
     }

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -49,7 +49,7 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   protected:
-    ItemType getNextItemType() override;
+    ItemTypeInfo getNextItemType() override;
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     void readEvent_(EventPrincipal& eventPrincipal) override;

--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -112,7 +112,7 @@ namespace edm {
     };
 
   protected:
-    ItemType getNextItemType() override;
+    ItemTypeInfo getNextItemType() override;
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) override;
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     void readEvent_(EventPrincipal& eventPrincipal) override;
@@ -153,7 +153,7 @@ namespace edm {
     std::map<edm::ProductID, size_t> productIDToWrapperIndex_;
     std::vector<size_t> streamToCacheIndex_;
     size_t nextEventIndex_ = 0;
-    ItemType presentState_ = IsFile;
+    ItemType presentState_ = ItemType::IsFile;
     unsigned long long eventIndex_ = 0;
   };
 }  // namespace edm
@@ -344,17 +344,17 @@ std::shared_ptr<WrapperBase> RepeatingCachedRootSource::getProduct(unsigned int 
   return cachedWrappers_[streamToCacheIndex_[iStreamIndex]][branchIDToWrapperIndex_.find(k)->second];
 }
 
-RepeatingCachedRootSource::ItemType RepeatingCachedRootSource::getNextItemType() {
+RepeatingCachedRootSource::ItemTypeInfo RepeatingCachedRootSource::getNextItemType() {
   auto v = presentState_;
   switch (presentState_) {
-    case IsFile:
-      presentState_ = IsRun;
+    case ItemType::IsFile:
+      presentState_ = ItemType::IsRun;
       break;
-    case IsRun:
-      presentState_ = IsLumi;
+    case ItemType::IsRun:
+      presentState_ = ItemType::IsLumi;
       break;
-    case IsLumi:
-      presentState_ = IsEvent;
+    case ItemType::IsLumi:
+      presentState_ = ItemType::IsEvent;
       break;
     default:
       break;

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -226,31 +226,31 @@ namespace edm {
     return true;
   }
 
-  InputSource::ItemType RootPrimaryFileSequence::getNextItemType(RunNumber_t& run,
-                                                                 LuminosityBlockNumber_t& lumi,
-                                                                 EventNumber_t& event) {
+  InputSource::ItemTypeInfo RootPrimaryFileSequence::getNextItemType(RunNumber_t& run,
+                                                                     LuminosityBlockNumber_t& lumi,
+                                                                     EventNumber_t& event) {
     if (noMoreFiles() || skipToStop_) {
       skipToStop_ = false;
-      return InputSource::IsStop;
+      return InputSource::ItemType::IsStop;
     }
     if (firstFile_ || goToEventInNewFile_ || skipIntoNewFile_) {
-      return InputSource::IsFile;
+      return InputSource::ItemType::IsFile;
     }
     if (rootFile()) {
       IndexIntoFile::EntryType entryType = rootFile()->getNextItemType(run, lumi, event);
       if (entryType == IndexIntoFile::kEvent) {
-        return InputSource::IsEvent;
+        return InputSource::ItemType::IsEvent;
       } else if (entryType == IndexIntoFile::kLumi) {
-        return InputSource::IsLumi;
+        return InputSource::ItemType::IsLumi;
       } else if (entryType == IndexIntoFile::kRun) {
-        return InputSource::IsRun;
+        return InputSource::ItemType::IsRun;
       }
       assert(entryType == IndexIntoFile::kEnd);
     }
     if (atLastFile()) {
-      return InputSource::IsStop;
+      return InputSource::ItemType::IsStop;
     }
-    return InputSource::IsFile;
+    return InputSource::ItemType::IsFile;
   }
 
   // Rewind to before the first event that was read.

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -41,7 +41,7 @@ namespace edm {
 
     std::shared_ptr<FileBlock> readFile_();
     void endJob();
-    InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
+    InputSource::ItemTypeInfo getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     void skipEventsAtBeginning(int offset);
     void skipEvents(int offset);
     bool goToEvent(EventID const& eventID);

--- a/IOPool/Input/src/RunHelper.cc
+++ b/IOPool/Input/src/RunHelper.cc
@@ -106,8 +106,8 @@ namespace edm {
                                                               RunNumber_t,
                                                               LuminosityBlockNumber_t,
                                                               EventNumber_t) {
-    if (newItemType == InputSource::IsRun ||
-        (newItemType == InputSource::IsLumi && previousItemType != InputSource::IsRun)) {
+    if (newItemType == InputSource::ItemType::IsRun ||
+        (newItemType == InputSource::ItemType::IsLumi && previousItemType != InputSource::ItemType::IsRun)) {
       if (firstTime_) {
         firstTime_ = false;
       } else {
@@ -125,8 +125,8 @@ namespace edm {
       }
       bool sameRunNumber = (indexOfNextRunNumber_ != 0U && run == setRunNumberForEachLumi_[indexOfNextRunNumber_ - 1]);
       if (!sameRunNumber) {
-        fakeNewRun_ = (newItemType != InputSource::IsRun);
-        return InputSource::IsRun;
+        fakeNewRun_ = (newItemType != InputSource::ItemType::IsRun);
+        return InputSource::ItemType::IsRun;
       }
     }
     return newItemType;
@@ -174,7 +174,7 @@ namespace edm {
                                                                            RunNumber_t,
                                                                            LuminosityBlockNumber_t iLumi,
                                                                            EventNumber_t) {
-    if (newItemType == InputSource::IsLumi && previousItemType != InputSource::IsRun) {
+    if (newItemType == InputSource::ItemType::IsLumi && previousItemType != InputSource::ItemType::IsRun) {
       auto run = findRunFromLumi(iLumi);
       if (run == 0) {
         throw Exception(errors::Configuration, "PoolSource")
@@ -183,7 +183,7 @@ namespace edm {
       if (lastUsedRunNumber_ != run) {
         fakeNewRun_ = true;
         lastUsedRunNumber_ = run;
-        return InputSource::IsRun;
+        return InputSource::ItemType::IsRun;
       }
     }
     return newItemType;


### PR DESCRIPTION

#### PR description:

Allow an InputSource to declare that a run entry or a lumi entry is the last one that needs to be merged. The next run entry should have a different run number or ProcessHistoryID. Or the next lumi entry should be associated with a different run or have a different luminosity block number. Or the next run or lumi entry could be in a different file.

It is OK for InputSources not to make this declaration. The Framework can and already does figure this out by examining the next entry returned by getNextItemType. Existing sources should work OK.

This might be a useful optimization in an online source when the getNextItemType function takes a long time to return. If the last item is declared, then the global run transition or the global lumi transition can begin immediately. Otherwise, the Framework has to wait for getNextItemType to return for the next entry in order to know that the previous entry was the last. And that delays global begin run or global begin lumi.

This probably will not help much for offline input sources because getNextItemType returns quickly.

The Framework will detect the case where a source falsely declares an item is the last run or lumi entry. It will throw an exception indicating a bug in the InputSource.

This delay was noticed when investigating issue #42931, but this PR does not address either of the problems listed there.

There are some minor changes in the InputSource interface. The getNextItemType function now returns an object of type ```ItemTypeInfo``` instead of the enum ItemType. Also, the ItemType enum is changed to be an ```enum class``` (more of a style modernization, I could back that out if requested).

#### PR validation:

Three new unit tests are added for this feature. Existing core unit tests pass. Limited runTheMatrix passes.

Manually, you can also see the delay vanishes in the log file of one of the unit tests, but it is difficult to turn that into a pass/fail criteria as the timing of execution can vary and we don't want tests that occasionally fail due to timing variations.