### PR TITLE
temporarily add deepCore and displacedRegional workflows to runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
                      12434.0, #2023 ttbar
                      12634.0, #2023 ttbar PU
                      12434.7, #2023 ttbar mkFit
-                     12434.701 #2023 ttbar displacedRegional; Temporary
+                     12434.701, #2023 ttbar displacedRegional; Temporary
                      14034.0, #2023 ttbar fastsim
                      14234.0, #2023 ttbar PU fastsim
                      24834.0, #2026D98 ttbar (Phase-2 baseline)

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -92,10 +92,12 @@ if __name__ == '__main__':
                      11634.911, #2021 DD4hep ttbar reading geometry from XML
                      11634.914, #2021 DDD ttbar reading geometry from the DB
                      11634.0, #2021 ttbar (switching to DD4hep by default)
+                     11723.17, #2021 QCD Pt_1800_2400 seedingDeepCore; Temporary
                      13234.0, #2021 ttbar fastsim
                      12434.0, #2023 ttbar
                      12634.0, #2023 ttbar PU
                      12434.7, #2023 ttbar mkFit
+                     12434.701 #2023 ttbar displacedRegional; Temporary
                      14034.0, #2023 ttbar fastsim
                      14234.0, #2023 ttbar PU fastsim
                      24834.0, #2026D98 ttbar (Phase-2 baseline)


### PR DESCRIPTION
deepCore and displacedRegional tracking updates are planned for full incremental validation in 14_0 and once validated, will be proposed for production.

In view of this, to improve quality assurance this PR is proposed to add two test workflows in standard PR tests.
Up to several weeks should be enough to check behavior in non-standard builds as well as reproducibility.