### PR TITLE
[SIMULATION-UPGRADE] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/FTLDigi/interface/BTLSample.h
+++ b/DataFormats/FTLDigi/interface/BTLSample.h
@@ -25,6 +25,7 @@ public:
   BTLSample(uint32_t value, uint16_t flag, uint8_t row, uint8_t col)
       : value_(value), flag_(flag), row_(row), col_(col) {}
   BTLSample(const BTLSample& o) : value_(o.value_), flag_(o.flag_), row_(o.row_), col_(o.col_) {}
+  BTLSample& operator=(const BTLSample&) = default;
 
   /**
      @short setters

--- a/DataFormats/FTLDigi/interface/ETLSample.h
+++ b/DataFormats/FTLDigi/interface/ETLSample.h
@@ -35,6 +35,7 @@ public:
   ETLSample() : value_(0) {}
   ETLSample(uint32_t value) : value_(value) {}
   ETLSample(const ETLSample& o) : value_(o.value_) {}
+  ETLSample& operator=(const ETLSample&) = default;
 
   /**
      @short setters

--- a/DataFormats/HGCDigi/interface/HGCSample.h
+++ b/DataFormats/HGCDigi/interface/HGCSample.h
@@ -35,6 +35,7 @@ public:
   HGCSample() : value_(0) {}
   HGCSample(uint32_t value) : value_(value) {}
   HGCSample(const HGCSample& o) : value_(o.value_) {}
+  HGCSample& operator=(const HGCSample&) = default;
 
   /**
      @short setters

--- a/DataFormats/HGCalDigi/interface/HGCROCChannelDataFrame.h
+++ b/DataFormats/HGCalDigi/interface/HGCROCChannelDataFrame.h
@@ -38,6 +38,7 @@ public:
   HGCROCChannelDataFrame(uint32_t value) : id_(0), value_(value) {}
   HGCROCChannelDataFrame(const D& id, uint32_t value) : id_(id), value_(value) {}
   HGCROCChannelDataFrame(const HGCROCChannelDataFrame& o) : id_(o.id_), value_(o.value_) {}
+  HGCROCChannelDataFrame& operator=(const HGCROCChannelDataFrame&) = default;
 
   /**
      @short det id


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

Thanks,
Andrea