### PR TITLE
[SIMULATION] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/GeometryVector/interface/private/Basic3DVectorLD.h
+++ b/DataFormats/GeometryVector/interface/private/Basic3DVectorLD.h
@@ -35,6 +35,9 @@ public:
   /// constructor from 2D vector (X and Y from 2D vector, z set to zero)
   Basic3DVector(const Basic2DVector<T>& p) : theX(p.x()), theY(p.y()), theZ(0), theW(0) {}
 
+  /// Assignment operator
+  Basic3DVector& operator=(const Basic3DVector&) = default;
+
   /** Explicit constructor from other (possibly unrelated) vector classes 
    *  The only constraint on the argument type is that it has methods
    *  x(), y() and z(), and that these methods return a type convertible to T.

--- a/DataFormats/GeometryVector/interface/private/sseBasic2DVector.h
+++ b/DataFormats/GeometryVector/interface/private/sseBasic2DVector.h
@@ -26,6 +26,9 @@ public:
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
   Basic2DVector(const Basic2DVector& p) : v(p.v) {}
 
+  /// Assignment operator
+  Basic2DVector& operator=(const Basic2DVector&) = default;
+
   template <typename U>
   Basic2DVector(const Basic2DVector<U>& p) : v(p.v) {}
 

--- a/DataFormats/GeometryVector/interface/private/sseBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/private/sseBasic3DVector.h
@@ -45,6 +45,9 @@ public:
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
   Basic3DVector(const Basic3DVector& p) : v(p.v) {}
 
+  /// Assignment operator
+  Basic3DVector& operator=(const Basic3DVector&) = default;
+
   /// Copy constructor and implicit conversion from Basic3DVector of different precision
   template <class U>
   Basic3DVector(const Basic3DVector<U>& p) : v(p.v) {}


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

Thanks,
Andrea