### PR TITLE
[DAQ] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/FEDRawData/interface/FEDRawData.h
+++ b/DataFormats/FEDRawData/interface/FEDRawData.h
@@ -32,6 +32,9 @@ public:
   /// Copy constructor
   FEDRawData(const FEDRawData &);
 
+  /// Assignment operator
+  FEDRawData &operator=(const FEDRawData &) = default;
+
   /// Dtor
   ~FEDRawData();
 

--- a/DataFormats/FEDRawData/interface/FEDRawDataCollection.h
+++ b/DataFormats/FEDRawData/interface/FEDRawDataCollection.h
@@ -29,6 +29,8 @@ public:
 
   FEDRawDataCollection(const FEDRawDataCollection&);
 
+  FEDRawDataCollection& operator=(const FEDRawDataCollection&) = default;
+
   void swap(FEDRawDataCollection& other) { data_.swap(other.data_); }
 
 private:


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

Thanks,
Andrea