### PR TITLE
[RECONSTRUCTION] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/BTauReco/interface/TaggingVariable.h
+++ b/DataFormats/BTauReco/interface/TaggingVariable.h
@@ -195,6 +195,7 @@ namespace reco {
   public:
     TaggingVariableList() : m_list() {}
     TaggingVariableList(const TaggingVariableList& list) : m_list(list.m_list) {}
+    TaggingVariableList& operator=(const TaggingVariableList&) = default;
 
     // [begin, end) must identify a valid range of iterators to TaggingVariableList
     template <typename InputIterator>

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -40,6 +40,9 @@ namespace reco {
     /// constructor from values
     Photon(const LorentzVector& p4, const Point& caloPos, const PhotonCoreRef& core, const Point& vtx = Point(0, 0, 0));
 
+    /// assignment operator
+    Photon& operator=(const Photon&) = default;
+
     /// destructor
     ~Photon() override;
 

--- a/DataFormats/METReco/interface/CorrMETData.h
+++ b/DataFormats/METReco/interface/CorrMETData.h
@@ -21,6 +21,8 @@ struct CorrMETData {
 
   CorrMETData(const CorrMETData& corr) : mex(corr.mex), mey(corr.mey), sumet(corr.sumet) {}
 
+  CorrMETData& operator=(const CorrMETData&) = default;
+
   CorrMETData& operator+=(const CorrMETData& rhs) {
     mex += rhs.mex;
     mey += rhs.mey;

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -30,6 +30,7 @@ struct HaloTowerStrip {
     energyRatio = strip.energyRatio;
     emEt = strip.emEt;
   }
+  HaloTowerStrip& operator=(const HaloTowerStrip&) = default;
 };
 
 namespace reco {

--- a/DataFormats/ParticleFlowReco/interface/PFTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrack.h
@@ -68,6 +68,8 @@ namespace reco {
 
     PFTrack(const PFTrack& other);
 
+    PFTrack& operator=(const PFTrack& other) = default;
+
     /// add a trajectory measurement
     /// \todo throw an exception if the number of points is too large
     void addPoint(const reco::PFTrajectoryPoint& trajPt);

--- a/DataFormats/SiStripCommon/interface/SiStripFecKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripFecKey.h
@@ -73,6 +73,9 @@ public:
   /** Default constructor */
   SiStripFecKey();
 
+  /** Assignment operator */
+  SiStripFecKey& operator=(const SiStripFecKey&) = default;
+
   // ---------- Control structure ----------
 
   /** Returns VME crate. */

--- a/DataFormats/SiStripCommon/interface/SiStripFedKey.h
+++ b/DataFormats/SiStripCommon/interface/SiStripFedKey.h
@@ -78,6 +78,9 @@ public:
   /** Default constructor */
   SiStripFedKey();
 
+  /** Assignment operator */
+  SiStripFedKey& operator=(const SiStripFedKey&) = default;
+
   // ---------- Public interface to member data ----------
 
   /** Returns FED id. */


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

This PR is part of a campaign trying to get rid of warnings of this kind:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/test/plugins/examples_SiStripFecKey.cc: In member function 'virtual void examplesSiStripFecKey::beginJob()':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/test/plugins/examples_SiStripFecKey.cc:69:12: warning: implicitly-declared 'SiStripFecKey& SiStripFecKey::operator=(const SiStripFecKey&)' is deprecated [-Wdeprecated-copy]
    69 |   equals = valid;
      |            ^~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/test/plugins/examples_SiStripFecKey.cc:14:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/interface/SiStripFecKey.h:65:3: note: because 'SiStripFecKey' has user-provided 'SiStripFecKey::SiStripFecKey(const SiStripFecKey&)'
   65 |   SiStripFecKey(const SiStripFecKey&);
      |   ^~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/test/plugins/test_SiStripFecKey.cc: In member function 'virtual void testSiStripFecKey::beginJob()':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/a2b36a15ce1eab94715509bc9f78be2f/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-11-30-2300/src/DataFormats/SiStripCommon/test/plugins/test_SiStripFecKey.cc:116:26: warning: implicitly-declared 'SiStripFecKey& SiStripFecKey::operator=(const SiStripFecKey&)' is deprecated [-Wdeprecated-copy]
   116 |                   tmp5 = tmp1;
      |                          ^~~~
In file included from /data/cmsbld/je
```

Thanks,
Andrea