### PR TITLE
improve errors when pileup scenario requires inputs that are not specified

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -771,6 +771,11 @@ class ConfigBuilder(object):
         if self._options.pileup:
             pileupSpec=self._options.pileup.split(',')[0]
 
+            #make sure there is a set of pileup files specified when needed
+            if self._options.pileup != defaultOptions.pileup and self._options.pileup_input==None:
+                message = "Pileup scenerio requires input files. Please add an appropriate --pileup_input option"
+                raise Exception(message)
+
             # Does the requested pile-up scenario exist?
             from Configuration.StandardSequences.Mixing import Mixing,defineMixing
             if not pileupSpec in Mixing and '.' not in pileupSpec and 'file:' not in pileupSpec:

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -772,7 +772,8 @@ class ConfigBuilder(object):
             pileupSpec=self._options.pileup.split(',')[0]
 
             #make sure there is a set of pileup files specified when needed
-            if self._options.pileup != defaultOptions.pileup and self._options.pileup_input==None:
+            pileups_without_input=[defaultOptions.pileup,"Cosmics","default","HiMixNoPU",None]
+            if self._options.pileup not in pileups_without_input and self._options.pileup_input==None:
                 message = "Pileup scenerio requires input files. Please add an appropriate --pileup_input option"
                 raise Exception(message)
 

--- a/SimGeneral/MixingModule/python/mixPoolSource_cfi.py
+++ b/SimGeneral/MixingModule/python/mixPoolSource_cfi.py
@@ -1,7 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 
-#FileNames = cms.untracked.vstring('dataset:/RelValMinBias/CMSSW_4_2_0_pre4-START42_V1-v1/GEN-SIM-DIGI-RAW-HLTDEBUG')
-
-FileNames = cms.untracked.vstring('/store/relval/CMSSW_5_0_0_pre6/RelValProdMinBias/GEN-SIM-RAW/START50_V5-v1/0195/1AD9E627-7316-E111-B3A5-001A9281173C.root',
-                             '/store/relval/CMSSW_5_0_0_pre6/RelValProdMinBias/GEN-SIM-RAW/START50_V5-v1/0196/0477EED1-7516-E111-B834-0018F3D0962E.root',
-                             '/store/relval/CMSSW_5_0_0_pre6/RelValProdMinBias/GEN-SIM-RAW/START50_V5-v1/0197/3E1F5CF3-DB16-E111-A7C7-001A928116CE.root')
+FileNames = cms.untracked.vstring()


### PR DESCRIPTION
two changes
 - remove long since deleted default pileup inputs 
 - add exception to cmsDriver if pileup scenario is specified without a pileup_input.

(motivated by recent Mattermost discussion with production errors due to missing --pileup_input causing all jobs to fail)