### PR TITLE
[L1] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h
@@ -47,6 +47,9 @@ public:
   /// copy constructor
   L1MuGMTCand(const L1MuGMTCand&);
 
+  /// assignment operator
+  L1MuGMTCand& operator=(const L1MuGMTCand&) = default;
+
   /// destructor
   virtual ~L1MuGMTCand();
 

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h
@@ -54,6 +54,9 @@ public:
   /// copy constructor
   L1MuGMTExtendedCand(const L1MuGMTExtendedCand&);
 
+  /// assignment operator
+  L1MuGMTExtendedCand& operator=(const L1MuGMTExtendedCand&) = default;
+
   /// destructor
   ~L1MuGMTExtendedCand() override;
 

--- a/DataFormats/L1TMuon/interface/L1MuKBMTCombinedStub.h
+++ b/DataFormats/L1TMuon/interface/L1MuKBMTCombinedStub.h
@@ -60,6 +60,9 @@ public:
                        int eta2 = 0,
                        int qeta1 = -1,
                        int qeta2 = -1);
+  /// copy constructor
+  L1MuKBMTCombinedStub(const L1MuKBMTCombinedStub&) = default;
+  //destructor
   ~L1MuKBMTCombinedStub();
   /// return wheel
   inline int whNum() const { return whNum_; }


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

Thanks,
Andrea