### PR TITLE
[CORE] Define missing assignment operator to fix warnings reported in DEVEL IBs

### DIFF
--- a/DataFormats/Common/interface/MapOfVectors.h
+++ b/DataFormats/Common/interface/MapOfVectors.h
@@ -128,12 +128,6 @@ namespace edm {
       m_data.swap(other.m_data);
     }
 
-    MapOfVectors& operator=(MapOfVectors const& rhs) {
-      MapOfVectors temp(rhs);
-      this->swap(temp);
-      return *this;
-    }
-
   private:
     //for testing
     friend class ::TestMapOfVectors;


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/thu/14.0.DEVEL-thu-23/CMSSW_14_0_DEVEL_X_2023-11-30-2300) on deprecated implicit assignment operators present in the IBs on the `DataFormats` modules.

Thanks,
Andrea