### PR TITLE
SimTauCPLink - Adding a link between GenTaus and CaloParticles

### DIFF
--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -35,6 +35,7 @@ TICL_FEVT = cms.PSet(
       'keep *_ticlSimTracksters_*_*',
       'keep *_ticlSimTICLCandidates_*_*',
       'keep *_ticlSimTrackstersFromCP_*_*',
+      'keep *_SimTau*_*_*'
       )
     )
 TICL_FEVT.outputCommands.extend(TICL_RECO.outputCommands)

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -48,17 +48,16 @@ private:
                    int,
                    edm::Handle<std::vector<CaloParticle>>,
                    const std::vector<int>&);
-  int buildDecayModes(const SimTauCPLink&);
   // ----------member data ---------------------------
-  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticle_token_;
+  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticles_token_;
   const edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticles_token_;
   const edm::EDGetTokenT<std::vector<int>> genBarcodes_token_;
 };
 
 SimTauProducer::SimTauProducer(const edm::ParameterSet& iConfig)
-    : caloParticle_token_(consumes<std::vector<CaloParticle>>(iConfig.getParameter<edm::InputTag>("CaloParticle"))),
-      genParticles_token_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("GenParticles"))),
-      genBarcodes_token_(consumes<std::vector<int>>(iConfig.getParameter<edm::InputTag>("GenBarcodes"))) {
+    : caloParticles_token_(consumes<std::vector<CaloParticle>>(iConfig.getParameter<edm::InputTag>("caloParticles"))),
+      genParticles_token_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+      genBarcodes_token_(consumes<std::vector<int>>(iConfig.getParameter<edm::InputTag>("genBarcodes"))) {
   produces<std::vector<SimTauCPLink>>();
 }
 
@@ -103,140 +102,42 @@ void SimTauProducer::buildSimTau(SimTauCPLink& t,
   }
 }
 
-int SimTauProducer::buildDecayModes(const SimTauCPLink& t) {
-  enum decayModes {
-    kNull = -1,
-    kOneProng0PiZero,
-    kOneProng1PiZero,
-    kOneProng2PiZero,
-    kOneProng3PiZero,
-    kOneProngNPiZero,
-    kTwoProng0PiZero,
-    kTwoProng1PiZero,
-    kTwoProng2PiZero,
-    kTwoProng3PiZero,
-    kTwoProngNPiZero,
-    kThreeProng0PiZero,
-    kThreeProng1PiZero,
-    kThreeProng2PiZero,
-    kThreeProng3PiZero,
-    kThreeProngNPiZero,
-    kRareDecayMode,
-    kElectron,
-    kMuon
-  };
-
-  int numElectrons = 0;
-  int numMuons = 0;
-  int numHadrons = 0;
-  int numPhotons = 0;
-  auto& leaves = t.leaves;
-  for (auto leaf : leaves) {
-    int pdg_id = abs(leaf.pdgId());
-    switch (pdg_id) {
-      case 22:
-        numPhotons++;
-        break;
-      case 11:
-        numElectrons++;
-        break;
-      case 13:
-        numMuons++;
-        break;
-      case 16:
-        break;
-      default:
-        numHadrons++;
-    }
-  }
-
-  if (numElectrons == 1)
-    return kElectron;
-  else if (numMuons == 1)
-    return kMuon;
-  switch (numHadrons) {
-    case 1:
-      switch (numPhotons) {
-        case 0:
-          return kOneProng0PiZero;
-        case 2:
-          return kOneProng1PiZero;
-        case 4:
-          return kOneProng2PiZero;
-        case 6:
-          return kOneProng3PiZero;
-        default:
-          return kOneProngNPiZero;
-      }
-    case 2:
-      switch (numPhotons) {
-        case 0:
-          return kTwoProng0PiZero;
-        case 2:
-          return kTwoProng1PiZero;
-        case 4:
-          return kTwoProng2PiZero;
-        case 6:
-          return kTwoProng3PiZero;
-        default:
-          return kTwoProngNPiZero;
-      }
-    case 3:
-      switch (numPhotons) {
-        case 0:
-          return kThreeProng0PiZero;
-        case 2:
-          return kThreeProng1PiZero;
-        case 4:
-          return kThreeProng2PiZero;
-        case 6:
-          return kThreeProng3PiZero;
-        default:
-          return kThreeProngNPiZero;
-      }
-    default:
-      return kRareDecayMode;
-  }
-}
-
-// ------------ method called for each event  ------------
 void SimTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  Handle<std::vector<CaloParticle>> CaloParticle_h;
-  iEvent.getByToken(caloParticle_token_, CaloParticle_h);
+  Handle<std::vector<CaloParticle>> caloParticles_h;
+  iEvent.getByToken(caloParticles_token_, caloParticles_h);
 
-  edm::Handle<std::vector<reco::GenParticle>> gen_particles_h;
-  iEvent.getByToken(genParticles_token_, gen_particles_h);
+  edm::Handle<std::vector<reco::GenParticle>> genParticles_h;
+  iEvent.getByToken(genParticles_token_, genParticles_h);
 
-  Handle<std::vector<int>> gen_barcodes_h;
-  iEvent.getByToken(genBarcodes_token_, gen_barcodes_h);
+  Handle<std::vector<int>> genBarcodes_h;
+  iEvent.getByToken(genBarcodes_token_, genBarcodes_h);
 
-  const auto& genParticles = *gen_particles_h;
-  const auto& genBarcodes = *gen_barcodes_h;
+  const auto& genParticles = *genParticles_h;
+  const auto& genBarcodes = *genBarcodes_h;
   auto tauDecayVec = std::make_unique<std::vector<SimTauCPLink>>();
   for (auto const& g : genParticles) {
     auto const& flags = g.statusFlags();
     if (std::abs(g.pdgId()) == 15 and flags.isPrompt() and flags.isDecayedLeptonHadron()) {
       SimTauCPLink t;
-      buildSimTau(t, 0, -1, g, -1, CaloParticle_h, genBarcodes);
-      t.decayMode = buildDecayModes(t);
-      t.dump();
-      t.dumpFullDecay();
+      buildSimTau(t, 0, -1, g, -1, caloParticles_h, genBarcodes);
+      t.decayMode = t.buildDecayModes();
+      #ifdef EDM_ML_DEBUG
+        t.dumpFullDecay();
+        t.dump();
+      #endif
       (*tauDecayVec).push_back(t);
     }
   }
   iEvent.put(std::move(tauDecayVec));
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void SimTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
-}
+  desc.add<edm::InputTag>("caloParticles", edm::InputTag("mix", "MergedCaloTruth"));
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
+  desc.add<edm::InputTag>("genBarcodes", edm::InputTag("genParticles"));
+  descriptions.add("SimTauProducer", desc);}
 
-//define this as a plug-in
 DEFINE_FWK_MODULE(SimTauProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -67,36 +67,35 @@ void SimTauProducer::buildSimTau(SimTauCPLink& t,
   const auto& caloPartVec = *calo_particle_h;
   auto& daughters = gen_particle.daughterRefVector();
   bool is_leaf = (daughters.empty());
-  
+
   if (is_leaf) {
     LogDebug("SimTauProducer").format(" TO BE SAVED {} ", resonance_idx);
     auto const& gen_particle_barcode = gen_particle_barcodes[gen_particle_key];
     auto const& found_in_caloparticles = std::find_if(caloPartVec.begin(), caloPartVec.end(), [&](const auto& p) {
-        return p.g4Tracks()[0].genpartIndex() == gen_particle_barcode;
+      return p.g4Tracks()[0].genpartIndex() == gen_particle_barcode;
     });
     if (found_in_caloparticles != caloPartVec.end()) {
       auto calo_particle_idx = (found_in_caloparticles - caloPartVec.begin());
       t.calo_particle_leaves.push_back(CaloParticleRef(calo_particle_h, calo_particle_idx));
       t.leaves.push_back(
-      {gen_particle.pdgId(), resonance_idx, (int)t.calo_particle_leaves.size() - 1, gen_particle_key});
+          {gen_particle.pdgId(), resonance_idx, (int)t.calo_particle_leaves.size() - 1, gen_particle_key});
       LogDebug("SimTauProducer").format(" CP {} {}", calo_particle_idx, caloPartVec[calo_particle_idx]);
     } else {
       t.leaves.push_back({gen_particle.pdgId(), resonance_idx, -1, gen_particle_key});
     }
     return;
-    } else if (generation != 0) {
-      t.resonances.push_back({gen_particle.pdgId(), resonance_idx});
-      resonance_idx = t.resonances.size() - 1;
-      LogDebug("SimTauProducer").format(" RESONANCE/INTERMEDIATE {} ", resonance_idx);
-    }
+  } else if (generation != 0) {
+    t.resonances.push_back({gen_particle.pdgId(), resonance_idx});
+    resonance_idx = t.resonances.size() - 1;
+    LogDebug("SimTauProducer").format(" RESONANCE/INTERMEDIATE {} ", resonance_idx);
+  }
 
-    ++generation;
-    for (auto daughter = daughters.begin(); daughter != daughters.end(); ++daughter) {
-      int gen_particle_key = (*daughter).key();
-      LogDebug("SimTauProducer").format(" gen {} {} {} ", generation, gen_particle_key, (*daughter)->pdgId());
-      buildSimTau(t, generation, resonance_idx, *(*daughter), gen_particle_key, calo_particle_h, gen_particle_barcodes);
-    }
-  
+  ++generation;
+  for (auto daughter = daughters.begin(); daughter != daughters.end(); ++daughter) {
+    int gen_particle_key = (*daughter).key();
+    LogDebug("SimTauProducer").format(" gen {} {} {} ", generation, gen_particle_key, (*daughter)->pdgId());
+    buildSimTau(t, generation, resonance_idx, *(*daughter), gen_particle_key, calo_particle_h, gen_particle_barcodes);
+  }
 }
 
 void SimTauProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
@@ -105,7 +104,7 @@ void SimTauProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup 
   auto caloParticles_h = iEvent.getHandle(caloParticles_token_);
   const auto& genParticles = iEvent.get(genParticles_token_);
   const auto& genBarcodes = iEvent.get(genBarcodes_token_);
-  
+
   auto tauDecayVec = std::make_unique<std::vector<SimTauCPLink>>();
   for (auto const& g : genParticles) {
     auto const& flags = g.statusFlags();

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -1,0 +1,242 @@
+// -*- C++ -*-
+//
+//
+// Authors:  Marco Rovere, Andreas Gruber
+//         Created:  Mon, 16 Oct 2023 14:24:35 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/HGCalReco/interface/TICLCandidate.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+class SimTauProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SimTauProducer(const edm::ParameterSet&);
+  ~SimTauProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  void buildSimTau(SimTauCPLink&,
+                   uint8_t,
+                   int,
+                   const reco::GenParticle&,
+                   int,
+                   edm::Handle<std::vector<CaloParticle>>,
+                   const std::vector<int>&);
+  int buildDecayModes(const SimTauCPLink&);
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<std::vector<CaloParticle>> caloParticle_token_;
+  const edm::EDGetTokenT<std::vector<reco::GenParticle>> genParticles_token_;
+  const edm::EDGetTokenT<std::vector<int>> genBarcodes_token_;
+};
+
+SimTauProducer::SimTauProducer(const edm::ParameterSet& iConfig)
+    : caloParticle_token_(consumes<std::vector<CaloParticle>>(iConfig.getParameter<edm::InputTag>("CaloParticle"))),
+      genParticles_token_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("GenParticles"))),
+      genBarcodes_token_(consumes<std::vector<int>>(iConfig.getParameter<edm::InputTag>("GenBarcodes"))) {
+  produces<std::vector<SimTauCPLink>>();
+}
+
+void SimTauProducer::buildSimTau(SimTauCPLink& t,
+                                 uint8_t generation,
+                                 int resonance_idx,
+                                 const reco::GenParticle& gen_particle,
+                                 int gen_particle_key,
+                                 edm::Handle<std::vector<CaloParticle>> calo_particle_h,
+                                 const std::vector<int>& gen_particle_barcodes) {
+  const auto& caloPartVec = *calo_particle_h;
+  auto& daughters = gen_particle.daughterRefVector();
+  bool is_leaf = (daughters.empty());
+  if (is_leaf) {
+    LogDebug("SimTauProducer") << " TO BE SAVED " + std::to_string(resonance_idx) + " ";
+    auto const& gen_particle_barcode = gen_particle_barcodes[gen_particle_key];
+    auto const& found_in_caloparticles = std::find_if(caloPartVec.begin(), caloPartVec.end(), [&](const auto& p) {
+      return p.g4Tracks()[0].genpartIndex() == gen_particle_barcode;
+    });
+    if (found_in_caloparticles != caloPartVec.end()) {
+      auto calo_particle_idx = (found_in_caloparticles - caloPartVec.begin());
+      t.calo_particle_leaves.push_back(CaloParticleRef(calo_particle_h, calo_particle_idx));
+      t.leaves.push_back(
+          {gen_particle.pdgId(), resonance_idx, (int)t.calo_particle_leaves.size() - 1, gen_particle_key});
+      LogDebug("SimTauProducer") << " CP " + std::to_string(calo_particle_idx) + " " << caloPartVec[calo_particle_idx];
+    } else {
+      t.leaves.push_back({gen_particle.pdgId(), resonance_idx, -1, gen_particle_key});
+    }
+    return;
+  } else if (generation != 0) {
+    t.resonances.push_back({gen_particle.pdgId(), resonance_idx});
+    resonance_idx = t.resonances.size() - 1;
+    LogDebug("SimTauProducer") << " RESONANCE/INTERMEDIATE " + std::to_string(resonance_idx) + " ";
+  }
+
+  ++generation;
+  for (auto daughter = daughters.begin(); daughter != daughters.end(); ++daughter) {
+    int gen_particle_key = (*daughter).key();
+    LogDebug("SimTauProducer") << " gen " + std::to_string((int)generation) + " " + std::to_string(gen_particle_key) +
+                                      " " + std::to_string((*daughter)->pdgId()) + " ";
+    buildSimTau(t, generation, resonance_idx, *(*daughter), gen_particle_key, calo_particle_h, gen_particle_barcodes);
+  }
+}
+
+int SimTauProducer::buildDecayModes(const SimTauCPLink& t) {
+  enum decayModes {
+    kNull = -1,
+    kOneProng0PiZero,
+    kOneProng1PiZero,
+    kOneProng2PiZero,
+    kOneProng3PiZero,
+    kOneProngNPiZero,
+    kTwoProng0PiZero,
+    kTwoProng1PiZero,
+    kTwoProng2PiZero,
+    kTwoProng3PiZero,
+    kTwoProngNPiZero,
+    kThreeProng0PiZero,
+    kThreeProng1PiZero,
+    kThreeProng2PiZero,
+    kThreeProng3PiZero,
+    kThreeProngNPiZero,
+    kRareDecayMode,
+    kElectron,
+    kMuon
+  };
+
+  int numElectrons = 0;
+  int numMuons = 0;
+  int numHadrons = 0;
+  int numPhotons = 0;
+  auto& leaves = t.leaves;
+  for (auto leaf : leaves) {
+    int pdg_id = abs(leaf.pdgId());
+    switch (pdg_id) {
+      case 22:
+        numPhotons++;
+        break;
+      case 11:
+        numElectrons++;
+        break;
+      case 13:
+        numMuons++;
+        break;
+      case 16:
+        break;
+      default:
+        numHadrons++;
+    }
+  }
+
+  if (numElectrons == 1)
+    return kElectron;
+  else if (numMuons == 1)
+    return kMuon;
+  switch (numHadrons) {
+    case 1:
+      switch (numPhotons) {
+        case 0:
+          return kOneProng0PiZero;
+        case 2:
+          return kOneProng1PiZero;
+        case 4:
+          return kOneProng2PiZero;
+        case 6:
+          return kOneProng3PiZero;
+        default:
+          return kOneProngNPiZero;
+      }
+    case 2:
+      switch (numPhotons) {
+        case 0:
+          return kTwoProng0PiZero;
+        case 2:
+          return kTwoProng1PiZero;
+        case 4:
+          return kTwoProng2PiZero;
+        case 6:
+          return kTwoProng3PiZero;
+        default:
+          return kTwoProngNPiZero;
+      }
+    case 3:
+      switch (numPhotons) {
+        case 0:
+          return kThreeProng0PiZero;
+        case 2:
+          return kThreeProng1PiZero;
+        case 4:
+          return kThreeProng2PiZero;
+        case 6:
+          return kThreeProng3PiZero;
+        default:
+          return kThreeProngNPiZero;
+      }
+    default:
+      return kRareDecayMode;
+  }
+}
+
+// ------------ method called for each event  ------------
+void SimTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  Handle<std::vector<CaloParticle>> CaloParticle_h;
+  iEvent.getByToken(caloParticle_token_, CaloParticle_h);
+
+  edm::Handle<std::vector<reco::GenParticle>> gen_particles_h;
+  iEvent.getByToken(genParticles_token_, gen_particles_h);
+
+  Handle<std::vector<int>> gen_barcodes_h;
+  iEvent.getByToken(genBarcodes_token_, gen_barcodes_h);
+
+  const auto& genParticles = *gen_particles_h;
+  const auto& genBarcodes = *gen_barcodes_h;
+  auto tauDecayVec = std::make_unique<std::vector<SimTauCPLink>>();
+  for (auto const& g : genParticles) {
+    auto const& flags = g.statusFlags();
+    if (std::abs(g.pdgId()) == 15 and flags.isPrompt() and flags.isDecayedLeptonHadron()) {
+      SimTauCPLink t;
+      buildSimTau(t, 0, -1, g, -1, CaloParticle_h, genBarcodes);
+      t.decayMode = buildDecayModes(t);
+      t.dump();
+      t.dumpFullDecay();
+      (*tauDecayVec).push_back(t);
+    }
+  }
+  iEvent.put(std::move(tauDecayVec));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SimTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SimTauProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -123,10 +123,10 @@ void SimTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       SimTauCPLink t;
       buildSimTau(t, 0, -1, g, -1, caloParticles_h, genBarcodes);
       t.decayMode = t.buildDecayModes();
-      #ifdef EDM_ML_DEBUG
-        t.dumpFullDecay();
-        t.dump();
-      #endif
+#ifdef EDM_ML_DEBUG
+      t.dumpFullDecay();
+      t.dump();
+#endif
       (*tauDecayVec).push_back(t);
     }
   }
@@ -138,6 +138,7 @@ void SimTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<edm::InputTag>("caloParticles", edm::InputTag("mix", "MergedCaloTruth"));
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
   desc.add<edm::InputTag>("genBarcodes", edm::InputTag("genParticles"));
-  descriptions.add("SimTauProducer", desc);}
+  descriptions.add("SimTauProducer", desc);
+}
 
 DEFINE_FWK_MODULE(SimTauProducer);

--- a/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 SimTauCPLink = cms.EDProducer("SimTauProducer",
-                CaloParticle      = cms.InputTag('mix', 'MergedCaloTruth'),
-                GenParticles      = cms.InputTag('genParticles'),
-                GenBarcodes       = cms.InputTag('genParticles')
+                caloParticles      = cms.InputTag('mix', 'MergedCaloTruth'),
+                genParticles      = cms.InputTag('genParticles'),
+                genBarcodes       = cms.InputTag('genParticles')
                 )

--- a/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+SimTauCPLink = cms.EDProducer("SimTauProducer",
+                CaloParticle      = cms.InputTag('mix', 'MergedCaloTruth'),
+                GenParticles      = cms.InputTag('genParticles'),
+                GenBarcodes       = cms.InputTag('genParticles')
+                )

--- a/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/SimTauCPLink_cfi.py
@@ -1,7 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-SimTauCPLink = cms.EDProducer("SimTauProducer",
-                caloParticles      = cms.InputTag('mix', 'MergedCaloTruth'),
-                genParticles      = cms.InputTag('genParticles'),
-                genBarcodes       = cms.InputTag('genParticles')
-                )

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -1,0 +1,82 @@
+#ifndef SimDataFormats_SimTauCPLink_h
+#define SimDataFormats_SimTauCPLink_h
+
+#include "DataFormats/HGCalReco/interface/TICLCandidate.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+class SimTauCPLink {
+public:
+  SimTauCPLink(){};
+  ~SimTauCPLink(){};
+  struct DecayNav {
+    int pdgId_;
+    int resonance_idx_;
+    int calo_particle_idx_;
+    int gen_particle_idx_;
+    int pdgId() const { return pdgId_; }
+    int resonance_idx() const { return resonance_idx_; }
+    int calo_particle_idx() const { return calo_particle_idx_; }
+    int gen_particle_idx() const { return gen_particle_idx_; }
+  };
+
+  std::vector<std::pair<int, int>> resonances;
+  std::vector<DecayNav> leaves;
+  CaloParticleRefVector calo_particle_leaves;
+  int decayMode;
+
+  enum decayModes {
+    kNull = -1,
+    kOneProng0PiZero,
+    kOneProng1PiZero,
+    kOneProng2PiZero,
+    kOneProng3PiZero,
+    kOneProngNPiZero,
+    kTwoProng0PiZero,
+    kTwoProng1PiZero,
+    kTwoProng2PiZero,
+    kTwoProng3PiZero,
+    kTwoProngNPiZero,
+    kThreeProng0PiZero,
+    kThreeProng1PiZero,
+    kThreeProng2PiZero,
+    kThreeProng3PiZero,
+    kThreeProngNPiZero,
+    kRareDecayMode,
+    kElectron,
+    kMuon
+  };
+
+  void dump(void) const {
+    for (auto const &l : leaves) {
+      LogDebug("SimTauProducer") << "L " + std::to_string(l.pdgId()) + " " + std::to_string(l.resonance_idx()) +
+                                        " CP: " + std::to_string(l.calo_particle_idx()) +
+                                        " GenP idx: " + std::to_string(l.gen_particle_idx());
+    }
+    for (auto const &r : resonances) {
+      LogDebug("SimTauProducer") << "R " + std::to_string(r.first) + " " + std::to_string(r.second);
+    }
+  }
+
+  void dumpDecay(const std::pair<int, int> &entry) const {
+    if (entry.second == -1) {  // No intermediate mother.
+      LogDebug("SimTauProducer") << std::to_string(entry.first) + " " + std::to_string(entry.second);
+    } else {
+      LogDebug("SimTauProducer") << std::to_string(entry.first) + " " + std::to_string(entry.second) + " coming from: ";
+      auto const &mother = resonances[entry.second];
+      dumpDecay(mother);
+    }
+  }
+
+  void dumpFullDecay(void) const {
+    for (auto const &leaf : leaves) {
+      dumpDecay({leaf.pdgId(), leaf.resonance_idx()});
+    }
+  }
+
+private:
+};
+
+#endif  //SimTauCPLink

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -20,6 +20,7 @@ public:
     int resonance_idx() const { return resonance_idx_; }
     int calo_particle_idx() const { return calo_particle_idx_; }
     int gen_particle_idx() const { return gen_particle_idx_; }
+    private:
   };
 
   std::vector<std::pair<int, int>> resonances;
@@ -51,20 +52,18 @@ public:
 
   void dump(void) const {
     for (auto const &l : leaves) {
-      LogDebug("SimTauProducer") << "L " + std::to_string(l.pdgId()) + " " + std::to_string(l.resonance_idx()) +
-                                        " CP: " + std::to_string(l.calo_particle_idx()) +
-                                        " GenP idx: " + std::to_string(l.gen_particle_idx());
+      LogDebug("SimTauProducer").format("L {} {} CP: {} GenP idx: {}", l.pdgId(), l.resonance_idx(), l.calo_particle_idx(), l.gen_particle_idx());
     }
     for (auto const &r : resonances) {
-      LogDebug("SimTauProducer") << "R " + std::to_string(r.first) + " " + std::to_string(r.second);
+      LogDebug("SimTauProducer").format("R {} {}", r.first, r.second);
     }
   }
 
   void dumpDecay(const std::pair<int, int> &entry) const {
     if (entry.second == -1) {  // No intermediate mother.
-      LogDebug("SimTauProducer") << std::to_string(entry.first) + " " + std::to_string(entry.second);
+      LogDebug("SimTauProducer").format("{} {}", entry.first, entry.second);
     } else {
-      LogDebug("SimTauProducer") << std::to_string(entry.first) + " " + std::to_string(entry.second) + " coming from: ";
+      LogDebug("SimTauProducer").format("{} {} coming from: ", entry.first, entry.second);
       auto const &mother = resonances[entry.second];
       dumpDecay(mother);
     }

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -77,78 +77,77 @@ public:
   }
 
   int buildDecayModes() {
+    int numElectrons = 0;
+    int numMuons = 0;
+    int numHadrons = 0;
+    int numPhotons = 0;
+    for (auto leaf : leaves) {
+      int pdg_id = abs(leaf.pdgId());
+      switch (pdg_id) {
+        case 22:
+          numPhotons++;
+          break;
+        case 11:
+          numElectrons++;
+          break;
+        case 13:
+          numMuons++;
+          break;
+        case 16:
+          break;
+        default:
+          numHadrons++;
+      }
+    }
 
-  int numElectrons = 0;
-  int numMuons = 0;
-  int numHadrons = 0;
-  int numPhotons = 0;
-  for (auto leaf : leaves) {
-    int pdg_id = abs(leaf.pdgId());
-    switch (pdg_id) {
-      case 22:
-        numPhotons++;
-        break;
-      case 11:
-        numElectrons++;
-        break;
-      case 13:
-        numMuons++;
-        break;
-      case 16:
-        break;
+    if (numElectrons == 1)
+      return kElectron;
+    else if (numMuons == 1)
+      return kMuon;
+    switch (numHadrons) {
+      case 1:
+        switch (numPhotons) {
+          case 0:
+            return kOneProng0PiZero;
+          case 2:
+            return kOneProng1PiZero;
+          case 4:
+            return kOneProng2PiZero;
+          case 6:
+            return kOneProng3PiZero;
+          default:
+            return kOneProngNPiZero;
+        }
+      case 2:
+        switch (numPhotons) {
+          case 0:
+            return kTwoProng0PiZero;
+          case 2:
+            return kTwoProng1PiZero;
+          case 4:
+            return kTwoProng2PiZero;
+          case 6:
+            return kTwoProng3PiZero;
+          default:
+            return kTwoProngNPiZero;
+        }
+      case 3:
+        switch (numPhotons) {
+          case 0:
+            return kThreeProng0PiZero;
+          case 2:
+            return kThreeProng1PiZero;
+          case 4:
+            return kThreeProng2PiZero;
+          case 6:
+            return kThreeProng3PiZero;
+          default:
+            return kThreeProngNPiZero;
+        }
       default:
-        numHadrons++;
+        return kRareDecayMode;
     }
   }
-
-  if (numElectrons == 1)
-    return kElectron;
-  else if (numMuons == 1)
-    return kMuon;
-  switch (numHadrons) {
-    case 1:
-      switch (numPhotons) {
-        case 0:
-          return kOneProng0PiZero;
-        case 2:
-          return kOneProng1PiZero;
-        case 4:
-          return kOneProng2PiZero;
-        case 6:
-          return kOneProng3PiZero;
-        default:
-          return kOneProngNPiZero;
-      }
-    case 2:
-      switch (numPhotons) {
-        case 0:
-          return kTwoProng0PiZero;
-        case 2:
-          return kTwoProng1PiZero;
-        case 4:
-          return kTwoProng2PiZero;
-        case 6:
-          return kTwoProng3PiZero;
-        default:
-          return kTwoProngNPiZero;
-      }
-    case 3:
-      switch (numPhotons) {
-        case 0:
-          return kThreeProng0PiZero;
-        case 2:
-          return kThreeProng1PiZero;
-        case 4:
-          return kThreeProng2PiZero;
-        case 6:
-          return kThreeProng3PiZero;
-        default:
-          return kThreeProngNPiZero;
-      }
-    default:
-      return kRareDecayMode;
-  }
-}
 
 private:
 };

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -76,6 +76,80 @@ public:
     }
   }
 
+  int buildDecayModes() {
+
+  int numElectrons = 0;
+  int numMuons = 0;
+  int numHadrons = 0;
+  int numPhotons = 0;
+  for (auto leaf : leaves) {
+    int pdg_id = abs(leaf.pdgId());
+    switch (pdg_id) {
+      case 22:
+        numPhotons++;
+        break;
+      case 11:
+        numElectrons++;
+        break;
+      case 13:
+        numMuons++;
+        break;
+      case 16:
+        break;
+      default:
+        numHadrons++;
+    }
+  }
+
+  if (numElectrons == 1)
+    return kElectron;
+  else if (numMuons == 1)
+    return kMuon;
+  switch (numHadrons) {
+    case 1:
+      switch (numPhotons) {
+        case 0:
+          return kOneProng0PiZero;
+        case 2:
+          return kOneProng1PiZero;
+        case 4:
+          return kOneProng2PiZero;
+        case 6:
+          return kOneProng3PiZero;
+        default:
+          return kOneProngNPiZero;
+      }
+    case 2:
+      switch (numPhotons) {
+        case 0:
+          return kTwoProng0PiZero;
+        case 2:
+          return kTwoProng1PiZero;
+        case 4:
+          return kTwoProng2PiZero;
+        case 6:
+          return kTwoProng3PiZero;
+        default:
+          return kTwoProngNPiZero;
+      }
+    case 3:
+      switch (numPhotons) {
+        case 0:
+          return kThreeProng0PiZero;
+        case 2:
+          return kThreeProng1PiZero;
+        case 4:
+          return kThreeProng2PiZero;
+        case 6:
+          return kThreeProng3PiZero;
+        default:
+          return kThreeProngNPiZero;
+      }
+    default:
+      return kRareDecayMode;
+  }
+}
+
 private:
 };
 

--- a/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
+++ b/SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h
@@ -20,7 +20,8 @@ public:
     int resonance_idx() const { return resonance_idx_; }
     int calo_particle_idx() const { return calo_particle_idx_; }
     int gen_particle_idx() const { return gen_particle_idx_; }
-    private:
+
+  private:
   };
 
   std::vector<std::pair<int, int>> resonances;
@@ -52,7 +53,9 @@ public:
 
   void dump(void) const {
     for (auto const &l : leaves) {
-      LogDebug("SimTauProducer").format("L {} {} CP: {} GenP idx: {}", l.pdgId(), l.resonance_idx(), l.calo_particle_idx(), l.gen_particle_idx());
+      LogDebug("SimTauProducer")
+          .format(
+              "L {} {} CP: {} GenP idx: {}", l.pdgId(), l.resonance_idx(), l.calo_particle_idx(), l.gen_particle_idx());
     }
     for (auto const &r : resonances) {
       LogDebug("SimTauProducer").format("R {} {}", r.first, r.second);

--- a/SimDataFormats/CaloAnalysis/src/classes.h
+++ b/SimDataFormats/CaloAnalysis/src/classes.h
@@ -10,3 +10,5 @@
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h"
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimTrackster.h"
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -52,8 +52,8 @@
   <class name="MtdSimTracksterRefProd"/>
   <class name="MtdSimTracksterContainer"/>
 
-  <class name="SimTauCPLink" ClassVersion="10">
-   <version ClassVersion="10" checksum="213448491"/>
+  <class name="SimTauCPLink" ClassVersion="3">
+   <version ClassVersion="3" checksum="213448491"/>
   </class>
   <class name="std::vector<SimTauCPLink>"/>
   <class name="edm::Wrapper<std::vector<SimTauCPLink> >" />

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -52,6 +52,12 @@
   <class name="MtdSimTracksterRefProd"/>
   <class name="MtdSimTracksterContainer"/>
 
+  <class name="SimTauCPLink" ClassVersion="10">
+   <version ClassVersion="10" checksum="213448491"/>
+  </class>
+  <class name="std::vector<SimTauCPLink>"/>
+  <class name="edm::Wrapper<std::vector<SimTauCPLink> >" />
+
   <class name="std::pair<uint64_t,float>"/>
   <class name="std::vector<std::pair<uint64_t,float>>"/>
   <class name="edm::Wrapper<std::vector<std::pair<uint64_t,float>> >"/>

--- a/SimGeneral/Debugging/plugins/BuildFile.xml
+++ b/SimGeneral/Debugging/plugins/BuildFile.xml
@@ -11,4 +11,4 @@
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="FWCore/ServiceRegistry"/>
-\<flags EDM_PLUGIN="1"/>
+<flags EDM_PLUGIN="1"/>

--- a/SimGeneral/Debugging/plugins/BuildFile.xml
+++ b/SimGeneral/Debugging/plugins/BuildFile.xml
@@ -9,4 +9,6 @@
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="Geometry/HGCalGeometry"/>
 <use name="Geometry/Records"/>
-<flags EDM_PLUGIN="1"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="FWCore/ServiceRegistry"/>
+\<flags EDM_PLUGIN="1"/>

--- a/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
+++ b/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
@@ -1,0 +1,62 @@
+// -*- C++ -*-
+//
+//
+// Original Author:  Andreas Gruber
+//         Created:  Mon, 16 Oct 2023 14:24:35 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "TH1.h"
+
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticleFwd.h"
+#include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
+#include "SimDataFormats/CaloAnalysis/interface/SimTauCPLink.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+class SimTauAnalyzer : public edm::one::EDAnalyzer<> {
+public:
+  explicit SimTauAnalyzer(const edm::ParameterSet&);
+  ~SimTauAnalyzer() override = default;
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  const edm::EDGetTokenT<std::vector<SimTauCPLink>> simTau_token_;
+  TH1D* DM_histo;
+};
+
+SimTauAnalyzer::SimTauAnalyzer(const edm::ParameterSet& iConfig)
+    : simTau_token_(consumes<std::vector<SimTauCPLink>>(iConfig.getParameter<edm::InputTag>("simTau"))) {
+  edm::Service<TFileService> fs;
+  DM_histo = fs->make<TH1D>("DM_histo", "DM_histo", 20, -1, 19);
+}
+
+// ------------ method called for each event  ------------
+void SimTauAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<SimTauCPLink>> simTau_h;
+  iEvent.getByToken(simTau_token_, simTau_h);
+
+  const auto& simTaus = *simTau_h;
+
+  for (auto const& simTau : simTaus) {
+    simTau.dumpFullDecay();
+    simTau.dump();
+    DM_histo->Fill(simTau.decayMode);
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SimTauAnalyzer);

--- a/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
+++ b/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
@@ -26,7 +26,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-class SimTauAnalyzer : public edm::one::EDAnalyzer<> {
+class SimTauAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit SimTauAnalyzer(const edm::ParameterSet&);
   ~SimTauAnalyzer() override = default;
@@ -40,6 +40,7 @@ private:
 
 SimTauAnalyzer::SimTauAnalyzer(const edm::ParameterSet& iConfig)
     : simTau_token_(consumes<std::vector<SimTauCPLink>>(iConfig.getParameter<edm::InputTag>("simTau"))) {
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   DM_histo = fs->make<TH1D>("DM_histo", "DM_histo", 20, -1, 19);
 }

--- a/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
+++ b/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
@@ -52,8 +52,10 @@ void SimTauAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   const auto& simTaus = *simTau_h;
 
   for (auto const& simTau : simTaus) {
-    simTau.dumpFullDecay();
-    simTau.dump();
+    #ifdef EDM_ML_DEBUG
+      simTau.dumpFullDecay();
+      simTau.dump();
+    #endif
     DM_histo->Fill(simTau.decayMode);
   }
 }

--- a/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
+++ b/SimGeneral/Debugging/plugins/SimTauAnalyzer.cc
@@ -52,10 +52,10 @@ void SimTauAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   const auto& simTaus = *simTau_h;
 
   for (auto const& simTau : simTaus) {
-    #ifdef EDM_ML_DEBUG
-      simTau.dumpFullDecay();
-      simTau.dump();
-    #endif
+#ifdef EDM_ML_DEBUG
+    simTau.dumpFullDecay();
+    simTau.dump();
+#endif
     DM_histo->Fill(simTau.decayMode);
   }
 }

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -8,7 +8,7 @@ options.parseArguments()
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('Configuration.Geometry.GeometryExtended2026D96Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026Default_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')

--- a/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
+++ b/SimGeneral/Debugging/python/caloParticleDebugger_cfg.py
@@ -8,7 +8,7 @@ options.parseArguments()
 process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load('Configuration.Geometry.GeometryExtended2026Default_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D96_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')

--- a/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
+++ b/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+import sys
+
+process = cms.Process("SimTauAnalyzer")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["SimTauCPLink", "SimTauProducer", "SimTauAnalyzer"]
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1)
+                                        )
+process.source = cms.Source("PoolSource",
+                                fileNames = cms.untracked.vstring(
+                                #'file:/data/agruber/patatrack/CMSSW_13_3_0_pre3/src/24034.0_TTbar_14TeV+2026D96/step3.root'
+                                'file:SimTauProducer_test.root'
+                                )
+                            )
+
+process.TFileService = cms.Service("TFileService",
+                                       fileName = cms.string('test.root')
+                                   )
+
+process.SimTauAnalyzer = cms.EDAnalyzer('SimTauAnalyzer',
+GenParticles      = cms.InputTag('genParticles'),
+simTau            = cms.InputTag('SimTauCPLink')
+                              )
+
+process.p = cms.Path(process.SimTauAnalyzer)

--- a/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
+++ b/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
@@ -11,7 +11,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1)
                                         )
 process.source = cms.Source("PoolSource",
                                 fileNames = cms.untracked.vstring(
-                                #'file:/data/agruber/patatrack/CMSSW_13_3_0_pre3/src/24034.0_TTbar_14TeV+2026D96/step3.root'
+                                #'file:/data/agruber/patatrack/CMSSW_14_0_0_pre0/src/24036.0_ZTT_14TeV+2026D96/step3.root'
                                 'file:SimTauProducer_test.root'
                                 )
                             )
@@ -21,7 +21,6 @@ process.TFileService = cms.Service("TFileService",
                                    )
 
 process.SimTauAnalyzer = cms.EDAnalyzer('SimTauAnalyzer',
-GenParticles      = cms.InputTag('genParticles'),
 simTau            = cms.InputTag('SimTauCPLink')
                               )
 

--- a/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
+++ b/SimGeneral/Debugging/test/simTauAnalyzer_cfg.py
@@ -11,8 +11,8 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1)
                                         )
 process.source = cms.Source("PoolSource",
                                 fileNames = cms.untracked.vstring(
-                                #'file:/data/agruber/patatrack/CMSSW_14_0_0_pre0/src/24036.0_ZTT_14TeV+2026D96/step3.root'
-                                'file:SimTauProducer_test.root'
+                                'file:/data/agruber/patatrack/CMSSW_14_0_0_pre0/src/24036.0_ZTT_14TeV+2026D96/step3.root'
+                                #'file:SimTauProducer_test.root'
                                 )
                             )
 

--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -10,7 +10,7 @@ from SimCalorimetry.HGCalAssociatorProducers.LCToSimTSAssociation_cfi import lay
 from SimCalorimetry.HGCalAssociatorProducers.LCToCPAssociation_cfi import layerClusterCaloParticleAssociationHFNose as layerClusterCaloParticleAssociationProducerHFNose
 from SimCalorimetry.HGCalAssociatorProducers.LCToSCAssociation_cfi import layerClusterSimClusterAssociationHFNose as layerClusterSimClusterAssociationProducerHFNose
 from SimCalorimetry.HGCalAssociatorProducers.TSToSimTSAssociation_cfi import tracksterSimTracksterAssociationLinking, tracksterSimTracksterAssociationPR,tracksterSimTracksterAssociationLinkingbyCLUE3D, tracksterSimTracksterAssociationPRbyCLUE3D, tracksterSimTracksterAssociationLinkingPU, tracksterSimTracksterAssociationPRPU
-from SimCalorimetry.HGCalAssociatorProducers.SimTauCPLink_cfi import *
+from SimCalorimetry.HGCalAssociatorProducers.SimTauProducer_cfi import *
 
 from Validation.HGCalValidation.simhitValidation_cff    import *
 from Validation.HGCalValidation.digiValidation_cff      import *
@@ -40,7 +40,7 @@ hgcalAssociators = cms.Task(lcAssocByEnergyScoreProducer, layerClusterCaloPartic
                             tracksterSimTracksterAssociationLinking, tracksterSimTracksterAssociationPR,
                             tracksterSimTracksterAssociationLinkingbyCLUE3D, tracksterSimTracksterAssociationPRbyCLUE3D,
                             tracksterSimTracksterAssociationLinkingPU, tracksterSimTracksterAssociationPRPU,
-                            SimTauCPLink
+                            SimTauProducer
                             )
 
 hgcalValidation = cms.Sequence(hgcalSimHitValidationEE

--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -10,6 +10,7 @@ from SimCalorimetry.HGCalAssociatorProducers.LCToSimTSAssociation_cfi import lay
 from SimCalorimetry.HGCalAssociatorProducers.LCToCPAssociation_cfi import layerClusterCaloParticleAssociationHFNose as layerClusterCaloParticleAssociationProducerHFNose
 from SimCalorimetry.HGCalAssociatorProducers.LCToSCAssociation_cfi import layerClusterSimClusterAssociationHFNose as layerClusterSimClusterAssociationProducerHFNose
 from SimCalorimetry.HGCalAssociatorProducers.TSToSimTSAssociation_cfi import tracksterSimTracksterAssociationLinking, tracksterSimTracksterAssociationPR,tracksterSimTracksterAssociationLinkingbyCLUE3D, tracksterSimTracksterAssociationPRbyCLUE3D, tracksterSimTracksterAssociationLinkingPU, tracksterSimTracksterAssociationPRPU
+from SimCalorimetry.HGCalAssociatorProducers.SimTauCPLink_cfi import *
 
 from Validation.HGCalValidation.simhitValidation_cff    import *
 from Validation.HGCalValidation.digiValidation_cff      import *
@@ -38,7 +39,8 @@ hgcalAssociators = cms.Task(lcAssocByEnergyScoreProducer, layerClusterCaloPartic
                             simTsAssocByEnergyScoreProducer,  simTracksterHitLCAssociatorByEnergyScoreProducer,
                             tracksterSimTracksterAssociationLinking, tracksterSimTracksterAssociationPR,
                             tracksterSimTracksterAssociationLinkingbyCLUE3D, tracksterSimTracksterAssociationPRbyCLUE3D,
-                            tracksterSimTracksterAssociationLinkingPU, tracksterSimTracksterAssociationPRPU
+                            tracksterSimTracksterAssociationLinkingPU, tracksterSimTracksterAssociationPRPU,
+                            SimTauCPLink
                             )
 
 hgcalValidation = cms.Sequence(hgcalSimHitValidationEE


### PR DESCRIPTION
This PR introduces a new object called SimTauCPLink, which creates a link between a tau GenParticle and CaloParticles in HGCal (if any are found). 
This should be useful for validation purposes, to have truth information available for whether a CaloParticle is coming from a tau or not. 
This PR contains the new SimTauCPLink object, its corresponding EDProducer and an EDAnalyzer for testing purposes. 

### Validation
```runTheMatrix.py -l limited -i all --ibeos```