### PR TITLE
enable seedingDeepCore displacedRegionalTracking in phase-1 eras

### DIFF
--- a/Configuration/Eras/python/Era_Phase2_cff.py
+++ b/Configuration/Eras/python/Era_Phase2_cff.py
@@ -11,6 +11,8 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+from Configuration.ProcessModifiers.displacedRegionalTracking_cff import displacedRegionalTracking
 from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
@@ -18,4 +20,5 @@ from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
 from Configuration.Eras.Modifier_ctpps_2022_cff import ctpps_2022
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,ctpps_2022,dd4hep]), phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger)
+Phase2 = cms.ModifierChain(Run3_noMkFit.copyAndExclude([phase1Pixel,trackingPhase1,seedingDeepCore,displacedRegionalTracking,ctpps_2022,dd4hep]), 
+                           phase2_common, phase2_tracker, trackingPhase2PU140, phase2_ecal, phase2_hcal, phase2_hgcal, phase2_muon, phase2_GEM, hcalHardcodeConditions, phase2_timing, phase2_timing_layer, phase2_trigger)

--- a/Configuration/Eras/python/Era_Run2_2017_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2017_cff.py
@@ -11,6 +11,8 @@ from Configuration.Eras.Modifier_run2_HEPlan1_2017_cff import run2_HEPlan1_2017
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 from Configuration.ProcessModifiers.trackingParabolicMf_cff import trackingParabolicMf
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+from Configuration.ProcessModifiers.displacedRegionalTracking_cff import displacedRegionalTracking
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
 from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
@@ -28,5 +30,6 @@ from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 
 Run2_2017 = cms.ModifierChain(Run2_2016.copyAndExclude([run2_muon_2016, run2_HLTconditions_2016, run2_ECAL_2016, run2_egamma_2016,pixel_2016,run2_jme_2016, strips_vfp30_2016, ctpps_2016]),
                               phase1Pixel, run2_ECAL_2017, run2_HF_2017, run2_HCAL_2017, run2_HE_2017, run2_HEPlan1_2017, 
-                              trackingPhase1, trackdnn, trackingMkFitProd, trackingParabolicMf, run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
+                              trackingPhase1, trackdnn, trackingMkFitProd, trackingParabolicMf, seedingDeepCore, displacedRegionalTracking,
+                              run2_GEM_2017, stage2L1Trigger_2017, run2_HLTconditions_2017, run2_muon_2017,run2_egamma_2017, ctpps_2017, run2_jme_2017)
 

--- a/RecoTracker/FinalTrackSelectors/python/displacedRegionalStepInputTracks_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/displacedRegionalStepInputTracks_cfi.py
@@ -15,3 +15,9 @@ displacedRegionalStepInputTracks =  TrackCollectionMerger.clone(
         "muonSeededTracksOutInClassifier"
     ]
 )
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
+(pp_on_AA | pp_on_XeXe_2017).toModify(displacedRegionalStepInputTracks,
+    trackProducers = [],
+    inputClassifiers = []
+)

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -241,7 +241,9 @@ _fastSim_jetCoreRegionalStepTracks = RecoTracker.FinalTrackSelectors.trackListMe
     copyExtras         = True
 )
 fastSim.toReplaceWith(jetCoreRegionalStepTracks,_fastSim_jetCoreRegionalStepTracks)
-
+from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
+(seedingDeepCore & fastSim).toReplaceWith(jetCoreRegionalStepBarrelTracks,_fastSim_jetCoreRegionalStepTracks)
+(seedingDeepCore & fastSim).toReplaceWith(jetCoreRegionalStepEndcapTracks,_fastSim_jetCoreRegionalStepTracks)
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackCutClassifier_cff import *
@@ -335,10 +337,8 @@ JetCoreRegionalStepEndcapTask = cms.Task(jetsForCoreTrackingEndcap,
                                          jetCoreRegionalStepEndcap)
 
 
-from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
-
 from RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi import *
-seedingDeepCore.toReplaceWith(jetCoreRegionalStepTracks, TrackCollectionMerger.clone(
+(seedingDeepCore & ~fastSim).toReplaceWith(jetCoreRegionalStepTracks, TrackCollectionMerger.clone(
     trackProducers   = ["jetCoreRegionalStepBarrelTracks",
                         "jetCoreRegionalStepEndcapTracks",],
     inputClassifiers = ["jetCoreRegionalStepBarrel",
@@ -355,6 +355,12 @@ seedingDeepCore.toReplaceWith(JetCoreRegionalStepTask, cms.Task(
     cms.Task(jetCoreRegionalStepTracks,jetCoreRegionalStep)
 ))
 
+# short-circuit tracking parts for fastsim
 fastSim.toReplaceWith(JetCoreRegionalStepTask, 
-                      cms.Task(jetCoreRegionalStepTracks,
-                                   jetCoreRegionalStep))
+    cms.Task(jetCoreRegionalStepTracks,
+             jetCoreRegionalStep))
+(seedingDeepCore & fastSim).toReplaceWith(JetCoreRegionalStepTask,
+    cms.Task(jetCoreRegionalStepBarrelTracks, jetCoreRegionalStepEndcapTracks,
+             jetCoreRegionalStepTracks,
+             jetCoreRegionalStepBarrel, jetCoreRegionalStepEndcap,
+             jetCoreRegionalStep))


### PR DESCRIPTION
Following a presentation in the RECO meeting
https://indico.cern.ch/event/1352807/#13-tracking-devs-tagetting-202

it was proposed by RECO to validate the tracking updates directly in the production setup

This PR enables seedingDeepCore displacedRegionalTracking in phase-1 eras by default
and this way can naturally be covered in 14_0_0_pre2 relvals.
In case a revert is needed, it will be simple to go back.

The updates in tracking are somewhat restricted to either high pt hadronic jets or to very displaced tracks. This should have little interference of other possible more prompt-related updates.

@cms-sw/reconstruction-l2 
@cms-sw/tracking-pog-l2 

