### PR TITLE
Miscellaneous updates to ` DQM/TrackingMonitorSource`

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -1853,8 +1853,10 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
     }
   }
 
-  // off track cluster properties
-  processClusters(iEvent, iSetup, tkGeom, wfac);
+  // off track cluster properties (only on RECO data-tier)
+  if (isRECO_) {
+    processClusters(iEvent, iSetup, tkGeom, wfac);
+  }
 
   if (verbose_)
     edm::LogInfo("StandaloneTrackMonitor") << "Ends StandaloneTrackMonitor successfully";

--- a/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0EventSelector.cc
@@ -1,0 +1,43 @@
+#include <memory>
+#include <vector>
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class V0EventSelector : public edm::stream::EDFilter<> {
+public:
+  explicit V0EventSelector(const edm::ParameterSet&);
+  ~V0EventSelector() override = default;
+
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> vccToken_;
+  const unsigned int minNumCandidates_;
+};
+
+V0EventSelector::V0EventSelector(const edm::ParameterSet& iConfig)
+    : vccToken_{consumes<reco::VertexCompositeCandidateCollection>(
+          iConfig.getParameter<edm::InputTag>("vertexCompositeCandidates"))},
+      minNumCandidates_{iConfig.getParameter<unsigned int>("minCandidates")} {}
+
+bool V0EventSelector::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
+  iEvent.getByToken(vccToken_, vccHandle);
+
+  return vccHandle->size() >= minNumCandidates_;
+}
+
+void V0EventSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("vertexCompositeCandidates", edm::InputTag("generalV0Candidates:Kshort"));
+  desc.add<unsigned int>("minCandidates", 1);  // Change '1' to your desired minimum number of candidates
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(V0EventSelector);

--- a/DQM/TrackingMonitorSource/plugins/V0VertexTrackProducer.cc
+++ b/DQM/TrackingMonitorSource/plugins/V0VertexTrackProducer.cc
@@ -1,0 +1,63 @@
+#include <memory>
+#include <vector>
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+class V0VertexTrackProducer : public edm::global::EDProducer<> {
+public:
+  explicit V0VertexTrackProducer(const edm::ParameterSet&);
+  ~V0VertexTrackProducer() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::StreamID streamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const override;
+
+private:
+  const edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> vccToken_;
+};
+
+V0VertexTrackProducer::V0VertexTrackProducer(const edm::ParameterSet& iConfig)
+    : vccToken_{consumes<reco::VertexCompositeCandidateCollection>(
+          iConfig.getParameter<edm::InputTag>("vertexCompositeCandidates"))} {
+  produces<std::vector<reco::Track>>();
+}
+
+void V0VertexTrackProducer::produce(edm::StreamID streamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
+  edm::Handle<reco::VertexCompositeCandidateCollection> vccHandle;
+  iEvent.getByToken(vccToken_, vccHandle);
+
+  std::unique_ptr<std::vector<reco::Track>> outputTracks(new std::vector<reco::Track>());
+
+  if (vccHandle.isValid()) {
+    // Loop over VertexCompositeCandidates and associate tracks
+    for (const auto& vcc : *vccHandle) {
+      for (size_t i = 0; i < vcc.numberOfDaughters(); ++i) {
+        const reco::Candidate* daughter = vcc.daughter(i);
+        const reco::RecoChargedCandidate* chargedDaughter = dynamic_cast<const reco::RecoChargedCandidate*>(daughter);
+        if (chargedDaughter) {
+          const reco::TrackRef trackRef = chargedDaughter->track();
+          if (trackRef.isNonnull()) {
+            outputTracks->push_back(*trackRef);
+          }
+        }
+      }
+    }
+  } else {
+    edm::LogError("V0VertexTrackProducer") << "Error >> Failed to get VertexCompositeCandidateCollection";
+  }
+  iEvent.put(std::move(outputTracks));
+}
+
+void V0VertexTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("vertexCompositeCandidates", edm::InputTag("generalV0Candidates:Kshort"));
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(V0VertexTrackProducer);

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -1,12 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitorSource.StandaloneTrackMonitor_cfi import *
 from DQM.TrackingMonitorSource.ZEEDetails_cfi import *
-# from DQM.TrackingMonitor.V0Monitor_cfi import *
+from DQM.TrackingMonitor.V0Monitor_cfi import *
 
 # Primary Vertex Selector
 selectedPrimaryVertices = cms.EDFilter("VertexSelector",
                                        src = cms.InputTag('offlinePrimaryVertices'),
-                                      # cut = cms.string("!isFake && ndof >= 4 && abs(z) < 24 && abs(position.Rho) < 2.0"),
+                                       # cut = cms.string("!isFake && ndof >= 4 && abs(z) < 24 && abs(position.Rho) < 2.0"),
                                        cut = cms.string(""),
                                        filter = cms.bool(True)
                                        )
@@ -32,11 +32,11 @@ selectedAlcaRecoZBTracks = cms.EDProducer("AlcaRecoTrackSelector",
                                         src = cms.InputTag('generalTracks'),
                                         #cut = cms.string("pt > 0.65 && abs(eta) < 3.5 && p > 1.5 && hitPattern.numberOfAllHits('TRACK_HITS') > 7"),
                                         #cut = cms.string(""),
-                                          ptmin = cms.untracked.double(0.65),
+                                        ptmin = cms.untracked.double(0.65),
                                         pmin = cms.untracked.double(1.5),
                                         etamin = cms.untracked.double(-3.5),
                                         etamax = cms.untracked.double(3.5),
-                                          nhits = cms.untracked.uint32(7)
+                                        nhits = cms.untracked.uint32(7)
 )
 '''
 # Track ALCARECO Selection for singlemuon
@@ -93,16 +93,20 @@ electronTracks = cms.EDProducer("ZtoEEElectronTrackProducer")
 ttbarEventSelector = cms.EDFilter("ttbarEventSelector")
 ttbarTracks = cms.EDProducer("TtbarTrackProducer")
 
-# Added module for V0Monitoring for Ks only
-# KshortMonitor = v0Monitor.clone()
-# KshortMonitor.FolderName = cms.string("Tracking/V0Monitoring/Ks")
-# KshortMonitor.v0         = cms.InputTag('generalV0Candidates:Kshort')
-# KshortMonitor.histoPSet.massPSet = cms.PSet(
-#   nbins = cms.int32 ( 100 ),
-#   xmin  = cms.double( 0.400),
-#   xmax  = cms.double( 0.600),
-# )
+# Added modules for V0Monitoring
+KshortMonitor = v0Monitor.clone()
+KshortMonitor.FolderName = "StandaloneTrackMonitor/V0Monitoring/Ks"
+KshortMonitor.v0         = "generalV0Candidates:Kshort"
+KshortMonitor.histoPSet.massPSet = cms.PSet(nbins = cms.int32 (100),
+                                            xmin  = cms.double(0.400),
+                                            xmax  = cms.double(0.600))
 
+LambdaMonitor = v0Monitor.clone()
+LambdaMonitor.FolderName = "StandaloneTrackMonitor/V0Monitoring/Lambda"
+LambdaMonitor.v0 = "generalV0Candidates:Lambda"
+LambdaMonitor.histoPSet.massPSet = cms.PSet(nbins = cms.int32(100),
+                                            xmin  = cms.double(1.050),
+                                            xmax  = cms.double(1.250))
 # For MinBias
 standaloneTrackMonitorMC = standaloneTrackMonitor.clone(
     puScaleFactorFile = "PileupScaleFactor_316060_wrt_nVertex_ZeroBias.root",
@@ -115,14 +119,20 @@ standaloneValidationMinbias = cms.Sequence(
 #    * selectedMultiplicityTracks  # Use selectedMultiplicityTracks if needed nTracks > desired multiplicity
 #    * selectedAlcaRecoZBTracks
     * selectedTracks
-    * standaloneTrackMonitor)
+    * standaloneTrackMonitor
+    * KshortMonitor
+    * LambdaMonitor)
+
 standaloneValidationMinbiasMC = cms.Sequence(
     hltPathFilter
     * selectedPrimaryVertices 
 #    * selectedMultiplicityTracks  # Use selectedMultiplicityTracks if needed nTracks > desired multiplicity
 #    * selectedAlcaRecoZBTracks
     * selectedTracks
-    * standaloneTrackMonitorMC)
+    * standaloneTrackMonitorMC
+    * KshortMonitor
+    * LambdaMonitor)
+
 # For ZtoEE
 standaloneTrackMonitorElec = standaloneTrackMonitor.clone(
     folderName = "ElectronTracks",

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from DQM.TrackingMonitorSource.StandaloneTrackMonitor_cfi import *
 from DQM.TrackingMonitorSource.ZEEDetails_cfi import *
+from DQM.TrackingMonitorSource.V0Selections_cfi import *
 from DQM.TrackingMonitor.V0Monitor_cfi import *
 
 # Primary Vertex Selector
@@ -107,7 +108,9 @@ LambdaMonitor.v0 = "generalV0Candidates:Lambda"
 LambdaMonitor.histoPSet.massPSet = cms.PSet(nbins = cms.int32(100),
                                             xmin  = cms.double(1.050),
                                             xmax  = cms.double(1.250))
+##################
 # For MinBias
+##################
 standaloneTrackMonitorMC = standaloneTrackMonitor.clone(
     puScaleFactorFile = "PileupScaleFactor_316060_wrt_nVertex_ZeroBias.root",
     doPUCorrection    = True,
@@ -133,7 +136,70 @@ standaloneValidationMinbiasMC = cms.Sequence(
     * KshortMonitor
     * LambdaMonitor)
 
+##################
+# For V0s in MinBias
+##################
+standaloneTrackMonitorK0 = standaloneTrackMonitor.clone(
+    folderName = "K0Tracks",
+    trackInputTag = 'KshortTracks',
+    )
+
+standaloneTrackMonitorK0MC = standaloneTrackMonitor.clone(
+    folderName = "K0Tracks",
+    trackInputTag = 'KshortTracks',
+    puScaleFactorFile = "PileupScaleFactor_316082_wrt_nVertex_DYToLL.root",
+    doPUCorrection    = True,
+    isMC              = True
+    )
+
+standaloneTrackMonitorLambda = standaloneTrackMonitor.clone(
+    folderName = "LambdaTracks",
+    trackInputTag = 'LambdaTracks',
+    )
+
+standaloneTrackMonitorLambdaMC = standaloneTrackMonitor.clone(
+    folderName = "LambdaTracks",
+    trackInputTag = 'LambdaTracks',
+    puScaleFactorFile = "PileupScaleFactor_316082_wrt_nVertex_DYToLL.root",
+    doPUCorrection    = True,
+    isMC              = True
+    )
+
+standaloneValidationK0s = cms.Sequence(
+    hltPathFilter
+    * selectedPrimaryVertices
+    * KShortEventSelector
+    * KshortTracks
+    * standaloneTrackMonitorK0
+    * KshortMonitor)
+
+standaloneValidationK0sMC = cms.Sequence(
+    hltPathFilter
+    * selectedPrimaryVertices
+    * KShortEventSelector
+    * KshortTracks
+    * standaloneTrackMonitorK0
+    * KshortMonitor)
+
+standaloneValidationLambdas = cms.Sequence(
+    hltPathFilter
+    * selectedPrimaryVertices
+    * LambdaEventSelector
+    * LambdaTracks
+    * standaloneTrackMonitorLambda
+    * LambdaMonitor)
+
+standaloneValidationLambdasMC = cms.Sequence(
+    hltPathFilter
+    * selectedPrimaryVertices
+    * LambdaEventSelector
+    * LambdaTracks
+    * standaloneTrackMonitorLambdaMC
+    * LambdaMonitor)
+
+##################
 # For ZtoEE
+##################
 standaloneTrackMonitorElec = standaloneTrackMonitor.clone(
     folderName = "ElectronTracks",
     trackInputTag = 'electronTracks',
@@ -171,7 +237,10 @@ standaloneValidationElecMC = cms.Sequence(
     * standaloneTrackMonitorElecMC   
     * standaloneTrackMonitorMC
     * ZEEDetailsMC)
+
+##################
 # For ZtoMM
+##################
 standaloneTrackMonitorMuon = standaloneTrackMonitor.clone(
     folderName = "MuonTracks",
     trackInputTag = 'muonTracks',
@@ -202,7 +271,9 @@ standaloneValidationMuonMC = cms.Sequence(
     * standaloneTrackMonitorMuonMC 
     * standaloneTrackMonitorMC)
 
+##################
 # For ttbar
+##################
 standaloneTrackMonitorTTbar = standaloneTrackMonitor.clone(
     folderName = "TTbarTracks",
     trackInputTag = 'ttbarTracks',

--- a/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
+++ b/DQM/TrackingMonitorSource/python/V0Selections_cfi.py
@@ -1,0 +1,12 @@
+from DQM.TrackingMonitorSource.v0EventSelector_cfi import *
+from DQM.TrackingMonitorSource.v0VertexTrackProducer_cfi import *
+
+KShortEventSelector = v0EventSelector.clone()
+LambdaEventSelector = v0EventSelector.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Lambda"  
+)
+
+KshortTracks = v0VertexTrackProducer.clone()
+LambdaTracks = v0VertexTrackProducer.clone(
+    vertexCompositeCandidates = "generalV0Candidates:Lambda"
+)

--- a/DQM/TrackingMonitorSource/test/Tracker_DataMCValidation_cfg.py
+++ b/DQM/TrackingMonitorSource/test/Tracker_DataMCValidation_cfg.py
@@ -19,6 +19,11 @@ options.register('sequenceType',
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
                  "type of sequence to run")
+options.register('isRECO',
+                 False,
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "is the input sample RECO or AOD, assume AOD")
 options.parseArguments()
 
 # import of standard configurations
@@ -73,6 +78,12 @@ process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
 
 # Tracker Data MC validation suite
 process.load('DQM.TrackingMonitorSource.TrackingDataMCValidation_Standalone_cff')
+
+# Set the flag is this is AOD or RECO analysis
+process.standaloneTrackMonitor.isRECO = options.isRECO
+process.standaloneTrackMonitorElec.isRECO = options.isRECO
+process.standaloneTrackMonitorMuon.isRECO = options.isRECO
+process.standaloneTrackMonitorTTbar.isRECO = options.isRECO
 
 minbias_analysis_step = cms.Path(process.standaloneValidationMinbias)
 zee_analysis_step = cms.Path(process.standaloneValidationElec)

--- a/DQM/TrackingMonitorSource/test/Tracker_DataMCValidation_cfg.py
+++ b/DQM/TrackingMonitorSource/test/Tracker_DataMCValidation_cfg.py
@@ -81,11 +81,15 @@ process.load('DQM.TrackingMonitorSource.TrackingDataMCValidation_Standalone_cff'
 
 # Set the flag is this is AOD or RECO analysis
 process.standaloneTrackMonitor.isRECO = options.isRECO
+process.standaloneTrackMonitorK0.isRECO = options.isRECO
+process.standaloneTrackMonitorLambda.isRECO = options.isRECO
 process.standaloneTrackMonitorElec.isRECO = options.isRECO
 process.standaloneTrackMonitorMuon.isRECO = options.isRECO
 process.standaloneTrackMonitorTTbar.isRECO = options.isRECO
 
 minbias_analysis_step = cms.Path(process.standaloneValidationMinbias)
+k0_analysis_step =  cms.Path(process.standaloneValidationK0s)
+lambda_analysis_step =  cms.Path(process.standaloneValidationLambdas)
 zee_analysis_step = cms.Path(process.standaloneValidationElec)
 zmm_analysis_step = cms.Path(process.standaloneValidationMuon)
 ttbar_analysis_step = cms.Path(process.standaloneValidationTTbar)
@@ -98,6 +102,9 @@ elif (options.sequenceType == "ttbar") :
     process.analysis_step = ttbar_analysis_step
 elif (options.sequenceType == "minbias") :
     process.analysis_step = minbias_analysis_step
+elif (options.sequenceType == "V0s") :
+    process.analysis_1_step = k0_analysis_step
+    process.analysis_2_step = lambda_analysis_step
 else :
     raise RuntimeError("Unrecognized sequenceType given option: %. Exiting" % options.sequenceType)
 
@@ -106,7 +113,10 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 process.DQMoutput_step = cms.EndPath(process.DQMoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.analysis_step, process.endjob_step, process.DQMoutput_step)
+if (options.sequenceType == "V0s"):
+    process.schedule = cms.Schedule(process.analysis_1_step, process.analysis_2_step, process.endjob_step, process.DQMoutput_step)
+else:
+    process.schedule = cms.Schedule(process.analysis_step, process.endjob_step, process.DQMoutput_step)
 
 ###################################################################
 # Set the process to run multi-threaded

--- a/DQM/TrackingMonitorSource/test/testTrackingDATAMC.sh
+++ b/DQM/TrackingMonitorSource/test/testTrackingDATAMC.sh
@@ -31,18 +31,24 @@ function runTests {
     echo -e "================== Done with testing $testType ==================\n\n"
 }
 
-echo "TESTING Tracking DATA/MC comparison codes ..."
+#######################################################
+# RECO checks
+#######################################################
+echo "TESTING Tracking DATA/MC comparison codes on RECO ..."
 
 runTests "electrons" "/store/relval/CMSSW_13_3_0_pre2/RelValZEE_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/c02ca5ba-f454-4cd3-b114-b55e0309f9db.root" "" "True"
 runTests "muons" "/store/relval/CMSSW_13_3_0_pre2/RelValZMM_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/4096bfe7-bc10-4f7f-81ab-4f4adb59e838.root" "muons" "True"
 runTests "ttbar" "/store/relval/CMSSW_13_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/fc1ccb5e-b038-45f2-a06b-e26a6a01681e.root" "ttbar" "True"
 runTests "minbias" "/store/relval/CMSSW_13_3_0_pre2/RelValNuGun/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/bc506605-d659-468e-b75a-5d3de82e579f.root" "minbias" "True"
+runTests "V0s" "/store/relval/CMSSW_13_3_0_pre2/RelValNuGun/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/bc506605-d659-468e-b75a-5d3de82e579f.root" "V0s" "True"
 
-####################################################### AOD checks #######################################################################
-
+#######################################################
+# AOD checks
+#######################################################
 echo "TESTING Tracking DATA/MC comparison codes on AOD..."
 
 runTests "electrons (AOD)" "/store/relval/CMSSW_13_0_12/RelValZEE_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/0d49e310-e06f-4c26-a637-1116b02ef1ce.root" "" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
 runTests "muons (AOD)" "/store/relval/CMSSW_13_0_12/RelValZMM_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/d2a2506c-8954-464b-beda-48242472406d.root" "muons" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
 runTests "ttbar (AOD)" "/store/relval/CMSSW_13_0_12/RelValTTbar_SemiLeptonic_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/08c015c3-c9bd-4017-b21d-264dbaa06445.root" "ttbar" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
 runTests "minbias (AOD)" "/store/relval/CMSSW_13_0_12/RelValSingleNuGun_E10_PU/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/37ee5a61-8896-4eb3-8e6c-20ed0ad5b2dc.root" "minbias" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
+runTests "V0s (AOD)" "/store/relval/CMSSW_13_0_12/RelValSingleNuGun_E10_PU/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/37ee5a61-8896-4eb3-8e6c-20ed0ad5b2dc.root" "V0s" "False" "130X_mcRun3_2023_realistic_postBPix_v2"

--- a/DQM/TrackingMonitorSource/test/testTrackingDATAMC.sh
+++ b/DQM/TrackingMonitorSource/test/testTrackingDATAMC.sh
@@ -2,44 +2,47 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
+function runTests {
+
+    # local variables
+    local testType="$1"
+    local inputFiles="$2"
+    local sequenceType="$3"
+    local isRECO="$4"
+    local globalTag="$5"
+
+    echo -e "TESTING step1 ($testType) ...\n\n"
+
+    # optional for the cmsRun sequence
+    local sequenceArg=""
+    [ -n "$sequenceType" ] && sequenceArg="sequenceType=$sequenceType"
+    local globalTagArg=""
+    [ -n "$globalTag" ] && globalTagArg="globalTag=$globalTag"
+
+    cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_cfg.py maxEvents=100 inputFiles="$inputFiles" $sequenceArg isRECO="$isRECO" $globalTagArg || die "Failure running Tracker_DataMCValidation_cfg.py sequenceType=$sequenceType" $?
+
+    mv step1_DQM_1.root "step1_DQM_1_${testType}.root"
+
+    echo -e "TESTING step2 ($testType)...\n\n"
+    cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_Harvest_cfg.py inputFiles="file:step1_DQM_1_${testType}.root" || die "Failure running Tracker_DataMCValidation_Harvest_cfg.py" $?
+
+    mv DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root "step2_DQM_${testType}.root"
+
+    echo -e "================== Done with testing $testType ==================\n\n"
+}
+
 echo "TESTING Tracking DATA/MC comparison codes ..."
 
-echo -e "TESTING step1 (electrons) ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_cfg.py maxEvents=100 inputFiles=/store/relval/CMSSW_13_3_0_pre2/RelValZEE_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/c02ca5ba-f454-4cd3-b114-b55e0309f9db.root || die "Failure running Tracker_DataMCValidation_cfg.py" $?
+runTests "electrons" "/store/relval/CMSSW_13_3_0_pre2/RelValZEE_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/c02ca5ba-f454-4cd3-b114-b55e0309f9db.root" "" "True"
+runTests "muons" "/store/relval/CMSSW_13_3_0_pre2/RelValZMM_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/4096bfe7-bc10-4f7f-81ab-4f4adb59e838.root" "muons" "True"
+runTests "ttbar" "/store/relval/CMSSW_13_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/fc1ccb5e-b038-45f2-a06b-e26a6a01681e.root" "ttbar" "True"
+runTests "minbias" "/store/relval/CMSSW_13_3_0_pre2/RelValNuGun/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/bc506605-d659-468e-b75a-5d3de82e579f.root" "minbias" "True"
 
-mv step1_DQM_1.root step1_DQM_1_electrons.root
+####################################################### AOD checks #######################################################################
 
-echo -e "TESTING step2 (electrons)...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_Harvest_cfg.py inputFiles=file:step1_DQM_1_electrons.root || die "Failure running Tracker_DataMCValidation_Harvest_cfg.py" $?
+echo "TESTING Tracking DATA/MC comparison codes on AOD..."
 
-echo -e "================== Done with testing electrons ==================\n\n"
-
-echo -e "TESTING step1 (muons) ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_cfg.py maxEvents=100 inputFiles=/store/relval/CMSSW_13_3_0_pre2/RelValZMM_14/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/4096bfe7-bc10-4f7f-81ab-4f4adb59e838.root sequenceType=muons || die "Failure running Tracker_DataMCValidation_cfg.py sequenceType=muons" $?
-
-mv step1_DQM_1.root step1_DQM_1_muons.root
-
-echo -e "TESTING step2 (muons)...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_Harvest_cfg.py inputFiles=file:step1_DQM_1_muons.root || die "Failure running Tracker_DataMCValidation_Harvest_cfg.py" $?
-
-echo -e "================== Done with testing muons ==================...\n\n"
-
-echo -e "TESTING step1 (ttbar) ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_cfg.py maxEvents=100 inputFiles=/store/relval/CMSSW_13_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/fc1ccb5e-b038-45f2-a06b-e26a6a01681e.root sequenceType=ttbar || die "Failure running Tracker_DataMCValidation_cfg.py sequenceType=ttbar" $?
-
-mv step1_DQM_1.root step1_DQM_1_ttbar.root
-
-echo -e "TESTING step2 (ttbar)...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_Harvest_cfg.py inputFiles=file:step1_DQM_1_ttbar.root || die "Failure running Tracker_DataMCValidation_Harvest_cfg.py" $?
-
-echo -e "================== Done with testing ttbar ==================...\n\n"
-
-echo "TESTING step1 (minbias) ...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_cfg.py maxEvents=100 inputFiles=/store/relval/CMSSW_13_3_0_pre2/RelValNuGun/GEN-SIM-RECO/PU_132X_mcRun3_2023_realistic_v2_RV213-v1/2580000/bc506605-d659-468e-b75a-5d3de82e579f.root sequenceType=minbias || die "Failure running Tracker_DataMCValidation_cfg.py sequenceType=ttbar" $?
-
-mv step1_DQM_1.root step1_DQM_1_minbias.root
-
-echo "TESTING step2 (minbias)...\n\n"
-cmsRun ${SCRAM_TEST_PATH}/Tracker_DataMCValidation_Harvest_cfg.py inputFiles=file:step1_DQM_1_minbias.root || die "Failure running Tracker_DataMCValidation_Harvest_cfg.py" $?
-
-echo -e "================== Done with testing minbias ==================...\n\n"
+runTests "electrons (AOD)" "/store/relval/CMSSW_13_0_12/RelValZEE_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/0d49e310-e06f-4c26-a637-1116b02ef1ce.root" "" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
+runTests "muons (AOD)" "/store/relval/CMSSW_13_0_12/RelValZMM_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/d2a2506c-8954-464b-beda-48242472406d.root" "muons" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
+runTests "ttbar (AOD)" "/store/relval/CMSSW_13_0_12/RelValTTbar_SemiLeptonic_PU_13p6/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/08c015c3-c9bd-4017-b21d-264dbaa06445.root" "ttbar" "False" "130X_mcRun3_2023_realistic_postBPix_v2"
+runTests "minbias (AOD)" "/store/relval/CMSSW_13_0_12/RelValSingleNuGun_E10_PU/AODSIM/PU_130X_mcRun3_2023_realistic_postBPix_v2_RV201-v1/2580000/37ee5a61-8896-4eb3-8e6c-20ed0ad5b2dc.root" "minbias" "False" "130X_mcRun3_2023_realistic_postBPix_v2"


### PR DESCRIPTION
#### PR description:

Miscellaneous updates to ` DQM/TrackingMonitorSource`:
   * 89517116dc56c30301d0d1aaf2aee0da8866473e: `StandaloneTrackMonitor`: do not run cluster analysis in AOD;
   * ac174709177e3c3c518d92aa8df8c3fb81769704: add V0 analysis for MinBias samples in `TrackingDataMCValidation_Standalone_cff;`
   * b7d72dcc6c1068c88344dceea6255e9581197b7a : update `Tracker_DataMCValidation` test configuration to comply with `AOD` and rationalize testing script;
   * 3c5a1a326816d25dea41d20494930cde9ebfed56: introduce `V0VertexTrackProducer` and `V0EventSelector` and adapt configuration to run V0 analysis sequence.

#### PR validation:

Run successfully `scram b runtests` in the affected package (and checked that in the MinBias samples analysis there are now plots for tracks coming from K0→ππ and Λ→pπ).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
