### PR TITLE
Add placeholders of phase2 geometry config files

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026DefaultReco_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026Default_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Geometry.GeometryDD4hepExtended2026D98_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026DefaultReco_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Geometry.GeometryExtended2026D98Reco_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026Default_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Geometry.GeometryExtended2026D98_cff import *


### PR DESCRIPTION
#### PR description:
As discussed in https://github.com/cms-sw/cmssw/issues/42945, we currently have obsolete config files which can't run because geometry config is old. This PR introduces the default config file so that any scripts which do not need specific geometry can use. Those scripts will be forwarded port every time we update the baseline. No change on geometry-specific configs. 

#### PR validation:
No test. No change is expected as the introduced configs are not used anywhere.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.
