### PR TITLE
[14_0_X SIM] Improved initialisation of sensitive detectors Sens detectors

### DIFF
--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -40,9 +40,9 @@
 #include "Randomize.hh"
 
 // for some reason void doesn't compile
-class OscarMTProducer : public edm::stream::EDProducer<edm::GlobalCache<OscarMTMasterThread>, edm::RunCache<int> > {
+class OscarMTProducer : public edm::stream::EDProducer<edm::GlobalCache<OscarMTMasterThread>, edm::RunCache<int>> {
 public:
-  typedef std::vector<std::shared_ptr<SimProducer> > Producers;
+  typedef std::vector<std::shared_ptr<SimProducer>> Producers;
 
   explicit OscarMTProducer(edm::ParameterSet const& p, const OscarMTMasterThread*);
   ~OscarMTProducer() override;
@@ -122,71 +122,28 @@ OscarMTProducer::OscarMTProducer(edm::ParameterSet const& p, const OscarMTMaster
   assert(m_masterThread);
   m_masterThread->callConsumes(consumesCollector());
 
-  // List of produced containers
+  // declair hit collections
   produces<edm::SimTrackContainer>().setBranchAlias("SimTracks");
   produces<edm::SimVertexContainer>().setBranchAlias("SimVertices");
-  produces<edm::PSimHitContainer>("TrackerHitsPixelBarrelLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsPixelBarrelHighTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTIBLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTIBHighTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTIDLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTIDHighTof");
-  produces<edm::PSimHitContainer>("TrackerHitsPixelEndcapLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsPixelEndcapHighTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTOBLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTOBHighTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTECLowTof");
-  produces<edm::PSimHitContainer>("TrackerHitsTECHighTof");
 
-  produces<edm::PSimHitContainer>("TotemHitsT1");
-  produces<edm::PSimHitContainer>("TotemHitsT2Gem");
-  produces<edm::PSimHitContainer>("TotemHitsRP");
-  produces<edm::PSimHitContainer>("CTPPSPixelHits");
-  produces<edm::PSimHitContainer>("CTPPSTimingHits");
-  produces<edm::PSimHitContainer>("FP420SI");
-  produces<edm::PSimHitContainer>("BSCHits");
-  produces<edm::PSimHitContainer>("PLTHits");
-  produces<edm::PSimHitContainer>("BCM1FHits");
-  produces<edm::PSimHitContainer>("BHMHits");
-  produces<edm::PSimHitContainer>("FastTimerHitsBarrel");
-  produces<edm::PSimHitContainer>("FastTimerHitsEndcap");
+  auto trackHits = p.getParameter<std::vector<std::string>>("TrackHits");
+  for (auto const& ss : trackHits) {
+    produces<edm::PSimHitContainer>(ss);
+  }
 
-  produces<edm::PCaloHitContainer>("EcalHitsEB");
-  produces<edm::PCaloHitContainer>("EcalHitsEE");
-  produces<edm::PCaloHitContainer>("EcalHitsES");
-  produces<edm::PCaloHitContainer>("HcalHits");
-  produces<edm::PCaloHitContainer>("CaloHitsTk");
-  produces<edm::PCaloHitContainer>("HGCHitsEE");
-  produces<edm::PCaloHitContainer>("HGCHitsHEfront");
-  produces<edm::PCaloHitContainer>("HGCHitsHEback");
-  produces<edm::PCaloHitContainer>("CalibrationHGCHitsEE");
-  produces<edm::PCaloHitContainer>("CalibrationHGCHitsHEfront");
-  produces<edm::PCaloHitContainer>("CalibrationHGCHitsHEback");
-
-  produces<edm::PSimHitContainer>("MuonDTHits");
-  produces<edm::PSimHitContainer>("MuonCSCHits");
-  produces<edm::PSimHitContainer>("MuonRPCHits");
-  produces<edm::PSimHitContainer>("MuonGEMHits");
-  produces<edm::PSimHitContainer>("MuonME0Hits");
-  produces<edm::PCaloHitContainer>("CastorPL");
-  produces<edm::PCaloHitContainer>("CastorFI");
-  produces<edm::PCaloHitContainer>("CastorBU");
-  produces<edm::PCaloHitContainer>("CastorTU");
-  produces<edm::PCaloHitContainer>("EcalTBH4BeamHits");
-  produces<edm::PCaloHitContainer>("HcalTB06BeamHits");
-  produces<edm::PCaloHitContainer>("ZDCHITS");
-  produces<edm::PCaloHitContainer>("ChamberHits");
-  produces<edm::PCaloHitContainer>("FibreHits");
-  produces<edm::PCaloHitContainer>("WedgeHits");
-  produces<edm::PCaloHitContainer>("HFNoseHits");
-  produces<edm::PCaloHitContainer>("TotemHitsT2Scint");
+  auto caloHits = p.getParameter<std::vector<std::string>>("CaloHits");
+  for (auto const& ss : caloHits) {
+    produces<edm::PCaloHitContainer>(ss);
+  }
 
   //register any products
   auto& producers = m_runManagerWorker->producers();
   for (auto& ptr : producers) {
     ptr->registerProducts(producesCollector());
   }
-  edm::LogVerbatim("SimG4CoreApplication") << "OscarMTProducer is constructed";
+  edm::LogVerbatim("SimG4CoreApplication")
+      << "OscarMTProducer is constructed with hit collections:" << trackHits.size() << " tracking type; "
+      << caloHits.size() << " calo type; " << producers.size() << " watcher type.";
 }
 
 OscarMTProducer::~OscarMTProducer() {

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -92,7 +92,9 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     ThresholdForGeometryExceptions = cms.double(0.1), ## in GeV
     TraceExceptions = cms.bool(False),
     CheckGeometry = cms.untracked.bool(False),
-    OnlySDs = cms.vstring('ZdcSensitiveDetector', 'TotemT2ScintSensitiveDetector', 'TotemSensitiveDetector', 'RomanPotSensitiveDetector', 'PLTSensitiveDetector', 'MuonSensitiveDetector', 'MtdSensitiveDetector', 'BCM1FSensitiveDetector', 'EcalSensitiveDetector', 'CTPPSSensitiveDetector', 'BSCSensitiveDetector', 'CTPPSDiamondSensitiveDetector', 'FP420SensitiveDetector', 'BHMSensitiveDetector', 'CastorSensitiveDetector', 'CaloTrkProcessing', 'HcalSensitiveDetector', 'TkAccumulatingSensitiveDetector'),
+    OnlySDs = cms.vstring('BSCSensitiveDetector','BCM1FSensitiveDetector','BHMSensitiveDetector','CTPPSDiamondSensitiveDetector','CTPPSSensitiveDetector','CaloTrkProcessing','CastorSensitiveDetector','EcalSensitiveDetector','HcalSensitiveDetector','MuonSensitiveDetector','PLTSensitiveDetector','RomanPotSensitiveDetector','TkAccumulatingSensitiveDetector','TotemSensitiveDetector','TotemT2ScintSensitiveDetector','ZdcSensitiveDetector'),
+    TrackHits = cms.vstring('BCM1FHits','BHMHits','BSCHits','CTPPSPixelHits','CTPPSTimingHits','MuonCSCHits','MuonDTHits','MuonGEMHits','MuonME0Hits','MuonRPCHits','PLTHits','TotemHitsRP','TotemHitsT1','TrackerHitsPixelEndcapLowTof','TrackerHitsPixelEndcapHighTof','TrackerHitsPixelBarrelLowTof','TrackerHitsPixelBarrelHighTof','TrackerHitsTECLowTof','TrackerHitsTECHighTof','TrackerHitsTIBLowTof','TrackerHitsTIBHighTof','TrackerHitsTIDLowTof','TrackerHitsTIDHighTof','TrackerHitsTOBLowTof','TrackerHitsTOBHighTof'),
+    CaloHits = cms.vstring('CaloHitsTk','CastorBU','CastorFI','CastorPL','CastorTU','EcalHitsEB','EcalHitsEE','EcalHitsES','HcalHits','ZDCHITS'),
     Init = cms.PSet(
         DefaultVoxelDensity = cms.double(2.0),
         VoxelRegions = cms.vstring(),
@@ -670,6 +672,10 @@ run2_HCAL_2017.toModify( g4SimHits, HCalSD = dict( TestNumberingScheme = True ) 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( g4SimHits, CastorSD = dict( useShowerLibrary = False ) ) 
 run3_common.toModify( g4SimHits, LHCTransport = True )
+run3_common.toModify( g4SimHits,
+                      OnlySDs = ['BSCSensitiveDetector','BCM1FSensitiveDetector','BHMSensitiveDetector','CTPPSDiamondSensitiveDetector','CTPPSSensitiveDetector','CaloTrkProcessing','EcalSensitiveDetector','HcalSensitiveDetector','MuonSensitiveDetector','PLTSensitiveDetector','RomanPotSensitiveDetector','TkAccumulatingSensitiveDetector','TotemSensitiveDetector','TotemT2ScintSensitiveDetector','ZdcSensitiveDetector'],
+                      TrackHits = ['BCM1FHits','BHMHits','BSCHits','CTPPSPixelHits','CTPPSTimingHits','MuonCSCHits','MuonDTHits','MuonGEMHits','MuonME0Hits','MuonRPCHits','PLTHits','TotemHitsRP','TotemHitsT1','TrackerHitsPixelEndcapLowTof','TrackerHitsPixelEndcapHighTof','TrackerHitsPixelBarrelLowTof','TrackerHitsPixelBarrelHighTof','TrackerHitsTECLowTof','TrackerHitsTECHighTof','TrackerHitsTIBLowTof','TrackerHitsTIBHighTof','TrackerHitsTIDLowTof','TrackerHitsTIDHighTof','TrackerHitsTOBLowTof','TrackerHitsTOBHighTof'],
+                      CaloHits = ['CaloHitsTk','EcalHitsEB','EcalHitsEE','EcalHitsES','HcalHits','TotemHitsT2Scint','ZDCHITS'] )
 
 ##
 ## Disable PPS from Run 3 PbPb runs
@@ -697,7 +703,9 @@ from Configuration.ProcessModifiers.ecal_component_finely_sampled_waveforms_cff 
 ##
 from Configuration.Eras.Modifier_h2tb_cff import h2tb
 h2tb.toModify(g4SimHits,
-              OnlySDs = ['EcalSensitiveDetector', 'CaloTrkProcessing', 'HcalTB06BeamDetector', 'HcalSensitiveDetector'],
+              OnlySDs = ['CaloTrkProcessing','EcalSensitiveDetector','FP420SensitiveDetector','HcalTB06BeamDetector','HcalSensitiveDetector'],
+              TrackHits = ['FP420SI'],
+              CaloHits = ['CaloHitsTk','ChamberHits','EcalHitsEB','EcalHitsEE','EcalHitsES','EcalTBH4BeamHits','FibreHits','HFNoseHits','HcalHits','HcalTB06BeamHits','WedgeHits'],
               ECalSD = dict(
                   TestBeam = True ),
               CaloSD = dict(
@@ -721,7 +729,9 @@ dd4hep.toModify( g4SimHits, g4GeometryDD4hepSource = True )
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(g4SimHits,
-                       OnlySDs = ['ZdcSensitiveDetector', 'RomanPotSensitiveDetector', 'PLTSensitiveDetector', 'MuonSensitiveDetector', 'MtdSensitiveDetector', 'BCM1FSensitiveDetector', 'EcalSensitiveDetector', 'CTPPSSensitiveDetector', 'HGCalSensitiveDetector', 'CTPPSDiamondSensitiveDetector', 'FP420SensitiveDetector', 'BHMSensitiveDetector', 'HFNoseSensitiveDetector', 'HGCScintillatorSensitiveDetector', 'CaloTrkProcessing', 'HcalSensitiveDetector', 'TkAccumulatingSensitiveDetector'],
+                       OnlySDs = ['BCM1FSensitiveDetector','BHMSensitiveDetector','CTPPSDiamondSensitiveDetector','CTPPSSensitiveDetector','CaloTrkProcessing','EcalSensitiveDetector','HFNoseSensitiveDetector','HGCScintillatorSensitiveDetector','HGCalSensitiveDetector','HcalSensitiveDetector','MtdSensitiveDetector','MuonSensitiveDetector','PLTSensitiveDetector','RomanPotSensitiveDetector','TkAccumulatingSensitiveDetector','ZdcSensitiveDetector'],
+                       TrackHits = ['BCM1FHits','BHMHits','CTPPSPixelHits','CTPPSTimingHits','FastTimerHitsBarrel','FastTimerHitsEndcap','HFNoseHits','MuonCSCHits','MuonDTHits','MuonGEMHits','MuonME0Hits','MuonRPCHits','PLTHits','TrackerHitsPixelEndcapLowTof','TrackerHitsPixelEndcapHighTof','TrackerHitsPixelBarrelLowTof','TrackerHitsPixelBarrelHighTof','TrackerHitsTECLowTof','TrackerHitsTECHighTof','TrackerHitsTIBLowTof','TrackerHitsTIBHighTof','TrackerHitsTIDLowTof','TrackerHitsTIDHighTof','TrackerHitsTOBLowTof','TrackerHitsTOBHighTof'],
+                       CaloHits = ["CalibrationHGCHitsEE",'CalibrationHGCHitsHEback',"CalibrationHGCHitsHEfront",'CaloHitsTk','EcalHitsEB','HFNoseHits',"HGCHitsEE","HGCHitsHEback","HGCHitsHEfront",'HcalHits','ZDCHITS'],
                        LHCTransport = False, 
                        MuonSD = dict( 
                        HaveDemoChambers = False ) 
@@ -729,7 +739,9 @@ phase2_common.toModify(g4SimHits,
 
 from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 hgcaltb.toModify(g4SimHits,
-                 OnlySDs = ['AHcalSensitiveDetector', 'HGCSensitiveDetector', 'HGCalSensitiveDetector', 'HGCalTB1601SensitiveDetector', 'HcalTB06BeamDetector'],
+                 OnlySDs = ['AHcalSensitiveDetector','CaloTrkProcessing','FP420SensitiveDetector','HFNoseSensitiveDetector','HGCSensitiveDetector','HGCalSensitiveDetector','HGCalTB1601SensitiveDetector','HcalTB06BeamDetector'],
+                 TrackHits = ['FP420SI'],
+                 CaloHits = ['CalibrationHGCHitsEE','CalibrationHGCHitsHEback','CalibrationHGCHitsHEfront','CaloHitsTk','ChamberHits','EcalHitsEB','EcalHitsEE','EcalHitsES','EcalTBH4BeamHits','FibreHits','HFNoseHits','HcalSensitiveDetector','HGCHitsEE','HGCHitsHEback','HGCHitsHEfront','HcalHits','HcalTB06BeamHits','WedgeHits'],
                  NonBeamEvent = True,
                  UseMagneticField = False,
                  CaloSD = dict(

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -328,8 +328,8 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   auto sensDets = sim::attachSD(
       m_sdMakers, es, runManagerMaster->catalog(), m_p, m_tls->trackManager.get(), *(m_tls->registry.get()));
 
-  m_tls->sensTkDets.swap(sensDets.first);
-  m_tls->sensCaloDets.swap(sensDets.second);
+  m_tls->sensTkDets = sensDets.first;
+  m_tls->sensCaloDets = sensDets.second;
 
   edm::LogVerbatim("SimG4CoreApplication")
       << "RunManagerMTWorker::InitializeG4: Sensitive Detectors are built in thread " << thisID << " found "

--- a/SimG4Core/SensitiveDetector/src/AttachSD.cc
+++ b/SimG4Core/SensitiveDetector/src/AttachSD.cc
@@ -36,10 +36,10 @@ std::pair<std::vector<SensitiveTkDetector*>, std::vector<SensitiveCaloDetector*>
 
     if (sd->isCaloSD()) {
       detList.second.push_back(static_cast<SensitiveCaloDetector*>(sd.release()));
-      ss << " + calo SD";
+      ss << " is calo SD";
     } else {
       detList.first.push_back(static_cast<SensitiveTkDetector*>(sd.release()));
-      ss << " + tracking SD";
+      ss << " is tracking SD";
     }
     edm::LogVerbatim("SimG4CoreSensitiveDetector") << ss.str();
   }


### PR DESCRIPTION
PR description:

This PR is created to address https://github.com/cms-sw/cmssw/issues/42986. For each type of Run it is possible to customize the list of SD classes and the list of produced hit collections. It is not expected to have a visible CPU or memory reduction but this will allow to increase clarity of the configuration. If a new detector and an extra hit collection will appears it would be easy to add to the g4SimHits configuration file. No change in any WF is expected. This PR substitutes  #43454 in order to have less volume of the PR.

PR validation:

short matrix + private
If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO