### PR TITLE
[13.3.X]  Fix `SiStripHashedDetId` constructor / operator and add more SiStripLorentzAngle PCL unit testings

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
@@ -29,6 +29,23 @@ public:
   /** Copy constructor. */
   SiStripHashedDetId(const SiStripHashedDetId &);
 
+  /** Assignment operator. */
+  SiStripHashedDetId &operator=(const SiStripHashedDetId &other) {
+    if (this != &other) {  // Self-assignment check
+      this->id_ = 0;
+      this->iter_ = other.begin();
+      // auxilliary vector to store the list of raw IDs
+      std::vector<uint32_t> raw_ids;
+      raw_ids.reserve(other.size());
+
+      // Copy elements from input vector to detIds_ vector
+      std::copy(other.begin(), other.end(), std::back_inserter(raw_ids));
+
+      this->init(raw_ids);
+    }
+    return *this;
+  }
+
   /** Public default constructor. */
   SiStripHashedDetId();
 

--- a/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h
@@ -56,6 +56,8 @@ public:
 
   inline const_iterator end() const;
 
+  inline const size_t size() const { return detIds_.size(); }
+
 private:
   void init(const std::vector<uint32_t> &);
 

--- a/CalibFormats/SiStripObjects/src/SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripHashedDetId.cc
@@ -36,8 +36,15 @@ SiStripHashedDetId::SiStripHashedDetId(const std::vector<DetId> &det_ids) : detI
 SiStripHashedDetId::SiStripHashedDetId(const SiStripHashedDetId &input) : detIds_(), id_(0), iter_(detIds_.begin()) {
   LogTrace(mlCabling_) << "[SiStripHashedDetId::" << __func__ << "]"
                        << " Constructing object...";
-  detIds_.reserve(input.end() - input.begin());
-  std::copy(input.begin(), input.end(), detIds_.begin());
+
+  // auxilliary vector to store the list of raw IDs
+  std::vector<uint32_t> raw_ids;
+  raw_ids.reserve(input.size());
+
+  // Copy elements from input vector to detIds_ vector
+  std::copy(input.begin(), input.end(), std::back_inserter(raw_ids));
+
+  init(raw_ids);
 }
 
 // -----------------------------------------------------------------------------

--- a/CalibFormats/SiStripObjects/test/BuildFile.xml
+++ b/CalibFormats/SiStripObjects/test/BuildFile.xml
@@ -15,4 +15,11 @@
   <use name="cppunit"/>
 </bin>
 
+<bin file="test_catch2_*.cc" name="test_catch2_SiStripHashedDetId">
+  <use name="CalibFormats/SiStripObjects"/>
+  <use name="CalibTracker/SiStripCommon"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="catch2"/>
+</bin>
+
 <test name="testSiStripHashedDetId" command="testSiStripHashedDetId.sh"/>

--- a/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
@@ -102,6 +102,49 @@ TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
   }
 
   //_____________________________________________________________
+  SECTION("Check SiStripHashedDetId assignment operator") {
+    const auto& detInfo =
+        SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+    const auto& dets = detInfo.getAllDetIds();
+
+    SiStripHashedDetId hash(dets);
+    SiStripHashedDetId hash2;
+
+    // Retrieve hashed indices
+    std::vector<uint32_t> hashes;
+    hashes.clear();
+    hashes.reserve(dets.size());
+    for (const auto& idet : dets) {
+      hashes.push_back(hash.hashedIndex(idet));
+    }
+
+    std::sort(hashes.begin(), hashes.end());
+
+    // assign hash to hash2
+    hash2 = hash;
+
+    // Retrieve hashed indices
+    std::vector<uint32_t> hashes2;
+    hashes2.clear();
+    hashes2.reserve(dets.size());
+    for (const auto& idet : dets) {
+      hashes2.push_back(hash2.hashedIndex(idet));
+    }
+
+    std::sort(hashes2.begin(), hashes2.end());
+
+    if (hashes == hashes2) {
+      std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+                << " Assigned SiStripHashedDetId matches original one!" << std::endl;
+    } else {
+      std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+                << " Assigned SiStripHashedDetId does not match the original one!" << std::endl;
+    }
+
+    REQUIRE(hashes == hashes2);
+  }
+
+  //_____________________________________________________________
   SECTION("Check manipulating SiStripHashedDetId") {
     const auto& detInfo =
         SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());

--- a/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
@@ -3,22 +3,121 @@
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "catch.hpp"
+
+#include <set>
+#include <vector>
+#include <algorithm>
 #include <iostream>
 
 TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
   //_____________________________________________________________
   SECTION("Check constructing SiStripHashedDetId from DetId list") {
-    const auto& detInfo = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+    const auto& detInfo =
+        SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
     const auto& detIds = detInfo.getAllDetIds();
     SiStripHashedDetId hash(detIds);
-    std::cout << "Successfully created hash!" << std::endl;
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " Successfully created hash!" << std::endl;
     REQUIRE(true);
   }
 
   //_____________________________________________________________
-  SECTION("Check manipulating SiStripHashedDetId") {
-    const auto& detInfo = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+  SECTION("Check SiStripHashedDetId copy constructor") {
+    const auto& detInfo =
+        SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
     const auto& dets = detInfo.getAllDetIds();
+
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " dets.size(): " << dets.size() << std::endl;
+
+    SiStripHashedDetId hash(dets);
+
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " hash.size(): " << hash.size() << std::endl;
+
+    // Retrieve hashed indices
+    std::vector<uint32_t> hashes;
+    hashes.clear();
+    hashes.reserve(dets.size());
+    for (const auto& idet : dets) {
+      hashes.push_back(hash.hashedIndex(idet));
+    }
+
+    std::sort(hashes.begin(), hashes.end());
+
+    SiStripHashedDetId hash2(hash);
+
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " Successfully copied hash map!" << std::endl;
+
+    // Retrieve hashed indices
+    std::vector<uint32_t> hashes2;
+
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " hashs2.size(): " << hash2.size() << std::endl;
+
+    hashes2.clear();
+    hashes2.reserve(dets.size());
+    for (const auto& idet : dets) {
+      hashes2.push_back(hash2.hashedIndex(idet));
+    }
+
+    std::sort(hashes2.begin(), hashes2.end());
+
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+              << " Successfully sorted second hash map!" << std::endl;
+
+    // Convert vectors to sets for easy set operations
+    std::set<uint32_t> set1(hashes.begin(), hashes.end());
+    std::set<uint32_t> set2(hashes2.begin(), hashes2.end());
+
+    std::vector<uint32_t> diff1to2, diff2to1;
+
+    // Find elements in vec1 that are not in vec2
+    std::set_difference(set1.begin(), set1.end(), set2.begin(), set2.end(), std::inserter(diff1to2, diff1to2.begin()));
+
+    // Find elements in vec2 that are not in vec1
+    std::set_difference(set2.begin(), set2.end(), set1.begin(), set1.end(), std::inserter(diff2to1, diff2to1.begin()));
+
+    // Output the differences
+    if (!diff1to2.empty()) {
+      std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+                << " Elements in hash that are not in hash2: ";
+      for (const auto& elem : diff1to2) {
+        std::cout << elem << " ";
+      }
+      std::cout << std::endl;
+    }
+
+    if (!diff2to1.empty()) {
+      std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+                << " Elements in hash2 that are not in hash: ";
+      for (const auto& elem : diff2to1) {
+        std::cout << elem << " ";
+      }
+      std::cout << std::endl;
+    }
+
+    REQUIRE(hashes == hashes2);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check manipulating SiStripHashedDetId") {
+    const auto& detInfo =
+        SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+
+    const auto& unsortedDets = detInfo.getAllDetIds();
+
+    // unfortunately SiStripDetInfo::getAllDetIds() returns a const vector
+    // so in order to sory we're gonna need to copy it first
+
+    std::vector<uint32_t> dets;
+    dets.reserve(unsortedDets.size());
+    std::copy(unsortedDets.begin(), unsortedDets.end(), std::back_inserter(dets));
+
+    // sort the vector of detIds (otherwise the test won't work!)
+    std::sort(dets.begin(), dets.end());
+
     SiStripHashedDetId hash(dets);
 
     // Retrieve hashed indices
@@ -26,44 +125,44 @@ TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
     uint32_t istart = time(NULL);
     hashes.clear();
     hashes.reserve(dets.size());
-    std::vector<uint32_t>::const_iterator idet = dets.begin();
-    for (; idet != dets.end(); ++idet) {
-      hashes.push_back(hash.hashedIndex(*idet));
+    for (const auto& idet : dets) {
+      hashes.push_back(hash.hashedIndex(idet));
     }
-    
+
     // Some debug
     std::stringstream ss;
     ss << "[testSiStripHashedDetId::" << __func__ << "]";
-    std::vector<uint32_t>::const_iterator ii = hashes.begin();
     uint16_t cntr1 = 0;
-    for (; ii != hashes.end(); ++ii) {
-      if (*ii == sistrip::invalid32_) {
-	cntr1++;
-	ss << std::endl << " Invalid index " << *ii;
-	continue;
+    for (const auto& ii : hashes) {
+      if (ii == sistrip::invalid32_) {
+        cntr1++;
+        ss << std::endl << " Invalid index " << ii;
+        continue;
       }
-      uint32_t detid = hash.unhashIndex(*ii);
+      uint32_t detid = hash.unhashIndex(ii);
       std::vector<uint32_t>::const_iterator iter = find(dets.begin(), dets.end(), detid);
       if (iter == dets.end()) {
-	cntr1++;
-	ss << std::endl << " Did not find value " << detid << " at index " << ii - hashes.begin() << " in vector!";
-      } else if (*ii != static_cast<uint32_t>(iter - dets.begin())) {
-	cntr1++;
-	ss << std::endl
-	   << " Found same value " << detid << " at different indices " << *ii << " and " << iter - dets.begin();
+        cntr1++;
+        ss << std::endl << " Did not find value " << detid << " at index " << ii - *(hashes.begin()) << " in vector!";
+      } else if (ii != static_cast<uint32_t>(iter - dets.begin())) {
+        cntr1++;
+        ss << std::endl
+           << " Found same value " << detid << " at different indices " << ii << " and " << iter - dets.begin();
       }
     }
+
     if (cntr1) {
       ss << std::endl << " Found " << cntr1 << " incompatible values!";
     } else {
       ss << " Found no incompatible values!";
     }
     std::cout << ss.str() << std::endl;
-    
+
     std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
-	      << " Processed " << hashes.size() << " DetIds in " << (time(NULL) - istart)
-	      << " seconds" << std::endl;
-    
+              << " Processed " << hashes.size() << " DetIds in " << (time(NULL) - istart) << " seconds" << std::endl;
+
+    REQUIRE(cntr1 == 0);
+
     // Retrieve DetIds
     std::vector<uint32_t> detids;
     uint32_t jstart = time(NULL);
@@ -73,7 +172,7 @@ TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
     for (uint16_t idet = 0; idet < dets.size(); ++idet) {
       detids.push_back(hash.unhashIndex(idet));
     }
-    
+
     // Some debug
     std::stringstream sss;
     sss << "[testSiStripHashedDetId::" << __func__ << "]";
@@ -81,10 +180,10 @@ TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
     std::vector<uint32_t>::const_iterator iii = detids.begin();
     for (; iii != detids.end(); ++iii) {
       if (*iii != dets.at(iii - detids.begin())) {
-	cntr2++;
-	sss << std::endl
-	    << " Diff values " << *iii << " and " << dets.at(iii - detids.begin()) << " found at index "
-	    << iii - detids.begin() << " ";
+        cntr2++;
+        sss << std::endl
+            << " Diff values " << *iii << " and " << dets.at(iii - detids.begin()) << " found at index "
+            << iii - detids.begin() << " ";
       }
     }
     if (cntr2) {
@@ -93,14 +192,13 @@ TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
       sss << " Found no incompatible values!";
     }
     std::cout << sss.str() << std::endl;
-    
+
     std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
-	      << " Processed " << detids.size() << " hashed indices in " << (time(NULL) - jstart)
-	      << " seconds" << std::endl;
-    
+              << " Processed " << detids.size() << " hashed indices in " << (time(NULL) - jstart) << " seconds"
+              << std::endl;
+
+    REQUIRE(cntr2 == 0);
+
     REQUIRE(true);
   }
-  
-  
-  
 }

--- a/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_SiStripHashedDetId.cc
@@ -1,0 +1,106 @@
+#include "CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetInfo.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "catch.hpp"
+#include <iostream>
+
+TEST_CASE("SiStripHashedDetId testing", "[SiStripHashedDetId]") {
+  //_____________________________________________________________
+  SECTION("Check constructing SiStripHashedDetId from DetId list") {
+    const auto& detInfo = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+    const auto& detIds = detInfo.getAllDetIds();
+    SiStripHashedDetId hash(detIds);
+    std::cout << "Successfully created hash!" << std::endl;
+    REQUIRE(true);
+  }
+
+  //_____________________________________________________________
+  SECTION("Check manipulating SiStripHashedDetId") {
+    const auto& detInfo = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+    const auto& dets = detInfo.getAllDetIds();
+    SiStripHashedDetId hash(dets);
+
+    // Retrieve hashed indices
+    std::vector<uint32_t> hashes;
+    uint32_t istart = time(NULL);
+    hashes.clear();
+    hashes.reserve(dets.size());
+    std::vector<uint32_t>::const_iterator idet = dets.begin();
+    for (; idet != dets.end(); ++idet) {
+      hashes.push_back(hash.hashedIndex(*idet));
+    }
+    
+    // Some debug
+    std::stringstream ss;
+    ss << "[testSiStripHashedDetId::" << __func__ << "]";
+    std::vector<uint32_t>::const_iterator ii = hashes.begin();
+    uint16_t cntr1 = 0;
+    for (; ii != hashes.end(); ++ii) {
+      if (*ii == sistrip::invalid32_) {
+	cntr1++;
+	ss << std::endl << " Invalid index " << *ii;
+	continue;
+      }
+      uint32_t detid = hash.unhashIndex(*ii);
+      std::vector<uint32_t>::const_iterator iter = find(dets.begin(), dets.end(), detid);
+      if (iter == dets.end()) {
+	cntr1++;
+	ss << std::endl << " Did not find value " << detid << " at index " << ii - hashes.begin() << " in vector!";
+      } else if (*ii != static_cast<uint32_t>(iter - dets.begin())) {
+	cntr1++;
+	ss << std::endl
+	   << " Found same value " << detid << " at different indices " << *ii << " and " << iter - dets.begin();
+      }
+    }
+    if (cntr1) {
+      ss << std::endl << " Found " << cntr1 << " incompatible values!";
+    } else {
+      ss << " Found no incompatible values!";
+    }
+    std::cout << ss.str() << std::endl;
+    
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+	      << " Processed " << hashes.size() << " DetIds in " << (time(NULL) - istart)
+	      << " seconds" << std::endl;
+    
+    // Retrieve DetIds
+    std::vector<uint32_t> detids;
+    uint32_t jstart = time(NULL);
+    // meaasurement!
+    detids.clear();
+    detids.reserve(dets.size());
+    for (uint16_t idet = 0; idet < dets.size(); ++idet) {
+      detids.push_back(hash.unhashIndex(idet));
+    }
+    
+    // Some debug
+    std::stringstream sss;
+    sss << "[testSiStripHashedDetId::" << __func__ << "]";
+    uint16_t cntr2 = 0;
+    std::vector<uint32_t>::const_iterator iii = detids.begin();
+    for (; iii != detids.end(); ++iii) {
+      if (*iii != dets.at(iii - detids.begin())) {
+	cntr2++;
+	sss << std::endl
+	    << " Diff values " << *iii << " and " << dets.at(iii - detids.begin()) << " found at index "
+	    << iii - detids.begin() << " ";
+      }
+    }
+    if (cntr2) {
+      sss << std::endl << " Found " << cntr2 << " incompatible values!";
+    } else {
+      sss << " Found no incompatible values!";
+    }
+    std::cout << sss.str() << std::endl;
+    
+    std::cout << "[testSiStripHashedDetId::" << __func__ << "]"
+	      << " Processed " << detids.size() << " hashed indices in " << (time(NULL) - jstart)
+	      << " seconds" << std::endl;
+    
+    REQUIRE(true);
+  }
+  
+  
+  
+}

--- a/CalibFormats/SiStripObjects/test/test_catch2_main.cc
+++ b/CalibFormats/SiStripObjects/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLorentzAngleCalibrationStruct.h
@@ -28,7 +28,7 @@ public:
   std::map<std::string, dqm::reco::MonitorElement*> p_;
 
   // These are vectors since std:map::find is expensive
-  // we're going to profi of the dense indexing offered by
+  // we're going to profit of the dense indexing offered by
   // SiStripHashedDetId and index the histogram position
   // with the natural booking order
   std::vector<dqm::reco::MonitorElement*> h2_ct_w_m_;

--- a/CalibTracker/SiStripLorentzAngle/interface/SiStripLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiStripLorentzAngle/interface/SiStripLorentzAngleCalibrationStruct.h
@@ -7,6 +7,7 @@
 
 // user includes
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h"
 
 struct SiStripLorentzAngleCalibrationHistograms {
 public:
@@ -31,6 +32,8 @@ public:
   // we're going to profit of the dense indexing offered by
   // SiStripHashedDetId and index the histogram position
   // with the natural booking order
+  SiStripHashedDetId hash_;
+
   std::vector<dqm::reco::MonitorElement*> h2_ct_w_m_;
   std::vector<dqm::reco::MonitorElement*> h2_ct_var2_m_;
   std::vector<dqm::reco::MonitorElement*> h2_ct_var3_m_;

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLMonitor.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLorentzAnglePCLMonitor.cc
@@ -22,7 +22,6 @@
 #include <fmt/printf.h>
 
 // user include files
-#include "CalibFormats/SiStripObjects/interface/SiStripHashedDetId.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 #include "CalibTracker/SiStripCommon/interface/ShallowTools.h"
 #include "CalibTracker/SiStripLorentzAngle/interface/SiStripLorentzAngleCalibrationHelpers.h"
@@ -74,7 +73,6 @@ private:
   // ------------ member data ------------
   SiStripClusterInfo m_clusterInfo;
   SiStripLorentzAngleCalibrationHistograms iHists_;
-  SiStripHashedDetId m_hash;
 
   // for magnetic field conversion
   static constexpr float teslaToInverseGeV_ = 2.99792458e-3f;
@@ -183,8 +181,11 @@ void SiStripLorentzAnglePCLMonitor::dqmBeginRun(edm::Run const& run, edm::EventS
   // Sorted DetId list gives max performance, anything else is worse
   std::sort(c_rawid.begin(), c_rawid.end());
 
-  // initialized the hash map
-  m_hash = SiStripHashedDetId(c_rawid);
+  // initialize the hash map
+  // in case it's not already initialized
+  if (iHists_.hash_.size() == 0) {
+    iHists_.hash_ = SiStripHashedDetId(c_rawid);
+  }
 
   //reserve the size of the vector
   if (saveHistosMods_) {
@@ -310,7 +311,8 @@ void SiStripLorentzAnglePCLMonitor::analyze(const edm::Event& iEvent, const edm:
     if (locationtype.empty())
       return;
 
-    const auto& hashedIndex = m_hash.hashedIndex(mod);
+    // retrive the hashed index
+    const auto& hashedIndex = iHists_.hash_.hashedIndex(mod);
 
     if (saveHistosMods_) {
       LogDebug("SiStripLorentzAnglePCLMonitor") << "module ID: " << mod << " hashedIndex: " << hashedIndex;
@@ -331,6 +333,12 @@ void SiStripLorentzAnglePCLMonitor::analyze(const edm::Event& iEvent, const edm:
     iHists_.h2_[Form("%s_tanthcosphtrk_nstrip", locationtype.c_str())]->Fill(sign * cosphi * tantheta, c_nstrips);
     iHists_.h2_[Form("%s_thetatrk_nstrip", locationtype.c_str())]->Fill(sign * theta * cosphi, c_nstrips);
 
+    if (saveHistosMods_) {
+      iHists_.h1_[Form("%s_%d_nstrips", locationtype.c_str(), mod)]->Fill(c_nstrips);
+      iHists_.h1_[Form("%s_%d_tanthetatrk", locationtype.c_str(), mod)]->Fill(sign * tantheta);
+      iHists_.h1_[Form("%s_%d_cosphitrk", locationtype.c_str(), mod)]->Fill(cosphi);
+    }
+
     // variance for width == 2
     if (c_nstrips == 2) {
       iHists_.h1_[Form("%s_variance_w2", locationtype.c_str())]->Fill(c_variance);
@@ -339,6 +347,8 @@ void SiStripLorentzAnglePCLMonitor::analyze(const edm::Event& iEvent, const edm:
 
       // not in PCL
       if (saveHistosMods_) {
+        LogDebug("SiStripLorentzAnglePCLMonitor") << iHists_.h2_ct_var2_m_[hashedIndex]->getName();
+        iHists_.h1_[Form("%s_%d_variance_w2", locationtype.c_str(), mod)]->Fill(c_variance);
         iHists_.h2_ct_var2_m_[hashedIndex]->Fill(sign * cosphi * tantheta, c_variance);
         iHists_.h2_t_var2_m_[hashedIndex]->Fill(sign * cosphi * theta, c_variance);
       }
@@ -351,6 +361,7 @@ void SiStripLorentzAnglePCLMonitor::analyze(const edm::Event& iEvent, const edm:
 
       // not in PCL
       if (saveHistosMods_) {
+        iHists_.h1_[Form("%s_%d_variance_w3", locationtype.c_str(), mod)]->Fill(c_variance);
         iHists_.h2_ct_var3_m_[hashedIndex]->Fill(sign * cosphi * tantheta, c_variance);
         iHists_.h2_t_var3_m_[hashedIndex]->Fill(sign * cosphi * theta, c_variance);
       }
@@ -403,9 +414,9 @@ void SiStripLorentzAnglePCLMonitor::bookHistograms(DQMStore::IBooker& ibook,
   if (saveHistosMods_) {
     iHists_.h1_["occupancyPerIndex"] = ibook.book1D("ClusterOccupancyPerHashedIndex",
                                                     "cluster occupancy;hashed index;# clusters per module",
-                                                    m_hash.size(),
+                                                    iHists_.hash_.size(),
                                                     -0.5,
-                                                    m_hash.size() - 0.5);
+                                                    iHists_.hash_.size() - 0.5);
   }
 
   // fill in the module types
@@ -467,6 +478,7 @@ void SiStripLorentzAnglePCLMonitor::bookHistograms(DQMStore::IBooker& ibook,
   if (saveHistosMods_) {
     ibook.setCurrentFolder(folderToBook + "/modules");
     for (const auto& [mod, locationType] : iHists_.moduleLocationType_) {
+      ibook.setCurrentFolder(folderToBook + "/modules" + Form("/%s", locationType.c_str()));
       // histograms for each module
       iHists_.h1_[Form("%s_%d_nstrips", locationType.c_str(), mod)] =
           ibook.book1D(Form("%s_%d_nstrips", locationType.c_str(), mod), "", 10, 0, 10);
@@ -481,9 +493,12 @@ void SiStripLorentzAnglePCLMonitor::bookHistograms(DQMStore::IBooker& ibook,
     }
 
     int counter{0};
-    SiStripHashedDetId::const_iterator iter = m_hash.begin();
-    for (; iter != m_hash.end(); ++iter) {
+    SiStripHashedDetId::const_iterator iter = iHists_.hash_.begin();
+    for (; iter != iHists_.hash_.end(); ++iter) {
+      LogDebug("SiStripLorentzAnglePCLMonitor")
+          << "detId: " << (*iter) << " hashed index: " << iHists_.hash_.hashedIndex((*iter));
       const auto& locationType = iHists_.moduleLocationType_[(*iter)];
+      ibook.setCurrentFolder(folderToBook + "/modules" + Form("/%s", locationType.c_str()));
       iHists_.h2_ct_w_m_.push_back(
           ibook.book2D(Form("ct_w_m_%s_%d", locationType.c_str(), *iter), "", 90, -0.9, 0.9, 10, 0, 10));
       iHists_.h2_t_w_m_.push_back(

--- a/CalibTracker/SiStripLorentzAngle/test/BuildFile.xml
+++ b/CalibTracker/SiStripLorentzAngle/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testPromptCalibProdSiStripLA" command="testPromptCalibProdSiStripLA.sh"/>

--- a/CalibTracker/SiStripLorentzAngle/test/step_PromptCalibProdSiStripLA_cfg.py
+++ b/CalibTracker/SiStripLorentzAngle/test/step_PromptCalibProdSiStripLA_cfg.py
@@ -13,6 +13,7 @@ process = cms.Process('ReAlCa',Run3_2023)
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
 process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport.reportEvery = 100 # limit the output for the unit test
 process.load('Configuration.EventContent.EventContentCosmics_cff')
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
@@ -21,13 +22,13 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100000),
+    input = cms.untracked.int32(1000), # 1000000
     output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
 )
 
 # Input source
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/data/Commissioning2023/Cosmics/ALCARECO/SiStripCalCosmics-PromptReco-v1/000/364/141/00000/062e670e-40e3-4950-b0bb-dd354844d16f.root'),
+    fileNames = cms.untracked.vstring('/store/data/Commissioning2023/Cosmics/ALCARECO/SiStripCalCosmics-PromptReco-v1/000/364/174/00000/59a465b4-6e25-4ea0-8fe3-2319bdea7fcb.root'),
     secondaryFileNames = cms.untracked.vstring()
 )
 
@@ -104,11 +105,12 @@ process.schedule = cms.Schedule(process.pathALCARECOPromptCalibProdSiStripLorent
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
-#Setup FWK for multithreaded
+# Setup FWK for multithreaded
 process.options.numberOfThreads = 4
 process.options.numberOfStreams = 0
 
-
+# Save the per-histogram modules in order to test the SiStripHashedDetId
+process.ALCARECOSiStripLACalib.saveHistoMods = cms.bool(True)
 
 # Customisation from command line
 

--- a/CalibTracker/SiStripLorentzAngle/test/testPromptCalibProdSiStripLA.sh
+++ b/CalibTracker/SiStripLorentzAngle/test/testPromptCalibProdSiStripLA.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+function die { echo $1: status $2 ; exit $2; }
+
+# test worker
+printf "TESTING SiStrip Lorentz Angle Worker ...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/step_PromptCalibProdSiStripLA_cfg.py || die "Failure running step_PromptCalibProdSiStripLA_cfg.py" $?
+
+# test harvester
+printf "TESTING SiStrip Lorentz Angle Harvester ...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/step_PromptCalibProdSiStripLA_ALCAHARVEST_cfg.py || die "Failure running step_PromptCalibProdSiStripLA_ALCAHARVEST_cfg.py" $?


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43469

#### PR description:

This PR is a follow up to https://github.com/cms-sw/cmssw/pull/43423/ and implements several different fixes and improvements.
First it fixes the `SiStripHashedDetId` class, both in terms of the copy constructor (472005bd1359618f1bf52a63c728ca3465022a0e) and assignment operator (f1ec80bc58d1798986b6743b3bf03a5491d37304). It also adds a new `size()` public method (38ff1c883a3dac56f317e88b73e961d234e9b7cc).
Then it adds a `catch2`-based unit test for basic `SiStripHashedDetId` operations (done in commits 3edaa3d906f892cc1b4abe27c9a80b0dcc14b56b, b1aa2dd8761f0e14bae16e1c681fcff29d77ddce, ff86f969a04cd0e3637ca965ee8953e28b544dc6).
Finally it improves the filling of the per-module histograms in SiStripLorentzAnglePCLMonitor (commits 3c324b47254b42d38901eeade8ac80962550c530 and b956d97d72fad5bfe92afed2db8ae5e77d45c6bb) as well as adding a dedicated unit test of both the AlCASkimming and AlCaHarvesting steps (00250a4b25405e6818ad52b31d87af98f9a7f3bf).

#### PR validation:

The validation of this PR relies on running the augment battery of unit tests of this package.
Running `scam b runtests` returns

```
Creating test log file logs/slc7_amd64_gcc12/testing.log
Pass    1s ... CalibFormats/SiStripObjects/TestCalibFormatsSiStripObjects
Pass   11s ... CalibFormats/SiStripObjects/testSiStripHashedDetId
Pass    0s ... CalibFormats/SiStripObjects/test_catch2_SiStripHashedDetId
Pass   58s ... CalibTracker/SiStripLorentzAngle/testPromptCalibProdSiStripLA
>> Test sequence completed for CMSSW CMSSW_13_3_X_2023-12-02-1100
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/43469 in case there is prolonged cosmics data-taking in 13_3_X.
