### PR TITLE
Use likelihood fit instead of chi-square fit in DQMGenericClient::limitedFit

### DIFF
--- a/DQMServices/Components/plugins/DQMGenericClient.cc
+++ b/DQMServices/Components/plugins/DQMGenericClient.cc
@@ -1162,7 +1162,7 @@ void DQMGenericClient::limitedFit(MonitorElement* srcME, MonitorElement* meanME,
       //To avoid DQMGenericClient maintains state between fit calls
       fitFcn->SetParameters(histoY->Integral(), histoY->GetMean(), histoY->GetRMS());
 
-      histoY->Fit(fitFcn, "QR0 SERIAL", "", x1, x2);
+      histoY->Fit(fitFcn, "QR0L SERIAL", "", x1, x2);
 
       //      histoY->Fit(fitFcn->GetName(),"RME");
       double* par = fitFcn->GetParameters();


### PR DESCRIPTION
[Some Relvals](https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_14_0/2023-12-03-2300?selectedArchs=el8_aarch64_gcc12&selectedFlavors=ROOT630_X&selectedStatus=failed) in CMSSW_14_0_ROOT630/aarch64 IBs are failing with error [a]. We have already seen such errors with newer root versions (https://github.com/cms-sw/cmssw/issues/42979 ) and using `likelihood` fit (https://github.com/cms-sw/cmssw/pull/43106 ) was proposed to avoid such failures. This PR also proposes to use  likelihood fit instead of chi-square for `DQMGenericClient::limitedFit`

[a]
```
----- Begin Fatal Exception 04-Dec-2023 15:13:35 CET-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Processing global end Run run: 1
   [1] Calling method for module DQMGenericClient/'postProcessorMuonTrack'
   Additional Info:
      [a] Fatal Root Error: @SUB=Minuit2
VariableMetricBuilder Initial matrix not pos.def.

----- End Fatal Exception -------------------------------------------------
```