### PR TITLE
more all D* geometry >= D98 to use the @relval2026 menu

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2804,7 +2804,7 @@ upgradeProperties[2026] = {
     },
     '2026D102' : {
         'Geom' : 'Extended2026D102',
-        'HLTmenu': '@fake2',
+        'HLTmenu': '@relval2026',
         'GT' : 'auto:phase2_realistic_T33',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
@@ -2818,7 +2818,7 @@ upgradeProperties[2026] = {
     },
     '2026D104' : {
         'Geom' : 'Extended2026D104',
-        'HLTmenu': '@fake2',
+        'HLTmenu': '@relval2026',
         'GT' : 'auto:phase2_realistic_T33',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],


### PR DESCRIPTION
#### PR description:

As privately disccussed with @srimanob I am moving all the phase-2 relvals for geometries >= D98 to use the `@relval2026` menu instead of the fake one. This should avoid having too many spurious `LogWarning`s concerning missing collections in the  DQM and validation steps.
I don't touch geometries < D98 as it is in any case in the plans to remove them (see also https://github.com/cms-sw/cmssw/issues/43251 )

#### PR validation:

`runTheMatrix.py --what upgrade -l 27224.0,26424.0 -t 4 -j 8` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backported, not useful to backport.