### PR TITLE
Removal of ZDC LUT file in caloParamsHelper and L1T workflow

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloStage2ParamsESProducer.cc
@@ -344,12 +344,6 @@ L1TCaloStage2ParamsESProducer::L1TCaloStage2ParamsESProducer(const edm::Paramete
   std::shared_ptr<LUT> q2LUT(new LUT(q2LUTStream));
   m_params_helper.setQ2LUT(*q2LUT);
 
-  // HI ZDC calibration LUT for trigger
-  edm::FileInPath zdcLUTFile = conf.getParameter<edm::FileInPath>("zdcLUTFile");
-  std::ifstream zdcLUTStream(zdcLUTFile.fullPath());
-  std::shared_ptr<LUT> zdcLUT(new LUT(zdcLUTStream));
-  m_params_helper.setZDCLUT(*zdcLUT);
-
   // Layer 1 LUT specification
   m_params_helper.setLayer1ECalScaleFactors(conf.getParameter<std::vector<double>>("layer1ECalScaleFactors"));
   m_params_helper.setLayer1HCalScaleFactors(conf.getParameter<std::vector<double>>("layer1HCalScaleFactors"));

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -142,7 +142,6 @@ caloParams = cms.ESProducer(
     minimumBiasThresholds = cms.vint32(0, 0, 0, 0),
     centralityLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/centralityLUT_stage1.txt"),
     q2LUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/q2LUT_stage1.txt"),
-#    zdcLUTFile        = cms.FileInPath("L1Trigger/L1TZDC/data/zdcLUT_HI_v0_1.txt"),
     
     # HCal FB LUT
     layer1HCalFBLUTUpper = cms.vuint32([

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -142,7 +142,7 @@ caloParams = cms.ESProducer(
     minimumBiasThresholds = cms.vint32(0, 0, 0, 0),
     centralityLUTFile = cms.FileInPath("L1Trigger/L1TCalorimeter/data/centralityLUT_stage1.txt"),
     q2LUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/q2LUT_stage1.txt"),
-    zdcLUTFile        = cms.FileInPath("L1Trigger/L1TZDC/data/zdcLUT_HI_v0_1.txt"),
+#    zdcLUTFile        = cms.FileInPath("L1Trigger/L1TZDC/data/zdcLUT_HI_v0_1.txt"),
     
     # HCal FB LUT
     layer1HCalFBLUTUpper = cms.vuint32([


### PR DESCRIPTION
Removal of zdc LUT file query from L1TCaloStage2ParamsESProducer - obsolete

Also need to mod the caloParams file

#### PR description:

This PR removes ZDC LUT in CaloParamsHelper, made obsolete by recent PR:
https://github.com/cms-sw/cmssw/pull/42818

 * There should be no changes to output expected
 * This should not depend on other PRs (PR above already removed any LUT use)
 * Needed simply for L1 trigger development workflow

#### PR validation:

With PR, pre-existing L1Trigger development workflows no longer require presence of an unused and obsolete LUT

scram b runtests has some seemingly unrelated failures, but the most relevant test, L1Trigger/L1TGlobal/testL1TGlobalProducer, passes

Both of the below are applied
scram build code-checks
scram build code-format

Unclear if backport is necessary at this time; @bundocka can comment - given the small size of the PR, should be quick to prepare 