### PR TITLE
Add `BeamSpotOnlineShifter` class and related configuration

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -15,8 +15,9 @@
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/Math/interface/deltaPhi.h"  // for deltaPhi
 #include "DataFormats/Math/interface/Rounding.h"  // for rounding
+#include "DataFormats/Math/interface/deltaPhi.h"  // for deltaPhi
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/CondTools/BeamSpot/plugins/BeamSpotOnlineShifter.cc
+++ b/CondTools/BeamSpot/plugins/BeamSpotOnlineShifter.cc
@@ -1,0 +1,222 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/BeamSpot
+// Class:      BeamSpotOnlineShifter
+//
+/**\class BeamSpotOnlineShifter BeamSpotOnlineShifter.cc CondTools/BeamSpot/plugins/BeamSpotOnlineShifter.cc
+
+ Description: EDAnalyzer to create a BeamSpotOnlineHLTObjectsRcd from a BeamSpotObjectsRcd (inserting some parameters manually)
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Sat, 06 May 2023 21:10:00 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <ctime>
+
+// user include files
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+//
+// class declaration
+//
+
+class BeamSpotOnlineShifter : public edm::one::EDAnalyzer<> {
+public:
+  explicit BeamSpotOnlineShifter(const edm::ParameterSet&);
+  ~BeamSpotOnlineShifter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  cond::Time_t pack(uint32_t, uint32_t);
+  template <class Record>
+  void writeToDB(const edm::Event& iEvent,
+                 const edm::EventSetup& iSetup,
+                 const edm::ESGetToken<BeamSpotOnlineObjects, Record>& token);
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> hltToken;
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> legacyToken;
+
+  edm::ESWatcher<BeamSpotOnlineHLTObjectsRcd> bsHLTWatcher_;
+  edm::ESWatcher<BeamSpotOnlineLegacyObjectsRcd> bsLegayWatcher_;
+
+  // IoV-structure
+  const bool fIsHLT_;
+  const double xShift_;
+  const double yShift_;
+  const double zShift_;
+  uint32_t fIOVStartRun_;
+  uint32_t fIOVStartLumi_;
+  cond::Time_t fnewSince_;
+  bool fuseNewSince_;
+  std::string fLabel_;
+};
+
+//
+// constructors and destructor
+//
+BeamSpotOnlineShifter::BeamSpotOnlineShifter(const edm::ParameterSet& iConfig)
+    : fIsHLT_(iConfig.getParameter<bool>("isHLT")),
+      xShift_(iConfig.getParameter<double>("xShift")),
+      yShift_(iConfig.getParameter<double>("yShift")),
+      zShift_(iConfig.getParameter<double>("zShift")) {
+  if (iConfig.exists("IOVStartRun") && iConfig.exists("IOVStartLumi")) {
+    fIOVStartRun_ = iConfig.getUntrackedParameter<uint32_t>("IOVStartRun");
+    fIOVStartLumi_ = iConfig.getUntrackedParameter<uint32_t>("IOVStartLumi");
+    fnewSince_ = BeamSpotOnlineShifter::pack(fIOVStartRun_, fIOVStartLumi_);
+    fuseNewSince_ = true;
+    edm::LogPrint("BeamSpotOnlineShifter") << "useNewSince = True";
+  } else {
+    fuseNewSince_ = false;
+    edm::LogPrint("BeamSpotOnlineShifter") << "useNewSince = False";
+  }
+  fLabel_ = (fIsHLT_) ? "BeamSpotOnlineHLTObjectsRcd" : "BeamSpotOnlineLegacyObjectsRcd";
+
+  if (fIsHLT_) {
+    hltToken = esConsumes();
+  } else {
+    legacyToken = esConsumes();
+  }
+}
+
+//
+// member functions
+//
+
+// ------------ Create a since object (cond::Time_t) by packing Run and LS (both uint32_t)  ------------
+cond::Time_t BeamSpotOnlineShifter::pack(uint32_t fIOVStartRun, uint32_t fIOVStartLumi) {
+  return ((uint64_t)fIOVStartRun << 32 | fIOVStartLumi);
+}
+
+template <class Record>
+void BeamSpotOnlineShifter::writeToDB(const edm::Event& iEvent,
+                                      const edm::EventSetup& iSetup,
+                                      const edm::ESGetToken<BeamSpotOnlineObjects, Record>& token) {
+  // input object
+  const BeamSpotOnlineObjects* inputSpot = &iSetup.getData(token);
+
+  // output object
+  BeamSpotOnlineObjects abeam;
+
+  abeam.setPosition(inputSpot->x() + xShift_, inputSpot->y() + yShift_, inputSpot->z() + zShift_);
+  abeam.setSigmaZ(inputSpot->sigmaZ());
+  abeam.setdxdz(inputSpot->dxdz());
+  abeam.setdydz(inputSpot->dydz());
+  abeam.setBeamWidthX(inputSpot->beamWidthX());
+  abeam.setBeamWidthY(inputSpot->beamWidthY());
+  abeam.setBeamWidthXError(inputSpot->beamWidthXError());
+  abeam.setBeamWidthYError(inputSpot->beamWidthYError());
+
+  for (unsigned int i = 0; i < 7; i++) {
+    for (unsigned int j = 0; j < 7; j++) {
+      abeam.setCovariance(i, j, inputSpot->covariance(i, j));
+    }
+  }
+
+  abeam.setType(inputSpot->beamType());
+  abeam.setEmittanceX(inputSpot->emittanceX());
+  abeam.setEmittanceY(inputSpot->emittanceY());
+  abeam.setBetaStar(inputSpot->betaStar());
+
+  // online BeamSpot object specific
+  abeam.setLastAnalyzedLumi(inputSpot->lastAnalyzedLumi());
+  abeam.setLastAnalyzedRun(inputSpot->lastAnalyzedRun());
+  abeam.setLastAnalyzedFill(inputSpot->lastAnalyzedFill());
+  abeam.setStartTimeStamp(inputSpot->startTimeStamp());
+  abeam.setEndTimeStamp(inputSpot->endTimeStamp());
+  abeam.setNumTracks(inputSpot->numTracks());
+  abeam.setNumPVs(inputSpot->numPVs());
+  abeam.setUsedEvents(inputSpot->usedEvents());
+  abeam.setMaxPVs(inputSpot->maxPVs());
+  abeam.setMeanPV(inputSpot->meanPV());
+  abeam.setMeanErrorPV(inputSpot->meanErrorPV());
+  abeam.setRmsPV(inputSpot->rmsPV());
+  abeam.setRmsErrorPV(inputSpot->rmsErrorPV());
+  abeam.setStartTime(inputSpot->startTime());
+  abeam.setEndTime(inputSpot->endTime());
+  abeam.setLumiRange(inputSpot->lumiRange());
+  abeam.setCreationTime(inputSpot->creationTime());
+
+  edm::LogPrint("BeamSpotOnlineShifter") << " Writing results to DB...";
+  edm::LogPrint("BeamSpotOnlineShifter") << abeam;
+
+  edm::Service<cond::service::PoolDBOutputService> poolDbService;
+  if (poolDbService.isAvailable()) {
+    edm::LogPrint("BeamSpotOnlineShifter") << "poolDBService available";
+    if (poolDbService->isNewTagRequest(fLabel_)) {
+      edm::LogPrint("BeamSpotOnlineShifter") << "new tag requested";
+      if (fuseNewSince_) {
+        edm::LogPrint("BeamSpotOnlineShifter") << "Using a new Since: " << fnewSince_;
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, fnewSince_, fLabel_);
+      } else
+        poolDbService->createOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->beginOfTime(), fLabel_);
+    } else {
+      edm::LogPrint("BeamSpotOnlineShifter") << "no new tag requested";
+      if (fuseNewSince_) {
+        cond::Time_t thisSince = BeamSpotOnlineShifter::pack(iEvent.getLuminosityBlock().run(),
+                                                             iEvent.getLuminosityBlock().luminosityBlock());
+        edm::LogPrint("BeamSpotOnlineShifter") << "Using a new Since: " << thisSince;
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, thisSince, fLabel_);
+      } else
+        poolDbService->appendOneIOV<BeamSpotOnlineObjects>(abeam, poolDbService->currentTime(), fLabel_);
+    }
+  }
+  edm::LogPrint("BeamSpotOnlineShifter") << "[BeamSpotOnlineShifter] analyze done \n";
+}
+
+// ------------ method called for each event  ------------
+void BeamSpotOnlineShifter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  if (fIsHLT_) {
+    if (bsHLTWatcher_.check(iSetup)) {
+      writeToDB<BeamSpotOnlineHLTObjectsRcd>(iEvent, iSetup, hltToken);
+    }
+  } else {
+    if (bsLegayWatcher_.check(iSetup)) {
+      writeToDB<BeamSpotOnlineLegacyObjectsRcd>(iEvent, iSetup, legacyToken);
+    }
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void BeamSpotOnlineShifter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("isHLT", true);
+  desc.add<double>("xShift", 0.0)->setComment("in cm");
+  desc.add<double>("yShift", 0.0)->setComment("in cm");
+  desc.add<double>("zShift", 0.0)->setComment("in cm");
+  desc.addOptionalUntracked<uint32_t>("IOVStartRun", 1);
+  desc.addOptionalUntracked<uint32_t>("IOVStartLumi", 1);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(BeamSpotOnlineShifter);

--- a/CondTools/BeamSpot/plugins/BuildFile.xml
+++ b/CondTools/BeamSpot/plugins/BuildFile.xml
@@ -1,11 +1,16 @@
-<use name="CondTools/BeamSpot"/>
-<use name="CondCore/PopCon"/>
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="CondFormats/DataRecord"/>
-<use name="CondFormats/BeamSpotObjects"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="CondCore/CondDB"/>
+<use name="CondCore/PopCon"/>
+<use name="CondFormats/Alignment"/>
+<use name="CondFormats/AlignmentRecord"/>
+<use name="CondFormats/BeamSpotObjects"/>
+<use name="CondFormats/DataRecord"/>
+<use name="CondTools/BeamSpot"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/Records"/>
 <library file="*.cc" name="CondToolsBeamSpotPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CondTools/BeamSpot/test/BeamSpotOnlineShifter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineShifter_cfg.py
@@ -1,0 +1,116 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("READ")
+
+options = VarParsing.VarParsing()
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "are we running the unit test?")
+options.register('inputTag',
+                 "myTagName", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "output tag name")
+options.register('inputRecord',
+                 "BeamSpotOnlineLegacyObjectsRcd", # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "type of record")
+options.register('startRun',
+                 306171, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "location of the input data")
+options.register('startLumi',
+                 497, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "IOV Start Lumi")
+options.parseArguments()
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100000                         # do not clog output with IO
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1 if options.unitTest else 10000000) )   # large number of events is needed since we probe 5000LS for run (see below)
+
+####################################################################
+# Empty source 
+####################################################################
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.startRun),                  # Run in ../data/BeamFitResults_Run306171.txt
+                            firstLuminosityBlock = cms.untracked.uint32(options.startLumi),         # Lumi in ../data/BeamFitResults_Run306171.txt
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),  # probe one event per LS
+                            numberEventsInRun = cms.untracked.uint32(5000),           # a number of events > the number of LS possible in a real run (5000 s ~ 32 h)
+                            )
+
+####################################################################
+# Connect to conditions DB
+####################################################################
+
+# either from Global Tag
+# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
+# from Configuration.AlCa.GlobalTag import GlobalTag
+# process.GlobalTag = GlobalTag(process.GlobalTag,"auto:run2_data")
+
+# ...or specify database connection and tag:  
+#from CondCore.CondDB.CondDB_cfi import *
+#CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'))
+#process.dbInput = cms.ESSource("PoolDBESSource",
+#                               CondDBBeamSpotObjects,
+#                               toGet = cms.VPSet(cms.PSet(record = cms.string('BeamSpotOnlineLegacyObjectsRcd'), # BeamSpotOnlineLegacy record
+#                                                          tag = cms.string('BSLegacy_tag')                       # choose your favourite tag
+#                                                          )
+#                                                 )
+#                               )
+# ...or from a local db file
+# input database (in this case the local sqlite file)
+
+if options.unitTest :
+    if options.inputRecord ==  "BeamSpotOnlineLegacyObjectsRcd" : 
+        myTagName = 'BSLegacy_tag'
+    else:
+        myTagName = 'BSHLT_tag'
+else:
+    myTagName = options.inputTag
+
+from CondCore.CondDB.CondDB_cfi import *
+#CondDBBeamSpotOnlineLegacy = CondDB.clone(connect = cms.string("sqlite_file:test_%s.db" % myTagName)) # customize with input db file
+CondDBBeamSpotOnlineLegacy = CondDB.clone(connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")) # customize with input db file
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    CondDBBeamSpotOnlineLegacy,
+    DumpStat=cms.untracked.bool(True),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string(options.inputRecord),  # BeamSpotOnline record
+        tag = cms.string(myTagName)                 # choose your favourite tag
+    ))
+)
+
+print("isForHLT: ",(options.inputRecord ==  "BeamSpotOnlineHLTObjectsRcd"))
+
+#################################
+# Produce a SQLITE FILE
+#################################
+CondDBBeamSpotObjects = CondDB.clone(connect = cms.string('sqlite_file:test_%s.db' % myTagName)) # choose an output name
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBBeamSpotObjects,
+                                          timetype = cms.untracked.string('lumiid'), #('lumiid'), #('runnumber')
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string(options.inputRecord), # BeamSpotOnline record
+                                                                     tag = cms.string(myTagName))),             # choose your favourite tag
+                                          loadBlobStreamer = cms.untracked.bool(False)
+                                          )
+
+####################################################################
+# Load and configure analyzer
+####################################################################
+process.beamspotonlineshifter = cms.EDAnalyzer("BeamSpotOnlineShifter",
+                                              isHLT = cms.bool((options.inputRecord ==  "BeamSpotOnlineHLTObjectsRcd")),
+                                              xShift =  cms.double(+0.000141),
+                                              yShift =  cms.double(+0.000826),
+                                              zShift =  cms.double(+0.000277))
+                                   
+# Put module in path:
+process.p = cms.Path(process.beamspotonlineshifter)

--- a/CondTools/BeamSpot/test/BeamSpotOnlineShifter_cfg.py
+++ b/CondTools/BeamSpot/test/BeamSpotOnlineShifter_cfg.py
@@ -24,12 +24,17 @@ options.register('startLumi',
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.int, # string, int, or float
                  "IOV Start Lumi")
+options.register('maxLSToRead',
+                 10, ## default value for unit test
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.int, # string, int, or float
+                 "total number of LumiSections to read in input")
 options.parseArguments()
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 100000                         # do not clog output with IO
+process.MessageLogger.cerr.FwkReport.reportEvery = 100000 # do not clog output with IO
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000000))   # large number of events is needed since we probe 5000LS for run (see below)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxLSToRead))   # large number of events is needed since we probe 5000LS for run (see below)
 
 ####################################################################
 # Empty source 
@@ -55,11 +60,12 @@ process.GlobalTag.toGet =  cms.VPSet(cms.PSet(record = cms.string("TrackerAlignm
                                               tag = cms.string("TrackerAlignment_collisions23_forHLT_v9"), # choose your favourite tag
                                               label = cms.untracked.string("target")))                     # target label
 
-process.GlobalTag.DumpStats = cms.untracked.bool(True)
+#process.GlobalTag.DumpStat = cms.untracked.bool(True)
 
 myTagName = options.inputTag
 
 print("isForHLT: ",(options.inputRecord ==  "BeamSpotOnlineHLTObjectsRcd"))
+print("max LS to Read: ",options.maxLSToRead)
 
 #################################
 # Produce a SQLITE FILE

--- a/CondTools/BeamSpot/test/BuildFile.xml
+++ b/CondTools/BeamSpot/test/BuildFile.xml
@@ -1,1 +1,2 @@
 <test name="testReadWriteBeamSpotsFromDB" command="testReadWriteBeamSpotsFromDB.sh"/>
+<test name="testShiftBeamSpotsFromDB" command="testShiftBeamSpotsFromDB.sh"/>

--- a/CondTools/BeamSpot/test/testShiftBeamSpotsFromDB.sh
+++ b/CondTools/BeamSpot/test/testShiftBeamSpotsFromDB.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING BeamSpotOnline From DB shifting codes ..."
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineShifter_cfg.py inputTag=BeamSpotOnlineLegacy startRun=375491 startLumi=1 || die "Failure shifting payload from BeamSpotOnlineLegacy" $?
+cmsRun ${SCRAM_TEST_PATH}/BeamSpotOnlineShifter_cfg.py inputTag=BeamSpotOnlineHLT startRun=375491 startLumi=1 inputRecord=BeamSpotOnlineHLTObjectsRcd  || die "Failure shifting payload from BeamSpotOnlineHLT" $?


### PR DESCRIPTION
#### PR description:

In full track validations for tracker alignment purposes it frequently happens that the HLT tracking report is inconclusive because changing the HLT alignment without a correponding HLT beamspot update results in various shifts in variables related to the track DCA w.r.t the beamspot.
In a first approximation (without a full re-derivation of the beamspot) one could think of shifting by hand the values of the x,y,z parameters in the `BeamSpotOnlineObjects` used in HLT reconstruction by the amount of which the (Barrel) pixel is moved from the alignment updated.
This PR supplies in `cmssw` the tool for doing such operation, automatically and programmatically IoV by IoV in a given lumi section range.

#### PR validation:

Privately run the following commands:

```
cmsRun BeamSpotOnlineShifter_cfg.py inputTag=BeamSpotOnlineHLT startRun=375491 startLumi=1 inputRecord=BeamSpotOnlineHLTObjectsRcd
```

and

```
cmsRun BeamSpotOnlineShifter_cfg.py inputTag=BeamSpotOnlineLegacy startRun=375491 startLumi=1
```

in the context of https://its.cern.ch/jira/browse/CMSALCA-240.
In addition this PR adds a unit test that was exercises successfully before submitting.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
