### PR TITLE
Update the DependencyGraph service

### DIFF
--- a/FWCore/Services/plugins/DependencyGraph.cc
+++ b/FWCore/Services/plugins/DependencyGraph.cc
@@ -361,6 +361,12 @@ void DependencyGraph::postBeginJob() {
   if (not m_initialized)
     return;
 
+  // remove the nodes corresponding to the modules that have been removed from the process
+  for (int i = boost::num_vertices(m_graph) - 1; i > 1; --i) {
+    if (m_graph.m_graph[i].label.empty())
+      boost::remove_vertex(i, m_graph.m_graph);
+  }
+
   // draw the dependency graph
   std::ofstream out(m_filename);
   boost::write_graphviz(out, m_graph);


### PR DESCRIPTION
#### PR description:

Update the DependencyGraph service:
  - save each Path and EndPath as a Graphviz subgraph
  - remove nodes corresponding to removed modules
  - add soft dependencies for PathStatusInserter and TriggerResults
 
#### PR validation:

Tested on the step2 of the 24834.75_TTbar_14TeV+2026D98_HLT75e33 workflow:
  - [dependency.dot.gz](https://github.com/cms-sw/cmssw/files/13590053/dependency.dot.gz)
  - [dependency.pdf](https://github.com/cms-sw/cmssw/files/13590060/dependency.pdf)


