### PR TITLE
Allow a stream to skip a lumi if all events processed

### DIFF
--- a/FWCore/Framework/test/modules_2_concurrent_lumis_cfg.py
+++ b/FWCore/Framework/test/modules_2_concurrent_lumis_cfg.py
@@ -15,45 +15,45 @@ process.prod = cms.EDProducer("BusyWaitIntProducer",
                               iterations = cms.uint32(50*1000*20) )
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
-    transitions = cms.int32(60)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
 )
 
 process.LumiSumLumiProd = cms.EDProducer("edmtest::global::LumiSummaryLumiProducer",
-    transitions = cms.int32(70)
+    transitions = cms.int32(34)
     ,cachevalue = cms.int32(2)
 )
 
 process.LumiSumIntFilter = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
-    transitions = cms.int32(84)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
 )
 
 process.LumiSumIntAnalyzer = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(84)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
 )
 
 process.LimitedLumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
-    transitions = cms.int32(60)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
     ,concurrencyLimit = cms.untracked.uint32(1)
 )
 
 process.LimitedLumiSumLumiProd = cms.EDProducer("edmtest::limited::LumiSummaryLumiProducer",
-    transitions = cms.int32(70)
+    transitions = cms.int32(34)
     ,cachevalue = cms.int32(2)
     ,concurrencyLimit = cms.untracked.uint32(1)
 )
 
 process.LimitedLumiSumIntFilter = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
-    transitions = cms.int32(84)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
     ,concurrencyLimit = cms.untracked.uint32(1)
 )
 
 process.LimitedLumiSumIntAnalyzer = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(84)
+    transitions = cms.int32(44)
     ,cachevalue = cms.int32(2)
     ,concurrencyLimit = cms.untracked.uint32(1)
 )

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -55,15 +55,21 @@ namespace edmtest {
 
     class StreamIntFilter : public edm::global::EDFilter<edm::StreamCache<UnsafeCache>> {
     public:
-      explicit StreamIntFilter(edm::ParameterSet const& p) : trans_(p.getParameter<int>("transitions")) {
+      explicit StreamIntFilter(edm::ParameterSet const& p)
+          : trans_(p.getParameter<int>("transitions")), nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
         produces<unsigned int>();
       }
 
       const unsigned int trans_;
+      const unsigned int nLumis_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamBeginLumiTransitions{0};
+      mutable std::atomic<unsigned int> m_countStreamEndLumiTransitions{0};
 
       std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
         ++m_count;
+        ++m_countStreams;
         auto sCache = std::make_unique<UnsafeCache>();
         ++(sCache->strm);
         sCache->value = iID.value();
@@ -85,7 +91,7 @@ namespace edmtest {
       void streamBeginLuminosityBlock(edm::StreamID iID,
                                       edm::LuminosityBlock const&,
                                       edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamBeginLumiTransitions;
         auto sCache = streamCache(iID);
         if (sCache->value != iID.value()) {
           throw cms::Exception("cache value") << (streamCache(iID))->value << " but it was supposed to be " << iID;
@@ -114,7 +120,7 @@ namespace edmtest {
       void streamEndLuminosityBlock(edm::StreamID iID,
                                     edm::LuminosityBlock const&,
                                     edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamEndLumiTransitions;
         auto sCache = streamCache(iID);
         if (sCache->value != iID.value()) {
           throw cms::Exception("cache value") << (streamCache(iID))->value << " but it was supposed to be " << iID;
@@ -156,6 +162,19 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "StreamIntFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamBeginLumiTransitions = m_countStreamBeginLumiTransitions.load();
+        unsigned int nStreamEndLumiTransitions = m_countStreamEndLumiTransitions.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamBeginLumiTransitions < nLumis_ || nStreamBeginLumiTransitions > (nLumis_ * nStreams)) {
+          throw cms::Exception("transitions")
+              << "StreamIntFilter stream begin lumi transitions " << nStreamBeginLumiTransitions
+              << " but it was supposed to be between " << nLumis_ << " and " << nLumis_ * nStreams;
+        }
+        if (nStreamEndLumiTransitions != nStreamBeginLumiTransitions) {
+          throw cms::Exception("transitions")
+              << "StreamIntFilter stream end lumi transitions " << nStreamEndLumiTransitions
+              << " does not equal stream begin lumi transitions " << nStreamBeginLumiTransitions;
         }
       }
     };
@@ -364,15 +383,20 @@ namespace edmtest {
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countLumis{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamLumiTransitions{0};
 
       std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
         ++m_count;
+        ++m_countStreams;
         return std::make_unique<Cache>();
       }
 
       std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                                                      edm::EventSetup const&) const override {
         ++m_count;
+        ++m_countLumis;
         auto gCache = std::make_shared<UnsafeCache>();
         gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return gCache;
@@ -388,7 +412,7 @@ namespace edmtest {
                                            edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
-        ++m_count;
+        ++m_countStreamLumiTransitions;
         if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("out of sequence")
               << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
@@ -415,6 +439,14 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiSummaryIntFilter transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamLumiTransitions = m_countStreamLumiTransitions.load();
+        unsigned int nLumis = m_countLumis.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamLumiTransitions < nLumis || nStreamLumiTransitions > (nLumis * nStreams)) {
+          throw cms::Exception("transitions")
+              << "LumiSummaryIntFilter stream lumi transitions " << nStreamLumiTransitions
+              << " but it was supposed to be between " << nLumis << " and " << nLumis * nStreams;
         }
       }
     };

--- a/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedAnalyzers.cc
@@ -52,16 +52,22 @@ namespace edmtest {
       explicit StreamIntAnalyzer(edm::ParameterSet const& p)
           : edm::limited::EDAnalyzerBase(p),
             edm::limited::EDAnalyzer<edm::StreamCache<UnsafeCache>>(p),
-            trans_(p.getParameter<int>("transitions")) {
+            trans_(p.getParameter<int>("transitions")),
+            nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
         callWhenNewProductsRegistered([](edm::BranchDescription const& desc) {
           std::cout << "limited::StreamIntAnalyzer " << desc.moduleLabel() << std::endl;
         });
       }
       const unsigned int trans_;
+      const unsigned int nLumis_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamBeginLumiTransitions{0};
+      mutable std::atomic<unsigned int> m_countStreamEndLumiTransitions{0};
 
       std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
         ++m_count;
+        ++m_countStreams;
         auto pCache = std::make_unique<UnsafeCache>();
         pCache->value = iID.value();
         return pCache;
@@ -78,7 +84,7 @@ namespace edmtest {
       void streamBeginLuminosityBlock(edm::StreamID iID,
                                       edm::LuminosityBlock const&,
                                       edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamBeginLumiTransitions;
         if ((streamCache(iID))->value != iID.value()) {
           throw cms::Exception("cache value")
               << "StreamIntAnalyzer cache value " << (streamCache(iID))->value << " but it was supposed to be " << iID;
@@ -96,7 +102,7 @@ namespace edmtest {
       void streamEndLuminosityBlock(edm::StreamID iID,
                                     edm::LuminosityBlock const&,
                                     edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamEndLumiTransitions;
         if ((streamCache(iID))->value != iID.value()) {
           throw cms::Exception("cache value")
               << "StreamIntAnalyzer cache value " << (streamCache(iID))->value << " but it was supposed to be " << iID;
@@ -123,6 +129,19 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "StreamIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamBeginLumiTransitions = m_countStreamBeginLumiTransitions.load();
+        unsigned int nStreamEndLumiTransitions = m_countStreamEndLumiTransitions.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamBeginLumiTransitions < nLumis_ || nStreamBeginLumiTransitions > (nLumis_ * nStreams)) {
+          throw cms::Exception("transitions")
+              << "StreamIntAnalyzer stream begin lumi transitions " << nStreamBeginLumiTransitions
+              << " but it was supposed to be between " << nLumis_ << " and " << nLumis_ * nStreams;
+        }
+        if (nStreamEndLumiTransitions != nStreamBeginLumiTransitions) {
+          throw cms::Exception("transitions")
+              << "StreamIntAnalyzer stream end lumi transitions " << nStreamEndLumiTransitions
+              << " does not equal stream begin lumi transitions " << nStreamBeginLumiTransitions;
         }
       }
     };
@@ -272,15 +291,20 @@ namespace edmtest {
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countLumis{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamLumiTransitions{0};
 
       std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
         ++m_count;
+        ++m_countStreams;
         return std::make_unique<UnsafeCache>();
       }
 
       std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                                                      edm::EventSetup const&) const override {
         ++m_count;
+        ++m_countLumis;
         auto gCache = std::make_shared<UnsafeCache>();
         gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return gCache;
@@ -295,7 +319,7 @@ namespace edmtest {
                                            edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
-        ++m_count;
+        ++m_countStreamLumiTransitions;
         if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("UnexpectedValue")
               << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
@@ -321,6 +345,14 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiSummaryIntAnalyzer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamLumiTransitions = m_countStreamLumiTransitions.load();
+        unsigned int nLumis = m_countLumis.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamLumiTransitions < nLumis || nStreamLumiTransitions > (nLumis * nStreams)) {
+          throw cms::Exception("transitions")
+              << "LumiSummaryIntAnalyzer stream lumi transitions " << nStreamLumiTransitions
+              << " but it was supposed to be between " << nLumis << " and " << nLumis * nStreams;
         }
       }
     };

--- a/FWCore/Framework/test/stubs/TestLimitedProducers.cc
+++ b/FWCore/Framework/test/stubs/TestLimitedProducers.cc
@@ -59,15 +59,21 @@ namespace edmtest {
       explicit StreamIntProducer(edm::ParameterSet const& p)
           : edm::limited::EDProducerBase(p),
             edm::limited::EDProducer<edm::StreamCache<UnsafeCache>>(p),
-            trans_(p.getParameter<int>("transitions")) {
+            trans_(p.getParameter<int>("transitions")),
+            nLumis_(p.getUntrackedParameter<unsigned int>("nLumis", 1)) {
         produces<unsigned int>();
       }
 
       const unsigned int trans_;
+      const unsigned int nLumis_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamBeginLumiTransitions{0};
+      mutable std::atomic<unsigned int> m_countStreamEndLumiTransitions{0};
 
       std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
         ++m_count;
+        ++m_countStreams;
         auto sCache = std::make_unique<UnsafeCache>();
         ++(sCache->strm);
         sCache->value = iID.value();
@@ -79,7 +85,7 @@ namespace edmtest {
         auto sCache = streamCache(iID);
         if (sCache->value != iID.value()) {
           throw cms::Exception("cache value")
-              << "StreamIntAnalyzer cache value " << (streamCache(iID))->value << " but it was supposed to be " << iID;
+              << "StreamIntProducer cache value " << (streamCache(iID))->value << " but it was supposed to be " << iID;
         }
         if (sCache->run != 0 || sCache->lumi != 0 || sCache->work != 0 || sCache->strm != 1) {
           throw cms::Exception("out of sequence") << "streamBeginRun out of sequence in Stream " << iID.value();
@@ -90,7 +96,7 @@ namespace edmtest {
       void streamBeginLuminosityBlock(edm::StreamID iID,
                                       edm::LuminosityBlock const&,
                                       edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamBeginLumiTransitions;
         auto sCache = streamCache(iID);
         if (sCache->lumi != 0 || sCache->work != 0) {
           throw cms::Exception("out of sequence")
@@ -111,7 +117,7 @@ namespace edmtest {
       void streamEndLuminosityBlock(edm::StreamID iID,
                                     edm::LuminosityBlock const&,
                                     edm::EventSetup const&) const override {
-        ++m_count;
+        ++m_countStreamEndLumiTransitions;
         auto sCache = streamCache(iID);
         --(sCache->lumi);
         sCache->work = 0;
@@ -144,6 +150,19 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "StreamIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamBeginLumiTransitions = m_countStreamBeginLumiTransitions.load();
+        unsigned int nStreamEndLumiTransitions = m_countStreamEndLumiTransitions.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamBeginLumiTransitions < nLumis_ || nStreamBeginLumiTransitions > (nLumis_ * nStreams)) {
+          throw cms::Exception("transitions")
+              << "StreamIntProducer stream begin lumi transitions " << nStreamBeginLumiTransitions
+              << " but it was supposed to be between " << nLumis_ << " and " << nLumis_ * nStreams;
+        }
+        if (nStreamEndLumiTransitions != nStreamBeginLumiTransitions) {
+          throw cms::Exception("transitions")
+              << "StreamIntProducer stream end lumi transitions " << nStreamEndLumiTransitions
+              << " does not equal stream begin lumi transitions " << nStreamBeginLumiTransitions;
         }
       }
     };
@@ -354,18 +373,27 @@ namespace edmtest {
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countLumis{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamLumiTransitions{0};
 
-      std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override { return std::make_unique<UnsafeCache>(); }
+      std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+        ++m_count;
+        ++m_countStreams;
+        return std::make_unique<UnsafeCache>();
+      }
 
       std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                                                      edm::EventSetup const&) const override {
         ++m_count;
+        ++m_countLumis;
         auto gCache = std::make_shared<UnsafeCache>();
         gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return gCache;
       }
 
       void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+        ++m_count;
         auto sCache = streamCache(iID);
         ++(sCache->value);
       }
@@ -374,7 +402,7 @@ namespace edmtest {
                                            edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
-        ++m_count;
+        ++m_countStreamLumiTransitions;
         if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("UnexpectedValue")
               << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
@@ -402,6 +430,14 @@ namespace edmtest {
           throw cms::Exception("transitions")
               << "LumiSummaryIntProducer transitions " << m_count << " but it was supposed to be " << trans_;
         }
+        unsigned int nStreamLumiTransitions = m_countStreamLumiTransitions.load();
+        unsigned int nLumis = m_countLumis.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamLumiTransitions < nLumis || nStreamLumiTransitions > (nLumis * nStreams)) {
+          throw cms::Exception("transitions")
+              << "LumiSummaryIntProducer stream lumi transitions " << nStreamLumiTransitions
+              << " but it was supposed to be between " << nLumis << " and " << nLumis * nStreams;
+        }
       }
     };
 
@@ -421,12 +457,20 @@ namespace edmtest {
       const unsigned int trans_;
       const unsigned int cvalue_;
       mutable std::atomic<unsigned int> m_count{0};
+      mutable std::atomic<unsigned int> m_countLumis{0};
+      mutable std::atomic<unsigned int> m_countStreams{0};
+      mutable std::atomic<unsigned int> m_countStreamLumiTransitions{0};
 
-      std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override { return std::make_unique<UnsafeCache>(); }
+      std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+        ++m_count;
+        ++m_countStreams;
+        return std::make_unique<UnsafeCache>();
+      }
 
       std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB,
                                                                      edm::EventSetup const&) const override {
         ++m_count;
+        ++m_countLumis;
         auto gCache = std::make_shared<UnsafeCache>();
         gCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return gCache;
@@ -441,7 +485,7 @@ namespace edmtest {
                                            edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            UnsafeCache* gCache) const override {
-        ++m_count;
+        ++m_countStreamLumiTransitions;
         if (gCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("UnexpectedValue")
               << "streamEndLuminosityBlockSummary unexpected lumi number in Stream " << iID.value();
@@ -477,6 +521,14 @@ namespace edmtest {
         if (m_count != trans_) {
           throw cms::Exception("transitions")
               << "LumiSummaryLumiProducer transitions " << m_count << " but it was supposed to be " << trans_;
+        }
+        unsigned int nStreamLumiTransitions = m_countStreamLumiTransitions.load();
+        unsigned int nLumis = m_countLumis.load();
+        unsigned int nStreams = m_countStreams.load();
+        if (nStreamLumiTransitions < nLumis || nStreamLumiTransitions > (nLumis * nStreams)) {
+          throw cms::Exception("transitions")
+              << "LumiSummaryLumiProducer stream lumi transitions " << nStreamLumiTransitions
+              << " but it was supposed to be between " << nLumis << " and " << nLumis * nStreams;
         }
       }
     };

--- a/FWCore/Framework/test/testRunLumiCaches_cfg.py
+++ b/FWCore/Framework/test/testRunLumiCaches_cfg.py
@@ -49,7 +49,7 @@ process.globalLumiIntProd = cms.EDProducer("edmtest::global::LumiIntProducer",
 )
 
 process.globalLumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
-    transitions = cms.int32(2*nLumis+nStreams*nLumis)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 
@@ -69,7 +69,7 @@ process.globalLumiIntFilt = cms.EDFilter("edmtest::global::LumiIntFilter",
 )
 
 process.globalLumiSumIntFilt = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
-    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 
@@ -90,7 +90,7 @@ process.globalLumiIntAna = cms.EDAnalyzer("edmtest::global::LumiIntAnalyzer",
 )
 
 process.globalLumiSumIntAna = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 
@@ -114,7 +114,7 @@ process.limitedLumiIntProd = cms.EDProducer("edmtest::limited::LumiIntProducer",
 
 process.limitedLumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams*nLumis+2*nLumis)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 
@@ -138,7 +138,7 @@ process.limitedLumiIntFilt = cms.EDFilter("edmtest::limited::LumiIntFilter",
 
 process.limitedLumiSumIntFilt = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 
@@ -163,7 +163,7 @@ process.limitedLumiIntAna = cms.EDAnalyzer("edmtest::limited::LumiIntAnalyzer",
 
 process.limitedLumiSumIntAna = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    transitions = cms.int32(nStreams+2*nLumis+nEvents)
     ,cachevalue = cms.int32(nEventsPerLumi)
 )
 

--- a/FWCore/Framework/test/test_earlyTerminationSignal.sh
+++ b/FWCore/Framework/test/test_earlyTerminationSignal.sh
@@ -22,7 +22,7 @@ echo "running cmsRun test_dependentRunDataAndException_cfg.py"
 (cmsRun ${LOCAL_TEST_DIR}/test_dependentRunDataAndException_cfg.py 2>&1 | grep -q "Intentional 'NotFound' exception for testing purposes") || die "dependent Run data and Exceptions failed" $?
 
 echo "running cmsRun test_exceptionAtGlobalBeginRun_cfg.py"
-(cmsRun ${LOCAL_TEST_DIR}/test_exceptionAtGlobalBeginRun_cfg.py 2>&1 | grep -q -v "An exception of category 'transitions' occurred") || die "exception at globalBeginRun failed" $?
+(cmsRun ${LOCAL_TEST_DIR}/test_exceptionAtGlobalBeginRun_cfg.py 2>&1 | grep "Another exception was caught while endJob was running") && die "test_exceptionAtGlobalBeginRun failed, should not be any endJob exceptions" 1
 
 echo "running cmsRun  test_exceptionInShortLumi_cfg.py"
 cmsRun ${LOCAL_TEST_DIR}/test_exceptionInShortLumi_cfg.py; test_failure "test_exceptionInShortLumi_cfg.py failed" $?

--- a/FWCore/Framework/test/test_exceptionAtGlobalBeginRun_cfg.py
+++ b/FWCore/Framework/test/test_exceptionAtGlobalBeginRun_cfg.py
@@ -6,7 +6,9 @@ process.source = cms.Source("EmptySource")
 
 process.fail = cms.EDProducer("edmtest::FailingInRunProducer")
 
-process.tstStream = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions=cms.int32(2))
+process.tstStream = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer",
+                                   transitions=cms.int32(2),
+                                   nLumis = cms.untracked.uint32(0))
 process.tstGlobal = cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
                                    transitions=cms.int32(2),
                                    cachevalue = cms.int32(0))
@@ -16,7 +18,9 @@ process.p = cms.Path(process.fail+process.tstStream+process.tstGlobal)
 process.add_(cms.Service("Tracer"))
 
 process2 = cms.Process("Test2")
-process2.tstStreamSub = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions=cms.int32(2))
+process2.tstStreamSub = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer",
+                                       transitions=cms.int32(2),
+                                       nLumis = cms.untracked.uint32(0))
 process2.tstGlobalSub = cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
                                    transitions=cms.int32(2),
                                    cachevalue = cms.int32(0))

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -28,8 +28,9 @@ process.source = cms.Source("EmptySource",
 )
 
 process.StreamIntProd = cms.EDProducer("edmtest::global::StreamIntProducer",
-    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2)))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntProd = cms.EDProducer("edmtest::global::RunIntProducer",
@@ -48,7 +49,7 @@ process.RunSumIntProd = cms.EDProducer("edmtest::global::RunSummaryIntProducer",
 )
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
-    transitions = cms.int32(int(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi)))
+    transitions = cms.int32(int(nEvt+nStreams+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
@@ -95,8 +96,9 @@ process.TestEndLumiBlockProd = cms.EDProducer("edmtest::global::TestEndLumiBlock
 )
 
 process.StreamIntAn = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer",
-    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2)))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntAn= cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
@@ -117,7 +119,7 @@ process.RunSumIntAn = cms.EDAnalyzer("edmtest::global::RunSummaryIntAnalyzer",
 )
 
 process.LumiSumIntAn = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
-    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi)))
+    transitions = cms.int32(int(nEvt+nStreams+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
@@ -128,8 +130,9 @@ process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::global::ProcessBlockIntAnal
 )
 
 process.StreamIntFil = cms.EDFilter("edmtest::global::StreamIntFilter",
-    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2)))
+    transitions = cms.int32(int(nEvt+nStreams*(2*(nEvt/nEvtRun)+2)))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntFil = cms.EDFilter("edmtest::global::RunIntFilter",
@@ -148,7 +151,7 @@ process.RunSumIntFil = cms.EDFilter("edmtest::global::RunSummaryIntFilter",
 )
 
 process.LumiSumIntFil = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
-    transitions = cms.int32(int(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi)))
+    transitions = cms.int32(int(nEvt+nStreams+2*(nEvt/nEvtLumi)))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 

--- a/FWCore/Framework/test/test_limited_modules_cfg.py
+++ b/FWCore/Framework/test/test_limited_modules_cfg.py
@@ -30,8 +30,9 @@ process.source = cms.Source("EmptySource",
 
 process.StreamIntProd = cms.EDProducer("edmtest::limited::StreamIntProducer",
     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntProd = cms.EDProducer("edmtest::limited::RunIntProducer",
@@ -54,7 +55,7 @@ process.RunSumIntProd = cms.EDProducer("edmtest::limited::RunSummaryIntProducer"
 
 process.LumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
                                         concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nStreams*int(nEvt/nEvtLumi)+2*int(nEvt/nEvtLumi))
+    transitions = cms.int32(nStreams+nEvt+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
@@ -111,8 +112,9 @@ process.TestEndLumiBlockProd = cms.EDProducer("edmtest::limited::TestEndLumiBloc
 
 process.StreamIntAn = cms.EDAnalyzer("edmtest::limited::StreamIntAnalyzer",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntAn= cms.EDAnalyzer("edmtest::limited::RunIntAnalyzer",
@@ -137,7 +139,7 @@ process.RunSumIntAn = cms.EDAnalyzer("edmtest::limited::RunSummaryIntAnalyzer",
 
 process.LumiSumIntAn = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
                                       concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtLumi)+1)+2*int(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+nStreams+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 
@@ -150,8 +152,9 @@ process.ProcessBlockIntAn = cms.EDAnalyzer("edmtest::limited::ProcessBlockIntAna
 
 process.StreamIntFil = cms.EDFilter("edmtest::limited::StreamIntFilter",
                                     concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2*int(nEvt/nEvtLumi)+2))
+    transitions = cms.int32(nEvt+nStreams*(2*int(nEvt/nEvtRun)+2))
     ,cachevalue = cms.int32(1)
+    ,nLumis = cms.untracked.uint32(int(nEvt/nEvtLumi))
 )
 
 process.RunIntFil = cms.EDFilter("edmtest::limited::RunIntFilter",
@@ -174,7 +177,7 @@ process.RunSumIntFil = cms.EDFilter("edmtest::limited::RunSummaryIntFilter",
 
 process.LumiSumIntFil = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
                                      concurrencyLimit = cms.untracked.uint32(1),
-    transitions = cms.int32(nEvt+nStreams*(int(nEvt/nEvtLumi)+1)+2*int(nEvt/nEvtLumi))
+    transitions = cms.int32(nEvt+nStreams+2*int(nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvtLumi)
 )
 

--- a/FWCore/Integration/test/test_TryToContinue_cfg.py
+++ b/FWCore/Integration/test/test_TryToContinue_cfg.py
@@ -25,9 +25,9 @@ elif args.inLumi:
 else:
     process.fail = cms.EDProducer("FailingProducer")
 
-process.shouldRun1 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6+3), verbose = cms.untracked.bool(False))
-process.shouldRun2 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6+3), verbose = cms.untracked.bool(False))
-process.shouldNotRun = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(6), verbose = cms.untracked.bool(False))
+process.shouldRun1 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(4+3), nLumis = cms.untracked.uint32(1), verbose = cms.untracked.bool(False))
+process.shouldRun2 = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(4+3), nLumis = cms.untracked.uint32(1), verbose = cms.untracked.bool(False))
+process.shouldNotRun = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer", transitions = cms.int32(4), nLumis = cms.untracked.uint32(1), verbose = cms.untracked.bool(False))
 process.dependentFilter = cms.EDFilter("IntProductFilter",
    label = cms.InputTag("fail"),
    threshold = cms.int32(0),
@@ -52,12 +52,18 @@ if args.inRun:
     process.shouldRun1.transitions=2
     process.shouldRun2.transitions=2
     process.shouldNotRun.transitions=2
+    process.shouldRun1.nLumis=0
+    process.shouldRun2.nLumis=0
+    process.shouldNotRun.nLumis=0
 
 if args.inLumi:
     process.independentAnalyzer.expectedSum = 0
     process.shouldRun1.transitions=4
     process.shouldRun2.transitions=4
     process.shouldNotRun.transitions=4
+    process.shouldRun1.nLumis=0
+    process.shouldRun2.nLumis=0
+    process.shouldNotRun.nLumis=0
 
 process.seq = cms.Sequence()
 process.t = cms.Task(process.intProd,process.addInts)
@@ -71,5 +77,3 @@ process.goodPath = cms.Path(process.shouldRun2)
 
 process.errorEndPath = cms.EndPath(process.dependentAnalyzer)
 process.goodEndPath = cms.EndPath(process.independentAnalyzer)
-
-


### PR DESCRIPTION
#### PR description:

This PR will make the Framework try to direct a stream to skip a lumi if all events have been processed by other streams and the stream has not started the luminosity block yet.

Note that a stream might have started a lumi but not gotten any events yet and then it is too late to skip the lumi. Even after this PR is merged, it will still be possible for a stream to just run begin stream lumi and end stream lumi with no events. 

This new behavior will be a performance improvement when one event takes a very long time to process. Before this PR, the stream processing that event cannot process any subsequent lumis and those lumis cannot complete until after the event completes. If the limit on the number of lumis is reached, all other work might become stuck until the slow event completes.

#### PR validation:

All pre-existing unit Core unit tests pass.
