### PR TITLE
Add integer hw accessor function to P2GTCandidate

### DIFF
--- a/DataFormats/L1Trigger/interface/P2GTCandidate.h
+++ b/DataFormats/L1Trigger/interface/P2GTCandidate.h
@@ -256,6 +256,27 @@ namespace l1t {
 
     ObjectType objectType() const { return objectType_; }
 
+    // Nano SimpleCandidateFlatTableProducer accessor functions
+    int hwPT_toInt() const { return hwPT().to_int(); }
+    int hwPhi_toInt() const { return hwPhi().to_int(); }
+    int hwEta_toInt() const { return hwEta().to_int(); }
+    int hwZ0_toInt() const { return hwZ0().to_int(); }
+    int hwIso_toInt() const { return hwIso().to_int(); }
+    int hwQual_toInt() const { return hwQual().to_int(); }
+    int hwCharge_toInt() const { return hwCharge().to_int(); }
+    int hwD0_toInt() const { return hwD0().to_int(); }
+    int hwBeta_toInt() const { return hwBeta().to_int(); }
+    int hwMass_toInt() const { return hwMass().to_int(); }
+    int hwIndex_toInt() const { return hwIndex().to_int(); }
+    int hwSeed_pT_toInt() const { return hwSeed_pT().to_int(); }
+    int hwSeed_z0_toInt() const { return hwSeed_z0().to_int(); }
+    int hwSca_sum_toInt() const { return hwSca_sum().to_int(); }
+    int hwNumber_of_tracks_toInt() const { return hwNumber_of_tracks().to_int(); }
+    int hwSum_pT_pv_toInt() const { return hwSum_pT_pv().to_int(); }
+    int hwType_toInt() const { return hwType().to_int(); }
+    int hwNumber_of_tracks_in_pv_toInt() const { return hwNumber_of_tracks_in_pv().to_int(); }
+    int hwNumber_of_tracks_not_in_pv_toInt() const { return hwNumber_of_tracks_not_in_pv().to_int(); }
+
     bool operator==(const P2GTCandidate& rhs) const;
     bool operator!=(const P2GTCandidate& rhs) const;
 


### PR DESCRIPTION
#### PR description:

Integer hardware accessor function intended to be used with the `SimpleCandidateFlatTableProducer` to store our object within Nano. The nicer solution would be if something like this was possible

```python
 cms.EDProducer(
    "SimpleCandidateFlatTableProducer",
    src = cms.InputTag('l1tGTProducer','GTTPrimaryVert'),
    name = cms.string("L1GTVertex"),
    doc = cms.string("GT GTT Vertices"),
    singleton = cms.bool(False), # the number of entries is variable
    variables = cms.PSet(
        hwZ0 = Var("hwZ0().to_int()", int, doc = "HW primary vertex position z coordinate")
    )
)
```

However, since `ap_int` doesn't have a ROOT dict (although `ap_int` itself is never stored in the file) it doesn't work. Hence, this PR.

