### PR TITLE
Protect against nEvents = 0 in denominator in Validation/RecoParticleFlow/plugins/PFJetDQMPostProcessor.cc

### DIFF
--- a/Validation/RecoParticleFlow/plugins/PFJetDQMPostProcessor.cc
+++ b/Validation/RecoParticleFlow/plugins/PFJetDQMPostProcessor.cc
@@ -124,6 +124,8 @@ void PFJetDQMPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGett
       continue;
     me = iget_.get(stitle);
     int nEvents = ((TH1F*)me->getTH1F())->GetEntries();
+    if (nEvents == 0)
+      continue;
     iget_.setCurrentFolder(jetResponseDir[idir]);
 
     bool isNoJEC = (jetResponseDir[idir].find("noJEC") != std::string::npos);


### PR DESCRIPTION
#### PR description:

Add simple protection in PFJetDQMPostProcessor.cc against zero in denominator to hopefully address this issue (https://github.com/cms-sw/cmssw/issues/43456)

@peteryouBuffalo 

#### PR validation:

Compiled, ran code checks, ran code format, and that example workflow runs (141.044)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
