### PR TITLE
[13_3_X] Set HF FG bit thresholds for 2023 HI run

### DIFF
--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_2023_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_pp_on_PbPb_cff import Run3_pp_on_PbPb
 from Configuration.Eras.Modifier_run3_egamma_2023_cff import run3_egamma_2023
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_2023_cff import pp_on_PbPb_run3_2023
 
-Run3_pp_on_PbPb_2023 = cms.ModifierChain(Run3_pp_on_PbPb, run3_egamma_2023)
+Run3_pp_on_PbPb_2023 = cms.ModifierChain(Run3_pp_on_PbPb, run3_egamma_2023, pp_on_PbPb_run3_2023)

--- a/Configuration/Eras/python/Modifier_pp_on_PbPb_run3_2023_cff.py
+++ b/Configuration/Eras/python/Modifier_pp_on_PbPb_run3_2023_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+pp_on_PbPb_run3_2023 =  cms.Modifier()
+

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cff.py
@@ -40,3 +40,6 @@ pp_on_AA_2018.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [15, 19])
 
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 pp_on_PbPb_run3.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [14, 19])
+
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_2023_cff import pp_on_PbPb_run3_2023
+pp_on_PbPb_run3_2023.toModify(HcalTPGCoderULUT, FG_HF_thresholds = [16, 19])


### PR DESCRIPTION
#### PR description:
This PR updates the values of the HF thresholds in the HCAL TP emulator with those used during the 2023 PbPb run (as documented in https://twiki.cern.ch/twiki/bin/view/CMS/L1HIOverview2023).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport for CMSSW_13_3_X for HI MC 

@mandrenguyen 