### PR TITLE
Fix haddnano.py to handle zero-events nanoAOD files properly

### DIFF
--- a/PhysicsTools/NanoAOD/scripts/haddnano.py
+++ b/PhysicsTools/NanoAOD/scripts/haddnano.py
@@ -32,7 +32,7 @@ def zeroFill(tree, brName, brObj, allowNonBool=False):
 fileHandles = []
 goFast = True
 for fn in files:
-    print("Adding file" + str(fn))
+    print("Adding file", str(fn))
     fileHandles.append(ROOT.TFile.Open(fn))
     if fileHandles[-1].GetCompressionSettings() != fileHandles[0].GetCompressionSettings():
         goFast = False
@@ -44,7 +44,7 @@ of.cd()
 
 for e in fileHandles[0].GetListOfKeys():
     name = e.GetName()
-    print("Merging" + str(name))
+    print("Merging", str(name))
     obj = e.ReadObj()
     cl = ROOT.TClass.GetClass(e.GetClassName())
     inputs = ROOT.TList()
@@ -53,7 +53,18 @@ for e in fileHandles[0].GetListOfKeys():
         obj = obj.CloneTree(-1, "fast" if goFast else "")
         branchNames = set([x.GetName() for x in obj.GetListOfBranches()])
     for fh in fileHandles[1:]:
+        if isTree and obj.GetName() == 'Events' and obj.GetEntries() == 0 :
+            # Zero-events first file. Skip to avoid messing up branches.
+            print(" 'Events' tree contsins no events; skipping")
+            obj = fh.GetListOfKeys().FindObject(name).ReadObj()
+            obj = obj.CloneTree(-1, "fast" if goFast else "")
+            branchNames = set([x.GetName() for x in obj.GetListOfBranches()])
+            continue
         otherObj = fh.GetListOfKeys().FindObject(name).ReadObj()
+        if isTree and obj.GetName() == 'Events' and otherObj.GetEntries() == 0 :
+            # Zero-events file; skip
+            print(" 'Events' tree contains no events; skipping")
+            continue
         inputs.Add(otherObj)
         if isTree and obj.GetName() == 'Events':
             otherObj.SetAutoFlush(0)
@@ -61,7 +72,7 @@ for e in fileHandles[0].GetListOfKeys():
                                  for x in otherObj.GetListOfBranches()])
             missingBranches = list(branchNames - otherBranches)
             additionalBranches = list(otherBranches - branchNames)
-            print("missing: " + str(missingBranches) + "\n Additional:" + str(additionalBranches))
+            print("missing: " + str(missingBranches) + "\n Additional: " + str(additionalBranches))
             for br in missingBranches:
                 # fill "Other"
                 zeroFill(otherObj, br, obj.GetListOfBranches().FindObject(br))
@@ -76,7 +87,7 @@ for e in fileHandles[0].GetListOfKeys():
                                  for x in otherObj.GetListOfBranches()])
             missingBranches = list(branchNames - otherBranches)
             additionalBranches = list(otherBranches - branchNames)
-            print("missing: " + str(missingBranches) + "\n Additional:" + str(additionalBranches))
+            print("missing: " + str(missingBranches) + "\n Additional: " + str(additionalBranches))
             for br in missingBranches:
                 # fill "Other"
                 zeroFill(otherObj, br, obj.GetListOfBranches(


### PR DESCRIPTION
#### PR description:

Fix a mis-handled case in haddnano.py, where nanoAOD files with no events were wrongly recognized as files with missing branches. As a result, the hadded file had branches screwed up.

#### PR validation:

Tested using a file with no events, ([/store/data/Run2022F/MuonEG/NANOAOD/22Sep2023-v1/50000/4d76213a-ef14-411a-9558-559a6df3f978.root](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=%2Fstore%2Fdata%2FRun2022F%2FMuonEG%2FNANOAOD%2F22Sep2023-v1%2F50000%2F4d76213a-ef14-411a-9558-559a6df3f978.root)) in all possible conditions:

- several valid files + zero-event file as the first in the list
- several valid files + zero-event file in the middle of the list
- several valid files + zero-event file as the last in the list
- zero-event file as the only in the list





