### PR TITLE
Making ECAL detector based isolation more robust against noise

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTOffHelper.h
+++ b/DQMOffline/Trigger/interface/EgHLTOffHelper.h
@@ -49,6 +49,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+
 class EgammaHLTTrackIsolation;
 class HLTConfigProvider;
 class EcalSeverityLevelAlgo;
@@ -200,6 +203,8 @@ namespace egHLT {
 
     template <class T>
     static bool getHandle(const edm::Event& event, const edm::EDGetTokenT<T>& token, edm::Handle<T>& handle);
+
+    const EcalPFRecHitThresholds* thresholds = nullptr;
   };
 
   template <class T>

--- a/DQMOffline/Trigger/src/EgHLTOffHelper.cc
+++ b/DQMOffline/Trigger/src/EgHLTOffHelper.cc
@@ -309,7 +309,7 @@ void OffHelper::fillIsolData(const reco::GsfElectron& ele, OffEle::IsolData& iso
   } else
     isolData.hltTrksPho = 0.;
   if (calHLTEmIsol_)
-    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&ele) + ecalIsolAlgoEE.getEtSum(&ele);
+    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&ele, *thresholds) + ecalIsolAlgoEE.getEtSum(&ele, *thresholds);
   else
     isolData.hltEm = 0.;
 }
@@ -475,7 +475,7 @@ void OffHelper::fillIsolData(const reco::Photon& pho, OffPho::IsolData& isolData
   } else
     isolData.hltTrks = 0.;
   if (calHLTEmIsol_)
-    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&pho) + ecalIsolAlgoEE.getEtSum(&pho);
+    isolData.hltEm = ecalIsolAlgoEB.getEtSum(&pho, *thresholds) + ecalIsolAlgoEE.getEtSum(&pho, *thresholds);
   else
     isolData.hltEm = 0.;
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1162,11 +1162,11 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
       dr04.hcalRecHitSumEtBc[id] = eventData.hadIsolation04Bc.getHcalEtSumBc(&ele, id + 1);
     }
 
-    dr03.ecalRecHitSumEt = eventData.ecalBarrelIsol03.getEtSum(&ele);
-    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele);
+    dr03.ecalRecHitSumEt = eventData.ecalBarrelIsol03.getEtSum(&ele, thresholds);
+    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele, thresholds);
 
-    dr04.ecalRecHitSumEt = eventData.ecalBarrelIsol04.getEtSum(&ele);
-    dr04.ecalRecHitSumEt += eventData.ecalEndcapIsol04.getEtSum(&ele);
+    dr04.ecalRecHitSumEt = eventData.ecalBarrelIsol04.getEtSum(&ele, thresholds);
+    dr04.ecalRecHitSumEt += eventData.ecalEndcapIsol04.getEtSum(&ele, thresholds);
   }
 
   dr03.pre7DepthHcal = false;

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
@@ -22,6 +22,8 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
 
 class EgammaRecHitIsolation {
 public:
@@ -36,11 +38,19 @@ public:
                         const EcalSeverityLevelAlgo*,
                         DetId::Detector detector);
 
-  double getEtSum(const reco::Candidate* emObject) const { return getSum_(emObject, true); }
-  double getEnergySum(const reco::Candidate* emObject) const { return getSum_(emObject, false); }
+  double getEtSum(const reco::Candidate* emObject, EcalPFRecHitThresholds const& thresholds) const {
+    return getSum_(emObject, true, &thresholds);
+  }
+  double getEnergySum(const reco::Candidate* emObject, EcalPFRecHitThresholds const& thresholds) const {
+    return getSum_(emObject, false, &thresholds);
+  }
 
-  double getEtSum(const reco::SuperCluster* emObject) const { return getSum_(emObject, true); }
-  double getEnergySum(const reco::SuperCluster* emObject) const { return getSum_(emObject, false); }
+  double getEtSum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const& thresholds) const {
+    return getSum_(emObject, true, &thresholds);
+  }
+  double getEnergySum(const reco::SuperCluster* emObject, EcalPFRecHitThresholds const& thresholds) const {
+    return getSum_(emObject, false, &thresholds);
+  }
 
   void setUseNumCrystals(bool b = true) { useNumCrystals_ = b; }
   void setVetoClustered(bool b = true) { vetoClustered_ = b; }
@@ -61,8 +71,8 @@ public:
   ~EgammaRecHitIsolation();
 
 private:
-  double getSum_(const reco::Candidate*, bool returnEt) const;
-  double getSum_(const reco::SuperCluster*, bool returnEt) const;
+  double getSum_(const reco::Candidate*, bool returnEt, const EcalPFRecHitThresholds* thresholds) const;
+  double getSum_(const reco::SuperCluster*, bool returnEt, const EcalPFRecHitThresholds* thresholds) const;
 
   double extRadius_;
   double intRadius_;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
@@ -55,6 +55,8 @@ private:
 
   edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> sevLvToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometrytoken_;
+
+  const EcalPFRecHitThresholds* thresholds = nullptr;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -150,21 +152,21 @@ void EgammaEcalRecHitIsolationProducer::produce(edm::StreamID,
 
     if (tryBoth_) {  //barrel + endcap
       if (useIsolEt_)
-        isoValue =
-            ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i))) + ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
+        isoValue = ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i)), *thresholds) +
+                   ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)), *thresholds);
       else
-        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i))) +
-                   ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
+        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i)), *thresholds) +
+                   ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)), *thresholds);
     } else if (fabs(superClus->eta()) < 1.479) {  //barrel
       if (useIsolEt_)
-        isoValue = ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i)));
+        isoValue = ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i)), *thresholds);
       else
-        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i)));
+        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i)), *thresholds);
     } else {  //endcap
       if (useIsolEt_)
-        isoValue = ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
+        isoValue = ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)), *thresholds);
       else
-        isoValue = ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
+        isoValue = ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)), *thresholds);
     }
 
     //we subtract off the electron energy here as well

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -220,7 +220,6 @@ double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc,
           if (thresholds != nullptr) {
             rhThres = (*thresholds)[j->detid()];  // access ECAL PFRechit thresholds for noise cleaning
           }
-          std::cout << "rhThres = " << rhThres << "  energy = " << energy << std::endl;
 
           if (energy <= rhThres)
             continue;

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -98,7 +98,7 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,
           float phiDiff = reco::deltaPhi(phi, phiclus);
           float energy = j->energy();
 
-	  float rhThres = (thresholds != nullptr) ? (*thresholds)[j->detid()] : 0.f;
+          float rhThres = (thresholds != nullptr) ? (*thresholds)[j->detid()] : 0.f;
           if (energy <= rhThres)
             continue;
 

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -64,7 +64,9 @@ EgammaRecHitIsolation::EgammaRecHitIsolation(double extRadius,
 
 EgammaRecHitIsolation::~EgammaRecHitIsolation() {}
 
-double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject, bool returnEt) const {
+double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,
+                                      bool returnEt,
+                                      const EcalPFRecHitThresholds* thresholds) const {
   double energySum = 0.;
   if (!caloHits_.empty()) {
     //Take the SC position
@@ -95,6 +97,13 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject, bool retu
           float etaDiff = eta - etaclus;
           float phiDiff = reco::deltaPhi(phi, phiclus);
           float energy = j->energy();
+
+          float rhThres = 0.0;
+          if (thresholds != nullptr) {
+            rhThres = (*thresholds)[j->detid()];  // access ECAL PFRechit thresholds for noise cleaning
+          }
+          if (energy <= rhThres)
+            continue;
 
           if (useNumCrystals_) {
             if (fabs(etaclus) < 1.479) {  // Barrel num crystals, crystal width = 0.0174
@@ -174,7 +183,9 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject, bool retu
   return energySum;
 }
 
-double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc, bool returnEt) const {
+double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc,
+                                      bool returnEt,
+                                      const EcalPFRecHitThresholds* thresholds) const {
   double energySum = 0.;
   if (!caloHits_.empty()) {
     //Take the SC position
@@ -204,6 +215,15 @@ double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc, bool returnE
           double etaDiff = eta - etaclus;
           double phiDiff = reco::deltaPhi(phi, phiclus);
           double energy = j->energy();
+
+          float rhThres = 0.0;
+          if (thresholds != nullptr) {
+            rhThres = (*thresholds)[j->detid()];  // access ECAL PFRechit thresholds for noise cleaning
+          }
+          std::cout << "rhThres = " << rhThres << "  energy = " << energy << std::endl;
+
+          if (energy <= rhThres)
+            continue;
 
           if (useNumCrystals_) {
             if (fabs(etaclus) < 1.479) {  // Barrel num crystals, crystal width = 0.0174

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -98,10 +98,7 @@ double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,
           float phiDiff = reco::deltaPhi(phi, phiclus);
           float energy = j->energy();
 
-          float rhThres = 0.0;
-          if (thresholds != nullptr) {
-            rhThres = (*thresholds)[j->detid()];  // access ECAL PFRechit thresholds for noise cleaning
-          }
+	  float rhThres = (thresholds != nullptr) ? (*thresholds)[j->detid()] : 0.f;
           if (energy <= rhThres)
             continue;
 
@@ -216,11 +213,7 @@ double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc,
           double phiDiff = reco::deltaPhi(phi, phiclus);
           double energy = j->energy();
 
-          float rhThres = 0.0;
-          if (thresholds != nullptr) {
-            rhThres = (*thresholds)[j->detid()];  // access ECAL PFRechit thresholds for noise cleaning
-          }
-
+          float rhThres = (thresholds != nullptr) ? (*thresholds)[j->detid()] : 0.f;
           if (energy <= rhThres)
             continue;
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ConversionTrackCandidateProducer.cc
@@ -43,7 +43,8 @@
 #include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h"
-
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
 #include <vector>
 
 class ConversionTrackCandidateProducer : public edm::stream::EDProducer<> {
@@ -77,6 +78,8 @@ private:
   const edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> navToken_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theCaloGeomToken_;
   const edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> sevlvToken_;
+  const edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> ecalPFRechitThresholdsToken_;
+  const EcalPFRecHitThresholds* thresholds = nullptr;
 
   double hOverEConeSize_;
   double maxHOverE_;
@@ -149,7 +152,7 @@ ConversionTrackCandidateProducer::ConversionTrackCandidateProducer(const edm::Pa
       navToken_(esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "SimpleNavigationSchool"))),
       theCaloGeomToken_(esConsumes()),
       sevlvToken_(esConsumes()),
-
+      ecalPFRechitThresholdsToken_{esConsumes()},
       theTrajectoryBuilder_(createBaseCkfTrajectoryBuilder(
           config.getParameter<edm::ParameterSet>("TrajectoryBuilderPSet"), consumesCollector())),
       outInSeedFinder_{config, consumesCollector()},
@@ -279,6 +282,8 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
     validEndcapSCHandle = false;
   }
 
+  thresholds = &theEventSetup.getData(ecalPFRechitThresholdsToken_);
+
   // get the geometry from the event setup:
   theCaloGeom_ = theEventSetup.getHandle(theCaloGeomToken_);
 
@@ -327,7 +332,7 @@ void ConversionTrackCandidateProducer::produce(edm::Event& theEvent, const edm::
   auto const refprodOutInTrackC = theEvent.put(std::move(outInTrackCandidate_p), OutInTrackCandidateCollection_);
   //std::cout  << "ConversionTrackCandidateProducer  refprodOutInTrackC size  " <<  (*(refprodOutInTrackC.product())).size()  <<  "\n";
   //
-  //std::cout  << "ConversionTrackCandidateProducer Putting in the event  " << (*inOutTrackCandidate_p).size() << " In Out track Candidates " <<  "\n";
+  //std::cout << "ConversionTrackCandidateProducer Putting in the event  " << (*inOutTrackCandidate_p).size() << " In Out track Candidates " <<  "\n";
   auto const refprodInOutTrackC = theEvent.put(std::move(inOutTrackCandidate_p), InOutTrackCandidateCollection_);
   //std::cout  << "ConversionTrackCandidateProducer  refprodInOutTrackC size  " <<  (*(refprodInOutTrackC.product())).size()  <<  "\n";
 
@@ -389,7 +394,7 @@ void ConversionTrackCandidateProducer::buildCollections(bool isBarrel,
       ecalIso.doSeverityChecks(&ecalRecHits, severitiesexclEE_);
     }
 
-    double ecalIsolation = ecalIso.getEtSum(sc);
+    double ecalIsolation = ecalIso.getEtSum(sc, *thresholds);
     if (ecalIsolation > ecalIsoCut_offset_ + ecalIsoCut_slope_ * scEt)
       continue;
 

--- a/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h
@@ -24,6 +24,8 @@
 #include "Geometry/CaloTopology/interface/CaloTowerConstituentsMap.h"
 
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
 
 class EcalSeverityLevelAlgo;
 class EcalSeverityLevelAlgoRcd;
@@ -103,6 +105,7 @@ private:
   edm::ESGetToken<HcalSeverityLevelComputer, HcalSeverityLevelComputerRcd> hcalSevLvlComputerToken_;
   edm::ESGetToken<CaloTowerConstituentsMap, CaloGeometryRecord> towerMapToken_;
   edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> ecalSevLvlToken_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> ecalPFRechitThresholdsToken_;
 
   edm::EDGetToken trackInputTag_;
   edm::EDGetToken beamSpotProducerTag_;

--- a/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonIsolationCalculator.cc
@@ -49,8 +49,7 @@ void PhotonIsolationCalculator::setup(const edm::ParameterSet& conf,
   hcalSevLvlComputerToken_ = decltype(hcalSevLvlComputerToken_){iC.esConsumes()};
   towerMapToken_ = decltype(towerMapToken_){iC.esConsumes()};
   ecalSevLvlToken_ = iC.esConsumes();
-
-  //  gsfRecoInputTag_ = conf.getParameter<edm::InputTag>("GsfRecoCollection");
+  ecalPFRechitThresholdsToken_ = iC.esConsumes();
   modulePhiBoundary_ = conf.getParameter<double>("modulePhiBoundary");
   moduleEtaBoundary_ = conf.getParameter<std::vector<double>>("moduleEtaBoundary");
   //
@@ -497,6 +496,8 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
 
   iEvent.getByToken(barrelecalCollection_, ecalhitsCollEB);
 
+  auto const& thresholds = iSetup.getData(ecalPFRechitThresholdsToken_);
+
   const EcalRecHitCollection* rechitsCollectionEE_ = ecalhitsCollEE.product();
   const EcalRecHitCollection* rechitsCollectionEB_ = ecalhitsCollEB.product();
 
@@ -511,7 +512,7 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   phoIsoEB.setUseNumCrystals(useNumXtals);
   phoIsoEB.doSeverityChecks(ecalhitsCollEB.product(), severityExclEB_);
   phoIsoEB.doFlagChecks(flagsEB_);
-  double ecalIsolEB = phoIsoEB.getEtSum(photon);
+  double ecalIsolEB = phoIsoEB.getEtSum(photon, thresholds);
 
   EgammaRecHitIsolation phoIsoEE(
       RCone, RConeInner, etaSlice, etMin, eMin, geoHandle, *rechitsCollectionEE_, sevLevel, DetId::Ecal);
@@ -521,7 +522,7 @@ double PhotonIsolationCalculator::calculateEcalRecHitIso(const reco::Photon* pho
   phoIsoEE.doSeverityChecks(ecalhitsCollEE.product(), severityExclEE_);
   phoIsoEE.doFlagChecks(flagsEE_);
 
-  double ecalIsolEE = phoIsoEE.getEtSum(photon);
+  double ecalIsolEE = phoIsoEE.getEtSum(photon, thresholds);
   //  delete phoIso;
   double ecalIsol = ecalIsolEB + ecalIsolEE;
 


### PR DESCRIPTION
#### PR description:

Using ECAL PF rechit thresholds for ECAL detector based isolation to make it more robust against noise. With this change, the distributions of ECAL isolation variables (cone size 0.3 and 0.4) should shift a bit towards lower values. The shift sould be more prominent in endcaps. 

#### PR validation:

Checked with run3 workflows.
