### PR TITLE
NONLTO: Fix use after delete warning for bqueue

### DIFF
--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -42,7 +42,6 @@ namespace edm {
   class ConsumesCollector;
 }
 
-#include "TrackingTools/PatternTools/interface/bqueue.h"
 #include "RecoTracker/CkfPattern/interface/PrintoutHelper.h"
 
 #include <string>

--- a/TrackingTools/PatternTools/interface/bqueue.h
+++ b/TrackingTools/PatternTools/interface/bqueue.h
@@ -60,13 +60,13 @@ namespace cmsutils {
 
   private:
     _bqueue_item() : back(0), value(), refCount(0) {}
-    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > tail, const T &val) : back(tail), value(val), refCount(0) {}
+    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > &tail, const T &val) : back(tail), value(val), refCount(0) {}
     // move
-    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > tail, T &&val)
+    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > &tail, T &&val)
         : back(tail), value(std::move(val)), refCount(0) {}
     // emplace
     template <typename... Args>
-    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > tail, Args &&...args)
+    _bqueue_item(boost::intrusive_ptr<_bqueue_item<T> > &tail, Args &&...args)
         : back(tail), value(std::forward<Args>(args)...), refCount(0) {}
     boost::intrusive_ptr<_bqueue_item<T> > back;
     T const value;


### PR DESCRIPTION
This should fix the warnings [a] for NONLTO based cmssw IBs. @dan131riley hint [here](https://github.com/cms-sw/cmssw/issues/42404#issuecomment-1808594808) helped to identify the issue. We are passing `tail` by value and on 2nd iteration copy of `tail` gets deleted (as its ref count reaches 0).

Locally building this changes for nonlto IB does not trigger this warning

Fixes #42404


[a]
```
  cmssw/src/TrackingTools/PatternTools/interface/bqueue.h:57:14: warning: pointer used after 'void operator delete(void*, std::size_t)' [-Wuse-after-free]
    57 |       if ((--refCount) == 0)
      |              ^~~~~~~~
In member function 'void cmsutils::_bqueue_item<T>::delRef() [with T = std::unique_ptr<int>]',
    inlined from 'void cmsutils::_bqueue_item<T>::delRef() [with T = std::unique_ptr<int>]' at cmssw/src/TrackingTools/PatternTools/interface/bqueue.h:56:10,
    inlined from 'void cmsutils::intrusive_ptr_release(_bqueue_item<T>*) [with T = std::unique_ptr<int>]' at cmssw/src/TrackingTools/PatternTools/interface/bqueue.h:82:15,
    inlined from 'boost::intrusive_ptr<T>::~intrusive_ptr() [with T = cmsutils::_bqueue_item<std::unique_ptr<int> >]' at boost/smart_ptr/intrusive_ptr.hpp:98:44,
    inlined from 'boost::intrusive_ptr<T>& boost::intrusive_ptr<T>::operator=(boost::intrusive_ptr<T>&&) [with T = cmsutils::_bqueue_item<std::unique_ptr<int> >]' at boost/smart_ptr/intrusive_ptr.hpp:122:9,
    inlined from 'void cmsutils::bqueue<T>::push_back(T&&) [with T = std::unique_ptr<int>]' at cmssw/src/TrackingTools/PatternTools/interface/bqueue.h:169:14:
cmssw/src/TrackingTools/PatternTools/interface/bqueue.h:58:9: note: call to 'void operator delete(void*, std::size_t)' here
   58 |         delete this;

```