### PR TITLE
new PI plugin added for TotemDAQMapping class

### DIFF
--- a/CondCore/CTPPSPlugins/interface/DAQMappingPayloadInspectorHelper.h
+++ b/CondCore/CTPPSPlugins/interface/DAQMappingPayloadInspectorHelper.h
@@ -1,0 +1,91 @@
+#ifndef CONDCORE_CTPPSPLUGINS_PPSDAQMAPPINGPAYLOADINSPECTORHELPER_H
+#define CONDCORE_CTPPSPLUGINS_PPSDAQMAPPINGPAYLOADINSPECTORHELPER_H
+
+// User includes
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+
+// ROOT includes
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TH2F.h"
+#include "TLatex.h"
+#include "TGraph.h"
+
+namespace DAQMappingPI {
+  inline std::string resolveDetIDForDAQMapping(int detIDNumber) {
+    static const std::map<int, std::string> mapping = {{CTPPSDetId::SubDetector::sdTrackingStrip, "Strip"},
+                                                       {CTPPSDetId::SubDetector::sdTrackingPixel, "Pixel"},
+                                                       {CTPPSDetId::SubDetector::sdTimingDiamond, "Diamond"},
+                                                       {CTPPSDetId::SubDetector::sdTimingFastSilicon, "FastSilicon"},
+                                                       {CTPPSDetId::SubDetector::sdTotemT2, "TotemT2"}};
+
+    auto it = mapping.find(detIDNumber);
+    if (it != mapping.end()) {
+      return it->second;
+    } else {
+      return "not defined";
+    }
+  }
+}  // namespace DAQMappingPI
+
+template <class PayloadType>
+class DAQMappingPayloadInfo
+    : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
+public:
+  DAQMappingPayloadInfo()
+      : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+            "DAQMappingPayloadInfo text") {}
+
+  bool fill() override {
+    auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+    auto tagname = tag.name;
+    auto iov = tag.iovs.back();
+    auto m_payload = this->fetchPayload(std::get<1>(iov));
+
+    if (m_payload != nullptr) {
+      std::stringstream payloadInfo, lineCountStream;
+      int subDet = CTPPSDetId(m_payload->VFATMapping.begin()->second.symbolicID.symbolicID).subdetId();
+      payloadInfo << "TAG: " << tagname << ", the mapping for: " << DAQMappingPI::resolveDetIDForDAQMapping(subDet)
+                  << std::endl;
+      payloadInfo << *m_payload;
+      lineCountStream << *m_payload;
+      std::string line;
+
+      //created to dynamically set canvas height
+      int lineCounter = 0;
+      while (std::getline(lineCountStream, line)) {
+        lineCounter++;
+      }
+
+      TCanvas canvas("canvas", "Canvas", 800, 20 * lineCounter);
+
+      TLatex latex;
+      latex.SetNDC();
+      latex.SetTextSize(0.015);
+      double yPos = 0.95;
+
+      while (std::getline(payloadInfo, line)) {
+        yPos -= 0.015;
+        latex.DrawLatex(0.1, yPos, line.c_str());
+      }
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+
+#endif

--- a/CondCore/CTPPSPlugins/plugins/BuildFile.xml
+++ b/CondCore/CTPPSPlugins/plugins/BuildFile.xml
@@ -13,3 +13,8 @@
   <use name="CondCore/CondDB"/>
   <use name="boost_python"/>
 </library>
+<library file="DAQMapping_PayloadInspector.cc" name="TotemDAQMapping_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/CTPPSPlugins/plugins/DAQMapping_PayloadInspector.cc
+++ b/CondCore/CTPPSPlugins/plugins/DAQMapping_PayloadInspector.cc
@@ -1,0 +1,18 @@
+/****************************************************************************
+ *
+ * This is a part of PPS PI software.
+ *
+ ****************************************************************************/
+
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+#include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
+#include "CondCore/CTPPSPlugins/interface/DAQMappingPayloadInspectorHelper.h"
+
+namespace {
+  typedef DAQMappingPayloadInfo<TotemDAQMapping> DAQMappingPayloadInfo_Text;
+}
+
+PAYLOAD_INSPECTOR_MODULE(TotemDAQMapping) { PAYLOAD_INSPECTOR_CLASS(DAQMappingPayloadInfo_Text); }

--- a/CondCore/CTPPSPlugins/src/plugin.cc
+++ b/CondCore/CTPPSPlugins/src/plugin.cc
@@ -1,32 +1,36 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
-#include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
-#include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
-#include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
-#include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
-#include "CondFormats/PPSObjects/interface/CTPPSPixelAnalysisMask.h"
-#include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
-#include "CondFormats/PPSObjects/interface/CTPPSPixelGainCalibrations.h"
-#include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
-#include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
 #include "CondFormats/AlignmentRecord/interface/CTPPSRPAlignmentCorrectionsDataRcd.h"
-#include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
 #include "CondFormats/AlignmentRecord/interface/RPMisalignedAlignmentRecord.h"
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
-#include "CondFormats/DataRecord/interface/PPSTimingCalibrationLUTRcd.h"
-#include "CondFormats/PPSObjects/interface/LHCOpticalFunctionsSetCollection.h"
+#include "CondFormats/AlignmentRecord/interface/RPRealAlignmentRecord.h"
+#include "CondFormats/DataRecord/interface/CTPPSBeamParametersRcd.h"
 #include "CondFormats/DataRecord/interface/CTPPSOpticsRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSDirectSimulationData.h"
-#include "CondFormats/DataRecord/interface/PPSDirectSimulationDataRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSPixelTopology.h"
-#include "CondFormats/DataRecord/interface/PPSPixelTopologyRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSAlignmentConfig.h"
+#include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
+#include "CondFormats/DataRecord/interface/CTPPSPixelDAQMappingRcd.h"
+#include "CondFormats/DataRecord/interface/CTPPSPixelGainCalibrationsRcd.h"
 #include "CondFormats/DataRecord/interface/PPSAlignmentConfigRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSAlignmentConfiguration.h"
 #include "CondFormats/DataRecord/interface/PPSAlignmentConfigurationRcd.h"
-#include "CondFormats/PPSObjects/interface/PPSAssociationCuts.h"
 #include "CondFormats/DataRecord/interface/PPSAssociationCutsRcd.h"
+#include "CondFormats/DataRecord/interface/PPSDirectSimulationDataRcd.h"
+#include "CondFormats/DataRecord/interface/PPSPixelTopologyRcd.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationLUTRcd.h"
+#include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
+#include "CondFormats/DataRecord/interface/TotemAnalysisMaskRcd.h"
+#include "CondFormats/DataRecord/interface/TotemReadoutRcd.h"
+#include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
+#include "CondFormats/PPSObjects/interface/CTPPSPixelAnalysisMask.h"
+#include "CondFormats/PPSObjects/interface/CTPPSPixelDAQMapping.h"
+#include "CondFormats/PPSObjects/interface/CTPPSPixelGainCalibrations.h"
+#include "CondFormats/PPSObjects/interface/CTPPSRPAlignmentCorrectionsData.h"
+#include "CondFormats/PPSObjects/interface/LHCOpticalFunctionsSetCollection.h"
+#include "CondFormats/PPSObjects/interface/PPSAlignmentConfig.h"
+#include "CondFormats/PPSObjects/interface/PPSAlignmentConfiguration.h"
+#include "CondFormats/PPSObjects/interface/PPSAssociationCuts.h"
+#include "CondFormats/PPSObjects/interface/PPSDirectSimulationData.h"
+#include "CondFormats/PPSObjects/interface/PPSPixelTopology.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
+#include "CondFormats/PPSObjects/interface/TotemAnalysisMask.h"
+#include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
 
 namespace {
   struct InitAssociationCuts {
@@ -39,8 +43,8 @@ REGISTER_PLUGIN(CTPPSPixelDAQMappingRcd, CTPPSPixelDAQMapping);
 REGISTER_PLUGIN(CTPPSPixelAnalysisMaskRcd, CTPPSPixelAnalysisMask);
 REGISTER_PLUGIN(CTPPSPixelGainCalibrationsRcd, CTPPSPixelGainCalibrations);
 REGISTER_PLUGIN(CTPPSRPAlignmentCorrectionsDataRcd, CTPPSRPAlignmentCorrectionsData);
-REGISTER_PLUGIN(RPRealAlignmentRecord, CTPPSRPAlignmentCorrectionsData);
-REGISTER_PLUGIN(RPMisalignedAlignmentRecord, CTPPSRPAlignmentCorrectionsData);
+REGISTER_PLUGIN_NO_SERIAL(RPRealAlignmentRecord, CTPPSRPAlignmentCorrectionsData);
+REGISTER_PLUGIN_NO_SERIAL(RPMisalignedAlignmentRecord, CTPPSRPAlignmentCorrectionsData);
 REGISTER_PLUGIN(PPSTimingCalibrationRcd, PPSTimingCalibration);
 REGISTER_PLUGIN(PPSTimingCalibrationLUTRcd, PPSTimingCalibrationLUT);
 REGISTER_PLUGIN(CTPPSOpticsRcd, LHCOpticalFunctionsSetCollection);
@@ -48,5 +52,7 @@ REGISTER_PLUGIN(PPSDirectSimulationDataRcd, PPSDirectSimulationData);
 REGISTER_PLUGIN(PPSPixelTopologyRcd, PPSPixelTopology);
 REGISTER_PLUGIN(PPSAlignmentConfigRcd, PPSAlignmentConfig);
 REGISTER_PLUGIN(PPSAlignmentConfigurationRcd, PPSAlignmentConfiguration);
+REGISTER_PLUGIN(TotemAnalysisMaskRcd, TotemAnalysisMask);
+REGISTER_PLUGIN(TotemReadoutRcd, TotemDAQMapping);
 
 REGISTER_PLUGIN_INIT(PPSAssociationCutsRcd, PPSAssociationCuts, InitAssociationCuts);

--- a/CondCore/CTPPSPlugins/test/testDAQMapping.sh
+++ b/CondCore/CTPPSPlugins/test/testDAQMapping.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ "$1" == "run" ]
+then
+    mkdir -p $CMSSW_BASE/src/CondCore/CTPPSPlugins/test/results
+    if [ -f *.png ]; then    
+    rm *.png
+    fi
+
+    echo "Testing DAQMapping info"
+
+    getPayloadData.py \
+        --plugin pluginTotemDAQMapping_PayloadInspector \
+        --plot plot_DAQMappingPayloadInfo_Text \
+        --tag PPSDAQMapping_TimingDiamond_v1 \
+        --time_type Run \
+        --iovs '{"start_iov": "283820", "end_iov": "283820"}' \
+        --db Prod \
+        --test    
+
+    mv *.png $CMSSW_BASE/src/CondCore/CTPPSPlugins/test/results/DAQMapping_TextInfo.png 
+     
+elif [ "$1" == "clear" ]
+then
+    rm -rf $CMSSW_BASE/src/CondCore/CTPPSPlugins/test/results
+
+else 
+    echo "Wrong option! (available options: run/clear)"
+fi


### PR DESCRIPTION
#### PR description:

This PR adds TotemDAQMapping class to Payload Inspector module so to be able to visualize it on dedicated PI tab on the cms-conddb website. It consists of a one plot that prints out all the information stored in the payload.

Also - in .clang-format - doubled line cleaned up.
 
#### PR validation:

The code can be tested by a script CondCore/CTPPSPlugins/test/testDAQMapping.sh also created in the PR (it uses getPayloadData.py from CondCore/Utilities) - test checks whether the new plugin is properly added to PI software and therefore it generates proper output file.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No backport.
