### PR TITLE
Run3-Sim152Y Enable the code to handle DD4hep and DDD inputs simultaneously in SimTracker

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -191,8 +191,9 @@ void TrackingMaterialProducer::update(const BeginOfTrack* event) {
 
 bool TrackingMaterialProducer::isSelectedFast(const G4TouchableHistory* touchable) {
   for (int d = touchable->GetHistoryDepth() - 1; d >= 0; --d) {
-    if (std::find(m_selectedNames.begin(), m_selectedNames.end(), (std::string)(dd4hep::dd::noNamespace(touchable->GetVolume(d)->GetName()))) !=
-        m_selectedNames.end())
+    if (std::find(m_selectedNames.begin(),
+                  m_selectedNames.end(),
+                  (std::string)(dd4hep::dd::noNamespace(touchable->GetVolume(d)->GetName()))) != m_selectedNames.end())
       return true;
   }
   return false;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -27,6 +27,8 @@
 #include "G4VPhysicalVolume.hh"
 #include "G4AffineTransform.hh"
 
+#include <DD4hep/Filter.h>
+
 #include "TrackingMaterialProducer.h"
 
 // Uncomment the following #define directive to have the full list of
@@ -48,7 +50,7 @@ static const G4LogicalVolume* GetVolume(const std::string& name) {
 #endif
 
   for (G4LogicalVolumeStore::const_iterator volume = lvs->begin(); volume != lvs->end(); ++volume) {
-    if ((const std::string&)(*volume)->GetName() == name)
+    if ((const std::string)(dd4hep::dd::noNamespace((*volume)->GetName())) == name)
       return (*volume);
   }
   return nullptr;
@@ -189,7 +191,7 @@ void TrackingMaterialProducer::update(const BeginOfTrack* event) {
 
 bool TrackingMaterialProducer::isSelectedFast(const G4TouchableHistory* touchable) {
   for (int d = touchable->GetHistoryDepth() - 1; d >= 0; --d) {
-    if (std::find(m_selectedNames.begin(), m_selectedNames.end(), touchable->GetVolume(d)->GetName()) !=
+    if (std::find(m_selectedNames.begin(), m_selectedNames.end(), (std::string)(dd4hep::dd::noNamespace(touchable->GetVolume(d)->GetName()))) !=
         m_selectedNames.end())
       return true;
   }


### PR DESCRIPTION
#### PR description:

Enable the code to handle DD4hep and DDD inputs simultaneously in SimTracker

#### PR validation:

Use the runTheMatrix test workflows

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

nothing special