### PR TITLE
Fix static warnings on DT L1T

### DIFF
--- a/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc
+++ b/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc
@@ -224,12 +224,6 @@ std::vector<double> GlobalCoordsObtainer::get_global_coordinates(uint32_t chid, 
   int tanpsi_msb = tanpsi >> (TANPSI_SIZE - PHIB_LUT_ADDR_WIDTH);
   tanpsi_msb = from_two_comp(tanpsi_msb, PHIB_LUT_ADDR_WIDTH);
 
-  x_msb = x >> (X_SIZE - PHI_LUT_ADDR_WIDTH);
-  x_msb = from_two_comp(x_msb, PHI_LUT_ADDR_WIDTH);
-
-  tanpsi_msb = tanpsi >> (TANPSI_SIZE - PHIB_LUT_ADDR_WIDTH);
-  tanpsi_msb = from_two_comp(tanpsi_msb, PHIB_LUT_ADDR_WIDTH);
-
   // The LSB part can be sliced right away because it must yield a positive integer
   int x_lsb = x & (int)(std::pow(2, (X_SIZE - PHI_LUT_ADDR_WIDTH)) - 1);
   int tanpsi_lsb = tanpsi & (int)(std::pow(2, (TANPSI_SIZE - PHIB_LUT_ADDR_WIDTH)) - 1);

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyzerInChamber.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyzerInChamber.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/DTTriggerPhase2/interface/MuonPathAnalyzerInChamber.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include <cmath>
 #include <memory>
 
@@ -242,7 +243,7 @@ void MuonPathAnalyzerInChamber::analyze(MuonPathPtr &inMPath, MuonPathPtrs &outM
     }
 
     // Protection against non-converged fits
-    if (isnan(jm_x))
+    if (edm::isNotFinite(jm_x))
       continue;
 
     // Updating muon-path horizontal position


### PR DESCRIPTION
#### PR description:

This PR fixes some static warnings in DT L1T emulator detected during integration of AMv2 in https://github.com/cms-sw/cmssw/pull/43390

Out of the 8 warnings (see below), only the first 2 have been fixed by this PR.

Those related to core.uninitialized.Branch look false positives as far as I can see, since the vectors pointed out have been initialized previously at the beginning on purpouse to false in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc#L123-L127

The last one claims a nonFinite computation but this is exactly what is being tried to avoid.

I am not sure if the code experts like @makortel have any advice on how to proceed. Thanks in advance.

Static Warnings:
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc:222:3: warning: Value stored to 'x_msb' is never read [deadcode.DeadStores]
  222 |   x_msb = from_two_comp(x_msb, PHI_LUT_ADDR_WIDTH);
      |   ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc:225:3: warning: Value stored to 'tanpsi_msb' is never read [deadcode.DeadStores]
  225 |   tanpsi_msb = from_two_comp(tanpsi_msb, PHIB_LUT_ADDR_WIDTH);
      |   ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:592:15: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
  592 |           if (useFitSL3[sl3])
      |               ^~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:844:19: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
  844 |               if (useFitSL1[sl1])
      |                   ^~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:905:19: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
  905 |               if (useFitSL3[sl3])
      |                   ^~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:1011:9: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
 1011 |     if (!useFit[i])
      |         ^~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc:1016:11: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
 1016 |       if (!useFit[j])

/data/cmsbld/jenkins/workspace/ib-run-pr-tests/CMSSW_14_0_X_2023-11-29-2300/src/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyzerInChamber.cc:245:9: warning: cms.NonFiniteMath [cms.NonFiniteMath]
  245 |     if (isnan(jm_x))
      |         ^
1 warning generated.
