### PR TITLE
[14_0_X SIM] Optimization of stepping when ZDC is ON

### DIFF
--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -40,6 +40,7 @@ private:
   const G4VPhysicalVolume* calo{nullptr};
   const CMSSteppingVerbose* steppingVerbose{nullptr};
   const G4LogicalVolume* m_CMStoZDC{nullptr};
+  const G4Region* m_ZDCRegion{nullptr};
   double theCriticalEnergyForVacuum;
   double theCriticalDensity;
   double maxTrackTime;

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -145,7 +145,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     if (sAlive == sVeryForward) {
       const G4Region* preRegion = preStep->GetPhysicalVolume()->GetLogicalVolume()->GetRegion();
       if (preRegion == m_ZDCRegion && preRegion != theRegion)
-	tstat = sDeadRegion;
+        tstat = sDeadRegion;
     }
 
     // kill out of time


### PR DESCRIPTION
#### PR description:
When ZDC simulation is enabled, CPU time for MinBias events increased in ~5.5 times, for ttbar - in ~1.5 times. In this PR some optimization is introduced, which is not significant: ~9% for MinBias and ~3% for ttbar. In the default simulation (ZDC is not enabled), no change is expected. Having not a big improvement, this PR is useful, because remove from simulation relatively rare tracks going out of ZDC, further tracking of these tracks has no sense.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: not clear if should be backported to 3_0_X

