### PR TITLE
Corrections to HD partial wafer cell pattern of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalTypes.h
+++ b/Geometry/HGCalCommonData/interface/HGCalTypes.h
@@ -94,17 +94,22 @@ public:
 
   static constexpr double c00 = 0.0;
   static constexpr double c22O = 0.225;
+  static constexpr double c221 = 0.2083;
   static constexpr double c22 = 0.1944;
   static constexpr double c25 = 0.25;
   static constexpr double c27O = 0.275;
+  static constexpr double c271 = 0.2917;
   static constexpr double c27 = 0.3056;
   static constexpr double c50 = 0.5;
   static constexpr double c61O = 0.6125;
+  static constexpr double c611 = 0.6042;
   static constexpr double c61 = 0.59722;
   static constexpr double c75 = 0.75;
   static constexpr double c77O = 0.775;
+  static constexpr double c771 = 0.7917;
   static constexpr double c77 = 0.8055;
   static constexpr double c88O = 0.8875;
+  static constexpr double c881 = 0.8958;
   static constexpr double c88 = 0.90277;
   static constexpr double c10 = 1.0;
 

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -1457,12 +1457,19 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(const int& part,
 #endif
   double c22(HGCalTypes::c22), c27(HGCalTypes::c27), c61(HGCalTypes::c61);
   double c77(HGCalTypes::c77), c88(HGCalTypes::c88);
+  double c221(HGCalTypes::c221), c271(HGCalTypes::c271), c611(HGCalTypes::c611);
+  double c771(HGCalTypes::c771), c881(HGCalTypes::c881);
   if (v17OrLess) {
     c22 = HGCalTypes::c22O;
     c27 = HGCalTypes::c27O;
     c61 = HGCalTypes::c61O;
     c77 = HGCalTypes::c77O;
     c88 = HGCalTypes::c88O;
+    c221 = c22;
+    c271 = c27;
+    c611 = c61;
+    c771 = c77;
+    c881 = c88;
   }
   /*
     The exact contour of partial wafers are obtained by joining points on
@@ -1501,17 +1508,17 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(const int& part,
       -HGCalTypes::c50 * delX,
       -HGCalTypes::c10 * delX,
       -HGCalTypes::c50 * delX,
-      c22 * delX,
+      c221 * delX,
       HGCalTypes::c10 * delX,
-      c77 * delX,
-      -c22 * delX,
+      c771 * delX,
+      -c221 * delX,
       -HGCalTypes::c10 * delX,
-      -c77 * delX,
-      c22 * delX,
-      -c77 * delX,
+      -c771 * delX,
+      c221 * delX,
+      -c771 * delX,
       -HGCalTypes::c10 * delX,
-      -c22 * delX,
-      c77 * delX,
+      -c221 * delX,
+      c771 * delX,
       HGCalTypes::c10 * delX,
       c22 * delX,
       HGCalTypes::c10 * delX,
@@ -1563,18 +1570,18 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(const int& part,
       HGCalTypes::c75 * delY,
       HGCalTypes::c00 * delY,
       -HGCalTypes::c75 * delY,
-      -c88 * delY,
-      -c27 * delY,
-      c61 * delY,
-      c88 * delY,
-      c27 * delY,
-      -c61 * delY,
-      c88 * delY,
-      c61 * delY,
-      -c27 * delY,
-      -c88 * delY,
-      -c61 * delY,
-      c27 * delY,
+      -c881 * delY,
+      -c271 * delY,
+      c611 * delY,
+      c881 * delY,
+      c271 * delY,
+      -c611 * delY,
+      c881 * delY,
+      c611 * delY,
+      -c271 * delY,
+      -c881 * delY,
+      -c611 * delY,
+      c271 * delY,
       -c88 * delY,
       -c27 * delY,
       c61 * delY,
@@ -1999,10 +2006,10 @@ std::vector<std::pair<double, double> > HGCalWaferMask::waferXY(const int& part,
 
 std::array<double, 4> HGCalWaferMask::maskCut(
     const int& part, const int& placement, const double& waferSize, const double& offset, const bool& v17OrLess) {
-  double c22(HGCalTypes::c22), c27(HGCalTypes::c27);
+  double c22(HGCalTypes::c22), c271(HGCalTypes::c271);
   if (v17OrLess) {
     c22 = HGCalTypes::c22O;
-    c27 = HGCalTypes::c27O;
+    c271 = HGCalTypes::c27O;
   }
   double delX = 0.5 * waferSize;
   double delY = 2 * delX / sqrt3_;
@@ -2068,21 +2075,21 @@ std::array<double, 4> HGCalWaferMask::maskCut(
     case (HGCalTypes::WaferHDLeft): {
       criterion[0] = 1.0;
       criterion[1] = -tan_1[placement];
-      criterion[2] = ((c27 * delY) / cos_1[placement]);
+      criterion[2] = ((c271 * delY) / cos_1[placement]);
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDRight): {
       criterion[0] = -1.0;
       criterion[1] = tan_1[placement];
-      criterion[2] = -((c27 * delY) / cos_1[placement]);
+      criterion[2] = -((c271 * delY) / cos_1[placement]);
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDFive): {
       criterion[0] = -1.0;
       criterion[1] = tan_1[placement];
-      criterion[2] = ((c27 * delY) / cos_1[placement]);
+      criterion[2] = ((c271 * delY) / cos_1[placement]);
       criterion[3] = tresh;
       break;
     }

--- a/SimG4CMS/Calo/plugins/HGCalMouseBiteTester.cc
+++ b/SimG4CMS/Calo/plugins/HGCalMouseBiteTester.cc
@@ -168,7 +168,12 @@ void HGCalMouseBiteTester::analyze(const edm::Event& iEvent, const edm::EventSet
     if (goodPoint) {  //Only allowing (x, y) inside a partial wafer 11, placement index 2
       partialType_ = HGCalWaferType::getPartial(index, hgcons_.getParameter()->waferInfoMap_);
       G4ThreeVector point(xi, yi, 0.0);
-      std::pair<int32_t, int32_t> uv5 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, partialType_, true, false);
+      std::pair<int32_t, int32_t> uv5;
+      if (hgcons_.v17OrLess()) {
+        uv5 = wafer.cellUVFromXY1(xi, yi, placeIndex_, waferType_, partialType_, true, false);
+      } else {
+        uv5 = wafer.cellUVFromXY2(xi, yi, placeIndex_, waferType_, partialType_, true, false);
+      }
       if (guardRingPartial_.exclude(point, zside, frontBack, layer_, waferU_, waferV_)) {
         guard_ring_partial << xi << "," << yi << std::endl;
       } else if (mouseBite_.exclude(point, zside, layer_, waferU_, waferV_)) {

--- a/SimG4CMS/Calo/test/python/testHGCalMouseBite_cfg.py
+++ b/SimG4CMS/Calo/test/python/testHGCalMouseBite_cfg.py
@@ -63,7 +63,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 
-process.load("Geometry.HGCalCommonData.hgcalMouseBiteTester_cfi")
+process.load("SimG4CMS.Calo.hgcalMouseBiteTester_cfi")
 
  
 process.p1 = cms.Path(process.generator*process.hgcalMouseBiteTester)


### PR DESCRIPTION
PR description:

Correcting the cell-pattern and dimensions of HD partial wafer in V18 version of HGCal geometry. Previous versions(v16, v17) are unaffected.

PR validation:

Use the runTheMatrix test workflow 27234.0 with 100 events

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special