### PR TITLE
introduce `requireL3MuonTrajectorySeed` data member in `HLTMuonL3PreFilter` and use it do define whether or not to consume certain products

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -250,6 +250,16 @@ def customizeHLTfor43025(process):
 
     return process
 
+def customizeHLTfor43549(process):
+    """ This customization is related to ticket https://its.cern.ch/jira/browse/CMSHLT-2975
+        If all 3 input tags L1CandTag, InpuLinks and inputMuonCollection are null (hence not consumed)
+        it means that the HLTMuonL3PreFilter should be configured such that the flag requireL3MuonTrajectorySeed is true
+    """
+    for filter in filters_by_type(process, "HLTMuonL3PreFilter"):
+        if (filter.L1CandTag == cms.InputTag("") and filter.InputLinks == cms.InputTag("") and filter.inputMuonCollection == cms.InputTag("")):
+            filter.requireL3MuonTrajectorySeed = cms.bool(True)
+
+    return process
 
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
@@ -260,5 +270,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customizeHLTfor43025(process)
+    process = customizeHLTfor43549(process)
     
     return process

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
@@ -46,8 +46,9 @@ private:
   const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_;  // token identifying product contains muons
   const edm::InputTag previousCandTag_;  // input tag identifying product contains muons passing the previous level
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>
-      previousCandToken_;          // token identifying product contains muons passing the previous level
-  const edm::InputTag l1CandTag_;  // input tag identifying product contains muons passing the L1 level
+      previousCandToken_;                   // token identifying product contains muons passing the previous level
+  const bool requireL3MuonTrajectorySeed_;  // bool requiring that there is a L3Muon trajectory seed
+  const edm::InputTag l1CandTag_;           // input tag identifying product contains muons passing the L1 level
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>
       l1CandToken_;                // token identifying product contains muons passing the L1 level
   const edm::InputTag recoMuTag_;  // input tag identifying reco muons


### PR DESCRIPTION
#### PR description:

Title says it all, follows-up from suggestion at https://github.com/cms-sw/cmssw/issues/43517#issuecomment-1849455057.

> One possibility to improve the implementation of `HLTMuonL3PreFilter` is to add a boolean parameter to the plugin (say, `requireL3MuonTrajectorySeed`) which, if true, would make the plugin throw an exception if [this cast](https://github.com/cms-sw/cmssw/blob/bb13ad112cad04ae2bcf5a11ec1362dda00c3fb9/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc#L173) fails. In the constructor, one could then call consumes on `InputLinks`, `L1CandTag` and `inputMuonCollection` only if `requireL3MuonTrajectorySeed == false` ([something like this (random example)](https://github.com/cms-sw/cmssw/blob/bb13ad112cad04ae2bcf5a11ec1362dda00c3fb9/DQM/HLTEvF/plugins/LumiMonitor.cc#L98-L100)). The parameter `requireL3MuonTrajectorySeed` would be false by default, but in the case of hltL3fDimuonL1f0L2NVf16L3NoFiltersNoVtxFiltered43 (and maybe other modules), we could set it to true.

This implements the first part (which to allow disentangling the consumes when they are not needed). A customize function in `customizeHLTforCMSSW` is added such that the newly added boolean is flipped for a list of selected modules in HLT menu. 

#### PR validation:

```bash
#!/bin/bash

hltGetConfiguration /dev/CMSSW_13_3_0/GRun \
   --globaltag auto:phase1_2024_realistic \
   --mc \
   --unprescale \
   --output minimal \
   --max-events 100 \
   --input /store/relval/CMSSW_13_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/133X_mcRun3_2023_realistic_v1_Standard_13_3_0_pre4-v1/2590000/4c47f6d7-9938-4c87-b795-ece3aa6d3d22.root \
   --eras Run3 --l1-emulator FullMC --l1 L1Menu_Collisions2023_v1_3_0_xml \
   > hlt.py
cat <<@EOF >> hlt.py
process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF
cmsRun hlt.py &> hlt.log
```

runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.
