### PR TITLE
Miscellaneous improvements for generating and validating Phase2 SiPixel Lorentz Angle payloads

### DIFF
--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -74,7 +74,9 @@ namespace {
       gStyle->SetOptStat("emr");
 
       auto tag = PlotBase::getTag<0>();
+      auto tagname = PlotBase::getTag<0>().name;
       auto iov = tag.iovs.front();
+      std::string IOVsince = std::to_string(std::get<0>(iov));
       std::shared_ptr<SiPixelLorentzAngle> payload = fetchPayload(std::get<1>(iov));
       std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
       auto extrema = SiPixelPI::findMinMaxInMap(LAMap_);
@@ -84,8 +86,8 @@ namespace {
       auto h1 = std::make_unique<TH1F>("value",
                                        "SiPixel LA value;SiPixel LorentzAngle #mu_{H}(tan#theta_{L}/B) [1/T];# modules",
                                        50,
-                                       extrema.first * 0.9,
-                                       extrema.second * 1.1);
+                                       (extrema.first * 0.9),
+                                       (extrema.second * 1.1));
 
       SiPixelPI::adjustCanvasMargins(canvas.cd(), 0.06, 0.12, 0.12, 0.05);
       canvas.Modified();
@@ -106,26 +108,25 @@ namespace {
 
       canvas.Update();
 
-      TLegend legend = TLegend(0.40, 0.88, 0.94, 0.93);
-      legend.SetHeader(("Payload hash: #bf{" + (std::get<1>(iov)) + "}").c_str(),
+      TLegend legend = TLegend(0.35, 0.88, 0.94, 0.93);
+      legend.SetHeader(("#splitline{Payload hash: #bf{" + (std::get<1>(iov)) + "}}{Tag,IOV: #bf{#color[2]{" + tagname +
+                        "}," + IOVsince + "}}")
+                           .c_str(),
                        "C");  // option "C" allows to center the header
-      //legend.AddEntry(h1.get(), ("IOV: " + std::to_string(std::get<0>(iov))).c_str(), "PL");
-      legend.SetTextSize(0.025);
+      legend.SetTextSize(0.023);
       legend.SetLineColor(10);
       legend.Draw("same");
 
       TPaveStats *st = (TPaveStats *)h1->FindObject("stats");
       st->SetTextSize(0.03);
-      SiPixelPI::adjustStats(st, 0.15, 0.83, 0.39, 0.93);
+      SiPixelPI::adjustStats(st, 0.15, 0.83, 0.34, 0.93);
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
       //ltx.SetTextColor(kBlue);
       ltx.SetTextSize(0.05);
       ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-                       1 - gPad->GetTopMargin() + 0.01,
-                       ("SiPixel Lorentz Angle IOV:" + std::to_string(std::get<0>(iov))).c_str());
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.01, "SiPixel Lorentz Angle Value");
 
       std::string fileName(m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondTools/SiPixel/test/SiPixelLorentzAngleDBLoader_Phase2_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleDBLoader_Phase2_cfg.py
@@ -25,39 +25,51 @@ tGeometry = opt.geometry
 if tGeometry == 'T5':
     geometry_cff = 'GeometryExtended2023D17_cff'
     recoGeometry_cff = 'GeometryExtended2023D17Reco_cff'
+    has3DinL1 = False
     LA_value = 0.106
     tag = 'SiPixelLorentzAngle_Phase2_T5' 
     
 elif tGeometry == 'T6':
     geometry_cff = 'GeometryExtended2023D35_cff'
     recoGeometry_cff = 'GeometryExtended2023D35Reco_cff'
+    has3DinL1 = False
     LA_value = 0.106
     tag = 'SiPixelLorentzAngle_Phase2_T6' 
     
 elif tGeometry == 'T11':
     geometry_cff = 'GeometryExtended2023D29_cff'
     recoGeometry_cff = 'GeometryExtended2023D29Reco_cff'
+    has3DinL1 = False
     LA_value = 0.106
     tag = 'SiPixelLorentzAngle_Phase2_T11' 
     
 elif tGeometry == 'T14':
     geometry_cff = 'GeometryExtended2023D41_cff'
     recoGeometry_cff = 'GeometryExtended2023D41Reco_cff'
+    has3DinL1 = False
     LA_value = 0.106
     tag = 'SiPixelLorentzAngle_Phase2_T14' 
     
 elif tGeometry == 'T15':
     geometry_cff = 'GeometryExtended2023D42_cff'
     recoGeometry_cff = 'GeometryExtended2023D42Reco_cff'
+    has3DinL1 = False
     LA_value = 0.0503
     tag = 'SiPixelLorentzAngle_Phase2_T15' 
 
 elif tGeometry == 'T25':
     geometry_cff = 'GeometryExtended2026D97_cff'
     recoGeometry_cff = 'GeometryExtended2026D97Reco_cff'
+    has3DinL1 = True
     LA_value = 0.0503
     tag = 'SiPixelLorentzAngle_Phase2_T25_v1'
-     
+
+elif tGeometry == 'T33':
+    geometry_cff = 'GeometryExtended2026D102_cff'
+    recoGeometry_cff = 'GeometryExtended2026D102Reco_cff'
+    has3DinL1 = True
+    LA_value = 0.0503
+    tag = 'SiPixelLorentzAngle_Phase2_T33_v1'
 else:
     print("Unknown tracker geometry")
     print("What are you doing ?!?!?!?!")
@@ -77,7 +89,7 @@ process.load(geometry_cff)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_'+tGeometry, '')
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
@@ -123,16 +135,16 @@ process.SiPixelLorentzAngle = cms.EDAnalyzer(
     "SiPixelLorentzAngleDBLoader",
     
     # enter -9999 if individual input
-    bPixLorentzAnglePerTesla = cms.untracked.double(-9999),
-    fPixLorentzAnglePerTesla = cms.untracked.double(-9999),    
+    bPixLorentzAnglePerTesla = cms.untracked.double(-9999 if has3DinL1 else LA_value),
+    fPixLorentzAnglePerTesla = cms.untracked.double(-9999 if has3DinL1 else LA_value),
 
     #in case of PSet (only works if above is -9999)
     # One common value for BPix for now
     BPixParameters = cms.untracked.VPSet(
-        cms.PSet(layer = cms.int32(1), angle = cms.double(0.0)),
-        cms.PSet(layer = cms.int32(2), angle = cms.double(0.053)),
-        cms.PSet(layer = cms.int32(3), angle = cms.double(0.053)),
-        cms.PSet(layer = cms.int32(4), angle = cms.double(0.053)),
+        cms.PSet(layer = cms.int32(1), angle = cms.double(0.00)),
+        cms.PSet(layer = cms.int32(2), angle = cms.double(LA_value)),
+        cms.PSet(layer = cms.int32(3), angle = cms.double(LA_value)),
+        cms.PSet(layer = cms.int32(4), angle = cms.double(LA_value)),
     ),
     FPixParameters = cms.untracked.VPSet(
         cms.PSet(angle = cms.double(0.0) 


### PR DESCRIPTION
#### PR description:

This PR contains a couple of minor improvements to `CondTools/SiPixel/test/SiPixelLorentzAngleDBLoader_Phase2_cfg.py` and to the `CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc` that were useful when providing / checking the conditions for https://github.com/cms-sw/cmssw/pull/43482. 

#### PR validation:

`scram b runtests` runs fine with this branch

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A 