### PR TITLE
Integrate FED25 handling in electron online reconstruction

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -341,7 +341,7 @@ int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const Traject
 bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,
                                         const TrajectoryStateOnSurface& hitSurState,
                                         const Propagator& propToLayerFromState) const {
-  //FIXME: do not hardcode with werid magic numbers stolen from ancient tracking code
+  //FIXME: do not hardcode with weird magic numbers stolen from ancient tracking code
   //its taken from https://cmssdt.cern.ch/dxr/CMSSW/source/RecoTracker/TrackProducer/interface/TrackProducerBase.icc#165
   //which inspires this code
   Chi2MeasurementEstimator estimator(30., -3.0, 0.5, 2.0, 0.5, 1.e12);  // same as defauts....
@@ -353,7 +353,8 @@ bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,
   else {
     DetId id = detWithState.front().first->geographicalId();
     MeasurementDetWithData measDet = measTkEvt_.idToDet(id);
-    if (measDet.isActive())
+    //Below, measDet.hasBadComponents handles the check that a Pixel module has or not errors like FED25
+    if (measDet.isActive() && !measDet.hasBadComponents(detWithState.front().second))
       return true;
     else
       return false;

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -153,19 +153,24 @@ bool TkPixelMeasurementDet::hasBadComponents(const TrajectoryStateOnSurface& tso
     return false;
 
   auto lp = tsos.localPosition();
-  auto le = tsos.localError().positionError();
+  float xx = 0.;
+  float yy = 0.;
+  if (tsos.hasError()) {
+    xx = tsos.localError().positionError().xx();
+    yy = tsos.localError().positionError().yy();
+  }
   for (auto const& broc : badRocPositions_) {
     auto dx = std::abs(broc.x() - lp.x()) - theRocWidth;
     auto dy = std::abs(broc.y() - lp.y()) - theRocHeight;
     if ((dx <= 0.f) & (dy <= 0.f))
       return true;
-    if ((dx * dx < 9.f * le.xx()) && (dy * dy < 9.f * le.yy()))
+    if ((dx * dx < 9.f * xx) && (dy * dy < 9.f * yy))
       return true;
   }
 
   if (badFEDChannelPositions == nullptr)
     return false;
-  float dx = 3.f * std::sqrt(le.xx()) + theRocWidth, dy = 3.f * std::sqrt(le.yy()) + theRocHeight;
+  float dx = 3.f * std::sqrt(xx) + theRocWidth, dy = 3.f * std::sqrt(yy) + theRocHeight;
   for (auto const& p : *badFEDChannelPositions) {
     if (lp.x() > (p.first.x() - dx) && lp.x() < (p.second.x() + dx) && lp.y() > (p.first.y() - dy) &&
         lp.y() < (p.second.y() + dy)) {

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -153,24 +153,20 @@ bool TkPixelMeasurementDet::hasBadComponents(const TrajectoryStateOnSurface& tso
     return false;
 
   auto lp = tsos.localPosition();
-  float xx = 0.;
-  float yy = 0.;
-  if (tsos.hasError()) {
-    xx = tsos.localError().positionError().xx();
-    yy = tsos.localError().positionError().yy();
-  }
+  float lexx = tsos.hasError() ? tsos.localError().positionError().xx() : 0.0f;
+  float leyy = tsos.hasError() ? tsos.localError().positionError().yy() : 0.0f;
   for (auto const& broc : badRocPositions_) {
     auto dx = std::abs(broc.x() - lp.x()) - theRocWidth;
     auto dy = std::abs(broc.y() - lp.y()) - theRocHeight;
     if ((dx <= 0.f) & (dy <= 0.f))
       return true;
-    if ((dx * dx < 9.f * xx) && (dy * dy < 9.f * yy))
+    if ((dx * dx < 9.f * lexx) && (dy * dy < 9.f * leyy))
       return true;
   }
 
   if (badFEDChannelPositions == nullptr)
     return false;
-  float dx = 3.f * std::sqrt(xx) + theRocWidth, dy = 3.f * std::sqrt(yy) + theRocHeight;
+  float dx = 3.f * std::sqrt(lexx) + theRocWidth, dy = 3.f * std::sqrt(leyy) + theRocHeight;
   for (auto const& p : *badFEDChannelPositions) {
     if (lp.x() > (p.first.x() - dx) && lp.x() < (p.second.x() + dx) && lp.y() > (p.first.y() - dy) &&
         lp.y() < (p.second.y() + dy)) {


### PR DESCRIPTION
#### PR description:

This PR contains changes needed for the electron online reconstruction to be able to handle errors such as FED25 to flag malfunctioning Pixel modules. With respect to the current way of handling errors, which is maintained via the `isActive()` method

https://github.com/cms-sw/cmssw/blob/754d4fbc8bf3e05df6de16937fe6f4d30f5d8699/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc#L356

the new method allows us to catch cases where the flagging happens on a per-event basis (i.e., no need to mask those modules permanently via SiPixelQualityRcd).

In addition, if in the future a 2023 MC will be made where the FED25 error is used to simulate the BPIX issue (e.g., via a probability function), with these changes the online electron reconstruction code should be able to handle it correctly.

#### PR validation:

I observed an improvement in efficiency for electron triggers (such as HLT_Ele32_WPTight_Gsf) when running them with the proposed changes. The sample used for the test was a DY simulation where the issue in the faulty BPIX modules in layers 3 and 4 in 2023 was simulated at the level of the digitizer (i.e., the channels corresponding to the faulty modules produce an error FED25). Some plots can be found [here](https://cernbox.cern.ch/s/iB7yjoSbo3ne3Uf). Please note that the efficiencies are calculated using gen-level electrons and basically no selection, so on an absolute scale they can look low.

The PR also passed some basic runTeMatrix tests.
