### PR TITLE
[14_0 Bug Fix] Remove GenFilter when pgen_smear is used.

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1469,7 +1469,7 @@ class ConfigBuilder(object):
                     elif isinstance(theObject, cms.Sequence) or isinstance(theObject, cmstypes.ESProducer):
                         self._options.inlineObjects+=','+name
 
-            if stepSpec == self.GENDefaultSeq or stepSpec == 'pgen_genonly' or stepSpec == 'pgen_smear':
+            if stepSpec == self.GENDefaultSeq or stepSpec == 'pgen_genonly':
                 if 'ProductionFilterSequence' in genModules and ('generator' in genModules):
                     self.productionFilterSequence = 'ProductionFilterSequence'
                 elif 'generator' in genModules:


### PR DESCRIPTION
#### PR description:
As title said, this PR is a bug-fix to remove GenFIlter when pgen_smear is used. The GenFilter is used already when we use `pgen_only`. pgen_smear is for smearing only, so no need of GenFilter.

Original PR: https://github.com/cms-sw/cmssw/pull/39965

Thanks to @bbilin @drkovalskyi @sunilUIET 

#### PR validation:
-

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This needs backports to all releases that have `pgen_smear` step. 12_4 is an important target as it is currently used.
