### PR TITLE
[14_0_X SIM] Optional addition of Russian roulette to ZDC and HGCal 

### DIFF
--- a/SimG4CMS/Forward/src/ZdcSD.cc
+++ b/SimG4CMS/Forward/src/ZdcSD.cc
@@ -96,6 +96,13 @@ bool ZdcSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
     int primaryID = getTrackID(theTrack);
     currentID[0].setID(unitID, time, primaryID, depth);
     double energy = calculateCherenkovDeposit(aStep);
+
+    // Russian Roulette
+    double wt2 = theTrack->GetWeight();
+    if (wt2 > 0.0) {
+      energy *= wt2;
+    }
+
     if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
       edepositEM = energy;
       edepositHAD = 0;

--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -79,6 +79,8 @@ private:
   const G4Region* regionMuonIron{nullptr};
   const G4Region* regionPreShower{nullptr};
   const G4Region* regionCastor{nullptr};
+  const G4Region* regionZDC{nullptr};
+  const G4Region* regionHGcal{nullptr};
   const G4Region* regionWorld{nullptr};
 
   // Russian roulette energy limits
@@ -96,6 +98,10 @@ private:
   double nRusRoPreShower;
   double gRusRoCastor;
   double nRusRoCastor;
+  double gRusRoZDC;
+  double nRusRoZDC;
+  double gRusRoHGcal;
+  double nRusRoHGcal;
   double gRusRoWorld;
   double nRusRoWorld;
   // flags

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -23,7 +23,6 @@
 #include "SimG4Core/Application/interface/RunManagerMTWorker.h"
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 #include "SimG4Core/Notification/interface/TmpSimVertex.h"
-#include "SimG4Core/Notification/interface/TmpSimTrack.h"
 
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
 #include "SimG4Core/SensitiveDetector/interface/SensitiveCaloDetector.h"
@@ -270,9 +269,9 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   e.put(std::move(p1));
   e.put(std::move(p2));
 
-  for (auto& tracker : sTk) {
+  for (auto const& tracker : sTk) {
     const std::vector<std::string>& v = tracker->getNames();
-    for (auto& name : v) {
+    for (auto const& name : v) {
       std::unique_ptr<edm::PSimHitContainer> product(new edm::PSimHitContainer);
       tracker->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())
@@ -280,9 +279,9 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       e.put(std::move(product), name);
     }
   }
-  for (auto& calo : sCalo) {
+  for (auto const& calo : sCalo) {
     const std::vector<std::string>& v = calo->getNames();
-    for (auto& name : v) {
+    for (auto const& name : v) {
       std::unique_ptr<edm::PCaloHitContainer> product(new edm::PCaloHitContainer);
       calo->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())

--- a/SimG4Core/Application/src/EventAction.cc
+++ b/SimG4Core/Application/src/EventAction.cc
@@ -2,7 +2,7 @@
 #include "SimG4Core/Application/interface/SimRunInterface.h"
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 #include "SimG4Core/Notification/interface/TmpSimVertex.h"
-#include "SimG4Core/Notification/interface/TmpSimTrack.h"
+//#include "SimG4Core/Notification/interface/TmpSimTrack.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
@@ -23,7 +23,7 @@ EventAction::EventAction(const edm::ParameterSet& p,
       m_debug(p.getUntrackedParameter<bool>("debug", false)) {}
 
 void EventAction::BeginOfEventAction(const G4Event* anEvent) {
-  m_trackManager->reset();
+  //  m_trackManager->reset();
 
   BeginOfEvent e(anEvent);
   m_beginOfEventSignal(&e);
@@ -41,17 +41,18 @@ void EventAction::BeginOfEventAction(const G4Event* anEvent) {
 void EventAction::EndOfEventAction(const G4Event* anEvent) {
   if (m_printRandom) {
     edm::LogVerbatim("SimG4CoreApplication")
-        << " EndOfEvent " << anEvent->GetEventID() << " Random number: " << G4UniformRand();
+        << "EventACtion::EndOfEventAction: " << anEvent->GetEventID() << " Random number: " << G4UniformRand();
   }
   if (!m_stopFile.empty() && std::ifstream(m_stopFile.c_str())) {
     edm::LogWarning("SimG4CoreApplication")
-        << "EndOfEventAction: termination signal received at event " << anEvent->GetEventID();
+        << "EventACtion::EndOfEventAction: termination signal received at event " << anEvent->GetEventID();
     // soft abort run
     m_runInterface->abortRun(true);
   }
   if (anEvent->GetNumberOfPrimaryVertex() == 0) {
-    edm::LogWarning("SimG4CoreApplication") << "EndOfEventAction: event " << anEvent->GetEventID()
-                                            << " must have failed (no G4PrimaryVertices found) and will be skipped ";
+    edm::LogWarning("SimG4CoreApplication") 
+        << "EventACtion::EndOfEventAction: event " << anEvent->GetEventID()
+        << " must have failed (no G4PrimaryVertices found) and will be skipped";
     return;
   }
 

--- a/SimG4Core/Application/src/EventAction.cc
+++ b/SimG4Core/Application/src/EventAction.cc
@@ -2,7 +2,6 @@
 #include "SimG4Core/Application/interface/SimRunInterface.h"
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 #include "SimG4Core/Notification/interface/TmpSimVertex.h"
-//#include "SimG4Core/Notification/interface/TmpSimTrack.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/EndOfEvent.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
@@ -23,8 +22,6 @@ EventAction::EventAction(const edm::ParameterSet& p,
       m_debug(p.getUntrackedParameter<bool>("debug", false)) {}
 
 void EventAction::BeginOfEventAction(const G4Event* anEvent) {
-  //  m_trackManager->reset();
-
   BeginOfEvent e(anEvent);
   m_beginOfEventSignal(&e);
 
@@ -50,9 +47,8 @@ void EventAction::EndOfEventAction(const G4Event* anEvent) {
     m_runInterface->abortRun(true);
   }
   if (anEvent->GetNumberOfPrimaryVertex() == 0) {
-    edm::LogWarning("SimG4CoreApplication") 
-        << "EventACtion::EndOfEventAction: event " << anEvent->GetEventID()
-        << " must have failed (no G4PrimaryVertices found) and will be skipped";
+    edm::LogWarning("SimG4CoreApplication") << "EventACtion::EndOfEventAction: event " << anEvent->GetEventID()
+                                            << " must have failed (no G4PrimaryVertices found) and will be skipped";
     return;
   }
 

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -245,8 +245,8 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
             }
           }
 
-          if (killDeltaRay && classification != fKill && aTrack->GetParentID() > 0 && 
-	      G4TrackToParticleID::isGammaElectronPositron(aTrack)) {
+          if (killDeltaRay && classification != fKill && aTrack->GetParentID() > 0 &&
+              G4TrackToParticleID::isGammaElectronPositron(aTrack)) {
             classification = fKill;
           }
 
@@ -324,9 +324,9 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
                   } else if (reg == regionMuonIron) {
                     prob = gRusRoMuonIron;
                   } else if (reg == regionHGcal) {
-		    prob = gRusRoHGcal;
+                    prob = gRusRoHGcal;
                   } else if (reg == regionZDC) {
-		    prob = gRusRoZDC;
+                    prob = gRusRoZDC;
                   } else if (reg == regionCastor) {
                     prob = gRusRoCastor;
                   } else if (reg == regionWorld) {

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -3,6 +3,7 @@
 #include "SimG4Core/Notification/interface/MCTruthUtil.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
+#include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -56,6 +57,11 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   nRusRoPreShower = p.getParameter<double>("RusRoPreShowerNeutron");
   nRusRoCastor = p.getParameter<double>("RusRoCastorNeutron");
   nRusRoWorld = p.getParameter<double>("RusRoWorldNeutron");
+
+  gRusRoZDC = gRusRoCastor;
+  gRusRoHGcal = gRusRoCastor;
+  nRusRoZDC = nRusRoCastor;
+  nRusRoHGcal = nRusRoCastor;
 
   if (gRusRoEnerLim > 0.0 && (gRusRoEcal < 1.0 || gRusRoHcal < 1.0 || gRusRoMuonIron < 1.0 || gRusRoPreShower < 1.0 ||
                               gRusRoCastor < 1.0 || gRusRoWorld < 1.0)) {
@@ -239,9 +245,11 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
             }
           }
 
-          if (killDeltaRay && classification != fKill && subType == fIonisation) {
+          if (killDeltaRay && classification != fKill && aTrack->GetParentID() > 0 && 
+	      G4TrackToParticleID::isGammaElectronPositron(aTrack)) {
             classification = fKill;
           }
+
           if (killInCalo && classification != fKill && isThisRegion(reg, caloRegions)) {
             classification = fKill;
           }
@@ -289,6 +297,10 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
                   prob = nRusRoMuonIron;
                 } else if (reg == regionPreShower) {
                   prob = nRusRoPreShower;
+                } else if (reg == regionHGcal) {
+                  prob = nRusRoHGcal;
+                } else if (reg == regionZDC) {
+                  prob = nRusRoZDC;
                 } else if (reg == regionCastor) {
                   prob = nRusRoCastor;
                 } else if (reg == regionWorld) {
@@ -311,6 +323,10 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
                     prob = gRusRoHcal;
                   } else if (reg == regionMuonIron) {
                     prob = gRusRoMuonIron;
+                  } else if (reg == regionHGcal) {
+		    prob = gRusRoHGcal;
+                  } else if (reg == regionZDC) {
+		    prob = gRusRoZDC;
                   } else if (reg == regionCastor) {
                     prob = gRusRoCastor;
                   } else if (reg == regionWorld) {
@@ -372,6 +388,12 @@ void StackingAction::initPointer() {
     }
     if ((gRusRoCastor < 1.0 || nRusRoCastor < 1.0) && rname == "CastorRegion") {
       regionCastor = reg;
+    }
+    if ((gRusRoZDC < 1.0 || nRusRoZDC < 1.0) && rname == "ZDCRegion") {
+      regionZDC = reg;
+    }
+    if ((gRusRoHGcal < 1.0 || nRusRoHGcal < 1.0) && rname == "HGCalRegion") {
+      regionHGcal = reg;
     }
     if ((gRusRoWorld < 1.0 || nRusRoWorld < 1.0) && rname == "DefaultRegionForTheWorld") {
       regionWorld = reg;


### PR DESCRIPTION
#### PR description:
Extra option to simulate faster ZDC and HGCal is added. If enabled the Russian roulette method is applied in these calorimeters. Also unused headers in few classes are removed. An option is added to remove e+-, gamma from simulation, which may be useful for GPU R&D.

Baseline simulation is expected to be unchanged.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO but this PR may be backported to HeavyIons release.

