### PR TITLE
Adapt Alpaka-based PF Clustering to read Hcal thresholds from GT

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFRecHitSoA.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitSoA.h
@@ -14,6 +14,7 @@ namespace reco {
   using PFRecHitsNeighbours = Eigen::Matrix<int32_t, 8, 1>;
   GENERATE_SOA_LAYOUT(PFRecHitSoALayout,
                       SOA_COLUMN(uint32_t, detId),
+                      SOA_COLUMN(uint32_t, denseId),
                       SOA_COLUMN(float, energy),
                       SOA_COLUMN(float, time),
                       SOA_COLUMN(int, depth),

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterParamsSoA.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterParamsSoA.h
@@ -1,5 +1,5 @@
-#ifndef RecoParticleFlow_PFClusterProducer_interface_PFRecHitHBHEParamsSoA_h
-#define RecoParticleFlow_PFClusterProducer_interface_PFRecHitHBHEParamsSoA_h
+#ifndef RecoParticleFlow_PFClusterProducer_interface_PFClusterParamsSoA_h
+#define RecoParticleFlow_PFClusterProducer_interface_PFClusterParamsSoA_h
 
 #include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
@@ -9,12 +9,12 @@ namespace reco {
 
   GENERATE_SOA_LAYOUT(PFClusterParamsSoALayout,
                       SOA_SCALAR(int32_t, nNeigh),
-                      SOA_SCALAR(float, seedPt2ThresholdEB),
-                      SOA_SCALAR(float, seedPt2ThresholdEE),
-                      SOA_COLUMN(float, seedEThresholdEB_vec),
-                      SOA_COLUMN(float, seedEThresholdEE_vec),
-                      SOA_COLUMN(float, topoEThresholdEB_vec),
-                      SOA_COLUMN(float, topoEThresholdEE_vec),
+                      SOA_SCALAR(float, seedPt2ThresholdHB),
+                      SOA_SCALAR(float, seedPt2ThresholdHE),
+                      SOA_COLUMN(float, seedEThresholdHB_vec),
+                      SOA_COLUMN(float, seedEThresholdHE_vec),
+                      SOA_COLUMN(float, topoEThresholdHB_vec),
+                      SOA_COLUMN(float, topoEThresholdHE_vec),
                       SOA_SCALAR(float, showerSigma2),
                       SOA_SCALAR(float, minFracToKeep),
                       SOA_SCALAR(float, minFracTot),
@@ -23,8 +23,8 @@ namespace reco {
                       SOA_SCALAR(float, stoppingTolerance),
                       SOA_SCALAR(float, minFracInCalc),
                       SOA_SCALAR(float, minAllowedNormalization),
-                      SOA_COLUMN(float, recHitEnergyNormInvEB_vec),
-                      SOA_COLUMN(float, recHitEnergyNormInvEE_vec),
+                      SOA_COLUMN(float, recHitEnergyNormInvHB_vec),
+                      SOA_COLUMN(float, recHitEnergyNormInvHE_vec),
                       SOA_SCALAR(float, barrelTimeResConsts_corrTermLowE),
                       SOA_SCALAR(float, barrelTimeResConsts_threshLowE),
                       SOA_SCALAR(float, barrelTimeResConsts_noiseTerm),

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterParamsESProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterParamsESProducer.cc
@@ -35,17 +35,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (thresholds.size() != kMaxDepth_barrel)
             throw cms::Exception("Configuration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel
                                                   << ") for \"\" vector of det = \"" << det << "\"";
-          view.seedPt2ThresholdEB() = seedPt2Threshold;
+          view.seedPt2ThresholdHB() = seedPt2Threshold;
           for (size_t idx = 0; idx < thresholds.size(); ++idx) {
-            view.seedEThresholdEB_vec()[idx] = thresholds[idx];
+            view.seedEThresholdHB_vec()[idx] = thresholds[idx];
           }
         } else if (det == "HCAL_ENDCAP") {
           if (thresholds.size() != kMaxDepth_endcap)
             throw cms::Exception("Configuration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap
                                                   << ") for \"\" vector of det = \"" << det << "\"";
-          view.seedPt2ThresholdEE() = seedPt2Threshold;
+          view.seedPt2ThresholdHE() = seedPt2Threshold;
           for (size_t idx = 0; idx < thresholds.size(); ++idx) {
-            view.seedEThresholdEE_vec()[idx] = thresholds[idx];
+            view.seedEThresholdHE_vec()[idx] = thresholds[idx];
           }
         } else {
           throw cms::Exception("Configuration") << "Unknown detector when parsing seedFinder: " << det;
@@ -63,14 +63,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             throw cms::Exception("Configuration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_barrel
                                                   << ") for \"\" vector of det = \"" << det << "\"";
           for (size_t idx = 0; idx < thresholds.size(); ++idx) {
-            view.topoEThresholdEB_vec()[idx] = thresholds[idx];
+            view.topoEThresholdHB_vec()[idx] = thresholds[idx];
           }
         } else if (det == "HCAL_ENDCAP") {
           if (thresholds.size() != kMaxDepth_endcap)
             throw cms::Exception("Configuration") << "Invalid size (" << thresholds.size() << " != " << kMaxDepth_endcap
                                                   << ") for \"\" vector of det = \"" << det << "\"";
           for (size_t idx = 0; idx < thresholds.size(); ++idx) {
-            view.topoEThresholdEE_vec()[idx] = thresholds[idx];
+            view.topoEThresholdHE_vec()[idx] = thresholds[idx];
           }
         } else {
           throw cms::Exception("Configuration") << "Unknown detector when parsing initClusteringStep: " << det;
@@ -99,7 +99,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_barrel
                 << ") for \"\" vector of det = \"" << det << "\"";
           for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
-            view.recHitEnergyNormInvEB_vec()[idx] = 1. / recHitNorms[idx];
+            view.recHitEnergyNormInvHB_vec()[idx] = 1. / recHitNorms[idx];
           }
         } else if (det == "HCAL_ENDCAP") {
           if (recHitNorms.size() != kMaxDepth_endcap)
@@ -107,7 +107,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 << "Invalid size (" << recHitNorms.size() << " != " << kMaxDepth_endcap
                 << ") for \"\" vector of det = \"" << det << "\"";
           for (size_t idx = 0; idx < recHitNorms.size(); ++idx) {
-            view.recHitEnergyNormInvEE_vec()[idx] = 1. / recHitNorms[idx];
+            view.recHitEnergyNormInvHE_vec()[idx] = 1. / recHitNorms[idx];
           }
         } else {
           throw cms::Exception("Configuration") << "Unknown detector when parsing recHitEnergyNorms: " << det;

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -88,14 +88,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   // Processing single seed clusters
   // Device function designed to be called by all threads of a given block
   template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-  ALPAKA_FN_ACC static void hcalFastCluster_singleSeed(const TAcc& acc,
-                                                       reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
-                                                       int topoId,   // from selection
-                                                       int nRHTopo,  // from selection
-                                                       reco::PFRecHitDeviceCollection::ConstView pfRecHits,
-                                                       reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
-                                                       reco::PFClusterDeviceCollection::View clusterView,
-                                                       reco::PFRecHitFractionDeviceCollection::View fracView) {
+  ALPAKA_FN_ACC static void hcalFastCluster_singleSeed(
+      const TAcc& acc,
+      reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+      const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
+      int topoId,   // from selection
+      int nRHTopo,  // from selection
+      reco::PFRecHitDeviceCollection::ConstView pfRecHits,
+      reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
+      reco::PFClusterDeviceCollection::View clusterView,
+      reco::PFRecHitFractionDeviceCollection::View fracView) {
     int tid = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];  // thread index is rechit number
     // Declaration of shared variables
     int& i = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -119,13 +121,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       clusterEnergy = seedEnergy;
       tol = pfClusParams.stoppingTolerance();  // stopping tolerance * tolerance scaling
 
-      if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEB_vec()[pfRecHits[i].depth() - 1];
-      else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEE_vec()[pfRecHits[i].depth() - 1];
-      else {
-        rhENormInv = 0.;
-        printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+      if (topology.cutsFromDB()) {
+        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+      } else {
+        if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
+        else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHE_vec()[pfRecHits[i].depth() - 1];
+        else {
+          rhENormInv = 0.;
+          printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+        }
       }
 
       iter = 0;
@@ -253,6 +259,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   ALPAKA_FN_ACC static void hcalFastCluster_multiSeedParallel(
       const TAcc& acc,
       reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+      const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
       int topoId,   // from selection
       int nSeeds,   // from selection
       int nRHTopo,  // from selection
@@ -289,12 +296,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       notDone = true;
 
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
-      if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEB_vec()[pfRecHits[i].depth() - 1];
-      else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEE_vec()[pfRecHits[i].depth() - 1];
-      else
-        printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+
+      if (topology.cutsFromDB()) {
+        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+      } else {
+        if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
+        else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHE_vec()[pfRecHits[i].depth() - 1];
+        else {
+          rhENormInv = 0.;
+          printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+        }
+      }
     }
     alpaka::syncBlockThreads(acc);  // all threads call sync
 
@@ -531,6 +545,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <bool debug = false, typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
   ALPAKA_FN_ACC static void hcalFastCluster_exotic(const TAcc& acc,
                                                    reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+                                                   const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                                    int topoId,
                                                    int nSeeds,
                                                    int nRHTopo,
@@ -572,12 +587,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       notDone = true;
 
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
-      if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEB_vec()[pfRecHits[i].depth() - 1];
-      else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEE_vec()[pfRecHits[i].depth() - 1];
-      else
-        printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+
+      if (topology.cutsFromDB()) {
+        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+      } else {
+        if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
+        else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHE_vec()[pfRecHits[i].depth() - 1];
+        else {
+          rhENormInv = 0.;
+          printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+        }
+      }
     }
     alpaka::syncBlockThreads(acc);  // all threads call sync
 
@@ -798,6 +820,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   ALPAKA_FN_ACC static void hcalFastCluster_multiSeedIterative(
       const TAcc& acc,
       reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+      const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
       int topoId,
       int nSeeds,
       int nRHTopo,
@@ -831,12 +854,19 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       notDone = true;
 
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
-      if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEB_vec()[pfRecHits[i].depth() - 1];
-      else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
-        rhENormInv = pfClusParams.recHitEnergyNormInvEE_vec()[pfRecHits[i].depth() - 1];
-      else
-        printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+
+      if (topology.cutsFromDB()) {
+        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+      } else {
+        if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
+        else if (pfRecHits[i].layer() == PFLayer::HCAL_ENDCAP)
+          rhENormInv = pfClusParams.recHitEnergyNormInvHE_vec()[pfRecHits[i].depth() - 1];
+        else {
+          rhENormInv = 0.;
+          printf("Rechit %d has invalid layer %d!\n", i, pfRecHits[i].layer());
+        }
+      }
     }
     alpaka::syncBlockThreads(acc);  // all threads call sync
 
@@ -1057,6 +1087,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   const reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+                                  const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                   const reco::PFRecHitHostCollection::ConstView pfRecHits,
                                   reco::PFClusterDeviceCollection::View clusterView,
                                   reco::PFRecHitFractionDeviceCollection::View fracView,
@@ -1082,15 +1113,28 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         int depthOffset = pfRecHits[i].depth() - 1;
         float energy = pfRecHits[i].energy();
         Position3 pos = Position3{pfRecHits[i].x(), pfRecHits[i].y(), pfRecHits[i].z()};
+        float seedThreshold = 9999.;
+        float topoThreshold = 9999.;
+
+        if (topology.cutsFromDB()) {
+          seedThreshold = topology[pfRecHits[i].denseId()].seedThreshold();
+          topoThreshold = topology[pfRecHits[i].denseId()].noiseThreshold();
+        } else {
+          if (layer == PFLayer::HCAL_BARREL1) {
+            seedThreshold = pfClusParams.seedEThresholdHB_vec()[depthOffset];
+            topoThreshold = pfClusParams.topoEThresholdHB_vec()[depthOffset];
+          } else if (layer == PFLayer::HCAL_ENDCAP) {
+            seedThreshold = pfClusParams.seedEThresholdHE_vec()[depthOffset];
+            topoThreshold = pfClusParams.topoEThresholdHE_vec()[depthOffset];
+          }
+        }
 
         // cmssdt.cern.ch/lxr/source/DataFormats/ParticleFlowReco/interface/PFRecHit.h#0108
         float pt2 = energy * energy * (pos.x * pos.x + pos.y * pos.y) / (pos.x * pos.x + pos.y * pos.y + pos.z * pos.z);
 
         // Seeding threshold test
-        if ((layer == PFLayer::HCAL_BARREL1 && energy > pfClusParams.seedEThresholdEB_vec()[depthOffset] &&
-             pt2 > pfClusParams.seedPt2ThresholdEB()) ||
-            (layer == PFLayer::HCAL_ENDCAP && energy > pfClusParams.seedEThresholdEE_vec()[depthOffset] &&
-             pt2 > pfClusParams.seedPt2ThresholdEE())) {
+        if ((layer == PFLayer::HCAL_BARREL1 && energy > seedThreshold && pt2 > pfClusParams.seedPt2ThresholdHB()) ||
+            (layer == PFLayer::HCAL_ENDCAP && energy > seedThreshold && pt2 > pfClusParams.seedPt2ThresholdHE())) {
           pfClusteringVars[i].pfrh_isSeed() = 1;
           for (int k = 0; k < 4; k++) {  // Does this seed candidate have a higher energy than four neighbours
             if (pfRecHits[i].neighbours()(k) < 0)
@@ -1104,8 +1148,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             alpaka::atomicAdd(acc, nSeeds, 1u);
         }
         // Topo clustering threshold test
-        if ((layer == PFLayer::HCAL_ENDCAP && energy > pfClusParams.topoEThresholdEE_vec()[depthOffset]) ||
-            (layer == PFLayer::HCAL_BARREL1 && energy > pfClusParams.topoEThresholdEB_vec()[depthOffset])) {
+
+        if ((layer == PFLayer::HCAL_ENDCAP && energy > topoThreshold) ||
+            (layer == PFLayer::HCAL_BARREL1 && energy > topoThreshold)) {
           pfClusteringVars[i].pfrh_passTopoThresh() = true;
           pfClusteringVars[i].pfrh_topoId() = i;
         } else {
@@ -1306,6 +1351,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   const reco::PFRecHitHostCollection::ConstView pfRecHits,
                                   const reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+                                  const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusterDeviceCollection::View clusterView,
                                   reco::PFRecHitFractionDeviceCollection::View fracView) const {
@@ -1339,14 +1385,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (nSeeds == 1) {
             // Single seed cluster
             hcalFastCluster_singleSeed(
-                acc, pfClusParams, topoId, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
+                acc, pfClusParams, topology, topoId, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
           } else if (nSeeds <= 100 && nRHTopo - nSeeds < threadsPerBlockForClustering) {
             hcalFastCluster_multiSeedParallel(
-                acc, pfClusParams, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
+                acc, pfClusParams, topology, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
           }
         } else if (nSeeds <= 400 && nRHTopo - nSeeds <= 1500) {
           hcalFastCluster_multiSeedIterative(
-              acc, pfClusParams, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
+              acc, pfClusParams, topology, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
         } else {
           if constexpr (debug) {
             if (once_per_block(acc))
@@ -1367,6 +1413,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   const reco::PFRecHitHostCollection::ConstView pfRecHits,
                                   const reco::PFClusterParamsDeviceCollection::ConstView pfClusParams,
+                                  const reco::PFRecHitHCALTopologyDeviceCollection::ConstView topology,
                                   reco::PFClusteringVarsDeviceCollection::View pfClusteringVars,
                                   reco::PFClusterDeviceCollection::View clusterView,
                                   reco::PFRecHitFractionDeviceCollection::View fracView,
@@ -1385,6 +1432,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         if (nRHTopo > 0 && nSeeds > 400 && nRHTopo - nSeeds > 1500) {
           hcalFastCluster_exotic(acc,
                                  pfClusParams,
+                                 topology,
                                  topoId,
                                  nSeeds,
                                  nRHTopo,
@@ -1420,6 +1468,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   void PFClusterProducerKernel::execute(Queue& queue,
                                         const reco::PFClusterParamsDeviceCollection& params,
+                                        const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                                         reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                                         reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
                                         const reco::PFRecHitHostCollection& pfRecHits,
@@ -1435,6 +1484,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         SeedingTopoThresh{},
                         pfClusteringVars.view(),
                         params.view(),
+                        topology.view(),
                         pfRecHits.view(),
                         pfClusters.view(),
                         pfrhFractions.view(),
@@ -1489,6 +1539,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         FastCluster{},
                         pfRecHits.view(),
                         params.view(),
+                        topology.view(),
                         pfClusteringVars.view(),
                         pfClusters.view(),
                         pfrhFractions.view());
@@ -1499,6 +1550,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         FastClusterExotic{},
                         pfRecHits.view(),
                         params.view(),
+                        topology.view(),
                         pfClusteringVars.view(),
                         pfClusters.view(),
                         pfrhFractions.view(),

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -122,7 +122,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       tol = pfClusParams.stoppingTolerance();  // stopping tolerance * tolerance scaling
 
       if (topology.cutsFromDB()) {
-        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+        rhENormInv = (1.f / topology[pfRecHits[i].denseId()].noiseThreshold());
       } else {
         if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
           rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
@@ -167,7 +167,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                 (clusterPos.z - rhPos.z) * (clusterPos.z - rhPos.z);
 
         d2 = dist2 / pfClusParams.showerSigma2();
-        fraction = clusterEnergy * rhENormInv * expf(-0.5 * d2);
+        fraction = clusterEnergy * rhENormInv * expf(-0.5f * d2);
 
         // For single seed clusters, rechit fraction is either 1 (100%) or -1 (not included)
         if (fraction > pfClusParams.minFracTot() && d2 < cutoffDistance)
@@ -298,7 +298,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
 
       if (topology.cutsFromDB()) {
-        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+        rhENormInv = (1.f / topology[pfRecHits[i].denseId()].noiseThreshold());
       } else {
         if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
           rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
@@ -405,7 +405,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           rhFracSum[tid] += fraction;
         }
@@ -420,7 +420,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           if (rhFracSum[tid] > pfClusParams.minFracTot()) {
             float fracpct = fraction / rhFracSum[tid];
@@ -589,7 +589,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
 
       if (topology.cutsFromDB()) {
-        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+        rhENormInv = (1.f / topology[pfRecHits[i].denseId()].noiseThreshold());
       } else {
         if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
           rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
@@ -673,7 +673,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           rhFracSum[tid] += fraction;
         }
@@ -691,7 +691,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           if (rhFracSum[tid] > pfClusParams.minFracTot()) {
             float fracpct = fraction / rhFracSum[tid];
@@ -856,7 +856,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       int i = pfClusteringVars[topoSeedBegin].topoSeedList();
 
       if (topology.cutsFromDB()) {
-        rhENormInv = (1. / topology[pfRecHits[i].denseId()].noiseThreshold());
+        rhENormInv = (1.f / topology[pfRecHits[i].denseId()].noiseThreshold());
       } else {
         if (pfRecHits[i].layer() == PFLayer::HCAL_BARREL1)
           rhENormInv = pfClusParams.recHitEnergyNormInvHB_vec()[pfRecHits[i].depth() - 1];
@@ -940,7 +940,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           rhFracSum[tid] += fraction;
         }
@@ -958,7 +958,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                         (clusterPos[s].z - rhThreadPos.z) * (clusterPos[s].z - rhThreadPos.z);
 
           float d2 = dist2 / pfClusParams.showerSigma2();
-          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5 * d2);
+          float fraction = clusterEnergy[s] * rhENormInv * expf(-0.5f * d2);
 
           if (rhFracSum[tid] > pfClusParams.minFracTot()) {
             float fracpct = fraction / rhFracSum[tid];

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.h
@@ -8,6 +8,8 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusterParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringVarsDeviceCollection.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/alpaka/PFClusteringEdgeVarsDeviceCollection.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -40,6 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     void execute(Queue& queue,
                  const reco::PFClusterParamsDeviceCollection& params,
+                 const reco::PFRecHitHCALTopologyDeviceCollection& topology,
                  reco::PFClusteringVarsDeviceCollection& pfClusteringVars,
                  reco::PFClusteringEdgeVarsDeviceCollection& pfClusteringEdgeVars,
                  const reco::PFRecHitHostCollection& pfRecHits,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -91,6 +91,6 @@ phase2_timing.toModify(particleFlowClusterECAL,
 from Configuration.ProcessModifiers.alpaka_cff import alpaka
 
 def _addProcessPFClusterAlpaka(process):
-    process.load("RecoParticleFlow.PFClusterProducerAlpaka.pfClusterHBHEAlpaka_cff")
+    process.load("RecoParticleFlow.PFClusterProducer.pfClusterHBHEAlpaka_cff")
 
 modifyConfigurationPFClusterAlpaka_ = alpaka.makeProcessModifier(_addProcessPFClusterAlpaka)

--- a/RecoParticleFlow/PFClusterProducer/python/pfClusterHBHEAlpaka_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/pfClusterHBHEAlpaka_cff.py
@@ -61,13 +61,14 @@ legacyPFRecHitProducer = _legacyPFRecHitProducer.clone(
 pfClusterParamsESProducer = _pfClusterParamsESProducer.clone()
 pfClusterSoAProducer = _pfClusterSoAProducer.clone(
         pfRecHits = 'pfRecHitSoAProducerHCAL',
+        topology = "pfRecHitHCALTopologyESProducer:",
         pfClusterParams = 'pfClusterParamsESProducer:',
         synchronise = cms.bool(False)
     )
 
 
 legacyPFClusterProducer = _legacyPFClusterProducer.clone(
-        src = 'pfClusterProducerAlpaka',
+        src = 'pfClusterSoAProducer',
         pfClusterParams = 'pfClusterParamsESProducer:',
         pfClusterBuilder = particleFlowClusterHBHE.pfClusterBuilder,
         recHitsSource = 'legacyPFRecHitProducer',

--- a/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
+++ b/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
@@ -184,7 +184,7 @@ process.hltParticleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
         name = cms.string('PFHBHERecHitCreator'),
         qualityTests = cms.VPSet(
             cms.PSet(
-                usePFThresholdsFromDB = cms.bool(False),
+                usePFThresholdsFromDB = cms.bool(True),
                 cuts = cms.VPSet(
                     cms.PSet(
                         depth = cms.vint32(1, 2, 3, 4),
@@ -224,7 +224,7 @@ if hcal:
             name = cms.string('PFHBHERecHitCreator'),
             qualityTests = cms.VPSet(
                 cms.PSet(
-                    usePFThresholdsFromDB = cms.bool(False),
+                    usePFThresholdsFromDB = cms.bool(True),
                     cuts = cms.VPSet(
                         cms.PSet(
                             depth = cms.vint32(1, 2, 3, 4),

--- a/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
+++ b/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
@@ -48,7 +48,6 @@ process.maxEvents = cms.untracked.PSet(
 # Need to use a file that contains HCAL/ECAL hits. Verify using:
 # root root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0088b51b-0cda-40f2-95fc-590f446624ee.root -e 'Events->Print()' -q | grep -E "hltHbhereco|hltEcalRecHit"
 process.source = cms.Source("PoolSource",
-    #fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/05ad6501-815f-4df6-b115-03ad028f9b76.root'),
     #fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0088b51b-0cda-40f2-95fc-590f446624ee.root'),
     fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_8/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v3_2022-v1/2580000/0e63ba30-251b-4034-93ca-4d400aaa399e.root'),
     secondaryFileNames = cms.untracked.vstring(),

--- a/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
+++ b/RecoParticleFlow/PFClusterProducer/test/test_PFRecHitAndClusterSoA.py
@@ -48,6 +48,7 @@ process.maxEvents = cms.untracked.PSet(
 # Need to use a file that contains HCAL/ECAL hits. Verify using:
 # root root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0088b51b-0cda-40f2-95fc-590f446624ee.root -e 'Events->Print()' -q | grep -E "hltHbhereco|hltEcalRecHit"
 process.source = cms.Source("PoolSource",
+    #fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/05ad6501-815f-4df6-b115-03ad028f9b76.root'),
     #fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_130X_mcRun3_2022_realistic_v2_HS-v4/2590000/0088b51b-0cda-40f2-95fc-590f446624ee.root'),
     fileNames = cms.untracked.vstring('/store/relval/CMSSW_13_0_8/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/130X_mcRun3_2022_realistic_v3_2022-v1/2580000/0e63ba30-251b-4034-93ca-4d400aaa399e.root'),
     secondaryFileNames = cms.untracked.vstring(),
@@ -316,7 +317,8 @@ process.pfRecHitParamsRecordSource = cms.ESSource('EmptyESSource',
     iovIsRunNotTime = cms.bool(True),
     firstValid = cms.vuint32(1)
 )
-process.hltParticleFlowRecHitTopologyESProducer = cms.ESProducer(alpaka_backend_str % f"PFRecHit{CAL}TopologyESProducer")
+process.hltParticleFlowRecHitTopologyESProducer = cms.ESProducer(alpaka_backend_str % f"PFRecHit{CAL}TopologyESProducer",
+        usePFThresholdsFromDB = cms.bool(True))
 if hcal:
     process.hltParticleFlowRecHitParamsESProducer = cms.ESProducer(alpaka_backend_str % "PFRecHitHCALParamsESProducer",
         energyThresholdsHB = cms.vdouble( 0.4, 0.3, 0.3, 0.3 ),
@@ -430,6 +432,7 @@ for idx, x in enumerate(process.hltParticleFlowClusterParamsESProducer.seedFinde
 
 process.hltParticleFlowPFClusterAlpaka = cms.EDProducer(alpaka_backend_str % "PFClusterSoAProducer",
                                                         pfClusterParams = cms.ESInputTag("hltParticleFlowClusterParamsESProducer:"),
+                                                        topology = cms.ESInputTag("hltParticleFlowRecHitTopologyESProducer:"),
                                                         synchronise = cms.bool(args.synchronise))
 process.hltParticleFlowPFClusterAlpaka.pfRecHits = cms.InputTag("hltParticleFlowPFRecHitAlpaka")
 
@@ -439,11 +442,12 @@ process.hltParticleFlowAlpakaToLegacyPFClusters = cms.EDProducer("LegacyPFCluste
                                                                  src = cms.InputTag("hltParticleFlowPFClusterAlpaka"),
                                                                  pfClusterParams = cms.ESInputTag("hltParticleFlowClusterParamsESProducer:"),
                                                                  pfClusterBuilder = process.hltParticleFlowClusterHBHE.pfClusterBuilder,
+                                                                 usePFThresholdsFromDB = cms.bool(True),
                                                                  recHitsSource = cms.InputTag("hltParticleFlowAlpakaToLegacyPFRecHits"))
 process.hltParticleFlowAlpakaToLegacyPFClusters.PFRecHitsLabelIn = cms.InputTag("hltParticleFlowPFRecHitAlpaka")
 
 process.hltParticleFlowClusterHBHE.pfClusterBuilder.maxIterations = 5
-process.hltParticleFlowClusterHBHE.usePFThresholdsFromDB = cms.bool(False)
+process.hltParticleFlowClusterHBHE.usePFThresholdsFromDB = cms.bool(True)
 
 # Additional customization
 process.FEVTDEBUGHLToutput.outputCommands = cms.untracked.vstring('drop  *_*_*_*')

--- a/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h
+++ b/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h
@@ -9,8 +9,7 @@
 
 class PFRecHitHCALTopologyRecord : public edm::eventsetup::DependentRecordImplementation<
                                        PFRecHitHCALTopologyRecord,
-                                       edm::mpl::Vector<HcalRecNumberingRecord, CaloGeometryRecord,
-                                       HcalPFCutsRcd>> {};
+                                       edm::mpl::Vector<HcalRecNumberingRecord, CaloGeometryRecord, HcalPFCutsRcd>> {};
 
 class PFRecHitECALTopologyRecord
     : public edm::eventsetup::DependentRecordImplementation<PFRecHitECALTopologyRecord,

--- a/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h
+++ b/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h
@@ -5,10 +5,12 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
 
 class PFRecHitHCALTopologyRecord : public edm::eventsetup::DependentRecordImplementation<
                                        PFRecHitHCALTopologyRecord,
-                                       edm::mpl::Vector<HcalRecNumberingRecord, CaloGeometryRecord>> {};
+                                       edm::mpl::Vector<HcalRecNumberingRecord, CaloGeometryRecord,
+                                       HcalPFCutsRcd>> {};
 
 class PFRecHitECALTopologyRecord
     : public edm::eventsetup::DependentRecordImplementation<PFRecHitECALTopologyRecord,

--- a/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologySoA.h
+++ b/RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologySoA.h
@@ -15,6 +15,9 @@ namespace reco {
                       SOA_COLUMN(float, positionX),
                       SOA_COLUMN(float, positionY),
                       SOA_COLUMN(float, positionZ),
+                      SOA_COLUMN(float, noiseThreshold),
+                      SOA_COLUMN(float, seedThreshold),
+                      SOA_SCALAR(bool, cutsFromDB),
                       SOA_EIGEN_COLUMN(PFRecHitsTopologyNeighbours, neighbours))
   GENERATE_SOA_LAYOUT(PFRecHitECALTopologySoALayout,
                       SOA_COLUMN(float, positionX),

--- a/RecoParticleFlow/PFRecHitProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/BuildFile.xml
@@ -13,6 +13,8 @@
 <!-- alpaka-based portable plugins -->
 <library name="RecoParticleFlowPFRecHitProducersPluginsPortable" file="alpaka/*.cc">
   <use name="CondFormats/EcalObjects"/>
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondTools/Hcal"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/EcalDetId"/>
   <use name="DataFormats/ParticleFlowReco"/>

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -16,6 +16,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
     ALPAKA_FN_ACC void operator()(const TAcc& acc,
                                   const typename CAL::ParameterType::ConstView params,
+                                  const typename CAL::TopologyTypeDevice::ConstView topology,
                                   const typename CAL::CaloRecHitSoATypeDevice::ConstView recHits,
                                   reco::PFRecHitDeviceCollection::View pfRecHits,
                                   uint32_t* __restrict__ denseId2pfRecHit,
@@ -23,7 +24,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // Strided loop over CaloRecHits
       for (int32_t i : cms::alpakatools::elements_with_stride(acc, recHits.metadata().size())) {
         // Check energy thresholds/quality cuts (specialised for HCAL/ECAL)
-        if (!applyCuts(recHits[i], params))
+        if (!applyCuts(recHits[i], params, topology))
           continue;
 
         // Use atomic operation to determine index of the PFRecHit to be constructed
@@ -40,7 +41,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     }
 
     ALPAKA_FN_ACC static bool applyCuts(const typename CAL::CaloRecHitSoATypeDevice::ConstView::const_element rh,
-                                        const typename CAL::ParameterType::ConstView params);
+                                        const typename CAL::ParameterType::ConstView params,
+                                        const typename CAL::TopologyTypeDevice::ConstView topology);
 
     ALPAKA_FN_ACC static void constructPFRecHit(
         reco::PFRecHitDeviceCollection::View::element pfrh,
@@ -50,26 +52,32 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <>
   ALPAKA_FN_ACC bool PFRecHitProducerKernelConstruct<HCAL>::applyCuts(
       const typename HCAL::CaloRecHitSoATypeDevice::ConstView::const_element rh,
-      const HCAL::ParameterType::ConstView params) {
+      const HCAL::ParameterType::ConstView params,
+      const HCAL::TopologyTypeDevice::ConstView topology) {
     // Reject HCAL recHits below enery threshold
     float threshold = 9999.;
     const uint32_t detId = rh.detId();
     const uint32_t depth = HCAL::getDepth(detId);
     const uint32_t subdet = getSubdet(detId);
-    if (subdet == HcalBarrel) {
-      threshold = params.energyThresholds()[depth - 1];
-    } else if (subdet == HcalEndcap) {
-      threshold = params.energyThresholds()[depth - 1 + HCAL::kMaxDepthHB];
+    if (topology.cutsFromDB()) {
+        threshold = topology.noiseThreshold()[HCAL::detId2denseId(detId)];
     } else {
-      printf("Rechit with detId %u has invalid subdetector %u!\n", detId, subdet);
-      return false;
+        if (subdet == HcalBarrel) {
+          threshold = params.energyThresholds()[depth - 1];
+        } else if (subdet == HcalEndcap) {
+          threshold = params.energyThresholds()[depth - 1 + HCAL::kMaxDepthHB];
+        } else {
+          printf("Rechit with detId %u has invalid subdetector %u!\n", detId, subdet);
+          return false;
+        }
     }
     return rh.energy() >= threshold;
   }
 
   template <>
   ALPAKA_FN_ACC bool PFRecHitProducerKernelConstruct<ECAL>::applyCuts(
-      const ECAL::CaloRecHitSoATypeDevice::ConstView::const_element rh, const ECAL::ParameterType::ConstView params) {
+      const ECAL::CaloRecHitSoATypeDevice::ConstView::const_element rh, const ECAL::ParameterType::ConstView params,
+      const ECAL::TopologyTypeDevice::ConstView topology) {
     // Reject ECAL recHits below energy threshold
     if (rh.energy() < params.energyThresholds()[ECAL::detId2denseId(rh.detId())])
       return false;
@@ -168,11 +176,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   void PFRecHitProducerKernel<CAL>::processRecHits(Queue& queue,
                                                    const typename CAL::CaloRecHitSoATypeDevice& recHits,
                                                    const typename CAL::ParameterType& params,
+                                                   const typename CAL::TopologyTypeDevice& topology,
                                                    reco::PFRecHitDeviceCollection& pfRecHits) {
     alpaka::exec<Acc1D>(queue,
                         work_div_,
                         PFRecHitProducerKernelConstruct<CAL>{},
                         params.view(),
+                        topology.view(),
                         recHits.view(),
                         pfRecHits.view(),
                         denseId2pfRecHit_.data(),

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -60,23 +60,24 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     const uint32_t depth = HCAL::getDepth(detId);
     const uint32_t subdet = getSubdet(detId);
     if (topology.cutsFromDB()) {
-        threshold = topology.noiseThreshold()[HCAL::detId2denseId(detId)];
+      threshold = topology.noiseThreshold()[HCAL::detId2denseId(detId)];
     } else {
-        if (subdet == HcalBarrel) {
-          threshold = params.energyThresholds()[depth - 1];
-        } else if (subdet == HcalEndcap) {
-          threshold = params.energyThresholds()[depth - 1 + HCAL::kMaxDepthHB];
-        } else {
-          printf("Rechit with detId %u has invalid subdetector %u!\n", detId, subdet);
-          return false;
-        }
+      if (subdet == HcalBarrel) {
+        threshold = params.energyThresholds()[depth - 1];
+      } else if (subdet == HcalEndcap) {
+        threshold = params.energyThresholds()[depth - 1 + HCAL::kMaxDepthHB];
+      } else {
+        printf("Rechit with detId %u has invalid subdetector %u!\n", detId, subdet);
+        return false;
+      }
     }
     return rh.energy() >= threshold;
   }
 
   template <>
   ALPAKA_FN_ACC bool PFRecHitProducerKernelConstruct<ECAL>::applyCuts(
-      const ECAL::CaloRecHitSoATypeDevice::ConstView::const_element rh, const ECAL::ParameterType::ConstView params,
+      const ECAL::CaloRecHitSoATypeDevice::ConstView::const_element rh,
+      const ECAL::ParameterType::ConstView params,
       const ECAL::TopologyTypeDevice::ConstView topology) {
     // Reject ECAL recHits below energy threshold
     if (rh.energy() < params.energyThresholds()[ECAL::detId2denseId(rh.detId())])
@@ -96,6 +97,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       reco::PFRecHitDeviceCollection::View::element pfrh,
       const HCAL::CaloRecHitSoATypeDevice::ConstView::const_element rh) {
     pfrh.detId() = rh.detId();
+    pfrh.denseId() = HCAL::detId2denseId(rh.detId());
     pfrh.energy() = rh.energy();
     pfrh.time() = rh.time();
     pfrh.depth() = HCAL::getDepth(pfrh.detId());
@@ -113,6 +115,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       reco::PFRecHitDeviceCollection::View::element pfrh,
       const ECAL::CaloRecHitSoATypeDevice::ConstView::const_element rh) {
     pfrh.detId() = rh.detId();
+    pfrh.denseId() = ECAL::detId2denseId(rh.detId());
     pfrh.energy() = rh.energy();
     pfrh.time() = rh.time();
     pfrh.depth() = 1;

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.h
@@ -17,6 +17,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void processRecHits(Queue& queue,
                         const typename CAL::CaloRecHitSoATypeDevice& recHits,
                         const typename CAL::ParameterType& params,
+                        const typename CAL::TopologyTypeDevice& topology,
                         reco::PFRecHitDeviceCollection& pfRecHits);
 
     // Run kernel: Associate topology information (position, neighbours)

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -41,7 +41,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
       for (const auto& token : recHitsToken_)
-        kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second),topology, pfRecHits);
+        kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
       kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
 
       if (synchronise_)

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -41,7 +41,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
       for (const auto& token : recHitsToken_)
-        kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second), pfRecHits);
+        kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second),topology, pfRecHits);
       kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
 
       if (synchronise_)

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -5,6 +5,8 @@
 #include <variant>
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
+#include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -24,15 +26,22 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <typename CAL>
   class PFRecHitTopologyESProducer : public ESProducer {
   public:
-    PFRecHitTopologyESProducer(edm::ParameterSet const& iConfig) : ESProducer(iConfig) {
+    PFRecHitTopologyESProducer(edm::ParameterSet const& iConfig) : ESProducer(iConfig),
+      cutsFromDB_(iConfig.getParameter<bool>("usePFThresholdsFromDB")) {
       auto cc = setWhatProduced(this);
       geomToken_ = cc.consumes();
-      if constexpr (std::is_same_v<CAL, HCAL>)
+      if constexpr (std::is_same_v<CAL, HCAL>) {
         hcalToken_ = cc.consumes();
+        hcalCutsToken_ = cc.consumes();
+      }
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
+      if constexpr (std::is_same_v<CAL, HCAL>)
+        desc.add<bool>("usePFThresholdsFromDB", "True");
+      else // only needs to be true for HBHE
+        desc.add<bool>("usePFThresholdsFromDB", "False");
       descriptions.addWithDefaultLabel(desc);
     }
 
@@ -40,7 +49,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const auto& geom = iRecord.get(geomToken_);
       auto product = std::make_unique<typename CAL::TopologyTypeHost>(CAL::kSize, cms::alpakatools::host());
       auto view = product->view();
-
       const int calEnums[2] = {CAL::kSubdetectorBarrelId, CAL::kSubdetectorEndcapId};
       for (const auto subdet : calEnums) {
         // Construct topology
@@ -60,6 +68,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         for (auto const detId : geom.getValidDetIds(CAL::kDetectorId, subdet)) {
           const uint32_t denseId = CAL::detId2denseId(detId);
           assert(denseId < CAL::kSize);
+
+          // Fill SoA members with HCAL PF Thresholds from GT
+          if constexpr (std::is_same_v<CAL, HCAL>) {
+              view.cutsFromDB() = false;
+              if (cutsFromDB_) {
+                  view.cutsFromDB() = true;
+                  const HcalPFCuts& pfCuts = iRecord.get(hcalCutsToken_);
+                  const HcalTopology& htopo = iRecord.get(hcalToken_);
+                  std::unique_ptr<HcalPFCuts> prod = std::make_unique<HcalPFCuts>(pfCuts);
+                  prod->setTopo(&htopo);
+                  view.noiseThreshold(denseId) = prod->getValues(detId.rawId())->noiseThreshold();
+                  view.seedThreshold(denseId) = prod->getValues(detId.rawId())->seedThreshold();
+              }
+          }
 
           const GlobalPoint pos = geo->getGeometry(detId)->getPosition();
           view.positionX(denseId) = pos.x();
@@ -119,6 +141,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   private:
     edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
     edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
+    edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
+    const bool cutsFromDB_;
+
 
     // specialised for HCAL/ECAL, because non-nearest neighbours are defined differently
     uint32_t getNeighbourDetId(const uint32_t detId, const uint32_t direction, const CaloSubdetectorTopology& topo);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -26,8 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   template <typename CAL>
   class PFRecHitTopologyESProducer : public ESProducer {
   public:
-    PFRecHitTopologyESProducer(edm::ParameterSet const& iConfig) : ESProducer(iConfig),
-      cutsFromDB_(iConfig.getParameter<bool>("usePFThresholdsFromDB")) {
+    PFRecHitTopologyESProducer(edm::ParameterSet const& iConfig)
+        : ESProducer(iConfig), cutsFromDB_(iConfig.getParameter<bool>("usePFThresholdsFromDB")) {
       auto cc = setWhatProduced(this);
       geomToken_ = cc.consumes();
       if constexpr (std::is_same_v<CAL, HCAL>) {
@@ -40,7 +40,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       edm::ParameterSetDescription desc;
       if constexpr (std::is_same_v<CAL, HCAL>)
         desc.add<bool>("usePFThresholdsFromDB", "True");
-      else // only needs to be true for HBHE
+      else  // only needs to be true for HBHE
         desc.add<bool>("usePFThresholdsFromDB", "False");
       descriptions.addWithDefaultLabel(desc);
     }
@@ -71,16 +71,16 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
           // Fill SoA members with HCAL PF Thresholds from GT
           if constexpr (std::is_same_v<CAL, HCAL>) {
-              view.cutsFromDB() = false;
-              if (cutsFromDB_) {
-                  view.cutsFromDB() = true;
-                  const HcalPFCuts& pfCuts = iRecord.get(hcalCutsToken_);
-                  const HcalTopology& htopo = iRecord.get(hcalToken_);
-                  std::unique_ptr<HcalPFCuts> prod = std::make_unique<HcalPFCuts>(pfCuts);
-                  prod->setTopo(&htopo);
-                  view.noiseThreshold(denseId) = prod->getValues(detId.rawId())->noiseThreshold();
-                  view.seedThreshold(denseId) = prod->getValues(detId.rawId())->seedThreshold();
-              }
+            view.cutsFromDB() = false;
+            if (cutsFromDB_) {
+              view.cutsFromDB() = true;
+              const HcalPFCuts& pfCuts = iRecord.get(hcalCutsToken_);
+              const HcalTopology& htopo = iRecord.get(hcalToken_);
+              std::unique_ptr<HcalPFCuts> prod = std::make_unique<HcalPFCuts>(pfCuts);
+              prod->setTopo(&htopo);
+              view.noiseThreshold(denseId) = prod->getValues(detId.rawId())->noiseThreshold();
+              view.seedThreshold(denseId) = prod->getValues(detId.rawId())->seedThreshold();
+            }
           }
 
           const GlobalPoint pos = geo->getGeometry(detId)->getPosition();
@@ -143,7 +143,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> hcalToken_;
     edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;
     const bool cutsFromDB_;
-
 
     // specialised for HCAL/ECAL, because non-nearest neighbours are defined differently
     uint32_t getNeighbourDetId(const uint32_t detId, const uint32_t direction, const CaloSubdetectorTopology& topo);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -39,9 +39,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       if constexpr (std::is_same_v<CAL, HCAL>)
-        desc.add<bool>("usePFThresholdsFromDB", "True");
+        desc.add<bool>("usePFThresholdsFromDB", true);
       else  // only needs to be true for HBHE
-        desc.add<bool>("usePFThresholdsFromDB", "False");
+        desc.add<bool>("usePFThresholdsFromDB", false);
       descriptions.addWithDefaultLabel(desc);
     }
 


### PR DESCRIPTION
#### PR description:

This is a follow up to  #43130. It is the adaptation of the Alpaka-based `PFRecHitSoAProducer` and `PFClusterSoAProducer` to read Hcal thresholds from GT similar to #43025. Included are some fixes to naming conventions that were missed in the initial implementation of #43130.

#### PR validation:

PR was validated using local testing of cluster-level comparison and PF Jet Response comparison as in #43130. The results are consistent between Alpaka and Legacy for the entire variety of configurations: Alpaka CPU and GPU backends with `usePFThresholdsFromDB` set to `true` or `false`.

The basic suite of tests, `runTheMatrix.py -l limited -i all --ibeos`, has also been passed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

PR is not a backport.

@hatakeyamak @swagata87 
