### PR TITLE
mkFit: overlap area candidate re-check and start using the new hit selection V2 in pixelLess iteration

### DIFF
--- a/RecoTracker/MkFitCMS/standalone/Shell.cc
+++ b/RecoTracker/MkFitCMS/standalone/Shell.cc
@@ -325,7 +325,9 @@ namespace mkfit {
     reco tracks labels are seed indices.
     seed labels are sim track indices
     --
-    mkfit labels are seed indices in given iteration after cleaning (at seed load-time)
+    mkfit labels are seed indices in given iteration after cleaning (at seed load-time).
+          This is no longer true -- was done like that in branch where this code originated from.
+          It seems the label is the same as seed label.
   */
 
   int Shell::LabelFromHits(Track &t, bool replace, float good_frac) {

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -90,6 +90,7 @@ namespace mkfit {
     float chi2Cut_min = 15.0;
     float chi2CutOverlap = 3.5;
     float pTCutOverlap = 0.0;
+    bool recheckOverlap = false;
 
     //quality filter params
     int minHitsQF = 4;

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -91,6 +91,7 @@ namespace mkfit {
     float chi2CutOverlap = 3.5;
     float pTCutOverlap = 0.0;
     bool recheckOverlap = false;
+    bool useHitSelectionV2 = false;
 
     //quality filter params
     int minHitsQF = 4;

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -224,6 +224,7 @@ namespace mkfit {
     }
 
     void addHitIdx(int hitIdx, int hitLyr, float chi2);
+    bool popOverlap();
 
     HoTNode& refLastHoTNode();              // for filling up overlap info
     const HoTNode& refLastHoTNode() const;  // for dump traversal
@@ -564,6 +565,25 @@ namespace mkfit {
     }
   }
 
+  inline bool TrackCand::popOverlap() {
+    auto popHitIdx = getLastHitIdx();
+    auto popHitLyr = getLastHitLyr();
+    auto popPrev = refLastHoTNode().m_prev_idx;
+    auto popChi2 = refLastHoTNode().m_chi2;
+    // sanity checks first, then just shift lastHitIdx_ to popPrev
+    if (lastHitIdx_ == 0 || popHitIdx < 0)
+      return false;
+    auto prevHitLyr = m_comb_candidate->hot(popPrev).layer;
+    auto prevHitIdx = m_comb_candidate->hot(popPrev).index;
+    if (popHitLyr != prevHitLyr || prevHitIdx < 0)
+      return false;
+    lastHitIdx_ = popPrev;
+
+    --nFoundHits_;
+    chi2_ -= popChi2;
+    --nOverlapHits_;
+    return true;
+  }
   //==============================================================================
 
   class EventOfCombCandidates {

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -24,11 +24,13 @@ namespace mkfit {
 
   void CandCloner::begin_eta_bin(EventOfCombCandidates *e_o_ccs,
                                  std::vector<UpdateIndices> *update_list,
+                                 std::vector<UpdateIndices> *overlap_list,
                                  std::vector<std::vector<TrackCand>> *extra_cands,
                                  int start_seed,
                                  int n_seeds) {
     mp_event_of_comb_candidates = e_o_ccs;
     mp_kalman_update_list = update_list;
+    mp_kalman_overlap_list = overlap_list;
     mp_extra_cands = extra_cands;
     m_start_seed = start_seed;
     m_n_seeds = n_seeds;
@@ -50,6 +52,7 @@ namespace mkfit {
     m_idx_max_prev = 0;
 
     mp_kalman_update_list->clear();
+    mp_kalman_overlap_list->clear();
 
 #ifdef CC_TIME_LAYER
     t_lay = dtime();
@@ -193,14 +196,13 @@ namespace mkfit {
             break;
 
           if (h2a.hitIdx >= 0) {
-            mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx));
-
-            // set the overlap if we have it and and pT > pTCutOverlap
+            // set the overlap if we have it and pT > pTCutOverlap
             HitMatch *hm;
             if (tc.pT() > mp_iteration_params->pTCutOverlap &&
                 (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
-              tc.addHitIdx(hm->m_hit_idx, m_layer, 0);
-              tc.incOverlapCount();
+              mp_kalman_overlap_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
+            } else {
+              mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, -1));
             }
           }
 

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -200,7 +200,14 @@ namespace mkfit {
             HitMatch *hm;
             if (tc.pT() > mp_iteration_params->pTCutOverlap &&
                 (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
-              mp_kalman_overlap_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
+              if (mp_iteration_params->recheckOverlap) {
+                // Special overlap_list if the overlap hit needs to be re-checked after primary update.
+                mp_kalman_overlap_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
+              } else {
+                tc.addHitIdx(hm->m_hit_idx, m_layer, 0);
+                tc.incOverlapCount();
+                mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, -1));
+              }
             } else {
               mp_kalman_update_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, -1));
             }

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -202,7 +202,8 @@ namespace mkfit {
                 (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
               if (mp_iteration_params->recheckOverlap) {
                 // Special overlap_list if the overlap hit needs to be re-checked after primary update.
-                mp_kalman_overlap_list->emplace_back(UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
+                mp_kalman_overlap_list->emplace_back(
+                    UpdateIndices(m_start_seed + is, n_pushed, h2a.hitIdx, hm->m_hit_idx));
               } else {
                 tc.addHitIdx(hm->m_hit_idx, m_layer, 0);
                 tc.incOverlapCount();

--- a/RecoTracker/MkFitCore/src/CandCloner.h
+++ b/RecoTracker/MkFitCore/src/CandCloner.h
@@ -25,6 +25,7 @@ namespace mkfit {
 
     void begin_eta_bin(EventOfCombCandidates *e_o_ccs,
                        std::vector<UpdateIndices> *update_list,
+                       std::vector<UpdateIndices> *overlap_list,
                        std::vector<std::vector<TrackCand>> *extra_cands,
                        int start_seed,
                        int n_seeds);
@@ -56,7 +57,7 @@ namespace mkfit {
 
     const IterationParams *mp_iteration_params = nullptr;
     EventOfCombCandidates *mp_event_of_comb_candidates;
-    std::vector<UpdateIndices> *mp_kalman_update_list;
+    std::vector<UpdateIndices> *mp_kalman_update_list, *mp_kalman_overlap_list;
     std::vector<std::vector<TrackCand>> *mp_extra_cands;
 
 #if defined(CC_TIME_ETA) or defined(CC_TIME_LAYER)

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -16,6 +16,10 @@ namespace mkfit {
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, MPlexQI &, \
       const int, const PropagationFlags &, const bool
 
+#define COMPUTE_CHI2_AND_UPDATE_ARGS \
+  const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLS &, MPlexLV &, \
+      MPlexQI &, const int, const PropagationFlags, const bool
+
   class FindingFoos {
   public:
     void (*m_compute_chi2_foo)(COMPUTE_CHI2_ARGS);

--- a/RecoTracker/MkFitCore/src/FindingFoos.h
+++ b/RecoTracker/MkFitCore/src/FindingFoos.h
@@ -16,7 +16,7 @@ namespace mkfit {
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexLS &, MPlexLV &, MPlexQI &, \
       const int, const PropagationFlags &, const bool
 
-#define COMPUTE_CHI2_AND_UPDATE_ARGS \
+#define COMPUTE_CHI2_AND_UPDATE_ARGS                                                                              \
   const MPlexLS &, const MPlexLV &, MPlexQI &, const MPlexHS &, const MPlexHV &, MPlexQF &, MPlexLS &, MPlexLV &, \
       MPlexQI &, const int, const PropagationFlags, const bool
 

--- a/RecoTracker/MkFitCore/src/HitStructures.cc
+++ b/RecoTracker/MkFitCore/src/HitStructures.cc
@@ -91,6 +91,9 @@ namespace mkfit {
       m_hit_infos.reserve(m_n_hits);
     }
 
+    // Factor to get from hit sigma to half-length in q direction.
+    const float hl_fac = is_pixel() ? 3.0f : std::sqrt(3.0f);
+
     for (unsigned int i = 0; i < m_n_hits; ++i) {
       const Hit &h = hitv[i];
 
@@ -100,13 +103,12 @@ namespace mkfit {
       m_binnor.register_entry_safe(phi, q);
 
       if (Config::usePhiQArrays) {
-        const float sqrt3 = std::sqrt(3);
         float half_length, qbar;
         if (m_is_barrel) {
-          half_length = sqrt3 * std::sqrt(h.ezz());
+          half_length = hl_fac * std::sqrt(h.ezz());
           qbar = h.r();
         } else {
-          half_length = sqrt3 * std::sqrt(h.exx() + h.eyy());
+          half_length = hl_fac * std::sqrt(h.exx() + h.eyy());
           qbar = h.z();
         }
         hinfos.emplace_back(HitInfo({phi, q, half_length, qbar}));

--- a/RecoTracker/MkFitCore/src/HitStructures.cc
+++ b/RecoTracker/MkFitCore/src/HitStructures.cc
@@ -170,13 +170,14 @@ namespace mkfit {
     m_binnor.register_entry_safe(phi, q);
 
     if (Config::usePhiQArrays) {
-      const float sqrt3 = std::sqrt(3);
+      // Factor to get from hit sigma to half-length in q direction.
+      const float hl_fac = is_pixel() ? 3.0f : std::sqrt(3.0f);
       float half_length, qbar;
       if (m_is_barrel) {
-        half_length = sqrt3 * std::sqrt(h.ezz());
+        half_length = hl_fac * std::sqrt(h.ezz());
         qbar = h.r();
       } else {
-        half_length = sqrt3 * std::sqrt(h.exx() + h.eyy());
+        half_length = hl_fac * std::sqrt(h.exx() + h.eyy());
         qbar = h.z();
       }
       m_hit_infos.emplace_back(HitInfo({phi, q, half_length, qbar}));

--- a/RecoTracker/MkFitCore/src/IterationConfig.cc
+++ b/RecoTracker/MkFitCore/src/IterationConfig.cc
@@ -62,6 +62,7 @@ namespace mkfit {
                                    /* float */ chi2CutOverlap,
                                    /* float */ pTCutOverlap,
                                    /* bool */ recheckOverlap,
+                                   /* bool */ useHitSelectionV2,
                                    /* int */ minHitsQF,
                                    /* float */ minPtCut,
                                    /* unsigned int */ maxClusterSize)

--- a/RecoTracker/MkFitCore/src/IterationConfig.cc
+++ b/RecoTracker/MkFitCore/src/IterationConfig.cc
@@ -61,6 +61,7 @@ namespace mkfit {
                                    /* float */ chi2Cut_min,
                                    /* float */ chi2CutOverlap,
                                    /* float */ pTCutOverlap,
+                                   /* bool */ recheckOverlap,
                                    /* int */ minHitsQF,
                                    /* float */ minPtCut,
                                    /* unsigned int */ maxClusterSize)

--- a/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/Matriplex.h
@@ -115,6 +115,24 @@ namespace Matriplex {
       return *this;
     }
 
+    Matriplex operator-() {
+      Matriplex t;
+      for (idx_t i = 0; i < kTotSize; ++i)
+        t.fArray[i] = -fArray[i];
+      return t;
+    }
+
+    Matriplex& abs(const Matriplex& a) {
+      for (idx_t i = 0; i < kTotSize; ++i)
+        fArray[i] = std::abs(a.fArray[i]);
+      return *this;
+    }
+    Matriplex& abs() {
+      for (idx_t i = 0; i < kTotSize; ++i)
+        fArray[i] = std::abs(fArray[i]);
+      return *this;
+    }
+
     Matriplex& sqrt(const Matriplex& a) {
       for (idx_t i = 0; i < kTotSize; ++i)
         fArray[i] = std::sqrt(a.fArray[i]);
@@ -402,6 +420,12 @@ namespace Matriplex {
   }
 
   template <typename T, idx_t D1, idx_t D2, idx_t N>
+  MPlex<T, D1, D2, N> abs(const MPlex<T, D1, D2, N>& a) {
+    MPlex<T, D1, D2, N> t;
+    return t.abs(a);
+  }
+
+  template <typename T, idx_t D1, idx_t D2, idx_t N>
   MPlex<T, D1, D2, N> sqrt(const MPlex<T, D1, D2, N>& a) {
     MPlex<T, D1, D2, N> t;
     return t.sqrt(a);
@@ -410,7 +434,7 @@ namespace Matriplex {
   template <typename T, idx_t D1, idx_t D2, idx_t N>
   MPlex<T, D1, D2, N> sqr(const MPlex<T, D1, D2, N>& a) {
     MPlex<T, D1, D2, N> t;
-    return t.sqrt(a);
+    return t.sqr(a);
   }
 
   template <typename T, idx_t D1, idx_t D2, idx_t N>

--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h
@@ -263,6 +263,14 @@ namespace Matriplex {
         a[5 * N + n] = s * c22;
       }
     }
+
+    Matriplex<T, 1, 1, N> ReduceFixedIJ(idx_t i, idx_t j) const {
+      Matriplex<T, 1, 1, N> t;
+      for (idx_t n = 0; n < N; ++n) {
+        t[n] = constAt(n, i, j);
+      }
+      return t;
+    }
   };
 
   template <typename T, idx_t D, idx_t N>

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1118,6 +1118,7 @@ namespace mkfit {
       // that need update (excluding all those with negative last hit index).
       // This is split into two sections - candidates without overlaps and with overlaps.
       // On CMS PU-50 the ratio of those is ~ 65 : 35 over all iterations.
+      // Note, overlap recheck is only enabled for some iterations, e.g. pixelLess.
 
       const int theEndUpdater = seed_cand_update_idx.size();
 
@@ -1166,24 +1167,6 @@ namespace mkfit {
               tc.popOverlap();
           }
         }
-
-        /*
-          perl -ne 'if (/^RT_OVLP/) { s/^RT_OVLP //og; print; }' | grep -v nan > ovlp.rtt
-          TTree t;
-          t.ReadFile("ovlp.rtt", "algo/I:region:layer:fail:chi2_est/F:chi2_real:pt:theta:phi:phi_pos");
-          // momEta() sometimes makes nans ... hmmh.
-        */
-        /*
-        for (int ii = itrack; ii < end; ++ii) {
-          const int fi = ii - itrack;
-          const TrackCand &trk = eoccs[seed_cand_overlap_idx[ii].seed_idx][seed_cand_overlap_idx[ii].cand_idx];
-          printf("RT_OVLP %d %d %d %d %f %f %f %f %f %f\n",
-                 m_job->m_iter_config.m_track_algorithm, region, curr_layer,
-                 mkfndr->m_FailFlag[fi],
-                 seed_cand_overlap_idx[ii].chi2_overlap, mkfndr->m_Chi2[fi], trk.pT(), trk.theta(), trk.momPhi(),
-                 trk.posPhi());
-        }
-        */
       }
 
       // Check if cands are sorted, as expected.

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1088,7 +1088,10 @@ namespace mkfit {
 
         dprint("now get hit range");
 
-        mkfndr->selectHitIndices(layer_of_hits, end - itrack);
+        if (iter_params.useHitSelectionV2)
+          mkfndr->selectHitIndicesV2(layer_of_hits, end - itrack);
+        else
+          mkfndr->selectHitIndices(layer_of_hits, end - itrack);
 
         find_tracks_handle_missed_layers(
             mkfndr, layer_info, extra_cands, seed_cand_idx, region, start_seed, itrack, end);

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1156,9 +1156,14 @@ namespace mkfit {
 
           // XXXX For now we DO NOT use chi2 as this was how things were done before the post-update
           // chi2 check. To use it we should retune scoring function (might be even simpler).
-          if (mkfndr->m_FailFlag[fi] == 0 && mkfndr->m_Chi2[fi] >= 0.0f && mkfndr->m_Chi2[fi] <= 60.0f) {
-            tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, mkfndr->m_Chi2[fi]);
+          auto chi2Ovlp = mkfndr->m_Chi2[fi];
+          if (mkfndr->m_FailFlag[fi] == 0 && chi2Ovlp >= 0.0f && chi2Ovlp <= 60.0f) {
+            auto scoreCand = getScoreCand(tc, true /*penalizeTailMissHits*/, true /*inFindCandidates*/);
+            tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, chi2Ovlp);
             tc.incOverlapCount();
+            auto scoreCandOvlp = getScoreCand(tc, true, true);
+            if (scoreCand > scoreCandOvlp)
+              tc.popOverlap();
           }
         }
 

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1157,7 +1157,7 @@ namespace mkfit {
           // XXXX For now we DO NOT use chi2 as this was how things were done before the post-update
           // chi2 check. To use it we should retune scoring function (might be even simpler).
           if (mkfndr->m_FailFlag[fi] == 0 && mkfndr->m_Chi2[fi] >= 0.0f && mkfndr->m_Chi2[fi] <= 60.0f) {
-            tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, 0.0f);
+            tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, mkfndr->m_Chi2[fi]);
             tc.incOverlapCount();
           }
         }

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -979,15 +979,16 @@ namespace mkfit {
     const int n_seeds = end_seed - start_seed;
 
     std::vector<std::pair<int, int>> seed_cand_idx;
-    std::vector<UpdateIndices> seed_cand_update_idx;
+    std::vector<UpdateIndices> seed_cand_update_idx, seed_cand_overlap_idx;
     seed_cand_idx.reserve(n_seeds * params.maxCandsPerSeed);
     seed_cand_update_idx.reserve(n_seeds * params.maxCandsPerSeed);
+    seed_cand_overlap_idx.reserve(n_seeds * params.maxCandsPerSeed);
 
     std::vector<std::vector<TrackCand>> extra_cands(n_seeds);
     for (int ii = 0; ii < n_seeds; ++ii)
       extra_cands[ii].reserve(params.maxCandsPerSeed);
 
-    cloner.begin_eta_bin(&eoccs, &seed_cand_update_idx, &extra_cands, start_seed, n_seeds);
+    cloner.begin_eta_bin(&eoccs, &seed_cand_update_idx, &seed_cand_overlap_idx, &extra_cands, start_seed, n_seeds);
 
     // Loop over layers, starting from after the seed.
 
@@ -1115,6 +1116,8 @@ namespace mkfit {
 
       // Update loop of best candidates. CandCloner prepares the list of those
       // that need update (excluding all those with negative last hit index).
+      // This is split into two sections - candidates without overlaps and with overlaps.
+      // On CMS PU-50 the ratio of those is ~ 65 : 35 over all iterations.
 
       const int theEndUpdater = seed_cand_update_idx.size();
 
@@ -1127,6 +1130,55 @@ namespace mkfit {
 
         // copy_out the updated track params, errors only (hit-idcs and chi2 already set)
         mkfndr->copyOutParErr(eoccs.refCandidates_nc(), end - itrack, false);
+      }
+
+      const int theEndOverlapper = seed_cand_overlap_idx.size();
+
+      for (int itrack = 0; itrack < theEndOverlapper; itrack += NN) {
+        const int end = std::min(itrack + NN, theEndOverlapper);
+
+        mkfndr->inputTracksAndHits(eoccs.refCandidates(), layer_of_hits, seed_cand_overlap_idx, itrack, end, true);
+
+        mkfndr->updateWithLoadedHit(end - itrack, fnd_foos);
+
+        mkfndr->copyOutParErr(eoccs.refCandidates_nc(), end - itrack, false);
+
+        mkfndr->inputOverlapHits(layer_of_hits, seed_cand_overlap_idx, itrack, end);
+
+        // XXXX Could also be calcChi2AndUpdate(), then copy-out would have to be done
+        // below, choosing appropriate slot (with or without the overlap hit).
+        // Probably in a dedicated MkFinder copyOutXyzz function.
+        mkfndr->chi2OfLoadedHit(end - itrack, fnd_foos);
+
+        for (int ii = itrack; ii < end; ++ii) {
+          const int fi = ii - itrack;
+          TrackCand &tc = eoccs[seed_cand_overlap_idx[ii].seed_idx][seed_cand_overlap_idx[ii].cand_idx];
+
+          // XXXX For now we DO NOT use chi2 as this was how things were done before the post-update
+          // chi2 check. To use it we should retune scoring function (might be even simpler).
+          if (mkfndr->m_FailFlag[fi] == 0 && mkfndr->m_Chi2[fi] >= 0.0f && mkfndr->m_Chi2[fi] <= 60.0f) {
+            tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, 0.0f);
+            tc.incOverlapCount();
+          }
+        }
+
+        /*
+          perl -ne 'if (/^RT_OVLP/) { s/^RT_OVLP //og; print; }' | grep -v nan > ovlp.rtt
+          TTree t;
+          t.ReadFile("ovlp.rtt", "algo/I:region:layer:fail:chi2_est/F:chi2_real:pt:theta:phi:phi_pos");
+          // momEta() sometimes makes nans ... hmmh.
+        */
+        /*
+        for (int ii = itrack; ii < end; ++ii) {
+          const int fi = ii - itrack;
+          const TrackCand &trk = eoccs[seed_cand_overlap_idx[ii].seed_idx][seed_cand_overlap_idx[ii].cand_idx];
+          printf("RT_OVLP %d %d %d %d %f %f %f %f %f %f\n",
+                 m_job->m_iter_config.m_track_algorithm, region, curr_layer,
+                 mkfndr->m_FailFlag[fi],
+                 seed_cand_overlap_idx[ii].chi2_overlap, mkfndr->m_Chi2[fi], trk.pT(), trk.theta(), trk.momPhi(),
+                 trk.posPhi());
+        }
+        */
       }
 
       // Check if cands are sorted, as expected.

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1140,7 +1140,7 @@ namespace mkfit {
 
         mkfndr->inputTracksAndHits(eoccs.refCandidates(), layer_of_hits, seed_cand_overlap_idx, itrack, end, true);
 
-        mkfndr->updateWithLoadedHit(end - itrack, fnd_foos);
+        mkfndr->updateWithLoadedHit(end - itrack, layer_of_hits, fnd_foos);
 
         mkfndr->copyOutParErr(eoccs.refCandidates_nc(), end - itrack, false);
 
@@ -1159,10 +1159,11 @@ namespace mkfit {
           // chi2 check. To use it we should retune scoring function (might be even simpler).
           auto chi2Ovlp = mkfndr->m_Chi2[fi];
           if (mkfndr->m_FailFlag[fi] == 0 && chi2Ovlp >= 0.0f && chi2Ovlp <= 60.0f) {
-            auto scoreCand = getScoreCand(tc, true /*penalizeTailMissHits*/, true /*inFindCandidates*/);
+            auto scoreCand =
+                getScoreCand(st_par.m_track_scorer, tc, true /*penalizeTailMissHits*/, true /*inFindCandidates*/);
             tc.addHitIdx(seed_cand_overlap_idx[ii].ovlp_idx, curr_layer, chi2Ovlp);
             tc.incOverlapCount();
-            auto scoreCandOvlp = getScoreCand(tc, true, true);
+            auto scoreCandOvlp = getScoreCand(st_par.m_track_scorer, tc, true, true);
             if (scoreCand > scoreCandOvlp)
               tc.popOverlap();
           }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -178,6 +178,19 @@ namespace mkfit {
     }
   }
 
+  void MkFinder::inputOverlapHits(const LayerOfHits &layer_of_hits,
+                                  const std::vector<UpdateIndices> &idxs,
+                                  int beg,
+                                  int end) {
+    // Copy overlap hit values in.
+
+    for (int i = beg, imp = 0; i < end; ++i, ++imp) {
+      const Hit &hit = layer_of_hits.refHit(idxs[i].ovlp_idx);
+      m_msErr.copyIn(imp, hit.errArray());
+      m_msPar.copyIn(imp, hit.posArray());
+    }
+  }
+
   void MkFinder::inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                                       const std::vector<std::pair<int, IdxChi2List>> &idxs,
                                       int beg,
@@ -1750,6 +1763,26 @@ namespace mkfit {
     //     m_Par[iC].copySlot(i, m_Par[iP]);
     //   }
     // }
+  }
+
+  void MkFinder::chi2OfLoadedHit(int N_proc, const FindingFoos &fnd_foos) {
+    // We expect input in iC slots from above function.
+    // See comment in MkBuilder::find_tracks_in_layer() about intra / inter flags used here
+    // for propagation to the hit.
+    clearFailFlag();
+    (*fnd_foos.m_compute_chi2_foo)(m_Err[iC],
+                                   m_Par[iC],
+                                   m_Chg,
+                                   m_msErr,
+                                   m_msPar,
+                                   m_Chi2,
+                                   m_Par[iP],
+                                   m_FailFlag,
+                                   N_proc,
+                                   m_prop_config->finding_inter_layer_pflags,
+                                   m_prop_config->finding_requires_propagation_to_hit_pos);
+
+    // PROP-FAIL-ENABLE .... removed here
   }
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -789,6 +789,8 @@ namespace mkfit {
       mp::StatePlex sp1, sp2;
       int n_proc;
 
+      MPlexQF dphi_track, dq_track;  // 3 sigma track errors at initial state
+
       // debug & ntuple dump -- to be local in functions
       MPlexQF phi_c, dphi;
       MPlexQF q_c, qmin, qmax;
@@ -808,10 +810,10 @@ namespace mkfit {
         }
       }
 
-      void find_bin_ranges(const LayerInfo &li, const LayerOfHits &loh) {
+      void find_bin_ranges(const LayerInfo &li, const LayerOfHits &loh, const MPlexLS &err) {
         // Below made members for debugging
         // MPlexQF phi_c, dphi_min, dphi_max;
-        phi_c = mp::fast_atan2(isp.y, isp.x);
+        // phi_c = mp::fast_atan2(isp.y, isp.x);  // calculated below as difference
 
         // Matriplex::min_max(sp1.dphi, sp2.dphi, dphi_min, dphi_max);
         // the above is wrong: dalpha is not dphi --> renamed variable in State
@@ -833,13 +835,27 @@ namespace mkfit {
           //       phi_c[ii], xp1[ii], xp2[ii], pmin[ii], pmax[ii], dphi[ii]);
         }
 
+        const auto calc_err_xy = [&](const MPlexQF &x, const MPlexQF &y) {
+          return x * x * err.ReduceFixedIJ(0, 0) + y * y * err.ReduceFixedIJ(1, 1) +
+                 2.0f * x * y * err.ReduceFixedIJ(0, 1);
+        };
+
+        // Calculate dphi_track, dq_track differs for barrel/endcap
+        MPlexQF r2_c = isp.x * isp.x + isp.y * isp.y;
+        MPlexQF r2inv_c = 1.0f / r2_c;
+        MPlexQF dphidx_c = -isp.y * r2inv_c;
+        MPlexQF dphidy_c = isp.x * r2inv_c;
+        dphi_track = 3.0f * calc_err_xy(dphidx_c, dphidy_c).abs().sqrt();
+
         // MPlexQF qmin, qmax;
         if (li.is_barrel()) {
           Matriplex::min_max(sp1.z, sp2.z, qmin, qmax);
           q_c = isp.z;
+          dq_track = 3.0f * err.ReduceFixedIJ(2, 2).abs().sqrt();
         } else {
           Matriplex::min_max(Matriplex::hypot(sp1.x, sp1.y), Matriplex::hypot(sp2.x, sp2.y), qmin, qmax);
-          q_c = Matriplex::hypot(isp.x, isp.y);
+          q_c = Matriplex::sqrt(r2_c);
+          dq_track = 3.0f * (r2inv_c * calc_err_xy(isp.x, isp.y).abs()).sqrt();
         }
 
         for (int i = 0; i < p1.kTotSize; ++i) {
@@ -847,19 +863,19 @@ namespace mkfit {
           // const float dphi_clamp = 0.1;
           // if (dphi_min[i] > 0.0f || dphi_min[i] < -dphi_clamp) dphi_min[i] = -dphi_clamp;
           // if (dphi_max[i] < 0.0f || dphi_max[i] > dphi_clampf) dphi_max[i] = dphi_clamp;
-          p1[i] = loh.phiBinChecked(pmin[i] - PHI_BIN_EXTRA_FAC * 0.0123f);
-          p2[i] = loh.phiBinChecked(pmax[i] + PHI_BIN_EXTRA_FAC * 0.0123f);
+          p1[i] = loh.phiBinChecked(pmin[i] - dphi_track[i] - PHI_BIN_EXTRA_FAC * 0.0123f);
+          p2[i] = loh.phiBinChecked(pmax[i] + dphi_track[i] + PHI_BIN_EXTRA_FAC * 0.0123f);
 
           q0[i] = loh.qBinChecked(q_c[i]);
-          q1[i] = loh.qBinChecked(qmin[i] - Q_BIN_EXTRA_FAC * 0.5f * li.q_bin());
-          q2[i] = loh.qBinChecked(qmax[i] + Q_BIN_EXTRA_FAC * 0.5f * li.q_bin()) + 1;
+          q1[i] = loh.qBinChecked(qmin[i] - dq_track[i] - Q_BIN_EXTRA_FAC * 0.5f * li.q_bin());
+          q2[i] = loh.qBinChecked(qmax[i] + dq_track[i] + Q_BIN_EXTRA_FAC * 0.5f * li.q_bin()) + 1;
         }
       }
     };
 
     Bins B(m_Par[iI], m_Chg, N_proc);
     B.prop_to_limits(LI);
-    B.find_bin_ranges(LI, L);
+    B.find_bin_ranges(LI, L, m_Err[iI]);
 
     for (int i = 0; i < N_proc; ++i) {
       m_XHitSize[i] = 0;
@@ -982,8 +998,8 @@ namespace mkfit {
             new_ddphi = cdist(std::abs(new_phi - L.hit_phi(hi)));
             new_ddq = std::abs(new_q - L.hit_q(hi));
 
-            bool dqdphi_presel =
-                new_ddq < DDQ_PRESEL_FAC * L.hit_q_half_length(hi) && new_ddphi < DDPHI_PRESEL_FAC * 0.0123f;
+            bool dqdphi_presel = new_ddq < B.dq_track[itrack] + DDQ_PRESEL_FAC * L.hit_q_half_length(hi) &&
+                                 new_ddphi < B.dphi_track[itrack] + DDPHI_PRESEL_FAC * 0.0123f;
 
             // clang-format off
             dprintf("     SHI %3u %4u %5u  %6.3f %6.3f %6.4f %7.5f  PROP-%s  %s\n",

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -86,10 +86,7 @@ namespace mkfit {
                             int beg,
                             int end,
                             bool inputProp);
-    void inputOverlapHits(const LayerOfHits &layer_of_hits,
-                          const std::vector<UpdateIndices> &idxs,
-                          int beg,
-                          int end);
+    void inputOverlapHits(const LayerOfHits &layer_of_hits, const std::vector<UpdateIndices> &idxs, int beg, int end);
 
     void inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                               const std::vector<std::pair<int, IdxChi2List>> &idxs,

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -30,8 +30,9 @@ namespace mkfit {
     int seed_idx;
     int cand_idx;
     int hit_idx;
+    int ovlp_idx;
 
-    UpdateIndices(int si, int ci, int hi) : seed_idx(si), cand_idx(ci), hit_idx(hi) {}
+    UpdateIndices(int si, int ci, int hi, int oi) : seed_idx(si), cand_idx(ci), hit_idx(hi), ovlp_idx(oi) {}
   };
 
   class MkFinder : public MkBase {
@@ -85,6 +86,10 @@ namespace mkfit {
                             int beg,
                             int end,
                             bool inputProp);
+    void inputOverlapHits(const LayerOfHits &layer_of_hits,
+                          const std::vector<UpdateIndices> &idxs,
+                          int beg,
+                          int end);
 
     void inputTracksAndHitIdx(const std::vector<CombCandidate> &tracks,
                               const std::vector<std::pair<int, IdxChi2List>> &idxs,
@@ -144,6 +149,8 @@ namespace mkfit {
                                    const FindingFoos &fnd_foos);
 
     void updateWithLoadedHit(int N_proc, const LayerOfHits &layer_of_hits, const FindingFoos &fnd_foos);
+
+    void chi2OfLoadedHit(int N_proc, const FindingFoos &fnd_foos);
 
     void copyOutParErr(std::vector<CombCandidate> &seed_cand_vec, int N_proc, bool outputProp) const;
 


### PR DESCRIPTION
requires cms-data/RecoTracker-MkFit#13
This PR is technical for the default mkFIt setup (running as in production excluding pixelLess).
The goal is to have this in 14_0 pre2 so that a special relval can be requested with pixelLess enabled.

New feature:
- (on demand/configurable) instead of independently adding hits from an overlapping module as a second hit, check the second hit after KF update with the first hit and use this post-update chi2 and the overlap hit chi2; keep the overlap if the score improves
    - enable this for the pixelLess iteration where the addition of pixel hits was quite ineffective

Updates in selecHitIndicesV2 (recently added in #43145 ):
- add propagation uncertainty when hits are selected (most important for pixels)
- sqr/sqrt mixup bugfix 
- make choice of selecHitIndicesV2 configurable
    - enable this for the pixelLess iteration where the old hit selector was overflowing and missing the right hits


Some observations with pixelLess re-enabled
- about 10% reduction in [tracking time](http://uaf-10.t2.ucsd.edu/~legianni/PR118/plots_time_v2_Dec15/plots_timing/summaryCPU.pdf): 6.6 s -> 6.0 s 
- <img width="200" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/faee2508-f2b4-47a9-bad1-603d1cc68177">
- 
    - blue: mkfit5/production before this PR
    - red: mkfit5/production with this PR (to show it's technical)
    - black: mkfit5+pixelLess before this PR
    - orange: mkfit5+pixelLess with this PR
- In [Standard ttbar  MTV](http://uaf-10.t2.ucsd.edu/~legianni/PR118/plots_TT_v2_Dec15) (or in the modified [MTV with pt sim < 0.9 GeV](http://uaf-10.t2.ucsd.edu/~legianni/PR118/plots_TTlowpt_v2_Dec15/)):
    -  <img width="600" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/ced378ce-cc82-4abc-b63d-e6b74eb15a52"> recover small inefficiency below 1 GeV
    - <img width="600" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/23312002-86af-4f5d-8369-e743f0f94293"> roughly full recovery of true tracks with large impact parameter (the plot is dominated by the low-pt PU tracks here) 
    - <img width="600" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/9366b1ad-6693-4942-9cf3-b0366dde41d2"> signal tracks (selected here with pt< 0.9 GeV) efficiency is recovered as expected at higher production radius 
- In XiMinus sample without PU  [standard MTV](http://uaf-10.t2.ucsd.edu/~legianni/PR118/plots_XiMinus_v2_Dec15/) (and [MTV with pt sim < 0.9 GeV](http://uaf-10.t2.ucsd.edu/~legianni/PR118/plots_XiMinuslowpt_v2_Dec15/)) : 
    - <img width="300" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/9d5818a7-25a7-40a6-ba98-7005b9cf1426"> the overall efficiency is as good as CKF 
    - <img width="280" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/e9d3b6bb-1d19-4aeb-aeca-07ae317dbebe"><img width="280" alt="image" src="https://github.com/cms-sw/cmssw/assets/4676718/20f508db-ea87-4b1c-8674-73d7d7232d7e"> slight improvement for pt < 0.9 GeV (left) and still slightly worse for pt > 0.9 GeV (right) 

