### PR TITLE
TeV jet RAW-RECO skim

### DIFF
--- a/DPGAnalysis/Skims/python/Skims_DPG_cff.py
+++ b/DPGAnalysis/Skims/python/Skims_DPG_cff.py
@@ -416,6 +416,20 @@ SKIMStreamIsoPhotonEB = cms.FilteredStream(
 
 #####################
 
+from DPGAnalysis.Skims.TeVJetSkim_cff import *
+teVJetPath = cms.Path( teVJetSequence )
+
+SKIMStreamTeVJet = cms.FilteredStream(
+    responsible = 'L1 DPG/JME POG',
+    name = 'TeVJet',
+    paths = ( teVJetPath ),
+    content = skimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('RAW-RECO')
+    )
+
+#####################
+
 from DPGAnalysis.Skims.HighMETSkim_cff import *
 condPath = cms.Path(CondMETSelSeq)
 #pfPath = cms.Path(pfMETSelSeq)

--- a/DPGAnalysis/Skims/python/TeVJetSkim_cff.py
+++ b/DPGAnalysis/Skims/python/TeVJetSkim_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+
+# run on MIONAOD
+RUN_ON_MINIAOD = False
+
+
+# cuts
+JET_CUT=("pt > 1000 && abs(eta)<5.0")
+
+# single lepton selectors
+if RUN_ON_MINIAOD:
+    teVJets = cms.EDFilter("CandViewRefSelector",
+                           src = cms.InputTag("slimmedJets"),
+                           cut = cms.string(JET_CUT)
+    )
+else:
+    teVJets = cms.EDFilter("CandViewRefSelector",
+                           src = cms.InputTag("ak4PFJets"),
+                           cut = cms.string(JET_CUT)
+                       )
+    
+teVJetsCountFilter = cms.EDFilter("CandViewCountFilter",
+                                  src = cms.InputTag("teVJets"),
+                                  minNumber = cms.uint32(1)
+                              )
+                           
+
+
+#sequences
+teVJetSequence = cms.Sequence(teVJets*teVJetsCountFilter )


### PR DESCRIPTION
#### PR description:

This PR introduces a new skim selecting events based on the presence of a TeV AK4 PF jet. The main purpose is to be able to quickly react to any anomaly observed with TeV jets (recent example: prefiring, but the scope is larger)
The skim passing rate is found to be 0.1%, i.e an order of magnitude lower than the existing `EXOHighMET` skim 
The proposal is presented in these [slides](https://indico.cern.ch/event/1353129/contributions/5709823/attachments/2772202/4830719/hcalprefiring_tevjetskim.pdf#page=11 ) shown at a PPD meeting. 

#### PR validation:
The following command runs locally
```
 cmsDriver.py SKIM --filein /store/data/Run2023D/JetMET1/RAW/v1/000/370/340/00000/e82d9e40-ebb8-4311-a083-0a248a220d87.root --fileout file:SKIM_TeVJet.root --nThreads 8 --no_exec --number 100 --python_filename SKIM_TeVJet.py --scenario pp --step RAW2DIGI,L1Reco,RECO,SKIM:TeVJet --data --conditions auto:run3_data_prompt --era Run3
```
However, given the low passing rate of the skim, no event is passing. Running on crab on `/JetMET0/Run2023C-v1/RAW` works and give passing events with the passing rate quoted above. 
The output dataset can be found [here](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FJetMET0%2Flathomas-JetMET0_2023D_SkimTeVJet-4512ca967b8e6177966e72bfc0ac1b43%2FUSER&instance=prod/phys03)



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport