### PR TITLE
Fix DQMOfflineConfiguration unit tests

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,290,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,300,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="cmsswSequenceInfo.py --runTheMatrix --steps DQM,VALIDATION --infile file://${LOCALTOP}/tmp/${INFILE_NAME} --limit 50 --offset 300 --threads 1 | grep 'Analyzing 0 seqs'">
+<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 310">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>

--- a/DQMOffline/Configuration/test/runrest.sh
+++ b/DQMOffline/Configuration/test/runrest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+ERR=0
+PYTHONUNBUFFERED=1 cmsswSequenceInfo.py --runTheMatrix --steps DQM,VALIDATION --infile $1 --offset $2 --dbfile sequences$2.db --threads 1 >run.log 2>&1 || ERR=1
+cat run.log
+seqs=$(grep 'Analyzing [0-9][0-9]* seqs' run.log | sed 's|.*Analyzing *||;s| .*||')
+echo "Sequences run by final DQMOfflineConfiguration: $seqs"
+if [ "$seqs" -gt 0 ] ; then
+  echo "Final DQMOfflineConfiguration should not run any sequences."
+  echo "Please update parameters for TestDQMOfflineConfiguration unittest run the extra sequences."
+  exit 1
+fi
+exit $ERR

--- a/DQMOffline/Configuration/test/runrest.sh
+++ b/DQMOffline/Configuration/test/runrest.sh
@@ -6,7 +6,7 @@ seqs=$(grep 'Analyzing [0-9][0-9]* seqs' run.log | sed 's|.*Analyzing *||;s| .*|
 echo "Sequences run by final DQMOfflineConfiguration: $seqs"
 if [ "$seqs" -gt 0 ] ; then
   echo "Final DQMOfflineConfiguration should not run any sequences."
-  echo "Please update parameters for TestDQMOfflineConfiguration unittest run the extra sequences."
+  echo "Please update parameters for TestDQMOfflineConfiguration unittest to run the extra sequences."
   exit 1
 fi
 exit $ERR


### PR DESCRIPTION
This fixes the `DQMOfflineConfiguration` unit tests. Unit tests was failing as `TestDQMOfflineConfigurationGotAll` was suppose to not run any sequence but as now there are over 300 sequences so this tests was running the extra 3 sequences and `grep 'Analyzing 0 seqs'` failed. I have updated the test to properly report the error
```
++ sed 's|.*Analyzing *||;s| .*||'
++ grep 'Analyzing [0-9][0-9]* seqs' run.log
+ seqs=3
+ echo 'Sequences run by final DQMOfflineConfiguration: 3'
Sequences run by final DQMOfflineConfiguration: 3
+ '[' 3 -gt 0 ']'
+ echo 'Final DQMOfflineConfiguration should not run any sequences.'
Final DQMOfflineConfiguration should not run any sequences.
+ echo 'Please update parameters for TestDQMOfflineConfiguration unittest to run the extra sequences.'
Please update parameters for TestDQMOfflineConfiguration unittest run the extra sequences.
+ exit 1

```