### PR TITLE
Use likelihood fit instead of chi-square fit in PVValidation

### DIFF
--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -234,7 +234,7 @@ std::pair<Measurement1D, Measurement1D> PVValHelper::fitResiduals(TH1* hist)
   float sigma = hist->GetRMS();
 
   TF1 func("tmp", "gaus", mean - 1.5 * sigma, mean + 1.5 * sigma);
-  if (0 == hist->Fit(&func, "QNR")) {  // N: do not blow up file by storing fit!
+  if (0 == hist->Fit(&func, "QNRL")) {  // N: do not blow up file by storing fit!
     mean = func.GetParameter(1);
     sigma = func.GetParameter(2);
     // second fit: three sigma of first fit around mean of first fit


### PR DESCRIPTION
This should fix the unit test failure for slc7 IB (see https://github.com/cms-sw/cmssw/pull/43106 and https://github.com/cms-sw/cmssw/issues/43577 )