### PR TITLE
[14_0] Another fix to avoid running genfilter with pgen_smear

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1500,7 +1500,7 @@ class ConfigBuilder(object):
         #register to the genstepfilter the name of the path (static right now, but might evolve)
         self.executeAndRemember('process.genstepfilter.triggerConditions=cms.vstring("generation_step")')
 
-        if 'reGEN' in self.stepMap:
+        if 'reGEN' in self.stepMap or stepSpec == 'pgen_smear':
             #stop here
             return
 


### PR DESCRIPTION
#### PR description:
This PR is on top of https://github.com/cms-sw/cmssw/pull/43562

#### PR validation:
Dump config from the following cmsDriver, and run.

`cmsDriver.py  --python_filename PPD-GenericGSmearS-00001_Dump_cfg.py --eventcontent RAWSIM --datatier GEN-SIM --fileout file:PPD-GenericGSmearS-00001.root --conditions 124X_mcRun3_2022_realistic_v12 --beamspot Realistic25ns13p6TeVEarly2022Collision --step GEN:pgen_smear,SIM --geometry DB:Extended --filein file:PPD-GenericNoSmearGEN-00001.root --era Run3 --no_exec --mc -n -1 --dump_python`

We get genfilter only from GEN step as expected:

Before fixing:
```

root [1] LuminosityBlocks->Print("GenFilterInfo_genFilterEfficiencyProducer*")
******************************************************************************
*Tree    :LuminosityBlocks:                                                        *
*Entries :        1 : Total =           95741 bytes  File  Size =      18913 *
*        :          : Tree compression factor =   1.00                       *
******************************************************************************
*Branch  :GenFilterInfo_genFilterEfficiencyProducer__GEN.                    *
*Entries :        1 : BranchElement (see below)                              *
*............................................................................*
*Br    0 :GenFilterInfo_genFilterEfficiencyProducer__GEN.present : Bool_t    *
*Entries :        1 : Total  Size=        819 bytes  File Size  =        134 *
*Baskets :        1 : Basket Size=      92160 bytes  Compression=   1.00     *
*............................................................................*
*Br    1 :GenFilterInfo_genFilterEfficiencyProducer__GEN.obj : GenFilterInfo *
*Entries :        1 : Total  Size=        864 bytes  File Size  =        195 *
*Baskets :        1 : Basket Size=     134144 bytes  Compression=   1.00     *
*............................................................................*
*Branch  :GenFilterInfo_genFilterEfficiencyProducer__SIM.                    *
*Entries :        1 : BranchElement (see below)                              *
*............................................................................*
*Br    2 :GenFilterInfo_genFilterEfficiencyProducer__SIM.present : Bool_t    *
*Entries :        1 : Total  Size=        819 bytes  File Size  =        134 *
*Baskets :        1 : Basket Size=      92160 bytes  Compression=   1.00     *
*............................................................................*
*Br    3 :GenFilterInfo_genFilterEfficiencyProducer__SIM.obj : GenFilterInfo *
*Entries :        1 : Total  Size=        864 bytes  File Size  =        195 *
*Baskets :        1 : Basket Size=     134144 bytes  Compression=   1.00     *
*............................................................................*
```

After fixing:
```
root [1] LuminosityBlocks->Print("GenFilterInfo_genFilterEfficiencyProducer*")
******************************************************************************
*Tree    :LuminosityBlocks:                                                        *
*Entries :        1 : Total =           93152 bytes  File  Size =      18396 *
*        :          : Tree compression factor =   1.00                       *
******************************************************************************
*Branch  :GenFilterInfo_genFilterEfficiencyProducer__GEN.                    *
*Entries :        1 : BranchElement (see below)                              *
*............................................................................*
*Br    0 :GenFilterInfo_genFilterEfficiencyProducer__GEN.present : Bool_t    *
*Entries :        1 : Total  Size=        819 bytes  File Size  =        134 *
*Baskets :        1 : Basket Size=      94208 bytes  Compression=   1.00     *
*............................................................................*
*Br    1 :GenFilterInfo_genFilterEfficiencyProducer__GEN.obj : GenFilterInfo *
*Entries :        1 : Total  Size=        864 bytes  File Size  =        195 *
*Baskets :        1 : Basket Size=     136704 bytes  Compression=   1.00     *
*............................................................................*
```
 
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to all releases with gen_smear.
