### PR TITLE
Added unit test for checking import ROOT openat calls

### DIFF
--- a/Utilities/General/test/BuildFile.xml
+++ b/Utilities/General/test/BuildFile.xml
@@ -9,6 +9,10 @@
   <use name="google-benchmark-main"/>
 </bin>
 
+<test name="test-import-root-openat" command="test-import-root-openat.sh">
+  <use name="root_interface"/>
+</test>
+
 <iftool name="cuda-gcc-support">
   <test name="CudaGCCSupport" command="echo Supported GCC version"/>
   <else/>

--- a/Utilities/General/test/test-import-root-openat.sh
+++ b/Utilities/General/test/test-import-root-openat.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+# PyROOT Test Script
+#
+# This script tests the following:
+# 1. The ability to import and access ROOT properties (e.g., kFALSE, kTRUE).
+# 2. Ensuring that PyROOT does not load any CMSSW shared libraries.
+#   (Refer to: https://github.com/cms-sw/cmssw/issues/43077)
+
+for sym in TTreeReader.fgEntryStatusText kFALSE kTRUE gStyle TTree.kMaxEntries TString.kNPOS gEnv gSystem kWarning gErrorIgnoreLevel kError ; do
+  strace -z -f -o log1.txt -e trace=openat python3 -c "import ROOT;print(ROOT.${sym});"
+  cmssw_lib=$(grep libFWCoreVersion.so log1.txt | wc -l)
+  rm -f log1.txt
+  if [ ${cmssw_lib} -gt 0 ] ; then
+    echo "ERROR: CMSSW libraries loaded by import ROOT"
+    exit 1
+  fi
+done


### PR DESCRIPTION
Following the discussion at https://github.com/cms-sw/cmssw/issues/43077 , I have added a unit tests for `import ROOT;ROOT.X` to make sure

- calling `ROOT.X` does not open any cmssw libraries
- two calls to `ROOT.X` does not change the number of open libraries. Change in open calls could mean that there might be a missing symbol and system has to open libraries again to find it.

Note that currently this unit test will fail for 14.0.X ( due to missing https://github.com/root-project/root/pull/14270 fix) but should work for 14.0.ROOT626.X IBs