### PR TITLE
[12_4] Another fix to avoid running genfilter with pgen_smear

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1428,7 +1428,7 @@ class ConfigBuilder(object):
         #register to the genstepfilter the name of the path (static right now, but might evolve)
         self.executeAndRemember('process.genstepfilter.triggerConditions=cms.vstring("generation_step")')
 
-        if 'reGEN' in self.stepMap:
+        if 'reGEN' in self.stepMap or sequence == 'pgen_smear':
             #stop here
             return
 


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/43591, but the difference on `stepSpec`, `sequence` come from https://github.com/cms-sw/cmssw/pull/39337

#### PR validation:
Check config file dumped from
`cmsDriver.py  --python_filename PPD-GenericGSmearS-00001_Dump_cfg.py --eventcontent RAWSIM --datatier GEN-SIM --fileout file:PPD-GenericGSmearS-00001.root --conditions 124X_mcRun3_2022_realistic_v12 --beamspot Realistic25ns13p6TeVEarly2022Collision --step GEN:pgen_smear,SIM --geometry DB:Extended --filein file:PPD-GenericNoSmearGEN-00001.root --era Run3 --no_exec --mc -n -1 --dump_python`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This is a backport PR.