### PR TITLE
Fixed std::accumulate use in L1Trigger/TrackFindingTracklet

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/DR.cc
+++ b/L1Trigger/TrackFindingTracklet/src/DR.cc
@@ -26,8 +26,8 @@ namespace trklet {
   // read in and organize input tracks and stubs
   void DR::consume(const StreamsTrack& streamsTrack, const StreamsStub& streamsStub) {
     const int offsetTrack = region_ * channelAssignment_->numNodesDR();
-    auto nonNullTrack = [](int& sum, const FrameTrack& frame) { return sum += (frame.first.isNonnull() ? 1 : 0); };
-    auto nonNullStub = [](int& sum, const FrameStub& frame) { return sum += (frame.first.isNonnull() ? 1 : 0); };
+    auto nonNullTrack = [](int sum, const FrameTrack& frame) { return sum + (frame.first.isNonnull() ? 1 : 0); };
+    auto nonNullStub = [](int sum, const FrameStub& frame) { return sum + (frame.first.isNonnull() ? 1 : 0); };
     // count tracks and stubs and reserve corresponding vectors
     int sizeTracks(0);
     int sizeStubs(0);

--- a/L1Trigger/TrackFindingTracklet/src/KFin.cc
+++ b/L1Trigger/TrackFindingTracklet/src/KFin.cc
@@ -28,8 +28,8 @@ namespace trklet {
   // read in and organize input tracks and stubs
   void KFin::consume(const StreamsTrack& streamsTrack, const StreamsStub& streamsStub) {
     const int offsetTrack = region_ * channelAssignment_->numNodesDR();
-    auto nonNullTrack = [](int& sum, const FrameTrack& frame) { return sum += (frame.first.isNonnull() ? 1 : 0); };
-    auto nonNullStub = [](int& sum, const FrameStub& frame) { return sum += (frame.first.isNonnull() ? 1 : 0); };
+    auto nonNullTrack = [](int sum, const FrameTrack& frame) { return sum + (frame.first.isNonnull() ? 1 : 0); };
+    auto nonNullStub = [](int sum, const FrameStub& frame) { return sum + (frame.first.isNonnull() ? 1 : 0); };
     // count tracks and stubs and reserve corresponding vectors
     int sizeTracks(0);
     int sizeStubs(0);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
@@ -200,8 +200,8 @@ namespace trklet {
         vector<vector<TTStubRef>> lost;
         formTracks(lostTracks, lostStubs, lost, offset + channel);
         nTracks += tracks.size();
-        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track) {
-          return sum += (int)track.size();
+        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int sum, const vector<TTStubRef>& track) {
+          return sum + static_cast<int>(track.size());
         });
         nLost += lost.size();
         allTracks += tracks.size();
@@ -289,8 +289,8 @@ namespace trklet {
                               int channel) const {
     const int offset = channel * setup_->numLayers();
     const StreamTrack& streamTrack = streamsTrack[channel];
-    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame) {
-      return sum += (frame.first.isNonnull() ? 1 : 0);
+    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int sum, const FrameTrack& frame) {
+      return sum + (frame.first.isNonnull() ? 1 : 0);
     });
     tracks.reserve(numTracks);
     for (int frame = 0; frame < (int)streamTrack.size(); frame++) {

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerDRin.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerDRin.cc
@@ -201,8 +201,8 @@ namespace trklet {
         vector<vector<TTStubRef>> lost;
         formTracks(lostTracks, lostStubs, lost, offset + channel);
         nTracks += tracks.size();
-        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track) {
-          return sum += (int)track.size();
+        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int sum, const vector<TTStubRef>& track) {
+          return sum + (int)track.size();
         });
         nLost += lost.size();
         allTracks += tracks.size();
@@ -290,8 +290,8 @@ namespace trklet {
                                 int channel) const {
     const int offset = channel * setup_->numLayers();
     const StreamTrack& streamTrack = streamsTrack[channel];
-    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame) {
-      return sum += (frame.first.isNonnull() ? 1 : 0);
+    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int sum, const FrameTrack& frame) {
+      return sum + (frame.first.isNonnull() ? 1 : 0);
     });
     tracks.reserve(numTracks);
     for (int frame = 0; frame < (int)streamTrack.size(); frame++) {


### PR DESCRIPTION
#### PR description:

C++20 requires the 1st argument of the operator passed to std::accumulate to be a copy, not a non-const reference.

#### PR validation:

Code compiles under CMSSW_14_0_CPP20_X_2023-12-15-1100