### PR TITLE
Removed std::unary_function from l1t::KeyGetter

### DIFF
--- a/DataFormats/L1THGCal/interface/HGCalMulticluster.h
+++ b/DataFormats/L1THGCal/interface/HGCalMulticluster.h
@@ -53,7 +53,7 @@ namespace l1t {
 
   private:
     template <typename Iter>
-    struct KeyGetter : std::unary_function<typename Iter::value_type, typename Iter::value_type::first_type> {
+    struct KeyGetter {
       const typename Iter::value_type::first_type& operator()(const typename Iter::value_type& p) const {
         return p.first;
       }


### PR DESCRIPTION
#### PR description:

std::unary_function was deprecated in C++11 and removed in C++17

#### PR validation:

Code compiles without warnings in CMSSW_14_0_DEVEL_X_2023-12-19-1100.