### PR TITLE
Removed std::unexpected from DTGeometryParserFromDDD

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -24,16 +24,14 @@ DTGeometryParserFromDDD::DTGeometryParserFromDDD(
   } catch (const cms::Exception& e) {
     std::cerr << "DTGeometryParserFromDDD::build() : DDD Exception: something went wrong during XML parsing!"
               << std::endl
-              << "  Message: " << e << std::endl
-              << "  Terminating execution ... " << std::endl;
+              << "  Message: " << e << std::endl;
     throw;
   } catch (const exception& e) {
     std::cerr << "DTGeometryParserFromDDD::build() : an unexpected exception occured: " << e.what() << std::endl;
     throw;
   } catch (...) {
-    std::cerr << "DTGeometryParserFromDDD::build() : An unexpected exception occured!" << std::endl
-              << "  Terminating execution ... " << std::endl;
-    std::unexpected();
+    std::cerr << "DTGeometryParserFromDDD::build() : An unexpected exception occured!" << std::endl;
+    throw;
   }
 }
 


### PR DESCRIPTION
#### PR description:

The method was removed in C++17.

#### PR validation:

Code compiles in CMSSW_14_0_DEVEL_X_2023-12-19-1100 without warnings.