### PR TITLE
Update L1 track jet cuts

### DIFF
--- a/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
+++ b/L1Trigger/DemonstratorTools/test/gtt/createFirmwareInputFiles_cfg.py
@@ -89,6 +89,7 @@ process.l1tTrackSelectionProducerForJets.cutSet = cms.PSet(
     nStubsMin = cms.int32(4), # number of stubs must be greater than or equal to this value
     nPSStubsMin = cms.int32(0), # the number of stubs in the PS Modules must be greater than or equal to this value
     
+    promptMVAMin = cms.double(-1.0), # MVA must be greater than this value
     reducedBendChi2Max = cms.double(2.25), # bend chi2 must be less than this value
     reducedChi2RZMax = cms.double(5.0), # chi2rz/dof must be less than this value
     reducedChi2RPhiMax = cms.double(20.0), # chi2rphi/dof must be less than this value
@@ -104,12 +105,7 @@ process.l1tTrackerEmuHTMiss.debug = (options.debug > 0)
 
 #Disable internal track selection
 #There is a problem with setting all of these (especially eta) to high numbers.
-process.l1tTrackJetsEmulation.MaxDzTrackPV = cms.double(10000.0)
 process.l1tTrackJetsEmulation.trk_zMax = cms.double(20.46912512)    # maximum track z from TrackWord
-process.l1tTrackJetsEmulation.nStubs4PromptChi2=cms.double(10000.0) #Prompt track quality flags for loose/tight
-process.l1tTrackJetsEmulation.nStubs4PromptBend=cms.double(10000.0)
-process.l1tTrackJetsEmulation.nStubs5PromptChi2=cms.double(10000.0)
-process.l1tTrackJetsEmulation.nStubs5PromptBend=cms.double(10000.0)
 
 if options.debug:
     process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(1000000000)

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
@@ -1,7 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////
 //                                                                       //
-// Producer of TkJet,                                                    //
+// Producer of TrackFastJet,                                             //
 // Cluster L1 tracks using fastjet                                       //
+//                                                                       //
+// Updates: Claire Savard (claire.savard@colorado.edu), Nov. 2023        //
 //                                                                       //
 ///////////////////////////////////////////////////////////////////////////
 
@@ -61,48 +63,20 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  //virtual void beginJob();
   void produce(edm::Event&, const edm::EventSetup&) override;
-  //virtual void endJob();
 
-  // track selection criteria
-  const float trkZMax_;          // in [cm]
-  const float trkChi2dofMax_;    // maximum track chi2dof
-  const double trkBendChi2Max_;  // maximum track bendchi2
-  const float trkPtMin_;         // in [GeV]
-  const float trkEtaMax_;        // in [rad]
-  const int trkNStubMin_;        // minimum number of stubs
-  const int trkNPSStubMin_;      // minimum number of PS stubs
-  const double deltaZ0Cut_;      // save with |L1z-z0| < maxZ0
+  // jet configurations
   const double coneSize_;        // Use anti-kt with this cone size
-  const bool doTightChi2_;
-  const float trkPtTightChi2_;
-  const float trkChi2dofTightChi2_;
   const bool displaced_;  //use prompt/displaced tracks
 
   const EDGetTokenT<L1TTTrackRefCollectionType> trackToken_;
-  edm::EDGetTokenT<VertexCollection> pvToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 };
 
 // constructor
 L1TrackFastJetProducer::L1TrackFastJetProducer(const edm::ParameterSet& iConfig)
-    : trkZMax_((float)iConfig.getParameter<double>("trk_zMax")),
-      trkChi2dofMax_((float)iConfig.getParameter<double>("trk_chi2dofMax")),
-      trkBendChi2Max_(iConfig.getParameter<double>("trk_bendChi2Max")),
-      trkPtMin_((float)iConfig.getParameter<double>("trk_ptMin")),
-      trkEtaMax_((float)iConfig.getParameter<double>("trk_etaMax")),
-      trkNStubMin_((int)iConfig.getParameter<int>("trk_nStubMin")),
-      trkNPSStubMin_((int)iConfig.getParameter<int>("trk_nPSStubMin")),
-      deltaZ0Cut_((float)iConfig.getParameter<double>("deltaZ0Cut")),
-      coneSize_((float)iConfig.getParameter<double>("coneSize")),
-      doTightChi2_(iConfig.getParameter<bool>("doTightChi2")),
-      trkPtTightChi2_((float)iConfig.getParameter<double>("trk_ptTightChi2")),
-      trkChi2dofTightChi2_((float)iConfig.getParameter<double>("trk_chi2dofTightChi2")),
+    : coneSize_((float)iConfig.getParameter<double>("coneSize")),
       displaced_(iConfig.getParameter<bool>("displaced")),
-      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))),
-      pvToken_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("L1PrimaryVertexTag"))),
-      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))) {
+      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))) {
   if (displaced_)
     produces<TkJetCollection>("L1TrackFastJetsExtended");
   else
@@ -120,59 +94,11 @@ void L1TrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   edm::Handle<L1TTTrackRefCollectionType> TTTrackHandle;
   iEvent.getByToken(trackToken_, TTTrackHandle);
 
-  // Tracker Topology
-  const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
-
-  edm::Handle<l1t::VertexCollection> L1PrimaryVertexHandle;
-  iEvent.getByToken(pvToken_, L1PrimaryVertexHandle);
-
   fastjet::JetDefinition jet_def(fastjet::antikt_algorithm, coneSize_);
   std::vector<fastjet::PseudoJet> JetInputs;
 
-  float recoVtx = L1PrimaryVertexHandle->begin()->z0();
   for (unsigned int this_l1track = 0; this_l1track < TTTrackHandle->size(); this_l1track++) {
     edm::Ptr<L1TTTrackType> iterL1Track(TTTrackHandle, this_l1track);
-
-    float trk_pt = iterL1Track->momentum().perp();
-    float trk_z0 = iterL1Track->z0();
-    float trk_chi2dof = iterL1Track->chi2Red();
-    float trk_bendchi2 = iterL1Track->stubPtConsistency();
-    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
-        theStubs = iterL1Track->getStubRefs();
-    int trk_nstub = (int)theStubs.size();
-
-    if (std::abs(trk_z0) > trkZMax_)
-      continue;
-    if (std::abs(iterL1Track->momentum().eta()) > trkEtaMax_)
-      continue;
-    if (trk_pt < trkPtMin_)
-      continue;
-    if (trk_nstub < trkNStubMin_)
-      continue;
-    if (trk_chi2dof > trkChi2dofMax_)
-      continue;
-    if (trk_bendchi2 > trkBendChi2Max_)
-      continue;
-    if (doTightChi2_ && (trk_pt > trkPtTightChi2_ && trk_chi2dof > trkChi2dofTightChi2_))
-      continue;
-
-    int trk_nPS = 0;
-    for (int istub = 0; istub < trk_nstub; istub++) {
-      DetId detId(theStubs.at(istub)->getDetId());
-      bool tmp_isPS = false;
-      if (detId.det() == DetId::Detector::Tracker) {
-        if (detId.subdetId() == StripSubdetector::TOB && tTopo.tobLayer(detId) <= 3)
-          tmp_isPS = true;
-        else if (detId.subdetId() == StripSubdetector::TID && tTopo.tidRing(detId) <= 9)
-          tmp_isPS = true;
-      }
-      if (tmp_isPS)
-        trk_nPS++;
-    }
-    if (trk_nPS < trkNPSStubMin_)
-      continue;
-    if (std::abs(recoVtx - trk_z0) > deltaZ0Cut_)
-      continue;
 
     fastjet::PseudoJet psuedoJet(iterL1Track->momentum().x(),
                                  iterL1Track->momentum().y(),
@@ -213,16 +139,12 @@ void L1TrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
     iEvent.put(std::move(L1TrackFastJets), "L1TrackFastJets");
 }
 
-//void L1TrackFastJetProducer::beginJob() {}
-
-//void L1TrackFastJetProducer::endJob() {}
-
 void L1TrackFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("L1PVertexInputTag", edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
+  desc.add<double>("coneSize", 0.5);
+  desc.add<bool>("displaced", false);
 }
 
 //define this as a plug-in

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackFastJetProducer.cc
@@ -66,8 +66,8 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // jet configurations
-  const double coneSize_;        // Use anti-kt with this cone size
-  const bool displaced_;  //use prompt/displaced tracks
+  const double coneSize_;  // Use anti-kt with this cone size
+  const bool displaced_;   //use prompt/displaced tracks
 
   const EDGetTokenT<L1TTTrackRefCollectionType> trackToken_;
 };
@@ -104,9 +104,9 @@ void L1TrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
                                  iterL1Track->momentum().y(),
                                  iterL1Track->momentum().z(),
                                  iterL1Track->momentum().mag());
-    JetInputs.push_back(psuedoJet);                     // input tracks for clustering
+    JetInputs.push_back(psuedoJet);                 // input tracks for clustering
     JetInputs.back().set_user_index(this_l1track);  // save track index in the collection
-  }                                                     // end loop over tracks
+  }                                                 // end loop over tracks
 
   fastjet::ClusterSequence cs(JetInputs, jet_def);  // define the output jet collection
   std::vector<fastjet::PseudoJet> JetOutputs =
@@ -142,7 +142,9 @@ void L1TrackFastJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
 void L1TrackFastJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("L1PVertexInputTag", edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
+  desc.add<edm::InputTag>(
+      "L1PVertexInputTag",
+      edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
   desc.add<double>("coneSize", 0.5);
   desc.add<bool>("displaced", false);
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -3,9 +3,10 @@
 //
 // Rewritting/Improvements:      George Karathanasis,
 //                          georgios.karathanasis@cern.ch, CU Boulder
+//                          Claire Savard (claire.savard@colorado.edu)
 //
 //         Created:  Wed, 01 Aug 2018 14:01:41 GMT
-//         Latest update: Nov 2022 (by GK)
+//         Latest update: Nov 2023 (by CS)
 //
 // Track jets are clustered in a two-layer process, first by clustering in phi,
 // then by clustering in eta. The code proceeds as following: putting all tracks// in a grid of eta vs phi space, and then cluster them. Finally we merge the cl
@@ -63,16 +64,9 @@ private:
   // ----------member data ---------------------------
 
   std::vector<edm::Ptr<L1TTTrackType>> L1TrkPtrs_;
-  vector<int> tdtrk_;
   const float trkZMax_;
   const float trkPtMax_;
-  const float trkPtMin_;
   const float trkEtaMax_;
-  const float nStubs4PromptChi2_;
-  const float nStubs5PromptChi2_;
-  const float nStubs4PromptBend_;
-  const float nStubs5PromptBend_;
-  const int trkNPSStubMin_;
   const int lowpTJetMinTrackMultiplicity_;
   const float lowpTJetThreshold_;
   const int highpTJetMinTrackMultiplicity_;
@@ -84,36 +78,22 @@ private:
   const bool displaced_;
   const float d0CutNStubs4_;
   const float d0CutNStubs5_;
-  const float nStubs4DisplacedChi2_;
-  const float nStubs5DisplacedChi2_;
-  const float nStubs4DisplacedBend_;
-  const float nStubs5DisplacedBend_;
   const int nDisplacedTracks_;
-  const float dzPVTrk_;
 
-  float PVz;
   float zStep_;
   glbeta_intern etaStep_;
   glbphi_intern phiStep_;
 
   TTTrack_TrackWord trackword;
 
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const EDGetTokenT<L1TTTrackRefCollectionType> trackToken_;
-  const EDGetTokenT<l1t::VertexWordCollection> PVtxToken_;
 };
 
 //constructor
 L1TrackJetEmulatorProducer::L1TrackJetEmulatorProducer(const ParameterSet &iConfig)
     : trkZMax_(iConfig.getParameter<double>("trk_zMax")),
       trkPtMax_(iConfig.getParameter<double>("trk_ptMax")),
-      trkPtMin_(iConfig.getParameter<double>("trk_ptMin")),
       trkEtaMax_(iConfig.getParameter<double>("trk_etaMax")),
-      nStubs4PromptChi2_(iConfig.getParameter<double>("nStubs4PromptChi2")),
-      nStubs5PromptChi2_(iConfig.getParameter<double>("nStubs5PromptChi2")),
-      nStubs4PromptBend_(iConfig.getParameter<double>("nStubs4PromptBend")),
-      nStubs5PromptBend_(iConfig.getParameter<double>("nStubs5PromptBend")),
-      trkNPSStubMin_(iConfig.getParameter<int>("trk_nPSStubMin")),
       lowpTJetMinTrackMultiplicity_(iConfig.getParameter<int>("lowpTJetMinTrackMultiplicity")),
       lowpTJetThreshold_(iConfig.getParameter<double>("lowpTJetThreshold")),
       highpTJetMinTrackMultiplicity_(iConfig.getParameter<int>("highpTJetMinTrackMultiplicity")),
@@ -125,15 +105,8 @@ L1TrackJetEmulatorProducer::L1TrackJetEmulatorProducer(const ParameterSet &iConf
       displaced_(iConfig.getParameter<bool>("displaced")),
       d0CutNStubs4_(iConfig.getParameter<double>("d0_cutNStubs4")),
       d0CutNStubs5_(iConfig.getParameter<double>("d0_cutNStubs5")),
-      nStubs4DisplacedChi2_(iConfig.getParameter<double>("nStubs4DisplacedChi2")),
-      nStubs5DisplacedChi2_(iConfig.getParameter<double>("nStubs5DisplacedChi2")),
-      nStubs4DisplacedBend_(iConfig.getParameter<double>("nStubs4DisplacedBend")),
-      nStubs5DisplacedBend_(iConfig.getParameter<double>("nStubs5DisplacedBend")),
       nDisplacedTracks_(iConfig.getParameter<int>("nDisplacedTracks")),
-      dzPVTrk_(iConfig.getParameter<double>("MaxDzTrackPV")),
-      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
-      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))),
-      PVtxToken_(consumes<l1t::VertexWordCollection>(iConfig.getParameter<InputTag>("L1PVertexInputTag"))) {
+      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))) {
   zStep_ = 2.0 * trkZMax_ / (zBins_ + 1);                 // added +1 in denom
   etaStep_ = glbeta_intern(2.0 * trkEtaMax_ / etaBins_);  //etaStep is the width of an etabin
   phiStep_ = DoubleToBit(2.0 * (M_PI) / phiBins_,
@@ -148,58 +121,15 @@ L1TrackJetEmulatorProducer::L1TrackJetEmulatorProducer(const ParameterSet &iConf
 
 void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup) {
   unique_ptr<l1t::TkJetWordCollection> L1TrackJetContainer(new l1t::TkJetWordCollection);
-  // Read inputs
-  const TrackerTopology &tTopo = iSetup.getData(tTopoToken_);
 
+  // L1 tracks
   edm::Handle<L1TTTrackRefCollectionType> TTTrackHandle;
   iEvent.getByToken(trackToken_, TTTrackHandle);
 
-  edm::Handle<l1t::VertexWordCollection> PVtx;
-  iEvent.getByToken(PVtxToken_, PVtx);
-  float PVz = (PVtx->at(0)).z0();
-
   L1TrkPtrs_.clear();
-  tdtrk_.clear();
   // track selection
   for (unsigned int this_l1track = 0; this_l1track < TTTrackHandle->size(); this_l1track++) {
     edm::Ptr<L1TTTrackType> trkPtr(TTTrackHandle, this_l1track);
-    float trk_pt = trkPtr->momentum().perp();
-    int trk_nstubs = (int)trkPtr->getStubRefs().size();
-    float trk_chi2dof = trkPtr->chi2Red();
-    float trk_bendchi2 = trkPtr->stubPtConsistency();
-    int trk_nPS = 0;
-    for (int istub = 0; istub < trk_nstubs; istub++) {
-      DetId detId(trkPtr->getStubRefs().at(istub)->getDetId());
-      if (detId.det() == DetId::Detector::Tracker) {
-        if ((detId.subdetId() == StripSubdetector::TOB && tTopo.tobLayer(detId) <= 3) ||
-            (detId.subdetId() == StripSubdetector::TID && tTopo.tidRing(detId) <= 9))
-          trk_nPS++;
-      }
-    }
-    // selection tracks - supposed to happen on seperate module (kept for legacy/debug reasons)
-    if (trk_nPS < trkNPSStubMin_)
-      continue;
-    if (!TrackQualitySelection(trk_nstubs,
-                               trk_chi2dof,
-                               trk_bendchi2,
-                               nStubs4PromptBend_,
-                               nStubs5PromptBend_,
-                               nStubs4PromptChi2_,
-                               nStubs5PromptChi2_,
-                               nStubs4DisplacedBend_,
-                               nStubs5DisplacedBend_,
-                               nStubs4DisplacedChi2_,
-                               nStubs5DisplacedChi2_,
-                               displaced_))
-      continue;
-    if (std::abs(PVz - trkPtr->z0()) > dzPVTrk_ && dzPVTrk_ > 0)
-      continue;
-    if (std::abs(trkPtr->z0()) > trkZMax_)
-      continue;
-    if (std::abs(trkPtr->momentum().eta()) > trkEtaMax_)
-      continue;
-    if (trk_pt < trkPtMin_)
-      continue;
     L1TrkPtrs_.push_back(trkPtr);
   }
 
@@ -348,8 +278,6 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
 
   vector<edm::Ptr<L1TTTrackType>> L1TrackAssocJet;
   for (unsigned int j = 0; j < mzb.clusters.size(); ++j) {
-    if (mzb.clusters[j].pTtot < pt_intern(trkPtMin_))
-      continue;
 
     l1t::TkJetWord::glbeta_t jetEta = DoubleToBit(double(mzb.clusters[j].eta),
                                                   TkJetWord::TkJetBitWidths::kGlbEtaSize,
@@ -365,7 +293,7 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
     l1t::TkJetWord::dispflag_t dispflag = 0;
     l1t::TkJetWord::tkjetunassigned_t unassigned = 0;
 
-    if (total_disptracks > nDisplacedTracks_ || total_disptracks == nDisplacedTracks_)
+    if (total_disptracks >= nDisplacedTracks_)
       dispflag = 1;
     L1TrackAssocJet.clear();
     for (unsigned int itrk = 0; itrk < mzb.clusters[j].trackidx.size(); itrk++)
@@ -388,17 +316,9 @@ void L1TrackJetEmulatorProducer::fillDescriptions(ConfigurationDescriptions &des
   // Please change this to state exactly what you do use, even if it is no parameters
   ParameterSetDescription desc;
   desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
-  desc.add<edm::InputTag>("L1PVertexInputTag", edm::InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"));
-  desc.add<double>("MaxDzTrackPV", 1.0);
   desc.add<double>("trk_zMax", 15.0);
   desc.add<double>("trk_ptMax", 200.0);
-  desc.add<double>("trk_ptMin", 3.0);
   desc.add<double>("trk_etaMax", 2.4);
-  desc.add<double>("nStubs4PromptChi2", 5.0);
-  desc.add<double>("nStubs4PromptBend", 1.7);
-  desc.add<double>("nStubs5PromptChi2", 2.75);
-  desc.add<double>("nStubs5PromptBend", 3.5);
-  desc.add<int>("trk_nPSStubMin", -1);
   desc.add<double>("minTrkJetpT", -1.0);
   desc.add<int>("etaBins", 24);
   desc.add<int>("phiBins", 27);
@@ -410,10 +330,6 @@ void L1TrackJetEmulatorProducer::fillDescriptions(ConfigurationDescriptions &des
   desc.add<int>("highpTJetMinTrackMultiplicity", 3);
   desc.add<double>("highpTJetThreshold", 100.0);
   desc.add<bool>("displaced", false);
-  desc.add<double>("nStubs4DisplacedChi2", 5.0);
-  desc.add<double>("nStubs4DisplacedBend", 1.7);
-  desc.add<double>("nStubs5DisplacedChi2", 2.75);
-  desc.add<double>("nStubs5DisplacedBend", 3.5);
   desc.add<int>("nDisplacedTracks", 2);
   descriptions.add("l1tTrackJetsEmulator", desc);
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -278,7 +278,6 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
 
   vector<edm::Ptr<L1TTTrackType>> L1TrackAssocJet;
   for (unsigned int j = 0; j < mzb.clusters.size(); ++j) {
-
     l1t::TkJetWord::glbeta_t jetEta = DoubleToBit(double(mzb.clusters[j].eta),
                                                   TkJetWord::TkJetBitWidths::kGlbEtaSize,
                                                   TkJetWord::MAX_ETA / (1 << TkJetWord::TkJetBitWidths::kGlbEtaSize));

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -212,8 +212,8 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
           else
             epbins[i][j].pTtot += trkPtMax_;
           if ((std::abs(trkd0) > d0CutNStubs5_ && trknstubs >= 5 && d0CutNStubs5_ >= 0) ||
-	      (trknstubs == 4 && std::abs(trkd0) > d0CutNStubs4_ && d0CutNStubs4_ >= 0))
-	    epbins[i][j].nxtracks += 1;
+              (trknstubs == 4 && std::abs(trkd0) > d0CutNStubs4_ && d0CutNStubs4_ >= 0))
+            epbins[i][j].nxtracks += 1;
           epbins[i][j].trackidx.push_back(k);
           ++epbins[i][j].ntracks;
         }  // for each etabin
@@ -273,8 +273,7 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
     L1TrackJetProducer->push_back(trkJet);
   }
 
-  std::sort(
-      L1TrackJetProducer->begin(), L1TrackJetProducer->end(), [](auto &a, auto &b) { return a.pt() > b.pt(); });
+  std::sort(L1TrackJetProducer->begin(), L1TrackJetProducer->end(), [](auto &a, auto &b) { return a.pt() > b.pt(); });
   if (displaced_)
     iEvent.put(std::move(L1TrackJetProducer), "L1TrackJetsExtended");
   else
@@ -283,7 +282,8 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
 
 void L1TrackJetProducer::fillDescriptions(ConfigurationDescriptions &descriptions) {
   ParameterSetDescription desc;
-  desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
+  desc.add<edm::InputTag>(
+      "L1TrackInputTag", edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
   desc.add<double>("trk_zMax", 15.0);
   desc.add<double>("trk_ptMax", 200.0);
   desc.add<double>("trk_etaMax", 2.4);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -2,9 +2,10 @@
 //
 // Rewritting/improvements:  George Karathanasis,
 //                           georgios.karathanasis@cern.ch, CU Boulder
+//                           Claire Savard (claire.savard@colorado.edu)
 //
 //         Created:  Wed, 01 Aug 2018 14:01:41 GMT
-//         Latest update: Nov 2022 (by GK)
+//         Latest update: Nov 2023 (by CS)
 //
 // Track jets are clustered in a two-layer process, first by clustering in phi,
 // then by clustering in eta. The code proceeds as following: putting all tracks
@@ -57,16 +58,9 @@ private:
   // ----------member data ---------------------------
 
   vector<Ptr<L1TTTrackType>> L1TrkPtrs_;
-  vector<int> tdtrk_;
   const float trkZMax_;
   const float trkPtMax_;
-  const float trkPtMin_;
   const float trkEtaMax_;
-  const float nStubs4PromptChi2_;
-  const float nStubs5PromptChi2_;
-  const float nStubs4PromptBend_;
-  const float nStubs5PromptBend_;
-  const int trkNPSStubMin_;
   const int lowpTJetMinTrackMultiplicity_;
   const float lowpTJetThreshold_;
   const int highpTJetMinTrackMultiplicity_;
@@ -81,28 +75,15 @@ private:
   const bool displaced_;
   const float d0CutNStubs4_;
   const float d0CutNStubs5_;
-  const float nStubs4DisplacedChi2_;
-  const float nStubs5DisplacedChi2_;
-  const float nStubs4DisplacedBend_;
-  const float nStubs5DisplacedBend_;
   const int nDisplacedTracks_;
-  const float dzPVTrk_;
 
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const EDGetTokenT<L1TTTrackRefCollectionType> trackToken_;
-  const EDGetTokenT<l1t::VertexWordCollection> PVtxToken_;
 };
 
 L1TrackJetProducer::L1TrackJetProducer(const ParameterSet &iConfig)
     : trkZMax_(iConfig.getParameter<double>("trk_zMax")),
       trkPtMax_(iConfig.getParameter<double>("trk_ptMax")),
-      trkPtMin_(iConfig.getParameter<double>("trk_ptMin")),
       trkEtaMax_(iConfig.getParameter<double>("trk_etaMax")),
-      nStubs4PromptChi2_(iConfig.getParameter<double>("nStubs4PromptChi2")),
-      nStubs5PromptChi2_(iConfig.getParameter<double>("nStubs5PromptChi2")),
-      nStubs4PromptBend_(iConfig.getParameter<double>("nStubs4PromptBend")),
-      nStubs5PromptBend_(iConfig.getParameter<double>("nStubs5PromptBend")),
-      trkNPSStubMin_(iConfig.getParameter<int>("trk_nPSStubMin")),
       lowpTJetMinTrackMultiplicity_(iConfig.getParameter<int>("lowpTJetMinTrackMultiplicity")),
       lowpTJetThreshold_(iConfig.getParameter<double>("lowpTJetThreshold")),
       highpTJetMinTrackMultiplicity_(iConfig.getParameter<int>("highpTJetMinTrackMultiplicity")),
@@ -114,15 +95,8 @@ L1TrackJetProducer::L1TrackJetProducer(const ParameterSet &iConfig)
       displaced_(iConfig.getParameter<bool>("displaced")),
       d0CutNStubs4_(iConfig.getParameter<double>("d0_cutNStubs4")),
       d0CutNStubs5_(iConfig.getParameter<double>("d0_cutNStubs5")),
-      nStubs4DisplacedChi2_(iConfig.getParameter<double>("nStubs4DisplacedChi2")),
-      nStubs5DisplacedChi2_(iConfig.getParameter<double>("nStubs5DisplacedChi2")),
-      nStubs4DisplacedBend_(iConfig.getParameter<double>("nStubs4DisplacedBend")),
-      nStubs5DisplacedBend_(iConfig.getParameter<double>("nStubs5DisplacedBend")),
       nDisplacedTracks_(iConfig.getParameter<int>("nDisplacedTracks")),
-      dzPVTrk_(iConfig.getParameter<double>("MaxDzTrackPV")),
-      tTopoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>(edm::ESInputTag("", ""))),
-      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))),
-      PVtxToken_(consumes<l1t::VertexWordCollection>(iConfig.getParameter<InputTag>("L1PVertexInputTag"))) {
+      trackToken_(consumes<L1TTTrackRefCollectionType>(iConfig.getParameter<InputTag>("L1TrackInputTag"))) {
   zStep_ = 2.0 * trkZMax_ / (zBins_ + 1);  // added +1 in denom
   etaStep_ = 2.0 * trkEtaMax_ / etaBins_;  //etaStep is the width of an etabin
   phiStep_ = 2 * M_PI / phiBins_;          ////phiStep is the width of a phibin
@@ -134,78 +108,26 @@ L1TrackJetProducer::L1TrackJetProducer(const ParameterSet &iConfig)
 }
 
 void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
-  unique_ptr<TkJetCollection> L1L1TrackJetProducer(new TkJetCollection);
+  unique_ptr<TkJetCollection> L1TrackJetProducer(new TkJetCollection);
 
-  // Read inputs
-  const TrackerTopology &tTopo = iSetup.getData(tTopoToken_);
-
+  // L1 tracks
   edm::Handle<L1TTTrackRefCollectionType> TTTrackHandle;
   iEvent.getByToken(trackToken_, TTTrackHandle);
 
-  edm::Handle<l1t::VertexWordCollection> PVtx;
-  iEvent.getByToken(PVtxToken_, PVtx);
-  float PVz = (PVtx->at(0)).z0();
-
   L1TrkPtrs_.clear();
-  tdtrk_.clear();
 
   // track selection
   for (unsigned int this_l1track = 0; this_l1track < TTTrackHandle->size(); this_l1track++) {
     edm::Ptr<L1TTTrackType> trkPtr(TTTrackHandle, this_l1track);
-    float trk_pt = trkPtr->momentum().perp();
-    int trk_nstubs = (int)trkPtr->getStubRefs().size();
-    float trk_chi2dof = trkPtr->chi2Red();
-    float trk_d0 = trkPtr->d0();
-    float trk_bendchi2 = trkPtr->stubPtConsistency();
-
-    int trk_nPS = 0;
-    for (int istub = 0; istub < trk_nstubs; istub++) {  // loop over the stubs
-      DetId detId(trkPtr->getStubRefs().at(istub)->getDetId());
-      if (detId.det() == DetId::Detector::Tracker) {
-        if ((detId.subdetId() == StripSubdetector::TOB && tTopo.tobLayer(detId) <= 3) ||
-            (detId.subdetId() == StripSubdetector::TID && tTopo.tidRing(detId) <= 9))
-          trk_nPS++;
-      }
-    }
-    // select tracks
-    if (trk_nPS < trkNPSStubMin_)
-      continue;
-    if (!TrackQualitySelection(trk_nstubs,
-                               trk_chi2dof,
-                               trk_bendchi2,
-                               nStubs4PromptBend_,
-                               nStubs5PromptBend_,
-                               nStubs4PromptChi2_,
-                               nStubs5PromptChi2_,
-                               nStubs4DisplacedBend_,
-                               nStubs5DisplacedBend_,
-                               nStubs4DisplacedChi2_,
-                               nStubs5DisplacedChi2_,
-                               displaced_))
-      continue;
-    if (std::abs(PVz - trkPtr->z0()) > dzPVTrk_ && dzPVTrk_ > 0)
-      continue;
-    if (std::abs(trkPtr->z0()) > trkZMax_)
-      continue;
-    if (std::abs(trkPtr->momentum().eta()) > trkEtaMax_)
-      continue;
-    if (trk_pt < trkPtMin_)
-      continue;
     L1TrkPtrs_.push_back(trkPtr);
-
-    if ((std::abs(trk_d0) > d0CutNStubs5_ && trk_nstubs >= 5 && d0CutNStubs5_ >= 0) ||
-        (trk_nstubs == 4 && std::abs(trk_d0) > d0CutNStubs4_ && d0CutNStubs4_ >= 0))
-      tdtrk_.push_back(1);  //displaced track
-    else
-      tdtrk_.push_back(0);  // not displaced track
   }
 
   // if no tracks pass selection return empty containers
   if (L1TrkPtrs_.empty()) {
     if (displaced_)
-      iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJetsExtended");
+      iEvent.put(std::move(L1TrackJetProducer), "L1TrackJetsExtended");
     else
-      iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJets");
+      iEvent.put(std::move(L1TrackJetProducer), "L1TrackJets");
     return;
   }
 
@@ -273,6 +195,8 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
       float trkpt = L1TrkPtrs_[k]->momentum().perp();
       float trketa = L1TrkPtrs_[k]->momentum().eta();
       float trkphi = L1TrkPtrs_[k]->momentum().phi();
+      float trkd0 = L1TrkPtrs_[k]->d0();
+      int trknstubs = (int)L1TrkPtrs_[k]->getStubRefs().size();
       for (int i = 0; i < phiBins_; ++i) {
         for (int j = 0; j < etaBins_; ++j) {
           float eta_min = epbins[i][j].eta - etaStep_ / 2.0;  //eta min
@@ -287,7 +211,9 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
             epbins[i][j].pTtot += trkpt;
           else
             epbins[i][j].pTtot += trkPtMax_;
-          epbins[i][j].nxtracks += tdtrk_[k];
+          if ((std::abs(trkd0) > d0CutNStubs5_ && trknstubs >= 5 && d0CutNStubs5_ >= 0) ||
+	      (trknstubs == 4 && std::abs(trkd0) > d0CutNStubs4_ && d0CutNStubs4_ >= 0))
+	    epbins[i][j].nxtracks += 1;
           epbins[i][j].trackidx.push_back(k);
           ++epbins[i][j].ntracks;
         }  // for each etabin
@@ -335,7 +261,7 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
     float jetPz = jetPt * sinh(jetEta);
     float jetP = jetPt * cosh(jetEta);
     int totalDisptrk = mzb.clusters[j].nxtracks;
-    bool isDispJet = (totalDisptrk > nDisplacedTracks_ || totalDisptrk == nDisplacedTracks_);
+    bool isDispJet = (totalDisptrk >= nDisplacedTracks_);
 
     math::XYZTLorentzVector jetP4(jetPx, jetPy, jetPz, jetP);
     L1TrackAssocJet.clear();
@@ -344,31 +270,23 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
 
     TkJet trkJet(jetP4, L1TrackAssocJet, mzb.zbincenter, mzb.clusters[j].ntracks, 0, totalDisptrk, 0, isDispJet);
 
-    L1L1TrackJetProducer->push_back(trkJet);
+    L1TrackJetProducer->push_back(trkJet);
   }
 
   std::sort(
-      L1L1TrackJetProducer->begin(), L1L1TrackJetProducer->end(), [](auto &a, auto &b) { return a.pt() > b.pt(); });
+      L1TrackJetProducer->begin(), L1TrackJetProducer->end(), [](auto &a, auto &b) { return a.pt() > b.pt(); });
   if (displaced_)
-    iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJetsExtended");
+    iEvent.put(std::move(L1TrackJetProducer), "L1TrackJetsExtended");
   else
-    iEvent.put(std::move(L1L1TrackJetProducer), "L1TrackJets");
+    iEvent.put(std::move(L1TrackJetProducer), "L1TrackJets");
 }
 
 void L1TrackJetProducer::fillDescriptions(ConfigurationDescriptions &descriptions) {
   ParameterSetDescription desc;
-  desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
-  desc.add<edm::InputTag>("L1PVertexInputTag", edm::InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"));
-  desc.add<double>("MaxDzTrackPV", 1.0);
+  desc.add<edm::InputTag>("L1TrackInputTag", edm::InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"));
   desc.add<double>("trk_zMax", 15.0);
   desc.add<double>("trk_ptMax", 200.0);
-  desc.add<double>("trk_ptMin", 3.0);
   desc.add<double>("trk_etaMax", 2.4);
-  desc.add<double>("nStubs4PromptChi2", 5.0);
-  desc.add<double>("nStubs4PromptBend", 1.7);
-  desc.add<double>("nStubs5PromptChi2", 2.75);
-  desc.add<double>("nStubs5PromptBend", 3.5);
-  desc.add<int>("trk_nPSStubMin", -1);
   desc.add<double>("minTrkJetpT", -1.0);
   desc.add<int>("etaBins", 24);
   desc.add<int>("phiBins", 27);
@@ -380,10 +298,6 @@ void L1TrackJetProducer::fillDescriptions(ConfigurationDescriptions &description
   desc.add<int>("highpTJetMinTrackMultiplicity", 3);
   desc.add<double>("highpTJetThreshold", 100.0);
   desc.add<bool>("displaced", false);
-  desc.add<double>("nStubs4DisplacedChi2", 5.0);
-  desc.add<double>("nStubs4DisplacedBend", 1.7);
-  desc.add<double>("nStubs5DisplacedChi2", 2.75);
-  desc.add<double>("nStubs5DisplacedBend", 3.5);
   desc.add<int>("nDisplacedTracks", 2);
   descriptions.add("l1tTrackJets", desc);
 }

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -201,6 +201,24 @@ private:
     double nPSStubsMin_;
     const TrackerTopology& tTopo_;
   };
+  struct TTTrackChi2MaxSelector {
+    TTTrackChi2MaxSelector(double reducedChi2Max) : reducedChi2Max_(reducedChi2Max) {}
+    TTTrackChi2MaxSelector(const edm::ParameterSet& cfg)
+      : reducedChi2Max_(cfg.template getParameter<double>("reducedChi2Max")) {}
+    bool operator()(const L1Track& t) const { return t.chi2Red() < reducedChi2Max_; }
+
+  private:
+    double reducedChi2Max_;
+  };
+  struct TTTrackWordChi2MaxSelector {
+    TTTrackWordChi2MaxSelector(double reducedChi2Max) : reducedChi2Max_(reducedChi2Max) {}
+    TTTrackWordChi2MaxSelector(const edm::ParameterSet& cfg)
+      : reducedChi2Max_(cfg.template getParameter<double>("reducedChi2Max")) {}
+    bool operator()(const L1Track& t) const { return t.chi2Red() < reducedChi2Max_; }
+
+  private:
+    double reducedChi2Max_;
+  };
   struct TTTrackBendChi2MaxSelector {
     TTTrackBendChi2MaxSelector(double bendChi2Max) : bendChi2Max_(bendChi2Max) {}
     TTTrackBendChi2MaxSelector(const edm::ParameterSet& cfg)
@@ -263,9 +281,9 @@ private:
                       TTTrackWordAbsZ0MaxSelector,
                       TTTrackWordNStubsMinSelector>
       TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector;
-  typedef AndSelector<TTTrackBendChi2MaxSelector, TTTrackChi2RZMaxSelector, TTTrackChi2RPhiMaxSelector>
+  typedef AndSelector<TTTrackBendChi2MaxSelector, TTTrackChi2RZMaxSelector, TTTrackChi2RPhiMaxSelector, TTTrackChi2MaxSelector>
       TTTrackBendChi2Chi2RZChi2RPhiMaxSelector;
-  typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector>
+  typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector, TTTrackWordChi2MaxSelector>
       TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector;
 
   // ----------member data ---------------------------
@@ -273,7 +291,7 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const std::string outputCollectionName_;
   const edm::ParameterSet cutSet_;
-  const double ptMin_, absEtaMax_, absZ0Max_, bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
+  const double ptMin_, absEtaMax_, absZ0Max_, bendChi2Max_, reducedChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
   const int nStubsMin_, nPSStubsMin_;
   bool processSimulatedTracks_, processEmulatedTracks_;
   int debug_;
@@ -292,6 +310,7 @@ L1TrackSelectionProducer::L1TrackSelectionProducer(const edm::ParameterSet& iCon
       absEtaMax_(cutSet_.getParameter<double>("absEtaMax")),
       absZ0Max_(cutSet_.getParameter<double>("absZ0Max")),
       bendChi2Max_(cutSet_.getParameter<double>("reducedBendChi2Max")),
+  reducedChi2Max_(cutSet_.getParameter<double>("reducedChi2Max")),
       reducedChi2RZMax_(cutSet_.getParameter<double>("reducedChi2RZMax")),
       reducedChi2RPhiMax_(cutSet_.getParameter<double>("reducedChi2RPhiMax")),
       nStubsMin_(cutSet_.getParameter<int>("nStubsMin")),
@@ -414,8 +433,8 @@ void L1TrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
   TTTrackPtMinEtaMaxZ0MaxNStubsMinSelector kinSel(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
   TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector kinSelEmu(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
-  TTTrackBendChi2Chi2RZChi2RPhiMaxSelector chi2Sel(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
-  TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector chi2SelEmu(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
+  TTTrackBendChi2Chi2RZChi2RPhiMaxSelector chi2Sel(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_, reducedChi2Max_);
+  TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector chi2SelEmu(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_, reducedChi2Max_);
   TTTrackNPSStubsMinSelector nPSStubsSel(nPSStubsMin_, tTopo);
 
   for (size_t i = 0; i < nOutputApproximate; i++) {
@@ -461,6 +480,7 @@ void L1TrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& 
         ->setComment("number of stubs in the PS Modules must be greater than or equal to this value");
 
     descCutSet.add<double>("reducedBendChi2Max", 2.25)->setComment("bend chi2 must be less than this value");
+    descCutSet.add<double>("reducedChi2Max", 9999.0)->setComment("chi2/dof must be less than this value");
     descCutSet.add<double>("reducedChi2RZMax", 5.0)->setComment("chi2rz/dof must be less than this value");
     descCutSet.add<double>("reducedChi2RPhiMax", 20.0)->setComment("chi2rphi/dof must be less than this value");
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -206,7 +206,7 @@ private:
     TTTrackPromptMVAMinSelector(double promptMVAMin) : promptMVAMin_(promptMVAMin) {}
     TTTrackPromptMVAMinSelector(const edm::ParameterSet& cfg)
         : promptMVAMin_(cfg.template getParameter<double>("promptMVAMin")) {}
-    bool operator()(const L1Track& t) const { return t.trkMVA1() > promptMVAMin_; }
+    bool operator()(const L1Track& t) const { return t.trkMVA1() >= promptMVAMin_; }
 
   private:
     double promptMVAMin_;
@@ -216,7 +216,7 @@ private:
     TTTrackWordPromptMVAMinSelector(const edm::ParameterSet& cfg)
         : promptMVAMin_(cfg.template getParameter<double>("promptMVAMin")) {}
     bool operator()(const L1Track& t) const {
-      return t.trkMVA1() > promptMVAMin_;
+      return t.trkMVA1() >= promptMVAMin_;
     }  //change when mva bins in word are set
 
   private:

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackSelectionProducer.cc
@@ -19,6 +19,7 @@
 // Original Author:  Alexx Perloff
 //         Created:  Thu, 16 Dec 2021 19:02:50 GMT
 //
+// Updates: Claire Savard (claire.savard@colorado.edu), Nov. 2023
 //
 
 // system include files
@@ -201,23 +202,25 @@ private:
     double nPSStubsMin_;
     const TrackerTopology& tTopo_;
   };
-  struct TTTrackChi2MaxSelector {
-    TTTrackChi2MaxSelector(double reducedChi2Max) : reducedChi2Max_(reducedChi2Max) {}
-    TTTrackChi2MaxSelector(const edm::ParameterSet& cfg)
-      : reducedChi2Max_(cfg.template getParameter<double>("reducedChi2Max")) {}
-    bool operator()(const L1Track& t) const { return t.chi2Red() < reducedChi2Max_; }
+  struct TTTrackPromptMVAMinSelector {
+    TTTrackPromptMVAMinSelector(double promptMVAMin) : promptMVAMin_(promptMVAMin) {}
+    TTTrackPromptMVAMinSelector(const edm::ParameterSet& cfg)
+        : promptMVAMin_(cfg.template getParameter<double>("promptMVAMin")) {}
+    bool operator()(const L1Track& t) const { return t.trkMVA1() > promptMVAMin_; }
 
   private:
-    double reducedChi2Max_;
+    double promptMVAMin_;
   };
-  struct TTTrackWordChi2MaxSelector {
-    TTTrackWordChi2MaxSelector(double reducedChi2Max) : reducedChi2Max_(reducedChi2Max) {}
-    TTTrackWordChi2MaxSelector(const edm::ParameterSet& cfg)
-      : reducedChi2Max_(cfg.template getParameter<double>("reducedChi2Max")) {}
-    bool operator()(const L1Track& t) const { return t.chi2Red() < reducedChi2Max_; }
+  struct TTTrackWordPromptMVAMinSelector {
+    TTTrackWordPromptMVAMinSelector(double promptMVAMin) : promptMVAMin_(promptMVAMin) {}
+    TTTrackWordPromptMVAMinSelector(const edm::ParameterSet& cfg)
+        : promptMVAMin_(cfg.template getParameter<double>("promptMVAMin")) {}
+    bool operator()(const L1Track& t) const {
+      return t.trkMVA1() > promptMVAMin_;
+    }  //change when mva bins in word are set
 
   private:
-    double reducedChi2Max_;
+    double promptMVAMin_;
   };
   struct TTTrackBendChi2MaxSelector {
     TTTrackBendChi2MaxSelector(double bendChi2Max) : bendChi2Max_(bendChi2Max) {}
@@ -273,6 +276,66 @@ private:
   private:
     double reducedChi2RPhiMax_;
   };
+  struct TTTrackChi2MaxNstubSelector {
+    TTTrackChi2MaxNstubSelector(double reducedChi2MaxNstub4, double reducedChi2MaxNstub5)
+        : reducedChi2MaxNstub4_(reducedChi2MaxNstub4), reducedChi2MaxNstub5_(reducedChi2MaxNstub5) {}
+    TTTrackChi2MaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2MaxNstub4_(cfg.template getParameter<double>("reducedChi2MaxNstub4")),
+          reducedChi2MaxNstub5_(cfg.template getParameter<double>("reducedChi2MaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.chi2Red() < reducedChi2MaxNstub4_) && (t.getStubRefs().size() == 4)) ||
+              ((t.chi2Red() < reducedChi2MaxNstub5_) && (t.getStubRefs().size() > 4)));
+    }
+
+  private:
+    double reducedChi2MaxNstub4_;
+    double reducedChi2MaxNstub5_;
+  };
+  struct TTTrackWordChi2MaxNstubSelector {  // using simulated chi2 since not implemented in track word, updates needed
+    TTTrackWordChi2MaxNstubSelector(double reducedChi2MaxNstub4, double reducedChi2MaxNstub5)
+        : reducedChi2MaxNstub4_(reducedChi2MaxNstub4), reducedChi2MaxNstub5_(reducedChi2MaxNstub5) {}
+    TTTrackWordChi2MaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedChi2MaxNstub4_(cfg.template getParameter<double>("reducedChi2MaxNstub4")),
+          reducedChi2MaxNstub5_(cfg.template getParameter<double>("reducedChi2MaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.chi2Red() < reducedChi2MaxNstub4_) && (t.getNStubs() == 4)) ||
+              ((t.chi2Red() < reducedChi2MaxNstub5_) && (t.getNStubs() > 4)));
+    }
+
+  private:
+    double reducedChi2MaxNstub4_;
+    double reducedChi2MaxNstub5_;
+  };
+  struct TTTrackBendChi2MaxNstubSelector {
+    TTTrackBendChi2MaxNstubSelector(double reducedBendChi2MaxNstub4, double reducedBendChi2MaxNstub5)
+        : reducedBendChi2MaxNstub4_(reducedBendChi2MaxNstub4), reducedBendChi2MaxNstub5_(reducedBendChi2MaxNstub5) {}
+    TTTrackBendChi2MaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedBendChi2MaxNstub4_(cfg.template getParameter<double>("reducedBendChi2MaxNstub4")),
+          reducedBendChi2MaxNstub5_(cfg.template getParameter<double>("reducedBendChi2MaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.stubPtConsistency() < reducedBendChi2MaxNstub4_) && (t.getStubRefs().size() == 4)) ||
+              ((t.stubPtConsistency() < reducedBendChi2MaxNstub5_) && (t.getStubRefs().size() > 4)));
+    }
+
+  private:
+    double reducedBendChi2MaxNstub4_;
+    double reducedBendChi2MaxNstub5_;
+  };
+  struct TTTrackWordBendChi2MaxNstubSelector {
+    TTTrackWordBendChi2MaxNstubSelector(double reducedBendChi2MaxNstub4, double reducedBendChi2MaxNstub5)
+        : reducedBendChi2MaxNstub4_(reducedBendChi2MaxNstub4), reducedBendChi2MaxNstub5_(reducedBendChi2MaxNstub5) {}
+    TTTrackWordBendChi2MaxNstubSelector(const edm::ParameterSet& cfg)
+        : reducedBendChi2MaxNstub4_(cfg.template getParameter<double>("reducedBendChi2MaxNstub4")),
+          reducedBendChi2MaxNstub5_(cfg.template getParameter<double>("reducedBendChi2MaxNstub5")) {}
+    bool operator()(const L1Track& t) const {
+      return (((t.getBendChi2() < reducedBendChi2MaxNstub4_) && (t.getNStubs() == 4)) ||
+              ((t.getBendChi2() < reducedBendChi2MaxNstub5_) && (t.getNStubs() > 4)));
+    }
+
+  private:
+    double reducedBendChi2MaxNstub4_;
+    double reducedBendChi2MaxNstub5_;
+  };
 
   typedef AndSelector<TTTrackPtMinSelector, TTTrackAbsEtaMaxSelector, TTTrackAbsZ0MaxSelector, TTTrackNStubsMinSelector>
       TTTrackPtMinEtaMaxZ0MaxNStubsMinSelector;
@@ -281,17 +344,21 @@ private:
                       TTTrackWordAbsZ0MaxSelector,
                       TTTrackWordNStubsMinSelector>
       TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector;
-  typedef AndSelector<TTTrackBendChi2MaxSelector, TTTrackChi2RZMaxSelector, TTTrackChi2RPhiMaxSelector, TTTrackChi2MaxSelector>
+  typedef AndSelector<TTTrackBendChi2MaxSelector, TTTrackChi2RZMaxSelector, TTTrackChi2RPhiMaxSelector>
       TTTrackBendChi2Chi2RZChi2RPhiMaxSelector;
-  typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector, TTTrackWordChi2MaxSelector>
+  typedef AndSelector<TTTrackWordBendChi2MaxSelector, TTTrackWordChi2RZMaxSelector, TTTrackWordChi2RPhiMaxSelector>
       TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector;
+  typedef AndSelector<TTTrackChi2MaxNstubSelector, TTTrackBendChi2MaxNstubSelector> TTTrackChi2BendChi2MaxNstubSelector;
+  typedef AndSelector<TTTrackWordChi2MaxNstubSelector, TTTrackWordBendChi2MaxNstubSelector>
+      TTTrackWordChi2BendChi2MaxNstubSelector;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<TTTrackCollection> l1TracksToken_;
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
   const std::string outputCollectionName_;
   const edm::ParameterSet cutSet_;
-  const double ptMin_, absEtaMax_, absZ0Max_, bendChi2Max_, reducedChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
+  const double ptMin_, absEtaMax_, absZ0Max_, promptMVAMin_, bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_;
+  const double reducedChi2MaxNstub4_, reducedChi2MaxNstub5_, reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_;
   const int nStubsMin_, nPSStubsMin_;
   bool processSimulatedTracks_, processEmulatedTracks_;
   int debug_;
@@ -309,10 +376,14 @@ L1TrackSelectionProducer::L1TrackSelectionProducer(const edm::ParameterSet& iCon
       ptMin_(cutSet_.getParameter<double>("ptMin")),
       absEtaMax_(cutSet_.getParameter<double>("absEtaMax")),
       absZ0Max_(cutSet_.getParameter<double>("absZ0Max")),
+      promptMVAMin_(cutSet_.getParameter<double>("promptMVAMin")),
       bendChi2Max_(cutSet_.getParameter<double>("reducedBendChi2Max")),
-  reducedChi2Max_(cutSet_.getParameter<double>("reducedChi2Max")),
       reducedChi2RZMax_(cutSet_.getParameter<double>("reducedChi2RZMax")),
       reducedChi2RPhiMax_(cutSet_.getParameter<double>("reducedChi2RPhiMax")),
+      reducedChi2MaxNstub4_(cutSet_.getParameter<double>("reducedChi2MaxNstub4")),
+      reducedChi2MaxNstub5_(cutSet_.getParameter<double>("reducedChi2MaxNstub5")),
+      reducedBendChi2MaxNstub4_(cutSet_.getParameter<double>("reducedBendChi2MaxNstub4")),
+      reducedBendChi2MaxNstub5_(cutSet_.getParameter<double>("reducedBendChi2MaxNstub5")),
       nStubsMin_(cutSet_.getParameter<int>("nStubsMin")),
       nPSStubsMin_(cutSet_.getParameter<int>("nPSStubsMin")),
       processSimulatedTracks_(iConfig.getParameter<bool>("processSimulatedTracks")),
@@ -433,20 +504,27 @@ void L1TrackSelectionProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 
   TTTrackPtMinEtaMaxZ0MaxNStubsMinSelector kinSel(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
   TTTrackWordPtMinEtaMaxZ0MaxNStubsMinSelector kinSelEmu(ptMin_, absEtaMax_, absZ0Max_, nStubsMin_);
-  TTTrackBendChi2Chi2RZChi2RPhiMaxSelector chi2Sel(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_, reducedChi2Max_);
-  TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector chi2SelEmu(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_, reducedChi2Max_);
+  TTTrackBendChi2Chi2RZChi2RPhiMaxSelector chi2Sel(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
+  TTTrackWordBendChi2Chi2RZChi2RPhiMaxSelector chi2SelEmu(bendChi2Max_, reducedChi2RZMax_, reducedChi2RPhiMax_);
   TTTrackNPSStubsMinSelector nPSStubsSel(nPSStubsMin_, tTopo);
+  TTTrackPromptMVAMinSelector mvaSel(promptMVAMin_);
+  TTTrackWordPromptMVAMinSelector mvaSelEmu(promptMVAMin_);
+  TTTrackChi2BendChi2MaxNstubSelector chi2NstubSel({reducedChi2MaxNstub4_, reducedChi2MaxNstub5_},
+                                                   {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
+  TTTrackWordChi2BendChi2MaxNstubSelector chi2NstubSelEmu({reducedChi2MaxNstub4_, reducedChi2MaxNstub5_},
+                                                          {reducedBendChi2MaxNstub4_, reducedBendChi2MaxNstub5_});
 
   for (size_t i = 0; i < nOutputApproximate; i++) {
     const auto& track = l1TracksHandle->at(i);
 
     // Select tracks based on the floating point TTTrack
-    if (processSimulatedTracks_ && kinSel(track) && nPSStubsSel(track) && chi2Sel(track)) {
+    if (processSimulatedTracks_ && kinSel(track) && nPSStubsSel(track) && chi2Sel(track) && mvaSel(track) &&
+        chi2NstubSel(track)) {
       vTTTrackOutput->push_back(TTTrackRef(l1TracksHandle, i));
     }
 
     // Select tracks based on the bitwise accurate TTTrack_TrackWord
-    if (processEmulatedTracks_ && kinSelEmu(track) && chi2SelEmu(track)) {
+    if (processEmulatedTracks_ && kinSelEmu(track) && chi2SelEmu(track) && mvaSelEmu(track) && chi2NstubSelEmu(track)) {
       vTTTrackEmulationOutput->push_back(TTTrackRef(l1TracksHandle, i));
     }
   }
@@ -479,10 +557,18 @@ void L1TrackSelectionProducer::fillDescriptions(edm::ConfigurationDescriptions& 
     descCutSet.add<int>("nPSStubsMin", 0)
         ->setComment("number of stubs in the PS Modules must be greater than or equal to this value");
 
+    descCutSet.add<double>("promptMVAMin", -1.0)->setComment("MVA must be greater than this value");
     descCutSet.add<double>("reducedBendChi2Max", 2.25)->setComment("bend chi2 must be less than this value");
-    descCutSet.add<double>("reducedChi2Max", 9999.0)->setComment("chi2/dof must be less than this value");
     descCutSet.add<double>("reducedChi2RZMax", 5.0)->setComment("chi2rz/dof must be less than this value");
     descCutSet.add<double>("reducedChi2RPhiMax", 20.0)->setComment("chi2rphi/dof must be less than this value");
+    descCutSet.add<double>("reducedChi2MaxNstub4", 999.9)
+        ->setComment("chi2/dof must be less than this value in nstub==4");
+    descCutSet.add<double>("reducedChi2MaxNstub5", 999.9)
+        ->setComment("chi2/dof must be less than this value in nstub>4");
+    descCutSet.add<double>("reducedBendChi2MaxNstub4", 999.9)
+        ->setComment("bend chi2 must be less than this value in nstub==4");
+    descCutSet.add<double>("reducedBendChi2MaxNstub5", 999.9)
+        ->setComment("bend chi2 must be less than this value in nstub>4");
 
     desc.add<edm::ParameterSetDescription>("cutSet", descCutSet);
   }

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackFastJets_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackFastJets_cfi.py
@@ -2,36 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 l1tTrackFastJets = cms.EDProducer("L1TrackFastJetProducer",
     L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"),
-    L1PrimaryVertexTag=cms.InputTag("l1tVertexFinder", "L1Vertices"),
-    trk_zMax = cms.double(15.),       # max track z0 [cm]
-    trk_chi2dofMax = cms.double(10.), # max track chi2/dof
-    trk_bendChi2Max = cms.double(2.2),# max bendChi2 cut
-    trk_ptMin = cms.double(2.0),      # minimum track pt [GeV]
-    trk_etaMax = cms.double(2.5),     # maximum track eta
-    trk_nStubMin = cms.int32(4),      # minimum number of stubs in track
-    trk_nPSStubMin = cms.int32(-1),   # minimum number of PS stubs in track
-    deltaZ0Cut=cms.double(0.5),       # cluster tracks within |dz|<X
-    doTightChi2 = cms.bool( True ),   # chi2dof < 5 for tracks with PT > 20
-    trk_ptTightChi2 = cms.double(20.0),
-    trk_chi2dofTightChi2 = cms.double(5.0),
     coneSize=cms.double(0.4),         #cone size for anti-kt fast jet
     displaced = cms.bool(False)       # use prompt/displaced tracks
 )
 
 l1tTrackFastJetsExtended = cms.EDProducer("L1TrackFastJetProducer",
     L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerExtendedForJets", "Level1TTTracksExtendedSelectedAssociated"),
-    L1PrimaryVertexTag=cms.InputTag("l1tVertexFinder", "L1Vertices"),
-    trk_zMax = cms.double(15.),       # max track z0 [cm]
-    trk_chi2dofMax = cms.double(40.),    # max track chi2 for extended tracks
-    trk_bendChi2Max = cms.double(2.4),#Bendchi2 cut for extended tracks
-    trk_ptMin = cms.double(3.0),      # minimum track pt [GeV]
-    trk_etaMax = cms.double(2.5),     # maximum track eta
-    trk_nStubMin = cms.int32(4),      # minimum number of stubs on track
-    trk_nPSStubMin = cms.int32(-1),   # minimum number of stubs in PS modules on track
-    deltaZ0Cut=cms.double(3.0),       #cluster tracks within |dz|<X
-    doTightChi2 = cms.bool( True ),   # chi2dof < 5 for tracks with PT > 20
-    trk_ptTightChi2 = cms.double(20.0),
-    trk_chi2dofTightChi2 = cms.double(5.0),
     coneSize=cms.double(0.4),         #cone size for anti-kt fast jet
     displaced = cms.bool(True)        # use prompt/displaced tracks
 )

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackFastJets_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackFastJets_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tTrackFastJets = cms.EDProducer("L1TrackFastJetProducer",
-    L1TrackInputTag = cms.InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"),
+    L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"),
     L1PrimaryVertexTag=cms.InputTag("l1tVertexFinder", "L1Vertices"),
     trk_zMax = cms.double(15.),       # max track z0 [cm]
     trk_chi2dofMax = cms.double(10.), # max track chi2/dof
@@ -19,7 +19,7 @@ l1tTrackFastJets = cms.EDProducer("L1TrackFastJetProducer",
 )
 
 l1tTrackFastJetsExtended = cms.EDProducer("L1TrackFastJetProducer",
-    L1TrackInputTag = cms.InputTag("l1tTTTracksFromExtendedTrackletEmulation", "Level1TTTracks"),
+    L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerExtendedForJets", "Level1TTTracksExtendedSelectedAssociated"),
     L1PrimaryVertexTag=cms.InputTag("l1tVertexFinder", "L1Vertices"),
     trk_zMax = cms.double(15.),       # max track z0 [cm]
     trk_chi2dofMax = cms.double(40.),    # max track chi2 for extended tracks

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackJetsEmulation_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackJetsEmulation_cfi.py
@@ -2,17 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 l1tTrackJetsEmulation = cms.EDProducer('L1TrackJetEmulatorProducer',
         L1TrackInputTag= cms.InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociatedEmulation"),
-        L1PVertexInputTag=cms.InputTag("l1tVertexFinderEmulator","L1VerticesEmulation"),
-        MaxDzTrackPV = cms.double(1.0),
         trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
-	trk_ptMin = cms.double(2.0),     # minimum track pt [GeV]
    	trk_etaMax = cms.double(2.4),    # maximum track eta
-        nStubs4PromptChi2=cms.double(10.0), #Prompt track quality flags for loose/tight
-        nStubs4PromptBend=cms.double(2.2),
-        nStubs5PromptChi2=cms.double(10.0),
-        nStubs5PromptBend=cms.double(2.2),
-	trk_nPSStubMin=cms.int32(-1),    # minimum PS stubs, -1 means no cut
 	minTrkJetpT=cms.double(-1.),      # minimum track pt to be considered for track jet
 	etaBins=cms.int32(24),
 	phiBins=cms.int32(27),
@@ -24,24 +16,14 @@ l1tTrackJetsEmulation = cms.EDProducer('L1TrackJetEmulatorProducer',
 	highpTJetMinTrackMultiplicity=cms.int32(3),
         highpTJetThreshold=cms.double(100.),
 	displaced=cms.bool(False), #Flag for displaced tracks
-	nStubs4DisplacedChi2=cms.double(5.0), #Displaced track quality flags for loose/tight
-	nStubs4DisplacedBend=cms.double(1.7),
-	nStubs5DisplacedChi2=cms.double(2.75),
-	nStubs5DisplacedBend=cms.double(3.5),
 	nDisplacedTracks=cms.int32(2) #Number of displaced tracks required per jet
 )
 
 l1tTrackJetsExtendedEmulation = l1tTrackJetsEmulation.clone(
 	L1TrackInputTag= cms.InputTag("l1tTrackVertexAssociationProducerExtendedForJets", "Level1TTTracksExtendedSelectedAssociatedEmulation"),
-        L1PVertexInputTag=cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
 	minTrkJetpT= 5.0,      # minimum track pt to be considered for track jet
-        MaxDzTrackPV = 5.0,
 	d0_cutNStubs4= -1, # -1 excludes nstub=4 from disp tag
 	d0_cutNStubs5= 0.22,
 	displaced= True, #Flag for displaced tracks
-	nStubs4DisplacedChi2= 3.3, #Disp tracks selection [trk<cut]
-	nStubs4DisplacedBend= 2.3,
-	nStubs5DisplacedChi2= 11.3,
-	nStubs5DisplacedBend= 9.8,
 	nDisplacedTracks= 3 #min Ntracks to tag a jet as displaced
 )

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackJets_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackJets_cfi.py
@@ -3,17 +3,9 @@ import FWCore.ParameterSet.Config as cms
 #prompt jet selection
 l1tTrackJets = cms.EDProducer('L1TrackJetProducer',
         L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerForJets", "Level1TTTracksSelectedAssociated"),
-        L1PVertexInputTag = cms.InputTag("l1tVertexFinderEmulator", "L1VerticesEmulation"),
-        MaxDzTrackPV = cms.double( 1.0 ), #max distance from PV;negative=no cut
 	trk_zMax = cms.double (15.) ,    # maximum track z
 	trk_ptMax = cms.double(200.),    # maximumum track pT before saturation [GeV]
-	trk_ptMin = cms.double(2.0),     # minimum track pt [GeV]
    	trk_etaMax = cms.double(2.4),    # maximum track eta
-	nStubs4PromptChi2=cms.double(10.0), #Prompt track quality flags for loose/tight
-        nStubs4PromptBend=cms.double(2.2),
-        nStubs5PromptChi2=cms.double(10.0),
-        nStubs5PromptBend=cms.double(2.2),
-	trk_nPSStubMin=cms.int32(-1),    # minimum PS stubs, -1 means no cut
 	minTrkJetpT=cms.double(-1.),     # min track jet pt to be considered for most energetic zbin finding 
 	etaBins=cms.int32(24),
 	phiBins=cms.int32(27),
@@ -25,24 +17,15 @@ l1tTrackJets = cms.EDProducer('L1TrackJetProducer',
 	highpTJetMinTrackMultiplicity=cms.int32(3),#used only for more than 1 z-bins (ie not *prompt*)
         highpTJetThreshold=cms.double(100.),#used only for more than 1 z-bins (ie not *prompt*)
 	displaced=cms.bool(False), #Flag for displaced tracks
-	nStubs4DisplacedChi2=cms.double(5.0), #Displaced track quality flags for loose/tight
-	nStubs4DisplacedBend=cms.double(1.7),
-	nStubs5DisplacedChi2=cms.double(2.75),
-	nStubs5DisplacedBend=cms.double(3.5),
         nDisplacedTracks=cms.int32(2)
 )
 
 #displaced jets
 l1tTrackJetsExtended = l1tTrackJets.clone(
         L1TrackInputTag = cms.InputTag("l1tTrackVertexAssociationProducerExtendedForJets", "Level1TTTracksExtendedSelectedAssociated"),
-	MaxDzTrackPV = 5.0 ,             # tracks with dz(trk,PV)>cut excluded
 	minTrkJetpT = 5.,                 # min track jet pt to be considered for most energetic zbin finding
 	d0_cutNStubs5 = 0.22,             # -1 excludes nstub>4 from disp tag process
 	displaced = True,                  #Flag for displaced tracks
-	nStubs4DisplacedChi2 = 3.3,       #Disp tracks selection [trk<cut]
-	nStubs4DisplacedBend = 2.3,
-	nStubs5DisplacedChi2 = 11.3,
-	nStubs5DisplacedBend = 9.8,
         nDisplacedTracks = 3              #min Ntracks to tag a jet as displaced
 )
 

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
@@ -10,9 +10,14 @@ l1tTrackSelectionProducer = cms.EDProducer('L1TrackSelectionProducer',
                     nStubsMin = cms.int32(4), # number of stubs must be greater than or equal to this value
                     nPSStubsMin = cms.int32(0), # the number of stubs in the PS Modules must be greater than or equal to this value
 
+                    promptMVAMin = cms.double(-1.0), # MVA must be greater than this value
                     reducedBendChi2Max = cms.double(2.25), # bend chi2 must be less than this value
                     reducedChi2RZMax = cms.double(5.0), # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = cms.double(20.0), # chi2rphi/dof must be less than this value
+                    reducedChi2MaxNstub4 = cms.double(999.9), # chi2/dof with nstub==4 must be less than this value
+                    reducedChi2MaxNstub5 = cms.double(999.9), # chi2/dof with nstub>4 must be less than this value
+                    reducedBendChi2MaxNstub4 = cms.double(999.9), # bend chi2 with nstub==4 must be less than this value
+                    reducedBendChi2MaxNstub5 = cms.double(999.9), # bend chi2 with nstub>4 must be less than this value
                     ),
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
@@ -29,9 +34,14 @@ l1tTrackSelectionProducerExtended = l1tTrackSelectionProducer.clone(
                     nStubsMin = 4, # number of stubs must be greater than or equal to this value
                     nPSStubsMin = 0, # the number of stubs in the PS Modules must be greater than or equal to this value
 
+                    promptMVAMin = -1.0, # MVA must be greater than this value 
                     reducedBendChi2Max = 2.4, # bend chi2 must be less than this value
                     reducedChi2RZMax = 10.0, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 40.0, # chi2rphi/dof must be less than this value
+                    reducedChi2MaxNstub4 = 999.9,# chi2/dof with nstub==4 must be less than this value 
+                    reducedChi2MaxNstub5 = 999.9,# chi2/dof with nstub>4 must be less than this value
+                    reducedBendChi2MaxNstub4 = 999.9, # bend chi2 with nstub==4 must be less than this value
+                    reducedBendChi2MaxNstub5 = 999.9, # bend chi2 with nstub>4 must be less than this value 
                     ),
   processSimulatedTracks = cms.bool(True), # return selected tracks after cutting on the floating point values
   processEmulatedTracks = cms.bool(True), # return selected tracks after cutting on the bitwise emulated values
@@ -45,24 +55,33 @@ l1tTrackSelectionProducerForJets = l1tTrackSelectionProducer.clone(
                     nStubsMin = 4, # number of stubs must be greater than or equal to this value
                     nPSStubsMin = 0, # the number of stubs in the PS Modules must be greater than or equal to this value
 
-                    reducedBendChi2Max = 2.2, # bend chi2 must be less than this value
-                    reducedChi2Max = cms.double(10.0),
+                    promptMVAMin = 0.1, # MVA must be greater than this value
+                    reducedBendChi2Max = 999.9, # bend chi2 must be less than this value
                     reducedChi2RZMax = 999.9, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 999.9, # chi2rphi/dof must be less than this value
+      reducedChi2MaxNstub4 = 999.9, # chi2/dof with nstub==4 must be less than this value
+      reducedChi2MaxNstub5 = 999.9, # chi2/dof with nstub>4 must be less than this value
+      reducedBendChi2MaxNstub4 = 999.9, # bend chi2 with nstub==4 must be less than this value
+      reducedBendChi2MaxNstub5 = 999.9, # bend chi2 with nstub>4 must be less than this value
                     ),
 )
 
 l1tTrackSelectionProducerExtendedForJets = l1tTrackSelectionProducerExtended.clone(
   cutSet = dict(
-                    ptMin = 0.0, # pt must be greater than this value, [GeV]
-                    absEtaMax = 999.9, # absolute value of eta must be less than this value
-                    absZ0Max = 999.9, # z0 must be less than this value, [cm]
-                    nStubsMin = 0, # number of stubs must be greater than or equal to this value
+                    ptMin = 2.0, # pt must be greater than this value, [GeV]
+                    absEtaMax = 2.4, # absolute value of eta must be less than this value
+                    absZ0Max = 15.0, # z0 must be less than this value, [cm]
+                    nStubsMin = 4, # number of stubs must be greater than or equal to this value
                     nPSStubsMin = 0, # the number of stubs in the PS Modules must be greater than or equal to this value
 
+                    promptMVAMin = -1.0, # MVA must be greater than this value
                     reducedBendChi2Max = 999.9, # bend chi2 must be less than this value
                     reducedChi2RZMax = 999.9, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 999.9, # chi2rphi/dof must be less than this value
+      reducedChi2MaxNstub4 = cms.double(3.3), # chi2/dof with nstub==4 must be less than this value
+      reducedChi2MaxNstub5 = cms.double(11.3), # chi2/dof with nstub>4 must be less than this value
+      reducedBendChi2MaxNstub4 = cms.double(2.3), # bend chi2 with nstub==4 must be less than this value
+      reducedBendChi2MaxNstub5 = cms.double(9.8), # bend chi2 with nstub>4 must be less than this value
                     ),
 )
 

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackSelectionProducer_cfi.py
@@ -39,13 +39,14 @@ l1tTrackSelectionProducerExtended = l1tTrackSelectionProducer.clone(
 
 l1tTrackSelectionProducerForJets = l1tTrackSelectionProducer.clone(
   cutSet = dict(
-                    ptMin = 0.0, # pt must be greater than this value, [GeV]
-                    absEtaMax = 999.9, # absolute value of eta must be less than this value
-                    absZ0Max = 999.9, # z0 must be less than this value, [cm]
-                    nStubsMin = 0, # number of stubs must be greater than or equal to this value
+                    ptMin = 2.0, # pt must be greater than this value, [GeV]
+                    absEtaMax = 2.4, # absolute value of eta must be less than this value
+                    absZ0Max = 15.0, # z0 must be less than this value, [cm]
+                    nStubsMin = 4, # number of stubs must be greater than or equal to this value
                     nPSStubsMin = 0, # the number of stubs in the PS Modules must be greater than or equal to this value
 
-                    reducedBendChi2Max = 999.9, # bend chi2 must be less than this value
+                    reducedBendChi2Max = 2.2, # bend chi2 must be less than this value
+                    reducedChi2Max = cms.double(10.0),
                     reducedChi2RZMax = 999.9, # chi2rz/dof must be less than this value
                     reducedChi2RPhiMax = 999.9, # chi2rphi/dof must be less than this value
                     ),

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -42,7 +42,7 @@ l1tTrackVertexAssociationProducerForJets = l1tTrackVertexAssociationProducer.clo
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     deltaZMaxEtaBounds = cms.vdouble(0.0, 2.4), # these values define the bin boundaries in |eta|
-                    deltaZMax = cms.vdouble(1.0), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
+                    deltaZMax = cms.vdouble(0.55), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
 )
 

--- a/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/l1tTrackVertexAssociationProducer_cfi.py
@@ -41,8 +41,8 @@ l1tTrackVertexAssociationProducerForJets = l1tTrackVertexAssociationProducer.clo
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
-                    deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
-                    deltaZMax = cms.vdouble(999.0, 999.0, 999.0, 999.0, 999.0, 999.0), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
+                    deltaZMaxEtaBounds = cms.vdouble(0.0, 2.4), # these values define the bin boundaries in |eta|
+                    deltaZMax = cms.vdouble(1.0), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
 )
 
@@ -52,8 +52,8 @@ l1tTrackVertexAssociationProducerExtendedForJets = l1tTrackVertexAssociationProd
   cutSet = cms.PSet(
                     #deltaZMaxEtaBounds = cms.vdouble(0.0, absEtaMax.value), # these values define the bin boundaries in |eta|
                     #deltaZMax = cms.vdouble(0.5), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
-                    deltaZMaxEtaBounds = cms.vdouble(0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4), # these values define the bin boundaries in |eta|
-                    deltaZMax = cms.vdouble(999.0, 999.0, 999.0, 999.0, 999.0, 999.0), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
+                    deltaZMaxEtaBounds = cms.vdouble(0.0, 2.4), # these values define the bin boundaries in |eta|
+                    deltaZMax = cms.vdouble(5.0), # delta z must be less than these values, there will be one less value here than in deltaZMaxEtaBounds, [cm]
                     ),
 )
 


### PR DESCRIPTION
This PR is a copy of [this one](https://github.com/cms-l1t-offline/cmssw/pull/1182) that was accepted by the L1T group.

#### PR description:

This PR does two things:
1. All of the track selection cuts in the TrackJet, TrackJetEmulation, and TrackFastJet producers are moved into the TrackSelection (TS)->TrackVertexAssociation (TVA)->TrackJet chain. This follows what is being done in emulation and allows users to change that track selection cuts in one single place instead of in 3 separate producers where inconsistencies can occur often.
2. The track selection cuts are updated to new cuts that achieve higher jet efficiency, as can be seen [here](https://indico.cern.ch/event/1340389/contributions/5642800/attachments/2741793/4769440/GTT_trkjet_27_10_23.pdf) (slide 6). These new cuts were presented to and accepted by the GTT group.

#### PR validation:

I have checked that the performance before and after each step above (moving track selection out of the jer producers and changing the track cuts) works exactly as expected. I have also run the code checks and formatting.
