### PR TITLE
Including short tracks resolution method in DQM

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/ShortenedTrackResolution.cc
+++ b/DQM/TrackingMonitorSource/plugins/ShortenedTrackResolution.cc
@@ -1,0 +1,130 @@
+// user includes
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/transform.h"  // for edm::vector_transform
+
+// ROOT includes
+#include "TLorentzVector.h"
+
+class ShortenedTrackResolution : public DQMEDAnalyzer {
+public:
+  ShortenedTrackResolution(const edm::ParameterSet &);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+protected:
+  void analyze(edm::Event const &iEvent, edm::EventSetup const &iSetup) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+
+private:
+  const std::string folderName_;
+  const std::vector<std::string> hitsRemain_;
+  const double minTracksEta_;
+  const double maxTracksEta_;
+  const double minTracksPt_;
+  const double maxTracksPt_;
+
+  const double maxDr_;
+  const edm::InputTag tracksTag_;
+  const std::vector<edm::InputTag> tracksRerecoTag_;
+  const edm::EDGetTokenT<std::vector<reco::Track>> tracksToken_;
+  const std::vector<edm::EDGetTokenT<std::vector<reco::Track>>> tracksRerecoToken_;
+
+  std::vector<MonitorElement *> histsPtAll_;
+};
+
+// -----------------------------
+// constructors and destructor
+// -----------------------------
+ShortenedTrackResolution::ShortenedTrackResolution(const edm::ParameterSet &ps)
+    : folderName_(ps.getUntrackedParameter<std::string>("folderName", "TrackRefitting")),
+      hitsRemain_(ps.getUntrackedParameter<std::vector<std::string>>("hitsRemainInput")),
+      minTracksEta_(ps.getUntrackedParameter<double>("minTracksEtaInput", 0.0)),
+      maxTracksEta_(ps.getUntrackedParameter<double>("maxTracksEtaInput", 2.2)),
+      minTracksPt_(ps.getUntrackedParameter<double>("minTracksPtInput", 15.0)),
+      maxTracksPt_(ps.getUntrackedParameter<double>("maxTracksPtInput", 99999.9)),
+      maxDr_(ps.getUntrackedParameter<double>("maxDrInput", 0.01)),
+      tracksTag_(ps.getUntrackedParameter<edm::InputTag>("tracksInputTag", edm::InputTag("generalTracks", "", "DQM"))),
+      tracksRerecoTag_(ps.getUntrackedParameter<std::vector<edm::InputTag>>("tracksRerecoInputTag")),
+      tracksToken_(consumes<std::vector<reco::Track>>(tracksTag_)),
+      tracksRerecoToken_(edm::vector_transform(
+          tracksRerecoTag_, [this](edm::InputTag const &tag) { return consumes<std::vector<reco::Track>>(tag); })) {
+  histsPtAll_.clear();
+}
+
+//__________________________________________________________________________________
+void ShortenedTrackResolution::bookHistograms(DQMStore::IBooker &iBook,
+                                              edm::Run const &iRun,
+                                              edm::EventSetup const &iSetup) {
+  std::string currentFolder = folderName_ + "/";
+  iBook.setCurrentFolder(currentFolder);
+
+  for (int i = 0; i < int(hitsRemain_.size()); ++i) {
+    histsPtAll_.push_back(iBook.book1D(
+        "trackPt" + hitsRemain_[i] + "lAllPt", "Track p_{T} - " + hitsRemain_[i] + " layers", 41, 0.0, 2.0));
+  }
+}
+
+//__________________________________________________________________________________
+void ShortenedTrackResolution::analyze(edm::Event const &iEvent, edm::EventSetup const &iSetup) {
+  const auto &tracks = iEvent.getHandle(tracksToken_);
+
+  if (!tracks.isValid()) {
+    edm::LogError("ShortenedTrackResolution") << "Missing input track collection " << tracksTag_.encode() << std::endl;
+    return;
+  }
+
+  for (const auto &track : *tracks) {
+    const reco::HitPattern &hp = track.hitPattern();
+    if (int(int(hp.numberOfValidHits()) - int(hp.numberOfAllHits(reco::HitPattern::TRACK_HITS))) != 0) {
+      break;
+    }
+
+    TLorentzVector tvec;
+    tvec.SetPtEtaPhiM(track.pt(), track.eta(), track.phi(), 0.0);
+
+    int i = 0;  // token index
+    for (const auto &token : tracksRerecoToken_) {
+      const auto &tracks_rereco = iEvent.getHandle(token);
+
+      for (const auto &track_rereco : *tracks_rereco) {
+        TLorentzVector trerecovec;
+        trerecovec.SetPtEtaPhiM(track_rereco.pt(), track_rereco.eta(), track_rereco.phi(), 0.0);
+        double deltaR = tvec.DeltaR(trerecovec);
+
+        if (deltaR < maxDr_) {
+          if (track_rereco.pt() >= minTracksPt_ && track_rereco.pt() <= maxTracksPt_ &&
+              std::abs(track_rereco.eta()) >= minTracksEta_ && std::abs(track_rereco.eta()) <= maxTracksEta_) {
+            histsPtAll_[i]->Fill(1.0 * track_rereco.pt() / track.pt());
+          }
+        }
+      }
+      ++i;
+    }
+  }
+}
+
+//__________________________________________________________________________________
+void ShortenedTrackResolution::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("folderName", "TrackRefitting");
+  desc.addUntracked<std::vector<std::string>>("hitsRemainInput", {});
+  desc.addUntracked<double>("minTracksEtaInput", 0.0);
+  desc.addUntracked<double>("maxTracksEtaInput", 2.2);
+  desc.addUntracked<double>("minTracksPtInput", 15.0);
+  desc.addUntracked<double>("maxTracksPtInput", 99999.9);
+  desc.addUntracked<double>("maxDrInput", 0.01);
+  desc.addUntracked<edm::InputTag>("tracksInputTag", edm::InputTag("generalTracks", "", "DQM"));
+  desc.addUntracked<std::vector<edm::InputTag>>("tracksRerecoInputTag", {});
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// Define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(ShortenedTrackResolution);

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -397,6 +397,8 @@ seedingDeepCore.toReplaceWith(TrackSeedMonSequence,_seedingDeepCore_TrackSeedMon
 
 TrackingDQMSourceTier0 += TrackSeedMonSequence
 
+from DQM.TrackingMonitorSource.shortTrackResolution_cff import *
+
 # MessageLog
 for module in selectedModules :
     label = str(module)+'LogMessageMonCommon'
@@ -404,6 +406,7 @@ for module in selectedModules :
 TrackingDQMSourceTier0 += voMonitoringSequence
 TrackingDQMSourceTier0 += voWcutMonitoringSequence
 TrackingDQMSourceTier0 += primaryVertexResolution
+TrackingDQMSourceTier0 += shortTrackResolution3to8
 TrackingDQMSourceTier0 += dqmInfoTracking
 
 
@@ -426,6 +429,7 @@ for module in selectedModules :
 TrackingDQMSourceTier0Common += voMonitoringCommonSequence
 TrackingDQMSourceTier0Common += voWcutMonitoringCommonSequence
 TrackingDQMSourceTier0Common += primaryVertexResolution
+TrackingDQMSourceTier0Common += shortTrackResolution3to8
 TrackingDQMSourceTier0Common += dqmInfoTracking
 
 TrackingDQMSourceTier0MinBias = cms.Sequence(cms.ignore(trackingDQMgoodOfflinePrimaryVertices))

--- a/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
+++ b/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+
+from RecoTracker.FinalTrackSelectors.SingleLongTrackProducer_cfi import *
+
+from RecoTracker.FinalTrackSelectors.trackerTrackHitFilter_cfi import trackerTrackHitFilter as _trackerTrackHitFilter
+TrackerTrackHitFilter = _trackerTrackHitFilter.clone(src = "SingleLongTrackProducer",
+                                                     truncateTracks = True,
+                                                     replaceWithInactiveHits = True,
+                                                     rejectBadStoNHits = True,
+                                                     usePixelQualityFlag = True)
+
+TrackerTrackHitFilter3 = TrackerTrackHitFilter.clone(minimumHits = 3,
+                                                     layersRemaining = 3)
+
+TrackerTrackHitFilter4 = TrackerTrackHitFilter.clone(minimumHits = 4,
+                                                     layersRemaining = 4)
+
+TrackerTrackHitFilter5 = TrackerTrackHitFilter.clone(minimumHits = 5,
+                                                     layersRemaining = 5)
+
+TrackerTrackHitFilter6 = TrackerTrackHitFilter.clone(minimumHits = 6,
+                                                     layersRemaining = 6)
+
+TrackerTrackHitFilter7 = TrackerTrackHitFilter.clone(minimumHits = 7,
+                                                     layersRemaining = 7)
+
+TrackerTrackHitFilter8 = TrackerTrackHitFilter.clone(minimumHits = 8,
+                                                     layersRemaining = 8)
+
+import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff
+HitFilteredTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff.ctfWithMaterialTracks.clone(src = 'TrackerTrackHitFilter')
+
+HitFilteredTracks3 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter3')
+HitFilteredTracks4 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter4')
+HitFilteredTracks5 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter5')
+HitFilteredTracks6 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter6')
+HitFilteredTracks7 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter7')
+HitFilteredTracks8 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter8')
+
+from DQM.TrackingMonitorSource.shortenedTrackResolution_cfi import shortenedTrackResolution as _shortenedTrackResolution
+trackingResolution = _shortenedTrackResolution.clone(folderName           = "Tracking/ShortTrackResolution",
+                                                     hitsRemainInput      = ["3","4","5","6","7","8"],
+                                                     minTracksEtaInput    = 0.0,
+                                                     maxTracksEtaInput    = 2.2,
+                                                     minTracksPtInput     = 15.0,
+                                                     maxTracksPtInput     = 99999.9,
+                                                     maxDrInput           = 0.01,
+                                                     tracksInputTag       = "SingleLongTrackProducer",
+                                                     tracksRerecoInputTag = ["HitFilteredTracks3","HitFilteredTracks4","HitFilteredTracks5","HitFilteredTracks6","HitFilteredTracks7","HitFilteredTracks8"])
+                                                     
+shortTrackResolution3to8 = cms.Sequence(SingleLongTrackProducer *
+                                        TrackerTrackHitFilter3 *
+                                        TrackerTrackHitFilter4 *
+                                        TrackerTrackHitFilter5 *
+                                        TrackerTrackHitFilter6 *
+                                        TrackerTrackHitFilter7 *
+                                        TrackerTrackHitFilter8 *
+                                        HitFilteredTracks3 *
+                                        HitFilteredTracks4 *
+                                        HitFilteredTracks5 *
+                                        HitFilteredTracks6 *
+                                        HitFilteredTracks7 *
+                                        HitFilteredTracks8 *
+                                        trackingResolution)

--- a/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
+++ b/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
@@ -5,32 +5,32 @@ from RecoTracker.FinalTrackSelectors.SingleLongTrackProducer_cfi import *
 
 from RecoTracker.FinalTrackSelectors.trackerTrackHitFilter_cfi import trackerTrackHitFilter as _trackerTrackHitFilter
 ShortTrackCandidates = _trackerTrackHitFilter.clone(src = "SingleLongTrackProducer",
-                                                     truncateTracks = True,
-                                                     replaceWithInactiveHits = True,
-                                                     rejectBadStoNHits = True,
-                                                     usePixelQualityFlag = True)
+                                                    truncateTracks = True,
+                                                    replaceWithInactiveHits = True,
+                                                    rejectBadStoNHits = True,
+                                                    usePixelQualityFlag = True)
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ShortTrackCandidates,
                         isPhase2 = True)
 
 ShortTrackCandidates3 = ShortTrackCandidates.clone(minimumHits = 3,
-                                                     layersRemaining = 3)
+                                                   layersRemaining = 3)
 
 ShortTrackCandidates4 = ShortTrackCandidates.clone(minimumHits = 4,
-                                                     layersRemaining = 4)
+                                                   layersRemaining = 4)
 
 ShortTrackCandidates5 = ShortTrackCandidates.clone(minimumHits = 5,
-                                                     layersRemaining = 5)
+                                                   layersRemaining = 5)
 
 ShortTrackCandidates6 = ShortTrackCandidates.clone(minimumHits = 6,
-                                                     layersRemaining = 6)
+                                                   layersRemaining = 6)
 
 ShortTrackCandidates7 = ShortTrackCandidates.clone(minimumHits = 7,
-                                                     layersRemaining = 7)
+                                                   layersRemaining = 7)
 
 ShortTrackCandidates8 = ShortTrackCandidates.clone(minimumHits = 8,
-                                                     layersRemaining = 8)
+                                                   layersRemaining = 8)
 
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff
 RefittedShortTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff.ctfWithMaterialTracks.clone(src = 'ShortTrackCandidates')
@@ -51,7 +51,12 @@ trackingResolution = _shortenedTrackResolution.clone(folderName           = "Tra
                                                      maxTracksPtInput     = 99999.9,
                                                      maxDrInput           = 0.01,
                                                      tracksInputTag       = "SingleLongTrackProducer",
-                                                     tracksRerecoInputTag = ["RefittedShortTracks3","RefittedShortTracks4","RefittedShortTracks5","RefittedShortTracks6","RefittedShortTracks7","RefittedShortTracks8"])
+                                                     tracksRerecoInputTag = ["RefittedShortTracks3",
+                                                                             "RefittedShortTracks4",
+                                                                             "RefittedShortTracks5",
+                                                                             "RefittedShortTracks6",
+                                                                             "RefittedShortTracks7",
+                                                                             "RefittedShortTracks8"])
                                                      
 shortTrackResolution3to8 = cms.Sequence(SingleLongTrackProducer *
                                         ShortTrackCandidates3 *

--- a/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
+++ b/DQM/TrackingMonitorSource/python/shortTrackResolution_cff.py
@@ -4,39 +4,43 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from RecoTracker.FinalTrackSelectors.SingleLongTrackProducer_cfi import *
 
 from RecoTracker.FinalTrackSelectors.trackerTrackHitFilter_cfi import trackerTrackHitFilter as _trackerTrackHitFilter
-TrackerTrackHitFilter = _trackerTrackHitFilter.clone(src = "SingleLongTrackProducer",
+ShortTrackCandidates = _trackerTrackHitFilter.clone(src = "SingleLongTrackProducer",
                                                      truncateTracks = True,
                                                      replaceWithInactiveHits = True,
                                                      rejectBadStoNHits = True,
                                                      usePixelQualityFlag = True)
 
-TrackerTrackHitFilter3 = TrackerTrackHitFilter.clone(minimumHits = 3,
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(ShortTrackCandidates,
+                        isPhase2 = True)
+
+ShortTrackCandidates3 = ShortTrackCandidates.clone(minimumHits = 3,
                                                      layersRemaining = 3)
 
-TrackerTrackHitFilter4 = TrackerTrackHitFilter.clone(minimumHits = 4,
+ShortTrackCandidates4 = ShortTrackCandidates.clone(minimumHits = 4,
                                                      layersRemaining = 4)
 
-TrackerTrackHitFilter5 = TrackerTrackHitFilter.clone(minimumHits = 5,
+ShortTrackCandidates5 = ShortTrackCandidates.clone(minimumHits = 5,
                                                      layersRemaining = 5)
 
-TrackerTrackHitFilter6 = TrackerTrackHitFilter.clone(minimumHits = 6,
+ShortTrackCandidates6 = ShortTrackCandidates.clone(minimumHits = 6,
                                                      layersRemaining = 6)
 
-TrackerTrackHitFilter7 = TrackerTrackHitFilter.clone(minimumHits = 7,
+ShortTrackCandidates7 = ShortTrackCandidates.clone(minimumHits = 7,
                                                      layersRemaining = 7)
 
-TrackerTrackHitFilter8 = TrackerTrackHitFilter.clone(minimumHits = 8,
+ShortTrackCandidates8 = ShortTrackCandidates.clone(minimumHits = 8,
                                                      layersRemaining = 8)
 
 import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff
-HitFilteredTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff.ctfWithMaterialTracks.clone(src = 'TrackerTrackHitFilter')
+RefittedShortTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cff.ctfWithMaterialTracks.clone(src = 'ShortTrackCandidates')
 
-HitFilteredTracks3 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter3')
-HitFilteredTracks4 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter4')
-HitFilteredTracks5 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter5')
-HitFilteredTracks6 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter6')
-HitFilteredTracks7 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter7')
-HitFilteredTracks8 = HitFilteredTracks.clone(src = 'TrackerTrackHitFilter8')
+RefittedShortTracks3 = RefittedShortTracks.clone(src = 'ShortTrackCandidates3')
+RefittedShortTracks4 = RefittedShortTracks.clone(src = 'ShortTrackCandidates4')
+RefittedShortTracks5 = RefittedShortTracks.clone(src = 'ShortTrackCandidates5')
+RefittedShortTracks6 = RefittedShortTracks.clone(src = 'ShortTrackCandidates6')
+RefittedShortTracks7 = RefittedShortTracks.clone(src = 'ShortTrackCandidates7')
+RefittedShortTracks8 = RefittedShortTracks.clone(src = 'ShortTrackCandidates8')
 
 from DQM.TrackingMonitorSource.shortenedTrackResolution_cfi import shortenedTrackResolution as _shortenedTrackResolution
 trackingResolution = _shortenedTrackResolution.clone(folderName           = "Tracking/ShortTrackResolution",
@@ -47,19 +51,19 @@ trackingResolution = _shortenedTrackResolution.clone(folderName           = "Tra
                                                      maxTracksPtInput     = 99999.9,
                                                      maxDrInput           = 0.01,
                                                      tracksInputTag       = "SingleLongTrackProducer",
-                                                     tracksRerecoInputTag = ["HitFilteredTracks3","HitFilteredTracks4","HitFilteredTracks5","HitFilteredTracks6","HitFilteredTracks7","HitFilteredTracks8"])
+                                                     tracksRerecoInputTag = ["RefittedShortTracks3","RefittedShortTracks4","RefittedShortTracks5","RefittedShortTracks6","RefittedShortTracks7","RefittedShortTracks8"])
                                                      
 shortTrackResolution3to8 = cms.Sequence(SingleLongTrackProducer *
-                                        TrackerTrackHitFilter3 *
-                                        TrackerTrackHitFilter4 *
-                                        TrackerTrackHitFilter5 *
-                                        TrackerTrackHitFilter6 *
-                                        TrackerTrackHitFilter7 *
-                                        TrackerTrackHitFilter8 *
-                                        HitFilteredTracks3 *
-                                        HitFilteredTracks4 *
-                                        HitFilteredTracks5 *
-                                        HitFilteredTracks6 *
-                                        HitFilteredTracks7 *
-                                        HitFilteredTracks8 *
+                                        ShortTrackCandidates3 *
+                                        ShortTrackCandidates4 *
+                                        ShortTrackCandidates5 *
+                                        ShortTrackCandidates6 *
+                                        ShortTrackCandidates7 *
+                                        ShortTrackCandidates8 *
+                                        RefittedShortTracks3 *
+                                        RefittedShortTracks4 *
+                                        RefittedShortTracks5 *
+                                        RefittedShortTracks6 *
+                                        RefittedShortTracks7 *
+                                        RefittedShortTracks8 *
                                         trackingResolution)

--- a/RecoTracker/FinalTrackSelectors/plugins/SingleLongTrackProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SingleLongTrackProducer.cc
@@ -1,0 +1,217 @@
+// user includes
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+// ROOT includes
+#include "TLorentzVector.h"
+
+class SingleLongTrackProducer : public edm::stream::EDProducer<> {
+public:
+  explicit SingleLongTrackProducer(const edm::ParameterSet &);
+  ~SingleLongTrackProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+  const edm::EDGetTokenT<std::vector<reco::Track>> tracksToken;
+  const edm::EDGetTokenT<std::vector<reco::Muon>> muonsToken;
+  const edm::EDGetTokenT<reco::VertexCollection> PrimVtxToken;
+
+  const int minNumberOfLayers;
+  const double matchInDr;
+  const bool onlyValidHits;
+  const bool debug;
+  const double minPt;
+  const double maxEta;
+  const double maxDxy;
+  const double maxDz;
+};
+
+SingleLongTrackProducer::SingleLongTrackProducer(const edm::ParameterSet &iConfig)
+    : tracksToken{consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("allTracks"))},
+      muonsToken{consumes<std::vector<reco::Muon>>(iConfig.getParameter<edm::InputTag>("matchMuons"))},
+      PrimVtxToken{consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PrimaryVertex"))},
+      minNumberOfLayers{iConfig.getParameter<int>("minNumberOfLayers")},
+      matchInDr{iConfig.getParameter<double>("requiredDr")},
+      onlyValidHits{iConfig.getParameter<bool>("onlyValidHits")},
+      debug{iConfig.getParameter<bool>("debug")},
+      minPt{iConfig.getParameter<double>("minPt")},
+      maxEta{iConfig.getParameter<double>("maxEta")},
+      maxDxy{iConfig.getParameter<double>("maxDxy")},
+      maxDz{iConfig.getParameter<double>("maxDz")} {
+  produces<reco::TrackCollection>("").setBranchAlias("");
+}
+
+void SingleLongTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  using namespace edm;
+
+  // register input collections:
+  const auto &tracks = iEvent.getHandle(tracksToken);
+  const auto &muons = iEvent.getHandle(muonsToken);
+
+  const auto &vtx_h = iEvent.getHandle(PrimVtxToken);
+  const reco::Vertex vtx = vtx_h->at(0);
+
+  // register output collection:
+  std::unique_ptr<reco::TrackCollection> goodTracks(new reco::TrackCollection);
+
+  // Preselection of long quality tracks
+  std::vector<reco::Track> selTracks;
+  reco::Track bestTrack;
+  unsigned int tMuon = 0;
+  double fitProb = 100;
+
+  for (const auto &track : *tracks) {
+    const reco::HitPattern &hitpattern = track.hitPattern();
+    double dRmin = 10;
+    double chiNdof = track.normalizedChi2();
+    double dxy = std::abs(track.dxy(vtx.position()));
+    double dz = std::abs(track.dz(vtx.position()));
+
+    if (track.pt() < minPt)
+      continue;
+
+    if (abs(track.eta()) > maxEta)
+      continue;
+
+    if (hitpattern.trackerLayersWithMeasurement() < minNumberOfLayers)
+      continue;
+
+    TLorentzVector pTrack(track.px(), track.py(), track.pz(), track.pt());
+
+    // Long track needs to be close to a good muon
+    for (const auto &m : *muons) {
+      if (m.isTrackerMuon()) {
+        tMuon++;
+        reco::Track matchedTrack = *(m.innerTrack());
+        TLorentzVector pMatched(matchedTrack.px(), matchedTrack.py(), matchedTrack.pz(), matchedTrack.pt());
+        // match to general track in deltaR
+        double dr = pTrack.DeltaR(pMatched);
+        if (dr < dRmin)
+          dRmin = dr;
+      }
+    }
+
+    if (dRmin >= matchInDr)
+      continue;
+    // do vertex consistency:
+    bool vertex_match = dxy < maxDxy && dz < maxDz;
+    if (!(vertex_match))
+      continue;
+    if (track.validFraction() < 1.0)
+      continue;
+    // only save the track with the smallest chiNdof
+    if (chiNdof < fitProb) {
+      fitProb = chiNdof;
+      bestTrack = track;
+      bestTrack.setExtra(track.extra());
+    }
+    if (debug)
+      edm::LogPrint("SingleLongTrackProducer") << " deltaR (general) track to matched Track: " << dRmin << std::endl;
+    if (debug)
+      edm::LogPrint("SingleLongTrackProducer") << "chi2Ndof:" << chiNdof << " best Track: " << fitProb << std::endl;
+  }
+
+  selTracks.push_back(bestTrack);
+
+  if (debug)
+    edm::LogPrint("SingleLongTrackProducer") << " number of Tracker Muons: " << tMuon << ", thereof "
+                                             << selTracks.size() << " tracks passed preselection." << std::endl;
+
+  // check hits validity in preselected tracks
+  bool hitIsNotValid{false};
+
+  for (const auto &track : selTracks) {
+    reco::HitPattern hitpattern = track.hitPattern();
+    int deref{0};
+
+    // this checks track recHits
+    try {  // (Un)Comment this line with /* to (not) allow for events with not valid hits
+      auto hb = track.recHitsBegin();
+
+      for (unsigned int h = 0; h < track.recHitsSize(); h++) {
+        auto recHit = *(hb + h);
+        auto const &hit = *recHit;
+
+        if (onlyValidHits && !hit.isValid()) {
+          hitIsNotValid = true;
+          continue;
+        }
+      }
+    } catch (cms::Exception const &e) {
+      deref += 1;
+      if (debug)
+        std::cerr << e.explainSelf() << std::endl;
+    }
+
+    if (hitIsNotValid == true)
+      break;  // (Un)Comment this line with */ to (not) allow for events with not valid hits
+
+    int deref2{0};
+
+    // this checks track hitPattern hits
+    try {
+      auto hb = track.recHitsBegin();
+
+      for (unsigned int h = 0; h < track.recHitsSize(); h++) {
+        uint32_t pHit = hitpattern.getHitPattern(reco::HitPattern::TRACK_HITS, h);
+
+        auto recHit = *(hb + h);
+        auto const &hit = *recHit;
+
+        if (onlyValidHits && !hit.isValid()) {
+          if (debug)
+            edm::LogPrint("SingleLongTrackProducer") << "hit not valid: " << h << std::endl;
+          continue;
+        }
+
+        // loop over the hits of the track.
+        if (onlyValidHits && !(hitpattern.validHitFilter(pHit))) {
+          if (debug)
+            edm::LogPrint("SingleLongTrackProducer") << "hit not valid: " << h << std::endl;
+          continue;
+        }
+      }
+      goodTracks->push_back(track);
+    } catch (cms::Exception const &e) {
+      deref2 += 1;
+      if (debug)
+        std::cerr << e.explainSelf() << std::endl;
+    }
+
+    if (debug)
+      edm::LogPrint("SingleLongTrackProducer")
+          << "found tracks with " << deref << "missing valid hits and " << deref2 << " missing hit pattern";
+  }
+
+  // save track collection in event:
+  iEvent.put(std::move(goodTracks), "");
+}
+
+void SingleLongTrackProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("allTracks", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("matchMuons", edm::InputTag("muons"));
+  desc.add<edm::InputTag>("PrimaryVertex", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<int>("minNumberOfLayers", 10);
+  desc.add<double>("requiredDr", 0.01);
+  desc.add<bool>("onlyValidHits", true);
+  desc.add<bool>("debug", false);
+  desc.add<double>("minPt", 15.0);
+  desc.add<double>("maxEta", 2.2);
+  desc.add<double>("maxDxy", 0.02);
+  desc.add<double>("maxDz", 0.5);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SingleLongTrackProducer);

--- a/RecoTracker/FinalTrackSelectors/python/SingleLongTrackProducer_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/SingleLongTrackProducer_cfi.py
@@ -4,7 +4,7 @@ from RecoTracker.FinalTrackSelectors.singleLongTrackProducer_cfi import singleLo
 
 SingleLongTrackProducer = singleLongTrackProducer.clone(
     allTracks = "generalTracks",
-    matchMuons = "muons",
+    matchMuons = "earlyMuons",
     requiredDr= 0.01,
     minNumberOfLayers = 10,
     onlyValidHits = True,

--- a/RecoTracker/FinalTrackSelectors/python/SingleLongTrackProducer_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/SingleLongTrackProducer_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.FinalTrackSelectors.singleLongTrackProducer_cfi import singleLongTrackProducer 
+
+SingleLongTrackProducer = singleLongTrackProducer.clone(
+    allTracks = "generalTracks",
+    matchMuons = "muons",
+    requiredDr= 0.01,
+    minNumberOfLayers = 10,
+    onlyValidHits = True,
+    debug = False,
+    minPt = 15.0,
+    maxEta = 2.2,
+    maxDxy = 0.02,
+    maxDz = 0.5,
+    PrimaryVertex = "offlinePrimaryVertices")


### PR DESCRIPTION
#### PR description:

This PR implements a data-driven method to artificially shorten muon tracks to assess the tracking pT resolution of short tracks.

It relies on shortening the muon tracks by creating track candidates with new hit collections that have the outermost hits removed from the original collection. The new track candidates are refitted to calculate the pT resolution, defined as pT short track / pT of long track. Currently, tracks are being shortened to have 3 to 8 layers, with no missing middle layers. The pT resolution histograms have been included in the tracking DQM sequence, and will also be included in the DQM GUI offline tracking layout.

The latest presentation about this work can be found [here](https://indico.cern.ch/event/1247012/#5-update-on-tracking-pt-resolu), and contains links to older presentations as well.

#### PR validation:

The shortening procedure was verified in CMSSW 13_1_0_pre2 with MC events using RelValZMM_14 dataset with and without PU, and with events from collected data using Run 3 Muon_2022G dataset. It works as intended and provides the pT resolution histograms following the expectations.

The complete set of changes comprising the inclusion of the tracks shortening module in the DQM sequence and the creation of the histograms inside the DQM root file was checked in CMSSW 14_0_0_pre0 with runTheMatrix workflows 11650.0 (Run 3 ZMM) to check that the shortening procedure worked as expected and that the histograms were added to the DQM root file, and 11634.0 (Run 3 ttbar) to ensure that the DQM step throughput wouldn't be affected in processes having few muon tracks. Both checks were successful.
