### PR TITLE
[HETEROGENEOUS] Fix deprecated call to `hipMallocHost` in DEVEL IBs

### DIFF
--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.hip.cc
@@ -125,7 +125,7 @@ int main(void) {
   // Allocate buffer and store on host
   size_t hostDeviceSize = SoAHostDeviceLayout::computeDataSize(numElements);
   std::byte* h_buf = nullptr;
-  hipCheck(hipMallocHost((void**)&h_buf, hostDeviceSize));
+  hipCheck(hipHostMalloc((void**)&h_buf, hostDeviceSize));
   SoAHostDeviceLayout h_soahdLayout(h_buf, numElements);
   SoAHostDeviceView h_soahd(h_soahdLayout);
   SoAHostDeviceConstView h_soahd_c(h_soahdLayout);
@@ -133,7 +133,7 @@ int main(void) {
   // Alocate buffer, stores and views on the device (single, shared buffer).
   size_t deviceOnlySize = SoADeviceOnlyLayout::computeDataSize(numElements);
   std::byte* d_buf = nullptr;
-  hipCheck(hipMallocHost((void**)&d_buf, hostDeviceSize + deviceOnlySize));
+  hipCheck(hipHostMalloc((void**)&d_buf, hostDeviceSize + deviceOnlySize));
   SoAHostDeviceLayout d_soahdLayout(d_buf, numElements);
   SoADeviceOnlyLayout d_soadoLayout(d_soahdLayout.metadata().nextByte(), numElements);
   SoAHostDeviceView d_soahdView(d_soahdLayout);


### PR DESCRIPTION
Hello,

This PR solves the deprecated call to `hipMallocHost` in the `DataFormats/SoATemplate` module. The compiler was reporting this issue in the following warning in [DEVEL IBs](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/tue/14.0.DEVEL-tue-23/CMSSW_14_0_DEVEL_X_2023-12-19-2300):
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/1f96a863c5d8d17b900b6f7f5336eee9/opt/cmssw
/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-1100/src/DataFormats/SoATemplate/test/
SoALayoutAndView_t.hip.cc:128:12: warning: 'hipMallocHost' is deprecated: use hipHostMalloc instead [-Wdeprecated-declarations]
```

Thanks,
Andrea