### PR TITLE
[RECONSTRUCTION] Define missing copy constructir to fix warnings reported in DEVEL IBs

### DIFF
--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexSym.h
@@ -78,6 +78,8 @@ namespace Matriplex {
       return *this;
     }
 
+    MatriplexSym(const MatriplexSym& m) = default;
+
     void copySlot(idx_t n, const MatriplexSym& m) {
       for (idx_t i = n; i < kTotSize; i += N) {
         fArray[i] = m.fArray[i];

--- a/TrackingTools/PatternTools/interface/bqueue.h
+++ b/TrackingTools/PatternTools/interface/bqueue.h
@@ -110,6 +110,7 @@ namespace cmsutils {
       it = t2.it;
       return *this;
     }
+    _bqueue_itr<T>(const _bqueue_itr<T> &t2) = default;
     friend class bqueue<T>;
 
   private:


### PR DESCRIPTION
Hello,

This PR solves the [DEVEL warnings](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc12/www/tue/14.0.DEVEL-tue-23/CMSSW_14_0_DEVEL_X_2023-12-19-2300) on deprecated implicit assignment operators present in the IBs on two reconstruction modules.

This PR is part of a campaign trying to get rid of warnings of this kind:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc: In member function 'void {anonymous}::LayersInTraj::fill(TempTrajectory&)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc:700:63: warning: implicitly-declared 'constexpr cmsutils::_bqueue_itr<TrajectoryMeasurement>::_bqueue_itr(const cmsutils::_bqueue_itr<TrajectoryMeasurement>&)' is deprecated [-Wdeprecated-copy]
   700 |       for (TempTrajectory::DataContainer::const_iterator im = ifirst; im != measurements.rend(); --im) {
      |                                                               ^~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/TrackingTools/PatternTools/interface/TempTrajectory.h:14,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h:14,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h:8,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc:4:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/TrackingTools/PatternTools/interface/bqueue.h:109:27: note: because 'cmsutils::_bqueue_itr<TrajectoryMeasurement>' has user-provided 'const cmsutils::_bqueue_itr<T>& cmsutils::_bqueue_itr<T>::operator=(const cmsutils::_bqueue_itr<T>&) [with T = TrajectoryMeasurement]'
  109 |     const _bqueue_itr<T> &operator=(const _bqueue_itr<T> &t2) {
      |                           ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc: In member function 'bool GroupedCkfTrajectoryBuilder::verifyHits(cmsutils::bqueue<TrajectoryMeasurement>::const_iterator, size_t, const std::vector<const TrackingRecHit*>&) const':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e6d935e61222b80ffe228234721ba577/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_0_DEVEL_X_2023-12-19-2300/src/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.cc:1143:15: warning: implicitly-declared 'constexpr cmsutils::_bqueue_itr<TrajectoryMeasurement>::_bqueue_itr(const cmsutils::_bqueue_itr<TrajectoryMeasurement>&)' is deprecated [-Wdeprecated-copy]
  1143 |   auto rend = rbegin;
      |               ^~~~~~
```

Thanks,
Andrea