### PR TITLE
Check that lumiSectionInterval_ is valid in StreamerOutputModuleCommon

### DIFF
--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -227,18 +227,15 @@ namespace edm {
     std::vector<unsigned char> hltbits;
     setHltMask(e, triggerResults, hltbits);
 
-    uint32 lumi;
-    if (lumiSectionInterval_ == 0) {
-      lumi = e.luminosityBlock();
-    } else {
+    uint32 lumi = e.luminosityBlock();
+    if (lumiSectionInterval_ != 0) {
       struct timeval now;
       struct timezone dummyTZ;
       gettimeofday(&now, &dummyTZ);
       double timeInSec =
           static_cast<double>(now.tv_sec) + (static_cast<double>(now.tv_usec) / 1000000.0) - timeInSecSinceUTC;
       // what about overflows?
-      if (lumiSectionInterval_ > 0)
-        lumi = static_cast<uint32>(timeInSec / lumiSectionInterval_) + 1;
+      lumi = static_cast<uint32>(timeInSec / std::abs(lumiSectionInterval_)) + 1;
     }
 
     serializer_.serializeEvent(sbuf, e, selectorCfg, compressionAlgo_, compressionLevel_, reserve_size);


### PR DESCRIPTION
#### PR description:

Avoid potential uninitialized value by requiring lumiSectionInterval_ to not be negative. This fixes a possible uninitialized value warning in gcc.

#### PR validation:

Code compiles without issuing a possible uninitialized value warning.