### PR TITLE
Add Phase-2 workflow with Phase-2 ECal TP, also with ECal component 

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -69,6 +69,9 @@ The offsets currently in use are:
 * 0.612: ECAL `phase2_ecal_devel` era, with automatic offload to GPU if available
 * 0.631: ECAL component-method based digis
 * 0.632: ECAL component-method based finely-sampled waveforms
+* 0.633: ECAL phase2 Trigger Primitive
+* 0.634: ECAL phase2 Trigger Primitive + component-method based digis
+* 0.635: ECAL phase2 Trigger Primitive + component-method based finely-sampled waveforms
 * 0.75: Phase-2 HLT
 * 0.91: Track DNN modifier
 * 0.97: Premixing stage1

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1884,7 +1884,7 @@ upgradeWFs['ecalDevelGPU'] = UpgradeWorkflow_ecalDevel(
 
 # ECAL component
 class UpgradeWorkflow_ECalComponent(UpgradeWorkflow):
-    def __init__(self, suffix, offset, ecalMod,
+    def __init__(self, suffix, offset, ecalTPPh2, ecalMod,
                  steps = [
                      'GenSim',
                      'GenSimHLBeamSpot',
@@ -1892,6 +1892,9 @@ class UpgradeWorkflow_ECalComponent(UpgradeWorkflow):
                      'GenSimHLBeamSpotHGCALCloseBy',
                      'Digi',
                      'DigiTrigger',
+                     'RecoGlobal',
+                     'HARVESTGlobal',
+                     'ALCAPhase2',
                  ],
                  PU = [
                      'GenSim',
@@ -1900,14 +1903,35 @@ class UpgradeWorkflow_ECalComponent(UpgradeWorkflow):
                      'GenSimHLBeamSpotHGCALCloseBy',
                      'Digi',
                      'DigiTrigger',
+                     'RecoGlobal',
+                     'HARVESTGlobal',
+                     'ALCAPhase2',
                  ]):
         super(UpgradeWorkflow_ECalComponent, self).__init__(steps, PU, suffix, offset)
+        self.__ecalTPPh2 = ecalTPPh2
         self.__ecalMod = ecalMod
-    
+
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Sim' in step or 'Digi' in step:
+        stepDict[stepName][k] = deepcopy(stepDict[step][k])
+        if 'Sim' in step:
             if self.__ecalMod is not None:
                 stepDict[stepName][k] = merge([{'--procModifiers':self.__ecalMod},stepDict[step][k]])
+        if 'Digi' in step:
+            if self.__ecalMod is not None:
+                stepDict[stepName][k] = merge([{'--procModifiers':self.__ecalMod},stepDict[step][k]])
+            if self.__ecalTPPh2 is not None:
+                mods = {'--era': stepDict[step][k]['--era']+',phase2_ecal_devel,phase2_ecalTP_devel'}
+                mods['-s'] = 'DIGI:pdigi_valid,DIGI2RAW,HLT:@fake2'
+                stepDict[stepName][k] = merge([mods, stepDict[step][k]])
+        if 'RecoGlobal' in step:
+            stepDict[stepName][k] = merge([{'-s': 'RAW2DIGI,RECO,RECOSIM,PAT',
+                                            '--datatier':'GEN-SIM-RECO',
+                                            '--eventcontent':'FEVTDEBUGHLT',
+                                        }, stepDict[step][k]])
+        if 'HARVESTGlobal' in step:
+            stepDict[stepName][k] = None
+        if 'ALCAPhase2' in step:
+            stepDict[stepName][k] = None
 
     def condition(self, fragment, stepList, key, hasHarvest):
         return ('2021' in key or '2023' in key or '2026' in key)
@@ -1915,12 +1939,35 @@ class UpgradeWorkflow_ECalComponent(UpgradeWorkflow):
 upgradeWFs['ECALComponent'] = UpgradeWorkflow_ECalComponent(
     suffix = '_ecalComponent',
     offset = 0.631,
+    ecalTPPh2 = None,
     ecalMod = 'ecal_component',
 )
 
 upgradeWFs['ECALComponentFSW'] = UpgradeWorkflow_ECalComponent(
     suffix = '_ecalComponentFSW',
     offset = 0.632,
+    ecalTPPh2 = None,
+    ecalMod = 'ecal_component_finely_sampled_waveforms',
+)
+
+upgradeWFs['ECALTPPh2'] = UpgradeWorkflow_ECalComponent(
+    suffix = '_ecalTPPh2',
+    offset = 0.633,
+    ecalTPPh2 = 'phase2_ecal_devel,phase2_ecalTP_devel',
+    ecalMod = None,
+)
+
+upgradeWFs['ECALTPPh2Component'] = UpgradeWorkflow_ECalComponent(
+    suffix = '_ecalTPPh2Component',
+    offset = 0.634,
+    ecalTPPh2 = 'phase2_ecal_devel,phase2_ecalTP_devel',
+    ecalMod = 'ecal_component',
+)
+
+upgradeWFs['ECALTPPh2ComponentFSW'] = UpgradeWorkflow_ECalComponent(
+    suffix = '_ecalTPPh2ComponentFSW',
+    offset = 0.635,
+    ecalTPPh2 = 'phase2_ecal_devel,phase2_ecalTP_devel',
     ecalMod = 'ecal_component_finely_sampled_waveforms',
 )
 


### PR DESCRIPTION
#### PR description:
This PR is to add new Phase-2 workflows with new Phase-2 ECAL TP, and with ECAL component. The L1T step is dropped at the moment, because we need to adapt few classes as template to support both simEcalEBTriggerPrimitiveDigis, simEcalEBTriggerPrimitivePhase2Digis. When it is done, these new workflows will be updated to be full chain again.

This PR is to allow to develop on top of new Phase-2 ECAL TP.

#### PR validation:
Run fine with 24834.634 (no L1T, no validation and DQM)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport.