### PR TITLE
Start work for stream modules to explicitly request Run/Lumis

### DIFF
--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -45,49 +45,13 @@ namespace edm {
       kOneSharedResources,
       kOneWatchRuns,
       kOneWatchLuminosityBlocks,
+      kStreamWatchRuns,
+      kStreamWatchLuminosityBlocks,
       kWatchInputFiles,
       kExternalWork,
       kAccumulator,
       kTransformer
     };
-
-    namespace AbilityBits {
-      enum Bits {
-        kGlobalCache = 1,
-        kStreamCache = 2,
-        kRunCache = 4,
-        kLuminosityBlockCache = 8,
-        kRunSummaryCache = 16,
-        kLuminosityBlockSummaryCache = 32,
-        kBeginRunProducer = 64,
-        kEndRunProducer = 128,
-        kOneSharedResources = 256,
-        kOneWatchRuns = 512,
-        kOneWatchLuminosityBlocks = 1024,
-        kWatchInputFiles = 2048
-      };
-    }
-
-    namespace AbilityToTransitions {
-      enum Bits {
-        kBeginStream = AbilityBits::kStreamCache,
-        kEndStream = AbilityBits::kStreamCache,
-
-        kGlobalBeginRun = AbilityBits::kRunCache | AbilityBits::kRunSummaryCache | AbilityBits::kOneWatchRuns,
-        kGlobalEndRun = AbilityBits::kRunCache | AbilityBits::kRunSummaryCache | AbilityBits::kEndRunProducer |
-                        AbilityBits::kOneWatchRuns,
-        kStreamBeginRun = AbilityBits::kStreamCache,
-        kStreamEndRun = AbilityBits::kStreamCache | AbilityBits::kRunSummaryCache,
-
-        kGlobalBeginLuminosityBlock = AbilityBits::kLuminosityBlockCache | AbilityBits::kLuminosityBlockSummaryCache |
-                                      AbilityBits::kOneWatchLuminosityBlocks,
-        kGlobalEndLuminosityBlock = AbilityBits::kLuminosityBlockCache | AbilityBits::kLuminosityBlockSummaryCache |
-                                    AbilityBits::kOneWatchLuminosityBlocks,
-        kStreamBeginLuminosityBlock = AbilityBits::kStreamCache | AbilityBits::kLuminosityBlockSummaryCache,
-        kStreamEndLuminosityBlock = AbilityBits::kStreamCache | AbilityBits::kLuminosityBlockSummaryCache
-
-      };
-    }
   }  // namespace module
 }  // namespace edm
 

--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -22,6 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/stream/moduleAbilities.h"
 
 // forward declarations
 namespace edm {
@@ -112,6 +113,16 @@ namespace edm {
         static constexpr bool kAccumulator = true;
       };
 
+      template <typename... U>
+      struct HasAbility<edm::stream::WatchLuminosityBlocks, U...> : public HasAbility<U...> {
+        static constexpr bool kWatchLuminosityBlocks = true;
+      };
+
+      template <typename... U>
+      struct HasAbility<edm::stream::WatchRuns, U...> : public HasAbility<U...> {
+        static constexpr bool kWatchRuns = true;
+      };
+
       template <>
       struct HasAbility<LastCheck> {
         static constexpr bool kGlobalCache = false;
@@ -130,6 +141,8 @@ namespace edm {
         static constexpr bool kExternalWork = false;
         static constexpr bool kAccumulator = false;
         static constexpr bool kTransformer = false;
+        static constexpr bool kWatchLuminosityBlocks = true;
+        static constexpr bool kWatchRuns = true;
       };
     }  // namespace impl
     template <typename... T>

--- a/FWCore/Framework/interface/stream/AbilityToImplementor.h
+++ b/FWCore/Framework/interface/stream/AbilityToImplementor.h
@@ -22,6 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/stream/moduleAbilities.h"
 #include "FWCore/Framework/interface/stream/implementors.h"
 
 // forward declarations
@@ -113,6 +114,17 @@ namespace edm {
     struct AbilityToImplementor<edm::Accumulator> {
       using Type = edm::stream::impl::Accumulator;
     };
+
+    template <>
+    struct AbilityToImplementor<edm::stream::WatchRuns> {
+      using Type = edm::stream::impl::WatchRuns;
+    };
+
+    template <>
+    struct AbilityToImplementor<edm::stream::WatchLuminosityBlocks> {
+      using Type = edm::stream::impl::WatchLuminosityBlocks;
+    };
+
   }  // namespace stream
 }  // namespace edm
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -73,9 +73,11 @@ namespace edm {
       bool wantsProcessBlocks() const final { return T::HasAbility::kWatchProcessBlock; }
       bool wantsInputProcessBlocks() const final { return T::HasAbility::kInputProcessBlockCache; }
       bool wantsGlobalRuns() const final { return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache; }
+      bool wantsStreamRuns() const final { return T::HasAbility::kWatchRuns; }
       bool wantsGlobalLuminosityBlocks() const final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache;
       }
+      bool wantsStreamLuminosityBlocks() const final { return T::HasAbility::kWatchLuminosityBlocks; }
 
     private:
       using MyGlobal = CallGlobal<T>;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -86,8 +86,8 @@ namespace edm {
       virtual bool wantsInputProcessBlocks() const = 0;
       virtual bool wantsGlobalRuns() const = 0;
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
-      bool wantsStreamRuns() const { return true; }
-      bool wantsStreamLuminosityBlocks() const { return true; }
+      virtual bool wantsStreamRuns() const = 0;
+      virtual bool wantsStreamLuminosityBlocks() const = 0;
 
       std::string workerType() const { return "WorkerT<EDAnalyzerAdaptorBase>"; }
       void registerProductsAndCallbacks(EDAnalyzerAdaptorBase const*, ProductRegistry* reg);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -67,10 +67,13 @@ namespace edm {
         return T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer or
                T::HasAbility::kEndRunProducer;
       }
+      bool wantsStreamRuns() const final { return T::HasAbility::kWatchRuns; }
+
       bool wantsGlobalLuminosityBlocks() const final {
         return T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or
                T::HasAbility::kBeginLuminosityBlockProducer or T::HasAbility::kEndLuminosityBlockProducer;
       }
+      bool wantsStreamLuminosityBlocks() const final { return T::HasAbility::kWatchLuminosityBlocks; }
 
       bool hasAcquire() const final { return T::HasAbility::kExternalWork; }
 

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -93,8 +93,8 @@ namespace edm {
       virtual bool wantsGlobalLuminosityBlocks() const = 0;
       virtual bool hasAcquire() const = 0;
       virtual bool hasAccumulator() const = 0;
-      bool wantsStreamRuns() const { return true; }
-      bool wantsStreamLuminosityBlocks() const { return true; }
+      virtual bool wantsStreamRuns() const = 0;
+      virtual bool wantsStreamLuminosityBlocks() const = 0;
 
       void registerProductsAndCallbacks(ProducingModuleAdaptorBase const*, ProductRegistry* reg);
 

--- a/FWCore/Framework/interface/stream/implementors.h
+++ b/FWCore/Framework/interface/stream/implementors.h
@@ -291,6 +291,27 @@ namespace edm {
         virtual void acquire(Event const&, edm::EventSetup const&, WaitingTaskWithArenaHolder) = 0;
       };
 
+      class WatchLuminosityBlocks {
+      public:
+        WatchLuminosityBlocks() = default;
+        WatchLuminosityBlocks(WatchLuminosityBlocks const&) = delete;
+        WatchLuminosityBlocks& operator=(WatchLuminosityBlocks const&) = delete;
+        virtual ~WatchLuminosityBlocks() noexcept(false){};
+
+        // virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
+        // virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
+      };
+
+      class WatchRuns {
+      public:
+        WatchRuns() = default;
+        WatchRuns(WatchRuns const&) = delete;
+        WatchRuns& operator=(WatchRuns const&) = delete;
+        virtual ~WatchRuns() noexcept(false){};
+
+        // virtual void beginRun(edm::Run const&, edm::EventSetup const&) = 0;
+        // virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
+      };
       class Transformer : private TransformerBase, public EDProducerBase {
       public:
         Transformer() = default;

--- a/FWCore/Framework/interface/stream/moduleAbilities.h
+++ b/FWCore/Framework/interface/stream/moduleAbilities.h
@@ -1,0 +1,42 @@
+#ifndef FWCore_Framework_stream_moduleAbilities_h
+#define FWCore_Framework_stream_moduleAbilities_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     moduleAbilities
+//
+/**\file moduleAbilities moduleAbilities.h "FWCore/Framework/interface/one/moduleAbilities.h"
+
+ Description: Template arguments which only apply to stream::{Module} classes
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 22 Dec 2023 19:38:53 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace stream {
+    struct WatchRuns {
+      static constexpr module::Abilities kAbilities = module::Abilities::kStreamWatchRuns;
+      using Type = module::Empty;
+    };
+
+    struct WatchLuminosityBlocks {
+      static constexpr module::Abilities kAbilities = module::Abilities::kStreamWatchLuminosityBlocks;
+      using Type = module::Empty;
+    };
+  }  // namespace stream
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -105,7 +105,7 @@ namespace edmtest {
       }
     };
 
-    class RunIntAnalyzer : public edm::stream::EDAnalyzer<edm::RunCache<Cache>> {
+    class RunIntAnalyzer : public edm::stream::EDAnalyzer<edm::RunCache<Cache>, edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -163,7 +163,8 @@ namespace edmtest {
       }
     };
 
-    class LumiIntAnalyzer : public edm::stream::EDAnalyzer<edm::LuminosityBlockCache<Cache>> {
+    class LumiIntAnalyzer
+        : public edm::stream::EDAnalyzer<edm::LuminosityBlockCache<Cache>, edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -236,8 +237,9 @@ namespace edmtest {
       }
     };
 
-    class RunSummaryIntAnalyzer
-        : public edm::stream::EDAnalyzer<edm::RunCache<Cache>, edm::RunSummaryCache<SummaryCache>> {
+    class RunSummaryIntAnalyzer : public edm::stream::EDAnalyzer<edm::RunCache<Cache>,
+                                                                 edm::RunSummaryCache<SummaryCache>,
+                                                                 edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -321,7 +323,8 @@ namespace edmtest {
     };
 
     class LumiSummaryIntAnalyzer : public edm::stream::EDAnalyzer<edm::LuminosityBlockCache<Cache>,
-                                                                  edm::LuminosityBlockSummaryCache<SummaryCache>> {
+                                                                  edm::LuminosityBlockSummaryCache<SummaryCache>,
+                                                                  edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -106,7 +106,7 @@ namespace edmtest {
       }
     };
 
-    class RunIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>> {
+    class RunIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -163,7 +163,8 @@ namespace edmtest {
       }
     };
 
-    class LumiIntFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>> {
+    class LumiIntFilter
+        : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>, edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -235,7 +236,8 @@ namespace edmtest {
       }
     };
 
-    class RunSummaryIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::RunSummaryCache<SummaryCache>> {
+    class RunSummaryIntFilter
+        : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::RunSummaryCache<SummaryCache>, edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -321,8 +323,9 @@ namespace edmtest {
       }
     };
 
-    class LumiSummaryIntFilter
-        : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>, edm::LuminosityBlockSummaryCache<SummaryCache>> {
+    class LumiSummaryIntFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>,
+                                                              edm::LuminosityBlockSummaryCache<SummaryCache>,
+                                                              edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -105,7 +105,7 @@ namespace edmtest {
       }
     };
 
-    class RunIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>> {
+    class RunIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>, edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -160,7 +160,8 @@ namespace edmtest {
       }
     };
 
-    class LumiIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>> {
+    class LumiIntProducer
+        : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>, edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -229,8 +230,9 @@ namespace edmtest {
       }
     };
 
-    class RunSummaryIntProducer
-        : public edm::stream::EDProducer<edm::RunCache<Cache>, edm::RunSummaryCache<SummaryCache>> {
+    class RunSummaryIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,
+                                                                 edm::RunSummaryCache<SummaryCache>,
+                                                                 edm::stream::WatchRuns> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
@@ -315,7 +317,8 @@ namespace edmtest {
     };
 
     class LumiSummaryIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,
-                                                                  edm::LuminosityBlockSummaryCache<SummaryCache>> {
+                                                                  edm::LuminosityBlockSummaryCache<SummaryCache>,
+                                                                  edm::stream::WatchLuminosityBlocks> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;

--- a/FWCore/Modules/src/LogErrorFilter.cc
+++ b/FWCore/Modules/src/LogErrorFilter.cc
@@ -32,7 +32,7 @@
 // class declaration
 //
 
-class LogErrorFilter : public edm::stream::EDFilter<> {
+class LogErrorFilter : public edm::stream::EDFilter<edm::stream::WatchLuminosityBlocks> {
 public:
   explicit LogErrorFilter(edm::ParameterSet const&);
   ~LogErrorFilter() override;


### PR DESCRIPTION
#### PR description:

Added edm::stream::WatchRuns/WatchLuminosityBlocks as template arguments for stream modules. This will later be required to use Run/LuminosityBlock transition calls.
Added all the additional classes that will ultimately be needed though for now the base class still has the needed virtual functions.

#### PR validation:

Code compiles and all framework unit tests passed. Also tried test with new feature on and modified all the framework modules that need the feature.