### PR TITLE
[14_0_X SIM] Updated low-energy GFlash method in ECAL

### DIFF
--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -93,7 +93,7 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
   spot.SetPosition(pos);
   fHitMaker.make(&spot, &fastTrack);
 
-  // Russian Roulette
+  // Russian roulette
   double wt2 = track->GetWeight();
   if (wt2 <= 0.0) { wt2 = 1.0; }
 

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -95,12 +95,14 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
 
   // Russian roulette
   double wt2 = track->GetWeight();
-  if (wt2 <= 0.0) { wt2 = 1.0; }
+  if (wt2 <= 0.0) {
+    wt2 = 1.0;
+  }
 
   // tail energy deposition
   const G4double etail = energy - inPointEnergy;
   const G4int nspots = etail;
-  const G4double tailEnergy = etail*wt2 / (nspots + 1);
+  const G4double tailEnergy = etail * wt2 / (nspots + 1);
   /*  
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -93,10 +93,14 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
   spot.SetPosition(pos);
   fHitMaker.make(&spot, &fastTrack);
 
+  // Russian Roulette
+  double wt2 = track->GetWeight();
+  if (wt2 <= 0.0) { wt2 = 1.0; }
+
   // tail energy deposition
   const G4double etail = energy - inPointEnergy;
   const G4int nspots = etail;
-  const G4double tailEnergy = etail / (nspots + 1);
+  const G4double tailEnergy = etail*wt2 / (nspots + 1);
   /*  
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"


### PR DESCRIPTION
#### PR description:
There are a problem in low-energy GFlash method for ECAL to speed-up FullSIm. This is an attempt to improve. By default the method is disable, so no effect on regression is expected.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

