### PR TITLE
CTPPS create Reconstruction workflow test

### DIFF
--- a/RecoPPS/Local/test/2023_lhcinfo_test_recoCTPPS.sh
+++ b/RecoPPS/Local/test/2023_lhcinfo_test_recoCTPPS.sh
@@ -1,0 +1,5 @@
+ #!/bin/bash -ex
+TEST_DIR=$CMSSW_BASE/src/RecoPPS/Local/test
+echo "test dir: $TEST_DIR"
+
+cmsRun ${TEST_DIR}/2023_lhcinfo_test_recoCTPPS_cfg.py

--- a/RecoPPS/Local/test/2023_lhcinfo_test_recoCTPPS_cfg.py
+++ b/RecoPPS/Local/test/2023_lhcinfo_test_recoCTPPS_cfg.py
@@ -3,7 +3,7 @@ from Configuration.Eras.Era_Run3_cff import Run3
 
 process = cms.Process('RECODQM', Run3)
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(50) )
 process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 # minimum of logs

--- a/RecoPPS/Local/test/BuildFile.xml
+++ b/RecoPPS/Local/test/BuildFile.xml
@@ -1,1 +1,2 @@
 <test name="RecoPPSLocalNewT2" command="testNT2.sh"/>
+<test name="TestCTPPSReconstruction" command="2023_lhcinfo_test_recoCTPPS.sh"/>


### PR DESCRIPTION
#### PR description:
This PR adds a new test `RecoPPS/Local/TestCTPPSReconstruction` that runs `RecoPPS/Local/test/2023_lhcinfo_test_recoCTPPS_cfg.py`, checking if the standard reconstruction workflow is not crashing.
This workflow:
* transforms data using `RawToDigi`
* reconstructs collisions using `recoCTPPS` 
* creates proton reconstruction plots using `CTPPSProtonReconstructionPlotter`

 and uses `auto:run3_data` Global Tag
#### PR validation:
Run `scram b runtests` to see the mentioned test in the test sequence

