### PR TITLE
use `reco::deltaR2` in `HLTrigger/*/` packages

### DIFF
--- a/HLTrigger/Egamma/plugins/BuildFile.xml
+++ b/HLTrigger/Egamma/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
+<use name="FWCore/Utilities"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>

--- a/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.h
@@ -1,5 +1,5 @@
-#ifndef HLTDisplacedEgammaFilter_h
-#define HLTDisplacedEgammaFilter_h
+#ifndef HLTrigger_Egamma_HLTDisplacedEgammaFilter_h
+#define HLTrigger_Egamma_HLTDisplacedEgammaFilter_h
 
 /** \class HLTDisplacedEgammaFilter
  *
@@ -7,24 +7,19 @@
  *
  */
 
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
-
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
-//
-// class decleration
-//
-typedef math::XYZTLorentzVector LorentzVector;
-#include <Math/VectorUtil.h>
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 
 class HLTDisplacedEgammaFilter : public HLTFilter {
 public:
   explicit HLTDisplacedEgammaFilter(const edm::ParameterSet&);
-  ~HLTDisplacedEgammaFilter() override;
+  ~HLTDisplacedEgammaFilter() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   bool hltFilter(edm::Event&,
                  const edm::EventSetup&,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
@@ -51,8 +46,8 @@ private:
   edm::InputTag inputTrk;
   edm::EDGetTokenT<reco::TrackCollection> inputTrkToken_;
   double trkPtCut;
-  double trkdRCut;
+  double trkDr2Cut;
   int maxTrkCut;
 };
 
-#endif  //HLTDisplacedEgammaFilter_h
+#endif

--- a/HLTrigger/HLTfilters/plugins/BuildFile.xml
+++ b/HLTrigger/HLTfilters/plugins/BuildFile.xml
@@ -11,6 +11,7 @@
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/L1TGlobal"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TauReco"/>

--- a/HLTrigger/HLTfilters/plugins/HLTDoublet.h
+++ b/HLTrigger/HLTfilters/plugins/HLTDoublet.h
@@ -1,5 +1,5 @@
-#ifndef HLTDoublet_h
-#define HLTDoublet_h
+#ifndef HLTrigger_HLTfilters_HLTDoublet_h
+#define HLTrigger_HLTfilters_HLTDoublet_h
 
 /** \class HLTDoublet
  *
@@ -19,28 +19,35 @@
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include <string>
+
 #include <vector>
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
 namespace trigger {
   class TriggerFilterObjectWithRefs;
 }
-
-//
-// class declaration
-//
 
 template <typename T1, typename T2>
 class HLTDoublet : public HLTFilter {
 public:
   explicit HLTDoublet(const edm::ParameterSet&);
-  ~HLTDoublet() override;
+  ~HLTDoublet() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   bool hltFilter(edm::Event&,
                  const edm::EventSetup&,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
 private:
+  typedef std::vector<T1> T1Collection;
+  typedef edm::Ref<T1Collection> T1Ref;
+  typedef std::vector<T2> T2Collection;
+  typedef edm::Ref<T2Collection> T2Ref;
+
   // configuration
   const std::vector<edm::InputTag> originTag1_;  // input tag identifying originals 1st product
   const std::vector<edm::InputTag> originTag2_;  // input tag identifying originals 2nd product
@@ -50,22 +57,18 @@ private:
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
   const int triggerType1_;
   const int triggerType2_;
-  const double min_Dphi_, max_Dphi_;  // Delta phi window
-  const double min_Deta_, max_Deta_;  // Delta eta window
-  const double min_Minv_, max_Minv_;  // Minv(1,2) window
-  const double min_DelR_, max_DelR_;  // Delta R window
-  const double min_Pt_, max_Pt_;      // Pt(1,2) window
-  const int min_N_;                   // number of pairs passing cuts required
+  const double min_Deta_, max_Deta_;    // Delta eta window
+  const double min_Dphi_, max_Dphi_;    // Delta phi window
+  const double min_DelR2_, max_DelR2_;  // Delta R^2 window
+  const double min_Pt_, max_Pt_;        // Pt(1,2) window
+  const double min_Minv_, max_Minv_;    // Minv(1,2) window
+  const int min_N_;                     // number of pairs passing cuts required
 
   // calculated from configuration in c'tor
-  const bool same_;                                           // 1st and 2nd product are one and the same
-  const bool cutdphi_, cutdeta_, cutminv_, cutdelr_, cutpt_;  // cuts are on=true or off=false
-
-  //
-  typedef std::vector<T1> T1Collection;
-  typedef edm::Ref<T1Collection> T1Ref;
-  typedef std::vector<T2> T2Collection;
-  typedef edm::Ref<T2Collection> T2Ref;
+  // 1st and 2nd product are one and the same
+  const bool same_;
+  // cuts are on=true or off=false
+  const bool cutdeta_, cutdphi_, cutdelr2_, cutpt_, cutminv_;
 };
 
-#endif  //HLTDoublet_h
+#endif  // HLTrigger_HLTfilters_HLTDoublet_h

--- a/HLTrigger/JetMET/BuildFile.xml
+++ b/HLTrigger/JetMET/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="CommonTools/Utils"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/BTauReco"/>
 <use name="DataFormats/HLTReco"/>

--- a/HLTrigger/JetMET/interface/HLTCATopTagFilter.h
+++ b/HLTrigger/JetMET/interface/HLTCATopTagFilter.h
@@ -16,8 +16,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
-#include "CommonTools/CandUtils/interface/AddFourMomenta.h"
-#include "DataFormats/Candidate/interface/CandMatchMap.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/HLTrigger/JetMET/interface/HLTCAWZTagFilter.h
+++ b/HLTrigger/JetMET/interface/HLTCAWZTagFilter.h
@@ -14,8 +14,6 @@
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
-#include "CommonTools/CandUtils/interface/AddFourMomenta.h"
-#include "DataFormats/Candidate/interface/CandMatchMap.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/HLTrigger/JetMET/interface/HLTHPDFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHPDFilter.h
@@ -1,5 +1,5 @@
-#ifndef HLTHPDFilter_h
-#define HLTHPDFilter_h
+#ifndef HLTrigger_JetMET_HLTHPDFilter_h
+#define HLTrigger_JetMET_HLTHPDFilter_h
 
 /** \class HLTHPDFilter
  *
@@ -35,4 +35,4 @@ private:
   double mRBXSpikeUnbalanceThreshold;
 };
 
-#endif  //HLTHPDFilter_h
+#endif

--- a/HLTrigger/JetMET/interface/HLTJetCollForElePlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollForElePlusJets.h
@@ -1,5 +1,5 @@
-#ifndef HLTJetCollForElePlusJets_h
-#define HLTJetCollForElePlusJets_h
+#ifndef HLTrigger_JetMET_HLTJetCollForElePlusJets_h
+#define HLTrigger_JetMET_HLTJetCollForElePlusJets_h
 
 /** \class HLTJetCollForElePlusJets
  *
@@ -17,30 +17,21 @@
  */
 
 // user include files
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-#include "DataFormats/JetReco/interface/CaloJetCollection.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
 
 namespace edm {
   class ConfigurationDescriptions;
 }
 
-//
-// class declaration
-//
-
 template <typename T>
 class HLTJetCollForElePlusJets : public edm::stream::EDProducer<> {
 public:
   explicit HLTJetCollForElePlusJets(const edm::ParameterSet&);
-  ~HLTJetCollForElePlusJets() override;
+  ~HLTJetCollForElePlusJets() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -54,12 +45,9 @@ private:
   double minJetPt_;        // jet pt threshold in GeV
   double maxAbsJetEta_;    // jet |eta| range
   unsigned int minNJets_;  // number of required jets passing cuts after cleaning
-
-  double minDeltaR_;  //min dR for jets and electrons not to match
-
-  double minSoftJetPt_;  // jet pt threshold for the soft jet in the VBF pair
-  double minDeltaEta_;   // pseudorapidity separation for the VBF pair
-
-  // ----------member data ---------------------------
+  double minDeltaR2_;      // min dR^2 (with sign) for jets and electrons not to match
+  double minSoftJetPt_;    // jet pt threshold for the soft jet in the VBF pair
+  double minDeltaEta_;     // pseudorapidity separation for the VBF pair
 };
-#endif  //HLTJetCollForElePlusJets_h
+
+#endif

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsForBoostedLeptonPlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsForBoostedLeptonPlusJets.h
@@ -1,5 +1,5 @@
-#ifndef HLTJetCollectionsForBoostedLeptonPlusJets_h
-#define HLTJetCollectionsForBoostedLeptonPlusJets_h
+#ifndef HLTrigger_JetMET_HLTJetCollectionsForBoostedLeptonPlusJets_h
+#define HLTrigger_JetMET_HLTJetCollectionsForBoostedLeptonPlusJets_h
 
 /** \class HLTJetCollectionsForBoostedLeptonPlusJets
  *
@@ -16,25 +16,14 @@
  *
  */
 
-// user include files
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
 
 namespace edm {
   class ConfigurationDescriptions;
 }
-
-//
-// class declaration
-//
 
 template <typename jetType>
 class HLTJetCollectionsForBoostedLeptonPlusJets : public edm::stream::EDProducer<> {
@@ -51,8 +40,7 @@ private:
   edm::InputTag hltLeptonTag;
   edm::InputTag sourceJetTag;
 
-  double minDeltaR_;  //min dR to consider cleaning
-
-  // ----------member data ---------------------------
+  double minDeltaR2_;  // min dR^2 (with sign) to consider cleaning
 };
-#endif  //HLTJetCollectionsForBoostedLeptonPlusJets_h
+
+#endif

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsForLeptonPlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsForLeptonPlusJets.h
@@ -1,5 +1,5 @@
-#ifndef HLTJetCollectionsForLeptonPlusJets_h
-#define HLTJetCollectionsForLeptonPlusJets_h
+#ifndef HLTrigger_JetMET_HLTJetCollectionsForLeptonPlusJets_h
+#define HLTrigger_JetMET_HLTJetCollectionsForLeptonPlusJets_h
 
 /** \class HLTJetCollectionsForLeptonPlusJets
  *
@@ -17,16 +17,10 @@
  */
 
 // user include files
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-#include "DataFormats/JetReco/interface/CaloJetCollection.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -40,7 +34,7 @@ template <typename jetType>
 class HLTJetCollectionsForLeptonPlusJets : public edm::stream::EDProducer<> {
 public:
   explicit HLTJetCollectionsForLeptonPlusJets(const edm::ParameterSet&);
-  ~HLTJetCollectionsForLeptonPlusJets() override;
+  ~HLTJetCollectionsForLeptonPlusJets() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -51,8 +45,7 @@ private:
   edm::InputTag hltLeptonTag;
   edm::InputTag sourceJetTag;
 
-  double minDeltaR_;  //min dR for jets and leptons not to match
-
-  // ----------member data ---------------------------
+  double minDeltaR2_;  // min dR^2 (with sign) for jets and leptons not to match
 };
-#endif  //HLTJetCollectionsForLeptonPlusJets_h
+
+#endif

--- a/HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h
+++ b/HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h
@@ -34,8 +34,7 @@ private:
   edm::InputTag L1TauJets_;
   edm::InputTag L1CenJets_;
   edm::InputTag L1ForJets_;
-  //  std::string jetType_;
-  double DeltaR_;  // DeltaR(HLT,L1)
+  double DeltaR2_;  // DeltaR2(HLT,L1) with sign
 };
 
 #endif

--- a/HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h
+++ b/HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h
@@ -20,19 +20,19 @@
 template <typename T>
 class HLTJetL1TMatchProducer : public edm::stream::EDProducer<> {
 public:
-  explicit HLTJetL1TMatchProducer(const edm::ParameterSet &);
-  ~HLTJetL1TMatchProducer() override;
-  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
-  virtual void beginJob();
-  void produce(edm::Event &, const edm::EventSetup &) override;
+  explicit HLTJetL1TMatchProducer(const edm::ParameterSet&);
+  ~HLTJetL1TMatchProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  edm::EDGetTokenT<std::vector<T>> m_theJetToken;
-  edm::EDGetTokenT<l1t::JetBxCollection> m_theL1JetToken;
   edm::InputTag jetsInput_;
   edm::InputTag L1Jets_;
-  //  std::string jetType_;
-  double DeltaR_;  // DeltaR(HLT,L1)
+  double DeltaR2_;  // DeltaR2(HLT,L1) with sign
+  edm::EDGetTokenT<std::vector<T>> m_theJetToken;
+  edm::EDGetTokenT<l1t::JetBxCollection> m_theL1JetToken;
 };
 
 #endif

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -36,9 +36,12 @@ public:
   static bool comparator(const Jpair& l, const Jpair& r) { return l.first < r.first; }
 
   explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
-  ~HLTJetSortedVBFFilter() override;
+  ~HLTJetSortedVBFFilter() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   static float findCSV(const typename std::vector<T>::const_iterator& jet, const reco::JetTagCollection& jetTags);
+
   bool hltFilter(edm::Event&,
                  const edm::EventSetup&,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;

--- a/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
+++ b/HLTrigger/JetMET/plugins/HLTJetHbbFilter.cc
@@ -5,16 +5,15 @@
  *  \author Ann Wang
  *
  */
-
-#include <vector>
+#include <cmath>
 #include <string>
+#include <vector>
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
@@ -78,12 +77,12 @@ void HLTJetHbbFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descri
 template <typename T>
 float HLTJetHbbFilter<T>::findCSV(const typename std::vector<T>::const_iterator& jet,
                                   const reco::JetTagCollection& jetTags) {
-  float minDr = 0.1;  //matching jet tag with jet
+  float minDr2 = 0.01f;  //matching jet tag with jet
   float tmpCSV = -20;
   for (auto jetb = jetTags.begin(); (jetb != jetTags.end()); ++jetb) {
-    float tmpDr = reco::deltaR(*jet, *(jetb->first));
-    if (tmpDr < minDr) {
-      minDr = tmpDr;
+    float tmpDr2 = reco::deltaR2(*jet, *(jetb->first));
+    if (tmpDr2 < minDr2) {
+      minDr2 = tmpDr2;
       tmpCSV = jetb->second;
     }
   }

--- a/HLTrigger/JetMET/src/HLTHPDFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHPDFilter.cc
@@ -4,31 +4,17 @@
  * Fedor Ratnikov (UMd) May 19, 2008
  */
 
-#include "HLTrigger/JetMET/interface/HLTHPDFilter.h"
-
 #include <array>
-
 #include <cmath>
-
-#include <set>
+#include <utility>
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "Geometry/CaloTopology/interface/HcalTopology.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "TH1F.h"
-#include "TH2F.h"
-
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "HLTrigger/JetMET/interface/HLTHPDFilter.h"
 
 namespace {
   enum Partition { HBM = 0, HBP = 1, HEM = 2, HEP = 3 };

--- a/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1MatchProducer.cc
@@ -1,13 +1,14 @@
-#include <string>
+#include <cmath>
+#include <memory>
 
-#include "HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+#include "HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h"
 
 template <typename T>
 HLTJetL1MatchProducer<T>::HLTJetL1MatchProducer(const edm::ParameterSet& iConfig) {
@@ -15,7 +16,10 @@ HLTJetL1MatchProducer<T>::HLTJetL1MatchProducer(const edm::ParameterSet& iConfig
   L1TauJets_ = iConfig.template getParameter<edm::InputTag>("L1TauJets");
   L1CenJets_ = iConfig.template getParameter<edm::InputTag>("L1CenJets");
   L1ForJets_ = iConfig.template getParameter<edm::InputTag>("L1ForJets");
-  DeltaR_ = iConfig.template getParameter<double>("DeltaR");
+
+  // minimum delta-R^2 threshold with sign
+  auto const DeltaR = iConfig.template getParameter<double>("DeltaR");
+  DeltaR2_ = DeltaR * std::abs(DeltaR);
 
   typedef std::vector<T> TCollection;
   m_theJetToken = consumes<TCollection>(jetsInput_);
@@ -44,53 +48,54 @@ void HLTJetL1MatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& 
 
 template <typename T>
 void HLTJetL1MatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  typedef std::vector<T> TCollection;
+  auto const& jets = iEvent.get(m_theJetToken);
 
-  edm::Handle<TCollection> jets;
-  iEvent.getByToken(m_theJetToken, jets);
+  auto result = std::make_unique<std::vector<T>>();
+  result->reserve(jets.size());
 
-  std::unique_ptr<TCollection> result(new TCollection);
+  auto const& l1TauJets = iEvent.get(m_theL1TauJetToken);
+  auto const& l1CenJets = iEvent.get(m_theL1CenJetToken);
+  auto const& l1ForJets = iEvent.get(m_theL1ForJetToken);
 
-  edm::Handle<l1extra::L1JetParticleCollection> l1TauJets;
-  iEvent.getByToken(m_theL1TauJetToken, l1TauJets);
-
-  edm::Handle<l1extra::L1JetParticleCollection> l1CenJets;
-  iEvent.getByToken(m_theL1CenJetToken, l1CenJets);
-
-  edm::Handle<l1extra::L1JetParticleCollection> l1ForJets;
-  iEvent.getByToken(m_theL1ForJetToken, l1ForJets);
-
-  typename TCollection::const_iterator jet_iter;
-  for (jet_iter = jets->begin(); jet_iter != jets->end(); ++jet_iter) {
+  for (auto const& jet : jets) {
     bool isMatched = false;
 
-    //std::cout << "FL: l1TauJets.size  = " << l1TauJets->size() << std::endl;
-    for (unsigned int jetc = 0; jetc < l1TauJets->size(); ++jetc) {
-      const double deltaeta = jet_iter->eta() - (*l1TauJets)[jetc].eta();
-      const double deltaphi = deltaPhi(jet_iter->phi(), (*l1TauJets)[jetc].phi());
-      //std::cout << "FL: sqrt(2) = " << sqrt(2) << std::endl;
-      if (sqrt(deltaeta * deltaeta + deltaphi * deltaphi) < DeltaR_)
+    for (auto const& l1t_obj : l1TauJets) {
+      if (reco::deltaR2(jet.eta(), jet.phi(), l1t_obj.eta(), l1t_obj.phi()) < DeltaR2_) {
         isMatched = true;
+        break;
+      }
     }
 
-    for (unsigned int jetc = 0; jetc < l1CenJets->size(); ++jetc) {
-      const double deltaeta = jet_iter->eta() - (*l1CenJets)[jetc].eta();
-      const double deltaphi = deltaPhi(jet_iter->phi(), (*l1CenJets)[jetc].phi());
-      if (sqrt(deltaeta * deltaeta + deltaphi * deltaphi) < DeltaR_)
-        isMatched = true;
+    if (isMatched) {
+      result->emplace_back(jet);
+      continue;
     }
 
-    for (unsigned int jetc = 0; jetc < l1ForJets->size(); ++jetc) {
-      const double deltaeta = jet_iter->eta() - (*l1ForJets)[jetc].eta();
-      const double deltaphi = deltaPhi(jet_iter->phi(), (*l1ForJets)[jetc].phi());
-      if (sqrt(deltaeta * deltaeta + deltaphi * deltaphi) < DeltaR_)
+    for (auto const& l1t_obj : l1CenJets) {
+      if (reco::deltaR2(jet.eta(), jet.phi(), l1t_obj.eta(), l1t_obj.phi()) < DeltaR2_) {
         isMatched = true;
+        break;
+      }
     }
 
-    if (isMatched == true)
-      result->push_back(*jet_iter);
+    if (isMatched) {
+      result->emplace_back(jet);
+      continue;
+    }
 
-  }  // jet_iter
+    for (auto const& l1t_obj : l1ForJets) {
+      if (reco::deltaR2(jet.eta(), jet.phi(), l1t_obj.eta(), l1t_obj.phi()) < DeltaR2_) {
+        isMatched = true;
+        break;
+      }
+    }
+
+    if (isMatched) {
+      result->emplace_back(jet);
+      continue;
+    }
+  }
 
   iEvent.put(std::move(result));
 }

--- a/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
+++ b/HLTrigger/JetMET/src/HLTJetL1TMatchProducer.cc
@@ -1,32 +1,29 @@
-#include <string>
+#include <cmath>
+#include <memory>
 
-#include "HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/Math/interface/deltaPhi.h"
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+#include "HLTrigger/JetMET/interface/HLTJetL1TMatchProducer.h"
 
 template <typename T>
 HLTJetL1TMatchProducer<T>::HLTJetL1TMatchProducer(const edm::ParameterSet& iConfig) {
   jetsInput_ = iConfig.template getParameter<edm::InputTag>("jetsInput");
   L1Jets_ = iConfig.template getParameter<edm::InputTag>("L1Jets");
-  DeltaR_ = iConfig.template getParameter<double>("DeltaR");
 
-  typedef std::vector<T> TCollection;
-  m_theJetToken = consumes<TCollection>(jetsInput_);
-  m_theL1JetToken = consumes<l1t::JetBxCollection>(L1Jets_);
-  produces<TCollection>();
+  // minimum delta-R^2 threshold with sign
+  auto const DeltaR = iConfig.template getParameter<double>("DeltaR");
+  DeltaR2_ = DeltaR * std::abs(DeltaR);
+
+  m_theJetToken = consumes(jetsInput_);
+  m_theL1JetToken = consumes(L1Jets_);
+
+  produces<std::vector<T>>();
 }
-
-template <typename T>
-void HLTJetL1TMatchProducer<T>::beginJob() {}
-
-template <typename T>
-HLTJetL1TMatchProducer<T>::~HLTJetL1TMatchProducer() = default;
 
 template <typename T>
 void HLTJetL1TMatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -39,20 +36,15 @@ void HLTJetL1TMatchProducer<T>::fillDescriptions(edm::ConfigurationDescriptions&
 
 template <typename T>
 void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  typedef std::vector<T> TCollection;
+  auto const& jets = iEvent.get(m_theJetToken);
+  auto const l1Jets = iEvent.getHandle(m_theL1JetToken);
 
-  edm::Handle<TCollection> jets;
-  iEvent.getByToken(m_theJetToken, jets);
-
-  std::unique_ptr<TCollection> result(new TCollection);
-
-  edm::Handle<l1t::JetBxCollection> l1Jets;
-  iEvent.getByToken(m_theL1JetToken, l1Jets);
   bool trigger_bx_only = true;  // selection of BX not implemented
 
+  auto result = std::make_unique<std::vector<T>>();
+
   if (l1Jets.isValid()) {
-    typename TCollection::const_iterator jet_iter;
-    for (jet_iter = jets->begin(); jet_iter != jets->end(); ++jet_iter) {
+    for (auto const& jet : jets) {
       bool isMatched = false;
       for (int ibx = l1Jets->getFirstBX(); ibx <= l1Jets->getLastBX(); ++ibx) {
         if (trigger_bx_only && (ibx != 0))
@@ -60,18 +52,18 @@ void HLTJetL1TMatchProducer<T>::produce(edm::Event& iEvent, const edm::EventSetu
         for (auto it = l1Jets->begin(ibx); it != l1Jets->end(ibx); it++) {
           if (it->et() == 0)
             continue;  // if you don't care about L1T candidates with zero ET.
-          const double deltaeta = jet_iter->eta() - it->eta();
-          const double deltaphi = deltaPhi(jet_iter->phi(), it->phi());
-          if (sqrt(deltaeta * deltaeta + deltaphi * deltaphi) < DeltaR_)
+          if (reco::deltaR2(jet.eta(), jet.phi(), it->eta(), it->phi()) < DeltaR2_) {
             isMatched = true;
-          //cout << "bx:  " << ibx << "  et:  "  << it->et() << "  eta:  "  << it->eta() << "  phi:  "  << it->phi() << "\n";
+            break;
+          }
         }
       }
-      if (isMatched == true)
-        result->push_back(*jet_iter);
-    }  // jet_iter
+      if (isMatched) {
+        result->emplace_back(jet);
+      }
+    }
   } else {
-    edm::LogWarning("MissingProduct") << "L1Upgrade l1Jets bx collection not found." << std::endl;
+    edm::LogWarning("MissingProduct") << "L1Upgrade l1Jets bx collection not found.";
   }
 
   iEvent.put(std::move(result));

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -2,15 +2,13 @@
  *
  * See header file for documentation
  *
-
-
  *
  *  \author Jacopo Bernardini
  *
  */
-
-#include <vector>
+#include <cmath>
 #include <string>
+#include <vector>
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -50,9 +48,6 @@ HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig
 }
 
 template <typename T>
-HLTJetSortedVBFFilter<T>::~HLTJetSortedVBFFilter() = default;
-
-template <typename T>
 void HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
@@ -74,13 +69,12 @@ void HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& 
 template <typename T>
 float HLTJetSortedVBFFilter<T>::findCSV(const typename std::vector<T>::const_iterator& jet,
                                         const reco::JetTagCollection& jetTags) {
-  float minDr = 0.1;
+  float minDr2 = 0.01f;
   float tmpCSV = -20;
   for (auto jetb = jetTags.begin(); (jetb != jetTags.end()); ++jetb) {
-    float tmpDr = reco::deltaR(*jet, *(jetb->first));
-
-    if (tmpDr < minDr) {
-      minDr = tmpDr;
+    float tmpDr2 = reco::deltaR2(*jet, *(jetb->first));
+    if (tmpDr2 < minDr2) {
+      minDr2 = tmpDr2;
       tmpCSV = jetb->second;
     }
   }

--- a/HLTrigger/Muon/plugins/HLTDiMuonGlbTrkFilter.h
+++ b/HLTrigger/Muon/plugins/HLTDiMuonGlbTrkFilter.h
@@ -1,10 +1,12 @@
-#ifndef HLTDiMuonGlbTrkFilter_h
-#define HLTDiMuonGlbTrkFilter_h
+#ifndef HLTrigger_Muon_HLTDiMuonGlbTrkFilter_h
+#define HLTrigger_Muon_HLTDiMuonGlbTrkFilter_h
+
 // author D.Kovalskyi
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -15,8 +17,10 @@ namespace edm {
 class HLTDiMuonGlbTrkFilter : public HLTFilter {
 public:
   HLTDiMuonGlbTrkFilter(const edm::ParameterSet&);
-  ~HLTDiMuonGlbTrkFilter() override {}
+  ~HLTDiMuonGlbTrkFilter() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   bool hltFilter(edm::Event&,
                  const edm::EventSetup&,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
@@ -34,7 +38,7 @@ private:
   unsigned int m_allowedTypeMask;
   unsigned int m_requiredTypeMask;
   double m_maxNormalizedChi2;
-  double m_minDR;
+  double m_minDR2;
   double m_minPtMuon1;
   double m_minPtMuon2;
   double m_maxEtaMuon;
@@ -48,4 +52,4 @@ private:
   bool m_saveTags;
 };
 
-#endif  //HLTMuonDimuonFilter_h
+#endif

--- a/HLTrigger/Muon/plugins/HLTMuonTrackSelector.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackSelector.cc
@@ -6,6 +6,7 @@
 * Author: Kyeongpil Lee (kplee@cern.ch)
 * 
 */
+#include <cmath>
 
 #include "HLTMuonTrackSelector.h"
 
@@ -26,8 +27,6 @@ HLTMuonTrackSelector::HLTMuonTrackSelector(const edm::ParameterSet& iConfig)
       flag_copyMVA(iConfig.getParameter<bool>("copyMVA")) {
   produces<MVACollection>("MVAValues");
 }
-
-HLTMuonTrackSelector::~HLTMuonTrackSelector() {}
 
 void HLTMuonTrackSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -89,7 +88,7 @@ void HLTMuonTrackSelector::produce(edm::StreamID, edm::Event& iEvent, const edm:
       double trackEta = track.eta();
       double trackPhi = track.phi();
 
-      if (deltaR(trackEta, trackPhi, muonEta, muonPhi) < 0.1) {
+      if (reco::deltaR2(trackEta, trackPhi, muonEta, muonPhi) < 0.01) {
         double dPt = fabs(trackPt - muonPt);
 
         if (dPt < smallestDPt) {

--- a/HLTrigger/Muon/plugins/HLTMuonTrackSelector.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrackSelector.h
@@ -1,12 +1,12 @@
-#ifndef HLTMuonTrackSelector_h
-#define HLTMuonTrackSelector_h
+#ifndef HLTrigger_Muon_HLTMuonTrackSelector_h
+#define HLTrigger_Muon_HLTMuonTrackSelector_h
 
 /*
 * class HLTMuonTrackSelector
 * 
 * Select tracks matched to the reco::Muon
 * 
-* base on RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
+* based on RecoTracker/FinalTrackSelectors/plugins/TrackCollectionFilterCloner.cc
 * 
 * Author: Kyeongpil Lee (kplee@cern.ch)
 * 
@@ -30,7 +30,7 @@
 class HLTMuonTrackSelector : public edm::global::EDProducer<> {
 public:
   explicit HLTMuonTrackSelector(const edm::ParameterSet &);
-  ~HLTMuonTrackSelector() override;
+  ~HLTMuonTrackSelector() override = default;
 
   using MVACollection = std::vector<float>;
 
@@ -47,4 +47,4 @@ private:
   const bool flag_copyMVA;
 };
 
-#endif  //HLTMuonTrackSelector_h
+#endif

--- a/HLTrigger/btau/plugins/HLTmumutkVtxProducer.h
+++ b/HLTrigger/btau/plugins/HLTmumutkVtxProducer.h
@@ -1,7 +1,7 @@
-#ifndef HLTmumutkVtxProducer_h
-#define HLTmumutkVtxProducer_h
+#ifndef HLTrigger_btau_HLTmumutkVtxProducer_h
+#define HLTrigger_btau_HLTmumutkVtxProducer_h
 //
-// Package:    HLTstaging
+// Package:    HLTrigger/btau
 // Class:      HLTmumutkVtxProducer
 //
 /**\class HLTmumutkVtxProducer
@@ -12,8 +12,8 @@
      <Notes on implementation>
 */
 
-// system include files
 #include <memory>
+#include <vector>
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,6 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include <vector>
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -47,8 +46,10 @@ class MagneticField;
 class HLTmumutkVtxProducer : public edm::stream::EDProducer<> {
 public:
   explicit HLTmumutkVtxProducer(const edm::ParameterSet&);
-  ~HLTmumutkVtxProducer() override;
+  ~HLTmumutkVtxProducer() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -74,9 +75,10 @@ private:
   const double minInvMass_;
   const double maxInvMass_;
   const double minD0Significance_;
-  const double overlapDR_;
+  const double overlapDR2_;
 
   const edm::InputTag beamSpotTag_;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
 };
+
 #endif

--- a/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.cc
+++ b/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.cc
@@ -23,7 +23,6 @@ using namespace reco;
 using namespace std;
 using namespace trigger;
 
-// ----------------------------------------------------------------------
 HLTmumutktkVtxProducer::HLTmumutktkVtxProducer(const edm::ParameterSet& iConfig)
     : transientTrackRecordToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
       muCandTag_(iConfig.getParameter<edm::InputTag>("MuCand")),
@@ -44,14 +43,12 @@ HLTmumutktkVtxProducer::HLTmumutktkVtxProducer(const edm::ParameterSet& iConfig)
       maxTrkTrkMass_(iConfig.getParameter<double>("MaxTrkTrkMass")),
       minD0Significance_(iConfig.getParameter<double>("MinD0Significance")),
       oppositeSign_(iConfig.getParameter<bool>("OppositeSign")),
-      overlapDR_(iConfig.getParameter<double>("OverlapDR")),
+      // minimum delta-R^2 threshold (with sign) for non-overlapping tracks
+      overlapDR2_(iConfig.getParameter<double>("OverlapDR") * std::abs(iConfig.getParameter<double>("OverlapDR"))),
       beamSpotTag_(iConfig.getParameter<edm::InputTag>("BeamSpotTag")),
       beamSpotToken_(consumes<reco::BeamSpot>(beamSpotTag_)) {
   produces<VertexCollection>();
 }
-
-// ----------------------------------------------------------------------
-HLTmumutktkVtxProducer::~HLTmumutktkVtxProducer() = default;
 
 void HLTmumutktkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -74,7 +71,6 @@ void HLTmumutktkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& de
   descriptions.add("HLTmumutktkVtxProducer", desc);
 }
 
-// ----------------------------------------------------------------------
 void HLTmumutktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const double MuMass(0.106);
   const double MuMass2(MuMass * MuMass);
@@ -278,9 +274,7 @@ FreeTrajectoryState HLTmumutktkVtxProducer::initialFreeState(const reco::Track& 
 }
 
 bool HLTmumutktkVtxProducer::overlap(const TrackRef& trackref1, const TrackRef& trackref2) {
-  if (deltaR(trackref1->eta(), trackref1->phi(), trackref2->eta(), trackref2->phi()) < overlapDR_)
-    return true;
-  return false;
+  return (reco::deltaR2(trackref1->eta(), trackref1->phi(), trackref2->eta(), trackref2->phi()) < overlapDR2_);
 }
 
 bool HLTmumutktkVtxProducer::checkPreviousCand(const TrackRef& trackref,

--- a/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.h
+++ b/HLTrigger/btau/plugins/HLTmumutktkVtxProducer.h
@@ -1,11 +1,14 @@
-#ifndef HLTmumutktkVtxProducer_h
-#define HLTmumutktkVtxProducer_h
+#ifndef HLTrigger_btau_HLTmumutktkVtxProducer_h
+#define HLTrigger_btau_HLTmumutktkVtxProducer_h
 //
-// Package:    HLTstaging
+// Package:    HLTrigger/btau
 // Class:      HLTmumutktkVtxProducer
 //
 /**\class HLTmumutktkVtxProducer
 */
+
+#include <vector>
+#include <memory>
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,8 +24,6 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include <vector>
-#include <memory>
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -41,8 +42,10 @@ class MagneticField;
 class HLTmumutktkVtxProducer : public edm::stream::EDProducer<> {
 public:
   explicit HLTmumutktkVtxProducer(const edm::ParameterSet&);
-  ~HLTmumutktkVtxProducer() override;
+  ~HLTmumutktkVtxProducer() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
@@ -72,8 +75,9 @@ private:
   const double maxTrkTrkMass_;
   const double minD0Significance_;
   const bool oppositeSign_;
-  const double overlapDR_;
+  const double overlapDR2_;
   const edm::InputTag beamSpotTag_;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
 };
+
 #endif

--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -38,6 +38,7 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CaloTopology"/>

--- a/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
+++ b/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
@@ -109,9 +109,6 @@ private:
   int diff_neta_s(int, int);
   int diff_nphi_s(int, int);
 
-  static float DeltaPhi(float phi1, float phi2);
-  static float GetDeltaR(float eta1, float eta2, float phi1, float phi2);
-
   edm::ESGetToken<CaloTopology, CaloTopologyRecord> const caloTopologyRecordToken_;
   edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> const ecalChannelStatusRcdToken_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> const caloGeometryRecordToken_;
@@ -141,7 +138,7 @@ private:
   double seleMinvMinBarrel_;
   double seleS4S9Gamma_;
   double seleS9S25Gamma_;
-  double seleBeltDR_;
+  double seleBeltDR2_;
   double seleBeltDeta_;
   double seleIso_;
   double ptMinForIsolation_;
@@ -166,7 +163,7 @@ private:
   double seleS4S9GammaEndCap_;
   double seleS9S25GammaEndCap_;
   double seleIsoEndCap_;
-  double seleBeltDREndCap_;
+  double seleBeltDR2EndCap_;
   double seleBeltDetaEndCap_;
   double ptMinForIsolationEndCap_;
   bool store5x5RecHitEE_;

--- a/HLTrigger/special/plugins/HLTHcalNoiseFilter.cc
+++ b/HLTrigger/special/plugins/HLTHcalNoiseFilter.cc
@@ -85,8 +85,8 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent,
         JetContainer.push_back(calojetIter);
         double maxTowerE = 0.0;
         for (auto const& kal : *towerHandle) {
-          double dR = deltaR(calojetIter.eta(), calojetIter.phi(), kal.eta(), kal.phi());
-          if ((dR < 0.50) and (kal.p() > maxTowerE)) {
+          double const dR2 = reco::deltaR2(calojetIter.eta(), calojetIter.phi(), kal.eta(), kal.phi());
+          if (dR2 < 0.25 and kal.p() > maxTowerE) {
             maxTowerE = kal.p();
             seedTower = kal;
           }


### PR DESCRIPTION
#### PR description:

This PR replaces calls to `reco::deltaR` (or similar methods) with the faster `reco::deltaR2` (or, where appropriate, delta-R^2 calculated explicitly as `deta*deta + dphi*dphi`) in the `HLTrigger/*/` packages. Some notes below.
 - Not all the plugins touched by this PR are used in the current Run-3 HLT menu (many plugins in `HLTrigger/*/` are old and unused).
 - The changes in this PR are meant to preserve the current behaviour of all involved plugins.
 - In plugins where an upper/lower bound on a Delta-R distance is taken from the PSet, the value is converted to Delta-R^2 times the sign of the input value (using `deltaR x |deltaR|`). This preserves the current behaviour of these plugins when a negative `deltaR` value is specified in the PSet.
 - The change in throughput for the current Run-3 HLT menu was not quantified. It is assumed to be small (and in the right direction, i.e. faster).
 - Minor technical improvements are also applied to some of the plugins touched by this PR.

Merely technical. No changes expected.

#### PR validation:

`addOnTests.py` passed (I did not verify that the trigger results remain exactly the same).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
