### PR TITLE
use `HIDQM*` streams in online-DQM clients if `runType==hi_run`

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -46,14 +46,22 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
   process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
   from DQM.Integration.config.unitteststreamerinputsource_cfi import options
-  # new stream label
-  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+  # stream label
+  if process.runType.getRunType() == process.runType.hi_run:
+    process.source.streamLabel = 'streamHIDQMOnlineBeamspot'
+  else:
+    process.source.streamLabel = 'streamDQMOnlineBeamspot'
+
 elif live:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")
   from DQM.Integration.config.inputsource_cfi import options
-  # new stream label
-  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+  # stream label
+  if process.runType.getRunType() == process.runType.hi_run:
+    process.source.streamLabel = 'streamHIDQMOnlineBeamspot'
+  else:
+    process.source.streamLabel = 'streamDQMOnlineBeamspot'
+
 else:
   process.load("DQM.Integration.config.fileinputsource_cfi")
   from DQM.Integration.config.fileinputsource_cfi import options

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -38,13 +38,6 @@ else:
   process.load("DQM.Integration.config.fileinputsource_cfi")
   from DQM.Integration.config.fileinputsource_cfi import options
 
-# new stream label
-#process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
-
-# for testing in lxplus
-#process.load("DQM.Integration.config.fileinputsource_cfi")
-#from DQM.Integration.config.fileinputsource_cfi import options
-
 #--------------------------
 # HLT Filter
 # 0=random, 1=physics, 2=calibration, 3=technical
@@ -173,6 +166,4 @@ print("Configured frontierKey", options.runUniqueKey)
 # Final path
 print("Final Source settings:", process.source)
 
-process.p = cms.Path(process.dqmcommon
-                    * process.monitor )
-
+process.p = cms.Path( process.dqmcommon * process.monitor )

--- a/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
@@ -159,10 +159,8 @@ process.preScaler.prescaleFactor = 1
 
 process.source.streamLabel = "streamDQMCalibration"
 
-
 process.ecalPedestalMonitorTask.verbosity = 0
 process.ecalPedestalMonitorTask.commonParameters.onlineMode = True
-
 
 process.ecalLaserLedMonitorTask.verbosity = 0
 process.ecalLaserLedMonitorTask.collectionTags.EBLaserLedUncalibRecHit = "ecalLaserLedUncalibRecHit:EcalUncalibRecHitsEB"

--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -4,9 +4,7 @@ import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("process", Run3)
 
-unitTest = False
-if 'unitTest=True' in sys.argv:
-    unitTest=True
+unitTest = 'unitTest=True' in sys.argv
 
 ### Load cfis ###
 
@@ -58,7 +56,11 @@ process.maxEvents = cms.untracked.PSet(
 process.preScaler.prescaleFactor = 1
 
 if not options.inputFiles:
-    process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
+    # stream label
+    if process.runType.getRunType() == process.runType.hi_run:
+        process.source.streamLabel = "streamHIDQMGPUvsCPU"
+    else:
+        process.source.streamLabel = "streamDQMGPUvsCPU"
 
 process.dqmEnv.subSystemFolder = 'Ecal'
 process.dqmSaver.tag = 'EcalGPU'

--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -21,36 +21,42 @@ errorstr     = "### HcalDQM::cfg::ERROR:"
 useOfflineGT = False
 useFileInput = False
 useMap       = False
-
-unitTest = False
-if 'unitTest=True' in sys.argv:
-	unitTest=True
-	useFileInput=False
+unitTest     = 'unitTest=True' in sys.argv
 
 #-------------------------------------
 #	Central DQM Stuff imports
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
+
 if useOfflineGT:
-	process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-	process.GlobalTag.globaltag = autoCond['run3_data_prompt'] 
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+    process.GlobalTag.globaltag = autoCond['run3_data_prompt']
 else:
-	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+    process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+
 if unitTest:
-        process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
-        from DQM.Integration.config.unitteststreamerinputsource_cfi import options
+    process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+    from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 elif useFileInput:
-	process.load("DQM.Integration.config.fileinputsource_cfi")
-	from DQM.Integration.config.fileinputsource_cfi import options
+    process.load("DQM.Integration.config.fileinputsource_cfi")
+    from DQM.Integration.config.fileinputsource_cfi import options
 else:
-	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options
+    process.load('DQM.Integration.config.inputsource_cfi')
+    from DQM.Integration.config.inputsource_cfi import options
+
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
 #	Central DQM Customization
 #-------------------------------------
-process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
+
+if not useFileInput:
+    # stream label
+    if process.runType.getRunType() == process.runType.hi_run:
+        process.source.streamLabel = "streamHIDQMGPUvsCPU"
+    else:
+        process.source.streamLabel = "streamDQMGPUvsCPU"
+
 process.dqmEnv.subSystemFolder = subsystem
 process.dqmSaver.tag = 'HcalGPU'
 process.dqmSaver.runNumber = options.runNumber

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -23,10 +23,8 @@ process = cms.Process("OnlineBeamMonitor", Run3)
 #    destinations = cms.untracked.vstring('cerr'),
 #)
 
+unitTest = 'unitTest=True' in sys.argv
 
-unitTest=False
-if 'unitTest=True' in sys.argv:
-  unitTest=True
 #-----------------------------
 if unitTest:
   import FWCore.ParameterSet.VarParsing as VarParsing
@@ -97,16 +95,11 @@ if unitTest:
   process.source.firstRun = cms.untracked.uint32(options.runNumber)
   process.source.firstLuminosityBlock = cms.untracked.uint32(1)
   process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(2)
-  process.maxEvents = cms.untracked.PSet(
-              input = cms.untracked.int32(100)
-)
+  process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 else:
   process.load("DQM.Integration.config.inputsource_cfi")
   from DQM.Integration.config.inputsource_cfi import options
-  # for live online DQM in P5
-  # new stream label
-  #process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 #ESProducer
 process.load("CondCore.CondDB.CondDB_cfi")
@@ -168,7 +161,6 @@ process.monitor = cms.Sequence(process.dqmOnlineBeamMonitor)
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+process.p = cms.Path( process.dqmcommon * process.monitor )
 
-process.p = cms.Path( process.dqmcommon
-                        * process.monitor )
 print("Final Source settings:", process.source)

--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -21,36 +21,42 @@ errorstr     = "### PixelDQM::cfg::ERROR:"
 useOfflineGT = False
 useFileInput = False
 useMap       = False
-
-unitTest = False
-if 'unitTest=True' in sys.argv:
-	unitTest=True
-	useFileInput=False
+unitTest     = 'unitTest=True' in sys.argv
 
 #-------------------------------------
 #	Central DQM Stuff imports
 #-------------------------------------
 from DQM.Integration.config.online_customizations_cfi import *
+
 if useOfflineGT:
-        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-        process.GlobalTag.globaltag = autoCond['run3_data_prompt'] 
+    process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+    process.GlobalTag.globaltag = autoCond['run3_data_prompt']
 else:
-	process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+    process.load('DQM.Integration.config.FrontierCondition_GT_cfi')
+
 if unitTest:
-	process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
-	from DQM.Integration.config.unitteststreamerinputsource_cfi import options
+    process.load("DQM.Integration.config.unitteststreamerinputsource_cfi")
+    from DQM.Integration.config.unitteststreamerinputsource_cfi import options
 elif useFileInput:
-	process.load("DQM.Integration.config.fileinputsource_cfi")
-	from DQM.Integration.config.fileinputsource_cfi import options
+    process.load("DQM.Integration.config.fileinputsource_cfi")
+    from DQM.Integration.config.fileinputsource_cfi import options
 else:
-	process.load('DQM.Integration.config.inputsource_cfi')
-	from DQM.Integration.config.inputsource_cfi import options
+    process.load('DQM.Integration.config.inputsource_cfi')
+    from DQM.Integration.config.inputsource_cfi import options
+
 process.load('DQM.Integration.config.environment_cfi')
 
 #-------------------------------------
 #	Central DQM Customization
 #-------------------------------------
-process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
+
+if not useFileInput:
+    # stream label
+    if process.runType.getRunType() == process.runType.hi_run:
+        process.source.streamLabel = "streamHIDQMGPUvsCPU"
+    else:
+        process.source.streamLabel = "streamDQMGPUvsCPU"
+
 process.dqmEnv.subSystemFolder = subsystem
 process.dqmSaver.tag = 'PixelGPU'
 process.dqmSaver.runNumber = options.runNumber

--- a/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ppsrandom_dqm_sourceclient-live_cfg.py
@@ -5,10 +5,7 @@ from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process('CTPPSDQM', Run3)
 
 test = False
-unitTest = False
-
-if 'unitTest=True' in sys.argv:
-  unitTest=True
+unitTest = 'unitTest=True' in sys.argv
 
 # event source
 if unitTest:
@@ -29,7 +26,7 @@ else:
     'drop *',
     'keep FEDRawDataCollection_*_*_*'
   )
-  
+
 process.source.streamLabel = "streamDQMPPSRandom"
 
 # DQM environment

--- a/DQM/Integration/python/clients/ramdisk_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ramdisk_dqm_sourceclient-live_cfg.py
@@ -30,6 +30,10 @@ process.analyzer = DQMEDAnalyzer('RamdiskMonitor',
     )
 )
 
+# stream label
+if process.runType.getRunType() == process.runType.hi_run:
+    process.analyzer.streamLabels[0] = "streamHIDQM"
+
 process.p = cms.Path(process.analyzer)
 process.dqmsave_step = cms.Path(process.dqmEnv * process.dqmSaver)
 

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -7,9 +7,7 @@ from Configuration.DataProcessing.GetScenario import getScenario
 Example configuration for online reconstruction meant for visualization clients.
 """
 
-unitTest = False
-if 'unitTest=True' in sys.argv:
-    unitTest=True
+unitTest = 'unitTest=True' in sys.argv
 
 if unitTest:
     from DQM.Integration.config.unittestinputsource_cfi import options, runType, source
@@ -73,9 +71,15 @@ if not unitTest:
     process.source.skipFirstLumis                = True
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
-    process.source.streamLabel                   = 'streamDQMEventDisplay'
-    if options.BeamSplashRun :
-      set_BeamSplashRun_settings( process.source )
+
+    if options.BeamSplashRun:
+        set_BeamSplashRun_settings( process.source )
+
+    # stream label
+    if runType.getRunType() == runType.hi_run:
+        process.source.streamLabel = "streamHIDQMEventDisplay"
+    else:
+        process.source.streamLabel = "streamDQMEventDisplay"
 
     m = re.search(r"\((\w+)\)", str(source.runNumber))
     runno = str(m.group(1))

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -71,7 +71,6 @@ if not unitTest:
     process.source.skipFirstLumis                = True
     process.source.minEventsPerLumi              = 0
     process.source.nextLumiTimeoutMillis         = 10000
-    process.source.streamLabel                   = 'streamDQM'
     if options.BeamSplashRun :
       set_BeamSplashRun_settings( process.source )
 

--- a/DQM/Integration/python/config/inputsource_cfi.py
+++ b/DQM/Integration/python/config/inputsource_cfi.py
@@ -89,7 +89,7 @@ options.parseArguments()
 
 runType = RunType()
 if not options.runkey.strip():
-  options.runkey = 'pp_run'
+    options.runkey = 'pp_run'
 
 runType.setRunType(options.runkey.strip())
 
@@ -97,16 +97,22 @@ if not options.inputFiles:
     # Input source
     nextLumiTimeoutMillis = 240000
     endOfRunKills = True
-    
+
     if options.scanOnce:
         endOfRunKills = False
         nextLumiTimeoutMillis = 0
-    
+
+    # stream label
+    if runType.getRunType() == runType.hi_run:
+        streamLabel = 'streamHIDQM'
+    else:
+        streamLabel = 'streamDQM'
+
     source = cms.Source("DQMStreamerReader",
         runNumber = cms.untracked.uint32(options.runNumber),
         runInputDir = cms.untracked.string(options.runInputDir),
         SelectEvents = cms.untracked.vstring('*'),
-        streamLabel = cms.untracked.string('streamDQM'),
+        streamLabel = cms.untracked.string(streamLabel),
         scanOnce = cms.untracked.bool(options.scanOnce),
         datafnPosition = cms.untracked.uint32(options.datafnPosition),
         minEventsPerLumi = cms.untracked.int32(1),
@@ -117,6 +123,7 @@ if not options.inputFiles:
         endOfRunKills  = cms.untracked.bool(endOfRunKills),
         inputFileTransitionsEachEvent = cms.untracked.bool(False)
     )
+
 else:
     print("The list of input files is provided. Disabling discovery and running on everything.")
     files = ["file://" + x for x in options.inputFiles]


### PR DESCRIPTION
#### PR description:

As discussed in [CMSHLT-2884](https://its.cern.ch/jira/browse/CMSHLT-2884) and [CMSHLT-2923](https://its.cern.ch/jira/browse/CMSHLT-2923), the online-DQM clients currently expect the names of the streamer files produced at HLT to be the same during pp and heavy-ion (HI) data-taking alike.

On the other hand, the content of most of these DQM streams is different (in both event content and trigger selection) going from the pp to the HI menu. Because of this, during the development of the HLT menus for data-taking, TSG maintains separate DQM streams for the pp (`GRun`) and HI (`HIon`) menus in the HLT "combined table" in ConfDB. For example, the offline HI menu contains the streams `HIDQM` (main DQM stream, counterpart of the stream `DQM` in the pp menu), `HIDQMOnlineBeamspot` (counterpart of `DQMOnlineBeamspot`), `HIDQMEventDisplay` (counterpart of `DQMEventDisplay`), and `HIDQMGPUvsCPU` (counterpart of `DQMGPUvsCPU`). Right before deploying online an HI menu for real data-taking, TSG/STORM renames those streams to their "pp names" (removing the `HI`) to comply with what the online-DQM clients expect.

This PR tries to update all the online-DQM clients such that, when used for HI data-taking (`runType==hi_run`), the "HI names" of the DQM streamer files will be used instead, so that TSG will not have to do the manual renaming described above any longer. TSG and DQM agreed on this in [CMSHLT-2884](https://its.cern.ch/jira/browse/CMSHLT-2884).

For reference, the DQM streams of the HIon menu are currently as follows (`DQMCalibration` does not need a "HI" prefix, because it is exactly the same in the pp and HI menus).
```
DQMCalibration
HIDQM
HIDQMEventDisplay
HIDQMGPUvsCPU
HIDQMOnlineBeamspot
```

Merely technical. No changes expected.

FYI: @cms-sw/hlt-l2 @syuvivida

#### PR validation:

Existing unit tests pass, but I guess dedicated checks by DQM should be done. If streamer files from the 2023 HI run are available, maybe one option is to make a copy of them and rename them using the "HI names" (e.g. `*_streamDQM_*` -> `*_streamHIDQM_*`), then use those streamer files to test the online-DQM clients with `runType=hi_run` (and with this PR).

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
