### PR TITLE
Clean up some unnecessary {begin,end}{Run,LuminosityBlock} transition functions

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -116,9 +116,6 @@ public:
   /// called at end of luminosity block
   void endLuminosityBlock(const edm::EventSetup &) override;
 
-  /*   virtual void beginLuminosityBlock(const edm::EventSetup &setup) {} */
-  /*   virtual void endLuminosityBlock(const edm::EventSetup &setup) {} */
-
   /// Called in order to pass parameters to alignables for a specific run
   /// range in case the algorithm supports run range dependent alignment.
   bool setParametersForRunRange(const RunRange &runrange) override;

--- a/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
@@ -35,17 +35,9 @@
 class BooleanFlagFilter : public edm::global::EDFilter<> {
 public:
   explicit BooleanFlagFilter(const edm::ParameterSet&);
-  ~BooleanFlagFilter() override;
 
 private:
-  //virtual void beginJob() override;
   bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-  //virtual void endJob() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<bool> inputToken_;
@@ -69,11 +61,6 @@ BooleanFlagFilter::BooleanFlagFilter(const edm::ParameterSet& iConfig) {
   reverse_ = iConfig.getParameter<bool>("reverseDecision");
 }
 
-BooleanFlagFilter::~BooleanFlagFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
@@ -95,53 +82,6 @@ bool BooleanFlagFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::Eve
 
   return result;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-/*
-void 
-BooleanFlagFilter::beginJob()
-{
-}
-*/
-
-// ------------ method called once each job just after ending the event loop  ------------
-/*
-void 
-BooleanFlagFilter::endJob() {
-}
-*/
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-BooleanFlagFilter::beginRun(edm::Run const&, edm::EventSetup const&)
-{ 
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-BooleanFlagFilter::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-BooleanFlagFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-BooleanFlagFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(BooleanFlagFilter);

--- a/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectMonitor.cc
@@ -84,17 +84,12 @@ class HLTObjectMonitor : public DQMEDAnalyzer {
 
 public:
   explicit HLTObjectMonitor(const edm::ParameterSet&);
-  ~HLTObjectMonitor() override;
-
-  //      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   vector<hltPlot*> plotList;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   double dxyFinder(double, double, edm::Handle<reco::RecoChargedCandidateCollection>, edm::Handle<reco::BeamSpot>);
   double get_wall_time(void);
   // ----------member data ---------------------------
@@ -344,11 +339,6 @@ HLTObjectMonitor::HLTObjectMonitor(const edm::ParameterSet& iConfig)
   csvCaloJetsToken_ =
       consumes<vector<reco::CaloJet>>(edm::InputTag("hltSelector8CentralJetsL1FastJet", "", processName_));
   csvPfJetsToken_ = consumes<vector<reco::PFJet>>(edm::InputTag("hltPFJetForBtag", "", processName_));
-}
-
-HLTObjectMonitor::~HLTObjectMonitor() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //

--- a/DQM/HLTEvF/plugins/HLTObjectMonitorProtonLead.cc
+++ b/DQM/HLTEvF/plugins/HLTObjectMonitorProtonLead.cc
@@ -83,7 +83,6 @@ class HLTObjectMonitorProtonLead : public DQMEDAnalyzer {
 
 public:
   explicit HLTObjectMonitorProtonLead(const edm::ParameterSet&);
-  ~HLTObjectMonitorProtonLead() override;
 
   //      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -92,8 +91,6 @@ private:
   void bookHistograms(DQMStore::IBooker& i, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&) override;
   vector<hltPlot*> plotList;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   double get_wall_time(void);
   // ----------member data ---------------------------
 
@@ -325,11 +322,6 @@ HLTObjectMonitorProtonLead::HLTObjectMonitorProtonLead(const edm::ParameterSet& 
   //set Token(s)
   triggerResultsToken_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"));
   aodTriggerToken_ = consumes<trigger::TriggerEvent>(iConfig.getParameter<edm::InputTag>("triggerEvent"));
-}
-
-HLTObjectMonitorProtonLead::~HLTObjectMonitorProtonLead() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //

--- a/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TOccupancyClient.cc
@@ -248,14 +248,6 @@ void L1TOccupancyClient::dqmEndJob(DQMStore::IBooker& ibooker, DQMStore::IGetter
 }
 
 //____________________________________________________________________________
-// Function: beginLuminosityBlock
-// Description: This is will be run at the begining of each luminosity block
-// Inputs:
-// * const LuminosityBlock& lumiSeg = Luminosity Block information
-// * const EventSetup&      context = Event Setup information
-//____________________________________________________________________________
-
-//____________________________________________________________________________
 // Function: endLuminosityBlock
 // Description: This is will be run at the end of each luminosity block
 // Inputs:

--- a/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
+++ b/DQM/TrigXMonitorClient/interface/L1ScalersClient.h
@@ -28,14 +28,8 @@ public:
   /// Constructors
   L1ScalersClient(const edm::ParameterSet &ps);
 
-  /// Destructor
-  ~L1ScalersClient() override{};
-
   /// BeginJob
   void beginJob(void) override;
-
-  //   /// Endjob
-  //   void endJob(void);
 
   /// BeginRun
   void beginRun(const edm::Run &run, const edm::EventSetup &c) override;

--- a/DQMOffline/EGamma/plugins/PhotonOfflineClient.h
+++ b/DQMOffline/EGamma/plugins/PhotonOfflineClient.h
@@ -63,14 +63,7 @@ public:
   explicit PhotonOfflineClient(const edm::ParameterSet& pset);
   ~PhotonOfflineClient() override;
 
-  //  virtual void analyze(const edm::Event&, const edm::EventSetup&  ) ;
-  // virtual void beginJob() ;
-  //virtual void endJob() ;
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
-
-  //  virtual void endLuminosityBlock( const edm::LuminosityBlock& , const edm::EventSetup& ) ;
-  //virtual void endRun(const edm::Run& , const edm::EventSetup& ) ;
-  //virtual void runClient();
 
   virtual void runClient(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
   MonitorElement* bookHisto(

--- a/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineClient.h
@@ -33,7 +33,6 @@
 
 class EgHLTOfflineClient : public DQMEDHarvester {
 private:
-  // DQMStore* dbe_; //dbe seems to be the standard name for this, I dont know why. We of course dont own it
   std::string dirName_;
 
   std::vector<std::string> eleHLTFilterNames_;  //names of the filters monitored using electrons to make plots for
@@ -71,15 +70,8 @@ public:
   explicit EgHLTOfflineClient(const edm::ParameterSet&);
   ~EgHLTOfflineClient() override;
 
-  // virtual void beginJob();
-  // virtual void analyze(const edm::Event&, const edm::EventSetup&); //dummy
-  // virtual void endJob();
   void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
-  // virtual void endRun(const edm::Run& run, const edm::EventSetup& c);
-
-  // virtual void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& context){}
   // DQM Client Diagnostic
-  // virtual void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,const edm::EventSetup& c);
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;  //performed in the endJob
   void dqmEndLuminosityBlock(DQMStore::IBooker&,
                              DQMStore::IGetter&,

--- a/DQMOffline/Trigger/interface/FSQDiJetAve.h
+++ b/DQMOffline/Trigger/interface/FSQDiJetAve.h
@@ -66,8 +66,6 @@ private:
 
   void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
   void dqmBeginRun(edm::Run const& run, edm::EventSetup const& c) override;
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   //

--- a/DQMOffline/Trigger/plugins/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/plugins/FSQDiJetAve.cc
@@ -852,28 +852,6 @@ void FSQDiJetAve::bookHistograms(DQMStore::IBooker& booker, edm::Run const& run,
   }
 }
 //*/
-// ------------ method called when ending the processing of a run  ------------
-/*
-void 
-FSQDiJetAve::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void 
-FSQDiJetAve::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void 
-FSQDiJetAve::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{}
-// */
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void FSQDiJetAve::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/EGammaCutBasedEleIdAnalyzer.cc
@@ -51,7 +51,6 @@ public:
   typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsoDepositVals;
 
   explicit EGammaCutBasedEleIdAnalyzer(const edm::ParameterSet &);
-  ~EGammaCutBasedEleIdAnalyzer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget;
@@ -59,14 +58,7 @@ public:
 private:
   void beginJob() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
 
-  /*
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
-  void endRun(edm::Run const &, edm::EventSetup const &) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
-  void endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) override;
-  */
   // ----------member data ---------------------------
 
   // input tags
@@ -124,11 +116,6 @@ EGammaCutBasedEleIdAnalyzer::EGammaCutBasedEleIdAnalyzer(const edm::ParameterSet
   h1_pt_tight_ = fs->make<TH1F>("h1_pt_tight", "pt (tight)", 100, 0.0, 100.0);
   h1_pt_trig_ = fs->make<TH1F>("h1_pt_trig", "pt (trig)", 100, 0.0, 100.0);
   h1_pt_fbremeopin_ = fs->make<TH1F>("h1_pt_fbremeopin", "pt (fbremeopin)", 100, 0.0, 100.0);
-}
-
-EGammaCutBasedEleIdAnalyzer::~EGammaCutBasedEleIdAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -253,21 +240,6 @@ void EGammaCutBasedEleIdAnalyzer::beginJob() {
     EAtarget = ElectronEffectiveArea::kEleEAData2012;
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void EGammaCutBasedEleIdAnalyzer::endJob() {}
-/*
-// ------------ method called when starting to processes a run  ------------
-void EGammaCutBasedEleIdAnalyzer::beginRun(edm::Run const &, edm::EventSetup const &) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void EGammaCutBasedEleIdAnalyzer::endRun(edm::Run const &, edm::EventSetup const &) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void EGammaCutBasedEleIdAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void EGammaCutBasedEleIdAnalyzer::endLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) {}
-*/
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void EGammaCutBasedEleIdAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/MiniAODElectronIDValidationAnalyzer.cc
@@ -60,7 +60,6 @@
 class MiniAODElectronIDValidationAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit MiniAODElectronIDValidationAnalyzer(const edm::ParameterSet &);
-  ~MiniAODElectronIDValidationAnalyzer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
@@ -72,14 +71,7 @@ public:
   };  // The last does not include tau parents
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
-  void endJob() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   int matchToTruth(const reco::GsfElectron &el, const edm::Handle<edm::View<reco::GenParticle>> &genParticles);
   void findFirstNonElectronMother(const reco::Candidate *particle, int &ancestorPID, int &ancestorStatus);
@@ -157,11 +149,6 @@ MiniAODElectronIDValidationAnalyzer::MiniAODElectronIDValidationAnalyzer(const e
 
   electronTree_->Branch("isTrue", &isTrue_, "isTrue/I");
   electronTree_->Branch("isPass", &isPass_, "isPass/I");
-}
-
-MiniAODElectronIDValidationAnalyzer::~MiniAODElectronIDValidationAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -245,44 +232,6 @@ void MiniAODElectronIDValidationAnalyzer::analyze(const edm::Event &iEvent, cons
     electronTree_->Fill();
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void MiniAODElectronIDValidationAnalyzer::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void MiniAODElectronIDValidationAnalyzer::endJob() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void 
-MiniAODElectronIDValidationAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void 
-MiniAODElectronIDValidationAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void 
-MiniAODElectronIDValidationAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void 
-MiniAODElectronIDValidationAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void MiniAODElectronIDValidationAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {

--- a/EventFilter/L1TRawToDigi/plugins/AMC13DumpToRaw.cc
+++ b/EventFilter/L1TRawToDigi/plugins/AMC13DumpToRaw.cc
@@ -49,7 +49,6 @@ namespace l1t {
   class AMC13DumpToRaw : public edm::one::EDProducer<> {
   public:
     explicit AMC13DumpToRaw(const edm::ParameterSet&);
-    ~AMC13DumpToRaw() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -63,11 +62,6 @@ namespace l1t {
     //  void formatAMC(amc13::Packet& amc13, const std::vector<uint32_t>& load32);
 
     //  void formatRaw(edm::Event& iEvent, amc13::Packet& amc13, FEDRawData& fed_data);
-
-    //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
     // ----------member data ---------------------------
     std::ifstream file_;
@@ -104,11 +98,6 @@ namespace l1t {
         slinkHeaderSize_(iConfig.getUntrackedParameter<int>("lenSlinkHeader", 8)),
         slinkTrailerSize_(iConfig.getUntrackedParameter<int>("lenSlinkTrailer", 8)) {
     produces<FEDRawDataCollection>();
-  }
-
-  AMC13DumpToRaw::~AMC13DumpToRaw() {
-    // do anything here that needs to be done at desctruction time
-    // (e.g. close files, deallocate resources etc.)
   }
 
   //
@@ -226,38 +215,6 @@ namespace l1t {
 
   // ------------ method called once each job just after ending the event loop  ------------
   void AMC13DumpToRaw::endJob() { file_.close(); }
-
-  // ------------ method called when starting to processes a run  ------------
-  /*
-void 
-AMC13DumpToRaw::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when ending the processing of a run  ------------
-  /*
-void 
-AMC13DumpToRaw::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when starting to processes a luminosity block  ------------
-  /*
-vvoid 
-AMC13DumpToRaw::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when ending the processing of a luminosity block  ------------
-  /*
-void 
-AMC13DumpToRaw::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
   // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
   void AMC13DumpToRaw::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1TRawToDigi/plugins/L1TDigiToRaw.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TDigiToRaw.cc
@@ -47,19 +47,11 @@ namespace l1t {
   class L1TDigiToRaw : public edm::stream::EDProducer<> {
   public:
     explicit L1TDigiToRaw(const edm::ParameterSet&);
-    ~L1TDigiToRaw() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    using edm::stream::EDProducer<>::consumes;
-
   private:
     void produce(edm::Event&, const edm::EventSetup&) override;
-
-    void beginRun(edm::Run const&, edm::EventSetup const&) override{};
-    void endRun(edm::Run const&, edm::EventSetup const&) override{};
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
-    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
 
     // ----------member data ---------------------------
     int evtType_;
@@ -94,8 +86,6 @@ namespace l1t {
     slinkHeaderSize_ = config.getUntrackedParameter<int>("lenSlinkHeader", 8);
     slinkTrailerSize_ = config.getUntrackedParameter<int>("lenSlinkTrailer", 8);
   }
-
-  L1TDigiToRaw::~L1TDigiToRaw() {}
 
   // ------------ method called to produce the data  ------------
   void L1TDigiToRaw::produce(edm::Event& event, const edm::EventSetup& setup) {

--- a/EventFilter/L1TRawToDigi/plugins/TriggerRulePrefireVetoFilter.cc
+++ b/EventFilter/L1TRawToDigi/plugins/TriggerRulePrefireVetoFilter.cc
@@ -39,19 +39,11 @@
 class TriggerRulePrefireVetoFilter : public edm::stream::EDFilter<> {
 public:
   explicit TriggerRulePrefireVetoFilter(const edm::ParameterSet&);
-  ~TriggerRulePrefireVetoFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<TCDSRecord> tcdsRecordToken_;
@@ -71,11 +63,6 @@ private:
 TriggerRulePrefireVetoFilter::TriggerRulePrefireVetoFilter(const edm::ParameterSet& iConfig)
     : tcdsRecordToken_(consumes<TCDSRecord>(iConfig.getParameter<edm::InputTag>("tcdsRecordLabel"))) {
   //now do what ever initialization is needed
-}
-
-TriggerRulePrefireVetoFilter::~TriggerRulePrefireVetoFilter() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -130,44 +117,6 @@ bool TriggerRulePrefireVetoFilter::filter(edm::Event& iEvent, const edm::EventSe
 
   return false;
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void TriggerRulePrefireVetoFilter::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void TriggerRulePrefireVetoFilter::endStream() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-TriggerRulePrefireVetoFilter::beginRun(edm::Run const&, edm::EventSetup const&)
-{ 
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-TriggerRulePrefireVetoFilter::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-TriggerRulePrefireVetoFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-TriggerRulePrefireVetoFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void TriggerRulePrefireVetoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
+++ b/EventFilter/L1TXRawToDigi/plugins/L1TCaloLayer1RawToDigi.cc
@@ -67,14 +67,11 @@ using namespace edm;
 class L1TCaloLayer1RawToDigi : public stream::EDProducer<> {
 public:
   explicit L1TCaloLayer1RawToDigi(const ParameterSet&);
-  ~L1TCaloLayer1RawToDigi() override;
 
   static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(StreamID) override;
   void produce(Event&, const EventSetup&) override;
-  void endStream() override;
 
   void makeECalTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, std::unique_ptr<EcalTrigPrimDigiCollection>& ecalTPGs);
 
@@ -83,11 +80,6 @@ private:
   void makeHFTPGs(uint32_t lPhi, UCTCTP7RawData& ctp7Data, std::unique_ptr<HcalTrigPrimDigiCollection>& hcalTPGs);
 
   void makeRegions(uint32_t lPhi, UCTCTP7RawData& ctp7Data, std::unique_ptr<L1CaloRegionCollection>& regions);
-
-  //virtual void beginRun(Run const&, EventSetup const&) override;
-  //virtual void endRun(Run const&, EventSetup const&) override;
-  //virtual void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
-  //virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
 
   // ----------member data ---------------------------
 
@@ -121,8 +113,6 @@ L1TCaloLayer1RawToDigi::L1TCaloLayer1RawToDigi(const ParameterSet& iConfig)
 
   consumes<FEDRawDataCollection>(fedRawDataLabel);
 }
-
-L1TCaloLayer1RawToDigi::~L1TCaloLayer1RawToDigi() {}
 
 //
 // member functions
@@ -377,44 +367,6 @@ void L1TCaloLayer1RawToDigi::makeRegions(uint32_t lPhi,
     }
   }
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void L1TCaloLayer1RawToDigi::beginStream(StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void L1TCaloLayer1RawToDigi::endStream() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-  void
-  L1TCaloLayer1RawToDigi::beginRun(Run const&, EventSetup const&)
-  {
-  }
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-  void
-  L1TCaloLayer1RawToDigi::endRun(Run const&, EventSetup const&)
-  {
-  }
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-  void
-  L1TCaloLayer1RawToDigi::beginLuminosityBlock(LuminosityBlock const&, EventSetup const&)
-  {
-  }
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-  void
-  L1TCaloLayer1RawToDigi::endLuminosityBlock(LuminosityBlock const&, EventSetup const&)
-  {
-  }
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TCaloLayer1RawToDigi::fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -250,6 +250,4 @@ namespace evf {
     }
   }
 
-  void ExceptionGenerator::endLuminosityBlock(edm::LuminosityBlock const &lb, edm::EventSetup const &es) {}
-
 }  // end namespace evf

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.h
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.h
@@ -17,10 +17,8 @@ namespace evf {
     static const std::string menu[menu_items];
 
     explicit ExceptionGenerator(const edm::ParameterSet&);
-    ~ExceptionGenerator() override{};
     void beginRun(const edm::Run& r, const edm::EventSetup& iSetup) override;
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
-    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   private:
     int actionId_;

--- a/HLTrigger/HLTfilters/plugins/TestBXVectorRefProducer.cc
+++ b/HLTrigger/HLTfilters/plugins/TestBXVectorRefProducer.cc
@@ -39,19 +39,11 @@
 class TestBXVectorRefProducer : public edm::stream::EDProducer<> {
 public:
   explicit TestBXVectorRefProducer(const edm::ParameterSet&);
-  ~TestBXVectorRefProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   bool doRefs_;
@@ -82,11 +74,6 @@ TestBXVectorRefProducer::TestBXVectorRefProducer(const edm::ParameterSet& iConfi
   if (doRefs_) {
     produces<l1t::JetRefVector>("l1tJetRef").setBranchAlias("l1tJetRef");
   }
-}
-
-TestBXVectorRefProducer::~TestBXVectorRefProducer() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -126,44 +113,6 @@ void TestBXVectorRefProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
   return;
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void TestBXVectorRefProducer::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void TestBXVectorRefProducer::endStream() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-TestBXVectorRefProducer::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-TestBXVectorRefProducer::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-TestBXVectorRefProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-TestBXVectorRefProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void TestBXVectorRefProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HLTrigger/special/plugins/HLTRechitsToDigis.cc
+++ b/HLTrigger/special/plugins/HLTRechitsToDigis.cc
@@ -46,7 +46,6 @@
 class HLTRechitsToDigis : public edm::stream::EDProducer<> {
 public:
   explicit HLTRechitsToDigis(const edm::ParameterSet&);
-  ~HLTRechitsToDigis() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   enum ecalRegion { invalidRegion = 0, barrel, endcap };
   static const HLTRechitsToDigis::ecalRegion stringToRegion(const std::string& region);
@@ -123,11 +122,6 @@ HLTRechitsToDigis::HLTRechitsToDigis(const edm::ParameterSet& iConfig)
   }
 
   recHitsToken_ = consumes<EcalRecHitCollection>(recHits_);
-}
-
-HLTRechitsToDigis::~HLTRechitsToDigis() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -261,38 +255,6 @@ void HLTRechitsToDigis::produce(edm::Event& iEvent, edm::EventSetup const& setup
     }
   }  // end switch statement for the region (barrel, endcap, invalid)
 }
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-HLTRechitsToDigis::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-HLTRechitsToDigis::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-HLTRechitsToDigis::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-HLTRechitsToDigis::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HLTRechitsToDigis::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -66,10 +66,6 @@ private:
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
 
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-
   // ----------member data ---------------------------
 
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSource;
@@ -347,30 +343,6 @@ void L1TCaloLayer1::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
     twrList[twr]->setHFLUT(&hfLUT[hfPhiMap[iphi]]);
   }
 }
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-  void
-  L1TCaloLayer1::endRun(edm::Run const&, edm::EventSetup const&)
-  {
-  }
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-  void
-  L1TCaloLayer1::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-  {
-  }
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-  void
-  L1TCaloLayer1::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-  {
-  }
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TCaloLayer1::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1Validator.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1Validator.cc
@@ -46,19 +46,12 @@ using namespace l1t;
 class L1TCaloLayer1Validator : public edm::one::EDAnalyzer<> {
 public:
   explicit L1TCaloLayer1Validator(const edm::ParameterSet&);
-  ~L1TCaloLayer1Validator() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
 
@@ -143,8 +136,6 @@ L1TCaloLayer1Validator::L1TCaloLayer1Validator(const edm::ParameterSet& iConfig)
   for (uint32_t c = 0; c < 18; c++)
     ngCard[c] = nbCard[c] = zgCard[c] = zbCard[c] = 0;
 }
-
-L1TCaloLayer1Validator::~L1TCaloLayer1Validator() {}
 
 //
 // member functions
@@ -390,9 +381,6 @@ void L1TCaloLayer1Validator::analyze(const edm::Event& iEvent, const edm::EventS
   eventCount++;
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void L1TCaloLayer1Validator::beginJob() {}
-
 // ------------ method called once each job just after ending the event loop  ------------
 void L1TCaloLayer1Validator::endJob() {
   if (validateTowers)
@@ -419,38 +407,6 @@ void L1TCaloLayer1Validator::endJob() {
               << tLeTotET << " / " << tEeTotET << " / " << tGeTotET << std::endl;
   }
 }
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void 
-L1TCaloLayer1Validator::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void 
-L1TCaloLayer1Validator::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void 
-L1TCaloLayer1Validator::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void 
-L1TCaloLayer1Validator::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TCaloLayer1Validator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloAnalyzer.cc
@@ -29,19 +29,12 @@ namespace l1t {
   class L1TStage2CaloAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
   public:
     explicit L1TStage2CaloAnalyzer(const edm::ParameterSet&);
-    ~L1TStage2CaloAnalyzer() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     void beginJob() override;
     void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override;
-
-    //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
     // ----------member data ---------------------------
     edm::EDGetToken m_towerToken;
@@ -294,11 +287,6 @@ namespace l1t {
     typeStr_.push_back("sumasymethf");
     typeStr_.push_back("sumasymht");
     typeStr_.push_back("sumasymhthf");
-  }
-
-  L1TStage2CaloAnalyzer::~L1TStage2CaloAnalyzer() {
-    // do anything here that needs to be done at desctruction time
-    // (e.g. close files, deallocate resources etc.)
   }
 
   //
@@ -814,41 +802,6 @@ namespace l1t {
     hsort_ = fs->make<TH1F>("sort", "", 201, -100.5, 100.5);
     hsortMP_ = fs->make<TH1F>("sortMP", "", 201, -100.5, 100.5);
   }
-
-  // ------------ method called once each job just after ending the event loop  ------------
-  void L1TStage2CaloAnalyzer::endJob() {}
-
-  // ------------ method called when starting to processes a run  ------------
-  /*
-    void 
-    L1TStage2CaloAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
-    {
-    }
-  */
-
-  // ------------ method called when ending the processing of a run  ------------
-  /*
-    void 
-    L1TStage2CaloAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
-    {
-    }
-  */
-
-  // ------------ method called when starting to processes a luminosity block  ------------
-  /*
-    void 
-    L1TStage2CaloAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-    {
-    }
-  */
-
-  // ------------ method called when ending the processing of a luminosity block  ------------
-  /*
-    void 
-    L1TStage2CaloAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-    {
-    }
-  */
 
   // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
   void L1TStage2CaloAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2InputPatternWriter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2InputPatternWriter.cc
@@ -44,19 +44,12 @@
 class L1TStage2InputPatternWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit L1TStage2InputPatternWriter(const edm::ParameterSet&);
-  ~L1TStage2InputPatternWriter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   edm::EDGetToken m_towerToken;
@@ -116,11 +109,6 @@ L1TStage2InputPatternWriter::L1TStage2InputPatternWriter(const edm::ParameterSet
   nLink_ = nChan_ * nQuad_;
   data_.resize(nLink_);
   LogDebug("L1TDebug") << "Preparing for " << nLink_ << " links" << std::endl;
-}
-
-L1TStage2InputPatternWriter::~L1TStage2InputPatternWriter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -221,9 +209,6 @@ void L1TStage2InputPatternWriter::analyze(const edm::Event& iEvent, const edm::E
   }
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void L1TStage2InputPatternWriter::beginJob() {}
-
 // ------------ method called once each job just after ending the event loop  ------------
 void L1TStage2InputPatternWriter::endJob() {
   //frames per event
@@ -298,38 +283,6 @@ void L1TStage2InputPatternWriter::endJob() {
     outFiles[itFile].close();
   }
 }
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void 
-L1TStage2InputPatternWriter::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void 
-L1TStage2InputPatternWriter::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void 
-L1TStage2InputPatternWriter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void 
-L1TStage2InputPatternWriter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TStage2InputPatternWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer1Producer.cc
@@ -71,9 +71,6 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
 
@@ -354,27 +351,6 @@ void L1TStage2Layer1Producer::beginRun(edm::Run const& iRun, edm::EventSetup con
     }
   }
 }
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TStage2Layer1Producer::endRun(edm::Run const&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-L1TStage2Layer1Producer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup cons
-t&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-L1TStage2Layer1Producer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&
-)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TStage2Layer1Producer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2Layer2Producer.cc
@@ -65,9 +65,6 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
 
@@ -313,27 +310,6 @@ void L1TStage2Layer2Producer::beginRun(edm::Run const& iRun, edm::EventSetup con
     LogDebug("L1TDebug") << "Processor object : " << (m_processor ? 1 : 0) << std::endl;
   }
 }
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TStage2Layer2Producer::endRun(edm::Run const&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-L1TStage2Layer2Producer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup cons
-t&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-L1TStage2Layer2Producer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&
-)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TStage2Layer2Producer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalAnalyzer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalAnalyzer.cc
@@ -53,19 +53,12 @@ namespace l1t {
   class L1TGlobalAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit L1TGlobalAnalyzer(const edm::ParameterSet&);
-    ~L1TGlobalAnalyzer() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   private:
     void beginJob() override;
     void analyze(const edm::Event&, const edm::EventSetup&) override;
-    void endJob() override;
-
-    //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-    //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
     // ----------member data ---------------------------
     edm::EDGetToken m_gmuToken;
@@ -253,11 +246,6 @@ namespace l1t {
     typeStr_.push_back("tau");
     typeStr_.push_back("jet");
     typeStr_.push_back("sum");
-  }
-
-  L1TGlobalAnalyzer::~L1TGlobalAnalyzer() {
-    // do anything here that needs to be done at desctruction time
-    // (e.g. close files, deallocate resources etc.)
   }
 
   //
@@ -985,41 +973,6 @@ namespace l1t {
     hDmxVsGTSumEt_HFM1_ =
         dmxVGtDir_.make<TH2F>("hDmxVsGTSumEt_HFM1", "Dmx versus GT HFM1", 16, -0.5, 15.5, 16, -0.5, 15.5);
   }
-
-  // ------------ method called once each job just after ending the event loop  ------------
-  void L1TGlobalAnalyzer::endJob() {}
-
-  // ------------ method called when starting to processes a run  ------------
-  /*
-void 
-L1TGlobalAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when ending the processing of a run  ------------
-  /*
-void 
-L1TGlobalAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when starting to processes a luminosity block  ------------
-  /*
-void 
-L1TGlobalAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-  // ------------ method called when ending the processing of a luminosity block  ------------
-  /*
-void 
-L1TGlobalAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
   // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
   void L1TGlobalAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuDumper.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuDumper.cc
@@ -34,10 +34,9 @@ using namespace edm;
 using namespace std;
 using namespace tmeventsetup;
 
-class L1TUtmTriggerMenuDumper : public one::EDAnalyzer<edm::one::WatchLuminosityBlocks, edm::one::WatchRuns> {
+class L1TUtmTriggerMenuDumper : public one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit L1TUtmTriggerMenuDumper(const ParameterSet&);
-  ~L1TUtmTriggerMenuDumper() override;
 
   static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
@@ -48,15 +47,11 @@ private:
 
   void beginRun(Run const&, EventSetup const&) override;
   void endRun(Run const&, EventSetup const&) override;
-  void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
-  void endLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1TriggerMenuToken;
 };
 
 L1TUtmTriggerMenuDumper::L1TUtmTriggerMenuDumper(const ParameterSet& iConfig)
     : m_l1TriggerMenuToken(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd, edm::Transition::BeginRun>()) {}
-
-L1TUtmTriggerMenuDumper::~L1TUtmTriggerMenuDumper() {}
 
 void L1TUtmTriggerMenuDumper::analyze(Event const& iEvent, EventSetup const& iSetup) {}
 
@@ -186,10 +181,6 @@ void L1TUtmTriggerMenuDumper::beginRun(Run const& run, EventSetup const& iSetup)
 }
 
 void L1TUtmTriggerMenuDumper::endRun(Run const&, EventSetup const&) {}
-
-void L1TUtmTriggerMenuDumper::beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
-
-void L1TUtmTriggerMenuDumper::endLuminosityBlock(LuminosityBlock const&, EventSetup const&) {}
 
 void L1TUtmTriggerMenuDumper::fillDescriptions(ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/L1Trigger/L1TMuon/plugins/L1TBMTFConverter.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TBMTFConverter.cc
@@ -44,17 +44,12 @@ using namespace l1t;
 class L1TBMTFConverter : public edm::stream::EDProducer<> {
 public:
   explicit L1TBMTFConverter(const edm::ParameterSet&);
-  ~L1TBMTFConverter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void beginRun(const edm::Run&, edm::EventSetup const&) override;
-  void endRun(const edm::Run&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
   // ----------member data ---------------------------
   edm::EDGetTokenT<RegionalMuonCandBxCollection> m_barrelTfInputToken;
   edm::InputTag m_barrelTfInputTag;
@@ -111,11 +106,6 @@ L1TBMTFConverter::L1TBMTFConverter(const edm::ParameterSet& iConfig) {
   ptMap_[31] = 280;
 }
 
-L1TBMTFConverter::~L1TBMTFConverter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
@@ -143,18 +133,6 @@ void L1TBMTFConverter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   iEvent.put(std::move(convMuons), "ConvBMTFMuons");
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TBMTFConverter::beginRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TBMTFConverter::endRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TBMTFConverter::beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TBMTFConverter::endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TBMTFConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuon/plugins/L1TMicroGMTInputProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMicroGMTInputProducer.cc
@@ -53,11 +53,6 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void beginRun(const edm::Run&, edm::EventSetup const&) override;
-  void endRun(const edm::Run&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-
   void openFile();
   void skipHeader();
   int convertToInt(std::string& bitstr) const;
@@ -296,18 +291,6 @@ void L1TMicroGMTInputProducer::produce(edm::Event& iEvent, const edm::EventSetup
   iEvent.put(std::move(towerSums), "TriggerTowerSums");
   m_currEvt++;
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TMicroGMTInputProducer::beginRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TMicroGMTInputProducer::endRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TMicroGMTInputProducer::beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TMicroGMTInputProducer::endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TMicroGMTInputProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuon/plugins/L1TMicroGMTInputProducerFromGen.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMicroGMTInputProducerFromGen.cc
@@ -50,17 +50,11 @@ using namespace l1t;
 class L1TMicroGMTInputProducerFromGen : public edm::stream::EDProducer<> {
 public:
   explicit L1TMicroGMTInputProducerFromGen(const edm::ParameterSet&);
-  ~L1TMicroGMTInputProducerFromGen() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-
-  void beginRun(const edm::Run&, edm::EventSetup const&) override;
-  void endRun(const edm::Run&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
 
   static bool compareMuons(const RegionalMuonCand&, const RegionalMuonCand&);
 
@@ -91,11 +85,6 @@ L1TMicroGMTInputProducerFromGen::L1TMicroGMTInputProducerFromGen(const edm::Para
   produces<RegionalMuonCandBxCollection>("OverlapTFMuons");
   produces<RegionalMuonCandBxCollection>("ForwardTFMuons");
   produces<MuonCaloSumBxCollection>("TriggerTowerSums");
-}
-
-L1TMicroGMTInputProducerFromGen::~L1TMicroGMTInputProducerFromGen() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -241,18 +230,6 @@ void L1TMicroGMTInputProducerFromGen::produce(edm::Event& iEvent, const edm::Eve
   iEvent.put(std::move(towerSums), "TriggerTowerSums");
   m_currEvt++;
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TMicroGMTInputProducerFromGen::beginRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TMicroGMTInputProducerFromGen::endRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TMicroGMTInputProducerFromGen::beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TMicroGMTInputProducerFromGen::endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TMicroGMTInputProducerFromGen::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuon/plugins/L1TMuonCaloSumProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonCaloSumProducer.cc
@@ -47,17 +47,11 @@ using namespace l1t;
 class L1TMuonCaloSumProducer : public edm::stream::EDProducer<> {
 public:
   explicit L1TMuonCaloSumProducer(const edm::ParameterSet&);
-  ~L1TMuonCaloSumProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-
-  void beginRun(const edm::Run&, edm::EventSetup const&) override;
-  void endRun(const edm::Run&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
 
   edm::EDGetTokenT<CaloTowerBxCollection> m_caloTowerToken;
   edm::InputTag m_caloLabel;
@@ -81,11 +75,6 @@ L1TMuonCaloSumProducer::L1TMuonCaloSumProducer(const edm::ParameterSet& iConfig)
   //register your products
   produces<MuonCaloSumBxCollection>("TriggerTowerSums");
   produces<MuonCaloSumBxCollection>("TriggerTower2x2s");
-}
-
-L1TMuonCaloSumProducer::~L1TMuonCaloSumProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -190,18 +179,6 @@ void L1TMuonCaloSumProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   iEvent.put(std::move(towerSums), "TriggerTowerSums");
   iEvent.put(std::move(tower2x2s), "TriggerTower2x2s");
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TMuonCaloSumProducer::beginRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TMuonCaloSumProducer::endRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TMuonCaloSumProducer::beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TMuonCaloSumProducer::endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TMuonCaloSumProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -67,9 +67,6 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   static bool compareMuons(const std::shared_ptr<MicroGMTConfiguration::InterMuon>& mu1,
                            const std::shared_ptr<MicroGMTConfiguration::InterMuon>& mu2);
@@ -616,15 +613,6 @@ void L1TMuonProducer::beginRun(edm::Run const& run, edm::EventSetup const& iSetu
     // }
   }
 }
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TMuonProducer::endRun(edm::Run const&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TMuonProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TMuonProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TMuonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuon/plugins/L1TMuonQualityAdjuster.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonQualityAdjuster.cc
@@ -34,16 +34,11 @@ using namespace l1t;
 class L1TMuonQualityAdjuster : public edm::stream::EDProducer<> {
 public:
   explicit L1TMuonQualityAdjuster(const edm::ParameterSet&);
-  ~L1TMuonQualityAdjuster() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void beginRun(const edm::Run&, edm::EventSetup const&) override;
-  void endRun(const edm::Run&, edm::EventSetup const&) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
-  void endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) override;
   // ----------member data ---------------------------
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> m_barrelTfInputToken;
   edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> m_overlapTfInputToken;
@@ -78,11 +73,6 @@ L1TMuonQualityAdjuster::L1TMuonQualityAdjuster(const edm::ParameterSet& iConfig)
   produces<RegionalMuonCandBxCollection>("BMTF");
   produces<RegionalMuonCandBxCollection>("OMTF");
   produces<RegionalMuonCandBxCollection>("EMTF");
-}
-
-L1TMuonQualityAdjuster::~L1TMuonQualityAdjuster() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -160,18 +150,6 @@ void L1TMuonQualityAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& 
   iEvent.put(std::move(filteredOMTFMuons), "OMTF");
   iEvent.put(std::move(filteredEMTFMuons), "EMTF");
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TMuonQualityAdjuster::beginRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a run  ------------
-void L1TMuonQualityAdjuster::endRun(const edm::Run&, edm::EventSetup const&) {}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void L1TMuonQualityAdjuster::beginLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void L1TMuonQualityAdjuster::endLuminosityBlock(const edm::LuminosityBlock&, edm::EventSetup const&) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TMuonQualityAdjuster::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.cc
@@ -8,8 +8,6 @@ L1TMuonEndCapTrackProducer::L1TMuonEndCapTrackProducer(const edm::ParameterSet& 
   produces<l1t::RegionalMuonCandBxCollection>("EMTF");  // EMTF tracks output to uGMT
 }
 
-L1TMuonEndCapTrackProducer::~L1TMuonEndCapTrackProducer() {}
-
 void L1TMuonEndCapTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Create pointers to output products
   auto out_hits_tmp = std::make_unique<EMTFHitCollection>();  // before zero suppression

--- a/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
+++ b/L1Trigger/L1TMuonEndCap/plugins/L1TMuonEndCapTrackProducer.h
@@ -19,19 +19,11 @@
 class L1TMuonEndCapTrackProducer : public edm::stream::EDProducer<> {
 public:
   explicit L1TMuonEndCapTrackProducer(const edm::ParameterSet&);
-  ~L1TMuonEndCapTrackProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-
-  //void beginJob() override;
-  //void endJob() override;
-  //void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
 private:
   std::unique_ptr<TrackFinder> track_finder_;

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducer.cc
@@ -37,8 +37,6 @@ namespace citk {
   public:
     PFIsolationSumProducer(const edm::ParameterSet&);
 
-    ~PFIsolationSumProducer() override {}
-
     void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
     void produce(edm::Event&, const edm::EventSetup&) final;

--- a/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/CITKPFIsolationSumProducerForPUPPI.cc
@@ -27,8 +27,6 @@ namespace citk {
   public:
     PFIsolationSumProducerForPUPPI(const edm::ParameterSet&);
 
-    ~PFIsolationSumProducerForPUPPI() override {}
-
     void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
     void produce(edm::Event&, const edm::EventSetup&) final;

--- a/PhysicsTools/JetMCAlgos/plugins/ttHFGenFilter.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/ttHFGenFilter.cc
@@ -44,14 +44,11 @@
 class ttHFGenFilter : public edm::stream::EDFilter<> {
 public:
   explicit ttHFGenFilter(const edm::ParameterSet&);
-  ~ttHFGenFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
 
   virtual bool HasAdditionalBHadron(const std::vector<int>&,
                                     const std::vector<int>&,
@@ -98,11 +95,6 @@ ttHFGenFilter::ttHFGenFilter(const edm::ParameterSet& iConfig)
   taggingMode_ = iConfig.getParameter<bool>("taggingMode");
 
   produces<bool>();
-}
-
-ttHFGenFilter::~ttHFGenFilter() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -259,44 +251,6 @@ void ttHFGenFilter::FindAllTopMothers(const reco::Candidate* particle,
     }
   }
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void ttHFGenFilter::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void ttHFGenFilter::endStream() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-ttHFGenFilter::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-ttHFGenFilter::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-ttHFGenFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-ttHFGenFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void ttHFGenFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.cc
@@ -54,11 +54,6 @@ NanoAODBaseCrossCleaner::NanoAODBaseCrossCleaner(const edm::ParameterSet& params
   produces<nanoaod::FlatTable>("photons");
 }
 
-NanoAODBaseCrossCleaner::~NanoAODBaseCrossCleaner() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
@@ -129,12 +124,6 @@ void NanoAODBaseCrossCleaner::produce(edm::Event& iEvent, const edm::EventSetup&
   iEvent.put(std::move(photonsTable), "photons");
   iEvent.put(std::move(lowPtElectronsTable), "lowPtElectrons");
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void NanoAODBaseCrossCleaner::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void NanoAODBaseCrossCleaner::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void NanoAODBaseCrossCleaner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.h
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODBaseCrossCleaner.h
@@ -48,14 +48,11 @@
 class NanoAODBaseCrossCleaner : public edm::stream::EDProducer<> {
 public:
   explicit NanoAODBaseCrossCleaner(const edm::ParameterSet&);
-  ~NanoAODBaseCrossCleaner() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
   virtual void objectSelection(const edm::View<pat::Jet>& jets,
                                const edm::View<pat::Muon>& muons,
                                const edm::View<pat::Electron>& eles,
@@ -66,11 +63,6 @@ private:
                                std::vector<uint8_t>& eleBits,
                                std::vector<uint8_t>& tauBits,
                                std::vector<uint8_t>& photonBits){};
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   const std::string name_;

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -48,19 +48,11 @@
 class VertexTableProducer : public edm::stream::EDProducer<> {
 public:
   explicit VertexTableProducer(const edm::ParameterSet&);
-  ~VertexTableProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
 
@@ -97,11 +89,6 @@ VertexTableProducer::VertexTableProducer(const edm::ParameterSet& params)
   produces<nanoaod::FlatTable>("otherPVs");
   produces<nanoaod::FlatTable>("svs");
   produces<edm::PtrVector<reco::Candidate>>();
-}
-
-VertexTableProducer::~VertexTableProducer() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -194,12 +181,6 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.put(std::move(svsTable), "svs");
   iEvent.put(std::move(selCandSv));
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void VertexTableProducer::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void VertexTableProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void VertexTableProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
@@ -26,10 +26,8 @@ namespace pat {
   class PATElectronSlimmer : public edm::stream::EDProducer<> {
   public:
     explicit PATElectronSlimmer(const edm::ParameterSet& iConfig);
-    ~PATElectronSlimmer() override {}
 
     void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) final;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
   private:
     const edm::EDGetTokenT<edm::View<pat::Electron>> src_;
@@ -90,8 +88,6 @@ pat::PATElectronSlimmer::PATElectronSlimmer(const edm::ParameterSet& iConfig)
 
   produces<std::vector<pat::Electron>>();
 }
-
-void pat::PATElectronSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {}
 
 void pat::PATElectronSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;

--- a/PhysicsTools/PatAlgos/plugins/PATObjectCrossLinker.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATObjectCrossLinker.cc
@@ -46,14 +46,11 @@
 class PATObjectCrossLinker : public edm::stream::EDProducer<> {
 public:
   explicit PATObjectCrossLinker(const edm::ParameterSet&);
-  ~PATObjectCrossLinker() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
 
   template <class C1, class C2, class C3, class C4>
   void matchOneToMany(const C1& refProdOne,
@@ -84,11 +81,6 @@ private:
 
   template <class C1, class C2, class C3>
   void matchVertexToMany(const C1& refProdVtx, C2& itemsVtx, const std::string& nameVtx, C3& itemsMany);
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::View<pat::Jet>> jets_;
@@ -133,11 +125,6 @@ PATObjectCrossLinker::PATObjectCrossLinker(const edm::ParameterSet& params)
     vertices_ = consumes<edm::View<reco::VertexCompositePtrCandidate>>(verticesTag_);
     produces<std::vector<reco::VertexCompositePtrCandidate>>("vertices");
   }
-}
-
-PATObjectCrossLinker::~PATObjectCrossLinker() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -368,12 +355,6 @@ void PATObjectCrossLinker::produce(edm::Event& iEvent, const edm::EventSetup& iS
   if (!verticesTag_.label().empty())
     iEvent.put(std::move(vertices), "vertices");
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void PATObjectCrossLinker::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void PATObjectCrossLinker::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void PATObjectCrossLinker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonSlimmer.cc
@@ -28,10 +28,8 @@ namespace pat {
   class PATPhotonSlimmer : public edm::stream::EDProducer<> {
   public:
     explicit PATPhotonSlimmer(const edm::ParameterSet& iConfig);
-    ~PATPhotonSlimmer() override {}
 
     void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-    void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) final;
 
   private:
     const edm::EDGetTokenT<edm::View<pat::Photon>> src_;
@@ -85,8 +83,6 @@ pat::PATPhotonSlimmer::PATPhotonSlimmer(const edm::ParameterSet& iConfig)
 
   produces<std::vector<pat::Photon>>();
 }
-
-void pat::PATPhotonSlimmer::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup) {}
 
 void pat::PATPhotonSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;

--- a/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/DYToMuMuGenFilter.cc
@@ -15,24 +15,16 @@
 class DYToMuMuGenFilter : public edm::stream::EDFilter<> {
 public:
   explicit DYToMuMuGenFilter(const edm::ParameterSet&);
-  ~DYToMuMuGenFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
 
   edm::InputTag inputTag_;
   edm::EDGetTokenT<reco::GenParticleCollection> genParticleCollection_;
 
   edm::Handle<reco::GenParticleCollection> gen_handle;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
 };
@@ -41,8 +33,6 @@ DYToMuMuGenFilter::DYToMuMuGenFilter(const edm::ParameterSet& iConfig) {
   inputTag_ = iConfig.getParameter<edm::InputTag>("inputTag");
   genParticleCollection_ = consumes<reco::GenParticleCollection>(inputTag_);
 }
-
-DYToMuMuGenFilter::~DYToMuMuGenFilter() {}
 
 bool DYToMuMuGenFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(genParticleCollection_, gen_handle);
@@ -81,11 +71,6 @@ bool DYToMuMuGenFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
   }
   return false;
 }
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void DYToMuMuGenFilter::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void DYToMuMuGenFilter::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void DYToMuMuGenFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/MuMuForEmbeddingSelector.cc
@@ -39,19 +39,11 @@
 class MuMuForEmbeddingSelector : public edm::stream::EDProducer<> {
 public:
   explicit MuMuForEmbeddingSelector(const edm::ParameterSet&);
-  ~MuMuForEmbeddingSelector() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endStream() override;
-
-  //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<edm::View<reco::CompositeCandidate>> ZmumuCandidates_;
@@ -87,11 +79,6 @@ MuMuForEmbeddingSelector::MuMuForEmbeddingSelector(const edm::ParameterSet& iCon
   //now do what ever other initialization is needed
 }
 
-MuMuForEmbeddingSelector::~MuMuForEmbeddingSelector() {
-  // do anything here that needs to be done at destruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
@@ -119,44 +106,6 @@ void MuMuForEmbeddingSelector::produce(edm::Event& iEvent, const edm::EventSetup
   prod->push_back(chosenZCand->daughter(1)->masterClone().castTo<pat::MuonRef>());
   iEvent.put(std::move(prod));
 }
-
-// ------------ method called once each stream before processing any runs, lumis or events  ------------
-void MuMuForEmbeddingSelector::beginStream(edm::StreamID) {}
-
-// ------------ method called once each stream after processing all runs, lumis and events  ------------
-void MuMuForEmbeddingSelector::endStream() {}
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void
-MuMuForEmbeddingSelector::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void
-MuMuForEmbeddingSelector::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void
-MuMuForEmbeddingSelector::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void
-MuMuForEmbeddingSelector::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void MuMuForEmbeddingSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {


### PR DESCRIPTION
#### PR description:

This PR removes some empty or commented out {begin,end}{Run,LuminosityBlock} transition functions, destructors, or commented out functions that I came across while looking for stream modules that call `{begin,end}LuminosityBlock()` functions. Removing them makes future similar searches easier.

Resolves https://github.com/makortel/framework/issues/764

#### PR validation:

Code compiles.