### PR TITLE
Removed empty beginRun in DPGAnalysis/HcalNanoAOD modules

### DIFF
--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalUHTRTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalUHTRTableProducer.cc
@@ -56,11 +56,8 @@ public:
     */
 
 private:
-  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void produce(edm::Event&, edm::EventSetup const&) override;
 };
-
-void HcalUHTRTableProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
 void HcalUHTRTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<int> crate;

--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalUMNioTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalUMNioTableProducer.cc
@@ -40,11 +40,8 @@ public:
     */
 
 private:
-  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void produce(edm::Event&, edm::EventSetup const&) override;
 };
-
-void HcalUMNioTableProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
 void HcalUMNioTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<HcalUMNioDigi> uMNioDigi;


### PR DESCRIPTION
#### PR description:

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.

#### PR validation:

Code compiles.