### PR TITLE
Cleanup Run/LuminosityBlock methods in EventFilter

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
+++ b/EventFilter/L1TRawToDigi/plugins/L1TRawToDigi.cc
@@ -52,11 +52,6 @@ namespace l1t {
   private:
     void produce(edm::Event&, const edm::EventSetup&) override;
 
-    void beginRun(edm::Run const&, edm::EventSetup const&) override{};
-    void endRun(edm::Run const&, edm::EventSetup const&) override{};
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
-    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override{};
-
     // ----------member data ---------------------------
     edm::EDGetTokenT<FEDRawDataCollection> fedData_;
     std::vector<int> fedIds_;

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.cc
@@ -57,8 +57,6 @@ void RPCDigiMerger::fillDescriptions(edm::ConfigurationDescriptions& descs) {
   descs.add("rpcDigiMerger", desc);
 }
 
-void RPCDigiMerger::beginRun(edm::Run const& run, edm::EventSetup const& setup) {}
-
 void RPCDigiMerger::produce(edm::Event& event, edm::EventSetup const& setup) {
   // Get the digis
   // new RPCDigiCollection

--- a/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCDigiMerger.h
@@ -28,7 +28,6 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descs);
 
-  void beginRun(edm::Run const& run, edm::EventSetup const& setup) override;
   void produce(edm::Event& event, edm::EventSetup const& setup) override;
 
 protected:

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -18,26 +18,11 @@
 namespace sistrip {
 
   ExcludedFEDListProducer::ExcludedFEDListProducer(const edm::ParameterSet& pset)
-      : runNumber_(0),
-        cacheId_(0),
-        cabling_(nullptr),
-        token_(consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel"))),
-        cablingToken_(esConsumes<SiStripFedCabling, SiStripFedCablingRcd, edm::Transition::BeginRun>()) {
+      : runNumber_(0), token_(consumes(pset.getParameter<edm::InputTag>("ProductLabel"))), cablingToken_(esConsumes()) {
     produces<DetIdVector>();
   }
 
   ExcludedFEDListProducer::~ExcludedFEDListProducer() {}
-
-  void ExcludedFEDListProducer::beginRun(const edm::Run& run, const edm::EventSetup& es) {
-    uint32_t cacheId = es.get<SiStripFedCablingRcd>().cacheIdentifier();
-
-    if (cacheId_ != cacheId) {
-      cacheId_ = cacheId;
-
-      edm::ESHandle<SiStripFedCabling> c = es.getHandle(cablingToken_);
-      cabling_ = c.product();
-    }
-  }
 
   void ExcludedFEDListProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
@@ -49,6 +34,8 @@ namespace sistrip {
     if (runNumber_ != event.run()) {
       runNumber_ = event.run();
 
+      auto const& cabling = es.getData(cablingToken_);
+
       DetIdVector emptyDetIdVector;
       detids_.swap(emptyDetIdVector);
       // Reserve space in bad module list
@@ -58,7 +45,7 @@ namespace sistrip {
       event.getByToken(token_, buffers);
 
       // Retrieve FED ids from cabling map and iterate through
-      for (auto ifed = cabling_->fedIds().begin(); ifed != cabling_->fedIds().end(); ifed++) {
+      for (auto ifed = cabling.fedIds().begin(); ifed != cabling.fedIds().end(); ifed++) {
         // ignore trigger FED
         // if ( *ifed == triggerFedId_ ) { continue; }
 
@@ -69,7 +56,7 @@ namespace sistrip {
         if (input.size() == 0) {
           // std::cout << "Input size == 0 for FED number " << static_cast<int>(*ifed) << std::endl;
           // get the cabling connections for this FED
-          auto conns = cabling_->fedConnections(*ifed);
+          auto conns = cabling.fedConnections(*ifed);
           // Mark FED modules as bad
           detids_.reserve(detids_.size() + conns.size());
           for (auto iconn = conns.begin(); iconn != conns.end(); ++iconn) {

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
@@ -30,14 +30,11 @@ namespace sistrip {
     ExcludedFEDListProducer(const edm::ParameterSet& pset);
     /// default constructor
     ~ExcludedFEDListProducer() override;
-    void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     void produce(edm::Event& event, const edm::EventSetup& es) override;
 
   private:
     unsigned int runNumber_;
-    uint32_t cacheId_;
-    const SiStripFedCabling* cabling_;
     const edm::EDGetTokenT<FEDRawDataCollection> token_;
     edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> cablingToken_;
 


### PR DESCRIPTION
#### PR description:

- removed empty methods
- moved EventSetup get to produce in ExcludedFEDListProducer

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.

#### PR validation:

Code compiles.