### PR TITLE
Improve `SiPixelQualityProbabilities_PayloadInspector`

### DIFF
--- a/CondCore/SiPixelPlugins/test/testMiscellanea.sh
+++ b/CondCore/SiPixelPlugins/test/testMiscellanea.sh
@@ -19,3 +19,28 @@ getPayloadData.py \
     --test ;
 
 mv *.png $W_DIR/display/testPixelMap.png
+
+# test a given PU bin
+getPayloadData.py \
+    --plugin pluginSiPixelQualityProbabilities_PayloadInspector \
+    --plot plot_SiPixelQualityProbabilityDensityPerPUbin \
+    --tag SiPixelQualityProbabilities_UltraLegacy2018_v0_mc \
+    --input_params '{"PU bin": "10"}' \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/display/testSiPixelQualityProbabilityDensity.png
+
+# test all PU bins
+getPayloadData.py \
+    --plugin pluginSiPixelQualityProbabilities_PayloadInspector \
+    --plot plot_SiPixelQualityProbabilityDensityPerPUbin \
+    --tag SiPixelQualityProbabilities_2023_v2_BPix_mc \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+mv *.png $W_DIR/display/testSiPixelQualityProbabilityDensity_v2.png


### PR DESCRIPTION
#### PR description:

 - improve labeling for `SiPixelQualityProbabilitiesScenariosCount`
 - add an input parameter-driven class (`SiPixelQualityProbabilityDensityPerPUbin`) to display the aggregate probability density function vs scenario (per PU bin)

#### PR validation:

Relies on private tests (see e.g. [here](http://musich.web.cern.ch/musich/display/testPUbinSiPixelQualProb/)).
For example:

```bash
getPayloadData.py \
    --plugin pluginSiPixelQualityProbabilities_PayloadInspector \
    --plot plot_SiPixelQualityProbabilityDensityPerPUbin \
    --tag SiPixelQualityProbabilities_UltraLegacy2018_v0_mc \
    --input_params '{"PU bin": "10"}' \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test ;
```

yields

![image](https://github.com/cms-sw/cmssw/assets/5082376/cc33fde4-0b0d-486c-ace5-be7f74e0de52)



#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/a