### PR TITLE
Remove beginRun/beginLuminosityBlock methods in EGammaElectronProducers

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -82,8 +82,6 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
   //void endJob() override;
 
-  void beginRun(edm::Run const&, edm::EventSetup const&) override{};
-
   void print();
 
   // ----------member data ---------------------------

--- a/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
+++ b/L1Trigger/L1THGCalUtilities/plugins/CaloTruthCellsProducer.cc
@@ -31,7 +31,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, edm::EventSetup const&) override;
 
   std::unordered_map<uint32_t, double> makeHitMap(edm::Event const&,
@@ -47,7 +46,6 @@ private:
   edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEfront_;
   edm::EDGetTokenT<std::vector<PCaloHit>> simHitsTokenHEback_;
   edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
-  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeomHandle_;
 
   HGCalClusteringDummyImpl dummyClustering_;
   HGCalShowerShape showerShape_;
@@ -74,24 +72,19 @@ CaloTruthCellsProducer::CaloTruthCellsProducer(edm::ParameterSet const& config)
 
 CaloTruthCellsProducer::~CaloTruthCellsProducer() {}
 
-void CaloTruthCellsProducer::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
-  triggerGeomHandle_ = es.getHandle(triggerGeomToken_);
-}
-
 void CaloTruthCellsProducer::produce(edm::Event& event, edm::EventSetup const& setup) {
-  edm::Handle<CaloParticleCollection> caloParticlesHandle;
-  event.getByToken(caloParticlesToken_, caloParticlesHandle);
-  auto const& caloParticles(*caloParticlesHandle);
+  auto caloParticlesHandle = event.getHandle(caloParticlesToken_);
+  auto const& caloParticles = *caloParticlesHandle;
 
-  edm::Handle<l1t::HGCalTriggerCellBxCollection> triggerCellsHandle;
-  event.getByToken(triggerCellsToken_, triggerCellsHandle);
-  auto const& triggerCells(*triggerCellsHandle);
+  auto const& triggerCellsHandle = event.getHandle(triggerCellsToken_);
+  auto const& triggerCells = *triggerCellsHandle;
 
-  auto const& geometry(*triggerGeomHandle_);
+  auto const& geometry = setup.getData(triggerGeomToken_);
+  ;
 
-  dummyClustering_.setGeometry(triggerGeomHandle_.product());
-  showerShape_.setGeometry(triggerGeomHandle_.product());
-  triggerTools_.setGeometry(triggerGeomHandle_.product());
+  dummyClustering_.setGeometry(&geometry);
+  showerShape_.setGeometry(&geometry);
+  triggerTools_.setGeometry(&geometry);
 
   std::unordered_map<uint32_t, CaloParticleRef> tcToCalo;
 

--- a/L1Trigger/L1TZDC/plugins/L1TZDCProducer.cc
+++ b/L1Trigger/L1TZDC/plugins/L1TZDCProducer.cc
@@ -66,8 +66,6 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void beginRun(edm::Run const&, edm::EventSetup const&) override;
-
   // ----------member data ---------------------------
 
   // input tokens
@@ -156,9 +154,6 @@ void L1TZDCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   // Output in this case will be an empty collection
   iEvent.emplace(etToken_, std::move(etsumsReduced));
 }
-
-// ------------ method called when starting to processes a run  ------------
-void L1TZDCProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void L1TZDCProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
@@ -66,8 +66,6 @@ public:
 
   static void globalEndJob(lowptgsfeleseed::HeavyObjectCache const*) {}
 
-  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
@@ -184,7 +182,7 @@ LowPtGsfElectronSeedProducer::LowPtGsfElectronSeedProducer(const edm::ParameterS
       trajectoryFitterToken_{esConsumes(conf.getParameter<edm::ESInputTag>("Fitter"))},
       trajectorySmootherToken_{esConsumes(conf.getParameter<edm::ESInputTag>("Smoother"))},
       builderToken_{esConsumes(conf.getParameter<edm::ESInputTag>("TTRHBuilder"))},
-      magToken_{esConsumes<edm::Transition::BeginLuminosityBlock>()},
+      magToken_{esConsumes()},
       ecalClusterToolsESGetTokens_{consumesCollector()},
       passThrough_(conf.getParameter<bool>("PassThrough")),
       usePfTracks_(conf.getParameter<bool>("UsePfTracks")),
@@ -204,13 +202,8 @@ LowPtGsfElectronSeedProducer::LowPtGsfElectronSeedProducer(const edm::ParameterS
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
-void LowPtGsfElectronSeedProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const& setup) {
-  field_ = setup.getHandle(magToken_);
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////
-//
 void LowPtGsfElectronSeedProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  field_ = setup.getHandle(magToken_);
   // Products
   auto seeds = std::make_unique<reco::ElectronSeedCollection>();
   auto ecalPreIds = std::make_unique<reco::PreIdCollection>();


### PR DESCRIPTION
#### PR description:

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.

#### PR validation:

Code compiles.