### PR TITLE
Removed beginRun methods in  RecoLocalCalo

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalDetIdToBeRecoveredProducer.cc
@@ -38,7 +38,6 @@ class EcalDetIdToBeRecoveredProducer : public edm::stream::EDProducer<> {
 public:
   explicit EcalDetIdToBeRecoveredProducer(const edm::ParameterSet& ps);
   void produce(edm::Event& evt, const edm::EventSetup& es) final;
-  void beginRun(edm::Run const& run, const edm::EventSetup& es) final;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
@@ -82,9 +81,9 @@ private:
 };
 
 EcalDetIdToBeRecoveredProducer::EcalDetIdToBeRecoveredProducer(const edm::ParameterSet& ps) {
-  ecalMappingToken_ = esConsumes<EcalElectronicsMapping, EcalMappingRcd, edm::Transition::BeginRun>();
-  channelStatusToken_ = esConsumes<EcalChannelStatusMap, EcalChannelStatusRcd, edm::Transition::BeginRun>();
-  ttMapToken_ = esConsumes<EcalTrigTowerConstituentsMap, IdealGeometryRecord, edm::Transition::BeginRun>();
+  ecalMappingToken_ = esConsumes<EcalElectronicsMapping, EcalMappingRcd>();
+  channelStatusToken_ = esConsumes<EcalChannelStatusMap, EcalChannelStatusRcd>();
+  ttMapToken_ = esConsumes<EcalTrigTowerConstituentsMap, IdealGeometryRecord>();
   // SRP collections
   ebSrFlagToken_ = consumes<EBSrFlagCollection>(ps.getParameter<edm::InputTag>("ebSrFlagCollection"));
   eeSrFlagToken_ = consumes<EESrFlagCollection>(ps.getParameter<edm::InputTag>("eeSrFlagCollection"));
@@ -119,16 +118,6 @@ EcalDetIdToBeRecoveredProducer::EcalDetIdToBeRecoveredProducer(const edm::Parame
   produces<std::set<EcalScDetId>>(scDetIdCollection_);
 }
 
-void EcalDetIdToBeRecoveredProducer::beginRun(edm::Run const& run, const edm::EventSetup& es) {
-  edm::ESHandle<EcalElectronicsMapping> pEcalMapping = es.getHandle(ecalMappingToken_);
-  ecalMapping_ = pEcalMapping.product();
-
-  edm::ESHandle<EcalChannelStatusMap> pChStatus = es.getHandle(channelStatusToken_);
-  chStatus_ = pChStatus.product();
-
-  ttMap_ = es.getHandle(ttMapToken_);
-}
-
 // fuction return true if "coll" have "item"
 template <typename CollT, typename ItemT>
 bool include(const CollT& coll, const ItemT& item) {
@@ -137,6 +126,10 @@ bool include(const CollT& coll, const ItemT& item) {
 }
 
 void EcalDetIdToBeRecoveredProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
+  ecalMapping_ = &es.getData(ecalMappingToken_);
+  chStatus_ = &es.getData(channelStatusToken_);
+  ttMap_ = es.getHandle(ttMapToken_);
+
   std::vector<edm::Handle<EBDetIdCollection>> ebDetIdColls;
   std::vector<edm::Handle<EEDetIdCollection>> eeDetIdColls;
   std::vector<edm::Handle<EcalElectronicsIdCollection>> ttColls;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/EERecHitGPU.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/EERecHitGPU.cc
@@ -25,7 +25,6 @@ class EERecHitGPU : public edm::stream::EDProducer<> {
 public:
   explicit EERecHitGPU(const edm::ParameterSet &ps);
   ~EERecHitGPU() override;
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
@@ -105,8 +104,6 @@ void EERecHitGPU::assert_sizes_constants_(const HGCConstantVectorData &vd) {
     edm::LogError("WrongSize") << this->assert_error_message_(
         "weights", HGCeeUncalibRecHitConstantData::ee_weights, vdata_.weights_.size());
 }
-
-void EERecHitGPU::beginRun(edm::Run const &, edm::EventSetup const &setup) {}
 
 void EERecHitGPU::produce(edm::Event &event, const edm::EventSetup &setup) {
   cms::cuda::ScopedContextProduce ctx{event.streamID()};

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HEBRecHitGPU.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HEBRecHitGPU.cc
@@ -25,7 +25,6 @@ class HEBRecHitGPU : public edm::stream::EDProducer<> {
 public:
   explicit HEBRecHitGPU(const edm::ParameterSet &ps);
   ~HEBRecHitGPU() override;
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
@@ -87,8 +86,6 @@ void HEBRecHitGPU::assert_sizes_constants_(const HGCConstantVectorData &vd) {
   if (vdata_.weights_.size() != HGChebUncalibRecHitConstantData::heb_weights)
     edm::LogError("WrongSize") << this->assert_error_message_("weights", vdata_.fCPerMIP_.size());
 }
-
-void HEBRecHitGPU::beginRun(edm::Run const &, edm::EventSetup const &setup) {}
 
 void HEBRecHitGPU::produce(edm::Event &event, const edm::EventSetup &setup) {
   cms::cuda::ScopedContextProduce ctx{event.streamID()};

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HEFRecHitGPU.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HEFRecHitGPU.cc
@@ -25,7 +25,6 @@ class HEFRecHitGPU : public edm::stream::EDProducer<> {
 public:
   explicit HEFRecHitGPU(const edm::ParameterSet &ps);
   ~HEFRecHitGPU() override;
-  void beginRun(edm::Run const &, edm::EventSetup const &) override;
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
@@ -107,8 +106,6 @@ void HEFRecHitGPU::assert_sizes_constants_(const HGCConstantVectorData &vd) {
     edm::LogError("WrongSize") << this->assert_error_message_(
         "weights", HGChefUncalibRecHitConstantData::hef_weights, vdata_.weights_.size());
 }
-
-void HEFRecHitGPU::beginRun(edm::Run const &, edm::EventSetup const &setup) {}
 
 void HEFRecHitGPU::produce(edm::Event &event, const edm::EventSetup &setup) {
   cms::cuda::ScopedContextProduce ctx{event.streamID()};

--- a/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HFPreReconstructor.cc
@@ -60,7 +60,6 @@ private:
   typedef std::pair<HcalDetId, int> PmtAnodeId;
   typedef std::pair<PmtAnodeId, const HFQIE10Info*> QIE10InfoWithId;
 
-  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // Module configuration parameters
@@ -201,8 +200,6 @@ void HFPreReconstructor::fillInfos(const edm::Event& e, const edm::EventSetup& e
     }
   }
 }
-
-void HFPreReconstructor::beginRun(const edm::Run& r, const edm::EventSetup& es) {}
 
 // ------------ method called to produce the data  ------------
 void HFPreReconstructor::produce(edm::Event& e, const edm::EventSetup& eventSetup) {


### PR DESCRIPTION
#### PR description:

- removed empty beginRun methods
- moved EventSetup get from beginRun to produce

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.

#### PR validation:

Code compiles.