### PR TITLE
Removed empty beginRun from PFCandidateChecker

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/PFCandidateChecker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFCandidateChecker.cc
@@ -24,11 +24,7 @@ class PFCandidateChecker : public edm::stream::EDAnalyzer<> {
 public:
   explicit PFCandidateChecker(const edm::ParameterSet&);
 
-  ~PFCandidateChecker() override;
-
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-
-  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
 private:
   void printJets(const reco::PFJetCollection& pfJetsReco, const reco::PFJetCollection& pfJetsReReco) const;
@@ -95,10 +91,6 @@ PFCandidateChecker::PFCandidateChecker(const edm::ParameterSet& iConfig) {
   LogDebug("PFCandidateChecker") << " input collections : " << inputTagPFCandidatesReco_ << " "
                                  << inputTagPFCandidatesReReco_;
 }
-
-PFCandidateChecker::~PFCandidateChecker() {}
-
-void PFCandidateChecker::beginRun(const edm::Run& run, const edm::EventSetup& es) {}
 
 void PFCandidateChecker::analyze(const Event& iEvent, const EventSetup& iSetup) {
   LogDebug("PFCandidateChecker") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;


### PR DESCRIPTION
#### PR description:

Also removed empty destructor.

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.
#### PR validation:

Code compiles.