### PR TITLE
Removed beginRun/endRun methods in TrackTriggerAssociation modules

### DIFF
--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -47,9 +47,6 @@ public:
   /// Constructors
   explicit TTClusterAssociator(const edm::ParameterSet& iConfig);
 
-  /// Destructor
-  ~TTClusterAssociator() override;
-
 private:
   /// Data members
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > thePixelDigiSimLinkHandle_;
@@ -64,8 +61,6 @@ private:
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theTrackerGeometryToken_;
 
   /// Mandatory methods
-  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 };  /// Close class
@@ -93,22 +88,10 @@ TTClusterAssociator<T>::TTClusterAssociator(const edm::ParameterSet& iConfig) {
   }
 
   theTrackerGeometryToken_ = esConsumes();
-}
 
-/// Destructor
-template <typename T>
-TTClusterAssociator<T>::~TTClusterAssociator() {}
-
-/// Begin run
-template <typename T>
-void TTClusterAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   /// Print some information when loaded
   edm::LogInfo("TTClusterAssociator< ") << templateNameFinder<T>() << " > loaded.";
 }
-
-/// End run
-template <typename T>
-void TTClusterAssociator<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
 template <>

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
@@ -48,9 +48,6 @@ public:
   /// Constructors
   explicit TTStubAssociator(const edm::ParameterSet& iConfig);
 
-  /// Destructor
-  ~TTStubAssociator() override;
-
 private:
   /// Data members
   std::vector<edm::InputTag> ttStubsInputTags_;
@@ -63,8 +60,6 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTrackerTopologyToken_;
 
   /// Mandatory methods
-  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 };  /// Close class
@@ -94,22 +89,10 @@ TTStubAssociator<T>::TTStubAssociator(const edm::ParameterSet& iConfig) {
 
   theTrackerGeometryToken_ = esConsumes();
   theTrackerTopologyToken_ = esConsumes();
-}
 
-/// Destructor
-template <typename T>
-TTStubAssociator<T>::~TTStubAssociator() {}
-
-/// Begin run
-template <typename T>
-void TTStubAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   /// Print some information when loaded
   edm::LogInfo("TTStubAssociator< ") << templateNameFinder<T>() << " > loaded.";
 }
-
-/// End run
-template <typename T>
-void TTStubAssociator<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
 template <>

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
@@ -59,8 +59,6 @@ private:
   bool TTTrackAllowOneFalse2SStub;
 
   /// Mandatory methods
-  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  void endRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 };  /// Close class
@@ -90,22 +88,13 @@ TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
 
     produces<TTTrackAssociationMap<T> >(iTag.instance());
   }
+  /// Print some information when loaded
+  edm::LogInfo("TTStubAssociator< ") << "TTTrackAssociator< " << templateNameFinder<T>() << " > loaded.";
 }
 
 /// Destructor
 template <typename T>
 TTTrackAssociator<T>::~TTTrackAssociator() {}
-
-/// Begin run
-template <typename T>
-void TTTrackAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
-  /// Print some information when loaded
-  edm::LogInfo("TTStubAssociator< ") << "TTTrackAssociator< " << templateNameFinder<T>() << " > loaded.";
-}
-
-/// End run
-template <typename T>
-void TTTrackAssociator<T>::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
 /// Implement the producer
 template <>


### PR DESCRIPTION

#### PR description:

Moved printout to constructor.

This is part of framework change that will require stream modules to explicitly register to use Run/LuminosityBlock transitions.

#### PR validation:

Code compiles.