### PR TITLE
Always define stack variable in edm-global-class.py

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/edm-global-class.py
+++ b/Utilities/StaticAnalyzers/scripts/edm-global-class.py
@@ -135,6 +135,8 @@ for node in nodes:
     visited.add(node)
     if node in Hdg:
         stack = [(node, iter(Hdg[node]))]
+    else:
+        stack = []
     if node in Idg:
         Qdg = nx.dfs_preorder_nodes(Idg, node)
         for q in Qdg:


### PR DESCRIPTION
#### PR description:

Always define `stack` variable in edm-global-class.py, otherwise report creation might fail with

```
+ ./create_statics_esd_reports.sh
Traceback (most recent call last):
  File "/pool/condor/dir_2959731/jenkins/workspace/ib-run-static-checks/CMSSW_14_0_X_2024-01-07-0000/bin/el8_amd64_gcc12/edm-global-class.py", line 143, in <module>
    while stack:
NameError: name 'stack' is not defined
```

#### PR validation:

Bot tests
