### PR TITLE
Add more table producers to SiStrip AlCaNano

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/SiStripGainCalibTableProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripGainCalibTableProducer.cc
@@ -1,0 +1,164 @@
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+
+#include "CalibTracker/SiStripCommon/interface/SiStripOnTrackClusterTableProducerBase.h"
+
+class SiStripGainCalibTableProducer : public SiStripOnTrackClusterTableProducerBase {
+public:
+  explicit SiStripGainCalibTableProducer(const edm::ParameterSet& params)
+      : SiStripOnTrackClusterTableProducerBase(params), m_tkGeomToken{esConsumes<>()}, m_gainToken{esConsumes<>()} {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("name", "cluster");
+    desc.add<std::string>("doc", "");
+    desc.add<bool>("extension", false);
+    desc.add<edm::InputTag>("Tracks", edm::InputTag{"generalTracks"});
+    descriptions.add("siStripGainCalibTable", desc);
+  }
+
+  void fillTable(const std::vector<OnTrackCluster>& clusters,
+                 const edm::View<reco::Track>& tracks,
+                 nanoaod::FlatTable* table,
+                 const edm::EventSetup& iSetup) final;
+
+private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> m_tkGeomToken;
+  const edm::ESGetToken<SiStripGain, SiStripGainRcd> m_gainToken;
+
+  std::map<DetId, double> m_thicknessMap;
+  double thickness(DetId id, const TrackerGeometry* tGeom);
+};
+
+namespace {
+  bool isFarFromBorder(const TrajectoryStateOnSurface& trajState, uint32_t detId, const TrackerGeometry* tGeom) {
+    const auto gdu = tGeom->idToDetUnit(detId);
+    if ((!dynamic_cast<const StripGeomDetUnit*>(gdu)) && (!dynamic_cast<const PixelGeomDetUnit*>(gdu))) {
+      edm::LogWarning("SiStripGainCalibTableProducer")
+          << "DetId " << detId << " does not seem to belong to the tracker";
+      return false;
+    }
+    const auto plane = gdu->surface();
+    const auto trapBounds = dynamic_cast<const TrapezoidalPlaneBounds*>(&plane.bounds());
+    const auto rectBounds = dynamic_cast<const RectangularPlaneBounds*>(&plane.bounds());
+
+    static constexpr double distFromBorder = 1.0;
+    double halfLength = 0.;
+    if (trapBounds) {
+      halfLength = trapBounds->parameters()[3];
+    } else if (rectBounds) {
+      halfLength = .5 * gdu->surface().bounds().length();
+    } else {
+      return false;
+    }
+
+    const auto pos = trajState.localPosition();
+    const auto posError = trajState.localError().positionError();
+    if (std::abs(pos.y()) + posError.yy() >= (halfLength - distFromBorder))
+      return false;
+
+    return true;
+  }
+}  // namespace
+
+double SiStripGainCalibTableProducer::thickness(DetId id, const TrackerGeometry* tGeom) {
+  const auto it = m_thicknessMap.find(id);
+  if (m_thicknessMap.end() != it) {
+    return it->second;
+  } else {
+    double detThickness = 1.;
+    const auto gdu = tGeom->idToDetUnit(id);
+    const auto isPixel = (dynamic_cast<const PixelGeomDetUnit*>(gdu) != nullptr);
+    const auto isStrip = (dynamic_cast<const StripGeomDetUnit*>(gdu) != nullptr);
+    if (!isPixel && !isStrip) {
+      edm::LogWarning("SiStripGainCalibTableProducer")
+          << "DetId " << id.rawId() << " doesn't seem to belong to the Tracker";
+    } else {
+      detThickness = gdu->surface().bounds().thickness();
+    }
+    m_thicknessMap[id] = detThickness;
+    return detThickness;
+  }
+}
+
+void SiStripGainCalibTableProducer::fillTable(const std::vector<OnTrackCluster>& clusters,
+                                              const edm::View<reco::Track>& tracks,
+                                              nanoaod::FlatTable* table,
+                                              const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> tGeom = iSetup.getHandle(m_tkGeomToken);
+  edm::ESHandle<SiStripGain> stripGains = iSetup.getHandle(m_gainToken);
+
+  std::vector<double> c_localdirx;
+  std::vector<double> c_localdiry;
+  std::vector<double> c_localdirz;
+  std::vector<uint16_t> c_firststrip;
+  std::vector<uint16_t> c_nstrips;
+  std::vector<bool> c_saturation;
+  std::vector<bool> c_overlapping;
+  std::vector<bool> c_farfromedge;
+  std::vector<int> c_charge;
+  std::vector<double> c_path;
+  // NOTE only very few types are supported by NanoAOD, but more could be added (to discuss with XPOG / core software)
+  // NOTE removed amplitude vector, I don't think it was used anywhere
+  std::vector<float> c_gainused;      // NOTE was double
+  std::vector<float> c_gainusedTick;  // NOTE was double
+  for (const auto clus : clusters) {
+    const auto& ampls = clus.cluster->amplitudes();
+    const int firstStrip = clus.cluster->firstStrip();
+    const int nStrips = ampls.size();
+    double prevGain = -1;
+    double prevGainTick = -1;
+    if (stripGains.isValid()) {
+      prevGain = stripGains->getApvGain(firstStrip / 128, stripGains->getRange(clus.det, 1), 1);
+      prevGainTick = stripGains->getApvGain(firstStrip / 128, stripGains->getRange(clus.det, 0), 1);
+    }
+    const unsigned int charge = clus.cluster->charge();
+    const bool saturation = std::any_of(ampls.begin(), ampls.end(), [](uint8_t amp) { return amp >= 254; });
+
+    const bool overlapping = (((firstStrip % 128) == 0) || ((firstStrip / 128) != ((firstStrip + nStrips) / 128)) ||
+                              (((firstStrip + nStrips) % 128) == 127));
+    const auto& trajState = clus.measurement.updatedState();
+    const auto trackDir = trajState.localDirection();
+    const auto cosine = trackDir.z() / trackDir.mag();
+    const auto path = (10. * thickness(clus.det, tGeom.product())) / std::abs(cosine);
+    const auto farFromEdge = isFarFromBorder(trajState, clus.det, tGeom.product());
+    c_localdirx.push_back(trackDir.x());
+    c_localdiry.push_back(trackDir.y());
+    c_localdirz.push_back(trackDir.z());
+    c_firststrip.push_back(firstStrip);
+    c_nstrips.push_back(nStrips);
+    c_saturation.push_back(saturation);
+    c_overlapping.push_back(overlapping);
+    c_farfromedge.push_back(farFromEdge);
+    c_charge.push_back(charge);
+    c_path.push_back(path);
+    c_gainused.push_back(prevGain);
+    c_gainusedTick.push_back(prevGainTick);
+  }
+  // addColumn(table, "localdirx", c_localdirx, "<doc>");
+  // addColumn(table, "localdiry", c_localdiry, "<doc>");
+  // addColumn(table, "localdirz", c_localdirz, "<doc>");
+  // addColumn(table, "firststrip", c_firststrip, "<doc>");
+  // addColumn(table, "nstrips", c_nstrips, "<doc>");
+  addColumn(table, "saturation", c_saturation, "<doc>");
+  addColumn(table, "overlapping", c_overlapping, "<doc>");
+  addColumn(table, "farfromedge", c_farfromedge, "<doc>");
+  addColumn(table, "charge", c_charge, "<doc>");
+  // addColumn(table, "path", c_path, "<doc>");
+  // ExtendedCalibTree: also charge/path
+  addColumn(table, "gainused", c_gainused, "<doc>");
+  addColumn(table, "gainusedTick", c_gainusedTick, "<doc>");
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripGainCalibTableProducer);

--- a/CalibTracker/SiStripCommon/plugins/TkInstLumiTableProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkInstLumiTableProducer.cc
@@ -1,0 +1,73 @@
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
+#include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class TkInstLumiTableProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TkInstLumiTableProducer(const edm::ParameterSet& params)
+      : m_name(params.getParameter<std::string>("name")),
+        m_doc(params.existsAs<std::string>("doc") ? params.getParameter<std::string>("doc") : ""),
+        m_extension(params.existsAs<bool>("extension") ? params.getParameter<bool>("extension") : false),
+        m_scalerToken(consumes<LumiScalersCollection>(params.getParameter<edm::InputTag>("lumiScalers"))),
+        m_metaDataToken(consumes<OnlineLuminosityRecord>(params.getParameter<edm::InputTag>("metadata"))) {
+    produces<nanoaod::FlatTable>();
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("name", "");
+    desc.add<std::string>("doc", "");
+    desc.add<bool>("extension", false);
+    desc.add<edm::InputTag>("lumiScalers", edm::InputTag("scalersRawToDigi"));
+    desc.add<edm::InputTag>("metadata", edm::InputTag("onlineMetaDataDigis"));
+    descriptions.add("tkInstLumiTable", desc);
+  }
+
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  const std::string m_name;
+  const std::string m_doc;
+  bool m_extension;
+
+  const edm::EDGetTokenT<LumiScalersCollection> m_scalerToken;
+  const edm::EDGetTokenT<OnlineLuminosityRecord> m_metaDataToken;
+};
+
+void TkInstLumiTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto out = std::make_unique<nanoaod::FlatTable>(1, m_name, true, m_extension);
+
+  out->addColumnValue<int>("bx", iEvent.bunchCrossing(), "Bunch-crossing ID");
+
+  float instLumi{0.}, pu{0.};
+  edm::Handle<LumiScalersCollection> lumiScalers = iEvent.getHandle(m_scalerToken);
+  edm::Handle<OnlineLuminosityRecord> metaData = iEvent.getHandle(m_metaDataToken);
+
+  if (lumiScalers.isValid() && !lumiScalers->empty()) {
+    if (lumiScalers->begin() != lumiScalers->end()) {
+      instLumi = lumiScalers->begin()->instantLumi();
+      pu = lumiScalers->begin()->pileup();
+    }
+  } else if (metaData.isValid()) {
+    instLumi = metaData->instLumi();
+    pu = metaData->avgPileUp();
+  } else {
+    edm::LogInfo("TkInstLumiTableProducer")
+        << "Luminosity related collections not found in the event; will write dummy values";
+  }
+
+  out->addColumnValue<float>("instLumi", instLumi, "Instantaneous luminosity");
+  out->addColumnValue<float>("PU", pu, "Pileup");
+
+  iEvent.put(std::move(out));
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TkInstLumiTableProducer);

--- a/CalibTracker/SiStripCommon/test/testCalibTree_nano.py
+++ b/CalibTracker/SiStripCommon/test/testCalibTree_nano.py
@@ -1,0 +1,99 @@
+from __future__ import print_function
+
+## adapted from produceCalibrationTree_template_cfg.py
+
+import FWCore.ParameterSet.Config as cms
+##from CalibTracker.SiStripCommon.shallowTree_test_template import * ## TODO get rid of this one
+
+process = cms.Process('CALIB')
+process.load('Configuration/StandardSequences/MagneticField_cff')
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:run3_data_PromptAnalysis")
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.Services_cff')
+
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring("/store/express/Run2023F/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/373/710/00000/e2df2f78-b95a-4f33-ae22-add59aa2903f.root"))
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+
+inTracks = cms.InputTag("ALCARECOSiStripCalMinBias")
+
+process.load('CalibTracker.SiStripCommon.prescaleEvent_cfi')
+process.load('CalibTracker.Configuration.Filter_Refit_cff')
+## use CalibrationTracks (for clusters) and CalibrationTracksRefit (for tracks)
+process.CalibrationTracks.src = inTracks
+
+tracksForCalib = cms.InputTag("CalibrationTracksRefit")
+
+process.prescaleEvent.prescale = 1
+
+process.TkCalSeq = cms.Sequence(process.prescaleEvent*process.MeasurementTrackerEvent*process.trackFilterRefit)
+
+process.load("PhysicsTools.NanoAOD.nano_cff")
+process.load("PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff")
+
+## as a test: it should be possible to add tracks fully at configuration level (+ declaring the plugin)
+from PhysicsTools.NanoAOD.common_cff import *
+## this is equivalent to ShallowTrackProducer as configured for the gain calibration
+process.tracksTable = cms.EDProducer("SimpleTrackFlatTableProducer",
+        src=tracksForCalib,
+        cut=cms.string(""),
+        name=cms.string("track"),
+        doc=cms.string("SiStripCalMinBias ALCARECO tracks"),
+        singleton=cms.bool(False),
+        extension=cms.bool(False),
+        variables=cms.PSet(
+            #chi2=Var("chi2()", float),
+            #ndof=Var("ndof()", int),
+            chi2ndof=Var("chi2()/ndof", float),
+            #charge=Var("charge()", float),
+            momentum=Var("p()", float),
+            pt=Var("pt()", float),
+            #pterr=Var("ptError()", float),
+            hitsvalid=Var("numberOfValidHits()", int), ## unsigned?
+            #hitslost=Var("numberOfLostHits()", int), ## unsigned?
+            #theta=Var("theta()", float),
+            #thetaerr=Var("thetaError()", float),
+            phi=Var("phi()", float),
+            #phierr=Var("phiError()", float),
+            eta=Var("eta()", float),
+            #etaerr=Var("etaError()", float),
+            #dxy=Var("dxy()", float),
+            #dxyerr=Var("dxyError()", float),
+            #dsz=Var("dsz()", float),
+            #dszerr=Var("dszError()", float),
+            #qoverp=Var("qoverp()", float),
+            #qoverperr=Var("qoverpError()", float),
+            #vx=Var("vx()", float),
+            #vy=Var("vy()", float),
+            #vz=Var("vz()", float),
+            algo=Var("algo()", int)
+            )
+        )
+process.load("CalibTracker.SiStripCommon.tkInstLumiTable_cfi")
+process.tkInstLumiTable.extension = True
+process.load("CalibTracker.SiStripCommon.siStripPositionCorrectionsTable_cfi")
+process.load("CalibTracker.SiStripCommon.siStripGainCalibTable_cfi")
+process.siStripPositionCorrectionsTable.Tracks = tracksForCalib
+process.siStripGainCalibTable.Tracks = tracksForCalib
+
+process.nanoCTPath = cms.Path(process.TkCalSeq *
+                              process.nanoMetadata *
+                              process.tkInstLumiTable *
+                              process.tracksTable *
+                              process.siStripPositionCorrectionsTable) #*
+                              #process.siStripGainCalibTable)
+
+process.out = cms.OutputModule("NanoAODOutputModule",
+                               fileName=cms.untracked.string("CalibTreeMC_nano.root"),
+                               outputCommands=process.NANOAODEventContent.outputCommands)
+
+process.end = cms.EndPath(process.out)

--- a/CalibTracker/SiStripCommon/test/testCalibTree_nano_G2.py
+++ b/CalibTracker/SiStripCommon/test/testCalibTree_nano_G2.py
@@ -1,0 +1,77 @@
+from __future__ import print_function
+
+## adapted from produceCalibrationTree_template_cfg.py
+
+import FWCore.ParameterSet.Config as cms
+##from CalibTracker.SiStripCommon.shallowTree_test_template import * ## TODO get rid of this one
+
+process = cms.Process('CALIB')
+process.load('Configuration/StandardSequences/MagneticField_cff')
+process.load('Configuration.Geometry.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, "auto:run3_data_PromptAnalysis")
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.Services_cff')
+
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
+
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring("/store/express/Run2023F/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/373/710/00000/e2df2f78-b95a-4f33-ae22-add59aa2903f.root"))
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+
+inTracks = cms.InputTag("ALCARECOSiStripCalMinBias")
+
+process.load('CalibTracker.SiStripCommon.prescaleEvent_cfi')
+process.load('CalibTracker.Configuration.Filter_Refit_cff')
+## use CalibrationTracks (for clusters) and CalibrationTracksRefit (for tracks)
+process.CalibrationTracks.src = inTracks
+
+tracksForCalib = cms.InputTag("CalibrationTracksRefit")
+
+process.prescaleEvent.prescale = 1
+
+process.TkCalSeq = cms.Sequence(process.prescaleEvent*process.MeasurementTrackerEvent*process.trackFilterRefit)
+
+process.load("PhysicsTools.NanoAOD.nano_cff")
+process.load("PhysicsTools.NanoAOD.NanoAODEDMEventContent_cff")
+
+## as a test: it should be possible to add tracks fully at configuration level (+ declaring the plugin)
+from PhysicsTools.NanoAOD.common_cff import *
+## this is equivalent to ShallowTrackProducer as configured for the gain calibration
+process.tracksTable = cms.EDProducer("SimpleTrackFlatTableProducer",
+        src=tracksForCalib,
+        cut=cms.string(""),
+        name=cms.string("track"),
+        doc=cms.string("SiStripCalMinBias ALCARECO tracks"),
+        singleton=cms.bool(False),
+        extension=cms.bool(False),
+        variables=cms.PSet(
+            chi2ndof=Var("chi2()/ndof", float),
+            pt=Var("pt()", float),
+            hitsvalid=Var("numberOfValidHits()", int), ## unsigned?
+            phi=Var("phi()", float),
+            eta=Var("eta()", float),
+            )
+        )
+process.load("CalibTracker.SiStripCommon.tkInstLumiTable_cfi")
+process.tkInstLumiTable.extension = True
+process.load("CalibTracker.SiStripCommon.siStripGainCalibTable_cfi")
+process.siStripGainCalibTable.Tracks = tracksForCalib
+
+process.nanoCTPath = cms.Path(process.TkCalSeq*
+        process.nanoMetadata*process.tkInstLumiTable
+        *process.tracksTable
+        *process.siStripGainCalibTable
+        )
+
+process.out = cms.OutputModule("NanoAODOutputModule",
+        fileName=cms.untracked.string("CalibTreeMC_nano_G2.root"),
+        outputCommands=process.NANOAODEventContent.outputCommands
+        )
+
+process.end = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

Title says it all, this PR is a follow-up to https://github.com/CMSTrackerDPG/Tasks/issues/9. Adds a couple more of `NANOAOD` producers for a possible future collision ALCANANO-based Strip calibration tree production.

#### PR validation:

Privately produced trees using the configuration files included in this PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
