### PR TITLE
Use HCAL noise cuts from DB only for Run3 and Phase2

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowBlock_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowBlock_cfi.py
@@ -13,6 +13,7 @@ particleFlowBlock = cms.EDProducer("PFBlockProducer",
             hbheRecHitsTag = cms.InputTag("hltHbhereco"),
             maxSeverityHB = cms.int32(9),
             maxSeverityHE = cms.int32(9),
+            usePFThresholdsFromDB = cms.bool(True),
             superClustersArePF = cms.bool(True)
         ),
         cms.PSet(

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -54,6 +54,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
                   hbheRecHitsTag = cms.InputTag("hbhereco"),
                   maxSeverityHB = cms.int32(9),
                   maxSeverityHE = cms.int32(9),
+                  usePFThresholdsFromDB = cms.bool(True),
                   superClustersArePF = cms.bool(True) ),
     # all secondary track importers
     cms.PSet( importerName = cms.string("GeneralTracksImporter"),

--- a/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowBlock_cfi.py
@@ -30,6 +30,7 @@ particleFlowBlock = cms.EDProducer(
                   hbheRecHitsTag = cms.InputTag('hbhereco'),
                   maxSeverityHB = cms.int32(9),
                   maxSeverityHE = cms.int32(9),
+                  usePFThresholdsFromDB = cms.bool(False),
                   superClustersArePF = cms.bool(True) ),
         cms.PSet( importerName = cms.string("ConversionTrackImporter"),
                   source = cms.InputTag("pfConversions"),
@@ -248,3 +249,8 @@ phase2_timing_layer.toModify(
     particleFlowBlock,
     elementImporters = _addTimingLayer
 )
+
+#--- Use DB conditions for cuts&seeds for Run3 and phase2
+from Configuration.Eras.Modifier_hcalPfCutsFromDB_cff import hcalPfCutsFromDB
+hcalPfCutsFromDB.toModify( _scImporter,
+                           usePFThresholdsFromDB = True)


### PR DESCRIPTION
#### PR description:

Follow-up of the PR https://github.com/cms-sw/cmssw/pull/43612.
In particular, this aims to solve the issue discussed in https://github.com/cms-sw/cmssw/pull/43612#issuecomment-1882484274 and subsequent comments (https://github.com/cms-sw/cmssw/pull/43612#issuecomment-1882700117, https://github.com/cms-sw/cmssw/pull/43612#issuecomment-1883159855 etc). 

#### PR validation:

`136.8` and `136.781`, which are crashing in current IBs with this type of error[*] ran fine after the changes in this PR.

[*]  
Requested conditions of type HcalPFCuts for cell (0x4538403f) (HE 16,63,3) got conditions for cell (0x0) 
Requested conditions of type HcalPFCuts for cell (0x45184441) (HE 17,65,1) got conditions for cell (0x0) 
