### PR TITLE
Exclude EndPathStatus when only 1 EndPath exists

### DIFF
--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -311,11 +311,13 @@ namespace edm {
       if (pathStatusInserter_) {  // pathStatusInserter is null for EndPaths
         pathStatusInserter_->setPathStatus(streamID, status);
       }
-      std::exception_ptr jException =
-          pathStatusInserterWorker_->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-              iInfo, streamID, ParentContext(iContext), iContext);
-      if (jException && not iException) {
-        iException = jException;
+      if (pathStatusInserterWorker_) {
+        std::exception_ptr jException =
+            pathStatusInserterWorker_->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+                iInfo, streamID, ParentContext(iContext), iContext);
+        if (jException && not iException) {
+          iException = jException;
+        }
       }
       actReg_->postPathEventSignal_(*iContext, pathContext_, status);
     } catch (...) {

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -425,12 +425,14 @@ namespace edm {
             statusOfModules[mod->id()].pathsOn_.push_back(p + offset);
           }
         }
-        status.nModules_ = uniqueModules.size() + 1;
+        status.nModules_ = uniqueModules.size();
 
         //add the EndPathStatusInserter at the end
         auto found = pathStatusInserterModuleLabelToModuleID.find(iPnC.endPaths()[p]);
-        assert(found != pathStatusInserterModuleLabelToModuleID.end());
-        status.modulesOnPath_.push_back(found->second);
+        if (found != pathStatusInserterModuleLabelToModuleID.end()) {
+          status.modulesOnPath_.push_back(found->second);
+          ++status.nModules_;
+        }
       }
     }
 
@@ -450,6 +452,11 @@ namespace edm {
     }
 
     unsigned int nPathsFinished = 0;
+    for (auto const& status : statusOfPaths) {
+      if (status.nModules_ == 0) {
+        ++nPathsFinished;
+      }
+    }
 
     //if a circular dependency exception happens, stackTrace has the info
     std::vector<unsigned int> stackTrace;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -510,13 +510,16 @@ namespace edm {
                             processConfiguration,
                             std::string("PathStatusInserter"));
 
-    makePathStatusInserters(endPathStatusInserters_,
-                            *endPathNames_,
-                            prealloc,
-                            preg,
-                            areg,
-                            processConfiguration,
-                            std::string("EndPathStatusInserter"));
+    if (endPathNames_->size() > 1) {
+      //NOTE: FinalPaths are a type of EndPath
+      makePathStatusInserters(endPathStatusInserters_,
+                              *endPathNames_,
+                              prealloc,
+                              preg,
+                              areg,
+                              processConfiguration,
+                              std::string("EndPathStatusInserter"));
+    }
 
     assert(0 < prealloc.numberOfStreams());
     streamSchedules_.reserve(prealloc.numberOfStreams());

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -1027,13 +1027,16 @@ namespace edm {
           return;
         }
       }
-      for (int empty_end_path : empty_end_paths_) {
-        std::exception_ptr except = endPathStatusInserterWorkers_[empty_end_path]
-                                        ->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-                                            info, streamID_, ParentContext(&streamContext_), &streamContext_);
-        if (except) {
-          iTask.doneWaiting(except);
-          return;
+      if (not endPathStatusInserterWorkers_.empty()) {
+        for (int empty_end_path : empty_end_paths_) {
+          std::exception_ptr except =
+              endPathStatusInserterWorkers_[empty_end_path]
+                  ->runModuleDirectly<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+                      info, streamID_, ParentContext(&streamContext_), &streamContext_);
+          if (except) {
+            iTask.doneWaiting(except);
+            return;
+          }
         }
       }
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -96,6 +96,8 @@
   <test name="testFWCoreIntegrationTransform_onPath_exception" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --onPath --exception 2>&amp;1 | fgrep 'exception for testing purposes'"/>
   <test name="testFWCoreIntegrationTransform_onPath_async_exception" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py --onPath --async --exception 2>&amp;1 | fgrep 'exception for testing purposes'"/>
 
+  <test name="testFWCoreIntegrationNoEndPathStatus" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/check_empty_event_cfg.py 2>&amp;1 | fgrep 'contains 0 products'"/>
+  
   <test name="TestFWCoreIntegrationModuleThread" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/moduleThread_test_cfg.py"/>
 
   <bin file="RandomIntProducer_t.cpp">

--- a/FWCore/Integration/test/check_empty_event_cfg.py
+++ b/FWCore/Integration/test/check_empty_event_cfg.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EMPTY")
+
+process.test = cms.EDAnalyzer("EventContentAnalyzer", listPathStatus = cms.untracked.bool(True))
+
+process.e = cms.EndPath(process.test)
+
+#process.out = cms.OutputModule("AsciiOutputModule")
+#process.e2 = cms.EndPath(process.out)
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -6,73 +6,69 @@ Module type=IntSource, Module label=source, Parameter Set ID=6f0b3d3a362a6270c80
 ++++ finished: constructing module with label 'TriggerResults' id = 1
 ++++ starting: constructing module with label 'p' id = 2
 ++++ finished: constructing module with label 'p' id = 2
-++++ starting: constructing module with label 'e' id = 3
-++++ finished: constructing module with label 'e' id = 3
-++++ starting: constructing module with label 'intProducer' id = 4
-++++ finished: constructing module with label 'intProducer' id = 4
-++++ starting: constructing module with label 'a1' id = 5
+++++ starting: constructing module with label 'intProducer' id = 3
+++++ finished: constructing module with label 'intProducer' id = 3
+++++ starting: constructing module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
-++++ finished: constructing module with label 'a1' id = 5
+++++ finished: constructing module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
-++++ starting: constructing module with label 'a2' id = 6
-++++ finished: constructing module with label 'a2' id = 6
-++++ starting: constructing module with label 'a3' id = 7
-++++ finished: constructing module with label 'a3' id = 7
-++++ starting: constructing module with label 'out' id = 8
-++++ finished: constructing module with label 'out' id = 8
-++++ starting: constructing module with label 'intProducerA' id = 9
+++++ starting: constructing module with label 'a2' id = 5
+++++ finished: constructing module with label 'a2' id = 5
+++++ starting: constructing module with label 'a3' id = 6
+++++ finished: constructing module with label 'a3' id = 6
+++++ starting: constructing module with label 'out' id = 7
+++++ finished: constructing module with label 'out' id = 7
+++++ starting: constructing module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ finished: constructing module with label 'intProducerA' id = 9
+++++ finished: constructing module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ starting: constructing module with label 'intProducerB' id = 10
-++++ finished: constructing module with label 'intProducerB' id = 10
-++++ starting: constructing module with label 'intProducerBeginProcessBlock' id = 11
-++++ finished: constructing module with label 'intProducerBeginProcessBlock' id = 11
-++++ starting: constructing module with label 'intProducerEndProcessBlock' id = 12
-++++ finished: constructing module with label 'intProducerEndProcessBlock' id = 12
-++++ starting: constructing module with label 'intProducerU' id = 13
-++++ finished: constructing module with label 'intProducerU' id = 13
-++++ starting: constructing module with label 'intVectorProducer' id = 14
-++++ finished: constructing module with label 'intVectorProducer' id = 14
+++++ starting: constructing module with label 'intProducerB' id = 9
+++++ finished: constructing module with label 'intProducerB' id = 9
+++++ starting: constructing module with label 'intProducerBeginProcessBlock' id = 10
+++++ finished: constructing module with label 'intProducerBeginProcessBlock' id = 10
+++++ starting: constructing module with label 'intProducerEndProcessBlock' id = 11
+++++ finished: constructing module with label 'intProducerEndProcessBlock' id = 11
+++++ starting: constructing module with label 'intProducerU' id = 12
+++++ finished: constructing module with label 'intProducerU' id = 12
+++++ starting: constructing module with label 'intVectorProducer' id = 13
+++++ finished: constructing module with label 'intVectorProducer' id = 13
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'intProducerA' id = 9
+++++ starting: begin job for module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ finished: begin job for module with label 'intProducerA' id = 9
+++++ finished: begin job for module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ starting: begin job for module with label 'intProducerB' id = 10
-++++ finished: begin job for module with label 'intProducerB' id = 10
-++++ starting: begin job for module with label 'intProducerBeginProcessBlock' id = 11
-++++ finished: begin job for module with label 'intProducerBeginProcessBlock' id = 11
-++++ starting: begin job for module with label 'intProducerEndProcessBlock' id = 12
-++++ finished: begin job for module with label 'intProducerEndProcessBlock' id = 12
-++++ starting: begin job for module with label 'intProducerU' id = 13
-++++ finished: begin job for module with label 'intProducerU' id = 13
-++++ starting: begin job for module with label 'intVectorProducer' id = 14
-++++ finished: begin job for module with label 'intVectorProducer' id = 14
-++++ starting: begin job for module with label 'intProducer' id = 4
-++++ finished: begin job for module with label 'intProducer' id = 4
-++++ starting: begin job for module with label 'a1' id = 5
+++++ starting: begin job for module with label 'intProducerB' id = 9
+++++ finished: begin job for module with label 'intProducerB' id = 9
+++++ starting: begin job for module with label 'intProducerBeginProcessBlock' id = 10
+++++ finished: begin job for module with label 'intProducerBeginProcessBlock' id = 10
+++++ starting: begin job for module with label 'intProducerEndProcessBlock' id = 11
+++++ finished: begin job for module with label 'intProducerEndProcessBlock' id = 11
+++++ starting: begin job for module with label 'intProducerU' id = 12
+++++ finished: begin job for module with label 'intProducerU' id = 12
+++++ starting: begin job for module with label 'intVectorProducer' id = 13
+++++ finished: begin job for module with label 'intVectorProducer' id = 13
+++++ starting: begin job for module with label 'intProducer' id = 3
+++++ finished: begin job for module with label 'intProducer' id = 3
+++++ starting: begin job for module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
-++++ finished: begin job for module with label 'a1' id = 5
+++++ finished: begin job for module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
-++++ starting: begin job for module with label 'a2' id = 6
-++++ finished: begin job for module with label 'a2' id = 6
-++++ starting: begin job for module with label 'a3' id = 7
-++++ finished: begin job for module with label 'a3' id = 7
-++++ starting: begin job for module with label 'out' id = 8
-++++ finished: begin job for module with label 'out' id = 8
+++++ starting: begin job for module with label 'a2' id = 5
+++++ finished: begin job for module with label 'a2' id = 5
+++++ starting: begin job for module with label 'a3' id = 6
+++++ finished: begin job for module with label 'a3' id = 6
+++++ starting: begin job for module with label 'out' id = 7
+++++ finished: begin job for module with label 'out' id = 7
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
-++++ starting: begin job for module with label 'e' id = 3
-++++ finished: begin job for module with label 'e' id = 3
 ++ starting: begin job
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'a1' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -84,7 +80,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ finished: begin stream for module: stream = 0 label = 'a1' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -96,19 +92,17 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ starting: begin stream for module: stream = 0 label = 'a2' id = 6
-++++ finished: begin stream for module: stream = 0 label = 'a2' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'a3' id = 7
-++++ finished: begin stream for module: stream = 0 label = 'a3' id = 7
+++++ starting: begin stream for module: stream = 0 label = 'a2' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'a2' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'a3' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'a3' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 8
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 7
 ++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'e' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'e' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 9
+++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -120,7 +114,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 9
+++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -132,25 +126,25 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ starting: begin stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ finished: begin stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ starting: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
-++++ finished: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
-++++ starting: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
-++++ finished: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 13
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 13
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 14
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 14
+++++ starting: begin stream for module: stream = 0 label = 'intProducerB' id = 9
+++++ finished: begin stream for module: stream = 0 label = 'intProducerB' id = 9
+++++ starting: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 10
+++++ finished: begin stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 10
+++++ starting: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 11
+++++ finished: begin stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 11
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 12
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 12
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 13
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 13
 ++++ starting: begin process block
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'a1' id = 4
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -162,12 +156,12 @@ ModuleCallingContext state = Prefetching
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 12
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++ starting: begin process block for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++ finished: begin process block for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 11
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++ starting: begin process block for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++ finished: begin process block for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a1' id = 4
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -179,7 +173,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin process block for module: label = 'a1' id = 5
+++++++ starting: begin process block for module: label = 'a1' id = 4
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -191,7 +185,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: begin process block for module: label = 'a1' id = 5
+++++++ finished: begin process block for module: label = 'a1' id = 4
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -203,15 +197,15 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 12
-++++++ starting: begin process block for module: label = 'intProducerEndProcessBlock' id = 12
-++++++ finished: begin process block for module: label = 'intProducerEndProcessBlock' id = 12
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a2' id = 6
-++++++ starting: begin process block for module: label = 'a2' id = 6
-++++++ finished: begin process block for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a3' id = 7
-++++++ starting: begin process block for module: label = 'a3' id = 7
-++++++ finished: begin process block for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 11
+++++++ starting: begin process block for module: label = 'intProducerEndProcessBlock' id = 11
+++++++ finished: begin process block for module: label = 'intProducerEndProcessBlock' id = 11
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a2' id = 5
+++++++ starting: begin process block for module: label = 'a2' id = 5
+++++++ finished: begin process block for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'a3' id = 6
+++++++ starting: begin process block for module: label = 'a3' id = 6
+++++++ finished: begin process block for module: label = 'a3' id = 6
 ++++ finished: begin process block
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
@@ -243,9 +237,9 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing global begin Run for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing global begin Run for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing global begin Run for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing global begin Run for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing global begin Run for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing global begin Run for module: label = 'a1' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -257,7 +251,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global begin Run for module: label = 'a1' id = 5
+++++++++ finished: prefetching before processing global begin Run for module: label = 'a1' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -269,7 +263,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: global begin run for module: label = 'a1' id = 5
+++++++ starting: global begin run for module: label = 'a1' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -281,7 +275,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: global begin run for module: label = 'a1' id = 5
+++++++ finished: global begin run for module: label = 'a1' id = 4
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -293,12 +287,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global begin Run for module: label = 'a2' id = 6
-++++++ starting: global begin run for module: label = 'a2' id = 6
-++++++ finished: global begin run for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing global begin Run for module: label = 'a3' id = 7
-++++++ starting: global begin run for module: label = 'a3' id = 7
-++++++ finished: global begin run for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing global begin Run for module: label = 'a2' id = 5
+++++++ starting: global begin run for module: label = 'a2' id = 5
+++++++ finished: global begin run for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing global begin Run for module: label = 'a3' id = 6
+++++++ starting: global begin run for module: label = 'a3' id = 6
+++++++ finished: global begin run for module: label = 'a3' id = 6
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -325,11 +319,11 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 13
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 13
-++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 10
-++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 10
-++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -341,7 +335,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -353,8 +347,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -386,9 +380,9 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'a1' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -400,7 +394,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a1' id = 5
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a1' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -412,7 +406,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: global begin lumi for module: label = 'a1' id = 5
+++++++ starting: global begin lumi for module: label = 'a1' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -424,7 +418,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: global begin lumi for module: label = 'a1' id = 5
+++++++ finished: global begin lumi for module: label = 'a1' id = 4
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -436,12 +430,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a2' id = 6
-++++++ starting: global begin lumi for module: label = 'a2' id = 6
-++++++ finished: global begin lumi for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a3' id = 7
-++++++ starting: global begin lumi for module: label = 'a3' id = 7
-++++++ finished: global begin lumi for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a2' id = 5
+++++++ starting: global begin lumi for module: label = 'a2' id = 5
+++++++ finished: global begin lumi for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'a3' id = 6
+++++++ starting: global begin lumi for module: label = 'a3' id = 6
+++++++ finished: global begin lumi for module: label = 'a3' id = 6
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -468,11 +462,11 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 13
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 13
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 10
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 10
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -484,7 +478,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -496,8 +490,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -548,8 +542,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -565,8 +559,8 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -580,11 +574,11 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -598,7 +592,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -612,7 +606,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -626,7 +620,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -642,7 +636,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -658,7 +652,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -674,12 +668,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
@@ -695,24 +689,22 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 7
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -774,8 +766,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -791,8 +783,8 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -806,11 +798,11 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -824,7 +816,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -838,7 +830,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -852,7 +844,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -868,7 +860,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -884,7 +876,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -900,12 +892,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
@@ -921,24 +913,22 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 7
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -1000,8 +990,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1017,8 +1007,8 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1032,11 +1022,11 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1050,7 +1040,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1064,7 +1054,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1078,7 +1068,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1094,7 +1084,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1110,7 +1100,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1126,12 +1116,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 7
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 6
-++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 6
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 5
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
@@ -1147,24 +1137,22 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 14
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 13
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 10
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 8
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 13
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 12
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerB' id = 9
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 7
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 7
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -1205,11 +1193,11 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 13
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 13
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 10
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 10
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1221,7 +1209,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -1233,8 +1221,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1261,9 +1249,9 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'a1' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -1275,7 +1263,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a1' id = 5
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a1' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -1287,7 +1275,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: global end lumi for module: label = 'a1' id = 5
+++++++ starting: global end lumi for module: label = 'a1' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -1299,7 +1287,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: global end lumi for module: label = 'a1' id = 5
+++++++ finished: global end lumi for module: label = 'a1' id = 4
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -1311,12 +1299,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a2' id = 6
-++++++ starting: global end lumi for module: label = 'a2' id = 6
-++++++ finished: global end lumi for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a3' id = 7
-++++++ starting: global end lumi for module: label = 'a3' id = 7
-++++++ finished: global end lumi for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a2' id = 5
+++++++ starting: global end lumi for module: label = 'a2' id = 5
+++++++ finished: global end lumi for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'a3' id = 6
+++++++ starting: global end lumi for module: label = 'a3' id = 6
+++++++ finished: global end lumi for module: label = 'a3' id = 6
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -1343,8 +1331,8 @@ GlobalContext: transition = WriteLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: write lumi for module: label = 'out' id = 8
-++++++ finished: write lumi for module: label = 'out' id = 8
+++++++ starting: write lumi for module: label = 'out' id = 7
+++++++ finished: write lumi for module: label = 'out' id = 7
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -1371,11 +1359,11 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 13
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 13
-++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 10
-++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 10
-++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1387,7 +1375,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 9
+++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1399,8 +1387,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -1427,9 +1415,9 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing global end Run for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing global end Run for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing global end Run for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing global end Run for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing global end Run for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing global end Run for module: label = 'a1' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1441,7 +1429,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global end Run for module: label = 'a1' id = 5
+++++++++ finished: prefetching before processing global end Run for module: label = 'a1' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1453,7 +1441,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: global end run for module: label = 'a1' id = 5
+++++++ starting: global end run for module: label = 'a1' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1465,7 +1453,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: global end run for module: label = 'a1' id = 5
+++++++ finished: global end run for module: label = 'a1' id = 4
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -1477,12 +1465,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing global end Run for module: label = 'a2' id = 6
-++++++ starting: global end run for module: label = 'a2' id = 6
-++++++ finished: global end run for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing global end Run for module: label = 'a3' id = 7
-++++++ starting: global end run for module: label = 'a3' id = 7
-++++++ finished: global end run for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing global end Run for module: label = 'a2' id = 5
+++++++ starting: global end run for module: label = 'a2' id = 5
+++++++ finished: global end run for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing global end Run for module: label = 'a3' id = 6
+++++++ starting: global end run for module: label = 'a3' id = 6
+++++++ finished: global end run for module: label = 'a3' id = 6
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -1509,8 +1497,8 @@ GlobalContext: transition = WriteRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: write run for module: label = 'out' id = 8
-++++++ finished: write run for module: label = 'out' id = 8
+++++++ starting: write run for module: label = 'out' id = 7
+++++++ finished: write run for module: label = 'out' id = 7
 ++++ finished: global write run 1 : time = 15000001
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
@@ -1537,9 +1525,9 @@ GlobalContext: transition = EndProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a3' id = 7
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a2' id = 6
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a3' id = 6
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a2' id = 5
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'a1' id = 4
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1551,15 +1539,15 @@ ModuleCallingContext state = Prefetching
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 12
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++ starting: end process block for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++ finished: end process block for module: label = 'intProducerBeginProcessBlock' id = 11
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 12
-++++++ starting: end process block for module: label = 'intProducerEndProcessBlock' id = 12
-++++++ finished: end process block for module: label = 'intProducerEndProcessBlock' id = 12
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a1' id = 5
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 11
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++ starting: end process block for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++ finished: end process block for module: label = 'intProducerBeginProcessBlock' id = 10
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'intProducerEndProcessBlock' id = 11
+++++++ starting: end process block for module: label = 'intProducerEndProcessBlock' id = 11
+++++++ finished: end process block for module: label = 'intProducerEndProcessBlock' id = 11
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a1' id = 4
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1571,7 +1559,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end process block for module: label = 'a1' id = 5
+++++++ starting: end process block for module: label = 'a1' id = 4
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1583,7 +1571,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ finished: end process block for module: label = 'a1' id = 5
+++++++ finished: end process block for module: label = 'a1' id = 4
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1595,12 +1583,12 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a2' id = 6
-++++++ starting: end process block for module: label = 'a2' id = 6
-++++++ finished: end process block for module: label = 'a2' id = 6
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a3' id = 7
-++++++ starting: end process block for module: label = 'a3' id = 7
-++++++ finished: end process block for module: label = 'a3' id = 7
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a2' id = 5
+++++++ starting: end process block for module: label = 'a2' id = 5
+++++++ finished: end process block for module: label = 'a2' id = 5
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'a3' id = 6
+++++++ starting: end process block for module: label = 'a3' id = 6
+++++++ finished: end process block for module: label = 'a3' id = 6
 ++++ finished: end process block
 GlobalContext: transition = EndProcessBlock
     run: 0 luminosityBlock: 0
@@ -1655,8 +1643,8 @@ GlobalContext: transition = WriteProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: write process block for module: label = 'out' id = 8
-++++++ finished: write process block for module: label = 'out' id = 8
+++++++ starting: write process block for module: label = 'out' id = 7
+++++++ finished: write process block for module: label = 'out' id = 7
 ++++ finished: write process block
 GlobalContext: transition = WriteProcessBlock
     run: 0 luminosityBlock: 0
@@ -1677,9 +1665,9 @@ GlobalContext: transition = WriteProcessBlock
     ProcessContext: COPY 6f4335e86de793448be83fe14f12dcb7
     parent ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
-++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
-++++ starting: end stream for module: stream = 0 label = 'a1' id = 5
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 3
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 3
+++++ starting: end stream for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1691,7 +1679,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ finished: end stream for module: stream = 0 label = 'a1' id = 5
+++++ finished: end stream for module: stream = 0 label = 'a1' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1703,19 +1691,17 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ starting: end stream for module: stream = 0 label = 'a2' id = 6
-++++ finished: end stream for module: stream = 0 label = 'a2' id = 6
-++++ starting: end stream for module: stream = 0 label = 'a3' id = 7
-++++ finished: end stream for module: stream = 0 label = 'a3' id = 7
+++++ starting: end stream for module: stream = 0 label = 'a2' id = 5
+++++ finished: end stream for module: stream = 0 label = 'a2' id = 5
+++++ starting: end stream for module: stream = 0 label = 'a3' id = 6
+++++ finished: end stream for module: stream = 0 label = 'a3' id = 6
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'out' id = 8
-++++ finished: end stream for module: stream = 0 label = 'out' id = 8
+++++ starting: end stream for module: stream = 0 label = 'out' id = 7
+++++ finished: end stream for module: stream = 0 label = 'out' id = 7
 ++++ starting: end stream for module: stream = 0 label = 'p' id = 2
 ++++ finished: end stream for module: stream = 0 label = 'p' id = 2
-++++ starting: end stream for module: stream = 0 label = 'e' id = 3
-++++ finished: end stream for module: stream = 0 label = 'e' id = 3
-++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 9
+++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1727,7 +1713,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 9
+++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1739,49 +1725,47 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++ starting: end stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ finished: end stream for module: stream = 0 label = 'intProducerB' id = 10
-++++ starting: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
-++++ finished: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 11
-++++ starting: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
-++++ finished: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 12
-++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 13
-++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 13
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 14
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 14
-++++ starting: end job for module with label 'intProducerA' id = 9
+++++ starting: end stream for module: stream = 0 label = 'intProducerB' id = 9
+++++ finished: end stream for module: stream = 0 label = 'intProducerB' id = 9
+++++ starting: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 10
+++++ finished: end stream for module: stream = 0 label = 'intProducerBeginProcessBlock' id = 10
+++++ starting: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 11
+++++ finished: end stream for module: stream = 0 label = 'intProducerEndProcessBlock' id = 11
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 12
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 12
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 13
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 13
+++++ starting: end job for module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ finished: end job for module with label 'intProducerA' id = 9
+++++ finished: end job for module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
-++++ starting: end job for module with label 'intProducerB' id = 10
-++++ finished: end job for module with label 'intProducerB' id = 10
-++++ starting: end job for module with label 'intProducerBeginProcessBlock' id = 11
-++++ finished: end job for module with label 'intProducerBeginProcessBlock' id = 11
-++++ starting: end job for module with label 'intProducerEndProcessBlock' id = 12
-++++ finished: end job for module with label 'intProducerEndProcessBlock' id = 12
-++++ starting: end job for module with label 'intProducerU' id = 13
-++++ finished: end job for module with label 'intProducerU' id = 13
-++++ starting: end job for module with label 'intVectorProducer' id = 14
-++++ finished: end job for module with label 'intVectorProducer' id = 14
-++++ starting: end job for module with label 'intProducer' id = 4
-++++ finished: end job for module with label 'intProducer' id = 4
-++++ starting: end job for module with label 'a1' id = 5
+++++ starting: end job for module with label 'intProducerB' id = 9
+++++ finished: end job for module with label 'intProducerB' id = 9
+++++ starting: end job for module with label 'intProducerBeginProcessBlock' id = 10
+++++ finished: end job for module with label 'intProducerBeginProcessBlock' id = 10
+++++ starting: end job for module with label 'intProducerEndProcessBlock' id = 11
+++++ finished: end job for module with label 'intProducerEndProcessBlock' id = 11
+++++ starting: end job for module with label 'intProducerU' id = 12
+++++ finished: end job for module with label 'intProducerU' id = 12
+++++ starting: end job for module with label 'intVectorProducer' id = 13
+++++ finished: end job for module with label 'intVectorProducer' id = 13
+++++ starting: end job for module with label 'intProducer' id = 3
+++++ finished: end job for module with label 'intProducer' id = 3
+++++ starting: end job for module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
 TestFindProduct sum = 530021
-++++ finished: end job for module with label 'a1' id = 5
+++++ finished: end job for module with label 'a1' id = 4
 Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35dee69e4bd85169d4c
-++++ starting: end job for module with label 'a2' id = 6
+++++ starting: end job for module with label 'a2' id = 5
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a2' id = 6
-++++ starting: end job for module with label 'a3' id = 7
+++++ finished: end job for module with label 'a2' id = 5
+++++ starting: end job for module with label 'a3' id = 6
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a3' id = 7
-++++ starting: end job for module with label 'out' id = 8
-++++ finished: end job for module with label 'out' id = 8
+++++ finished: end job for module with label 'a3' id = 6
+++++ starting: end job for module with label 'out' id = 7
+++++ finished: end job for module with label 'out' id = 7
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
 ++++ starting: end job for module with label 'p' id = 2
 ++++ finished: end job for module with label 'p' id = 2
-++++ starting: end job for module with label 'e' id = 3
-++++ finished: end job for module with label 'e' id = 3
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -8,38 +8,34 @@ Module type=PoolSource, Module label=source, Parameter Set ID=e26370152bd22c8709
 ++++ finished: constructing module with label 'TriggerResults' id = 1
 ++++ starting: constructing module with label 'p' id = 2
 ++++ finished: constructing module with label 'p' id = 2
-++++ starting: constructing module with label 'e' id = 3
-++++ finished: constructing module with label 'e' id = 3
-++++ starting: constructing module with label 'intProducer' id = 4
+++++ starting: constructing module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ finished: constructing module with label 'intProducer' id = 4
+++++ finished: constructing module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ starting: constructing module with label 'out' id = 5
-++++ finished: constructing module with label 'out' id = 5
-++++ starting: constructing module with label 'intProducerU' id = 6
-++++ finished: constructing module with label 'intProducerU' id = 6
-++++ starting: constructing module with label 'intVectorProducer' id = 7
-++++ finished: constructing module with label 'intVectorProducer' id = 7
+++++ starting: constructing module with label 'out' id = 4
+++++ finished: constructing module with label 'out' id = 4
+++++ starting: constructing module with label 'intProducerU' id = 5
+++++ finished: constructing module with label 'intProducerU' id = 5
+++++ starting: constructing module with label 'intVectorProducer' id = 6
+++++ finished: constructing module with label 'intVectorProducer' id = 6
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
-++++ starting: begin job for module with label 'intProducerU' id = 6
-++++ finished: begin job for module with label 'intProducerU' id = 6
-++++ starting: begin job for module with label 'intVectorProducer' id = 7
-++++ finished: begin job for module with label 'intVectorProducer' id = 7
-++++ starting: begin job for module with label 'intProducer' id = 4
+++++ starting: begin job for module with label 'intProducerU' id = 5
+++++ finished: begin job for module with label 'intProducerU' id = 5
+++++ starting: begin job for module with label 'intVectorProducer' id = 6
+++++ finished: begin job for module with label 'intVectorProducer' id = 6
+++++ starting: begin job for module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ finished: begin job for module with label 'intProducer' id = 4
+++++ finished: begin job for module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ starting: begin job for module with label 'out' id = 5
-++++ finished: begin job for module with label 'out' id = 5
+++++ starting: begin job for module with label 'out' id = 4
+++++ finished: begin job for module with label 'out' id = 4
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
-++++ starting: begin job for module with label 'e' id = 3
-++++ finished: begin job for module with label 'e' id = 3
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -51,7 +47,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -65,16 +61,14 @@ ModuleCallingContext state = Running
 
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 5
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 4
 ++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'e' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'e' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 6
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 7
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 6
 ++++ starting: begin process block
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
@@ -107,8 +101,8 @@ GlobalContext: transition = WriteProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: write process block for module: label = 'out' id = 5
-++++++ finished: write process block for module: label = 'out' id = 5
+++++++ starting: write process block for module: label = 'out' id = 4
+++++++ finished: write process block for module: label = 'out' id = 4
 ++++ finished: write process block
 GlobalContext: transition = WriteProcessBlock
     run: 0 luminosityBlock: 0
@@ -138,9 +132,9 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 6
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -152,7 +146,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -193,9 +187,9 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 6
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -207,7 +201,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -255,7 +249,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -269,7 +263,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -283,7 +277,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -297,7 +291,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -326,36 +320,34 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 4
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -403,7 +395,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -417,7 +409,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -431,7 +423,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -445,7 +437,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -474,36 +466,34 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 4
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -551,7 +541,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -565,7 +555,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -579,7 +569,7 @@ ModuleCallingContext state = Prefetching
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -593,7 +583,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -622,36 +612,34 @@ PathContext: pathName = p pathID = 0
 
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 7
-++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 6
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 5
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 5
-++++++++ starting: processing event for module: stream = 0 label = 'e' id = 3
-++++++++ finished: processing event for module: stream = 0 label = 'e' id = 3
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 6
+++++++++++ finished: prefetching before processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 5
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ starting: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++++ finished: event delayed read from source: stream = 0 label = 'out' id = 4
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 4
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -678,9 +666,9 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 6
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -692,7 +680,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -728,8 +716,8 @@ GlobalContext: transition = WriteLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: write lumi for module: label = 'out' id = 5
-++++++ finished: write lumi for module: label = 'out' id = 5
+++++++ starting: write lumi for module: label = 'out' id = 4
+++++++ finished: write lumi for module: label = 'out' id = 4
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = WriteLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -742,9 +730,9 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 6
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 6
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 4
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -756,7 +744,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 4
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -792,8 +780,8 @@ GlobalContext: transition = WriteRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: write run for module: label = 'out' id = 5
-++++++ finished: write run for module: label = 'out' id = 5
+++++++ starting: write run for module: label = 'out' id = 4
+++++++ finished: write run for module: label = 'out' id = 4
 ++++ finished: global write run 1 : time = 15000001
 GlobalContext: transition = WriteRun
     run: 1 luminosityBlock: 0
@@ -820,15 +808,15 @@ GlobalContext: transition = WriteProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: write process block for module: label = 'out' id = 5
-++++++ finished: write process block for module: label = 'out' id = 5
+++++++ starting: write process block for module: label = 'out' id = 4
+++++++ finished: write process block for module: label = 'out' id = 4
 ++++ finished: write process block
 GlobalContext: transition = WriteProcessBlock
     run: 0 luminosityBlock: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 4
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -840,7 +828,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 4
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -854,30 +842,26 @@ ModuleCallingContext state = Running
 
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'out' id = 5
-++++ finished: end stream for module: stream = 0 label = 'out' id = 5
+++++ starting: end stream for module: stream = 0 label = 'out' id = 4
+++++ finished: end stream for module: stream = 0 label = 'out' id = 4
 ++++ starting: end stream for module: stream = 0 label = 'p' id = 2
 ++++ finished: end stream for module: stream = 0 label = 'p' id = 2
-++++ starting: end stream for module: stream = 0 label = 'e' id = 3
-++++ finished: end stream for module: stream = 0 label = 'e' id = 3
-++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 6
-++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 6
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 7
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 7
-++++ starting: end job for module with label 'intProducerU' id = 6
-++++ finished: end job for module with label 'intProducerU' id = 6
-++++ starting: end job for module with label 'intVectorProducer' id = 7
-++++ finished: end job for module with label 'intVectorProducer' id = 7
-++++ starting: end job for module with label 'intProducer' id = 4
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 5
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 5
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 6
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 6
+++++ starting: end job for module with label 'intProducerU' id = 5
+++++ finished: end job for module with label 'intProducerU' id = 5
+++++ starting: end job for module with label 'intVectorProducer' id = 6
+++++ finished: end job for module with label 'intVectorProducer' id = 6
+++++ starting: end job for module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ finished: end job for module with label 'intProducer' id = 4
+++++ finished: end job for module with label 'intProducer' id = 3
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a3015d748c803aa5c60a25d3
-++++ starting: end job for module with label 'out' id = 5
-++++ finished: end job for module with label 'out' id = 5
+++++ starting: end job for module with label 'out' id = 4
+++++ finished: end job for module with label 'out' id = 4
 ++++ starting: end job for module with label 'TriggerResults' id = 1
 ++++ finished: end job for module with label 'TriggerResults' id = 1
 ++++ starting: end job for module with label 'p' id = 2
 ++++ finished: end job for module with label 'p' id = 2
-++++ starting: end job for module with label 'e' id = 3
-++++ finished: end job for module with label 'e' id = 3
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -32,48 +32,44 @@
 ++++ finished: constructing module with label 'path3' id = 15
 ++++ starting: constructing module with label 'path4' id = 16
 ++++ finished: constructing module with label 'path4' id = 16
-++++ starting: constructing module with label 'endPath1' id = 17
-++++ finished: constructing module with label 'endPath1' id = 17
-++++ starting: constructing module with label 'thingWithMergeProducer' id = 18
-++++ finished: constructing module with label 'thingWithMergeProducer' id = 18
-++++ starting: constructing module with label 'test' id = 19
-++++ finished: constructing module with label 'test' id = 19
-++++ starting: constructing module with label 'testmerge' id = 20
-++++ finished: constructing module with label 'testmerge' id = 20
-++++ starting: constructing module with label 'get' id = 21
-++++ finished: constructing module with label 'get' id = 21
-++++ starting: constructing module with label 'getInt' id = 22
-++++ finished: constructing module with label 'getInt' id = 22
-++++ starting: constructing module with label 'dependsOnNoPut' id = 23
-++++ finished: constructing module with label 'dependsOnNoPut' id = 23
-++++ starting: constructing module with label 'out' id = 24
-++++ finished: constructing module with label 'out' id = 24
-++++ starting: constructing module with label 'TriggerResults' id = 25
-++++ finished: constructing module with label 'TriggerResults' id = 25
-++++ starting: constructing module with label 'path1' id = 26
-++++ finished: constructing module with label 'path1' id = 26
-++++ starting: constructing module with label 'path2' id = 27
-++++ finished: constructing module with label 'path2' id = 27
-++++ starting: constructing module with label 'path3' id = 28
-++++ finished: constructing module with label 'path3' id = 28
-++++ starting: constructing module with label 'path4' id = 29
-++++ finished: constructing module with label 'path4' id = 29
-++++ starting: constructing module with label 'endPath1' id = 30
-++++ finished: constructing module with label 'endPath1' id = 30
-++++ starting: constructing module with label 'thingWithMergeProducer' id = 31
-++++ finished: constructing module with label 'thingWithMergeProducer' id = 31
-++++ starting: constructing module with label 'test' id = 32
-++++ finished: constructing module with label 'test' id = 32
-++++ starting: constructing module with label 'testmerge' id = 33
-++++ finished: constructing module with label 'testmerge' id = 33
-++++ starting: constructing module with label 'get' id = 34
-++++ finished: constructing module with label 'get' id = 34
-++++ starting: constructing module with label 'getInt' id = 35
-++++ finished: constructing module with label 'getInt' id = 35
-++++ starting: constructing module with label 'dependsOnNoPut' id = 36
-++++ finished: constructing module with label 'dependsOnNoPut' id = 36
-++++ starting: constructing module with label 'out' id = 37
-++++ finished: constructing module with label 'out' id = 37
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 17
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 17
+++++ starting: constructing module with label 'test' id = 18
+++++ finished: constructing module with label 'test' id = 18
+++++ starting: constructing module with label 'testmerge' id = 19
+++++ finished: constructing module with label 'testmerge' id = 19
+++++ starting: constructing module with label 'get' id = 20
+++++ finished: constructing module with label 'get' id = 20
+++++ starting: constructing module with label 'getInt' id = 21
+++++ finished: constructing module with label 'getInt' id = 21
+++++ starting: constructing module with label 'dependsOnNoPut' id = 22
+++++ finished: constructing module with label 'dependsOnNoPut' id = 22
+++++ starting: constructing module with label 'out' id = 23
+++++ finished: constructing module with label 'out' id = 23
+++++ starting: constructing module with label 'TriggerResults' id = 24
+++++ finished: constructing module with label 'TriggerResults' id = 24
+++++ starting: constructing module with label 'path1' id = 25
+++++ finished: constructing module with label 'path1' id = 25
+++++ starting: constructing module with label 'path2' id = 26
+++++ finished: constructing module with label 'path2' id = 26
+++++ starting: constructing module with label 'path3' id = 27
+++++ finished: constructing module with label 'path3' id = 27
+++++ starting: constructing module with label 'path4' id = 28
+++++ finished: constructing module with label 'path4' id = 28
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 29
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 29
+++++ starting: constructing module with label 'test' id = 30
+++++ finished: constructing module with label 'test' id = 30
+++++ starting: constructing module with label 'testmerge' id = 31
+++++ finished: constructing module with label 'testmerge' id = 31
+++++ starting: constructing module with label 'get' id = 32
+++++ finished: constructing module with label 'get' id = 32
+++++ starting: constructing module with label 'getInt' id = 33
+++++ finished: constructing module with label 'getInt' id = 33
+++++ starting: constructing module with label 'dependsOnNoPut' id = 34
+++++ finished: constructing module with label 'dependsOnNoPut' id = 34
+++++ starting: constructing module with label 'out' id = 35
+++++ finished: constructing module with label 'out' id = 35
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
 ++ starting: begin job
@@ -102,20 +98,20 @@
 ++++ finished: begin job for module with label 'path2' id = 4
 ++ starting: begin job
 ++ starting: begin job
-++++ starting: begin job for module with label 'thingWithMergeProducer' id = 18
-++++ finished: begin job for module with label 'thingWithMergeProducer' id = 18
-++++ starting: begin job for module with label 'test' id = 19
-++++ finished: begin job for module with label 'test' id = 19
-++++ starting: begin job for module with label 'testmerge' id = 20
-++++ finished: begin job for module with label 'testmerge' id = 20
-++++ starting: begin job for module with label 'get' id = 21
-++++ finished: begin job for module with label 'get' id = 21
-++++ starting: begin job for module with label 'getInt' id = 22
-++++ finished: begin job for module with label 'getInt' id = 22
-++++ starting: begin job for module with label 'dependsOnNoPut' id = 23
-++++ finished: begin job for module with label 'dependsOnNoPut' id = 23
-++++ starting: begin job for module with label 'out' id = 24
-++++ finished: begin job for module with label 'out' id = 24
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 17
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 17
+++++ starting: begin job for module with label 'test' id = 18
+++++ finished: begin job for module with label 'test' id = 18
+++++ starting: begin job for module with label 'testmerge' id = 19
+++++ finished: begin job for module with label 'testmerge' id = 19
+++++ starting: begin job for module with label 'get' id = 20
+++++ finished: begin job for module with label 'get' id = 20
+++++ starting: begin job for module with label 'getInt' id = 21
+++++ finished: begin job for module with label 'getInt' id = 21
+++++ starting: begin job for module with label 'dependsOnNoPut' id = 22
+++++ finished: begin job for module with label 'dependsOnNoPut' id = 22
+++++ starting: begin job for module with label 'out' id = 23
+++++ finished: begin job for module with label 'out' id = 23
 ++++ starting: begin job for module with label 'TriggerResults' id = 12
 ++++ finished: begin job for module with label 'TriggerResults' id = 12
 ++++ starting: begin job for module with label 'path1' id = 13
@@ -126,35 +122,31 @@
 ++++ finished: begin job for module with label 'path3' id = 15
 ++++ starting: begin job for module with label 'path4' id = 16
 ++++ finished: begin job for module with label 'path4' id = 16
-++++ starting: begin job for module with label 'endPath1' id = 17
-++++ finished: begin job for module with label 'endPath1' id = 17
 ++ starting: begin job
-++++ starting: begin job for module with label 'thingWithMergeProducer' id = 31
-++++ finished: begin job for module with label 'thingWithMergeProducer' id = 31
-++++ starting: begin job for module with label 'test' id = 32
-++++ finished: begin job for module with label 'test' id = 32
-++++ starting: begin job for module with label 'testmerge' id = 33
-++++ finished: begin job for module with label 'testmerge' id = 33
-++++ starting: begin job for module with label 'get' id = 34
-++++ finished: begin job for module with label 'get' id = 34
-++++ starting: begin job for module with label 'getInt' id = 35
-++++ finished: begin job for module with label 'getInt' id = 35
-++++ starting: begin job for module with label 'dependsOnNoPut' id = 36
-++++ finished: begin job for module with label 'dependsOnNoPut' id = 36
-++++ starting: begin job for module with label 'out' id = 37
-++++ finished: begin job for module with label 'out' id = 37
-++++ starting: begin job for module with label 'TriggerResults' id = 25
-++++ finished: begin job for module with label 'TriggerResults' id = 25
-++++ starting: begin job for module with label 'path1' id = 26
-++++ finished: begin job for module with label 'path1' id = 26
-++++ starting: begin job for module with label 'path2' id = 27
-++++ finished: begin job for module with label 'path2' id = 27
-++++ starting: begin job for module with label 'path3' id = 28
-++++ finished: begin job for module with label 'path3' id = 28
-++++ starting: begin job for module with label 'path4' id = 29
-++++ finished: begin job for module with label 'path4' id = 29
-++++ starting: begin job for module with label 'endPath1' id = 30
-++++ finished: begin job for module with label 'endPath1' id = 30
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 29
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 29
+++++ starting: begin job for module with label 'test' id = 30
+++++ finished: begin job for module with label 'test' id = 30
+++++ starting: begin job for module with label 'testmerge' id = 31
+++++ finished: begin job for module with label 'testmerge' id = 31
+++++ starting: begin job for module with label 'get' id = 32
+++++ finished: begin job for module with label 'get' id = 32
+++++ starting: begin job for module with label 'getInt' id = 33
+++++ finished: begin job for module with label 'getInt' id = 33
+++++ starting: begin job for module with label 'dependsOnNoPut' id = 34
+++++ finished: begin job for module with label 'dependsOnNoPut' id = 34
+++++ starting: begin job for module with label 'out' id = 35
+++++ finished: begin job for module with label 'out' id = 35
+++++ starting: begin job for module with label 'TriggerResults' id = 24
+++++ finished: begin job for module with label 'TriggerResults' id = 24
+++++ starting: begin job for module with label 'path1' id = 25
+++++ finished: begin job for module with label 'path1' id = 25
+++++ starting: begin job for module with label 'path2' id = 26
+++++ finished: begin job for module with label 'path2' id = 26
+++++ starting: begin job for module with label 'path3' id = 27
+++++ finished: begin job for module with label 'path3' id = 27
+++++ starting: begin job for module with label 'path4' id = 28
+++++ finished: begin job for module with label 'path4' id = 28
 ++ finished: begin job
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -178,22 +170,22 @@
 ++++ finished: begin stream for module: stream = 0 label = 'path1' id = 3
 ++++ starting: begin stream for module: stream = 0 label = 'path2' id = 4
 ++++ finished: begin stream for module: stream = 0 label = 'path2' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: begin stream for module: stream = 0 label = 'test' id = 19
-++++ finished: begin stream for module: stream = 0 label = 'test' id = 19
-++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 20
-++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 20
-++++ starting: begin stream for module: stream = 0 label = 'get' id = 21
-++++ finished: begin stream for module: stream = 0 label = 'get' id = 21
-++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 22
-++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 22
-++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++ starting: begin stream for module: stream = 0 label = 'test' id = 18
+++++ finished: begin stream for module: stream = 0 label = 'test' id = 18
+++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 19
+++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 19
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 20
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 20
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 21
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 21
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 24
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 24
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 23
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 23
 ++++ starting: begin stream for module: stream = 0 label = 'path1' id = 13
 ++++ finished: begin stream for module: stream = 0 label = 'path1' id = 13
 ++++ starting: begin stream for module: stream = 0 label = 'path2' id = 14
@@ -202,34 +194,30 @@
 ++++ finished: begin stream for module: stream = 0 label = 'path3' id = 15
 ++++ starting: begin stream for module: stream = 0 label = 'path4' id = 16
 ++++ finished: begin stream for module: stream = 0 label = 'path4' id = 16
-++++ starting: begin stream for module: stream = 0 label = 'endPath1' id = 17
-++++ finished: begin stream for module: stream = 0 label = 'endPath1' id = 17
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++ starting: begin stream for module: stream = 0 label = 'test' id = 32
-++++ finished: begin stream for module: stream = 0 label = 'test' id = 32
-++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 33
-++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 33
-++++ starting: begin stream for module: stream = 0 label = 'get' id = 34
-++++ finished: begin stream for module: stream = 0 label = 'get' id = 34
-++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 35
-++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 35
-++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 25
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 25
-++++ starting: begin stream for module: stream = 0 label = 'out' id = 37
-++++ finished: begin stream for module: stream = 0 label = 'out' id = 37
-++++ starting: begin stream for module: stream = 0 label = 'path1' id = 26
-++++ finished: begin stream for module: stream = 0 label = 'path1' id = 26
-++++ starting: begin stream for module: stream = 0 label = 'path2' id = 27
-++++ finished: begin stream for module: stream = 0 label = 'path2' id = 27
-++++ starting: begin stream for module: stream = 0 label = 'path3' id = 28
-++++ finished: begin stream for module: stream = 0 label = 'path3' id = 28
-++++ starting: begin stream for module: stream = 0 label = 'path4' id = 29
-++++ finished: begin stream for module: stream = 0 label = 'path4' id = 29
-++++ starting: begin stream for module: stream = 0 label = 'endPath1' id = 30
-++++ finished: begin stream for module: stream = 0 label = 'endPath1' id = 30
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++ starting: begin stream for module: stream = 0 label = 'test' id = 30
+++++ finished: begin stream for module: stream = 0 label = 'test' id = 30
+++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 31
+++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 31
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 32
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 32
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 33
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 33
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 24
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 24
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 35
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 35
+++++ starting: begin stream for module: stream = 0 label = 'path1' id = 25
+++++ finished: begin stream for module: stream = 0 label = 'path1' id = 25
+++++ starting: begin stream for module: stream = 0 label = 'path2' id = 26
+++++ finished: begin stream for module: stream = 0 label = 'path2' id = 26
+++++ starting: begin stream for module: stream = 0 label = 'path3' id = 27
+++++ finished: begin stream for module: stream = 0 label = 'path3' id = 27
+++++ starting: begin stream for module: stream = 0 label = 'path4' id = 28
+++++ finished: begin stream for module: stream = 0 label = 'path4' id = 28
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ starting: begin process block
@@ -243,16 +231,16 @@
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ starting: begin process block
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 22
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 21
 ++++ starting: begin process block
-++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 35
-++++++ starting: begin process block for module: label = 'getInt' id = 35
-++++++ finished: begin process block for module: label = 'getInt' id = 35
+++++++++ starting: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 33
+++++++ starting: begin process block for module: label = 'getInt' id = 33
+++++++ finished: begin process block for module: label = 'getInt' id = 33
 ++++ finished: begin process block
-++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 22
-++++++ starting: begin process block for module: label = 'getInt' id = 22
-++++++ finished: begin process block for module: label = 'getInt' id = 22
+++++++++ finished: prefetching before processing begin ProcessBlock for module: label = 'getInt' id = 21
+++++++ starting: begin process block for module: label = 'getInt' id = 21
+++++++ finished: begin process block for module: label = 'getInt' id = 21
 ++++ finished: begin process block
 ++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
@@ -288,60 +276,60 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 21
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 20
 ++++++++ starting: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin run 1 : time = 1
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++ starting: global begin run for module: label = 'test' id = 32
-++++++ finished: global begin run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'testmerge' id = 33
-++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++ starting: global begin run for module: label = 'getInt' id = 35
-++++++ finished: global begin run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++ starting: global begin run for module: label = 'test' id = 19
-++++++ finished: global begin run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'testmerge' id = 20
-++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++ starting: global begin run for module: label = 'test' id = 30
+++++++ finished: global begin run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++ starting: global begin run for module: label = 'testmerge' id = 31
+++++++ finished: global begin run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++ starting: global begin run for module: label = 'getInt' id = 33
+++++++ finished: global begin run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 34
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 18
+++++++ finished: global begin run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 19
+++++++ finished: global begin run for module: label = 'testmerge' id = 19
 ++++++++ finished: prefetching for esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++++ starting: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 ++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 21
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 20
+++++++ finished: global begin run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++ starting: global begin run for module: label = 'get' id = 32
+++++++ finished: global begin run for module: label = 'get' id = 32
 ++++ finished: global begin run 1 : time = 1
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++ starting: global begin run for module: label = 'getInt' id = 22
-++++++ finished: global begin run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 21
+++++++ finished: global begin run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -391,56 +379,56 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -515,105 +503,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: source event
@@ -671,105 +655,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: source event
@@ -827,105 +807,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: source event
@@ -983,105 +959,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 2 event: 0
@@ -1130,56 +1102,56 @@
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
@@ -1191,11 +1163,11 @@
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1224,56 +1196,56 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -1348,105 +1320,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: source event
@@ -1504,105 +1472,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: source event
@@ -1660,105 +1624,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: source event
@@ -1816,105 +1776,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 3 event: 0
@@ -1963,56 +1919,56 @@
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
@@ -2024,11 +1980,11 @@
 ++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global write lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2057,56 +2013,56 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -2181,105 +2137,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: source event
@@ -2337,105 +2289,101 @@
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
@@ -2484,56 +2432,56 @@
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
@@ -2545,11 +2493,11 @@
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global write lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 2 lumi: 0 event: 0
@@ -2597,56 +2545,56 @@
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end run 1 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'testmerge' id = 33
-++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++ starting: global end run for module: label = 'test' id = 32
-++++++ finished: global end run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++ starting: global end run for module: label = 'getInt' id = 35
-++++++ finished: global end run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++ starting: global end run for module: label = 'testmerge' id = 31
+++++++ finished: global end run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++ starting: global end run for module: label = 'test' id = 30
+++++++ finished: global end run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++ starting: global end run for module: label = 'get' id = 32
+++++++ finished: global end run for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++ starting: global end run for module: label = 'getInt' id = 33
+++++++ finished: global end run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end run 1 : time = 0
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'testmerge' id = 20
-++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++ starting: global end run for module: label = 'test' id = 19
-++++++ finished: global end run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++ starting: global end run for module: label = 'getInt' id = 22
-++++++ finished: global end run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 19
+++++++ finished: global end run for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++ starting: global end run for module: label = 'test' id = 18
+++++++ finished: global end run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++ starting: global end run for module: label = 'get' id = 20
+++++++ finished: global end run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 21
+++++++ finished: global end run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global write run 1 : time = 50000001
 ++++ finished: global write run 1 : time = 50000001
@@ -2658,11 +2606,11 @@
 ++++ finished: global write run 1 : time = 0
 ++++ starting: global write run 1 : time = 0
 ++++ starting: global write run 1 : time = 0
-++++++ starting: write run for module: label = 'out' id = 37
-++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 35
+++++++ finished: write run for module: label = 'out' id = 35
 ++++ finished: global write run 1 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
+++++++ starting: write run for module: label = 'out' id = 23
+++++++ finished: write run for module: label = 'out' id = 23
 ++++ finished: global write run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -2691,56 +2639,56 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin run 2 : time = 55000001
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++ starting: global begin run for module: label = 'test' id = 32
-++++++ finished: global begin run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'testmerge' id = 33
-++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++ starting: global begin run for module: label = 'getInt' id = 35
-++++++ finished: global begin run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++ starting: global begin run for module: label = 'test' id = 30
+++++++ finished: global begin run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++ starting: global begin run for module: label = 'testmerge' id = 31
+++++++ finished: global begin run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++ starting: global begin run for module: label = 'get' id = 32
+++++++ finished: global begin run for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++ starting: global begin run for module: label = 'getInt' id = 33
+++++++ finished: global begin run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin run 2 : time = 55000001
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++ starting: global begin run for module: label = 'test' id = 19
-++++++ finished: global begin run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'testmerge' id = 20
-++++++ finished: global begin run for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 21
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++ starting: global begin run for module: label = 'getInt' id = 22
-++++++ finished: global begin run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 18
+++++++ finished: global begin run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 19
+++++++ finished: global begin run for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 20
+++++++ finished: global begin run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 21
+++++++ finished: global begin run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
@@ -2790,56 +2738,56 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -2914,105 +2862,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: source event
@@ -3070,105 +3014,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: source event
@@ -3226,105 +3166,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: source event
@@ -3382,105 +3318,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 2 event: 0
@@ -3529,56 +3461,56 @@
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
@@ -3590,11 +3522,11 @@
 ++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global write lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3623,56 +3555,56 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -3747,105 +3679,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: source event
@@ -3903,105 +3831,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: source event
@@ -4059,105 +3983,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: source event
@@ -4215,105 +4135,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 3 event: 0
@@ -4362,56 +4278,56 @@
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
@@ -4423,11 +4339,11 @@
 ++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global write lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4456,56 +4372,56 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -4580,105 +4496,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: source event
@@ -4736,105 +4648,101 @@
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ queuing: EventSetup synchronization run: 2 lumi: 4294967295 event: 18446744073709551615
@@ -4883,56 +4791,56 @@
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
@@ -4944,11 +4852,11 @@
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global write lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 3 lumi: 0 event: 0
@@ -4996,56 +4904,56 @@
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end run 2 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'testmerge' id = 33
-++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++ starting: global end run for module: label = 'test' id = 32
-++++++ finished: global end run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++ starting: global end run for module: label = 'getInt' id = 35
-++++++ finished: global end run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++ starting: global end run for module: label = 'testmerge' id = 31
+++++++ finished: global end run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++ starting: global end run for module: label = 'test' id = 30
+++++++ finished: global end run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++ starting: global end run for module: label = 'get' id = 32
+++++++ finished: global end run for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++ starting: global end run for module: label = 'getInt' id = 33
+++++++ finished: global end run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end run 2 : time = 0
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'testmerge' id = 20
-++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++ starting: global end run for module: label = 'test' id = 19
-++++++ finished: global end run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++ starting: global end run for module: label = 'getInt' id = 22
-++++++ finished: global end run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 19
+++++++ finished: global end run for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++ starting: global end run for module: label = 'test' id = 18
+++++++ finished: global end run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++ starting: global end run for module: label = 'get' id = 20
+++++++ finished: global end run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 21
+++++++ finished: global end run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global write run 2 : time = 100000001
 ++++ finished: global write run 2 : time = 100000001
@@ -5057,11 +4965,11 @@
 ++++ finished: global write run 2 : time = 0
 ++++ starting: global write run 2 : time = 0
 ++++ starting: global write run 2 : time = 0
-++++++ starting: write run for module: label = 'out' id = 37
-++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 35
+++++++ finished: write run for module: label = 'out' id = 35
 ++++ finished: global write run 2 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
+++++++ starting: write run for module: label = 'out' id = 23
+++++++ finished: write run for module: label = 'out' id = 23
 ++++ finished: global write run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -5090,56 +4998,56 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin run 3 : time = 105000001
-++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 32
-++++++ starting: global begin run for module: label = 'test' id = 32
-++++++ finished: global begin run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 33
-++++++ starting: global begin run for module: label = 'testmerge' id = 33
-++++++ finished: global begin run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 34
-++++++ starting: global begin run for module: label = 'get' id = 34
-++++++ finished: global begin run for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 35
-++++++ starting: global begin run for module: label = 'getInt' id = 35
-++++++ finished: global begin run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 30
+++++++ starting: global begin run for module: label = 'test' id = 30
+++++++ finished: global begin run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 31
+++++++ starting: global begin run for module: label = 'testmerge' id = 31
+++++++ finished: global begin run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 32
+++++++ starting: global begin run for module: label = 'get' id = 32
+++++++ finished: global begin run for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 33
+++++++ starting: global begin run for module: label = 'getInt' id = 33
+++++++ finished: global begin run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin run 3 : time = 105000001
-++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 19
-++++++ starting: global begin run for module: label = 'test' id = 19
-++++++ finished: global begin run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 20
-++++++ starting: global begin run for module: label = 'testmerge' id = 20
-++++++ finished: global begin run for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 21
-++++++ starting: global begin run for module: label = 'get' id = 21
-++++++ finished: global begin run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 22
-++++++ starting: global begin run for module: label = 'getInt' id = 22
-++++++ finished: global begin run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin Run for module: label = 'test' id = 18
+++++++ starting: global begin run for module: label = 'test' id = 18
+++++++ finished: global begin run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin Run for module: label = 'testmerge' id = 19
+++++++ starting: global begin run for module: label = 'testmerge' id = 19
+++++++ finished: global begin run for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin Run for module: label = 'get' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 20
+++++++ finished: global begin run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin Run for module: label = 'getInt' id = 21
+++++++ starting: global begin run for module: label = 'getInt' id = 21
+++++++ finished: global begin run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
@@ -5189,56 +5097,56 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -5313,105 +5221,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: source event
@@ -5469,105 +5373,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: source event
@@ -5625,105 +5525,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: source event
@@ -5781,105 +5677,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 2 event: 0
@@ -5928,56 +5820,56 @@
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
@@ -5989,11 +5881,11 @@
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global write lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -6022,56 +5914,56 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -6146,105 +6038,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: source event
@@ -6302,105 +6190,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: source event
@@ -6458,105 +6342,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: source event
@@ -6614,105 +6494,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 3 event: 0
@@ -6761,56 +6637,56 @@
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
@@ -6822,11 +6698,11 @@
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global write lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -6855,56 +6731,56 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global begin lumi for module: label = 'test' id = 32
-++++++ finished: global begin lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global begin lumi for module: label = 'get' id = 34
-++++++ finished: global begin lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global begin lumi for module: label = 'getInt' id = 35
-++++++ finished: global begin lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global begin lumi for module: label = 'test' id = 30
+++++++ finished: global begin lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 31
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global begin lumi for module: label = 'get' id = 32
+++++++ finished: global begin lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global begin lumi for module: label = 'getInt' id = 33
+++++++ finished: global begin lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global begin lumi for module: label = 'test' id = 19
-++++++ finished: global begin lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
-++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global begin lumi for module: label = 'get' id = 21
-++++++ finished: global begin lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global begin lumi for module: label = 'getInt' id = 22
-++++++ finished: global begin lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global begin lumi for module: label = 'test' id = 18
+++++++ finished: global begin lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 19
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 20
+++++++ finished: global begin lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global begin lumi for module: label = 'getInt' id = 21
+++++++ finished: global begin lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global begin LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
@@ -6979,105 +6855,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: source event
@@ -7135,105 +7007,101 @@
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 34
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 32
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 32
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 30
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'endPath1' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'get' id = 20
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'test' id = 18
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 13
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 19
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 19
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 20
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 18
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 18
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 19
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 19
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 14
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 21
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 21
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 22
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 22
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 20
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 20
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 21
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 21
 ++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 15
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 24
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 17
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 17
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 23
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 23
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 23
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 26
-++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 26
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++++++ starting: processing event for module: stream = 0 label = 'path1' id = 25
+++++++++ finished: processing event for module: stream = 0 label = 'path1' id = 25
 ++++++ finished: processing path 'path1' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 32
-++++++++ starting: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: processing event for module: stream = 0 label = 'test' id = 32
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 33
-++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 27
-++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 27
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'test' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 30
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 31
+++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 26
+++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 26
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 34
-++++++++ starting: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: processing event for module: stream = 0 label = 'get' id = 34
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 35
-++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 28
-++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 28
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'get' id = 32
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 32
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 33
+++++++++ starting: processing event for module: stream = 0 label = 'path3' id = 27
+++++++++ finished: processing event for module: stream = 0 label = 'path3' id = 27
 ++++++ finished: processing path 'path3' : stream = 0
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
-++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 28
+++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 28
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ finished: processing event for module: stream = 0 label = 'out' id = 37
-++++++++ starting: processing event for module: stream = 0 label = 'endPath1' id = 30
-++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 24
+++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: prefetching before processing event for module: stream = 0 label = 'out' id = 35
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 35
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 35
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 4294967295 event: 18446744073709551615
@@ -7282,56 +7150,56 @@
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 33
-++++++ starting: global end lumi for module: label = 'testmerge' id = 33
-++++++ finished: global end lumi for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 32
-++++++ starting: global end lumi for module: label = 'test' id = 32
-++++++ finished: global end lumi for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 34
-++++++ starting: global end lumi for module: label = 'get' id = 34
-++++++ finished: global end lumi for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 35
-++++++ starting: global end lumi for module: label = 'getInt' id = 35
-++++++ finished: global end lumi for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 31
+++++++ starting: global end lumi for module: label = 'testmerge' id = 31
+++++++ finished: global end lumi for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 30
+++++++ starting: global end lumi for module: label = 'test' id = 30
+++++++ finished: global end lumi for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 32
+++++++ finished: global end lumi for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 33
+++++++ starting: global end lumi for module: label = 'getInt' id = 33
+++++++ finished: global end lumi for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 20
-++++++ starting: global end lumi for module: label = 'testmerge' id = 20
-++++++ finished: global end lumi for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 19
-++++++ starting: global end lumi for module: label = 'test' id = 19
-++++++ finished: global end lumi for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 21
-++++++ starting: global end lumi for module: label = 'get' id = 21
-++++++ finished: global end lumi for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 22
-++++++ starting: global end lumi for module: label = 'getInt' id = 22
-++++++ finished: global end lumi for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'testmerge' id = 19
+++++++ starting: global end lumi for module: label = 'testmerge' id = 19
+++++++ finished: global end lumi for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'test' id = 18
+++++++ starting: global end lumi for module: label = 'test' id = 18
+++++++ finished: global end lumi for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'get' id = 20
+++++++ starting: global end lumi for module: label = 'get' id = 20
+++++++ finished: global end lumi for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'getInt' id = 21
+++++++ starting: global end lumi for module: label = 'getInt' id = 21
+++++++ finished: global end lumi for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end LuminosityBlock for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
@@ -7343,11 +7211,11 @@
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global write lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: write lumi for module: label = 'out' id = 37
-++++++ finished: write lumi for module: label = 'out' id = 37
+++++++ starting: write lumi for module: label = 'out' id = 35
+++++++ finished: write lumi for module: label = 'out' id = 35
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: write lumi for module: label = 'out' id = 24
-++++++ finished: write lumi for module: label = 'out' id = 24
+++++++ starting: write lumi for module: label = 'out' id = 23
+++++++ finished: write lumi for module: label = 'out' id = 23
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
@@ -7392,56 +7260,56 @@
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
 ++++ starting: global end run 3 : time = 0
-++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 31
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 31
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 33
-++++++ starting: global end run for module: label = 'testmerge' id = 33
-++++++ finished: global end run for module: label = 'testmerge' id = 33
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 32
-++++++ starting: global end run for module: label = 'test' id = 32
-++++++ finished: global end run for module: label = 'test' id = 32
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 34
-++++++ starting: global end run for module: label = 'get' id = 34
-++++++ finished: global end run for module: label = 'get' id = 34
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 35
-++++++ starting: global end run for module: label = 'getInt' id = 35
-++++++ finished: global end run for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 36
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 36
+++++++++ starting: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++++ starting: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++++ starting: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++++ starting: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++++ starting: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++++ starting: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 29
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 29
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 31
+++++++ starting: global end run for module: label = 'testmerge' id = 31
+++++++ finished: global end run for module: label = 'testmerge' id = 31
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 30
+++++++ starting: global end run for module: label = 'test' id = 30
+++++++ finished: global end run for module: label = 'test' id = 30
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 32
+++++++ starting: global end run for module: label = 'get' id = 32
+++++++ finished: global end run for module: label = 'get' id = 32
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 33
+++++++ starting: global end run for module: label = 'getInt' id = 33
+++++++ finished: global end run for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 34
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 34
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 34
 ++++ finished: global end run 3 : time = 0
-++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 18
-++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 18
-++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 20
-++++++ starting: global end run for module: label = 'testmerge' id = 20
-++++++ finished: global end run for module: label = 'testmerge' id = 20
-++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 19
-++++++ starting: global end run for module: label = 'test' id = 19
-++++++ finished: global end run for module: label = 'test' id = 19
-++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 21
-++++++ starting: global end run for module: label = 'get' id = 21
-++++++ finished: global end run for module: label = 'get' id = 21
-++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 22
-++++++ starting: global end run for module: label = 'getInt' id = 22
-++++++ finished: global end run for module: label = 'getInt' id = 22
-++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 23
-++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
-++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 23
+++++++++ finished: prefetching before processing global end Run for module: label = 'thingWithMergeProducer' id = 17
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 17
+++++++++ finished: prefetching before processing global end Run for module: label = 'testmerge' id = 19
+++++++ starting: global end run for module: label = 'testmerge' id = 19
+++++++ finished: global end run for module: label = 'testmerge' id = 19
+++++++++ finished: prefetching before processing global end Run for module: label = 'test' id = 18
+++++++ starting: global end run for module: label = 'test' id = 18
+++++++ finished: global end run for module: label = 'test' id = 18
+++++++++ finished: prefetching before processing global end Run for module: label = 'get' id = 20
+++++++ starting: global end run for module: label = 'get' id = 20
+++++++ finished: global end run for module: label = 'get' id = 20
+++++++++ finished: prefetching before processing global end Run for module: label = 'getInt' id = 21
+++++++ starting: global end run for module: label = 'getInt' id = 21
+++++++ finished: global end run for module: label = 'getInt' id = 21
+++++++++ finished: prefetching before processing global end Run for module: label = 'dependsOnNoPut' id = 22
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 22
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 22
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global write run 3 : time = 150000001
 ++++ finished: global write run 3 : time = 150000001
@@ -7453,11 +7321,11 @@
 ++++ finished: global write run 3 : time = 0
 ++++ starting: global write run 3 : time = 0
 ++++ starting: global write run 3 : time = 0
-++++++ starting: write run for module: label = 'out' id = 37
-++++++ finished: write run for module: label = 'out' id = 37
+++++++ starting: write run for module: label = 'out' id = 35
+++++++ finished: write run for module: label = 'out' id = 35
 ++++ finished: global write run 3 : time = 0
-++++++ starting: write run for module: label = 'out' id = 24
-++++++ finished: write run for module: label = 'out' id = 24
+++++++ starting: write run for module: label = 'out' id = 23
+++++++ finished: write run for module: label = 'out' id = 23
 ++++ finished: global write run 3 : time = 0
 ++++ starting: end process block
 ++++ finished: end process block
@@ -7472,16 +7340,16 @@
 ++++ starting: end process block
 ++++ finished: end process block
 ++++ starting: end process block
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 22
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 21
 ++++ starting: end process block
-++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 35
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 35
-++++++ starting: end process block for module: label = 'getInt' id = 35
-++++++ finished: end process block for module: label = 'getInt' id = 35
+++++++++ starting: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 33
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 33
+++++++ starting: end process block for module: label = 'getInt' id = 33
+++++++ finished: end process block for module: label = 'getInt' id = 33
 ++++ finished: end process block
-++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 22
-++++++ starting: end process block for module: label = 'getInt' id = 22
-++++++ finished: end process block for module: label = 'getInt' id = 22
+++++++++ finished: prefetching before processing end ProcessBlock for module: label = 'getInt' id = 21
+++++++ starting: end process block for module: label = 'getInt' id = 21
+++++++ finished: end process block for module: label = 'getInt' id = 21
 ++++ finished: end process block
 ++++ starting: write process block
 ++++ finished: write process block
@@ -7493,11 +7361,11 @@
 ++++ finished: write process block
 ++++ starting: write process block
 ++++ starting: write process block
-++++++ starting: write process block for module: label = 'out' id = 37
-++++++ finished: write process block for module: label = 'out' id = 37
+++++++ starting: write process block for module: label = 'out' id = 35
+++++++ finished: write process block for module: label = 'out' id = 35
 ++++ finished: write process block
-++++++ starting: write process block for module: label = 'out' id = 24
-++++++ finished: write process block for module: label = 'out' id = 24
+++++++ starting: write process block for module: label = 'out' id = 23
+++++++ finished: write process block for module: label = 'out' id = 23
 ++++ finished: write process block
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
@@ -7521,22 +7389,22 @@
 ++++ finished: end stream for module: stream = 0 label = 'path1' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'path2' id = 4
 ++++ finished: end stream for module: stream = 0 label = 'path2' id = 4
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 18
-++++ starting: end stream for module: stream = 0 label = 'test' id = 19
-++++ finished: end stream for module: stream = 0 label = 'test' id = 19
-++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 20
-++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 20
-++++ starting: end stream for module: stream = 0 label = 'get' id = 21
-++++ finished: end stream for module: stream = 0 label = 'get' id = 21
-++++ starting: end stream for module: stream = 0 label = 'getInt' id = 22
-++++ finished: end stream for module: stream = 0 label = 'getInt' id = 22
-++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
-++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 23
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
+++++ starting: end stream for module: stream = 0 label = 'test' id = 18
+++++ finished: end stream for module: stream = 0 label = 'test' id = 18
+++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 19
+++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 19
+++++ starting: end stream for module: stream = 0 label = 'get' id = 20
+++++ finished: end stream for module: stream = 0 label = 'get' id = 20
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 21
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 21
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 12
-++++ starting: end stream for module: stream = 0 label = 'out' id = 24
-++++ finished: end stream for module: stream = 0 label = 'out' id = 24
+++++ starting: end stream for module: stream = 0 label = 'out' id = 23
+++++ finished: end stream for module: stream = 0 label = 'out' id = 23
 ++++ starting: end stream for module: stream = 0 label = 'path1' id = 13
 ++++ finished: end stream for module: stream = 0 label = 'path1' id = 13
 ++++ starting: end stream for module: stream = 0 label = 'path2' id = 14
@@ -7545,34 +7413,30 @@
 ++++ finished: end stream for module: stream = 0 label = 'path3' id = 15
 ++++ starting: end stream for module: stream = 0 label = 'path4' id = 16
 ++++ finished: end stream for module: stream = 0 label = 'path4' id = 16
-++++ starting: end stream for module: stream = 0 label = 'endPath1' id = 17
-++++ finished: end stream for module: stream = 0 label = 'endPath1' id = 17
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 31
-++++ starting: end stream for module: stream = 0 label = 'test' id = 32
-++++ finished: end stream for module: stream = 0 label = 'test' id = 32
-++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 33
-++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 33
-++++ starting: end stream for module: stream = 0 label = 'get' id = 34
-++++ finished: end stream for module: stream = 0 label = 'get' id = 34
-++++ starting: end stream for module: stream = 0 label = 'getInt' id = 35
-++++ finished: end stream for module: stream = 0 label = 'getInt' id = 35
-++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 36
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 25
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 25
-++++ starting: end stream for module: stream = 0 label = 'out' id = 37
-++++ finished: end stream for module: stream = 0 label = 'out' id = 37
-++++ starting: end stream for module: stream = 0 label = 'path1' id = 26
-++++ finished: end stream for module: stream = 0 label = 'path1' id = 26
-++++ starting: end stream for module: stream = 0 label = 'path2' id = 27
-++++ finished: end stream for module: stream = 0 label = 'path2' id = 27
-++++ starting: end stream for module: stream = 0 label = 'path3' id = 28
-++++ finished: end stream for module: stream = 0 label = 'path3' id = 28
-++++ starting: end stream for module: stream = 0 label = 'path4' id = 29
-++++ finished: end stream for module: stream = 0 label = 'path4' id = 29
-++++ starting: end stream for module: stream = 0 label = 'endPath1' id = 30
-++++ finished: end stream for module: stream = 0 label = 'endPath1' id = 30
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
+++++ starting: end stream for module: stream = 0 label = 'test' id = 30
+++++ finished: end stream for module: stream = 0 label = 'test' id = 30
+++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 31
+++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 31
+++++ starting: end stream for module: stream = 0 label = 'get' id = 32
+++++ finished: end stream for module: stream = 0 label = 'get' id = 32
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 33
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 33
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 24
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 24
+++++ starting: end stream for module: stream = 0 label = 'out' id = 35
+++++ finished: end stream for module: stream = 0 label = 'out' id = 35
+++++ starting: end stream for module: stream = 0 label = 'path1' id = 25
+++++ finished: end stream for module: stream = 0 label = 'path1' id = 25
+++++ starting: end stream for module: stream = 0 label = 'path2' id = 26
+++++ finished: end stream for module: stream = 0 label = 'path2' id = 26
+++++ starting: end stream for module: stream = 0 label = 'path3' id = 27
+++++ finished: end stream for module: stream = 0 label = 'path3' id = 27
+++++ starting: end stream for module: stream = 0 label = 'path4' id = 28
+++++ finished: end stream for module: stream = 0 label = 'path4' id = 28
 ++++ starting: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ finished: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ starting: end job for module with label 'get' id = 6
@@ -7595,20 +7459,20 @@
 ++++ finished: end job for module with label 'path1' id = 3
 ++++ starting: end job for module with label 'path2' id = 4
 ++++ finished: end job for module with label 'path2' id = 4
-++++ starting: end job for module with label 'thingWithMergeProducer' id = 18
-++++ finished: end job for module with label 'thingWithMergeProducer' id = 18
-++++ starting: end job for module with label 'test' id = 19
-++++ finished: end job for module with label 'test' id = 19
-++++ starting: end job for module with label 'testmerge' id = 20
-++++ finished: end job for module with label 'testmerge' id = 20
-++++ starting: end job for module with label 'get' id = 21
-++++ finished: end job for module with label 'get' id = 21
-++++ starting: end job for module with label 'getInt' id = 22
-++++ finished: end job for module with label 'getInt' id = 22
-++++ starting: end job for module with label 'dependsOnNoPut' id = 23
-++++ finished: end job for module with label 'dependsOnNoPut' id = 23
-++++ starting: end job for module with label 'out' id = 24
-++++ finished: end job for module with label 'out' id = 24
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 17
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 17
+++++ starting: end job for module with label 'test' id = 18
+++++ finished: end job for module with label 'test' id = 18
+++++ starting: end job for module with label 'testmerge' id = 19
+++++ finished: end job for module with label 'testmerge' id = 19
+++++ starting: end job for module with label 'get' id = 20
+++++ finished: end job for module with label 'get' id = 20
+++++ starting: end job for module with label 'getInt' id = 21
+++++ finished: end job for module with label 'getInt' id = 21
+++++ starting: end job for module with label 'dependsOnNoPut' id = 22
+++++ finished: end job for module with label 'dependsOnNoPut' id = 22
+++++ starting: end job for module with label 'out' id = 23
+++++ finished: end job for module with label 'out' id = 23
 ++++ starting: end job for module with label 'TriggerResults' id = 12
 ++++ finished: end job for module with label 'TriggerResults' id = 12
 ++++ starting: end job for module with label 'path1' id = 13
@@ -7619,32 +7483,28 @@
 ++++ finished: end job for module with label 'path3' id = 15
 ++++ starting: end job for module with label 'path4' id = 16
 ++++ finished: end job for module with label 'path4' id = 16
-++++ starting: end job for module with label 'endPath1' id = 17
-++++ finished: end job for module with label 'endPath1' id = 17
-++++ starting: end job for module with label 'thingWithMergeProducer' id = 31
-++++ finished: end job for module with label 'thingWithMergeProducer' id = 31
-++++ starting: end job for module with label 'test' id = 32
-++++ finished: end job for module with label 'test' id = 32
-++++ starting: end job for module with label 'testmerge' id = 33
-++++ finished: end job for module with label 'testmerge' id = 33
-++++ starting: end job for module with label 'get' id = 34
-++++ finished: end job for module with label 'get' id = 34
-++++ starting: end job for module with label 'getInt' id = 35
-++++ finished: end job for module with label 'getInt' id = 35
-++++ starting: end job for module with label 'dependsOnNoPut' id = 36
-++++ finished: end job for module with label 'dependsOnNoPut' id = 36
-++++ starting: end job for module with label 'out' id = 37
-++++ finished: end job for module with label 'out' id = 37
-++++ starting: end job for module with label 'TriggerResults' id = 25
-++++ finished: end job for module with label 'TriggerResults' id = 25
-++++ starting: end job for module with label 'path1' id = 26
-++++ finished: end job for module with label 'path1' id = 26
-++++ starting: end job for module with label 'path2' id = 27
-++++ finished: end job for module with label 'path2' id = 27
-++++ starting: end job for module with label 'path3' id = 28
-++++ finished: end job for module with label 'path3' id = 28
-++++ starting: end job for module with label 'path4' id = 29
-++++ finished: end job for module with label 'path4' id = 29
-++++ starting: end job for module with label 'endPath1' id = 30
-++++ finished: end job for module with label 'endPath1' id = 30
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 29
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 29
+++++ starting: end job for module with label 'test' id = 30
+++++ finished: end job for module with label 'test' id = 30
+++++ starting: end job for module with label 'testmerge' id = 31
+++++ finished: end job for module with label 'testmerge' id = 31
+++++ starting: end job for module with label 'get' id = 32
+++++ finished: end job for module with label 'get' id = 32
+++++ starting: end job for module with label 'getInt' id = 33
+++++ finished: end job for module with label 'getInt' id = 33
+++++ starting: end job for module with label 'dependsOnNoPut' id = 34
+++++ finished: end job for module with label 'dependsOnNoPut' id = 34
+++++ starting: end job for module with label 'out' id = 35
+++++ finished: end job for module with label 'out' id = 35
+++++ starting: end job for module with label 'TriggerResults' id = 24
+++++ finished: end job for module with label 'TriggerResults' id = 24
+++++ starting: end job for module with label 'path1' id = 25
+++++ finished: end job for module with label 'path1' id = 25
+++++ starting: end job for module with label 'path2' id = 26
+++++ finished: end job for module with label 'path2' id = 26
+++++ starting: end job for module with label 'path3' id = 27
+++++ finished: end job for module with label 'path3' id = 27
+++++ starting: end job for module with label 'path4' id = 28
+++++ finished: end job for module with label 'path4' id = 28
 ++ finished: end job

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -278,21 +278,23 @@ namespace edm {
     std::map<std::string, int> cumulates_;
     bool listContent_;
     bool listProvenance_;
+    bool listPathStatus_;
   };
 
   //
   // constructors and destructor
   //
   EventContentAnalyzer::EventContentAnalyzer(ParameterSet const& iConfig)
-      : indentation_(iConfig.getUntrackedParameter("indentation", std::string("++"))),
-        verboseIndentation_(iConfig.getUntrackedParameter("verboseIndentation", std::string("  "))),
-        moduleLabels_(iConfig.getUntrackedParameter("verboseForModuleLabels", std::vector<std::string>())),
-        verbose_(iConfig.getUntrackedParameter("verbose", false) || !moduleLabels_.empty()),
-        getModuleLabels_(iConfig.getUntrackedParameter("getDataForModuleLabels", std::vector<std::string>())),
-        getData_(iConfig.getUntrackedParameter("getData", false) || !getModuleLabels_.empty()),
+      : indentation_(iConfig.getUntrackedParameter<std::string>("indentation")),
+        verboseIndentation_(iConfig.getUntrackedParameter<std::string>("verboseIndentation")),
+        moduleLabels_(iConfig.getUntrackedParameter<std::vector<std::string>>("verboseForModuleLabels")),
+        verbose_(iConfig.getUntrackedParameter<bool>("verbose") || !moduleLabels_.empty()),
+        getModuleLabels_(iConfig.getUntrackedParameter<std::vector<std::string>>("getDataForModuleLabels")),
+        getData_(iConfig.getUntrackedParameter<bool>("getData") || !getModuleLabels_.empty()),
         evno_(1),
-        listContent_(iConfig.getUntrackedParameter("listContent", true)),
-        listProvenance_(iConfig.getUntrackedParameter("listProvenance", false)) {
+        listContent_(iConfig.getUntrackedParameter<bool>("listContent")),
+        listProvenance_(iConfig.getUntrackedParameter<bool>("listProvenance")),
+        listPathStatus_(iConfig.getUntrackedParameter<bool>("listPathStatus")) {
     //now do what ever initialization is needed
     sort_all(moduleLabels_);
     sort_all(getModuleLabels_);
@@ -347,7 +349,7 @@ namespace edm {
       std::string const& className = provenance->className();
       const std::string kPathStatus("edm::PathStatus");
       const std::string kEndPathStatus("edm::EndPathStatus");
-      if (className == kPathStatus || className == kEndPathStatus) {
+      if (not listPathStatus_ and (className == kPathStatus || className == kEndPathStatus)) {
         continue;
       }
       std::string const& friendlyName = provenance->friendlyClassName();
@@ -448,36 +450,39 @@ namespace edm {
     ParameterDescriptionNode* np;
 
     std::string defaultString("++");
-    np = desc.addOptionalUntracked<std::string>("indentation", defaultString);
+    np = desc.addUntracked<std::string>("indentation", defaultString);
     np->setComment("This string is printed at the beginning of every line printed during event processing.");
 
-    np = desc.addOptionalUntracked<bool>("verbose", false);
+    np = desc.addUntracked<bool>("verbose", false);
     np->setComment("If true, the contents of products are printed.");
 
     defaultString = "  ";
-    np = desc.addOptionalUntracked<std::string>("verboseIndentation", defaultString);
+    np = desc.addUntracked<std::string>("verboseIndentation", defaultString);
     np->setComment(
         "This string is used to further indent lines when printing the contents of products in verbose mode.");
 
     std::vector<std::string> defaultVString;
 
-    np = desc.addOptionalUntracked<std::vector<std::string> >("verboseForModuleLabels", defaultVString);
+    np = desc.addUntracked<std::vector<std::string>>("verboseForModuleLabels", defaultVString);
     np->setComment("If this vector is not empty, then only products with module labels on this list are printed.");
 
-    np = desc.addOptionalUntracked<bool>("getData", false);
+    np = desc.addUntracked<bool>("getData", false);
     np->setComment("If true the products will be retrieved using getByLabel.");
 
-    np = desc.addOptionalUntracked<std::vector<std::string> >("getDataForModuleLabels", defaultVString);
+    np = desc.addUntracked<std::vector<std::string>>("getDataForModuleLabels", defaultVString);
     np->setComment(
         "If this vector is not empty, then only products with module labels on this list are retrieved by getByLabel.");
 
-    np = desc.addOptionalUntracked<bool>("listContent", true);
+    np = desc.addUntracked<bool>("listContent", true);
     np->setComment("If true then print a list of all the event content.");
 
-    np = desc.addOptionalUntracked<bool>("listProvenance", false);
+    np = desc.addUntracked<bool>("listProvenance", false);
     np->setComment("If true, and if listContent or verbose is true, print provenance information for each product");
 
+    desc.addUntracked<bool>("listPathStatus", false)
+        ->setComment("If true, also show PathStatus/EndPathStatus data products.");
     descriptions.add("printContent", desc);
+    descriptions.addDefault(desc);
   }
 }  // namespace edm
 

--- a/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
@@ -3,11 +3,11 @@
 RandomNumberGeneratorService dump
 
     Contents of seedsAndNameMap (label moduleID engineType seeds)
-        t1  4  HepJamesRandom  81
-        t2  5  RanecuEngine  1  2
-        t3  6  TRandom3  83
-        t4  7  HepJamesRandom  84
-        t6  8  MixMaxRng  85
+        t1  3  HepJamesRandom  81
+        t2  4  RanecuEngine  1  2
+        t3  5  TRandom3  83
+        t4  6  HepJamesRandom  84
+        t6  7  MixMaxRng  85
     nStreams_ = 3
     saveFileName_ = StashStateStream.data
     saveFileNameRecorded_ = 0

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -3,11 +3,11 @@
 RandomNumberGeneratorService dump
 
     Contents of seedsAndNameMap (label moduleID engineType seeds)
-        t1  4  HepJamesRandom  81
-        t2  5  RanecuEngine  1  2
-        t3  6  TRandom3  83
-        t4  7  HepJamesRandom  84
-        t6  8  MixMaxRng  85
+        t1  3  HepJamesRandom  81
+        t2  4  RanecuEngine  1  2
+        t3  5  TRandom3  83
+        t4  6  HepJamesRandom  84
+        t6  7  MixMaxRng  85
     nStreams_ = 1
     saveFileName_ = StashState1.data
     saveFileNameRecorded_ = 0


### PR DESCRIPTION
#### PR description:

The EndPathStatus was being added to the ProductRegistry for merge jobs. This caused the ProcessHistory (which excludes entries for jobs without Paths) and the branch list indices to get out of sync when a merge job happens.

#### PR validation:

Framework plus new unit tests pass.

fixes makortel/framework#755
