### PR TITLE
Fixed copy constructor name in bqueue_itr

### DIFF
--- a/TrackingTools/PatternTools/interface/bqueue.h
+++ b/TrackingTools/PatternTools/interface/bqueue.h
@@ -110,7 +110,7 @@ namespace cmsutils {
       it = t2.it;
       return *this;
     }
-    _bqueue_itr<T>(const _bqueue_itr<T> &t2) = default;
+    _bqueue_itr(const _bqueue_itr<T> &t2) = default;
     friend class bqueue<T>;
 
   private:


### PR DESCRIPTION
#### PR description:

The C++20 build was failing because of the incorrect copy constructor name.

#### PR validation:

Code compiles in CMSSW_14_0_CPP20_X_2024-01-08-2300.