### PR TITLE
Explicit default methods for SDSRawDataCollection

### DIFF
--- a/DataFormats/L1ScoutingRawData/interface/SDSRawDataCollection.h
+++ b/DataFormats/L1ScoutingRawData/interface/SDSRawDataCollection.h
@@ -14,14 +14,16 @@
 class SDSRawDataCollection : public edm::DoNotRecordParents {
 public:
   SDSRawDataCollection();
+  SDSRawDataCollection(const SDSRawDataCollection&) = default;
+  SDSRawDataCollection(SDSRawDataCollection&&) noexcept = default;
+  SDSRawDataCollection& operator=(const SDSRawDataCollection&) = default;
+  SDSRawDataCollection& operator=(SDSRawDataCollection&&) noexcept = default;
 
   // retrive data for the scouting source at sourceId
   const FEDRawData& FEDData(int sourceId) const;
 
   // retrive data for the scouting source at sourceId
   FEDRawData& FEDData(int sourceId);
-
-  SDSRawDataCollection(const SDSRawDataCollection&);
 
   void swap(SDSRawDataCollection& other) { data_.swap(other.data_); }
 

--- a/DataFormats/L1ScoutingRawData/src/SDSRawDataCollection.cc
+++ b/DataFormats/L1ScoutingRawData/src/SDSRawDataCollection.cc
@@ -3,8 +3,6 @@
 
 SDSRawDataCollection::SDSRawDataCollection() : data_(SDSNumbering::lastSDSId() + 1) {}
 
-SDSRawDataCollection::SDSRawDataCollection(const SDSRawDataCollection& in) : data_(in.data_) {}
-
 const FEDRawData& SDSRawDataCollection::FEDData(int sourceId) const { return data_[sourceId]; }
 
 FEDRawData& SDSRawDataCollection::FEDData(int sourceId) { return data_[sourceId]; }


### PR DESCRIPTION
#### PR description:

This fixes a compiler warning in DEVEL about implicit move operator= being deprecated.

#### PR validation:

Compiler warning is now gone.