### PR TITLE
Remove hackConditions as was done in L1T Offline fork

### DIFF
--- a/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1CaloEmulator_cff.py
@@ -4,7 +4,3 @@ from L1Trigger.L1TCalorimeter.simDigis_cff import *
 
 # define a core which can be extended in customizations:
 SimL1CaloEmulator = cms.Sequence( SimL1TCalorimeter )
-
-# Emulators are configured from DB (GlobalTags)
-# but in the integration branch conffigure from static hackConditions
-from L1Trigger.L1TCalorimeter.hackConditions_cff import *


### PR DESCRIPTION
#### PR description:

This PR removes the conditions hack from L1Trigger SimCaloEmulator configuration as was done in https://github.com/cms-l1t-offline/cmssw/pull/1068

This was noticed as an issue blocking some calo params cleanup in https://github.com/cms-sw/cmssw/pull/43154

@bundocka: FYI

#### PR validation:

Was done in L1T fork a while ago and never ported here, and I think everyone concerned believed this was already deprecated.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.