### PR TITLE
Introduce wf 7.5 (phase-2 cosmics D98) and necessary mods to make it run

### DIFF
--- a/Configuration/EventContent/python/EventContentCosmics_cff.py
+++ b/Configuration/EventContent/python/EventContentCosmics_cff.py
@@ -155,6 +155,17 @@ RAWSIMEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 RAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
+
+#
+# Temporary collections needed for Phase-2 RECO using RAWSIM as input in Prod-like workflow
+# They are until packer/unpackers are done.
+#
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(RAWSIMEventContent,
+    outputCommands = RAWSIMEventContent.outputCommands+[
+        'keep *_sim*Digis_*_*',
+        'keep *Phase2TrackerDigi*_*_*_*'])
+
 #
 #
 # RECOSIM Data Tier definition
@@ -204,6 +215,14 @@ FEVTEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
 FEVTEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)	
 FEVTEventContent.outputCommands.extend(OnlineMetaDataContent.outputCommands)	
 FEVTEventContent.outputCommands.extend(TcdsEventContent.outputCommands)	
+
+phase2_tracker.toModify(FEVTEventContent, 
+    outputCommands = FEVTEventContent.outputCommands + [
+        'keep Phase2TrackerDigiedmDetSetVector_mix_*_*',
+        'keep *_TTClustersFromPhase2TrackerDigis_*_*',
+        'keep *_TTStubsFromPhase2TrackerDigis_*_*',
+        'keep *_TrackerDTC_*_*',
+        'keep *_*_Level1TTTracks_*'])
 
 #replace FEVTEventContent.outputCommands += HLTriggerFEVT.outputCommands 
 FEVTHLTALLEventContent = cms.PSet(

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -688,6 +688,7 @@ workflows[7.23] = ['', ['Cosmics_UP21','DIGICOS_UP21','RECOCOS_UP21','ALCACOS_UP
 workflows[7.24] = ['', ['Cosmics_UP21_0T','DIGICOS_UP21_0T','RECOCOS_UP21_0T','ALCACOS_UP21_0T','HARVESTCOS_UP21_0T']]#2021 0T
 workflows[7.3] = ['CosmicsSPLoose2018', ['CosmicsSPLoose_UP18','DIGICOS_UP18','RECOCOS_UP18','ALCACOS_UP18','HARVESTCOS_UP18']]
 workflows[7.4] = ['CosmicsPEAK2018', ['Cosmics_UP18','DIGICOSPEAK_UP18','RECOCOSPEAK_UP18','ALCACOS_UP18','HARVESTCOS_UP18']]
+workflows[7.5] = ['', ['Cosmics_Phase2','DIGICOS_Phase2','RECOCOS_Phase2']] #,'ALCACOS_Phase2','HARVESTCOS_Phase2']] inactive at the moment
 
 workflows[8]  = ['', ['BeamHalo','DIGICOS','RECOCOS','ALCABH','HARVESTCOS']]
 workflows[8.1] = ['', ['BeamHalo_UP18','DIGICOS_UP18','RECOCOS_UP18','ALCABH_UP18','HARVESTCOS_UP18']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1089,6 +1089,19 @@ steps['Cosmics_UP21']=merge([{'cfg':'UndergroundCosmicMu_cfi.py','-n':'500','--c
 steps['Cosmics_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2022_cosmics_0T'},steps['Cosmics_UP21']])
 steps['CosmicsSPLoose_UP17']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','-n':'2000','--conditions':'auto:phase1_2017_cosmics','--scenario':'cosmics','--era':'Run2_2017'},Kby(5000,500000),step1Up2015Defaults])
 steps['CosmicsSPLoose_UP18']=merge([{'cfg':'UndergroundCosmicSPLooseMu_cfi.py','-n':'2000','--conditions':'auto:phase1_2018_cosmics','--scenario':'cosmics','--era':'Run2_2018'},Kby(5000,500000),step1Up2015Defaults])
+
+# Phase2 cosmics with geometry D98
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import upgradeProperties
+phase2CosInfo=upgradeProperties[2026]['2026D98'] # so if the default changes, change wf only here
+
+steps['Cosmics_Phase2']=merge([{'cfg':'UndergroundCosmicMu_cfi.py',
+                                '-n':'500',
+                                '--conditions': phase2CosInfo['GT'],
+                                '--scenario':'cosmics',
+                                '--era': phase2CosInfo['Era'],
+                                '--geometry': phase2CosInfo['Geom'],
+                                '--beamspot':'HLLHC14TeV'},Kby(666,100000),step1Defaults])
+
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
 steps['BeamHalo_UP18']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','-n':'500','--conditions':'auto:phase1_2018_cosmics','--scenario':'cosmics','--era':'Run2_2018','--beamspot':'Realistic25ns13TeVEarly2018Collision'},Kby(666,100000),step1Defaults])
@@ -1881,6 +1894,14 @@ steps['DIGICOS_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2
 
 steps['DIGICOSPEAK_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics_peak','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2017','--customise_commands': '"process.mix.digitizers.strip.APVpeakmode=cms.bool(True)"','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2017'},step2Upg2015Defaults])
 steps['DIGICOSPEAK_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics_peak','-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@relval2018','--customise_commands': '"process.mix.digitizers.strip.APVpeakmode=cms.bool(True)"','--scenario':'cosmics','--eventcontent':'FEVTDEBUG','--datatier':'GEN-SIM-DIGI-RAW', '--era' : 'Run2_2018'},step2Upg2015Defaults])
+
+steps['DIGICOS_Phase2']=merge([{'--conditions': phase2CosInfo['GT'],
+                                '-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:@fake2',
+                                '--scenario':'cosmics',
+                                '--eventcontent':'FEVTDEBUG',
+                                '--datatier':'GEN-SIM-DIGI-RAW',
+                                '--era' : phase2CosInfo['Era'],
+                                '--geometry': phase2CosInfo['Geom']},step2Upg2015Defaults])
 
 steps['DIGIPU1']=merge([PU,step2Defaults])
 steps['DIGIPU2']=merge([PU2,step2Defaults])
@@ -2899,7 +2920,11 @@ steps['RECOCOS_UP21']=merge([{'--conditions':'auto:phase1_2022_cosmics','-s':'RA
 steps['RECOCOS_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2022_cosmics_0T'},steps['RECOCOS_UP21']])
 steps['RECOCOSPEAK_UP17']=merge([{'--conditions':'auto:phase1_2017_cosmics_peak','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2017'},step3Up2015Hal])
 steps['RECOCOSPEAK_UP18']=merge([{'--conditions':'auto:phase1_2018_cosmics_peak','-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics,DQM','--scenario':'cosmics','--era':'Run2_2018'},step3Up2015Hal])
-
+steps['RECOCOS_Phase2']=merge([{'--conditions': phase2CosInfo['GT'],
+                                '-s':'RAW2DIGI,L1Reco,RECO,ALCA:MuAlGlobalCosmics',
+                                '--scenario':'cosmics',
+                                '--era': phase2CosInfo['Era'],
+                                '--geometry': phase2CosInfo['Geom']},step3Up2015Hal]) # DQM step excluded for the moment
 
 steps['RECOMIN']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},stCond,step3Defaults])
 steps['RECOMINUP15']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,ALCA:SiStripCalZeroBias+SiStripCalMinBias,VALIDATION,DQM'},step3Up2015Defaults])
@@ -3236,6 +3261,11 @@ steps['ALCACOSDRUN2']=merge([{'--conditions':'auto:run2_data','--era':'Run2_2016
 steps['ALCACOSDRUN3']=merge([{'--conditions':'auto:run3_data','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 steps['ALCACOSDPROMPTRUN3']=merge([{'--conditions':'auto:run3_data_prompt','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
 steps['ALCACOSDEXPRUN3']=merge([{'--conditions':'auto:run3_data_express','--era':'Run3','-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+SiStripCalCosmics+SiStripCalCosmicsNano+MuAlGlobalCosmics+HcalCalHOCosmics+DQM'},steps['ALCACOSD']])
+
+steps['ALCACOS_Phase2']=merge([{'--conditions': phase2CosInfo['GT'],
+                                '--era': phase2CosInfo['Era'],
+                                '-s':'ALCA:SiPixelCalCosmics+TkAlCosmics0T+DQM',
+                                '--geometry': phase2CosInfo['Geom']},steps['ALCACOSD']])
 
 steps['ALCAPROMPT']={'-s':'ALCA:PromptCalibProd',
                      '--filein':'file:TkAlMinBias.root',
@@ -3728,6 +3758,16 @@ steps['HARVESTCOS_UP21']={'-s'          :'HARVESTING:dqmHarvesting',
 
 steps['HARVESTCOS_UP21_0T']=merge([{'--magField':'0T','--conditions':'auto:phase1_2022_cosmics_0T'},steps['HARVESTCOS_UP21']])
 
+steps['HARVESTCOS_Phase2']={'-s'          : 'HARVESTING:@cosmics',
+                            '--conditions': phase2CosInfo['GT'],
+                            '--mc'        : '',
+                            '--filein'    : 'file:step3_inDQM.root',
+                            '--scenario'  : 'cosmics',
+                            '--filetype'  : 'DQM',
+                            '--era'       : phase2CosInfo['Era'],
+                            '--geometry'  : phase2CosInfo['Geom']
+                            }
+
 steps['HARVESTFS']={'-s':'HARVESTING:validationHarvestingFS',
                    '--conditions':'auto:run1_mc',
                    '--mc':'',
@@ -4117,7 +4157,7 @@ steps['HcalNanoCalibGap']={'-s':'RAW2DIGI,RECO,USER:DPGAnalysis/HcalNanoAOD/hcal
 ###
 #################################################################################
 
-from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 
 # imported from above, only non-empty values should be provided here
 defaultDataSets['2017']='CMSSW_12_0_0_pre4-113X_mc2017_realistic_v5-v'

--- a/Configuration/StandardSequences/python/DigiCosmics_cff.py
+++ b/Configuration/StandardSequences/python/DigiCosmics_cff.py
@@ -62,3 +62,12 @@ doAllDigi = cms.Sequence(doAllDigiTask)
 pdigi = cms.Sequence(pdigiTask)
 pdigi_valid = cms.Sequence(pdigiTask)
 
+#phase 2 common mods
+def _modifyEnableHcalHardcode( theProcess ):
+    from CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff import hcal_db_producer as _hcal_db_producer, es_hardcode as _es_hardcode, es_prefer_hcalHardcode as _es_prefer_hcalHardcode
+    theProcess.hcal_db_producer = _hcal_db_producer
+    theProcess.es_hardcode = _es_hardcode
+    theProcess.es_prefer_hcalHardcode = _es_prefer_hcalHardcode    
+
+from Configuration.Eras.Modifier_hcalHardcodeConditions_cff import hcalHardcodeConditions
+modifyEnableHcalHardcode_ = hcalHardcodeConditions.makeProcessModifier( _modifyEnableHcalHardcode )

--- a/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionCosmics_cff.py
@@ -21,6 +21,8 @@ from RecoTracker.Configuration.RecoTrackerBHM_cff import *
 #
 from RecoLocalCalo.Configuration.RecoLocalCalo_Cosmics_cff import *
 from RecoEcal.Configuration.RecoEcalCosmics_cff import *
+from RecoHGCal.Configuration.recoHGCAL_cff import *
+
 #
 # muons
 #
@@ -44,6 +46,11 @@ from RecoEgamma.Configuration.RecoEgammaCosmics_cff import *
 
 # local reco
 trackerCosmicsTask = cms.Task(offlineBeamSpot,trackerlocalrecoTask,MeasurementTrackerEvent,tracksP5Task)
+
+# ugly hack: for the time being remove tracking (no Cosmics seeding in Phase-2) 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toReplaceWith(trackerCosmicsTask,trackerCosmicsTask.copyAndExclude([tracksP5Task]))
+
 trackerCosmics = cms.Sequence(trackerCosmicsTask)
 caloCosmicsTask = cms.Task(calolocalrecoTaskCosmics,ecalClustersCosmicsTask)
 caloCosmics = cms.Sequence(caloCosmicsTask)
@@ -51,32 +58,49 @@ caloCosmics_HcalNZSTask = cms.Task(calolocalrecoTaskCosmicsNZS,ecalClustersCosmi
 caloCosmics_HcalNZS = cms.Sequence(caloCosmics_HcalNZSTask)
 muonsLocalRecoCosmicsTask = cms.Task(muonlocalrecoTask,muonlocalrecoT0SegTask)
 muonsLocalRecoCosmics = cms.Sequence(muonsLocalRecoCosmicsTask)
+localReconstructionCosmicsTask = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmicsTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask)
+#phase2_tracker.toReplaceWith(localReconstructionCosmicsTask,localReconstructionCosmicsTask.copyAndExclude([vertexrecoCosmicsTask]))  
 
-localReconstructionCosmicsTask         = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmicsTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask)
 localReconstructionCosmics         = cms.Sequence(localReconstructionCosmicsTask)
 localReconstructionCosmics_HcalNZSTask = cms.Task(bunchSpacingProducer,trackerCosmicsTask,caloCosmics_HcalNZSTask,muonsLocalRecoCosmicsTask,vertexrecoCosmicsTask)
 localReconstructionCosmics_HcalNZS = cms.Sequence(localReconstructionCosmics_HcalNZSTask)
-
 
 # global reco
 muonsCosmicsTask = cms.Task(muonRecoGRTask)
 jetsCosmicsTask = cms.Task(recoCaloTowersGRTask,recoJetsGRTask)
 egammaCosmicsTask = cms.Task(egammarecoGlobal_cosmicsTask,egammarecoCosmics_woElectronsTask)
 
-
 from FWCore.Modules.logErrorHarvester_cfi import *
 
+reconstructionCosmicsTask = cms.Task(localReconstructionCosmicsTask,
+                                     beamhaloTracksTask,
+                                     jetsCosmicsTask,
+                                     muonsCosmicsTask,
+                                     regionalCosmicTracksTask,
+                                     cosmicDCTracksSeqTask,
+                                     metrecoCosmicsTask,
+                                     egammaCosmicsTask,
+                                     logErrorHarvester)
 
-reconstructionCosmicsTask         = cms.Task(localReconstructionCosmicsTask,
-                                             beamhaloTracksTask,
-                                             jetsCosmicsTask,
-                                             muonsCosmicsTask,
-                                             regionalCosmicTracksTask,
-                                             cosmicDCTracksSeqTask,
-                                             metrecoCosmicsTask,
-                                             egammaCosmicsTask,
-                                             logErrorHarvester)
-reconstructionCosmics         = cms.Sequence(reconstructionCosmicsTask)
+# ugly hack
+# for the time being remove all tasks related to tracking
+phase2_tracker.toReplaceWith(reconstructionCosmicsTask,reconstructionCosmicsTask.copyAndExclude([beamhaloTracksTask,
+                                                                                                 cosmicDCTracksSeqTask,
+                                                                                                 regionalCosmicTracksTask,
+                                                                                                 metrecoCosmicsTask,
+                                                                                                 muonsCosmicsTask]))
+
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+_phase2HGALRecoTask = reconstructionCosmicsTask.copy()
+_phase2HGALRecoTask.add(iterTICLTask)
+phase2_hgcal.toReplaceWith(reconstructionCosmicsTask, _phase2HGALRecoTask)
+
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+_phase2HFNoseRecoTask = reconstructionCosmicsTask.copy()
+_phase2HFNoseRecoTask.add(iterHFNoseTICLTask)
+phase2_hfnose.toReplaceWith(reconstructionCosmicsTask, _phase2HFNoseRecoTask)
+
+reconstructionCosmics = cms.Sequence(reconstructionCosmicsTask)
 #logErrorHarvester should only wait for items produced in the reconstructionCosmics sequence
 _modulesInReconstruction = list()
 reconstructionCosmics.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInReconstruction))
@@ -91,7 +115,10 @@ reconstructionCosmics_HcalNZSTask = cms.Task(localReconstructionCosmics_HcalNZST
                                              metrecoCosmicsTask,
                                              egammaCosmicsTask,
                                              logErrorHarvester)
+
+phase2_tracker.toReplaceWith(reconstructionCosmics_HcalNZSTask,reconstructionCosmics_HcalNZSTask.copyAndExclude([beamhaloTracksTask,cosmicDCTracksSeqTask,regionalCosmicTracksTask]))
 reconstructionCosmics_HcalNZS = cms.Sequence(reconstructionCosmics_HcalNZSTask)
+
 reconstructionCosmics_woTkBHMTask = cms.Task(localReconstructionCosmicsTask,
                                              jetsCosmicsTask,
                                              muonsCosmicsTask,
@@ -99,4 +126,6 @@ reconstructionCosmics_woTkBHMTask = cms.Task(localReconstructionCosmicsTask,
                                              cosmicDCTracksSeqTask,
                                              metrecoCosmicsTask,
                                              egammaCosmicsTask)
+
+phase2_tracker.toReplaceWith(reconstructionCosmics_woTkBHMTask,reconstructionCosmics_woTkBHMTask.copyAndExclude([beamhaloTracksTask,cosmicDCTracksSeqTask,regionalCosmicTracksTask]))  
 reconstructionCosmics_woTkBHM = cms.Sequence(reconstructionCosmics_woTkBHMTask)

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -247,6 +247,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
             'none': ['DQMNone',
                      'PostDQMOffline',
                      'DQMNone'],
+
+            'cosmics' : ['DQMOfflineCosmics',
+                         'PostDQMOffline',
+                         'DQMOfflineCosmics']
             }
 
 _phase2_allowed = ['beam','trackingOnlyDQM','outerTracker', 'trackerPhase2', 'muon','hcal','hcal2','egamma','L1TMonPhase2','HLTMon']

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuonCosmics_cff.py
@@ -62,9 +62,13 @@ _run3_muonlocalrecoTask.add(gemLocalRecoTask)
 _phase2_muonlocalrecoTask = _run3_muonlocalrecoTask.copy()
 _phase2_muonlocalrecoTask.add(me0LocalRecoTask)
 
+_phase2_ge0_muonlocalrecoTask = _phase2_muonlocalrecoTask.copyAndExclude([me0LocalRecoTask])
+
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith( muonlocalrecoTask , _run2_GEM_2017_muonlocalrecoTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toReplaceWith( muonlocalrecoTask , _phase2_ge0_muonlocalrecoTask )

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_EventContent_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_EventContent_cff.py
@@ -19,8 +19,13 @@ RecoLocalTrackerRECO = cms.PSet(
 )
 RecoLocalTrackerRECO.outputCommands.extend(RecoLocalTrackerAOD.outputCommands)
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(RecoLocalTrackerRECO, outputCommands = RecoLocalTrackerRECO.outputCommands + ['keep *_siPhase2Clusters_*_*','keep *_siPhase2RecHits_*_*'] )
+
 # FEVT content
 RecoLocalTrackerFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 RecoLocalTrackerFEVT.outputCommands.extend(RecoLocalTrackerRECO.outputCommands)
+
+phase2_tracker.toModify(RecoLocalTrackerFEVT, outputCommands = RecoLocalTrackerFEVT.outputCommands + ['keep *_siPhase2Clusters_*_*','keep *_siPhase2RecHits_*_*'] )

--- a/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTracker_Cosmics_cff.py
@@ -11,4 +11,19 @@ from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff import *
 pixeltrackerlocalrecoTask = cms.Task(siPixelClusters,siPixelRecHits)
 striptrackerlocalrecoTask = cms.Task(siStripZeroSuppression,siStripClusters,siStripMatchedRecHits)
 trackerlocalrecoTask = cms.Task(pixeltrackerlocalrecoTask,striptrackerlocalrecoTask)
+
+from RecoLocalTracker.SiPhase2Clusterizer.phase2TrackerClusterizer_cfi import *
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEGeometricESProducer_cfi import *
+from RecoLocalTracker.SiPhase2VectorHitBuilder.siPhase2RecHitMatcher_cfi import *
+from RecoLocalTracker.SiPhase2VectorHitBuilder.siPhase2VectorHits_cfi import *
+from RecoLocalTracker.Phase2TrackerRecHits.Phase2TrackerRecHits_cfi import *
+
+_pixeltrackerlocalrecoTask_phase2 = pixeltrackerlocalrecoTask.copy()
+_pixeltrackerlocalrecoTask_phase2.add(siPhase2Clusters)
+_pixeltrackerlocalrecoTask_phase2.add(siPhase2RecHits)
+#_pixeltrackerlocalrecoTask_phase2.add(siPhase2VectorHits)
+phase2_tracker.toReplaceWith(pixeltrackerlocalrecoTask, _pixeltrackerlocalrecoTask_phase2)
+phase2_tracker.toReplaceWith(trackerlocalrecoTask, trackerlocalrecoTask.copyAndExclude([striptrackerlocalrecoTask]))
+
 trackerlocalreco = cms.Sequence(trackerlocalrecoTask)
+

--- a/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizersCosmics_cfi.py
@@ -8,6 +8,7 @@ from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+from SimGeneral.MixingModule.caloTruthProducer_cfi import *
 
 pixelDigitizer.TofLowerCut=cms.double(18.5)
 pixelDigitizer.TofUpperCut=cms.double(43.5)
@@ -34,30 +35,39 @@ theDigitizers = cms.PSet(
   )
 )
 
-theDigitizersValid = cms.PSet(
-  pixel = cms.PSet(
-    pixelDigitizer
-  ),
-  strip = cms.PSet(
-    stripDigitizer
-  ),
-  ecal = cms.PSet(
-    ecalDigitizer
-  ),
-  hcal = cms.PSet(
-    hcalDigitizer
-  ),
-  castor  = cms.PSet(
-    castorDigitizer
-  ),
-  mergedtruth = cms.PSet(
-    trackingParticles
-  )
-)
-
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify( theDigitizers, castor = None )
-run3_common.toModify( theDigitizersValid, castor = None )
 
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hgceeDigitizer, hgchebackDigitizer, hgchefrontDigitizer, HGCAL_noise_fC, HGCAL_noise_heback, HFNose_noise_fC, HGCAL_chargeCollectionEfficiencies, HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse, HGCAL_noises
 
+from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+phase2_hgcal.toModify( theDigitizers,
+                       hgceeDigitizer = cms.PSet(hgceeDigitizer),
+                       hgchebackDigitizer = cms.PSet(hgchebackDigitizer),
+                       hgchefrontDigitizer = cms.PSet(hgchefrontDigitizer),
+                       calotruth = cms.PSet(caloParticles), #HGCAL still needs calotruth for production mode
+)
 
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import hfnoseDigitizer
+
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+phase2_hfnose.toModify( theDigitizers,
+                        hfnoseDigitizer = cms.PSet(hfnoseDigitizer),
+)
+
+from SimGeneral.MixingModule.ecalTimeDigitizer_cfi import ecalTimeDigitizer
+from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
+phase2_timing.toModify( theDigitizers,
+                        ecalTime = ecalTimeDigitizer.clone() )
+
+from SimFastTiming.Configuration.SimFastTiming_cff import mtdDigitizer
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify( theDigitizers,
+                              fastTimingLayer = mtdDigitizer.clone() )
+
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(theDigitizers,
+                        strip = None)
+
+theDigitizersValid = cms.PSet(theDigitizers,
+                              mergedtruth = cms.PSet(trackingParticles))


### PR DESCRIPTION
#### PR description:

We currently don't have in the RelVal matrix any workflow running cosmic simulations for the phase-2 setup, while this is starting to become needed from the Tracker community because of alignment purposes (see [here](https://indico.cern.ch/event/1363492/contributions/5739059/attachments/2777810/4841418/TrkAl_090124.pdf) for more details).
I've tried to come up with a workflow (unfortunately not including full reconstruction as tracking in cosmics is not yet supported in the phase-2 setup) that does simulation of cosmics with the phase-2 detector (with geometry D88). 
This appears to work correctly up to recHits, but I have discovered that to allow doing so, I had to touch a variety of configuration files concerning different subdetectors (HGCal, Muons, etc.) and I am not fully sure that my changes are appropriate everywhere. 
I am opening ths PR for discussion to collect feedback.
If this is accepted, it can serve as a basis to develop more changes for a full cosmics reconstruction in phase-2.
This PR was presented at the Tracker DPG / Tracking POG meeting of [Jan 17th 2023](https://indico.cern.ch/event/1363140/contributions/5760900/attachments/2781831/4848877/mm_TrackerDPG_Phase2Cosmics.pdf)

#### PR validation:

Run successfully `runTheMatrix.py -l 7.5 --nEvents 10000`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A