### PR TITLE
Add relval for Herwig Matchbox

### DIFF
--- a/Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff.py
+++ b/Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+    herwig7StableParticlesForDetectorBlock,
+    herwig7CH3SettingsBlock,
+    run = cms.string('InterfaceMatchboxTest'),
+    dumpConfig = cms.untracked.string('HerwigConfig.in'),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    filterEfficiency = cms.untracked.double(1.0),
+    Matchbox = cms.vstring( 'read snippets/Matchbox.in',
+    'read snippets/PPCollider.in',
+    'cd /Herwig/EventHandlers',
+    'set EventHandler:LuminosityFunction:Energy 13000*GeV',
+    '## Model assumptions',
+    'read Matchbox/StandardModelLike.in',
+    'read Matchbox/DiagonalCKM.in',
+    '## Set the order of the couplings',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:OrderInAlphaS 0',
+    'set Factory:OrderInAlphaEW 2',
+    '## Select the process',
+    'do Factory:Process p p -> l+ l-',
+    '# read Matchbox/MadGraph-GoSam.in',
+    '# read Matchbox/MadGraph-MadGraph.in',
+    'read Matchbox/MadGraph-OpenLoops.in',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MinMass 50*GeV',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MaxMass 14000*GeV',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:ScaleChoice /Herwig/MatrixElements/Matchbox/Scales/LeptonPairMassScale',
+    'read Matchbox/MCatNLO-DefaultShower.in',
+    '# read Matchbox/NLO-NoShower.in',
+    '# read Matchbox/LO-NoShower.in',
+    'read Matchbox/FiveFlavourScheme.in',
+    'do /Herwig/MatrixElements/Matchbox/Factory:ProductionMode',
+    ),
+    parameterSets = cms.vstring('herwig7StableParticlesForDetector', 'Matchbox','herwig7CH3PDF', 'herwig7CH3AlphaS','herwig7CH3MPISettings'),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -47,6 +47,8 @@ workflows[520]=['VHToHtt_NLO_Pow_13TeV_py8_taurhonu',['VHToH_Pow_LHE_13TeV','Had
 workflows[535]=['',['TTbar_13TeV_Pow_herwig7','HARVESTGEN']]
 workflows[537]=['',['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7','HARVESTGEN']]
 workflows[538]=['',['DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7','HARVESTGEN']]
+workflows[539]=['',['DY_TuneCH3_13TeV_herwig_madgraph_matchbox','HARVESTGEN']]
+
 # External Decays
 
 workflows[521]=['WTolNuJets_LO_Mad_13TeV_py8_Ta',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCP5_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1592,6 +1592,7 @@ steps['sherpa_ttbar_2j_MENLOPS_13TeV_MASTER']=genvalid('sherpa_ttbar_2j_MENLOPS_
 steps['TTbar_13TeV_Pow_herwig7']=genvalid('Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff',step1LHEGenDQM)
 steps['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7']=genvalid('Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff',merge([{'-n':'12'},step1LHEGenDQM]))
 steps['DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7']=genvalid('Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff',step1LHEGenDQM)
+steps['DY_TuneCH3_13TeV_herwig_madgraph_matchbox']=genvalid('Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff',step1GenDefaults)
 
 
 # Heavy Ion


### PR DESCRIPTION
#### PR description:

Adds a new Herwig relval, 539, which tests running Madgraph inside Herwig using the "Matchbox" mode. Currently this process has a relatively large overhead (about 20 minutes) since it re-performs the Madgraph phase space integration every time - the addition of a gridpack system so that this does not need to be done is a high-priority item.

#### PR validation:

Have tested that the new relval runs in CMSSW_12_4_X

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/43261 for validation of changes to the matchbox for use in 2022 production