### PR TITLE
Avoid making voxels in TGeoManager

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -2314,7 +2314,7 @@ static long load_dddefinition(Detector& det, xml_h element) {
         wv.placeVolume(mfv1, 1);
 
       // Can not deal with reflections without closed geometry
-      det.manager().CloseGeometry();
+      det.manager().CloseGeometry("nv");
 
       det.endDocument();
     }


### PR DESCRIPTION
#### PR description:

Making voxels was the most time-consuming call and we do not use TGeoManager for particle propagation.
This was identified in the igprof reports from the IB.

#### PR validation:

Code compiles. Simple tests ran fine.