### PR TITLE
[HGCAL trigger] Fix hgcalTrigPrimValidation config name

### DIFF
--- a/Validation/HGCalValidation/python/hgcalValidationTPG_cfi.py
+++ b/Validation/HGCalValidation/python/hgcalValidationTPG_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from L1Trigger.L1THGCal.egammaIdentification import egamma_identification_histomax
 
-hgcalTrigPrimValidation = DQMEDAnalyzer(
+L1THGCalTrigPrimValidation = DQMEDAnalyzer(
         "HGCalTriggerValidator",
         TriggerCells = cms.InputTag('l1tHGCalConcentratorProducer:HGCalConcentratorProcessorSelection'),
         Clusters = cms.InputTag('l1tHGCalBackEndLayer1Producer:HGCalBackendLayer1Processor2DClustering'),


### PR DESCRIPTION
#### PR description
Fix name of `hgcalTrigPrimValidation` in cfi to match naming in:
https://github.com/cms-sw/cmssw/blob/f5cbbf1ab5806ffc54ccaab6a77201f35d63fca7/Validation/HGCalValidation/python/hgcalRunEmulatorValidationTPG_cff.py#L24

