### PR TITLE
Introduce matrix workflows for Alpaka-based Particle Flow

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -34,6 +34,10 @@ The offsets currently in use are:
 * 0.403: Alpaka, pixel only quadruplets, portable vs. CPU validation
 * 0.404: Alpaka, pixel only quadruplets, portable profiling
 * 0.412: Alpaka, ECAL only, portable
+* 0.422: Alpaka, HCAL only, portable
+* 0.423: Alpaka, HCAL only, portable vs CPU validation
+* 0.424: Alpaka, HCAL only, portable profiling
+* 0.492: Alpaka, full reco with pixel quadruplets
 * 0.5: Pixel tracking only + 0.1
 * 0.501: Patatrack, pixel only quadruplets, on CPU
 * 0.502: Patatrack, pixel only quadruplets, with automatic offload to GPU if available

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1063,7 +1063,7 @@ upgradeWFs['PatatrackPixelOnlyTripletsGPUProfiling'] = PatatrackWorkflow(
 upgradeWFs['PatatrackECALOnlyAlpaka'] = PatatrackWorkflow(
     digi = {
         # customize the ECAL Local Reco part of the HLT menu for Alpaka
-        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka 
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
@@ -1230,6 +1230,78 @@ upgradeWFs['PatatrackHCALOnlyGPUProfiling'] = PatatrackWorkflow(
     harvest = None,
     suffix = 'Patatrack_HCALOnlyGPU_Profiling',
     offset = 0.524,
+)
+
+# HCAL-PF Only workflow running HCAL local reco on GPU and PF with Alpaka with DQM and Validation
+# - HLT-alpaka
+# - HCAL-only reconstruction using Alpaka with DQM and Validation
+upgradeWFs['PatatrackHCALOnlyAlpakaValidation'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
+        '--procModifiers': 'alpaka'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@hcalOnlyValidation'
+    },
+    suffix = 'Patatrack_HCALOnlyAlpaka_Validation',
+    offset = 0.422,
+)
+
+# HCAL-PF Only workflow running HCAL local reco and PF with Alpaka with cluster level-validation
+# - HLT-alpaka
+# - HCAL-only reconstruction using GPU and Alpaka with DQM and Validation for PF Alpaka vs CPU comparisons
+upgradeWFs['PatatrackHCALOnlyGPUandAlpakaValidation'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnlyLegacy+reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation+pfClusterHBHEOnlyAlpakaComparisonSequence,DQM:@hcalOnly+@hcal2Only',
+        '--procModifiers': 'alpaka'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@hcalOnlyValidation'
+    },
+    suffix = 'Patatrack_HCALOnlyGPUandAlpaka_Validation',
+    offset = 0.423,
+)
+
+# HCAL-PF Only workflow running HCAL local reco on CPU and PF with Alpaka slimmed for benchmarking
+# - HLT-alpaka
+# - HCAL-only reconstruction using Alpaka
+upgradeWFs['PatatrackHCALOnlyAlpakaProfiling'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly',
+        '--procModifiers': 'alpaka'
+    },
+    harvest = None,
+    suffix = 'Patatrack_HCALOnlyAlpaka_Profiling',
+    offset = 0.424,
+)
+
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on GPU (optional), PF using Alpaka, together with the full offline reconstruction on CPU
+#  - HLT on GPU (optional)
+#  - reconstruction on Alpaka, with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackFullRecoAlpaka'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+    },
+    reco = {
+        # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
+        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
+        '--procModifiers': 'alpaka,pixelNtupletFit'
+    },
+    harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
+    },
+    suffix = 'Patatrack_FullRecoAlpaka',
+    offset = 0.492,
 )
 
 # Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU
@@ -1541,7 +1613,7 @@ upgradeWFs['PatatrackFullRecoTripletsGPUValidation'] = PatatrackWorkflow(
 
 upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka 
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
@@ -1556,7 +1628,7 @@ upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
 
 upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka 
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
@@ -1571,7 +1643,7 @@ upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
 
 upgradeWFs['PatatrackPixelOnlyAlpakaProfiling'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka 
+        '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly',

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -243,7 +243,16 @@ reconstruction_hcalOnlyTask = cms.Task(
     pfClusteringHBHEHFOnlyTask
 )
 
+# define secondary validation task running only Legacy
+reconstruction_hcalOnlyLegacyTask = cms.Task(
+        bunchSpacingProducer,
+        offlineBeamSpot,
+        hcalOnlyLegacyLocalRecoTask,
+        hcalOnlyLegacyGlobalRecoTask,
+        pfClusteringHBHEHFOnlyLegacyTask)
+
 reconstruction_hcalOnly = cms.Sequence(reconstruction_hcalOnlyTask)
+reconstruction_hcalOnlyLegacy = cms.Sequence(reconstruction_hcalOnlyLegacyTask)
 
 #need a fully expanded sequence copy
 modulesToRemove = list() # copy does not work well

--- a/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalGlobalReco_cff.py
@@ -19,6 +19,9 @@ from RecoLocalCalo.HcalRecProducers.HBHEPhase1Reconstructor_cfi import hbheprere
 run3_HB.toReplaceWith(hbhereco.cpu, _phase1_hbheprereco)
 run3_HB.toReplaceWith(hcalOnlyGlobalRecoTask, cms.Task(hbhereco))
 
+#-- Legacy HCAL Only Task
+hcalOnlyLegacyGlobalRecoTask = hcalOnlyGlobalRecoTask.copy()
+
 #--- for Run 3 on GPU
 from Configuration.ProcessModifiers.gpu_cff import gpu
 

--- a/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
+++ b/RecoLocalCalo/Configuration/python/hcalLocalReco_cff.py
@@ -58,6 +58,9 @@ _run3_hcalLocalRecoTask.remove(hbheprereco)
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB
 run3_HB.toReplaceWith(hcalLocalRecoTask, _run3_hcalLocalRecoTask)
 
+#--- Legacy HCAL Only Task
+hcalOnlyLegacyLocalRecoTask = hcalLocalRecoTask.copyAndExclude([zdcreco])
+
 #--- for Run 3 on GPU
 from Configuration.ProcessModifiers.gpu_cff import gpu
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -44,6 +44,9 @@ pfClusteringHBHEHFOnlyTask = cms.Task(particleFlowRecHitHBHEOnly,
                                       particleFlowClusterHF,
                                       particleFlowClusterHCALOnly)
 
+#--- Legacy HCAL Only Task
+pfClusteringHBHEHFOnlyLegacyTask = pfClusteringHBHEHFOnlyTask.copy()
+
 pfClusteringHOTask = cms.Task(particleFlowRecHitHO,particleFlowClusterHO)
 pfClusteringHO = cms.Sequence(pfClusteringHOTask)
 

--- a/Validation/RecoParticleFlow/python/PFClusterValidation_cff.py
+++ b/Validation/RecoParticleFlow/python/PFClusterValidation_cff.py
@@ -1,10 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 from Validation.RecoParticleFlow.pfClusterValidation_cfi import pfClusterValidation
+from Validation.RecoParticleFlow.pfCaloGPUComparisonTask_cfi import pfClusterHBHEOnlyAlpakaComparison, pfClusterHBHEAlpakaComparison
 
 pfClusterValidationSequence = cms.Sequence( pfClusterValidation )
+
+pfClusterAlpakaComparisonSequence = cms.Sequence( pfClusterHBHEAlpakaComparison )
 
 pfClusterCaloOnlyValidation = pfClusterValidation.clone(
     pflowClusterHCAL = 'particleFlowClusterHCALOnly'
 )
 
 pfClusterCaloOnlyValidationSequence = cms.Sequence( pfClusterCaloOnlyValidation )
+
+pfClusterHBHEOnlyAlpakaComparisonSequence = cms.Sequence( pfClusterHBHEOnlyAlpakaComparison )

--- a/Validation/RecoParticleFlow/python/pfCaloGPUComparisonTask_cfi.py
+++ b/Validation/RecoParticleFlow/python/pfCaloGPUComparisonTask_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+pfClusterHBHEOnlyAlpakaComparison = DQMEDAnalyzer("PFCaloGPUComparisonTask",
+                                                    pfClusterToken_ref = cms.untracked.InputTag('particleFlowClusterHBHEOnly'),
+                                                    pfClusterToken_target = cms.untracked.InputTag('legacyPFClusterProducerHBHEOnly'),
+                                                    pfCaloGPUCompDir = cms.untracked.string("pfClusterHBHEAlpakaV")
+)
+
+pfClusterHBHEAlpakaComparison = DQMEDAnalyzer("PFCaloGPUComparisonTask",
+                                                    pfClusterToken_ref = cms.untracked.InputTag('particleFlowClusterHBHE'),
+                                                    pfClusterToken_target = cms.untracked.InputTag('legacyPFClusterProducer'),
+                                                    pfCaloGPUCompDir = cms.untracked.string("pfClusterHBHEAlpakaV")
+)


### PR DESCRIPTION
#### PR description:

This PR adds new workflows to test Alpaka-based PF modules in CMSSW. Introduced are:

~~`.431` : HCAL Only Reconstruction using Alpaka-based PF, slimmed for benchmarking~~
~~`.432` : HCAL Only Reconstruction on GPU using Alpaka-based PF, with DQM and Validation~~
~~`.433` : HCAL Only Reconstruction on CPU using Alpaka-based PF, with DQM, Validation, and Alpaka vs Legacy PF Cluster comparison~~
~~`.434` : HCAL Only Reconstruction on GPU using Alpaka-based PF, with DQM, Validation, and Alpaka vs Legacy PF Cluster comparison~~
~~`.435` : HCAL Only Reconstruction on GPU using Alpaka-based PF (forced CUDA), with DQM, Validation, and Alpaka vs Legacy PF Cluster comparison~~

* `0.422`: Alpaka, HCAL only, portable
* `0.423`: Alpaka, HCAL only, portable vs CPU validation
* `0.424`: Alpaka, HCAL only, portable profiling
* `0.492` Alpaka, Pixel quadruplets, Full-Reco

#### PR validation:

All new workflows tested and passing on `12434.`

PF cluster Alpaka vs Legacy validation plots from `12434.423` are available at https://hep.baylor.edu/jsamudio/workflowValidation/

Usual `runTheMatrix.py -l limited -i all --ibeos` check is done and passes, ~~except for `step3` failure on `1000.0` from `Fatal Root Error: @SUB=TStorageFactorySystem::Unlink` which I believe is unrelated to the changes in this PR.~~

@hatakeyamak @fwyzard 