### PR TITLE
[14_0_X] [Phase-2] Enable support for P2GTCandidates in HLT

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -419,7 +419,7 @@ namespace trigger {
       const size_type end(filterObjects_.at(filter).l1tetsum_);
       return std::pair<size_type, size_type>(begin, end);
     }
-    
+
     std::pair<size_type, size_type> l1tp2gtcandSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tp2gtcand_);
       const size_type end(filterObjects_.at(filter).l1tp2gtcand_);
@@ -758,7 +758,7 @@ namespace trigger {
       const size_type end(l1tetsumSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tetsum, begin, end);
     }
-    
+
     void getObjects(size_type filter, Vids& ids, VRl1tp2gtcand& l1tp2gtcand) const {
       const size_type begin(l1tp2gtcandSlice(filter).first);
       const size_type end(l1tp2gtcandSlice(filter).second);

--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -63,6 +63,7 @@ namespace trigger {
       size_type l1tp2etsum_;
       size_type l1ttau_;
       size_type l1tetsum_;
+      size_type l1tp2gtcand_;
 
       /// constructor
       TriggerFilterObject()
@@ -96,7 +97,8 @@ namespace trigger {
             l1tpftrack_(0),
             l1tp2etsum_(0),
             l1ttau_(0),
-            l1tetsum_(0) {
+            l1tetsum_(0),
+            l1tp2gtcand_(0) {
         filterTag_ = edm::InputTag().encode();
       }
       TriggerFilterObject(const edm::InputTag& filterTag,
@@ -129,7 +131,8 @@ namespace trigger {
                           size_type l1tpftrack,
                           size_type l1tp2etsum,
                           size_type l1ttau,
-                          size_type l1tetsum)
+                          size_type l1tetsum,
+                          size_type l1tp2gtcand)
           : filterTag_(filterTag.encode()),
             photons_(np),
             electrons_(ne),
@@ -160,7 +163,8 @@ namespace trigger {
             l1tpftrack_(l1tpftrack),
             l1tp2etsum_(l1tp2etsum),
             l1ttau_(l1ttau),
-            l1tetsum_(l1tetsum) {}
+            l1tetsum_(l1tetsum),
+            l1tp2gtcand_(l1tp2gtcand) {}
     };
 
     /// data members
@@ -213,7 +217,8 @@ namespace trigger {
                               addObjects(tfowr.l1tpftrackIds(), tfowr.l1tpftrackRefs()),
                               addObjects(tfowr.l1tp2etsumIds(), tfowr.l1tp2etsumRefs()),
                               addObjects(tfowr.l1ttauIds(), tfowr.l1ttauRefs()),
-                              addObjects(tfowr.l1tetsumIds(), tfowr.l1tetsumRefs()))
+                              addObjects(tfowr.l1tetsumIds(), tfowr.l1tetsumRefs()),
+                              addObjects(tfowr.l1tp2gtcandIds(), tfowr.l1tp2gtcandRefs()))
 
       );
     }
@@ -412,6 +417,12 @@ namespace trigger {
     std::pair<size_type, size_type> l1tetsumSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tetsum_);
       const size_type end(filterObjects_.at(filter).l1tetsum_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    
+    std::pair<size_type, size_type> l1tp2gtcandSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tp2gtcand_);
+      const size_type end(filterObjects_.at(filter).l1tp2gtcand_);
       return std::pair<size_type, size_type>(begin, end);
     }
 
@@ -746,6 +757,17 @@ namespace trigger {
       const size_type begin(l1tetsumSlice(filter).first);
       const size_type end(l1tetsumSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tetsum, begin, end);
+    }
+    
+    void getObjects(size_type filter, Vids& ids, VRl1tp2gtcand& l1tp2gtcand) const {
+      const size_type begin(l1tp2gtcandSlice(filter).first);
+      const size_type end(l1tp2gtcandSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tp2gtcand, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tp2gtcand& l1tp2gtcand) const {
+      const size_type begin(l1tp2gtcandSlice(filter).first);
+      const size_type end(l1tp2gtcandSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tp2gtcand, begin, end);
     }
   };
 

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -44,6 +44,7 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
 #include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
@@ -102,6 +103,8 @@ namespace trigger {
   typedef std::vector<reco::PFJetRef> VRpfjet;
   typedef std::vector<reco::PFTauRef> VRpftau;
   typedef std::vector<reco::PFMETRef> VRpfmet;
+  
+  typedef l1t::P2GTCandidateVectorRef VRl1tp2gtcand;
 
   class TriggerRefsCollections {
     /// data members
@@ -172,6 +175,9 @@ namespace trigger {
     VRpftau pftauRefs_;
     Vids pfmetIds_;
     VRpfmet pfmetRefs_;
+    
+    Vids l1tp2gtcandIds_;
+    VRl1tp2gtcand l1tp2gtcandRefs_;
 
     /// methods
   public:
@@ -241,7 +247,10 @@ namespace trigger {
           pftauIds_(),
           pftauRefs_(),
           pfmetIds_(),
-          pfmetRefs_() {}
+          pfmetRefs_(),
+
+          l1tp2gtcandIds_(),
+          l1tp2gtcandRefs_() {}
 
     /// utility
     void swap(TriggerRefsCollections& other) {
@@ -310,6 +319,9 @@ namespace trigger {
       std::swap(pftauRefs_, other.pftauRefs_);
       std::swap(pfmetIds_, other.pfmetIds_);
       std::swap(pfmetRefs_, other.pfmetRefs_);
+      
+      std::swap(l1tp2gtcandIds_, other.l1tp2gtcandIds_);
+      std::swap(l1tp2gtcandRefs_, other.l1tp2gtcandRefs_);
     }
 
     /// setters for L3 collections: (id=physics type, and Ref<C>)
@@ -435,6 +447,10 @@ namespace trigger {
     void addObject(int id, const reco::PFMETRef& ref) {
       pfmetIds_.push_back(id);
       pfmetRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::P2GTCandidateRef& ref) {
+      l1tp2gtcandIds_.push_back(id);
+      l1tp2gtcandRefs_.push_back(ref);
     }
 
     ///
@@ -621,6 +637,12 @@ namespace trigger {
       pfmetIds_.insert(pfmetIds_.end(), ids.begin(), ids.end());
       pfmetRefs_.insert(pfmetRefs_.end(), refs.begin(), refs.end());
       return pfmetIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tp2gtcand& refs) {
+      assert(ids.size() == refs.size());
+      l1tp2gtcandIds_.insert(l1tp2gtcandIds_.end(), ids.begin(), ids.end());
+      l1tp2gtcandRefs_.insert(l1tp2gtcandRefs_.end(), refs.begin(), refs.end());
+      return l1tp2gtcandIds_.size();
     }
 
     /// various physics-level getters:
@@ -1674,6 +1696,41 @@ namespace trigger {
       }
       return;
     }
+    
+    void getObjects(Vids& ids, VRl1tp2gtcand& refs) const { getObjects(ids, refs, 0, l1tp2gtcandIds_.size()); }
+    void getObjects(Vids& ids, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tp2gtcandIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tp2gtcandIds_[i];
+        refs[j] = l1tp2gtcandRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tp2gtcand& refs) const { getObjects(id, refs, 0, l1tp2gtcandIds_.size()); }
+    void getObjects(int id, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tp2gtcandIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tp2gtcandIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tp2gtcandIds_[i]) {
+          refs[j] = l1tp2gtcandRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
 
     /// low-level getters for data members
     size_type photonSize() const { return photonIds_.size(); }
@@ -1797,6 +1854,10 @@ namespace trigger {
     size_type l1tetsumSize() const { return l1tetsumIds_.size(); }
     const Vids& l1tetsumIds() const { return l1tetsumIds_; }
     const VRl1tetsum& l1tetsumRefs() const { return l1tetsumRefs_; }
+    
+    size_type l1tp2gtcandSize() const { return l1tp2gtcandIds_.size(); }
+    const Vids& l1tp2gtcandIds() const { return l1tp2gtcandIds_; }
+    const VRl1tp2gtcand& l1tp2gtcandRefs() const { return l1tp2gtcandRefs_; }
   };
 
   // picked up via argument dependent lookup, e-g- by boost::swap()

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -103,7 +103,7 @@ namespace trigger {
   typedef std::vector<reco::PFJetRef> VRpfjet;
   typedef std::vector<reco::PFTauRef> VRpftau;
   typedef std::vector<reco::PFMETRef> VRpfmet;
-  
+
   typedef l1t::P2GTCandidateVectorRef VRl1tp2gtcand;
 
   class TriggerRefsCollections {
@@ -175,7 +175,7 @@ namespace trigger {
     VRpftau pftauRefs_;
     Vids pfmetIds_;
     VRpfmet pfmetRefs_;
-    
+
     Vids l1tp2gtcandIds_;
     VRl1tp2gtcand l1tp2gtcandRefs_;
 
@@ -319,7 +319,7 @@ namespace trigger {
       std::swap(pftauRefs_, other.pftauRefs_);
       std::swap(pfmetIds_, other.pfmetIds_);
       std::swap(pfmetRefs_, other.pfmetRefs_);
-      
+
       std::swap(l1tp2gtcandIds_, other.l1tp2gtcandIds_);
       std::swap(l1tp2gtcandRefs_, other.l1tp2gtcandRefs_);
     }
@@ -1696,7 +1696,7 @@ namespace trigger {
       }
       return;
     }
-    
+
     void getObjects(Vids& ids, VRl1tp2gtcand& refs) const { getObjects(ids, refs, 0, l1tp2gtcandIds_.size()); }
     void getObjects(Vids& ids, VRl1tp2gtcand& refs, size_type begin, size_type end) const {
       assert(begin <= end);
@@ -1854,7 +1854,7 @@ namespace trigger {
     size_type l1tetsumSize() const { return l1tetsumIds_.size(); }
     const Vids& l1tetsumIds() const { return l1tetsumIds_; }
     const VRl1tetsum& l1tetsumRefs() const { return l1tetsumRefs_; }
-    
+
     size_type l1tp2gtcandSize() const { return l1tp2gtcandIds_.size(); }
     const Vids& l1tp2gtcandIds() const { return l1tp2gtcandIds_; }
     const VRl1tp2gtcand& l1tp2gtcandRefs() const { return l1tp2gtcandRefs_; }

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -43,7 +43,8 @@
   </class>
 
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="17">
+  <class name="trigger::TriggerRefsCollections" ClassVersion="18">
+   <version ClassVersion="18" checksum="1144412089"/>
    <version ClassVersion="17" checksum="2974272653"/>
    <version ClassVersion="16" checksum="3574724031"/>
    <version ClassVersion="15" checksum="1920377523"/>
@@ -51,7 +52,8 @@
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="16">
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="17">
+   <version ClassVersion="17" checksum="3541298866"/>
    <version ClassVersion="16" checksum="1634484558"/>
    <version ClassVersion="15" checksum="2946786356"/>
    <version ClassVersion="14" checksum="4087045168"/>
@@ -69,7 +71,8 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="17">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="18">
+   <version ClassVersion="18" checksum="3279814163"/>
    <version ClassVersion="17" checksum="3926145865"/>
    <version ClassVersion="16" checksum="752200108"/>
    <version ClassVersion="15" checksum="450435068"/>
@@ -78,7 +81,8 @@
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="16">
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="17">
+   <version ClassVersion="17" checksum="482613136"/>
    <version ClassVersion="16" checksum="3502028356"/>
    <version ClassVersion="15" checksum="3947606822"/>
    <version ClassVersion="14" checksum="2001321210"/>

--- a/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
+++ b/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
@@ -131,6 +131,9 @@ private:
   trigger::VRpftau pftauRefs_;
   trigger::Vids pfmetIds_;
   trigger::VRpfmet pfmetRefs_;
+  
+  trigger::Vids l1tp2gtcandIds_;
+  trigger::VRl1tp2gtcand l1tp2gtcandRefs_;
 };
 
 template <class TVID, class TVREF>

--- a/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
+++ b/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
@@ -131,7 +131,7 @@ private:
   trigger::VRpftau pftauRefs_;
   trigger::Vids pfmetIds_;
   trigger::VRpfmet pfmetRefs_;
-  
+
   trigger::Vids l1tp2gtcandIds_;
   trigger::VRl1tp2gtcand l1tp2gtcandRefs_;
 };

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -43,6 +43,7 @@
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1EtMissParticleFwd.h"
 #include "DataFormats/L1Trigger/interface/L1HFRingsFwd.h"
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 
@@ -217,5 +218,6 @@ private:
   edm::GetterOfProducts<l1t::PFTauCollection> getL1TPFTauCollection_;
   edm::GetterOfProducts<l1t::HPSPFTauCollection> getL1THPSPFTauCollection_;
   edm::GetterOfProducts<l1t::PFTrackCollection> getL1TPFTrackCollection_;
+  edm::GetterOfProducts<l1t::P2GTCandidateCollection> getL1TP2GTCandCollection_;
 };
 #endif

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -247,7 +247,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   pftauRefs_.clear();
   pfmetIds_.clear();
   pfmetRefs_.clear();
-  
+
   l1tp2gtcandIds_.clear();
   l1tp2gtcandRefs_.clear();
 
@@ -380,7 +380,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       // PFMETs
       triggerEventWithRefsHandle_->getObjects(filterIndex, pfmetIds_, pfmetRefs_);
       showObjects(pfmetIds_, pfmetRefs_, "PFMETs");
-      
+
       // L1TP2GTCandidates
       triggerEventWithRefsHandle_->getObjects(filterIndex, l1tp2gtcandIds_, l1tp2gtcandRefs_);
       showObjects(l1tp2gtcandIds_, l1tp2gtcandRefs_, "L1TP2GTCandidates");

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -247,6 +247,9 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   pftauRefs_.clear();
   pfmetIds_.clear();
   pfmetRefs_.clear();
+  
+  l1tp2gtcandIds_.clear();
+  l1tp2gtcandRefs_.clear();
 
   // Attention: must look only for modules actually run in this path for this event!
   for (unsigned int j = 0; j <= moduleIndex; ++j) {
@@ -377,6 +380,10 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       // PFMETs
       triggerEventWithRefsHandle_->getObjects(filterIndex, pfmetIds_, pfmetRefs_);
       showObjects(pfmetIds_, pfmetRefs_, "PFMETs");
+      
+      // L1TP2GTCandidates
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tp2gtcandIds_, l1tp2gtcandRefs_);
+      showObjects(l1tp2gtcandIds_, l1tp2gtcandRefs_, "L1TP2GTCandidates");
     }
   }
 

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -154,10 +154,12 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1TPFTauCollection_ = edm::GetterOfProducts<l1t::PFTauCollection>(productMatch, this);
   getL1THPSPFTauCollection_ = edm::GetterOfProducts<l1t::HPSPFTauCollection>(productMatch, this);
   getL1TPFTrackCollection_ = edm::GetterOfProducts<l1t::PFTrackCollection>(productMatch, this);
-
+  
   getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(productMatch, this);
   getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(productMatch, this);
   getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(productMatch, this);
+
+  getL1TP2GTCandCollection_ = edm::GetterOfProducts<l1t::P2GTCandidateCollection>(productMatch, this);
 
   callWhenNewProductsRegistered([this](edm::BranchDescription const& bd) {
     getTriggerFilterObjectWithRefs_(bd);
@@ -190,6 +192,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
     getPFJetCollection_(bd);
     getPFTauCollection_(bd);
     getPFMETCollection_(bd);
+    getL1TP2GTCandCollection_(bd);
   });
 }
 
@@ -385,6 +388,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
   fillTriggerObjectCollections<reco::PFMETCollection>(
       toc, offset, tags, keys, iEvent, getPFMETCollection_, collectionTagsEvent);
   ///
+  fillTriggerObjectCollections<l1t::P2GTCandidateCollection>(
+      toc, offset, tags, keys, iEvent, getL1TP2GTCandCollection_, collectionTagsEvent);
   const unsigned int nk(tags.size());
   LogDebug("TriggerSummaryProducerAOD") << "Number of collections found: " << nk;
   const unsigned int no(toc.size());
@@ -457,6 +462,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pfjetIds(), fobs[ifob]->pfjetRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pftauIds(), fobs[ifob]->pftauRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pfmetIds(), fobs[ifob]->pfmetRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tp2gtcandIds(), fobs[ifob]->l1tp2gtcandRefs(), offset, keys, ids);
       product->addFilter(filterTag, ids, keys);
     }
   }

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -154,7 +154,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1TPFTauCollection_ = edm::GetterOfProducts<l1t::PFTauCollection>(productMatch, this);
   getL1THPSPFTauCollection_ = edm::GetterOfProducts<l1t::HPSPFTauCollection>(productMatch, this);
   getL1TPFTrackCollection_ = edm::GetterOfProducts<l1t::PFTrackCollection>(productMatch, this);
-  
+
   getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(productMatch, this);
   getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(productMatch, this);
   getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(productMatch, this);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -115,6 +115,11 @@ void TriggerSummaryProducerRAW::produce(edm::StreamID, edm::Event& iEvent, const
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tmuonShowerIds().size() = " << fobs[ifob]->l1tmuonShowerIds().size()
         << "\n fobs[ifob]->l1tmuonShowerRefs().size() = " << fobs[ifob]->l1tmuonShowerRefs().size();
+    LogTrace("TriggerSummaryProducerRaw")
+        << "TriggerSummaryProducerRaw::addFilterObjects(   )"
+        << "\n fobs[ifob]->l1tp2gtcandSize() = " << fobs[ifob]->l1tp2gtcandSize()
+        << "\n fobs[ifob]->l1tp2gtcandIds().size() = " << fobs[ifob]->l1tp2gtcandIds().size()
+        << "\n fobs[ifob]->11tp2gtcandRefs().size() = " << fobs[ifob]->l1tp2gtcandRefs().size();
     product.addFilterObject(tag, *fobs[ifob]);
   }
 


### PR DESCRIPTION
#### PR description:

First step towards migrating Phase-2 to HLT to use P2 GT emulator.
No changes are expected from this PR.
This just enables the usage of P2GTCandidate objects in HLT.

@rovere FYI