### PR TITLE
DQMStore avoids using 0 as invalid module ID

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -554,7 +554,8 @@ namespace dqm {
 
       DQMStore* store_ = nullptr;
       MonitorElementData::Scope scope_ = MonitorElementData::Scope::JOB;
-      uint64_t moduleID_ = 0;
+      static constexpr uint64_t kInvalidModuleID = std::numeric_limits<uint64_t>::max();
+      uint64_t moduleID_ = kInvalidModuleID;
       edm::LuminosityBlockID runlumi_ = edm::LuminosityBlockID();
     };
 
@@ -684,8 +685,8 @@ namespace dqm {
             oldid_ = booker_.setModuleID(newid);
             oldscope_ = booker_.setScope(newscope);
             oldrunlumi_ = booker_.setRunLumi(newrunlumi);
-            assert(newid != 0 || !"moduleID must be set for normal booking transaction");
-            assert(oldid_ == 0 || !"Nested booking transaction?");
+            assert(newid != kInvalidModuleID || !"moduleID must be set for normal booking transaction");
+            assert(oldid_ == kInvalidModuleID || !"Nested booking transaction?");
           }
           ~ModuleIdScope() {
             booker_.setModuleID(oldid_);


### PR DESCRIPTION
#### PR description:

The framework allows 0 as a valid ID.

#### PR validation:

Code compiles. Failing unit test now passes.

fixes #43711