### PR TITLE
Fix some MkFit valgrind warnings, improve loop vectorization

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -32,7 +32,7 @@
 class MkFitProducer : public edm::global::EDProducer<edm::StreamCache<mkfit::MkBuilderWrapper>> {
 public:
   explicit MkFitProducer(edm::ParameterSet const& iConfig);
-  ~MkFitProducer() override = default;
+  ~MkFitProducer() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -100,6 +100,8 @@ MkFitProducer::MkFitProducer(edm::ParameterSet const& iConfig)
   // TODO: what to do when we have multiple instances of MkFitProducer in a job?
   mkfit::MkBuilderWrapper::populate();
 }
+
+MkFitProducer::~MkFitProducer() { mkfit::MkBuilderWrapper::clear(); }
 
 void MkFitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;

--- a/RecoTracker/MkFitCore/interface/MkBuilder.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilder.h
@@ -38,6 +38,7 @@ namespace mkfit {
 
     static std::unique_ptr<MkBuilder> make_builder(bool silent = true);
     static void populate();
+    static void clear();
 
     int total_cands() const;
     std::pair<int, int> max_hits_layer(const EventOfHits &eoh) const;

--- a/RecoTracker/MkFitCore/interface/MkBuilderWrapper.h
+++ b/RecoTracker/MkFitCore/interface/MkBuilderWrapper.h
@@ -20,6 +20,7 @@ namespace mkfit {
     MkBuilder& get() { return *builder_; }
 
     static void populate();
+    static void clear();
 
   private:
     std::unique_ptr<MkBuilder> builder_;

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -1359,7 +1359,7 @@ namespace mkfit {
       kalmanOperationEndcap(KFO_Update_Params, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     }
     for (int n = 0; n < NN; ++n) {
-      if (outPar.At(n, 3, 0) < 0) {
+      if (n < N_proc && outPar.At(n, 3, 0) < 0) {
         Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
         outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
       }

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.cc
@@ -741,7 +741,7 @@ namespace mkfit {
           KFO_Update_Params | KFO_Local_Cov, psErr, psPar, msErr, msPar, outErr, outPar, dummy_chi2, N_proc);
     }
     for (int n = 0; n < NN; ++n) {
-      if (outPar.At(n, 3, 0) < 0) {
+      if (n < N_proc && outPar.At(n, 3, 0) < 0) {
         Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
         outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
       }
@@ -777,7 +777,11 @@ namespace mkfit {
       MPlexQF msRad;
 #pragma omp simd
       for (int n = 0; n < NN; ++n) {
-        msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
+        if (n < N_proc) {
+          msRad.At(n, 0, 0) = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
+        } else {
+          msRad.At(n, 0, 0) = 0.0f;
+        }
       }
 
       propagateHelixToRMPlex(psErr, psPar, inChg, msRad, propErr, propPar, outFailFlag, N_proc, propFlags);
@@ -843,9 +847,14 @@ namespace mkfit {
     MPlexQF rotT00;
     MPlexQF rotT01;
     for (int n = 0; n < NN; ++n) {
-      const float r = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
-      rotT00.At(n, 0, 0) = -(msPar.constAt(n, 1, 0) + psPar.constAt(n, 1, 0)) / (2 * r);
-      rotT01.At(n, 0, 0) = (msPar.constAt(n, 0, 0) + psPar.constAt(n, 0, 0)) / (2 * r);
+      if (n < N_proc) {
+        const float r = std::hypot(msPar.constAt(n, 0, 0), msPar.constAt(n, 1, 0));
+        rotT00.At(n, 0, 0) = -(msPar.constAt(n, 1, 0) + psPar.constAt(n, 1, 0)) / (2 * r);
+        rotT01.At(n, 0, 0) = (msPar.constAt(n, 0, 0) + psPar.constAt(n, 0, 0)) / (2 * r);
+      } else {
+        rotT00.At(n, 0, 0) = 0.0f;
+        rotT01.At(n, 0, 0) = 0.0f;
+      }
     }
 
     MPlexHV res_glo;  //position residual in global coordinates

--- a/RecoTracker/MkFitCore/src/MatriplexPackers.h
+++ b/RecoTracker/MkFitCore/src/MatriplexPackers.h
@@ -25,6 +25,8 @@ namespace mkfit {
 
     void reset() { m_pos = 0; }
 
+    int size() const { return m_pos; }
+
     void addNullInput() { m_idx[m_pos++] = 0; }
 
     void addInput(const D& item) {

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -44,6 +44,12 @@ namespace mkfit {
       m_fitters.populate(n_thr - m_fitters.size());
       m_finders.populate(n_thr - m_finders.size());
     }
+
+    void clear() {
+      m_cloners.clear();
+      m_fitters.clear();
+      m_finders.clear();
+    }
   };
 
   CMS_SA_ALLOW ExecutionContext g_exe_ctx;
@@ -166,6 +172,7 @@ namespace mkfit {
   std::unique_ptr<MkBuilder> MkBuilder::make_builder(bool silent) { return std::make_unique<MkBuilder>(silent); }
 
   void MkBuilder::populate() { g_exe_ctx.populate(Config::numThreadsFinder); }
+  void MkBuilder::clear() { g_exe_ctx.clear(); }
 
   std::pair<int, int> MkBuilder::max_hits_layer(const EventOfHits &eoh) const {
     int maxN = 0;

--- a/RecoTracker/MkFitCore/src/MkBuilderWrapper.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilderWrapper.cc
@@ -2,9 +2,10 @@
 #include "RecoTracker/MkFitCore/interface/MkBuilder.h"
 
 namespace mkfit {
-  MkBuilderWrapper::MkBuilderWrapper(bool silent) : builder_(MkBuilder::make_builder(silent)) {}
-
-  MkBuilderWrapper::~MkBuilderWrapper() {}
+  MkBuilderWrapper::MkBuilderWrapper(bool silent) : builder_(MkBuilder::make_builder(silent)) = default;
+  MkBuilderWrapper::~MkBuilderWrapper() = default;
 
   void MkBuilderWrapper::populate() { MkBuilder::populate(); }
+  void MkBuilderWrapper::clear() { MkBuilder::clear(); }
+
 }  // namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkBuilderWrapper.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilderWrapper.cc
@@ -2,7 +2,7 @@
 #include "RecoTracker/MkFitCore/interface/MkBuilder.h"
 
 namespace mkfit {
-  MkBuilderWrapper::MkBuilderWrapper(bool silent) : builder_(MkBuilder::make_builder(silent)) = default;
+  MkBuilderWrapper::MkBuilderWrapper(bool silent) : builder_(MkBuilder::make_builder(silent)) {}
   MkBuilderWrapper::~MkBuilderWrapper() = default;
 
   void MkBuilderWrapper::populate() { MkBuilder::populate(); }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -226,8 +226,8 @@ namespace mkfit {
 
   void MkFinder::packModuleNormDir(
       const LayerOfHits &layer_of_hits, int hit_cnt, MPlexHV &norm, MPlexHV &dir, int N_proc) const {
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
-      if (hit_cnt < m_XHitSize[itrack]) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
+      if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
         const auto &hit = layer_of_hits.refHit(m_XHitArr.constAt(itrack, hit_cnt, 0));
         unsigned int mid = hit.detIDinLayer();
         const ModuleInfo &mi = layer_of_hits.layer_info()->module_info(mid);
@@ -255,7 +255,7 @@ namespace mkfit {
 
     if (!v.empty()) {
       // dq hit selection window
-      float this_dq = v[dq_sf] * (v[dq_0] * max_invpt + v[dq_1] * theta + v[dq_2]);
+      const float this_dq = v[dq_sf] * (v[dq_0] * max_invpt + v[dq_1] * theta + v[dq_2]);
       // In case value is below 0 (bad window derivation or other reasons), leave original limits
       if (this_dq > 0.f) {
         min_dq = this_dq;
@@ -263,7 +263,7 @@ namespace mkfit {
       }
 
       // dphi hit selection window
-      float this_dphi = v[dp_sf] * (v[dp_0] * max_invpt + v[dp_1] * theta + v[dp_2]);
+      const float this_dphi = v[dp_sf] * (v[dp_0] * max_invpt + v[dp_1] * theta + v[dp_2]);
       // In case value is too low (bad window derivation or other reasons), leave original limits
       if (this_dphi > min_dphi) {
         min_dphi = this_dphi;
@@ -363,6 +363,8 @@ namespace mkfit {
 #pragma omp simd
 #endif
       for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack >= N_proc)
+          continue;
         m_XHitSize[itrack] = 0;
 
         float min_dq = ILC.min_dq();
@@ -474,7 +476,10 @@ namespace mkfit {
 
     // Vectorizing this makes it run slower!
     //#pragma omp simd
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
+      if (itrack >= N_proc) {
+        continue;
+      }
       // PROP-FAIL-ENABLE The following to be enabled when propagation failure
       // detection is properly implemented in propagate-to-R/Z.
       if (m_FailFlag[itrack]) {
@@ -809,15 +814,17 @@ namespace mkfit {
         // Matriplex::min_max(mp::fast_atan2(sp1.y, sp1.x), smp::fast_atan2(sp2.y, sp2.x), pmin, pmax);
         MPlexQF dp = pmax - pmin;
         phi_c = 0.5f * (pmax + pmin);
-        for (int ii = 0; ii < n_proc; ++ii) {
-          if (dp[ii] > Const::PI) {
-            std::swap(pmax[ii], pmin[ii]);
-            dp[ii] = Const::TwoPI - dp[ii];
-            phi_c[ii] = Const::PI - phi_c[ii];
+        for (int ii = 0; ii < NN; ++ii) {
+          if (ii < n_proc) {
+            if (dp[ii] > Const::PI) {
+              std::swap(pmax[ii], pmin[ii]);
+              dp[ii] = Const::TwoPI - dp[ii];
+              phi_c[ii] = Const::PI - phi_c[ii];
+            }
+            dphi[ii] = 0.5f * dp[ii];
+            // printf("phic: %f  p1: %f  p2: %f   pmin: %f  pmax: %f   dphi: %f\n",
+            //       phi_c[ii], xp1[ii], xp2[ii], pmin[ii], pmax[ii], dphi[ii]);
           }
-          dphi[ii] = 0.5f * dp[ii];
-          // printf("phic: %f  p1: %f  p2: %f   pmin: %f  pmax: %f   dphi: %f\n",
-          //       phi_c[ii], xp1[ii], xp2[ii], pmin[ii], pmax[ii], dphi[ii]);
         }
 
         // MPlexQF qmin, qmax;
@@ -848,16 +855,18 @@ namespace mkfit {
     B.prop_to_limits(LI);
     B.find_bin_ranges(LI, L);
 
-    for (int i = 0; i < N_proc; ++i) {
-      m_XHitSize[i] = 0;
-      // Notify failure. Ideally should be detected before selectHitIndices().
-      if (m_FailFlag[i]) {
-        m_XWsrResult[i].m_wsr = WSR_Failed;
-      } else {
-        if (LI.is_barrel()) {
-          m_XWsrResult[i] = L.is_within_z_sensitive_region(B.q_c[i], 0.5f * (B.q2[i] - B.q1[i]));
+    for (int i = 0; i < NN; ++i) {
+      if (i < N_proc) {
+        m_XHitSize[i] = 0;
+        // Notify failure. Ideally should be detected before selectHitIndices().
+        if (m_FailFlag[i]) {
+          m_XWsrResult[i].m_wsr = WSR_Failed;
         } else {
-          m_XWsrResult[i] = L.is_within_r_sensitive_region(B.q_c[i], 0.5f * (B.q2[i] - B.q1[i]));
+          if (LI.is_barrel()) {
+            m_XWsrResult[i] = L.is_within_z_sensitive_region(B.q_c[i], 0.5f * (B.q2[i] - B.q1[i]));
+          } else {
+            m_XWsrResult[i] = L.is_within_r_sensitive_region(B.q_c[i], 0.5f * (B.q2[i] - B.q1[i]));
+          }
         }
       }
     }
@@ -897,7 +906,11 @@ namespace mkfit {
 
     // Vectorizing this makes it run slower!
     //#pragma omp simd
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
+      if (itrack >= N_proc) {
+        continue;
+      }
+
       if (m_FailFlag[itrack]) {
         m_XWsrResult[itrack].m_wsr = WSR_Failed;
         continue;
@@ -1036,8 +1049,8 @@ namespace mkfit {
       mhp.reset();
 
       //#pragma omp simd doesn't vectorize with current compilers
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
-        if (hit_cnt < m_XHitSize[itrack]) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
           mhp.addInputAt(itrack, layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)));
         }
       }
@@ -1062,8 +1075,8 @@ namespace mkfit {
 
       //update best hit in case chi2<minChi2
 #pragma omp simd
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
-        if (hit_cnt < m_XHitSize[itrack]) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
           const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
           dprint("chi2=" << chi2 << " minChi2[itrack]=" << minChi2[itrack]);
           if (chi2 < minChi2[itrack]) {
@@ -1075,7 +1088,11 @@ namespace mkfit {
     }  // end loop over hits
 
     //#pragma omp simd
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
+      if (itrack >= N_proc) {
+        continue;
+      }
+
       if (m_XWsrResult[itrack].m_wsr == WSR_Outside) {
         // Why am I doing this?
         m_msErr.setDiagonal3x3(itrack, 666);
@@ -1252,8 +1269,8 @@ namespace mkfit {
       int charge_pcm[NN];
 
       //#pragma omp simd doesn't vectorize with current compilers
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
-        if (hit_cnt < m_XHitSize[itrack]) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
           const auto &hit = layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0));
           mhp.addInputAt(itrack, hit);
           charge_pcm[itrack] = hit.chargePerCM();
@@ -1305,7 +1322,10 @@ namespace mkfit {
       // 2. Still it's a waste of time in case the hit is not added to any of the
       // candidates, so check beforehand that at least one cand needs update.
       bool oneCandPassCut = false;
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack >= N_proc) {
+          continue;
+        }
         float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
 
         if (hit_cnt < m_XHitSize[itrack]) {
@@ -1364,10 +1384,9 @@ namespace mkfit {
 
         //create candidate with hit in case chi2 < max_c2
         //fixme: please vectorize me... (not sure it's possible in this case)
-        for (int itrack = 0; itrack < N_proc; ++itrack) {
-          float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
-
-          if (hit_cnt < m_XHitSize[itrack]) {
+        for (int itrack = 0; itrack < NN; ++itrack) {
+          if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
+            const float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
             const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
             dprint("chi2=" << chi2);
             if (chi2 < max_c2) {
@@ -1443,10 +1462,10 @@ namespace mkfit {
 
     //now add invalid hit
     //fixme: please vectorize me...
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
       // Cands that miss the layer are stashed away in MkBuilder(), before propagation,
       // and then merged back afterwards.
-      if (m_XWsrResult[itrack].m_wsr == WSR_Outside) {
+      if (itrack >= N_proc || m_XWsrResult[itrack].m_wsr == WSR_Outside) {
         continue;
       }
 
@@ -1519,8 +1538,8 @@ namespace mkfit {
       int charge_pcm[NN];
 
       //#pragma omp simd doesn't vectorize with current compilers
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
-        if (hit_cnt < m_XHitSize[itrack]) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
+        if (itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
           const auto &hit = layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0));
           mhp.addInputAt(itrack, hit);
           charge_pcm[itrack] = hit.chargePerCM();
@@ -1566,13 +1585,13 @@ namespace mkfit {
       }
 
       //#pragma omp simd  // DOES NOT VECTORIZE AS IT IS NOW
-      for (int itrack = 0; itrack < N_proc; ++itrack) {
+      for (int itrack = 0; itrack < NN; ++itrack) {
         // We can be in failed state from the initial propagation before selectHitIndices
         // and there hit_count for track is set to -1 and WSR state to Failed, handled below.
         // Or we might have hit it here in propagate-to-hit.
         // PROP-FAIL-ENABLE FailFlag check to be enabled when propagation failure
         // detection is properly implemented in propagate-to-R/Z.
-        if (/*!m_FailFlag[itrack] &&*/ hit_cnt < m_XHitSize[itrack]) {
+        if (/*!m_FailFlag[itrack] &&*/ itrack < N_proc && hit_cnt < m_XHitSize[itrack]) {
           // make sure the hit was in the compatiblity window for the candidate
           const float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
           const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
@@ -1651,12 +1670,12 @@ namespace mkfit {
     }  //end loop over hits
 
     //now add invalid hit
-    for (int itrack = 0; itrack < N_proc; ++itrack) {
+    for (int itrack = 0; itrack < NN; ++itrack) {
       dprint("num_all_minus_one_hits(" << itrack << ")=" << num_all_minus_one_hits(itrack));
 
       // Cands that miss the layer are stashed away in MkBuilder(), before propagation,
       // and then merged back afterwards.
-      if (m_XWsrResult[itrack].m_wsr == WSR_Outside) {
+      if (itrack >= N_proc || m_XWsrResult[itrack].m_wsr == WSR_Outside) {
         continue;
       }
 
@@ -1759,17 +1778,19 @@ namespace mkfit {
   void MkFinder::copyOutParErr(std::vector<CombCandidate> &seed_cand_vec, int N_proc, bool outputProp) const {
     const int iO = outputProp ? iP : iC;
 
-    for (int i = 0; i < N_proc; ++i) {
-      TrackCand &cand = seed_cand_vec[m_SeedIdx(i, 0, 0)][m_CandIdx(i, 0, 0)];
+    for (int i = 0; i < NN; ++i) {
+      if (i < N_proc) {
+        TrackCand &cand = seed_cand_vec[m_SeedIdx(i, 0, 0)][m_CandIdx(i, 0, 0)];
 
-      // Set the track state to the updated parameters
-      m_Err[iO].copyOut(i, cand.errors_nc().Array());
-      m_Par[iO].copyOut(i, cand.parameters_nc().Array());
-      cand.setCharge(m_Chg(i, 0, 0));
+        // Set the track state to the updated parameters
+        m_Err[iO].copyOut(i, cand.errors_nc().Array());
+        m_Par[iO].copyOut(i, cand.parameters_nc().Array());
+        cand.setCharge(m_Chg(i, 0, 0));
 
-      dprint((outputProp ? "propagated" : "updated")
-             << " track parameters x=" << cand.parameters()[0] << " y=" << cand.parameters()[1]
-             << " z=" << cand.parameters()[2] << " pt=" << 1. / cand.parameters()[3] << " posEta=" << cand.posEta());
+        dprint((outputProp ? "propagated" : "updated")
+               << " track parameters x=" << cand.parameters()[0] << " y=" << cand.parameters()[1]
+               << " z=" << cand.parameters()[2] << " pt=" << 1. / cand.parameters()[3] << " posEta=" << cand.posEta());
+      }
     }
   }
 
@@ -1961,8 +1982,8 @@ namespace mkfit {
       }
 
       //fixup invpt sign and charge
-      for (int n = 0; n < N_proc; ++n) {
-        if (m_Par[iC].At(n, 3, 0) < 0) {
+      for (int n = 0; n < NN; ++n) {
+        if (n < N_proc && m_Par[iC].At(n, 3, 0) < 0) {
           m_Chg.At(n, 0, 0) = -m_Chg.At(n, 0, 0);
           m_Par[iC].At(n, 3, 0) = -m_Par[iC].At(n, 3, 0);
         }
@@ -2165,7 +2186,7 @@ namespace mkfit {
 #endif
 
       // Fixup for failed propagation or invpt sign and charge.
-      for (int i = 0; i < N_proc; ++i) {
+      for (int i = 0; i < NN; ++i) {
         // PROP-FAIL-ENABLE The following to be enabled when propagation failure
         // detection is properly implemented in propagate-to-R/Z.
         // 1. The following code was only expecting barrel state to be restored.
@@ -2201,7 +2222,7 @@ namespace mkfit {
         }
         */
         // Fixup invpt sign and charge.
-        if (m_Par[iC].At(i, 3, 0) < 0) {
+        if (i < N_proc && m_Par[iC].At(i, 3, 0) < 0) {
           m_Chg.At(i, 0, 0) = -m_Chg.At(i, 0, 0);
           m_Par[iC].At(i, 3, 0) = -m_Par[iC].At(i, 3, 0);
         }

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -319,8 +319,8 @@ namespace mkfit {
     MPlexHitIdx m_XHitArr;
 
     // Hit errors / parameters for hit matching, update.
-    MPlexHS m_msErr;
-    MPlexHV m_msPar;
+    MPlexHS m_msErr{0.0f};
+    MPlexHV m_msPar{0.0f};
 
     // An idea: Do propagation to hit in FindTracksXYZZ functions.
     // Have some state / functions here that make this short to write.

--- a/RecoTracker/MkFitCore/src/MkFitter.h
+++ b/RecoTracker/MkFitCore/src/MkFitter.h
@@ -72,8 +72,8 @@ namespace mkfit {
   private:
     MPlexQF m_Chi2;
 
-    MPlexHS m_msErr[Config::nMaxTrkHits];
-    MPlexHV m_msPar[Config::nMaxTrkHits];
+    MPlexHS m_msErr[Config::nMaxTrkHits]{0.0f};
+    MPlexHV m_msPar[Config::nMaxTrkHits]{0.0f};
 
     MPlexQI m_Label;    //this is the seed index in global seed vector (for MC truth match)
     MPlexQI m_SeedIdx;  //this is the seed index in local thread (for bookkeeping at thread level)

--- a/RecoTracker/MkFitCore/src/Pool.h
+++ b/RecoTracker/MkFitCore/src/Pool.h
@@ -14,7 +14,9 @@ namespace mkfit {
   public:
     Pool() = default;
 
-    ~Pool() {
+    ~Pool() { clear(); }
+
+    void clear() {
       TT *x = nullptr;
       while (m_stack.try_pop(x)) {
         destroy(x);

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -690,9 +690,11 @@ namespace mkfit {
           hitsRl(n, 0, 0) = mat.radl;
           hitsXi(n, 0, 0) = mat.bbxi;
         }
-        const float zout = msZ.constAt(n, 0, 0);
-        const float zin = inPar.constAt(n, 2, 0);
-        propSign(n, 0, 0) = (std::abs(zout) > std::abs(zin) ? 1.f : -1.f);
+        if (n < N_proc) {
+          const float zout = msZ.constAt(n, 0, 0);
+          const float zin = inPar.constAt(n, 2, 0);
+          propSign(n, 0, 0) = (std::abs(zout) > std::abs(zin) ? 1.f : -1.f);
+        }
       }
       MPlexHV plNrm;
 #pragma omp simd

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -551,17 +551,19 @@ namespace mkfit {
 
 #pragma omp simd
       for (int n = 0; n < NN; ++n) {
-        if (n >= N_proc || (outFailFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0)))) {
-          hitsRl(n, 0, 0) = 0.f;
-          hitsXi(n, 0, 0) = 0.f;
-        } else {
-          auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), msRad(n, 0, 0));
-          hitsRl(n, 0, 0) = mat.radl;
-          hitsXi(n, 0, 0) = mat.bbxi;
+        if (n < N_proc) {
+          if (outFailFlag(n, 0, 0) || (noMatEffPtr && noMatEffPtr->constAt(n, 0, 0))) {
+            hitsRl(n, 0, 0) = 0.f;
+            hitsXi(n, 0, 0) = 0.f;
+          } else {
+            auto mat = tinfo.material_checked(std::abs(outPar(n, 2, 0)), msRad(n, 0, 0));
+            hitsRl(n, 0, 0) = mat.radl;
+            hitsXi(n, 0, 0) = mat.bbxi;
+          }
+          const float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
+          const float r = msRad(n, 0, 0);
+          propSign(n, 0, 0) = (r > r0 ? 1. : -1.);
         }
-        const float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
-        const float r = msRad(n, 0, 0);
-        propSign(n, 0, 0) = (r > r0 ? 1. : -1.);
       }
       MPlexHV plNrm;
 #pragma omp simd
@@ -1247,6 +1249,8 @@ namespace mkfit {
                             const int N_proc) {
 #pragma omp simd
     for (int n = 0; n < NN; ++n) {
+      if (n >= N_proc)
+        continue;
       float radL = hitsRl.constAt(n, 0, 0);
       if (radL < 1e-13f)
         continue;  //ugly, please fixme

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.h
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.h
@@ -10,10 +10,12 @@ namespace mkfit {
   inline void squashPhiMPlex(MPlexLV& par, const int N_proc) {
 #pragma omp simd
     for (int n = 0; n < NN; ++n) {
-      if (par(n, 4, 0) >= Const::PI)
-        par(n, 4, 0) -= Const::TwoPI;
-      if (par(n, 4, 0) < -Const::PI)
-        par(n, 4, 0) += Const::TwoPI;
+      if (n < N_proc) {
+        if (par(n, 4, 0) >= Const::PI)
+          par(n, 4, 0) -= Const::TwoPI;
+        if (par(n, 4, 0) < -Const::PI)
+          par(n, 4, 0) += Const::TwoPI;
+      }
     }
   }
 


### PR DESCRIPTION
#### PR description:

valgrind memcheck complains about uninitialised values in a few new places where we loop over NN. This PR quiets them, mostly by conditionals on N_proc and partly by initializing some MkFitter structures to 0.0f.

My working theory is that a loop over constant NN with an if on N_proc is more vectorizable than a loop over an unbounded N_proc, since the compiler can infer that N_proc <= NN, and use an N_proc mask to vectorize the loop. Therefore, this PR also switches some loop indices from N_proc to NN + a conditional on N_proc.

This PR also empties the pools of MkFitter/MkBuilder objects in the MkFit producer, to at least partially address https://github.com/cms-sw/cmssw/issues/42700. Emptying the pool is thread-safe, so this should be safe when there are multiple instances of MkFit. tbb::concurrent_queue::clear() however is not thread safe, so calling it would require some kind of concurrency protection.

#### PR validation:

Validation with a standard TTBar PU55-75 showed no significant differences (validation was run multi-threaded, so small differences were not unexpected).
