### PR TITLE
Make Minuit2 error on non-posdef initial matrix an error message instead of an exception

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -186,9 +186,11 @@ namespace {
                                                           "Inverter::Dinv",
                                                           "RTaskArenaWrapper"}};
 
-  constexpr std::array<const char* const, 3> in_message_print_error{{"number of iterations was insufficient",
-                                                                     "bad integrand behavior",
-                                                                     "integral is divergent, or slowly convergent"}};
+  constexpr std::array<const char* const, 4> in_message_print_error{
+      {"number of iterations was insufficient",
+       "bad integrand behavior",
+       "integral is divergent, or slowly convergent",
+       "VariableMetricBuilder Initial matrix not pos.def."}};
 
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
     bool die = false;


### PR DESCRIPTION
#### PR description:

This PR is a workaround (or possibly long term solution?) for the `VariableMetricBuilder Initial matrix not pos.def.` exceptions from Minuit2 that were first reported in https://github.com/cms-sw/cmssw/issues/42979, and later discussed in https://github.com/cms-sw/cmssw/issues/43722. 

Resolves https://github.com/makortel/framework/issues/792

#### PR validation:

Code compiles.