### PR TITLE
Add fillDescription to CommonTools/UtilAlgos/interface/Merger.h

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandMerger.cc
@@ -11,4 +11,15 @@
 
 typedef Merger<reco::CandidateCollection> CandMerger;
 
+template <>
+void CandMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("candMerger", desc);
+}
+
 DEFINE_FWK_MODULE(CandMerger);

--- a/CommonTools/CandAlgos/plugins/CandRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandRefMerger.cc
@@ -11,4 +11,15 @@
 
 typedef Merger<reco::CandidateBaseRefVector> CandRefMerger;
 
+template <>
+void CandRefMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("candRefMerger", desc);
+}
+
 DEFINE_FWK_MODULE(CandRefMerger);

--- a/CommonTools/CandAlgos/plugins/CandViewMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewMerger.cc
@@ -11,4 +11,16 @@
 
 typedef Merger<reco::CandidateView, reco::CandidateCollection> CandViewMerger;
 
+template <>
+void CandViewMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("candViewMerger", desc);
+}
+
+
 DEFINE_FWK_MODULE(CandViewMerger);

--- a/CommonTools/ParticleFlow/plugins/IsolatedPFCandidateMerger.cc
+++ b/CommonTools/ParticleFlow/plugins/IsolatedPFCandidateMerger.cc
@@ -7,4 +7,15 @@
 
 typedef Merger<reco::IsolatedPFCandidateCollection> IsolatedPFCandidateMerger;
 
+template <>
+void IsolatedPFCandidateMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("isolatedPFCandidateMerger", desc);
+}
+
 DEFINE_FWK_MODULE(IsolatedPFCandidateMerger);

--- a/CommonTools/RecoAlgos/plugins/BasicClusterMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/BasicClusterMerger.cc
@@ -5,4 +5,15 @@
 
 typedef Merger<reco::BasicClusterCollection> BasicClusterMerger;
 
+template <>
+void BasicClusterMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("basicClusterMerger", desc);
+}
+
 DEFINE_FWK_MODULE(BasicClusterMerger);

--- a/CommonTools/RecoAlgos/plugins/ElectronCollectionMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/ElectronCollectionMerger.cc
@@ -12,7 +12,27 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
 typedef Merger<reco::GsfElectronCollection> GsfElectronCollectionMerger;
+template <>
+void GsfElectronCollectionMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("gsfElectronCollectionMerger", desc);
+}
 DEFINE_FWK_MODULE(GsfElectronCollectionMerger);
 
 typedef Merger<pat::ElectronCollection> PATElectronCollectionMerger;
+template <>
+void PATElectronCollectionMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("patElectronCollectionMerger", desc);
+}
 DEFINE_FWK_MODULE(PATElectronCollectionMerger);

--- a/CommonTools/RecoAlgos/plugins/PFClusterCandidateMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/PFClusterCandidateMerger.cc
@@ -15,4 +15,14 @@
 
 typedef Merger<reco::RecoPFClusterRefCandidateCollection> PFClusterRefCandidateMerger;
 
+template <>
+void PFClusterRefCandidateMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("pfClusterRefCandidateMerger", desc);
+}
 DEFINE_FWK_MODULE(PFClusterRefCandidateMerger);

--- a/CommonTools/RecoAlgos/plugins/SuperClusterMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/SuperClusterMerger.cc
@@ -5,4 +5,15 @@
 
 typedef Merger<reco::SuperClusterCollection> SuperClusterMerger;
 
+template <>
+void SuperClusterMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("superClusterMerger", desc);
+}
+
 DEFINE_FWK_MODULE(SuperClusterMerger);

--- a/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
@@ -13,7 +13,7 @@ void TrackSimpleMerger::fillDescriptions(edm::ConfigurationDescriptions& descrip
                                            edm::InputTag("collection1"),
                                            edm::InputTag("collection2"),
                                        });
-  descriptions.add("simpleMergedTracks", desc);
+  descriptions.add("trackSimpleMerger", desc);
 }
 
 DEFINE_FWK_MODULE(TrackSimpleMerger);

--- a/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
+++ b/CommonTools/RecoAlgos/plugins/TrackSimpleMerger.cc
@@ -5,4 +5,15 @@
 
 typedef Merger<reco::TrackCollection> TrackSimpleMerger;
 
+template <>
+void TrackSimpleMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("simpleMergedTracks", desc);
+}
+
 DEFINE_FWK_MODULE(TrackSimpleMerger);

--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -19,6 +19,8 @@
  */
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,19 +36,20 @@ public:
   explicit Merger(const edm::ParameterSet&);
   /// destructor
   ~Merger() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   /// process an event
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   /// vector of strings
-  typedef std::vector<edm::EDGetTokenT<InputCollection> > vtoken;
+  typedef std::vector<edm::EDGetTokenT<InputCollection>> vtoken;
   /// labels of the collections to be merged
   vtoken srcToken_;
 };
 
 template <typename InputCollection, typename OutputCollection, typename P>
 Merger<InputCollection, OutputCollection, P>::Merger(const edm::ParameterSet& par)
-    : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag> >("src"),
+    : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag>>("src"),
                                       [this](edm::InputTag const& tag) { return consumes<InputCollection>(tag); })) {
   produces<OutputCollection>();
 }
@@ -67,6 +70,17 @@ void Merger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
     }
   }
   evt.put(std::move(coll));
+}
+
+template <typename InputCollection, typename OutputCollection, typename P>
+void Merger<InputCollection, OutputCollection, P>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("simpleMergedTracks", desc);
 }
 
 #endif

--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -72,15 +72,4 @@ void Merger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
   evt.put(std::move(coll));
 }
 
-template <typename InputCollection, typename OutputCollection, typename P>
-void Merger<InputCollection, OutputCollection, P>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-  desc.add<std::vector<edm::InputTag>>("src",
-                                       {
-                                           edm::InputTag("collection1"),
-                                           edm::InputTag("collection2"),
-                                       });
-  descriptions.add("simpleMergedTracks", desc);
-}
-
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMerger.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TPFCandMerger.cc
@@ -4,4 +4,15 @@
 
 typedef Merger<std::vector<l1t::PFCandidate>> L1TPFCandMerger;
 
+template <>
+void L1TPFCandMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("l1TPFCandMerger", desc);
+}
+
 DEFINE_FWK_MODULE(L1TPFCandMerger);

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/plugins.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/plugins.cc
@@ -4,4 +4,17 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 typedef Merger<reco::SuperClusterCollection> EgammaSuperClusterMerger;
+
+template <>
+void EgammaSuperClusterMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("egammaSuperClusterMerger", desc);
+}
+
+
 DEFINE_FWK_MODULE(EgammaSuperClusterMerger);

--- a/RecoParticleFlow/PFProducer/plugins/plugins.cc
+++ b/RecoParticleFlow/PFProducer/plugins/plugins.cc
@@ -17,6 +17,17 @@ typedef edm::ProductFromFwdPtrProducer<reco::PFCandidate, reco::PFCandidateWithS
     PFCandidateProductFromFwdPtrProducer;
 typedef edm::FwdPtrProducer<reco::PFCandidate, reco::PFCandidateFwdPtrFactory> PFCandidateFwdPtrProducer;
 
+template <>
+void PFCandidateListMerger::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.add("pfCandidateListMerger", desc);
+}
+
 DEFINE_FWK_MODULE(PFCandidateListMerger);
 DEFINE_FWK_MODULE(PFCandidateProductFromFwdPtrProducer);
 DEFINE_FWK_MODULE(PFCandidateFwdPtrProducer);


### PR DESCRIPTION
#### PR description:

This PR addd fillDescription to CommonTools/UtilAlgos/interface/Merger.h in order to make it available in ConfDB.
No "_cfi" was available previeusly.

#### PR validation:

```
[sdonato@lxplus713 src]$ edmPluginHelp  -p TrackSimpleMerger
1  TrackSimpleMerger  (global::EDProducer)  "pluginCommonToolsRecoAlgos_plugins.so"

This plugin has 1 PSet description. This description is always used to validate configurations. The label below is used when generating the cfi file.

  1.1 module label: simpleMergedTracks

    src
                        type: VInputTag 
                        default: (vector size = 2)
                          [0]: 'collection1'
                          [1]: 'collection2'

    mightGet
                        type: untracked vstring optional
                        default: none
                        List contains the branch names for the EDProducts which might be requested by the module.
                        The format for identifying the EDProduct is the same as the one used for OutputModules, except no wild cards are allowed. E.g.
                        Foos_foomodule_whichFoo_RECO
```

Without the PR the output is 
```
[sdonato@lxplus713 src]$ edmPluginHelp  -p TrackSimpleMerger
1  TrackSimpleMerger  (global::EDProducer)  "pluginCommonToolsRecoAlgos_plugins.so"

  This plugin has not implemented the function which defines its
  configuration descriptions yet. No descriptions are available.
  Its PSets will not be validated, and no cfi files will be generated.
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Yes, I will need a backport to 13_3_X.

cc: @mmusich 