### PR TITLE
Adding an option to make the HLTPrescaler reproducable for studies

### DIFF
--- a/HLTrigger/HLTcore/interface/HLTPrescaler.h
+++ b/HLTrigger/HLTcore/interface/HLTPrescaler.h
@@ -81,6 +81,15 @@ private:
   unsigned int offsetCount_;
   unsigned int offsetPhase_;
 
+  //this the number used to seed prescaler
+  //a negative value measures use the first event number it sees making it pseudorandom
+  //this is used to stagger the streams so they all dont accept the nth event they see
+  //eg if this is zero, each stream would accept the first event it sees so you wouldnt
+  //get an even sampling of time, you would be biased to selecting a specific time period
+  //however this isnt reproducable and for some offline studies its preferable to have the
+  //prescalers be always the same in each run
+  int initialSeed_;
+
   /// prescale service
   edm::service::PrescaleService* prescaleService_;
 

--- a/HLTrigger/HLTcore/test/testHLTPrescalerSeeds_cfy.py
+++ b/HLTrigger/HLTcore/test/testHLTPrescalerSeeds_cfy.py
@@ -1,0 +1,83 @@
+import FWCore.ParameterSet.Config as cms
+
+## VarParsing
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis')
+options.register('globalTag', 'auto:run3_data', options.multiplicity.singleton, options.varType.string, 'name of global tag')
+options.setDefault('maxEvents', 100000)
+options.register('initialSeed',-2,options.multiplicity.singleton,options.varType.int,'initialSeed')
+options.parseArguments()
+
+## Process
+process = cms.Process('TEST')
+
+process.options.wantSummary = False
+process.options.numberOfStreams = 10
+process.options.numberOfThreads = 10 
+process.maxEvents.input = options.maxEvents
+
+## Source
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring(options.inputFiles)
+)
+process.source = cms.Source("EmptySource")
+
+## MessageLogger
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(5000),
+    limit = cms.untracked.int32(10000000)
+)
+
+## GlobalTag
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.PrescaleService = cms.Service("PrescaleService",
+    forceDefault = cms.bool(True),
+    lvl1DefaultLabel = cms.string('Test'),
+    lvl1Labels = cms.vstring(
+        'Test',            
+    ),
+    prescaleTable = cms.VPSet( (
+        cms.PSet(
+            pathName = cms.string('HLT_PreTest_v1'),
+            prescales = cms.vuint32(
+                100,
+            )
+        ),
+       ))
+                                      )
+                                    
+      
+process.hltPreTest = cms.EDFilter("HLTPrescaler",
+    L1GtReadoutRecordTag = cms.InputTag("gtStage2Digis"),
+                                  offset = cms.uint32(0),
+                                  
+)
+
+if options.initialSeed>=-1:
+    print(f"setting seed to {options.initialSeed}")
+    process.hltPreTest.initialSeed = cms.int32(options.initialSeed)
+    
+
+process.HLT_PreTest_v1 = cms.Path(process.hltPreTest)
+
+process.outMod = cms.OutputModule("PoolOutputModule",
+                                  SelectEvents = cms.untracked.PSet(
+                                      SelectEvents = cms.vstring('HLT_PreTest_v1')
+                                  ),
+                                  compressionAlgorithm = cms.untracked.string('LZMA'),
+                                  compressionLevel = cms.untracked.int32(1),
+                                  dataset = cms.untracked.PSet(
+                                      dataTier = cms.untracked.string('GEN'),
+                                      filterName = cms.untracked.string('')
+                                  ),
+                                  eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+                                  fileName = cms.untracked.string(options.outputFile),
+                                  outputCommands = cms.untracked.vstring("keep *"),
+                                  splitLevel = cms.untracked.int32(0)
+                )
+
+process.outPath = cms.EndPath(process.outMod)


### PR DESCRIPTION
#### PR description:

This PR adds an option to HLTPrescaler to make it reproducible when doing repeated measurements. 

HLTPrescaler has a seed which is the event number of the first module the event sees. This breaks coherence between streams to have a uniform sampling in time.  The downside is that the prescales are not reproduceable between jobs (unless single stream) which can complicate measurements sometimes, for example timing measurements as an increase may be due to an expensive path running or not.  It would be nice to have the ability to rule this out when comparing measurements and understand how big of an effect this is. 

The downside of this is that this option is dangerous in that it should not be applied to p5 running and if it was mistakenly done, it would very difficult to impossible to spot. 

So we need to make sure that there are fool proof mechanisms to stop it even being deployed online. I would suggest two things

1) make it unsetable in confdb, this is why I made it optional, its my understanding this wont even show up in the confdb gui
2) add a menu check in the hilton for this

What do people think?



#### PR validation:

I added a config  testHLTPrescalerSeeds_cfy.py

The following is tests based on 10000 events, a prescale of 10 and 10 streams.  The default option (achieved by either not specifing or specifying negative) continues to be random.  The reproducible one now shows the expected clumping behaviour. 

Event numbers selected with seed not specified:
![image](https://github.com/cms-sw/cmssw/assets/5021403/4039f03f-b76f-470c-8861-55b473865223)
Output with  selected with seed set to -1
![image](https://github.com/cms-sw/cmssw/assets/5021403/aed432dc-a30b-4e49-9a20-0185f3d56ea1)
Output with  a seed of 0
![image](https://github.com/cms-sw/cmssw/assets/5021403/2dc92640-cc05-4aec-8d8b-149be2e6bfa9)

