### PR TITLE
MTD reconstruction: fix BTL time for missing correction in BTL geometry v3 (scenario I17)

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/src/MTDTimeCalib.cc
@@ -39,15 +39,12 @@ float MTDTimeCalib::getTimeCalib(const MTDDetId& id) const {
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
     BTLDetId::CrysLayout btlL = MTDTopologyMode::crysLayoutFromTopoMode(topo_->getMTDTopologyMode());
-    if (btlL == BTLDetId::CrysLayout::tile) {
-      time_calib -= btlLightCollTime_;  //simply remove the offset introduced at sim level
-    } else if (btlL == BTLDetId::CrysLayout::bar || btlL == BTLDetId::CrysLayout::barphiflat ||
-               btlL == BTLDetId::CrysLayout::v2) {
+    if (static_cast<int>(btlL) >= static_cast<int>(BTLDetId::CrysLayout::barphiflat)) {
       //for bars in phi
       time_calib -= 0.5 * topo.pitch().first * btlLightCollSlope_;  //time offset for bar time is L/2v
-    } else if (btlL == BTLDetId::CrysLayout::barzflat) {
-      //for bars in z
-      time_calib -= 0.5 * topo.pitch().second * btlLightCollSlope_;  //time offset for bar time is L/2v
+    } else {
+      throw cms::Exception("MTDTimeCalib")
+          << "BTL topology mode " << static_cast<int>(btlL) << " unsupported! Aborting";
     }
   } else if (id.mtdSubDetector() == MTDDetId::ETL) {
     time_calib += etlTimeOffset_;


### PR DESCRIPTION
#### PR description:

Tests with geometry D105 performed by @pauris123 show that there is an evident bias in the BTL reconstructed time. This is due to a missing update of ```MTDTimeCalib``` for this geometry scenario. This PR updates that class, excluding conditions for scenarios that are no more maintained in the release since a while.

#### PR validation:

The BTL hits time resolution plot for scenario D105 is now centred reasonably at 0, as it should (test wf. 27634.0):

![BTLTimeRes](https://github.com/cms-sw/cmssw/assets/4058194/b135b638-0c29-4369-9788-ed8e46defe95)

