### PR TITLE
Add fillDescription to CommonTools/UtilAlgos/interface/Merger.h - 133X

### DIFF
--- a/CommonTools/UtilAlgos/interface/Merger.h
+++ b/CommonTools/UtilAlgos/interface/Merger.h
@@ -19,6 +19,8 @@
  */
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,19 +36,20 @@ public:
   explicit Merger(const edm::ParameterSet&);
   /// destructor
   ~Merger() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   /// process an event
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   /// vector of strings
-  typedef std::vector<edm::EDGetTokenT<InputCollection> > vtoken;
+  typedef std::vector<edm::EDGetTokenT<InputCollection>> vtoken;
   /// labels of the collections to be merged
   vtoken srcToken_;
 };
 
 template <typename InputCollection, typename OutputCollection, typename P>
 Merger<InputCollection, OutputCollection, P>::Merger(const edm::ParameterSet& par)
-    : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag> >("src"),
+    : srcToken_(edm::vector_transform(par.template getParameter<std::vector<edm::InputTag>>("src"),
                                       [this](edm::InputTag const& tag) { return consumes<InputCollection>(tag); })) {
   produces<OutputCollection>();
 }
@@ -67,6 +70,17 @@ void Merger<InputCollection, OutputCollection, P>::produce(edm::StreamID,
     }
   }
   evt.put(std::move(coll));
+}
+
+template <typename InputCollection, typename OutputCollection, typename P>
+void Merger<InputCollection, OutputCollection, P>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::vector<edm::InputTag>>("src",
+                                       {
+                                           edm::InputTag("collection1"),
+                                           edm::InputTag("collection2"),
+                                       });
+  descriptions.addWithDefaultLabel(desc);
 }
 
 #endif


### PR DESCRIPTION
#### Backport of #43731 to 13_3_X




#### PR description:

This PR addd fillDescription to CommonTools/UtilAlgos/interface/Merger.h in order to make it available in ConfDB.
No "_cfi" was available previeusly.
Original PR 43728

#### PR validation:

```
[sdonato@lxplus713 src]$ edmPluginHelp  -p TrackSimpleMerger
1  TrackSimpleMerger  (global::EDProducer)  "pluginCommonToolsRecoAlgos_plugins.so"

This plugin has 1 PSet description. This description is always used to validate configurations. The label below is used when generating the cfi file.

  1.1 module label: simpleMergedTracks

    src
                        type: VInputTag 
                        default: (vector size = 2)
                          [0]: 'collection1'
                          [1]: 'collection2'

    mightGet
                        type: untracked vstring optional
                        default: none
                        List contains the branch names for the EDProducts which might be requested by the module.
                        The format for identifying the EDProduct is the same as the one used for OutputModules, except no wild cards are allowed. E.g.
                        Foos_foomodule_whichFoo_RECO
```

Without the PR the output is 
```
[sdonato@lxplus713 src]$ edmPluginHelp  -p TrackSimpleMerger
1  TrackSimpleMerger  (global::EDProducer)  "pluginCommonToolsRecoAlgos_plugins.so"

  This plugin has not implemented the function which defines its
  configuration descriptions yet. No descriptions are available.
  Its PSets will not be validated, and no cfi files will be generated.
```

The compilation of  `/cvmfs/cms-ci.cern.ch/week0/cms-sw/cmssw/43728/36882/install.sh` works after this fix.
