### PR TITLE
Update Patatrack wf in relval_2026

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -16,7 +16,6 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 numWFIB = []
 numWFIB.extend([20034.0]) #2026D86
 numWFIB.extend([20834.0]) #2026D88
-numWFIB.extend([20834.501,20834.502]) #2026D88 Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU (to remove when available in D98)
 numWFIB.extend([22034.0]) #2026D91
 numWFIB.extend([22434.0]) #2026D92
 numWFIB.extend([22834.0]) #2026D93
@@ -27,6 +26,7 @@ numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
 numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
 numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
+numWFIB.extend([24834.501,24834.502]) #2026D98 Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([24834.21,25034.21,25034.9921]) #2026D98 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([25034.114]) #2026D98 PU, with 10% OT ineffiency 


### PR DESCRIPTION
#### PR description:
This is a follow up of https://github.com/cms-sw/cmssw/pull/41011
Patatrack workflows now use the same geometry version as baseline.

#### PR validation:
None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need of backport
