### PR TITLE
Move DynamicWeightChoiceGenInfo into a LuminosityBlockCache

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -14,6 +14,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "boost/algorithm/string.hpp"
 
+#include <array>
 #include <memory>
 
 #include <vector>
@@ -173,6 +174,9 @@ namespace {
     std::string rwgtWeightDoc;
   };
 
+  constexpr std::array<unsigned int, 4> defPSWeightIDs = {{6, 7, 8, 9}};
+  constexpr std::array<unsigned int, 4> defPSWeightIDs_alt = {{27, 5, 26, 4}};
+
   struct DynamicWeightChoiceGenInfo {
     // choice of LHE weights
     // ---- scale ----
@@ -182,8 +186,6 @@ namespace {
     std::vector<unsigned int> pdfWeightIDs;
     std::string pdfWeightsDoc;
     // ---- ps ----
-    std::vector<unsigned int> defPSWeightIDs = {6, 7, 8, 9};
-    std::vector<unsigned int> defPSWeightIDs_alt = {27, 5, 26, 4};
     bool matchPS_alt = false;
     std::vector<unsigned int> psWeightIDs;
     unsigned int psBaselineID = 1;
@@ -196,11 +198,7 @@ namespace {
 
   struct LumiCacheInfoHolder {
     CounterMap countermap;
-    DynamicWeightChoiceGenInfo weightChoice;
-    void clear() {
-      countermap.clear();
-      weightChoice = DynamicWeightChoiceGenInfo();
-    }
+    void clear() { countermap.clear(); }
   };
 
   float stof_fortrancomp(const std::string& str) {
@@ -246,6 +244,7 @@ namespace {
 
 class GenWeightsTableProducer : public edm::global::EDProducer<edm::StreamCache<LumiCacheInfoHolder>,
                                                                edm::RunCache<DynamicWeightChoice>,
+                                                               edm::LuminosityBlockCache<DynamicWeightChoiceGenInfo>,
                                                                edm::RunSummaryCache<CounterMap>,
                                                                edm::EndRunProducer> {
 public:
@@ -321,7 +320,7 @@ public:
       }
     }
 
-    const auto genWeightChoice = &(streamCache(id)->weightChoice);
+    const auto genWeightChoice = luminosityBlockCache(iEvent.getLuminosityBlock().index());
     if (lheInfo.isValid()) {
       if (getLHEweightsFromGenInfo && !hasIssuedWarning_.exchange(true))
         edm::LogWarning("LHETablesProducer")
@@ -941,26 +940,19 @@ public:
   void streamBeginRun(edm::StreamID id, edm::Run const&, edm::EventSetup const&) const override {
     streamCache(id)->clear();
   }
-  void streamBeginLuminosityBlock(edm::StreamID id,
-                                  edm::LuminosityBlock const& lumiBlock,
-                                  edm::EventSetup const& eventSetup) const override {
-    auto counterMap = &(streamCache(id)->countermap);
+
+  std::shared_ptr<DynamicWeightChoiceGenInfo> globalBeginLuminosityBlock(edm::LuminosityBlock const& lumiBlock,
+                                                                         edm::EventSetup const&) const override {
+    auto dynamicWeightChoiceGenInfo = std::make_shared<DynamicWeightChoiceGenInfo>();
+
     edm::Handle<GenLumiInfoHeader> genLumiInfoHead;
     lumiBlock.getByToken(genLumiInfoHeadTag_, genLumiInfoHead);
     if (!genLumiInfoHead.isValid())
       edm::LogWarning("LHETablesProducer")
           << "No GenLumiInfoHeader product found, will not fill generator model string.\n";
 
-    std::string label;
     if (genLumiInfoHead.isValid()) {
-      label = genLumiInfoHead->configDescription();
-      boost::replace_all(label, "-", "_");
-      boost::replace_all(label, "/", "_");
-    }
-    counterMap->setLabel(label);
-
-    if (genLumiInfoHead.isValid()) {
-      auto weightChoice = &(streamCache(id)->weightChoice);
+      auto weightChoice = dynamicWeightChoiceGenInfo.get();
 
       std::vector<ScaleVarWeight> scaleVariationIDs;
       std::vector<PDFSetWeights> pdfSetWeightIDs;
@@ -1066,6 +1058,25 @@ public:
           break;
       }
     }
+    return dynamicWeightChoiceGenInfo;
+  }
+
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {}
+
+  void streamBeginLuminosityBlock(edm::StreamID id,
+                                  edm::LuminosityBlock const& lumiBlock,
+                                  edm::EventSetup const&) const override {
+    auto counterMap = &(streamCache(id)->countermap);
+    edm::Handle<GenLumiInfoHeader> genLumiInfoHead;
+    lumiBlock.getByToken(genLumiInfoHeadTag_, genLumiInfoHead);
+
+    std::string label;
+    if (genLumiInfoHead.isValid()) {
+      label = genLumiInfoHead->configDescription();
+      boost::replace_all(label, "-", "_");
+      boost::replace_all(label, "/", "_");
+    }
+    counterMap->setLabel(label);
   }
   // create an empty counter
   std::shared_ptr<CounterMap> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {


### PR DESCRIPTION
#### PR description:

Move DynamicWeightChoiceGenInfo into a LuminosityBlockCache. The primary goal for this change is to have DynamicWeightChoiceGenInfo always be set properly. Currently, it appears in the code that there is a possibility for it to use some values from an earlier lumi because all the values it contains are not always set at begin lumi. I'm not sure if this ever actually happens in practice. That would depend on the input.

The Core group's motivation to look at this code is that we are currently surveying all CMSSW to look for problems that a new Framework behavior might cause. The new behavior allows a stream to skip a lumi if at the time the stream is starting on the lumi at least one other stream has processed the lumi and all the events were already processed. Specifically the stream would skip the stream begin lumi and stream end lumi transitions. The performance advantage related to this occurs when there is an event that takes an extremely long time to process. That stream cannot finish its current lumi or any subsequent lumis. As other streams finish subsequent lumis, the limit on concurrent lumi is reached and all the other streams get stuck.

This lumi skipping would cause modules that rely on values set in previous lumis to get non reproducible results if those previous lumis might or might not have been skipped.

After this change, each weight choice object will be recreated from nothing for each lumi. This was already occurring for the first lumi in each run (but not later lumis in the run).

This change also has some side benefits.

* The weight choice is only initialized once per lumi instead of once per lumi per stream.
* There is only one copy in memory per lumi instead of one per stream per lumi.
* The weight choice object will be in the LuminosityBlockCache and that is similar to the way the other weight choice object is already in the RunCache.
* There were two constant vectors that I pulled out of the cache entirely and just made constexpr arrays.

The biggest change in the code is that a large block of code was moved from streamBeginLuminosityBlock to globalBeginLuminosityBlock.

Unless I made a mistake, I believe the results should be identical before and after. Exactly the same things should be happening during begin lumi to set the values in the weight choice object.

#### PR validation:

It builds. There is no unit test. Dozens of runTheMatrix.py tests at least execute this code. I also ran test 548.0 step3 and printed out values from the structure whose initialization was modified and contents are identical.

FYI @makortel 