### PR TITLE
Electron and Photon Scouting Data Format Update for 2024 pp Collisions

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingElectron.h
@@ -13,11 +13,18 @@ public:
                        float eta,
                        float phi,
                        float m,
+                       float rawEnergy,
+                       float preshowerEnergy,
+                       float corrEcalEnergyError,
                        std::vector<float> trkd0,
                        std::vector<float> trkdz,
                        std::vector<float> trkpt,
                        std::vector<float> trketa,
                        std::vector<float> trkphi,
+                       std::vector<float> trkpMode,
+                       std::vector<float> trketaMode,
+                       std::vector<float> trkphiMode,
+                       std::vector<float> trkqoverpModeError,
                        std::vector<float> trkchi2overndf,
                        float dEtaIn,
                        float dPhiIn,
@@ -26,6 +33,7 @@ public:
                        float ooEMOop,
                        int missingHits,
                        std::vector<int> trkcharge,
+                       float trackfbrem,
                        float ecalIso,
                        float hcalIso,
                        float trackIso,
@@ -33,6 +41,8 @@ public:
                        float sMin,
                        float sMaj,
                        uint32_t seedId,
+                       uint32_t nClusters,
+                       uint32_t nCrystals,
                        std::vector<float> energyMatrix,
                        std::vector<uint32_t> detIds,
                        std::vector<float> timingMatrix,
@@ -41,11 +51,18 @@ public:
         eta_(eta),
         phi_(phi),
         m_(m),
+        rawEnergy_(rawEnergy),
+        preshowerEnergy_(preshowerEnergy),
+        corrEcalEnergyError_(corrEcalEnergyError),
         trkd0_(std::move(trkd0)),
         trkdz_(std::move(trkdz)),
         trkpt_(std::move(trkpt)),
         trketa_(std::move(trketa)),
         trkphi_(std::move(trkphi)),
+        trkpMode_(std::move(trkpMode)),
+        trketaMode_(std::move(trketaMode)),
+        trkphiMode_(std::move(trkphiMode)),
+        trkqoverpModeError_(std::move(trkqoverpModeError)),
         trkchi2overndf_(std::move(trkchi2overndf)),
         dEtaIn_(dEtaIn),
         dPhiIn_(dPhiIn),
@@ -54,6 +71,7 @@ public:
         ooEMOop_(ooEMOop),
         missingHits_(missingHits),
         trkcharge_(std::move(trkcharge)),
+        trackfbrem_(trackfbrem),
         ecalIso_(ecalIso),
         hcalIso_(hcalIso),
         trackIso_(trackIso),
@@ -61,6 +79,8 @@ public:
         sMin_(sMin),
         sMaj_(sMaj),
         seedId_(seedId),
+        nClusters_(nClusters),
+        nCrystals_(nCrystals),
         energyMatrix_(std::move(energyMatrix)),
         detIds_(std::move(detIds)),
         timingMatrix_(std::move(timingMatrix)),
@@ -71,11 +91,18 @@ public:
         eta_(0),
         phi_(0),
         m_(0),
+        rawEnergy_(0),
+        preshowerEnergy_(0),
+        corrEcalEnergyError_(0),
         trkd0_(0),
         trkdz_(0),
         trkpt_(0),
         trketa_(0),
         trkphi_(0),
+        trkpMode_(0),
+        trketaMode_(0),
+        trkphiMode_(0),
+        trkqoverpModeError_(0),
         trkchi2overndf_(0),
         dEtaIn_(0),
         dPhiIn_(0),
@@ -84,6 +111,7 @@ public:
         ooEMOop_(0),
         missingHits_(0),
         trkcharge_(0),
+        trackfbrem_(0),
         ecalIso_(0),
         hcalIso_(0),
         trackIso_(0),
@@ -91,6 +119,8 @@ public:
         sMin_(0),
         sMaj_(0),
         seedId_(0),
+        nClusters_(0),
+        nCrystals_(0),
         rechitZeroSuppression_(false) {}
 
   //accessor functions
@@ -98,11 +128,18 @@ public:
   float eta() const { return eta_; }
   float phi() const { return phi_; }
   float m() const { return m_; }
+  float rawEnergy() const { return rawEnergy_; }
+  float preshowerEnergy() const { return preshowerEnergy_; }
+  float corrEcalEnergyError() const { return corrEcalEnergyError_; }
   std::vector<float> const& trkd0() const { return trkd0_; }
   std::vector<float> const& trkdz() const { return trkdz_; }
   std::vector<float> const& trkpt() const { return trkpt_; }
   std::vector<float> const& trketa() const { return trketa_; }
   std::vector<float> const& trkphi() const { return trkphi_; }
+  std::vector<float> const& trkpMode() const { return trkpMode_; }
+  std::vector<float> const& trketaMode() const { return trketaMode_; }
+  std::vector<float> const& trkphiMode() const { return trkphiMode_; }
+  std::vector<float> const& trkqoverpModeError() const { return trkqoverpModeError_; }
   std::vector<float> const& trkchi2overndf() const { return trkchi2overndf_; }
   float dEtaIn() const { return dEtaIn_; }
   float dPhiIn() const { return dPhiIn_; }
@@ -111,6 +148,7 @@ public:
   float ooEMOop() const { return ooEMOop_; }
   int missingHits() const { return missingHits_; }
   std::vector<int> const& trkcharge() const { return trkcharge_; }
+  float trackfbrem() const { return trackfbrem_; }
   float ecalIso() const { return ecalIso_; }
   float hcalIso() const { return hcalIso_; }
   float trackIso() const { return trackIso_; }
@@ -118,6 +156,8 @@ public:
   float sMin() const { return sMin_; }
   float sMaj() const { return sMaj_; }
   uint32_t seedId() const { return seedId_; }
+  uint32_t nClusters() const { return nClusters_; }
+  uint32_t nCrystals() const { return nCrystals_; }
   std::vector<float> const& energyMatrix() const { return energyMatrix_; }
   std::vector<uint32_t> const& detIds() const { return detIds_; }
   std::vector<float> const& timingMatrix() const { return timingMatrix_; }
@@ -128,11 +168,18 @@ private:
   float eta_;
   float phi_;
   float m_;
+  float rawEnergy_;
+  float preshowerEnergy_;
+  float corrEcalEnergyError_;
   std::vector<float> trkd0_;
   std::vector<float> trkdz_;
   std::vector<float> trkpt_;
   std::vector<float> trketa_;
   std::vector<float> trkphi_;
+  std::vector<float> trkpMode_;
+  std::vector<float> trketaMode_;
+  std::vector<float> trkphiMode_;
+  std::vector<float> trkqoverpModeError_;
   std::vector<float> trkchi2overndf_;
   float dEtaIn_;
   float dPhiIn_;
@@ -141,6 +188,7 @@ private:
   float ooEMOop_;
   int missingHits_;
   std::vector<int> trkcharge_;
+  float trackfbrem_;
   float ecalIso_;
   float hcalIso_;
   float trackIso_;
@@ -148,6 +196,8 @@ private:
   float sMin_;
   float sMaj_;
   uint32_t seedId_;
+  uint32_t nClusters_;
+  uint32_t nCrystals_;
   std::vector<float> energyMatrix_;
   std::vector<uint32_t> detIds_;
   std::vector<float> timingMatrix_;

--- a/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
@@ -13,6 +13,9 @@ public:
                      float eta,
                      float phi,
                      float m,
+                     float rawEnergy,
+                     float preshowerEnergy,
+                     float corrEcalEnergyError,
                      float sigmaIetaIeta,
                      float hOverE,
                      float ecalIso,
@@ -22,6 +25,8 @@ public:
                      float sMin,
                      float sMaj,
                      uint32_t seedId,
+                     uint32_t nClusters,
+                     uint32_t nCrystals,
                      std::vector<float> energyMatrix,
                      std::vector<uint32_t> detIds,
                      std::vector<float> timingMatrix,
@@ -30,6 +35,9 @@ public:
         eta_(eta),
         phi_(phi),
         m_(m),
+        rawEnergy_(rawEnergy),
+        preshowerEnergy_(preshowerEnergy),
+        corrEcalEnergyError_(corrEcalEnergyError),
         sigmaIetaIeta_(sigmaIetaIeta),
         hOverE_(hOverE),
         ecalIso_(ecalIso),
@@ -39,6 +47,8 @@ public:
         sMin_(sMin),
         sMaj_(sMaj),
         seedId_(seedId),
+        nClusters_(nClusters),
+        nCrystals_(nCrystals),
         energyMatrix_(std::move(energyMatrix)),
         detIds_(std::move(detIds)),
         timingMatrix_(std::move(timingMatrix)),
@@ -49,6 +59,9 @@ public:
         eta_(0),
         phi_(0),
         m_(0),
+        rawEnergy_(0),
+        preshowerEnergy_(0),
+        corrEcalEnergyError_(0),
         sigmaIetaIeta_(0),
         hOverE_(0),
         ecalIso_(0),
@@ -58,6 +71,8 @@ public:
         sMin_(0),
         sMaj_(0),
         seedId_(0),
+        nClusters_(0),
+        nCrystals_(0),
         energyMatrix_(0),
         timingMatrix_(0),
         rechitZeroSuppression_(false) {}
@@ -67,6 +82,9 @@ public:
   float eta() const { return eta_; }
   float phi() const { return phi_; }
   float m() const { return m_; }
+  float rawEnergy() const { return rawEnergy_; }
+  float preshowerEnergy() const { return preshowerEnergy_; }
+  float corrEcalEnergyError() const { return corrEcalEnergyError_; }
   float sigmaIetaIeta() const { return sigmaIetaIeta_; }
   float hOverE() const { return hOverE_; }
   float ecalIso() const { return ecalIso_; }
@@ -76,6 +94,8 @@ public:
   float sMin() const { return sMin_; }
   float sMaj() const { return sMaj_; }
   uint32_t seedId() const { return seedId_; }
+  uint32_t nClusters() const { return nClusters_; }
+  uint32_t nCrystals() const { return nCrystals_; }
   std::vector<float> const& energyMatrix() const { return energyMatrix_; }
   std::vector<uint32_t> const& detIds() const { return detIds_; }
   std::vector<float> const& timingMatrix() const { return timingMatrix_; }
@@ -86,6 +106,9 @@ private:
   float eta_;
   float phi_;
   float m_;
+  float rawEnergy_;
+  float preshowerEnergy_;
+  float corrEcalEnergyError_;
   float sigmaIetaIeta_;
   float hOverE_;
   float ecalIso_;
@@ -95,6 +118,8 @@ private:
   float sMin_;
   float sMaj_;
   uint32_t seedId_;
+  uint32_t nClusters_;
+  uint32_t nCrystals_;
   std::vector<float> energyMatrix_;
   std::vector<uint32_t> detIds_;
   std::vector<float> timingMatrix_;

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -2,11 +2,12 @@
   <class name="Run3ScoutingCaloJet" ClassVersion="3">
       <version ClassVersion="3" checksum="1173827345"/>
   </class>
-  <class name="Run3ScoutingElectron" ClassVersion="6">
+  <class name="Run3ScoutingElectron" ClassVersion="7">
       <version ClassVersion="3" checksum="1086011373"/>
       <version ClassVersion="4" checksum="1250202632"/>
       <version ClassVersion="5" checksum="2230390721"/>
       <version ClassVersion="6" checksum="2815634332"/>
+      <version ClassVersion="7" checksum="3525740167"/>
   </class>
 
   <!-- Adding ioread rules for backwards compatibility -->
@@ -50,10 +51,11 @@
   <class name="Run3ScoutingPFJet" ClassVersion="3">
       <version ClassVersion="3" checksum="3819751468"/>
   </class>
-  <class name="Run3ScoutingPhoton" ClassVersion="5">
+  <class name="Run3ScoutingPhoton" ClassVersion="6">
       <version ClassVersion="3" checksum="1683146807"/>
       <version ClassVersion="4" checksum="1725280278"/>
       <version ClassVersion="5" checksum="1238010495"/>
+      <version ClassVersion="6" checksum="2966069208"/>
   </class>
   <class name="Run3ScoutingTrack" ClassVersion="3">
       <version ClassVersion="3" checksum="3352318277"/>

--- a/DataFormats/Scouting/test/TestReadRun3Scouting.cc
+++ b/DataFormats/Scouting/test/TestReadRun3Scouting.cc
@@ -83,6 +83,7 @@ namespace edmtest {
     const std::vector<int> expectedPFJetIntegralValues_;
     const edm::EDGetTokenT<std::vector<Run3ScoutingPFJet>> pfJetsToken_;
 
+    const int inputPhotonClassVersion_;
     const std::vector<double> expectedPhotonFloatingPointValues_;
     const std::vector<int> expectedPhotonIntegralValues_;
     const edm::EDGetTokenT<std::vector<Run3ScoutingPhoton>> photonsToken_;
@@ -114,6 +115,7 @@ namespace edmtest {
         expectedPFJetFloatingPointValues_(iPSet.getParameter<std::vector<double>>("expectedPFJetFloatingPointValues")),
         expectedPFJetIntegralValues_(iPSet.getParameter<std::vector<int>>("expectedPFJetIntegralValues")),
         pfJetsToken_(consumes(iPSet.getParameter<edm::InputTag>("pfJetsTag"))),
+        inputPhotonClassVersion_(iPSet.getParameter<int>("photonClassVersion")),
         expectedPhotonFloatingPointValues_(
             iPSet.getParameter<std::vector<double>>("expectedPhotonFloatingPointValues")),
         expectedPhotonIntegralValues_(iPSet.getParameter<std::vector<int>>("expectedPhotonIntegralValues")),
@@ -128,12 +130,12 @@ namespace edmtest {
     if (expectedCaloJetsValues_.size() != 16) {
       throwWithMessageFromConstructor("test configuration error, expectedCaloJetsValues must have size 16");
     }
-    if (expectedElectronFloatingPointValues_.size() != 25) {
+    if (expectedElectronFloatingPointValues_.size() != 33) {
       throwWithMessageFromConstructor(
-          "test configuration error, expectedElectronFloatingPointValues must have size 25");
+          "test configuration error, expectedElectronFloatingPointValues must have size 33");
     }
-    if (expectedElectronIntegralValues_.size() != 6) {
-      throwWithMessageFromConstructor("test configuration error, expectedElectronIntegralValues must have size 6");
+    if (expectedElectronIntegralValues_.size() != 8) {
+      throwWithMessageFromConstructor("test configuration error, expectedElectronIntegralValues must have size 8");
     }
     if (expectedMuonFloatingPointValues_.size() != 37) {
       throwWithMessageFromConstructor("test configuration error, expectedMuonFloatingPointValues must have size 37");
@@ -154,11 +156,11 @@ namespace edmtest {
     if (expectedPFJetIntegralValues_.size() != 8) {
       throwWithMessageFromConstructor("test configuration error, expectedPFJetIntegralValues must have size 8");
     }
-    if (expectedPhotonFloatingPointValues_.size() != 14) {
-      throwWithMessageFromConstructor("test configuration error, expectedPhotonFloatingPointValues must have size 14");
+    if (expectedPhotonFloatingPointValues_.size() != 17) {
+      throwWithMessageFromConstructor("test configuration error, expectedPhotonFloatingPointValues must have size 17");
     }
-    if (expectedPhotonIntegralValues_.size() != 3) {
-      throwWithMessageFromConstructor("test configuration error, expectedPhotonIntegralValues must have size 3");
+    if (expectedPhotonIntegralValues_.size() != 5) {
+      throwWithMessageFromConstructor("test configuration error, expectedPhotonIntegralValues must have size 5");
     }
     if (expectedTrackFloatingPointValues_.size() != 29) {
       throwWithMessageFromConstructor("test configuration error, expectedTrackFloatingPointValues must have size 29");
@@ -202,6 +204,7 @@ namespace edmtest {
     desc.add<std::vector<double>>("expectedPFJetFloatingPointValues");
     desc.add<std::vector<int>>("expectedPFJetIntegralValues");
     desc.add<edm::InputTag>("pfJetsTag");
+    desc.add<int>("photonClassVersion");
     desc.add<std::vector<double>>("expectedPhotonFloatingPointValues");
     desc.add<std::vector<int>>("expectedPhotonIntegralValues");
     desc.add<edm::InputTag>("photonsTag");
@@ -393,7 +396,7 @@ namespace edmtest {
       if (electron.rechitZeroSuppression() != static_cast<bool>((expectedElectronIntegralValues_[4] + iOffset) % 2)) {
         throwWithMessage("analyzeElectrons, rechitZeroSuppression does not equal expected value");
       }
-      if (inputElectronClassVersion_ == 6) {
+      if (inputElectronClassVersion_ == 6 || inputElectronClassVersion_ == 7) {
         if (electron.trkd0().size() != vectorSize) {
           throwWithMessage("analyzeElectrons, trkd0 does not have expected size");
         }
@@ -463,6 +466,66 @@ namespace edmtest {
             throwWithMessage("analyzeElectrons, trkcharge does not contain expected value");
           }
           ++j;
+        }
+      }
+      if (inputElectronClassVersion_ == 7) {
+        if (electron.rawEnergy() != expectedElectronFloatingPointValues_[25] + offset) {
+          throwWithMessage("analyzeElectrons, rawEnergy does not equal expected value");
+        }
+        if (electron.preshowerEnergy() != expectedElectronFloatingPointValues_[26] + offset) {
+          throwWithMessage("analyzeElectrons, preshowerEnergy does not equal expected value");
+        }
+        if (electron.corrEcalEnergyError() != expectedElectronFloatingPointValues_[27] + offset) {
+          throwWithMessage("analyzeElectrons, corrEcalEnergyError does not equal expected value");
+        }
+        if (electron.trkpMode().size() != vectorSize) {
+          throwWithMessage("analyzeElectrons, trkpMode does not have expected size");
+        }
+        j = 0;
+        for (auto const& val : electron.trkpMode()) {
+          if (val != expectedElectronFloatingPointValues_[28] + offset + 10 * j) {
+            throwWithMessage("analyzeElectrons, trkpMode does not contain expected value");
+          }
+          ++j;
+        }
+        if (electron.trketaMode().size() != vectorSize) {
+          throwWithMessage("analyzeElectrons, trketaMode does not have expected size");
+        }
+        j = 0;
+        for (auto const& val : electron.trketaMode()) {
+          if (val != expectedElectronFloatingPointValues_[29] + offset + 10 * j) {
+            throwWithMessage("analyzeElectrons, trketaMode does not contain expected value");
+          }
+          ++j;
+        }
+        if (electron.trkphiMode().size() != vectorSize) {
+          throwWithMessage("analyzeElectrons, trkphiMode does not have expected size");
+        }
+        j = 0;
+        for (auto const& val : electron.trkphiMode()) {
+          if (val != expectedElectronFloatingPointValues_[30] + offset + 10 * j) {
+            throwWithMessage("analyzeElectrons, trkphiMode does not contain expected value");
+          }
+          ++j;
+        }
+        if (electron.trkqoverpModeError().size() != vectorSize) {
+          throwWithMessage("analyzeElectrons, trkqoverpModeError does not have expected size");
+        }
+        j = 0;
+        for (auto const& val : electron.trkqoverpModeError()) {
+          if (val != expectedElectronFloatingPointValues_[31] + offset + 10 * j) {
+            throwWithMessage("analyzeElectrons, trkqoverpModeError does not contain expected value");
+          }
+          ++j;
+        }
+        if (electron.trackfbrem() != expectedElectronFloatingPointValues_[32] + offset) {
+          throwWithMessage("analyzeElectrons, trackfbrem does not equal expected value");
+        }
+        if (electron.nClusters() != static_cast<unsigned int>(expectedElectronIntegralValues_[6] + iOffset)) {
+          throwWithMessage("analyzeElectrons, nClusters does not equal expected value");
+        }
+        if (electron.nCrystals() != static_cast<unsigned int>(expectedElectronIntegralValues_[7] + iOffset)) {
+          throwWithMessage("analyzeElectrons, nCrystals does not equal expected value");
         }
       }
       ++i;
@@ -916,6 +979,23 @@ namespace edmtest {
       }
       if (photon.rechitZeroSuppression() != static_cast<bool>((expectedPhotonIntegralValues_[2] + iOffset) % 2)) {
         throwWithMessage("analyzePhotons, rechitZeroSuppression does not equal expected value");
+      }
+      if (inputPhotonClassVersion_ == 6) {
+        if (photon.rawEnergy() != expectedPhotonFloatingPointValues_[14] + offset) {
+          throwWithMessage("analyzePhotons, rawEnergy does not equal expected value");
+        }
+        if (photon.preshowerEnergy() != expectedPhotonFloatingPointValues_[15] + offset) {
+          throwWithMessage("analyzePhotons, preshowerEnergy does not equal expected value");
+        }
+        if (photon.corrEcalEnergyError() != expectedPhotonFloatingPointValues_[16] + offset) {
+          throwWithMessage("analyzePhotons, corrEcalEnergyError does not equal expected value");
+        }
+        if (photon.nClusters() != static_cast<unsigned int>(expectedPhotonIntegralValues_[3] + iOffset)) {
+          throwWithMessage("analyzePhotons, nClusters does not equal expected value");
+        }
+        if (photon.nCrystals() != static_cast<unsigned int>(expectedPhotonIntegralValues_[4] + iOffset)) {
+          throwWithMessage("analyzePhotons, nCrystals does not equal expected value");
+        }
       }
       ++i;
     }

--- a/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
@@ -48,12 +48,12 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py || die "Failure using test
 
 file=testRun3Scouting_v3_v5_v3_v4_v5_v3_v5_v3_v3_CMSSW_12_4_0.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_12_4_0.root --electronVersion 5 --photonVersion 5"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 file=testRun3Scouting_v3_v6_v3_v4_v5_v3_v5_v3_v3_CMSSW_13_0_3.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
-argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_13_0_3.root --electronVersion 6"
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_13_0_3.root --electronVersion 6 --photonVersion 5"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 exit 0

--- a/DataFormats/Scouting/test/TestWriteRun3Scouting.cc
+++ b/DataFormats/Scouting/test/TestWriteRun3Scouting.cc
@@ -118,11 +118,11 @@ namespace edmtest {
     if (caloJetsValues_.size() != 16) {
       throwWithMessage("caloJetsValues must have 16 elements and it does not");
     }
-    if (electronsFloatingPointValues_.size() != 25) {
-      throwWithMessage("electronsFloatingPointValues must have 25 elements and it does not");
+    if (electronsFloatingPointValues_.size() != 33) {
+      throwWithMessage("electronsFloatingPointValues must have 33 elements and it does not");
     }
-    if (electronsIntegralValues_.size() != 6) {
-      throwWithMessage("electronsIntegralValues must have 6 elements and it does not");
+    if (electronsIntegralValues_.size() != 8) {
+      throwWithMessage("electronsIntegralValues must have 8 elements and it does not");
     }
     if (muonsFloatingPointValues_.size() != 37) {
       throwWithMessage("muonsFloatingPointValues must have 37 elements and it does not");
@@ -142,11 +142,11 @@ namespace edmtest {
     if (pfJetsIntegralValues_.size() != 8) {
       throwWithMessage("pfJetsIntegralValues must have 8 elements and it does not");
     }
-    if (photonsFloatingPointValues_.size() != 14) {
-      throwWithMessage("photonsFloatingPointValues must have 14 elements and it does not");
+    if (photonsFloatingPointValues_.size() != 17) {
+      throwWithMessage("photonsFloatingPointValues must have 17 elements and it does not");
     }
-    if (photonsIntegralValues_.size() != 3) {
-      throwWithMessage("photonsIntegralValues must have 3 elements and it does not");
+    if (photonsIntegralValues_.size() != 5) {
+      throwWithMessage("photonsIntegralValues must have 5 elements and it does not");
     }
     if (tracksFloatingPointValues_.size() != 29) {
       throwWithMessage("tracksFloatingPointValues must have 29 elements and it does not");
@@ -233,7 +233,7 @@ namespace edmtest {
       double offset = static_cast<double>(iEvent.id().event() + i);
       int iOffset = static_cast<int>(iEvent.id().event() + i);
 
-      // Note the first seven of these vectors use an out of sequence index
+      // Note the first eleven of these vectors use an out of sequence index
       // (starting at 19 or 5) because they are data members added in a format
       // change. In the CMSSW_12_4_0 version, they didn't exist.
       // Also the index values 4 and 5 in electronsFloatingPointValues_
@@ -244,6 +244,10 @@ namespace edmtest {
       std::vector<float> trkpt;
       std::vector<float> trketa;
       std::vector<float> trkphi;
+      std::vector<float> trkpMode;
+      std::vector<float> trketaMode;
+      std::vector<float> trkphiMode;
+      std::vector<float> trkqoverpModeError;
       std::vector<float> trkchi2overndf;
       std::vector<int> trkcharge;
       std::vector<float> energyMatrix;
@@ -254,6 +258,10 @@ namespace edmtest {
       trkpt.reserve(vectorSize);
       trketa.reserve(vectorSize);
       trkphi.reserve(vectorSize);
+      trkpMode.reserve(vectorSize);
+      trketaMode.reserve(vectorSize);
+      trkphiMode.reserve(vectorSize);
+      trkqoverpModeError.reserve(vectorSize);
       trkchi2overndf.reserve(vectorSize);
       trkcharge.reserve(vectorSize);
       energyMatrix.reserve(vectorSize);
@@ -265,6 +273,10 @@ namespace edmtest {
         trkpt.push_back(static_cast<float>(electronsFloatingPointValues_[21] + offset + j * 10));
         trketa.push_back(static_cast<float>(electronsFloatingPointValues_[22] + offset + j * 10));
         trkphi.push_back(static_cast<float>(electronsFloatingPointValues_[23] + offset + j * 10));
+        trkpMode.push_back(static_cast<float>(electronsFloatingPointValues_[28] + offset + j * 10));
+        trketaMode.push_back(static_cast<float>(electronsFloatingPointValues_[29] + offset + j * 10));
+        trkphiMode.push_back(static_cast<float>(electronsFloatingPointValues_[30] + offset + j * 10));
+        trkqoverpModeError.push_back(static_cast<float>(electronsFloatingPointValues_[31] + offset + j * 10));
         trkchi2overndf.push_back(static_cast<float>(electronsFloatingPointValues_[24] + offset + j * 10));
         trkcharge.push_back(static_cast<int>(electronsIntegralValues_[5] + offset + j * 10));
         energyMatrix.push_back(static_cast<float>(electronsFloatingPointValues_[17] + offset + j * 10));
@@ -275,11 +287,18 @@ namespace edmtest {
                                           static_cast<float>(electronsFloatingPointValues_[1] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[2] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[3] + offset),
+                                          static_cast<float>(electronsFloatingPointValues_[25] + offset),
+                                          static_cast<float>(electronsFloatingPointValues_[26] + offset),
+                                          static_cast<float>(electronsFloatingPointValues_[27] + offset),
                                           std::move(trkd0),
                                           std::move(trkdz),
                                           std::move(trkpt),
                                           std::move(trketa),
                                           std::move(trkphi),
+                                          std::move(trkpMode),
+                                          std::move(trketaMode),
+                                          std::move(trkphiMode),
+                                          std::move(trkqoverpModeError),
                                           std::move(trkchi2overndf),
                                           static_cast<float>(electronsFloatingPointValues_[6] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[7] + offset),
@@ -288,6 +307,7 @@ namespace edmtest {
                                           static_cast<float>(electronsFloatingPointValues_[10] + offset),
                                           electronsIntegralValues_[0] + iOffset,
                                           std::move(trkcharge),
+                                          static_cast<float>(electronsFloatingPointValues_[32] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[11] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[12] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[13] + offset),
@@ -295,6 +315,8 @@ namespace edmtest {
                                           static_cast<float>(electronsFloatingPointValues_[15] + offset),
                                           static_cast<float>(electronsFloatingPointValues_[16] + offset),
                                           static_cast<uint32_t>(electronsIntegralValues_[2] + iOffset),
+                                          static_cast<uint32_t>(electronsIntegralValues_[6] + iOffset),
+                                          static_cast<uint32_t>(electronsIntegralValues_[7] + iOffset),
                                           std::move(energyMatrix),
                                           std::move(detIds),
                                           std::move(timingMatrix),
@@ -482,6 +504,9 @@ namespace edmtest {
                                         static_cast<float>(photonsFloatingPointValues_[1] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[2] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[3] + offset),
+                                        static_cast<float>(photonsFloatingPointValues_[14] + offset),
+                                        static_cast<float>(photonsFloatingPointValues_[15] + offset),
+                                        static_cast<float>(photonsFloatingPointValues_[16] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[4] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[5] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[6] + offset),
@@ -491,6 +516,8 @@ namespace edmtest {
                                         static_cast<float>(photonsFloatingPointValues_[10] + offset),
                                         static_cast<float>(photonsFloatingPointValues_[11] + offset),
                                         static_cast<uint32_t>(photonsIntegralValues_[0] + iOffset),
+                                        static_cast<uint32_t>(photonsIntegralValues_[3] + iOffset),
+                                        static_cast<uint32_t>(photonsIntegralValues_[4] + iOffset),
                                         std::move(energyMatrix),
                                         std::move(detIds),
                                         std::move(timingMatrix),

--- a/DataFormats/Scouting/test/create_Run3Scouting_test_file_cfg.py
+++ b/DataFormats/Scouting/test/create_Run3Scouting_test_file_cfg.py
@@ -23,10 +23,12 @@ process.run3ScoutingProducer = cms.EDProducer("TestWriteRun3Scouting",
         60.0,   70.0,  80.0,  90.0, 100.0,
         110.0, 120.0, 130.0, 140.0, 150.0,
         160.0, 170.0, 180.0, 190.0, 200.0,
-        210.0, 220.0, 230.0, 240.0, 250.0
+        210.0, 220.0, 230.0, 240.0, 250.0,
+        260.0, 270.0, 280.0, 290.0, 300.0,
+        310.0, 320.0, 330.0
     ),
     electronsIntegralValues = cms.vint32(
-        10, 20, 30, 40, 50, 60
+        10, 20, 30, 40, 50, 60, 70, 80
     ),
     muonsFloatingPointValues = cms.vdouble(
         10.0,   20.0,  30.0,  40.0,  50.0,
@@ -66,10 +68,11 @@ process.run3ScoutingProducer = cms.EDProducer("TestWriteRun3Scouting",
     photonsFloatingPointValues = cms.vdouble(
         14.0,   23.0,  33.0,  43.0,  53.0,
         63.0,   73.0,  83.0,  93.0, 103.0,
-        113.0, 123.0, 133.0, 143.0
+        113.0, 123.0, 133.0, 143.0, 153.0,
+        163.0, 173.0
     ),
     photonsIntegralValues = cms.vint32(
-        14,   23,  33
+        14,   23,  33, 43, 53
     ),
     tracksFloatingPointValues = cms.vdouble(
         14.0,   24.0,  34.0,  44.0,  54.0,

--- a/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
+++ b/DataFormats/Scouting/test/test_readRun3Scouting_cfg.py
@@ -4,7 +4,8 @@ import argparse
 
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test Run 3 Scouting data formats')
 
-parser.add_argument("--electronVersion", type=int, help="electron data format version (default: 6)", default=6)
+parser.add_argument("--electronVersion", type=int, help="electron data format version (default: 7)", default=7)
+parser.add_argument("--photonVersion", type=int, help="photon data format version (default: 6)", default=6)
 parser.add_argument("--inputFile", type=str, help="Input file name (default: testRun3Scouting.root)", default="testRun3Scouting.root")
 parser.add_argument("--outputFileName", type=str, help="Output file name (default: testRun3Scouting2.root)", default="testRun3Scouting2.root")
 args = parser.parse_args()
@@ -28,8 +29,10 @@ process.testReadRun3Scouting = cms.EDAnalyzer("TestReadRun3Scouting",
         60.0,   70.0,  80.0,  90.0, 100.0,
         110.0, 120.0, 130.0, 140.0, 150.0,
         160.0, 170.0, 180.0, 190.0, 200.0,
-        210.0, 220.0, 230.0, 240.0, 250.0),
-    expectedElectronIntegralValues = cms.vint32(10, 20, 30, 40, 50, 60),
+        210.0, 220.0, 230.0, 240.0, 250.0,
+        260.0, 270.0, 280.0, 290.0, 300.0,
+        310.0, 320.0, 330.0),
+    expectedElectronIntegralValues = cms.vint32(10, 20, 30, 40, 50, 60, 70, 80),
     electronsTag = cms.InputTag("run3ScoutingProducer", "", "PROD"),
     expectedMuonFloatingPointValues = cms.vdouble(
         10.0,   20.0,  30.0,  40.0,  50.0,
@@ -69,13 +72,15 @@ process.testReadRun3Scouting = cms.EDAnalyzer("TestReadRun3Scouting",
         62,   72,  82
     ),
     pfJetsTag = cms.InputTag("run3ScoutingProducer", "", "PROD"),
+    photonClassVersion = cms.int32(args.photonVersion),
     expectedPhotonFloatingPointValues = cms.vdouble(
         14.0,   23.0,  33.0,  43.0,  53.0,
         63.0,   73.0,  83.0,  93.0, 103.0,
-        113.0, 123.0, 133.0, 143.0
+        113.0, 123.0, 133.0, 143.0, 153.0,
+        163.0, 173.0
     ),
     expectedPhotonIntegralValues = cms.vint32(
-        14,   23,  33
+        14,   23,  33,  43,  53
     ),
     photonsTag = cms.InputTag("run3ScoutingProducer", "", "PROD"),
     expectedTrackFloatingPointValues = cms.vdouble(

--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
@@ -279,6 +279,10 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
     std::vector<float> trkpt;
     std::vector<float> trketa;
     std::vector<float> trkphi;
+    std::vector<float> trkpMode;
+    std::vector<float> trketaMode;
+    std::vector<float> trkphiMode;
+    std::vector<float> trkqoverpModeError;
     std::vector<float> trkchi2overndf;
     std::vector<int> trkcharge;
     trkd0.reserve(maxTrkSize);
@@ -286,6 +290,10 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
     trkpt.reserve(maxTrkSize);
     trketa.reserve(maxTrkSize);
     trkphi.reserve(maxTrkSize);
+    trkpMode.reserve(maxTrkSize);
+    trketaMode.reserve(maxTrkSize);
+    trkphiMode.reserve(maxTrkSize);
+    trkqoverpModeError.reserve(maxTrkSize);
     trkchi2overndf.reserve(maxTrkSize);
     trkcharge.reserve(maxTrkSize);
 
@@ -300,6 +308,10 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
         trkpt.push_back(track.pt());
         trketa.push_back(track.eta());
         trkphi.push_back(track.phi());
+        trkpMode.push_back(track.pMode());
+        trketaMode.push_back(track.etaMode());
+        trkphiMode.push_back(track.phiMode());
+        trkqoverpModeError.push_back(track.qoverpModeError());
         auto const trackndof = track.ndof();
         trkchi2overndf.push_back(((trackndof == 0) ? -1 : (track.chi2() / trackndof)));
         trkcharge.push_back(track.charge());
@@ -310,6 +322,9 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                candidate.eta(),
                                candidate.phi(),
                                candidate.mass(),
+                               scRef->rawEnergy(),
+                               scRef->preshowerEnergy(),
+                               scRef->correctedEnergyUncertainty(),
                                (*SigmaIEtaIEtaMap)[candidateRef],
                                HoE,
                                (*EcalPFClusterIsoMap)[candidateRef],
@@ -319,6 +334,8 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                sMin,
                                sMaj,
                                seedId,
+                               scRef->clustersSize(),
+                               scRef->size(),
                                mEnergies,
                                mDetIdIds,
                                mTimes,
@@ -328,11 +345,18 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                  candidate.eta(),
                                  candidate.phi(),
                                  candidate.mass(),
+                                 scRef->rawEnergy(),
+                                 scRef->preshowerEnergy(),
+                                 scRef->correctedEnergyUncertainty(),
                                  trkd0,
                                  trkdz,
                                  trkpt,
                                  trketa,
                                  trkphi,
+                                 trkpMode,
+                                 trketaMode,
+                                 trkphiMode,
+                                 trkqoverpModeError,
                                  trkchi2overndf,
                                  (*DetaMap)[candidateRef],
                                  (*DphiMap)[candidateRef],
@@ -341,6 +365,7 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                  (*OneOEMinusOneOPMap)[candidateRef],
                                  (*MissingHitsMap)[candidateRef],
                                  trkcharge,
+                                 0.0 /* waiting implementation of the track fbrem producer*/,
                                  (*EcalPFClusterIsoMap)[candidateRef],
                                  (*HcalPFClusterIsoMap)[candidateRef],
                                  (*EleGsfTrackIsoMap)[candidateRef],
@@ -348,6 +373,8 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                  sMin,
                                  sMaj,
                                  seedId,
+                                 scRef->clustersSize(),
+                                 scRef->size(),
                                  mEnergies,
                                  mDetIdIds,
                                  mTimes,


### PR DESCRIPTION
#### PR description:

Update the scouting data format for electrons and photons to store additional variables for the 2024 data taking. This PR will cause changes to the scouting RAW output format. The additional memory required to store the variables is expected to be negligible. 

The added variables in both electrons and photons will enable better energy regression studies and they are expected to essentially match the resolution offline reconstruction. For more details, please check the slides at [Scouting meeting 18 Jan 2024](https://indico.cern.ch/event/1366361/#8-scouting-2024-egamma-updates).

#### PR validation:

 - The basic code check and formatting has been completed. 
 - Tests suggested in  [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) passed.
 - The test classes DataFormats/Scouting/test/TestWriteRun3Scouting.cc and  DataFormats/Scouting/test/test_readRun3Scouting_cfg.py were updated.
 - An HLT configuration was rerun on the DoubleElectronGun MC sample with the new commits. The configuration and the ROOT output can be found in AFS public workspace at /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/CMSSW_14_0_0_pre2/src. The output was manually verified to check whether the correct branches were filled and sensible values were obtained in the respective branches.
 - The PR will be back ported to the CMSSW_13_3_X release cycle to enable its test in the HLT development configuration.).