### PR TITLE
Added signed GSF track variable collections to the HLT producer

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -60,8 +60,11 @@ private:
 
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> missingHitsMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> validHitsMapPutToken_;
@@ -83,8 +86,13 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
       useDefaultValuesForEndcap_{config.getParameter<bool>("useDefaultValuesForEndcap")},
       dEtaMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Deta").setBranchAlias("deta")},
       dEtaSeedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DetaSeed").setBranchAlias("detaseed")},
+      dEtaSeedSignedMapPutToken_{
+          produces<reco::RecoEcalCandidateIsolationMap>("DetaSeedSigned").setBranchAlias("detaseedsigned")},
       dPhiMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Dphi").setBranchAlias("dphi")},
+      dPhiSignedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DphiSigned").setBranchAlias("dphisigned")},
       oneOverESuperMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOP")},
+      oneOverESuperMinusOneOverPSignedMapPutToken_{
+          produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOPSigned")},
       oneOverESeedMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESeedMinusOneOP")},
       missingHitsMapPutToken_{
           produces<reco::RecoEcalCandidateIsolationMap>("MissingHits").setBranchAlias("missinghits")},
@@ -117,8 +125,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   reco::RecoEcalCandidateIsolationMap dEtaMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dEtaSeedMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap dEtaSeedSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dPhiMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap dPhiSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap missingHitsMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap validHitsMap(recoEcalCandHandle);
@@ -153,8 +164,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
     float missingHitsValue = 9999999;
     float dEtaInValue = 999999;
     float dEtaSeedInValue = 999999;
+    float dEtaSeedInSignedValue = 999999;
     float dPhiInValue = 999999;
+    float dPhiInSignedValue = 999999;
     float oneOverESuperMinusOneOverPValue = 999999;
+    float oneOverESuperMinusOneOverPSignedValue = 999999;
     float oneOverESeedMinusOneOverPValue = 999999;
 
     const int nrTracks = gsfTracks.size();
@@ -168,11 +182,14 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
       nLayerITValue = 100;
       dEtaInValue = 0;
       dEtaSeedInValue = 0;
+      dEtaSeedInSignedValue = 0;
       dPhiInValue = 0;
+      dPhiInSignedValue = 0;
       missingHitsValue = 0;
       validHitsValue = 100;
       chi2Value = 0;
       oneOverESuperMinusOneOverPValue = 0;
+      oneOverESuperMinusOneOverPSignedValue = 0;
       oneOverESeedMinusOneOverPValue = 0;
     } else {
       for (size_t trkNr = 0; trkNr < gsfTracks.size(); trkNr++) {
@@ -192,6 +209,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
         if (scRef->energy() != 0 && trkP != 0) {
           if (std::abs(1 / scRef->energy() - 1 / trkP) < oneOverESuperMinusOneOverPValue) {
             oneOverESuperMinusOneOverPValue = std::abs(1 / scRef->energy() - 1 / trkP);
+            oneOverESuperMinusOneOverPSignedValue = 1 / scRef->energy() - 1 / trkP;
           }
         }
         if (scRef->seed().isNonnull() && scRef->seed()->energy() != 0 && trkP != 0) {
@@ -225,19 +243,24 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
         if (std::abs(scAtVtx.dEta()) < dEtaSeedInValue) {
           dEtaSeedInValue = std::abs(scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta());
+          dEtaSeedInSignedValue = scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta();
         }
 
         if (std::abs(scAtVtx.dPhi()) < dPhiInValue) {
           // we are allowing them to come from different tracks
           dPhiInValue = std::abs(scAtVtx.dPhi());
+          dPhiInSignedValue = scAtVtx.dPhi();
         }
       }
     }
 
     dEtaMap.insert(recoEcalCandRef, dEtaInValue);
     dEtaSeedMap.insert(recoEcalCandRef, dEtaSeedInValue);
+    dEtaSeedSignedMap.insert(recoEcalCandRef, dEtaSeedInSignedValue);
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
+    dPhiSignedMap.insert(recoEcalCandRef, dPhiInSignedValue);
     oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPValue);
+    oneOverESuperMinusOneOverPSignedMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPSignedValue);
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef, oneOverESeedMinusOneOverPValue);
     missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
     validHitsMap.insert(recoEcalCandRef, validHitsValue);
@@ -247,8 +270,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   iEvent.emplace(dEtaMapPutToken_, dEtaMap);
   iEvent.emplace(dEtaSeedMapPutToken_, dEtaSeedMap);
+  iEvent.emplace(dEtaSeedSignedMapPutToken_, dEtaSeedSignedMap);
   iEvent.emplace(dPhiMapPutToken_, dPhiMap);
+  iEvent.emplace(dPhiSignedMapPutToken_, dPhiSignedMap);
   iEvent.emplace(oneOverESuperMinusOneOverPMapPutToken_, oneOverESuperMinusOneOverPMap);
+  iEvent.emplace(oneOverESuperMinusOneOverPSignedMapPutToken_, oneOverESuperMinusOneOverPSignedMap);
   iEvent.emplace(oneOverESeedMinusOneOverPMapPutToken_, oneOverESeedMinusOneOverPMap);
   iEvent.emplace(missingHitsMapPutToken_, missingHitsMap);
   iEvent.emplace(validHitsMapPutToken_, validHitsMap);


### PR DESCRIPTION
#### PR description:

We plan to store the values of dEtaSigned, dPhi and 1/E-1/p for the best GSF track in the scouting electron collection. The default implementation is the absolute value. Hence, I named the new variable collections as signed parameters. The output of this HLT producer will now have three more variable collections. The corresponding change to computation time is expected to be negligible, as there is no additional computation required for these variables.

More details can be found in the following [Scouting Meeting Presentation](https://indico.cern.ch/event/1366361/#8-scouting-2024-egamma-updates).

#### PR validation:

 - Standard set of code checks and code-formatting done. 
 - Suggested test in [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) passed successfully.
 - An HLT configuration was re-run on 100 events on a single thread and the output was manually verified. As expected the new collections had different signs (+ or -) compared to the previous collections. However, the absolute value was identical. The test configuration and output files are on AFS at /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/CMSSW_14_0_0_pre2/src/TestSignedOutput_scoutingPFMC.py and /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/CMSSW_14_0_0_pre2/src/TestSignedOutput_outputScoutingPF.root respectively.

|    Row   | Instance | dEta | dPhi | 1/E-1/p | dEta (Signed) | dPhi (Signed) | 1/E-1/p (Signed) |
|---------|-----------|------|------|---------|------|------|---------|
|        0 |        0 | 0.0014388 | 0.0044460 | 0.0011451 | 0.0014388 | 0.0044460 | 0.0011451 |
|        0 |        1 | 0.0012900 | 0.0017273 | 0.0007097 | 0.0012900 | -0.001727 | 0.0007097 |
|        1 |        0 | 0.0059239 | 0.0636629 | 0.0038597 | 0.0059239 | -0.063662 | 0.0038597 |
|        2 |        0 |           |           |           |           |           |           |
|        3 |        0 | 0.0007234 | 0.0008861 | 0.0009526 |  0.0007234 | 0.0008861 | -0.000952 |
|        4 |        0 | 0.0018080 | 0.3457266 | 0.3404662 | -0.001808 | -0.345726 | -0.340466 |
|        5 |        0 | 0.0015170 | 0.0008683 | 5.430e-05 | -0.001517 | -0.000868 | -5.43e-05 |
|        5 |        1 | 0.0182280 | 0.0482790 | 0.0161032 | -0.018228 | 0.0482790 | 0.0161032 |
|        5 |        2 | 0.0057608 | 0.0288665 | 0.0362727 | 0.0057608 | 0.0288665 | -0.036272 |
|        6 |        0 | 0.0011856 | 0.0052164 | 0.0001695 | -0.001185 | 0.0052164 | 0.0001695 |
|        6 |        1 | 0.0104081 | 0.0089188 | 0.0003987 | 0.0104081 | -0.008918 | -0.000398 |
|        7 |        0 | 0.0014166 | 0.0006581 | 0.0011761 | -0.001416 | 0.0006581 | 0.0011761 |
|        7 |        1 | 0.0044303 | 0.0087084 | 0.0006514 | 0.0044303 | -0.008708 | 0.0006514 |
|        7 |        2 | 0.0110887 | 0.1865830 | 0.0057946 | -0.011088 | -0.186583 | -0.005794 |
|        8 |        0 | 0.0027326 | 0.0096881 | 0.0123428 | 0.0027326 | 0.0096881 | 0.0123428 |
|        8 |        1 | 0.0036929 | 0.0480504 | 0.0082893 | -0.003692 | 0.0480504 | -0.008289 |
|        9 |        0 | 8.153e-05 | 0.0036187 | 0.0020031 | -8.15e-05 | -0.003618 | -0.002003 |
|        9 |        1 | 0.0004655 | 0.0014679 | 0.0021860 | -0.000465 | 0.0014679 | 0.0021860 |
|        9 |        2 | 0.0039569 | 0.0109441 | 0.0023139 | -0.003956 | 0.0109441 | -0.002313 |
|       10 |        0 | 0.0044148 | 0.0165488 | 0.0016855 | 0.0044148 | -0.016548 | 0.0016855 |
|       10 |        1 | 0.0002905 | 0.0013964 | 0.0009109 | -0.000290 | -0.001396 | -0.000910 |
|       10 |        2 | 0.0073547 | 0.0221956 | 0.0041651 | 0.0073547 | -0.022195 | -0.004165 |
|       11 |        0 | 0.0120838 | 0.2586605 | 0.0030191 | 0.0120838 | 0.2586605 | -0.003019 |
|       11 |        1 | 0.0022847 | 0.0024123 | 0.0002324 | 0.0022847 | -0.002412 | 0.0002324 |
|       11 |        2 | 0.0006264 | 0.0059466 | 0.0005957 | -0.000626 | 0.0059466 | -0.000595 |

 - PR needs to be back ported to CMSSW_13_3_X release cycle to enable testing on HLT development configurations.