### PR TITLE
Fix warnings which are ignored by bot

### DIFF
--- a/Alignment/CocoaFit/src/Fit.cc
+++ b/Alignment/CocoaFit/src/Fit.cc
@@ -1210,8 +1210,9 @@ void Fit::dumpFittedValues(ALIFileOut& fileout, ALIbool printErrors, ALIbool pri
   //  const Entry* entry;
   int ii, siz;
   std::vector<OpticalObject*>::const_iterator vocite;
+  ALIstring sys = ALIstring("system");
   for (vocite = Model::OptOList().begin(); vocite != Model::OptOList().end(); ++vocite) {
-    if ((*vocite)->type() == ALIstring("system"))
+    if ((*vocite)->type() == sys)
       continue;
 
     fileout << " %%%% Optical Object: " << (*vocite)->longName() << std::endl;
@@ -1268,8 +1269,9 @@ void Fit::dumpFittedValuesInAllAncestorFrames(ALIFileOut& fileout, ALIbool print
   //---------- Iterate over OptO list
   std::vector<Entry*> entries;
   std::vector<OpticalObject*>::const_iterator vocite;
+  ALIstring sys = ALIstring("system");
   for (vocite = Model::OptOList().begin(); vocite != Model::OptOList().end(); ++vocite) {
-    if ((*vocite)->type() == ALIstring("system"))
+    if ((*vocite)->type() == sys)
       continue;
 
     fileout << " %%%% Optical Object: " << (*vocite)->longName() << std::endl;

--- a/Alignment/CocoaToDDL/src/UnitConverter.cc
+++ b/Alignment/CocoaToDDL/src/UnitConverter.cc
@@ -2,7 +2,6 @@
 #include "Alignment/CocoaToDDL/interface/CocoaUnitsTable.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include <sstream>
-#include <strstream>
 
 /*
 UnitConverter::UnitConverter(const G4BestUnit & bu)
@@ -23,7 +22,7 @@ UnitConverter::UnitConverter(ALIdouble val, const ALIstring& category)
 UnitConverter::~UnitConverter() { delete bu_; }
 
 std::string UnitConverter::ucstring() {
-  std::ostrstream str;
+  std::ostringstream str;
 
   if (angl_) {
     str.precision(11);
@@ -42,7 +41,7 @@ std::string UnitConverter::ucstring() {
 /*
 ostream & operator<<(ostream & os, const UnitConverter & uc)
 {
-  ostrstream temp;
+  std::ostringstream temp;
   //temp << uc.bu_;
   //temp << '\0';
   //string s(temp.str());

--- a/Alignment/CocoaUtilities/src/ALIFileIn.cc
+++ b/Alignment/CocoaUtilities/src/ALIFileIn.cc
@@ -9,8 +9,7 @@
 #include "Alignment/CocoaUtilities/interface/ALIFileIn.h"
 
 #include <cstdlib>
-#include <strstream>
-//#include <strstream.h>
+#include <sstream>
 
 //#include <algo.h>
 
@@ -112,7 +111,7 @@ ALIint ALIFileIn::getWordsInLine(std::vector<ALIstring>& wordlist) {
     }
 
     //---------- Convert line read to istrstream to split it in words
-    std::istrstream istr_line(ltemp);
+    std::istringstream istr_line(ltemp);
 
     //--------- count how many words are there in ltemp (this sohuld not be needed, but sun compiler has problems) !! this has to be nvestigated...
     ALIint NoWords = 0;

--- a/Alignment/CocoaUtilities/src/ALIFileOut.cc
+++ b/Alignment/CocoaUtilities/src/ALIFileOut.cc
@@ -8,7 +8,7 @@
 #include "Alignment/CocoaUtilities/interface/ALIFileOut.h"
 
 #include <cstdlib>
-#include <strstream>
+#include <sstream>
 
 std::vector<ALIFileOut*> ALIFileOut::theInstances;
 

--- a/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.cc
+++ b/CalibTracker/SiStripQuality/plugins/SiStripBadModuleByHandBuilder.cc
@@ -10,7 +10,6 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
-#include <ext/hash_map>
 
 class SiStripBadModuleByHandBuilder : public ConditionDBWriter<SiStripBadStrip> {
 public:

--- a/DQM/HcalTasks/plugins/UMNioTask.cc
+++ b/DQM/HcalTasks/plugins/UMNioTask.cc
@@ -60,7 +60,7 @@ UMNioTask::UMNioTask(edm::ParameterSet const& ps)
 }
 
 int UMNioTask::getOrbitGapIndex(uint8_t eventType, uint32_t laserType) {
-  constants::OrbitGapType orbitGapType;
+  constants::OrbitGapType orbitGapType = tNull;
   if (eventType == constants::EVENTTYPE_PHYSICS) {
     orbitGapType = tPhysics;
   } else if (eventType == constants::EVENTTYPE_PEDESTAL) {


### PR DESCRIPTION
This PR fixes some of the warnings which are ignored by the IB system as bot was not able to match a cmssw package for these
- Fix deprecated headers: `strstream` , `ext/hash_map`
```
backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
```
- operator delete called on unallocated object
```
Alignment/CocoaFit/src/Fit.cc:1272:30:
  .../gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/new_allocator.h:158:33: warning: 'operator delete' called on unallocated object '<anonymous>' [-Wfree-nonheap-object]
```
- warning: 'orbitGapType' may be used uninitialized