### PR TITLE
simplify MU-DPG custom nano configuration

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1836,7 +1836,15 @@ class ConfigBuilder(object):
         # build and inject the sequence
         if len(_nanoSeq) < 1 and '@' in stepSpec:
             raise Exception(f'The specified mapping: {stepSpec} generates an empty NANO sequence. Please provide a valid mappign')
-        self.scheduleSequence('+'.join(_nanoSeq), 'nanoAOD_step')
+        _seqToSchedule = []
+        for _subSeq in _nanoSeq:
+            if '.' in _subSeq:
+                _cff,_seq = _subSeq.split('.')
+                self.loadAndRemember(_cff)
+                _seqToSchedule.append(_seq)
+            else:
+                _seqToSchedule.append(_subSeq)
+        self.scheduleSequence('+'.join(_seqToSchedule), 'nanoAOD_step')
         
         # add the customisations
         for custom in _nanoCustoms:

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -14,26 +14,26 @@ def expandNanoMapping(seqList, mapping, key):
                 #  - An empty string recalls the default for the given key
                 #  - None is interpreted as "ignore this"
                 seqList.remove(specifiedCommand)
-                if key in mappedTo and mappedTo[key] is not None:                    
+                if key in mappedTo and mappedTo[key] is not None:
                     seqList.extend(mappedTo[key].split('+'))
                 break;
         if level==maxLevel:
             raise Exception("Could not fully expand "+repr(seqList)+" from "+repr(mapping))
 
 
-autoNANO = { 
+autoNANO = {
     # PHYS is a mapping to the default NANO config, i.e. empty strings
-    'PHYS': {'sequence': '', 
+    'PHYS': {'sequence': '',
              'customize': ''},
     # L1 flavours: add tables through customize, supposed to be combined with PHYS
     'L1' : {'customize': 'nanoL1TrigObjCustomize'},
     'L1FULL' : {'customize': 'nanoL1TrigObjCustomizeFull'},
-    # MUDPG flavours: use their own sequence 
-    'MUDPG' : {'sequence': 'muDPGNanoProducer',
-               'customize': 'muDPGNanoCustomize'},
-    'MUDPGBKG' : {'sequence': 'muDPGNanoProducerBkg',
-                  'customize': 'muDPGNanoBkgCustomize'},
+    # MUDPG flavours: use their own sequence
+    'MUDPG' : {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoProducer',
+               'customize': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoCustomize'},
+    'MUDPGBKG' : {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoProducerBkg',
+                  'customize': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoBkgCustomize'},
     # PromptReco config: PHYS+L1
-    'Prompt' : {'sequence': '@PHYS', 
+    'Prompt' : {'sequence': '@PHYS',
                 'customize': '@PHYS+@L1'}
 }

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -284,7 +284,3 @@ def nanoL1TrigObjCustomizeFull(process):
     process.nanoTableTaskCommon.add(process.l1TablesTask)
     return process
 
-### muon DPG NANO flavour sequences and customize functions
-from DPGAnalysis.MuonTools.muNtupleProducer_cff import *
-from DPGAnalysis.MuonTools.muNtupleProducerBkg_cff import *
-


### PR DESCRIPTION
#### PR description:

having imports at top level of nano cff was not desirable. With a simple change in ConfigBuilder, we can move everything in the autoNANO mapping.

#### PR validation:
nano matrix was successful 