### PR TITLE
fix `test_payload_sanity` unit test script

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
-INPUTFILE=${SCRAM_TEST_PATH}/alignments_MP.db
-(cmsRun ${SCRAM_TEST_PATH}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker'
+echo -e "Content of the current directory is: "`ls .`
+INPUTFILE=alignments_MP.db
+(cmsRun ${SCRAM_TEST_PATH}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker' $?
 rm $INPUTFILE

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
@@ -4,7 +4,7 @@ function die { echo $1: status $2; exit $2; }
 LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
 clean_up(){
-    echo "cleaning the local test area"
+    echo -e "\nCleaning the local test area"
     rm -fr milleBinary00* 
     rm -fr pedeSteer* 
     rm -fr millepede.*
@@ -13,7 +13,7 @@ clean_up(){
     rm -fr *.dat
     rm -fr *.tar
     rm -fr *.gz
-    rm -fr *.db
+    rm -fr *.dump
 }
 
 if test -f "milleBinary*"; then
@@ -39,10 +39,9 @@ if [ $STATUS -eq 0 ]; then
     echo -e "\n @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
     echo -e " @ MillePede Exit Status: "`cat millepede.end`
     echo -e " @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
-    ## mv the output file to the local test directory for the subsequent payload sanity check
-    mv alignments_MP.db ${LOCAL_TEST_DIR}
     ## clean the house now...
     clean_up
+    echo -e "\nContent of the current directory is: "`ls .`
 else 
   die "SKIPPING test, file ${TESTPACKAGE}.tar not found" 0
 fi


### PR DESCRIPTION
#### PR description:

Addresses https://github.com/cms-sw/cmsdist/pull/8953#issuecomment-1900453494. 
After this, it should be able to capture `cmsRun` runtime failures.

#### PR validation:

`scram b runtests_testPayloadSanity` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A