### PR TITLE
add `Era_Run3_2024`, `Era_Run3_2025`, Tier0 reco scenario for 2024, and change default era in `PyReleaseValidation`

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024.py
+++ b/Configuration/DataProcessing/python/Impl/ppEra_Run3_2024.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+_ppEra_Run3_2024_
+Scenario supporting proton collisions for 2024
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+
+from Configuration.DataProcessing.Impl.pp import pp
+
+class ppEra_Run3_2024(pp):
+    def __init__(self):
+        pp.__init__(self)
+        self.recoSeq=''
+        self.cbSc='pp'
+        self.eras=Run3_2024
+        self.promptCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024' ]
+        self.expressCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024' ]
+        self.visCustoms += [ 'Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024' ]
+    """
+    _ppEra_Run3_2024_
+    Implement configuration building for data processing for proton
+    collision data taking for Run3_2024
+    """

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -95,6 +95,11 @@ def customisePostEra_Run3_2023(process):
     customisePostEra_Run3(process)
     return process
 
+def customisePostEra_Run3_2024(process):
+    #start with a repeat of 2023
+    customisePostEra_Run3_2023(process)
+    return process
+
 def customisePostEra_Run3_express_trackingOnly(process):
     #start with a repeat of 2018
     customisePostEra_Run2_2018_express_trackingOnly(process)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -97,7 +97,7 @@ def customisePostEra_Run3_2023(process):
 
 def customisePostEra_Run3_2024(process):
     #start with a repeat of 2023
-    customisePostEra_Run3_2023(process)
+    customisePostEra_Run3(process)
     return process
 
 def customisePostEra_Run3_express_trackingOnly(process):

--- a/Configuration/DataProcessing/test/run_CfgTest_5.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_5.sh
@@ -10,7 +10,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3" "ppEra_Run3_pp_on_PbPb" "hcalnzsEra_Run3_pp_on_PbPb" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters" "ppEra_Run3_2023" "ppEra_Run3_pp_on_PbPb_2023" "ppEra_Run3_pp_on_PbPb_approxSiStripClusters_2023" "ppEra_Run3_2024")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/DataProcessing/test/run_CfgTest_8.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_8.sh
@@ -10,7 +10,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
-declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked")
+declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked" "ppEra_Run3_2024")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
+
+Run3_2024 = cms.ModifierChain(Run3_2023)

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Run3_2023_cff import Run3_2023
+from Configuration.Eras.Era_Run3_cff import Run3
 
-Run3_2024 = cms.ModifierChain(Run3_2023)
+Run3_2024 = cms.ModifierChain(Run3)

--- a/Configuration/Eras/python/Era_Run3_2025_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2025_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+
+Run3_2025 = cms.ModifierChain(Run3_2024)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2856,7 +2856,7 @@ upgradeProperties[2017] = {
         'Geom' : 'DB:Extended',
         'GT' : 'auto:phase1_2024_realistic',
         'HLTmenu': '@relval2024',
-        'Era' : 'Run3',
+        'Era' : 'Run3_2024',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
     },

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2707,7 +2707,7 @@ upgradeWFs['DD4hepDB'].allowReuse = False
 class UpgradeWorkflow_DDDDB(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         the_era = stepDict[step][k]['--era']
-        if 'Run3' in the_era  and '2023' not in the_era and 'Fast' not in the_era and "Pb" not in the_era:
+        if 'Run3' in the_era and '2023' not in the_era and '2024' not in the_era and 'Fast' not in the_era and "Pb" not in the_era:
             # retain any other eras
             tmp_eras = the_era.split(',')
             tmp_eras[tmp_eras.index("Run3")] = 'Run3_DDD'

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -35,6 +35,8 @@ class Eras (object):
                  'Run2_2018_noMkFit',
                  'Run3',
                  'Run3_2023',
+                 'Run3_2024',
+                 'Run3_2025',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',
                  'Run3_pp_on_PbPb_approxSiStripClusters',


### PR DESCRIPTION
#### PR description:

In response to https://github.com/cms-sw/cmssw/issues/43756, following https://github.com/cms-sw/cmssw/pull/41271#issuecomment-1506968258:
   * add `Era_Run3_2024`, `Era_Run3_2025` (currently straight copies of Run3) 
   * add Tier0 reco scenario for 2024
   * change default era in `PyReleaseValidation` for 2024 MC workflows

#### PR validation:

   * ` runTheMatrix.py --what upgrade -l 12824.0` runs fine
   * `scram b runtests` runs fine:
   
```
Creating test log file logs/el9_amd64_gcc12/testing.log
Pass    2s ... Configuration/DataProcessing/TestConfigDP_1
Pass   14s ... Configuration/DataProcessing/TestConfigDP_10
Pass   12s ... Configuration/DataProcessing/TestConfigDP_11
Pass  150s ... Configuration/DataProcessing/TestConfigDP_12
Pass  131s ... Configuration/DataProcessing/TestConfigDP_2
Pass   24s ... Configuration/DataProcessing/TestConfigDP_3
Pass   33s ... Configuration/DataProcessing/TestConfigDP_4
Pass  273s ... Configuration/DataProcessing/TestConfigDP_5
Pass   98s ... Configuration/DataProcessing/TestConfigDP_6
Pass  155s ... Configuration/DataProcessing/TestConfigDP_7
Pass  228s ... Configuration/DataProcessing/TestConfigDP_8
Pass   11s ... Configuration/DataProcessing/TestConfigDP_9
Pass    1s ... Configuration/PyReleaseValidation/test-das-selected-lumis
Pass  175s ... Configuration/PyReleaseValidation/test-runTheMatrix-interactive
```   

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A