### PR TITLE
Update 140X Run3 data and MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '133X_dataRun2_v2',
+    'run2_data'                    :    '140X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             :    '133X_dataRun2_HEfail_v2',
+    'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      :    '133X_dataRun2_PromptLike_HI_v2',
+    'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              :    '133X_dataRun2_HLT_relval_v2',
-    # GlobalTag for Run3 HLT: identical to the online GT (132X_dataRun3_HLT_v2) but with snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_hlt'                     :    '133X_dataRun3_HLT_frozen_v2',
-    # GlobalTag for Run3 data relvals (express GT) - 132X_dataRun3_Express_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_data_express'            :    '133X_dataRun3_Express_frozen_v2',
-    # GlobalTag for Run3 data relvals (prompt GT) - 132X_dataRun3_Prompt_v4 with Ecal CC timing tags and snapshot at 2023-10-04 21:27:37 (UTC)
-    'run3_data_prompt'             :    '133X_dataRun3_Prompt_frozen_v2',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2023-10-19 12:00:00 (UTC)
-    'run3_data'                    :    '133X_dataRun3_v4',
-    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2023-10-19 12:00:00 (UTC)
-    'run3_data_PromptAnalysis'     :    '133X_dataRun3_PromptAnalysis_v3',
+    'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
+    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v1 but with snapshot at 2024-01-20 12:00:00 (UTC)
+    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v1',
+    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
+    'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
+    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-01-19 05:46:14 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v1',
+    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-01-19 05:46:14 (UTC)
+    'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -64,33 +64,41 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     :    '131X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           :    '133X_mcRun3_2022_design_v3',
+    'phase1_2022_design'           :    '140X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '133X_mcRun3_2022_realistic_v3',
+    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' :    '133X_mcRun3_2022_realistic_postEE_v4',
-    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          :    '133X_mcRun3_2022cosmics_realistic_deco_v3',
+    'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v1',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022, Strip tracker in DECO mode
+    'phase1_2022_cosmics'          :    '140X_mcRun3_2022cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   :    '133X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'   :    '140X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '133X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
-    'phase1_2023_design'           :    '133X_mcRun3_2023_design_v3',
+    'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '133X_mcRun3_2023_realistic_v3',
-    # GlobalTag for MC production with realistic conditions for Phase1 post BPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '133X_mcRun3_2023_realistic_postBPix_v3',
-    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2023,  Strip tracker in DECO mode
-    'phase1_2023_cosmics'          :    '133X_mcRun3_2023cosmics_realistic_deco_v3',
+    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v1',
+    # GlobalTag for MC production with realistic conditions for Phase1 postBPix issue 2023
+    'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v1',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 preBPix 2023, Strip tracker in DECO mode
+    'phase1_2023_cosmics'          :    '140X_mcRun3_2023cosmics_realistic_deco_v1',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 postBPix 2023, Strip tracker in DECO mode
+    'phase1_2023_cosmics_postBPix' :    '140X_mcRun3_2023cosmics_realistic_postBPix_deco_v1',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_design'   :    '133X_mcRun3_2023cosmics_design_deco_v3',
+    'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '133X_mcRun3_2023_realistic_HI_v7',
+    'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v1',
+    # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '133X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v1',
+    # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v1',
+    # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '133X_mcRun4_realistic_v1'
+    'phase2_realistic'             :    '140X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR mainly updates the 140X Run3 MC and data GTs with the latest conditions available for Run3 GTs, in preparation for 2024 data-taking and Full 2022+2023 data ReReco along with MC planned by PPD in March. 

The relevant CMS Talk post with all the GT differences and details of the condition updates is available in:
https://cms-talk.web.cern.ch/t/new-140x-queues-and-gts/33492

In addition: 
- With the Phase2GT `140X_mcRun4_realistic_v1` we have moved the relevant tracking tags to the Phase2 geometry `D98` (current default Phase2 geometry)
   - See for details: https://github.com/cms-sw/cmssw/issues/42945 and the solution explicitly in https://github.com/cms-sw/cmssw/issues/42945#issuecomment-1900537297 
- It introduces new additional keys for the following 2024 scenarios: 
   - `phase1_2024_design`
   - `phase1_2024_cosmics`
   - `phase1_2024_cosmics_design`
-  A new key `phase1_2023_cosmics_postBPix'`  for separate cosmic conditions for 2023 postBPix 
- Some Run2 data GTs are also updated for the new PPS record tags as mentioned in the above linked CMS Talk post 

No workflow is testing the new keys for now.  We leave that to PdMV to include the relevant workflows as needed, but the conditions are already tested locally with the currently available workflows.

**GT Differences with the last ones in autoCond are here**:

- **Run2 data** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_v2/140X_dataRun2_v1
 
- **Run2 data HEfail** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_HEfail_v2/140X_dataRun2_HEfail_v1

- **Run2 data promptlike HI ** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_PromptLike_HI_v2/140X_dataRun2_PromptLike_HI_v1

- **Run2 data HLT RelVal** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun2_HLT_relval_v2/140X_dataRun2_HLT_relval_v1

- **Run3 data HLT** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_HLT_frozen_v2/140X_dataRun3_HLT_frozen_v1
  - Diff from HLT GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_HLT_v1/140X_dataRun3_HLT_frozen_v1
	
- **Run3 data Express** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_Express_frozen_v2/140X_dataRun3_Express_frozen_v1
  - Diff from Express GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Express_v1/140X_dataRun3_Express_frozen_v1

- **Run3 data Prompt** : 
  - Diff with last GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_Prompt_frozen_v2/140X_dataRun3_Prompt_frozen_v1
  - Diff from Prompt GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Prompt_v1/140X_dataRun3_Prompt_frozen_v1

- **Run3 data Offline** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_v4/140X_dataRun3_v1

- **Run3 data PromptAnalysis** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_dataRun3_PromptAnalysis_v3/140X_dataRun3_PromptAnalysis_v1

- **Phase1 2022 design** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_design_v3/140X_mcRun3_2022_design_v1

- **Phase1 2022 realistic** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_v3/140X_mcRun3_2022_realistic_v1

- **Phase1 2022 realistic postEE** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_postEE_v4/140X_mcRun3_2022_realistic_postEE_v1

- **Phase1 2022 cosmics** :
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022cosmics_realistic_deco_v3/140X_mcRun3_2022cosmics_realistic_deco_v1

- **Phase1 2022 cosmics design** : I
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022cosmics_design_deco_v3/140X_mcRun3_2022cosmics_design_deco_v1

- **Phase1 2022 realistic hi** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2022_realistic_HI_v3/140X_mcRun3_2022_realistic_HI_v1

- **Phase1 2023 design** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_design_v3/140X_mcRun3_2023_design_v1

- **Phase1 2023 realistic** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_v3/140X_mcRun3_2023_realistic_v1
	
- **Phase1 2023 realistic postBPix** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_postBPix_v3/140X_mcRun3_2023_realistic_postBPix_v1

- **Phase1 2023 cosmics reaslistic** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023cosmics_realistic_deco_v3/140X_mcRun3_2023cosmics_realistic_deco_v1

- **Phase1 2023 cosmics reaslistic postBPIx** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023cosmics_realistic_deco_v1/140X_mcRun3_2023cosmics_realistic_postBPix_deco_v1

- **Phase1 2023 cosmics design** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023cosmics_design_deco_v3/140X_mcRun3_2023cosmics_design_deco_v1

- **Phase1 2023 realistic hi** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_realistic_HI_v7/140X_mcRun3_2023_realistic_HI_v1

- **Phase1 2024 design** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2023_design_v3/140X_mcRun3_2024_design_v1

- **Phase1 2024 realistic** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun3_2024_realistic_v5/140X_mcRun3_2024_realistic_v1

- **Phase1 2024 cosmics design** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023cosmics_design_deco_v1/140X_mcRun3_2024cosmics_design_deco_v1

- **Phase1 2024 cosmics realistic** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v1/140X_mcRun3_2024cosmics_realistic_deco_v1

- **Phase2** : 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/133X_mcRun4_realistic_v1/140X_mcRun4_realistic_v1

#### PR validation:
Tested successfully with
- `runTheMatrix.py -l 7.23,136.897,138.1,140.113,141.009,159.1,138.2,138.4,138.5,139.001,141.002,141.003,159.1,160.1,312.0,1005.0,1052.0,12034.0,12834.0,12834.0, -j 8 --ibeos`
- `runTheMatrix.py --what upgrade -l 12803.0,12842.0,12874.0,12812.0,12859.0 -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. 