### PR TITLE
[MTD simulation] Update MtdSimCluster hit Ids

### DIFF
--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -28,13 +28,22 @@
   <class name="SimClusterRefProd"/>
   <class name="SimClusterContainer"/>
 
-  <class name="MtdSimCluster"/>
+  <class name="MtdSimCluster" ClassVersion="4">
+    <version ClassVersion="4" checksum="1001786642"/>
+    <version ClassVersion="3" checksum="1001786642"/>
+  </class>
+  <ioread sourceClass = "MtdSimCluster" version="[-4]" targetClass="MtdSimCluster" source="" target="">
+    <![CDATA[
+	     newObj->newForm();
+    ]]>
+  </ioread>
   <class name="MtdSimClusterCollection"/>
   <class name="edm::Wrapper<MtdSimClusterCollection>"/>
   <class name="MtdSimClusterRef"/>
   <class name="MtdSimClusterRefVector"/>
   <class name="MtdSimClusterRefProd"/>
   <class name="MtdSimClusterContainer"/>
+
 
   <class name="MtdSimLayerCluster"/>
   <class name="MtdSimLayerClusterCollection"/>

--- a/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
@@ -757,8 +757,19 @@ void MtdTruthAccumulator::fillSimHits(std::vector<std::pair<uint64_t, const PSim
       const auto &position = simHit.localPosition();
       LocalPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
       std::pair<uint8_t, uint8_t> pixel = geomTools_.pixelInModule(id, simscaled);
+      // -- Get sensor module id
+      DetId geoId;
+      MTDDetId mtdId = MTDDetId(id);
+      if (mtdId.mtdSubDetector() == MTDDetId::BTL) {
+        BTLDetId detId(id.rawId());
+        geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
+      }
+      if (mtdId.mtdSubDetector() == MTDDetId::ETL) {
+        ETLDetId detId(id.rawId());
+        geoId = detId.geographicalId();
+      }
       // create the unique id
-      uint64_t uniqueId = static_cast<uint64_t>(id.rawId()) << 32;
+      uint64_t uniqueId = static_cast<uint64_t>(geoId) << 32;
       uniqueId |= pixel.first << 16;
       uniqueId |= pixel.second;
 


### PR DESCRIPTION
#### PR description:
This PR changes the ids of the hits in MtdSimCluster for MTD BTL hits: the unique id in MtdTruthAccumulator.cc is now built using the BTL DeitId of the sensor module, row, column (instead of BTL DetID of the crystal, row, column). This change brings the advantage to have the same treatment for  BTL and ETL  and  aligns with the reconstruction geometry which is based on the sensor DetId both for BTL and ETL (sensor module for BTL, LGAD for ETL).

Backward compatibility is implemented trough a new class version of MtdSimCluster in classes_def.xml specifying a IO rule, which allows interpreting some bits of the same variable, mtdHits_, in a different way in the two versions.
Notice the discussion on the class versioning ongoing in this thread:
https://cms-talk.web.cern.ch/t/issue-with-class-versioning/33471
At the moment, the IO rule gets applied up to class version 4. On class version 4 (current version) it has no effect, i.e. bits that should be re-interpreted stay unchanged.

#### PR validation:

The code was tested on:
- runTheMatrix workflow 24807 
- existing RelVal samples (to test backward compatibility): /store//relval/CMSSW_14_0_0_pre2/RelValSingleMuPt10/GEN-SIM-RECO/133X_mcRun4_realistic_v1_STD_2026D98_noPU-v1/2590000/1095a786-6fc3-4cd1-a159-8
9175f5c868a.root

