### PR TITLE
Fix usage of deprecated RooDataSet constructors

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -222,10 +222,10 @@ string TagProbeFitter::calculateEfficiency(string dirName,
   if (not split_mode) {
     data = new RooDataSet("data",
                           "data",
-                          inputTree,
                           dataVars,
-                          /*selExpr=*/"",
-                          /*wgtVarName=*/(weightVar.empty() ? nullptr : weightVar.c_str()));
+                          Import(*inputTree),
+                          /*selExpr=*/Cut(""),
+                          /*wgtVarName=*/WeightVar(weightVar.empty() ? nullptr : weightVar.c_str()));
 
     // Now add all expressions that are computed dynamically
     for (vector<pair<pair<string, string>, pair<string, vector<string> > > >::const_iterator
@@ -355,7 +355,7 @@ string TagProbeFitter::calculateEfficiency(string dirName,
       //create the dataset
       data_bin = (RooDataSet*)data->reduce(Cut(TString::Format("allCats==%d", iCat)));
     } else {
-      data_bin = new RooDataSet("data", "data", dataVars, (weightVar.empty() ? nullptr : weightVar.c_str()));
+      data_bin = new RooDataSet("data", "data", dataVars, WeightVar(weightVar.empty() ? nullptr : weightVar.c_str()));
 
       TDirectory* tmp = gDirectory;
       gROOT->cd();


### PR DESCRIPTION
#### PR description:

Fix usage of deprecated RooDataSet constructors, [seen](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_ROOT6_X_2024-01-22-2300/PhysicsTools/TagAndProbe) in ROOT6_X IBs
```
<...>/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc: In member function 'std::string TagProbeFitter::calculateEfficiency(std::string, const std::vector<std::__cxx11::basic_string<char> >&, const std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&, std::map<std::__cxx11::basic_string<char>, std::vector<double> >&, std::map<std::__cxx11::basic_string<char>, std::vector<std::__cxx11::basic_string<char> > >&, std::vector<std::__cxx11::basic_string<char> >&)':
  <...>/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:228:91: warning: 'RooDataSet::RooDataSet(RooStringView, RooStringView, TTree*, const RooArgSet&, const char*, const char*)' is deprecated: will be removed in ROOT v6.34: Use RooDataSet(name, title, vars, Import(*tree), Cut(cuts), WeightVar(wgtVarName)). [-Wdeprecated-declarations]
   228 |                           /*wgtVarName=*/(weightVar.empty() ? nullptr : weightVar.c_str()));
      |                                                                                           ^
In file included from <...>/src/PhysicsTools/TagAndProbe/interface/TagProbeFitter.h:9,
                 from <...>/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:1:
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-184a5ee42f3c094c02e1b303c901e8e4/include/RooDataSet.h:85:3: note: declared here
   85 |   RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
      |   ^~~~~~~~~~
  <...>/src/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc:358:108: warning: 'RooDataSet::RooDataSet(RooStringView, RooStringView, const RooArgSet&, const char*)' is deprecated: will be removed in ROOT v6.34: Use RooDataSet(name, title, vars, RooFit::WeightVar(wgtVarName)). [-Wdeprecated-declarations]
   358 |       data_bin = new RooDataSet("data", "data", dataVars, (weightVar.empty() ? nullptr : weightVar.c_str()));
      |                                                                                                            ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.31.01-184a5ee42f3c094c02e1b303c901e8e4/include/RooDataSet.h:69:3: note: declared here
   69 |   RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName)
      |   ^~~~~~~~~~
```

#### PR validation:

Bot tests
