### PR TITLE
Fix deprecated-copy warnings in L1CaloTrigger

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -444,12 +444,6 @@ namespace p2eg {
       fb = 0;
     };
 
-    // copy constructor
-    towerHCAL(const towerHCAL& other) {
-      et = other.et;
-      fb = other.fb;
-    };
-
     // set members
     inline void zeroOut() {
       et = 0;
@@ -484,6 +478,12 @@ namespace p2eg {
           towersHCAL[i][j] = other.towersHCAL[i][j];
         }
       };
+    };
+
+    // overload operator= to use copy constructor
+    towers3x4 operator=(const towers3x4& other) {
+      const towers3x4& newTowers3x4(other);
+      return newTowers3x4;
     };
 
     // set members
@@ -606,13 +606,6 @@ namespace p2eg {
       phiMax = 0;
       etaMax = 0;
     }
-
-    crystalMax& operator=(const crystalMax& rhs) {
-      energy = rhs.energy;
-      phiMax = rhs.phiMax;
-      etaMax = rhs.etaMax;
-      return *this;
-    }
   };
 
   class ecaltp_t {
@@ -689,10 +682,6 @@ namespace p2eg {
     ap_uint<16> data;
 
     tower_t() { data = 0; }
-    tower_t& operator=(const tower_t& rhs) {
-      data = rhs.data;
-      return *this;
-    }
 
     tower_t(ap_uint<12> et, ap_uint<4> hoe) { data = (et) | (((ap_uint<16>)hoe) << 12); }
 
@@ -780,17 +769,6 @@ namespace p2eg {
       etaMax = 0;
       brems = 0;
     }
-
-    clusterInfo& operator=(const clusterInfo& rhs) {
-      seedEnergy = rhs.seedEnergy;
-      energy = rhs.energy;
-      et5x5 = rhs.et5x5;
-      et2x5 = rhs.et2x5;
-      phiMax = rhs.phiMax;
-      etaMax = rhs.etaMax;
-      brems = rhs.brems;
-      return *this;
-    }
   };
 
   //--------------------------------------------------------//
@@ -849,20 +827,6 @@ namespace p2eg {
       is_looseTkss = cluster_is_looseTkss;
       is_iso = cluster_is_iso;
       is_looseTkiso = cluster_is_looseTkiso;
-    }
-
-    Cluster& operator=(const Cluster& rhs) {
-      data = rhs.data;
-      regionIdx = rhs.regionIdx;
-      calib = rhs.calib;
-      brems = rhs.brems;
-      et5x5 = rhs.et5x5;
-      et2x5 = rhs.et2x5;
-      is_ss = rhs.is_ss;
-      is_looseTkss = rhs.is_looseTkss;
-      is_iso = rhs.is_iso;
-      is_looseTkiso = rhs.is_looseTkiso;
-      return *this;
     }
 
     void setRegionIdx(int regIdx) { regionIdx = regIdx; }  // Newly added


### PR DESCRIPTION
#### PR description:

Implicit copy-constructors are deprecated, and not necessary in most cases. This PR removes unnnecessary copy-assignment operators and destructors in favor of auto-generated ones.

Fixes the following [warnings](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_DEVEL_X_2024-01-22-2300/L1Trigger/L1CaloTrigger):
```
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::towers3x4::towers3x4(const p2eg::towers3x4&)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:484:51: warning: implicitly-declared 'p2eg::towerHCAL& p2eg::towerHCAL::operator=(const p2eg::towerHCAL&)' is deprecated [-Wdeprecated-copy]
   484 |           towersHCAL[i][j] = other.towersHCAL[i][j];
      |                                                   ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:448:5: note: because 'p2eg::towerHCAL' has user-provided 'p2eg::towerHCAL::towerHCAL(const p2eg::towerHCAL&)'
  448 |     towerHCAL(const towerHCAL& other) {
      |     ^~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::card::card(const p2eg::card&)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:537:49: warning: implicitly-declared 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)' is deprecated [-Wdeprecated-copy]
   537 |         card3x4Towers[i] = other.card3x4Towers[i];
      |                                                 ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:480:5: note: because 'p2eg::towers3x4' has user-provided 'p2eg::towers3x4::towers3x4(const p2eg::towers3x4&)'
  480 |     towers3x4(const towers3x4& other) {
      |     ^~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In member function 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:470:9: warning: implicitly-declared 'p2eg::towerHCAL& p2eg::towerHCAL::operator=(const p2eg::towerHCAL&)' is deprecated [-Wdeprecated-copy]
   470 |   class towers3x4 {
      |         ^~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:448:5: note: because 'p2eg::towerHCAL' has user-provided 'p2eg::towerHCAL::towerHCAL(const p2eg::towerHCAL&)'
  448 |     towerHCAL(const towerHCAL& other) {
      |     ^~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h: In copy constructor 'p2eg::card::card(const p2eg::card&)':
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:537:49: note: synthesized method 'p2eg::towers3x4& p2eg::towers3x4::operator=(const p2eg::towers3x4&)' first required here
  537 |         card3x4Towers[i] = other.card3x4Towers[i];
      |                                                 ^
In file included from <...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:55:
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::crystalMax p2eg::getPeakBin15N(etaStripPeak_t)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1007:10: warning: implicitly-declared 'p2eg::crystalMax::crystalMax(const p2eg::crystalMax&)' is deprecated [-Wdeprecated-copy]
  1007 |   return x;
      |          ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:610:17: note: because 'p2eg::crystalMax' has user-provided 'p2eg::crystalMax& p2eg::crystalMax::operator=(const p2eg::crystalMax&)'
  610 |     crystalMax& operator=(const crystalMax& rhs) {
      |                 ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getClusterPosition(ecalRegion_t)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1088:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1088 |   return cluster;
      |          ^~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:784:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  784 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::Cluster p2eg::packCluster(ap_uint<15>&, ap_uint<5>&, ap_uint<5>&)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1109:10: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1109 |   return pack;
      |          ^~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getBremsValuesPos(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1228:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1228 |   return cluster_tmp;
      |          ^~~~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:784:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  784 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getBremsValuesNeg(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1303:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1303 |   return cluster_tmp;
      |          ^~~~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:784:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  784 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::clusterInfo p2eg::getClusterValues(crystal (*)[20], ap_uint<5>, ap_uint<5>)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1407:10: warning: implicitly-declared 'p2eg::clusterInfo::clusterInfo(const p2eg::clusterInfo&)' is deprecated [-Wdeprecated-copy]
  1407 |   return cluster_tmp;
      |          ^~~~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:784:18: note: because 'p2eg::clusterInfo' has user-provided 'p2eg::clusterInfo& p2eg::clusterInfo::operator=(const p2eg::clusterInfo&)'
  784 |     clusterInfo& operator=(const clusterInfo& rhs) {
      |                  ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'p2eg::Cluster p2eg::getClusterFromRegion3x4(crystal (*)[20])':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1464:10: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1464 |   return returnCluster;
      |          ^~~~~~~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h: In function 'void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>&, int, int, int)':
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1490:40: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1490 |       p2eg::Cluster c1 = cluster_list[i];
      |                                        ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
  <...>/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h:1491:40: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
  1491 |       p2eg::Cluster c2 = cluster_list[j];
      |                                        ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
<...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc: In member function 'virtual void Phase2L1CaloEGammaEmulator::produce(edm::Event&, const edm::EventSetup&)':
  <...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:385:51: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
   385 |         p2eg::Cluster cExtra = cluster_list[cc][kk];
      |                                                   ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~
  <...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:526:67: warning: implicitly-declared 'p2eg::tower_t::tower_t(const p2eg::tower_t&)' is deprecated [-Wdeprecated-copy]
   526 |           p2eg::tower_t t0_ecal = towerECALCard[iTower][iLink][rcc];
      |                                                                   ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:692:14: note: because 'p2eg::tower_t' has user-provided 'p2eg::tower_t& p2eg::tower_t::operator=(const p2eg::tower_t&)'
  692 |     tower_t& operator=(const tower_t& rhs) {
      |              ^~~~~~~~
  <...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:527:67: warning: implicitly-declared 'p2eg::tower_t::tower_t(const p2eg::tower_t&)' is deprecated [-Wdeprecated-copy]
   527 |           p2eg::tower_t t0_hcal = towerHCALCard[iTower][iLink][rcc];
      |                                                                   ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:692:14: note: because 'p2eg::tower_t' has user-provided 'p2eg::tower_t& p2eg::tower_t::operator=(const p2eg::tower_t&)'
  692 |     tower_t& operator=(const tower_t& rhs) {
      |              ^~~~~~~~
  <...>/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloEGammaEmulator.cc:547:61: warning: implicitly-declared 'p2eg::Cluster::Cluster(const p2eg::Cluster&)' is deprecated [-Wdeprecated-copy]
   547 |         p2eg::Cluster c0 = cluster_list_merged[rcc][iCluster];
      |                                                             ^
<...>/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h:854:14: note: because 'p2eg::Cluster' has user-provided 'p2eg::Cluster& p2eg::Cluster::operator=(const p2eg::Cluster&)'
  854 |     Cluster& operator=(const Cluster& rhs) {
      |              ^~~~~~~~

```

#### PR validation:

Bot tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
