### PR TITLE
Fix compilation errro in Alignment/OfflineValidation/test/testTrackAnalyzers.cc

### DIFF
--- a/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
+++ b/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
@@ -46,7 +46,7 @@ void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyz
 //___________________________________________________________________________________________
 std::string generateBaseConfig(const std::string& analyzerName, const std::string& rootFileName) {
   // Define a raw string literal
-  const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
 from Alignment.OfflineValidation.{}_cfi import {}
 process = TestProcess()
 process.trackAnalyzer = {}


### PR DESCRIPTION
#### PR description:

Fix the following compilation error reported in [CMSSW_14_0_CPP20_X_2024-01-22-1100](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_CPP20_X_2024-01-22-1100/Alignment/OfflineValidation) IB:

````
<...>/Alignment/OfflineValidation/test/testTrackAnalyzers.cc:60:21:   in 'constexpr' expansion of 'fmt::v8::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&>(rawString)'
  <...>/Alignment/OfflineValidation/test/testTrackAnalyzers.cc:60:21: error: the value of 'rawString' is not usable in a constant expression
    60 |   return fmt::format(rawString, analyzerName, analyzerName, analyzerName, rootFileName);
      |          ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<...>/Alignment/OfflineValidation/test/testTrackAnalyzers.cc:49:15: note: 'rawString' was not declared 'constexpr'
   49 |   const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
      |               ^~~~~~~~~
  gmake: *** [tmp/el8_amd64_gcc12/src/Alignment/OfflineValidation/test/testTrackAnalysis/testTrackAnalyzers.cc.o] Error 1
```

#### PR validation:

Bot tests