### PR TITLE
Added signed GSF track variable collections to the HLT producer: 14_0

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -261,6 +261,18 @@ def customizeHLTfor43549(process):
 
     return process
 
+def customizeHLTfor43748(process):
+    filt_types = ["HLTEgammaGenericFilter","HLTEgammaGenericQuadraticEtaFilter","HLTEgammaGenericQuadraticFilter","HLTElectronGenericFilter"]
+    absAbleVar = ["DEta","deta","DetaSeed","Dphi","OneOESuperMinusOneOP","OneOESeedMinusOneOP"]
+    for filt_type in filt_types:
+        for filt in filters_by_type(process, filt_type):
+            if filt.varTag.productInstanceLabel in absAbleVar:
+                filt.useAbs = cms.bool(True)
+            
+    return process
+            
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -271,5 +283,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customizeHLTfor43025(process)
     process = customizeHLTfor43549(process)
-    
+    process = customizeHLTfor43748(process)
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -261,7 +261,7 @@ def customizeHLTfor43549(process):
 
     return process
 
-def customizeHLTfor43748(process):
+def customizeHLTfor43774(process):
     filt_types = ["HLTEgammaGenericFilter","HLTEgammaGenericQuadraticEtaFilter","HLTEgammaGenericQuadraticFilter","HLTElectronGenericFilter"]
     absAbleVar = ["DEta","deta","DetaSeed","Dphi","OneOESuperMinusOneOP","OneOESeedMinusOneOP"]
     for filt_type in filt_types:
@@ -283,5 +283,5 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = customizeHLTfor43025(process)
     process = customizeHLTfor43549(process)
-    process = customizeHLTfor43748(process)
+    process = customizeHLTfor43774(process)
     return process

--- a/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -31,6 +31,7 @@ HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm
   energyLowEdges_ = iConfig.getParameter<std::vector<double> >("energyLowEdges");
   lessThan_ = iConfig.getParameter<bool>("lessThan");
   useEt_ = iConfig.getParameter<bool>("useEt");
+  useAbs_ = iConfig.getParameter<bool>("useAbs");
 
   etaBoundaryEB12_ = iConfig.getParameter<double>("etaBoundaryEB12");
   etaBoundaryEE12_ = iConfig.getParameter<double>("etaBoundaryEE12");
@@ -101,6 +102,7 @@ void HLTEgammaGenericQuadraticEtaFilter::fillDescriptions(edm::ConfigurationDesc
   desc.add<std::vector<double> >("energyLowEdges", {0.0});  // No energy-dependent cuts by default
   desc.add<bool>("lessThan", true);
   desc.add<bool>("useEt", true);
+  desc.add<bool>("useAbs", false);
   desc.add<double>("etaBoundaryEB12", 1.0);
   desc.add<double>("etaBoundaryEE12", 2.0);
   desc.add<std::vector<double> >("thrRegularEB1", {4.0});
@@ -175,7 +177,7 @@ bool HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent,
     ref = recoecalcands[i];
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find(ref);
 
-    float vali = mapi->val;
+    float vali = useAbs_ ? std::abs(mapi->val) : mapi->val;
     float EtaSC = ref->eta();
 
     // Pick the right EA and do rhoCorr

--- a/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticEtaFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticEtaFilter.h
@@ -36,6 +36,7 @@ private:
   edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> varToken_;
   bool lessThan_;  // the cut is "<" or ">" ?
   bool useEt_;     // use E or Et in relative isolation cuts
+  bool useAbs_;    // use the standard abs of the variable (before any rho corr)
   /*  Barrel quadratic threshold function:
       vali (<= or >=) thrRegularEB_ + (E or Et)*thrOverEEB_ + (E or Et)*(E or Et)*thrOverE2EB_
     Endcap quadratic threshold function:

--- a/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticFilter.cc
@@ -31,6 +31,7 @@ HLTEgammaGenericQuadraticFilter::HLTEgammaGenericQuadraticFilter(const edm::Para
   energyLowEdges_ = iConfig.getParameter<std::vector<double> >("energyLowEdges");
   lessThan_ = iConfig.getParameter<bool>("lessThan");
   useEt_ = iConfig.getParameter<bool>("useEt");
+  useAbs_ = iConfig.getParameter<bool>("useAbs");
 
   thrRegularEB_ = iConfig.getParameter<std::vector<double> >("thrRegularEB");
   thrRegularEE_ = iConfig.getParameter<std::vector<double> >("thrRegularEE");
@@ -89,6 +90,7 @@ void HLTEgammaGenericQuadraticFilter::fillDescriptions(edm::ConfigurationDescrip
   desc.add<std::vector<double> >("energyLowEdges", {0.0});  // No energy-dependent cuts by default
   desc.add<bool>("lessThan", true);
   desc.add<bool>("useEt", false);
+  desc.add<bool>("useAbs", false);
   desc.add<std::vector<double> >("thrRegularEB", {0.0});
   desc.add<std::vector<double> >("thrRegularEE", {0.0});
   desc.add<std::vector<double> >("thrOverEEB", {-1.0});
@@ -155,7 +157,7 @@ bool HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent,
     ref = recoecalcands[i];
     reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find(ref);
 
-    float vali = mapi->val;
+    float vali = useAbs_ ? std::abs(mapi->val) : mapi->val;
     float EtaSC = ref->eta();
 
     // Pick the right EA and do rhoCorr

--- a/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTEgammaGenericQuadraticFilter.h
@@ -37,6 +37,7 @@ private:
 
   bool lessThan_;  // the cut is "<" or ">" ?
   bool useEt_;     // use E or Et in relative isolation cuts
+  bool useAbs_;    // use the standard abs of the variable (before any rho corr)
   /*  Barrel quadratic threshold function:
       vali (<= or >=) thrRegularEB_ + (E or Et)*thrOverEEB_ + (E or Et)*(E or Et)*thrOverE2EB_
     Endcap quadratic threshold function:

--- a/HLTrigger/Egamma/plugins/HLTGenericFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTGenericFilter.cc
@@ -33,6 +33,7 @@ HLTGenericFilter<T1>::HLTGenericFilter(const edm::ParameterSet& iConfig) : HLTFi
   energyLowEdges_ = iConfig.template getParameter<std::vector<double>>("energyLowEdges");
   lessThan_ = iConfig.template getParameter<bool>("lessThan");
   useEt_ = iConfig.template getParameter<bool>("useEt");
+  useAbs_ = iConfig.template getParameter<bool>("useAbs");
   thrRegularEB_ = iConfig.template getParameter<std::vector<double>>("thrRegularEB");
   thrRegularEE_ = iConfig.template getParameter<std::vector<double>>("thrRegularEE");
   thrOverEEB_ = iConfig.template getParameter<std::vector<double>>("thrOverEEB");
@@ -88,6 +89,7 @@ void HLTGenericFilter<T1>::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<std::vector<double>>("energyLowEdges", {0.0});  // No energy-dependent cuts by default
   desc.add<bool>("lessThan", true);
   desc.add<bool>("useEt", false);
+  desc.add<bool>("useAbs", false);
   desc.add<std::vector<double>>("thrRegularEB", {0.0});
   desc.add<std::vector<double>>("thrRegularEE", {0.0});
   desc.add<std::vector<double>>("thrOverEEB", {-1.0});
@@ -177,7 +179,11 @@ bool HLTGenericFilter<T1>::hltFilter(edm::Event& iEvent,
     T1Ref ref = recoCands[i];
     typename T1IsolationMap::const_iterator mapi = (*depMap).find(ref);
 
-    float vali = mapi->val;
+    //should we do the abs before or after the rho corr?
+    //note: its very unlikely to rho correct a variable that wants to be abs
+    //decided yes as it seems slightly better this way but can not think of a use case either way
+    float vali = useAbs_ ? std::abs(mapi->val) : mapi->val;
+
     float EtaSC = ref->eta();
 
     // Pick the right EA and do rhoCorr
@@ -191,7 +197,6 @@ bool HLTGenericFilter<T1>::hltFilter(edm::Event& iEvent,
       energy = getEt(ref);
     else
       energy = getEnergy(ref);
-    //if (energy < 0.) energy = 0.; // require energy to be positive (needed?)
 
     // Pick the right cut threshold
     double cutRegularEB_ = 9999., cutRegularEE_ = 9999.;

--- a/HLTrigger/Egamma/plugins/HLTGenericFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTGenericFilter.h
@@ -56,6 +56,7 @@ private:
   std::vector<double> energyLowEdges_;  // lower bin edges for energy-dependent cuts
   bool lessThan_;                       // the cut is "<" or ">" ?
   bool useEt_;                          // use E or Et in relative isolation cuts
+  bool useAbs_;                         // use the standard abs of the variable (before any rho corr)
   std::vector<double> thrRegularEB_;    // threshold for regular cut (x < thr) - ECAL barrel
   std::vector<double> thrRegularEE_;    // threshold for regular cut (x < thr) - ECAL endcap
   std::vector<double> thrOverEEB_;      // threshold for x/E < thr cut (isolations) - ECAL barrel

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -59,7 +59,7 @@ public:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   void fillAbsAbleVar(float& existVal, const float newVal) const {
-    if (std::abs(newVal) < existVal) {
+    if (std::abs(newVal) < std::abs(existVal)) {
       existVal = produceAbsValues_ ? std::abs(newVal) : newVal;
     }
   }

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -49,9 +49,8 @@ public:
     TrajectoryStateOnSurface outTSOS;
     TrajectoryStateOnSurface sclTSOS;
 
-    // mode
-    GlobalVector innMom, outMom, sclMom;
-    GlobalPoint innPos, outPos, sclPos;
+    GlobalVector innMom, outMom;
+    GlobalPoint sclPos;
   };
 
 public:
@@ -93,7 +92,7 @@ private:
 
 namespace {
 
-  float calRelDelta(float a, float b, float defaultVal = 0) { return b != 0 ? (a - b) / a : defaultVal; }
+  float calRelDelta(float a, float b, float defaultVal = 0.f) { return a != 0.f ? (a - b) / a : defaultVal; }
 
 }  // namespace
 
@@ -284,11 +283,8 @@ void EgammaHLTGsfTrackVarProducer::GsfTrackExtrapolations::operator()(
   sclTSOS = mtsTransform.extrapolatedState(innTSOS, GlobalPoint(sc.x(), sc.y(), sc.z()));
 
   multiTrajectoryStateMode::momentumFromModeCartesian(innTSOS, innMom);
-  multiTrajectoryStateMode::positionFromModeCartesian(innTSOS, innPos);
-  multiTrajectoryStateMode::momentumFromModeCartesian(sclTSOS, sclMom);
   multiTrajectoryStateMode::positionFromModeCartesian(sclTSOS, sclPos);
   multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS, outMom);
-  multiTrajectoryStateMode::positionFromModeCartesian(outTSOS, outPos);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -60,8 +60,11 @@ private:
 
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> missingHitsMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> validHitsMapPutToken_;
@@ -83,8 +86,13 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
       useDefaultValuesForEndcap_{config.getParameter<bool>("useDefaultValuesForEndcap")},
       dEtaMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Deta").setBranchAlias("deta")},
       dEtaSeedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DetaSeed").setBranchAlias("detaseed")},
+      dEtaSeedSignedMapPutToken_{
+          produces<reco::RecoEcalCandidateIsolationMap>("DetaSeedSigned").setBranchAlias("detaseedsigned")},
       dPhiMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Dphi").setBranchAlias("dphi")},
+      dPhiSignedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DphiSigned").setBranchAlias("dphisigned")},
       oneOverESuperMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOP")},
+      oneOverESuperMinusOneOverPSignedMapPutToken_{
+          produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOPSigned")},
       oneOverESeedMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESeedMinusOneOP")},
       missingHitsMapPutToken_{
           produces<reco::RecoEcalCandidateIsolationMap>("MissingHits").setBranchAlias("missinghits")},
@@ -117,8 +125,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   reco::RecoEcalCandidateIsolationMap dEtaMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dEtaSeedMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap dEtaSeedSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dPhiMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap dPhiSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap missingHitsMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap validHitsMap(recoEcalCandHandle);
@@ -153,8 +164,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
     float missingHitsValue = 9999999;
     float dEtaInValue = 999999;
     float dEtaSeedInValue = 999999;
+    float dEtaSeedInSignedValue = 999999;
     float dPhiInValue = 999999;
+    float dPhiInSignedValue = 999999;
     float oneOverESuperMinusOneOverPValue = 999999;
+    float oneOverESuperMinusOneOverPSignedValue = 999999;
     float oneOverESeedMinusOneOverPValue = 999999;
 
     const int nrTracks = gsfTracks.size();
@@ -168,11 +182,14 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
       nLayerITValue = 100;
       dEtaInValue = 0;
       dEtaSeedInValue = 0;
+      dEtaSeedInSignedValue = 0;
       dPhiInValue = 0;
+      dPhiInSignedValue = 0;
       missingHitsValue = 0;
       validHitsValue = 100;
       chi2Value = 0;
       oneOverESuperMinusOneOverPValue = 0;
+      oneOverESuperMinusOneOverPSignedValue = 0;
       oneOverESeedMinusOneOverPValue = 0;
     } else {
       for (size_t trkNr = 0; trkNr < gsfTracks.size(); trkNr++) {
@@ -192,6 +209,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
         if (scRef->energy() != 0 && trkP != 0) {
           if (std::abs(1 / scRef->energy() - 1 / trkP) < oneOverESuperMinusOneOverPValue) {
             oneOverESuperMinusOneOverPValue = std::abs(1 / scRef->energy() - 1 / trkP);
+            oneOverESuperMinusOneOverPSignedValue = 1 / scRef->energy() - 1 / trkP;
           }
         }
         if (scRef->seed().isNonnull() && scRef->seed()->energy() != 0 && trkP != 0) {
@@ -225,19 +243,24 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
         if (std::abs(scAtVtx.dEta()) < dEtaSeedInValue) {
           dEtaSeedInValue = std::abs(scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta());
+          dEtaSeedInSignedValue = scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta();
         }
 
         if (std::abs(scAtVtx.dPhi()) < dPhiInValue) {
           // we are allowing them to come from different tracks
           dPhiInValue = std::abs(scAtVtx.dPhi());
+          dPhiInSignedValue = scAtVtx.dPhi();
         }
       }
     }
 
     dEtaMap.insert(recoEcalCandRef, dEtaInValue);
     dEtaSeedMap.insert(recoEcalCandRef, dEtaSeedInValue);
+    dEtaSeedSignedMap.insert(recoEcalCandRef, dEtaSeedInSignedValue);
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
+    dPhiSignedMap.insert(recoEcalCandRef, dPhiInSignedValue);
     oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPValue);
+    oneOverESuperMinusOneOverPSignedMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPSignedValue);
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef, oneOverESeedMinusOneOverPValue);
     missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
     validHitsMap.insert(recoEcalCandRef, validHitsValue);
@@ -247,8 +270,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   iEvent.emplace(dEtaMapPutToken_, dEtaMap);
   iEvent.emplace(dEtaSeedMapPutToken_, dEtaSeedMap);
+  iEvent.emplace(dEtaSeedSignedMapPutToken_, dEtaSeedSignedMap);
   iEvent.emplace(dPhiMapPutToken_, dPhiMap);
+  iEvent.emplace(dPhiSignedMapPutToken_, dPhiSignedMap);
   iEvent.emplace(oneOverESuperMinusOneOverPMapPutToken_, oneOverESuperMinusOneOverPMap);
+  iEvent.emplace(oneOverESuperMinusOneOverPSignedMapPutToken_, oneOverESuperMinusOneOverPSignedMap);
   iEvent.emplace(oneOverESeedMinusOneOverPMapPutToken_, oneOverESeedMinusOneOverPMap);
   iEvent.emplace(missingHitsMapPutToken_, missingHitsMap);
   iEvent.emplace(validHitsMapPutToken_, validHitsMap);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -40,21 +40,31 @@
 
 class EgammaHLTGsfTrackVarProducer : public edm::global::EDProducer<> {
 public:
-  struct  GsfTrackExtrapolations {
-    GsfTrackExtrapolations(){}
-    void operator()(const reco::GsfTrack& trk,const reco::SuperCluster& sc,const MultiTrajectoryStateTransform& mtsTransform);
+  struct GsfTrackExtrapolations {
+    GsfTrackExtrapolations() {}
+    void operator()(const reco::GsfTrack& trk,
+                    const reco::SuperCluster& sc,
+                    const MultiTrajectoryStateTransform& mtsTransform);
     TrajectoryStateOnSurface innTSOS;
     TrajectoryStateOnSurface outTSOS;
     TrajectoryStateOnSurface sclTSOS;
-    
+
     // mode
     GlobalVector innMom, outMom, sclMom;
     GlobalPoint innPos, outPos, sclPos;
   };
+
 public:
   explicit EgammaHLTGsfTrackVarProducer(const edm::ParameterSet&);
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  float fillAbsAbleVar(float& existVal, const float newVal) const {
+    if (std::abs(newVal) < existVal) {
+      return produceAbsValues_ ? std::abs(newVal) : newVal;
+    } else {
+      return existVal;
+    }
+  }
 
 private:
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandToken_;
@@ -69,31 +79,25 @@ private:
   const int lowerTrackNrToRemoveCut_;
   const bool useDefaultValuesForBarrel_;
   const bool useDefaultValuesForEndcap_;
+  const bool produceAbsValues_;
 
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedMapPutToken_;
-  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dEtaSeedSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiMapPutToken_;
-  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> dPhiSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPMapPutToken_;
-  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESuperMinusOneOverPSignedMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> missingHitsMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> validHitsMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> nLayerITMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> chi2MapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> fbremMapPutToken_;
-
-
 };
 
-namespace{
-  
-  float calRelDelta(float a, float b,float defaultVal=0){
-    return b!=0 ? (a-b)/a : defaultVal;
-  }
+namespace {
 
-}
+  float calRelDelta(float a, float b, float defaultVal = 0) { return b != 0 ? (a - b) / a : defaultVal; }
+
+}  // namespace
 
 EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterSet& config)
     : recoEcalCandToken_(
@@ -107,22 +111,18 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
       lowerTrackNrToRemoveCut_{config.getParameter<int>("lowerTrackNrToRemoveCut")},
       useDefaultValuesForBarrel_{config.getParameter<bool>("useDefaultValuesForBarrel")},
       useDefaultValuesForEndcap_{config.getParameter<bool>("useDefaultValuesForEndcap")},
+      produceAbsValues_{config.getParameter<bool>("produceAbsValues")},
       dEtaMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Deta").setBranchAlias("deta")},
       dEtaSeedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DetaSeed").setBranchAlias("detaseed")},
-      dEtaSeedSignedMapPutToken_{
-          produces<reco::RecoEcalCandidateIsolationMap>("DetaSeedSigned").setBranchAlias("detaseedsigned")},
       dPhiMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Dphi").setBranchAlias("dphi")},
-      dPhiSignedMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("DphiSigned").setBranchAlias("dphisigned")},
       oneOverESuperMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOP")},
-      oneOverESuperMinusOneOverPSignedMapPutToken_{
-          produces<reco::RecoEcalCandidateIsolationMap>("OneOESuperMinusOneOPSigned")},
       oneOverESeedMinusOneOverPMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("OneOESeedMinusOneOP")},
       missingHitsMapPutToken_{
           produces<reco::RecoEcalCandidateIsolationMap>("MissingHits").setBranchAlias("missinghits")},
       validHitsMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("ValidHits").setBranchAlias("validhits")},
       nLayerITMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("NLayerIT").setBranchAlias("nlayerit")},
       chi2MapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Chi2").setBranchAlias("chi2")},
-      fbremMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("fbrem")}{}
+      fbremMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("fbrem")} {}
 
 void EgammaHLTGsfTrackVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -133,6 +133,7 @@ void EgammaHLTGsfTrackVarProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<int>(("lowerTrackNrToRemoveCut"), -1);
   desc.add<bool>(("useDefaultValuesForBarrel"), false);
   desc.add<bool>(("useDefaultValuesForEndcap"), false);
+  desc.add<bool>(("produceAbsValues"), false);
 
   descriptions.add("hltEgammaHLTGsfTrackVarProducer", desc);
 }
@@ -149,11 +150,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   reco::RecoEcalCandidateIsolationMap dEtaMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dEtaSeedMap(recoEcalCandHandle);
-  reco::RecoEcalCandidateIsolationMap dEtaSeedSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap dPhiMap(recoEcalCandHandle);
-  reco::RecoEcalCandidateIsolationMap dPhiSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPMap(recoEcalCandHandle);
-  reco::RecoEcalCandidateIsolationMap oneOverESuperMinusOneOverPSignedMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap missingHitsMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap validHitsMap(recoEcalCandHandle);
@@ -189,11 +187,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
     float missingHitsValue = 9999999;
     float dEtaInValue = 999999;
     float dEtaSeedInValue = 999999;
-    float dEtaSeedInSignedValue = 999999;
     float dPhiInValue = 999999;
-    float dPhiInSignedValue = 999999;
     float oneOverESuperMinusOneOverPValue = 999999;
-    float oneOverESuperMinusOneOverPSignedValue = 999999;
     float oneOverESeedMinusOneOverPValue = 999999;
     float fbrem = 999999;
 
@@ -204,7 +199,6 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
                                       ? useDefaultValuesForBarrel_ && nrTracks >= 1
                                       : useDefaultValuesForEndcap_ && nrTracks >= 1;
 
-
     MultiTrajectoryStateTransform mtsTransform(&trackerGeometry, &magneticField);
     GsfTrackExtrapolations gsfTrackExtrapolations;
 
@@ -212,37 +206,29 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
       nLayerITValue = 100;
       dEtaInValue = 0;
       dEtaSeedInValue = 0;
-      dEtaSeedInSignedValue = 0;
       dPhiInValue = 0;
-      dPhiInSignedValue = 0;
       missingHitsValue = 0;
       validHitsValue = 100;
       chi2Value = 0;
       oneOverESuperMinusOneOverPValue = 0;
-      oneOverESuperMinusOneOverPSignedValue = 0;
       oneOverESeedMinusOneOverPValue = 0;
       fbrem = 0;
     } else {
       for (size_t trkNr = 0; trkNr < gsfTracks.size(); trkNr++) {
         GlobalPoint scPos(scRef->x(), scRef->y(), scRef->z());
 
-	gsfTrackExtrapolations(*gsfTracks[trkNr],*scRef,mtsTransform);
-	
+        gsfTrackExtrapolations(*gsfTracks[trkNr], *scRef, mtsTransform);
+
         EleRelPointPair scAtVtx(scRef->position(), gsfTrackExtrapolations.sclPos, beamSpotPosition);
 
-	fbrem = calRelDelta(gsfTrackExtrapolations.innMom.mag(),gsfTrackExtrapolations.outMom.mag(),fbrem);
-	
+        fbrem = calRelDelta(gsfTrackExtrapolations.innMom.mag(), gsfTrackExtrapolations.outMom.mag(), fbrem);
+
         float trkP = gsfTracks[trkNr]->p();
         if (scRef->energy() != 0 && trkP != 0) {
-          if (std::abs(1 / scRef->energy() - 1 / trkP) < oneOverESuperMinusOneOverPValue) {
-            oneOverESuperMinusOneOverPValue = std::abs(1 / scRef->energy() - 1 / trkP);
-            oneOverESuperMinusOneOverPSignedValue = 1 / scRef->energy() - 1 / trkP;
-          }
+          fillAbsAbleVar(oneOverESuperMinusOneOverPValue, 1 / scRef->energy() - 1 / trkP);
         }
         if (scRef->seed().isNonnull() && scRef->seed()->energy() != 0 && trkP != 0) {
-          if (std::abs(1 / scRef->seed()->energy() - 1 / trkP) < oneOverESeedMinusOneOverPValue) {
-            oneOverESeedMinusOneOverPValue = std::abs(1 / scRef->seed()->energy() - 1 / trkP);
-          }
+          fillAbsAbleVar(oneOverESeedMinusOneOverPValue, 1 / scRef->seed()->energy() - 1 / trkP);
         }
 
         if (gsfTracks[trkNr]->missingInnerHits() < missingHitsValue) {
@@ -263,31 +249,16 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
           chi2Value = gsfTracks[trkNr]->normalizedChi2();
         }
 
-        if (std::abs(scAtVtx.dEta()) < dEtaInValue) {
-          // we are allowing them to come from different tracks
-          dEtaInValue = std::abs(scAtVtx.dEta());
-        }
-
-        if (std::abs(scAtVtx.dEta()) < dEtaSeedInValue) {
-          dEtaSeedInValue = std::abs(scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta());
-          dEtaSeedInSignedValue = scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta();
-        }
-
-        if (std::abs(scAtVtx.dPhi()) < dPhiInValue) {
-          // we are allowing them to come from different tracks
-          dPhiInValue = std::abs(scAtVtx.dPhi());
-          dPhiInSignedValue = scAtVtx.dPhi();
-        }
+        fillAbsAbleVar(dEtaInValue, scAtVtx.dEta());
+        fillAbsAbleVar(dEtaSeedInValue, scAtVtx.dEta() - scRef->position().eta() + scRef->seed()->position().eta());
+        fillAbsAbleVar(dPhiInValue, scAtVtx.dPhi());
       }
     }
 
     dEtaMap.insert(recoEcalCandRef, dEtaInValue);
     dEtaSeedMap.insert(recoEcalCandRef, dEtaSeedInValue);
-    dEtaSeedSignedMap.insert(recoEcalCandRef, dEtaSeedInSignedValue);
     dPhiMap.insert(recoEcalCandRef, dPhiInValue);
-    dPhiSignedMap.insert(recoEcalCandRef, dPhiInSignedValue);
     oneOverESuperMinusOneOverPMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPValue);
-    oneOverESuperMinusOneOverPSignedMap.insert(recoEcalCandRef, oneOverESuperMinusOneOverPSignedValue);
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef, oneOverESeedMinusOneOverPValue);
     missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
     validHitsMap.insert(recoEcalCandRef, validHitsValue);
@@ -298,11 +269,8 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
 
   iEvent.emplace(dEtaMapPutToken_, dEtaMap);
   iEvent.emplace(dEtaSeedMapPutToken_, dEtaSeedMap);
-  iEvent.emplace(dEtaSeedSignedMapPutToken_, dEtaSeedSignedMap);
   iEvent.emplace(dPhiMapPutToken_, dPhiMap);
-  iEvent.emplace(dPhiSignedMapPutToken_, dPhiSignedMap);
   iEvent.emplace(oneOverESuperMinusOneOverPMapPutToken_, oneOverESuperMinusOneOverPMap);
-  iEvent.emplace(oneOverESuperMinusOneOverPSignedMapPutToken_, oneOverESuperMinusOneOverPSignedMap);
   iEvent.emplace(oneOverESeedMinusOneOverPMapPutToken_, oneOverESeedMinusOneOverPMap);
   iEvent.emplace(missingHitsMapPutToken_, missingHitsMap);
   iEvent.emplace(validHitsMapPutToken_, validHitsMap);
@@ -311,23 +279,18 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
   iEvent.emplace(fbremMapPutToken_, fbremMap);
 }
 
-
-void EgammaHLTGsfTrackVarProducer::GsfTrackExtrapolations::operator()(const reco::GsfTrack& trk,const reco::SuperCluster& sc,const MultiTrajectoryStateTransform& mtsTransform)
-{
+void EgammaHLTGsfTrackVarProducer::GsfTrackExtrapolations::operator()(
+    const reco::GsfTrack& trk, const reco::SuperCluster& sc, const MultiTrajectoryStateTransform& mtsTransform) {
   innTSOS = mtsTransform.innerStateOnSurface(trk);
   outTSOS = mtsTransform.outerStateOnSurface(trk);
-  sclTSOS = mtsTransform.extrapolatedState(
-     innTSOS, GlobalPoint(sc.x(), sc.y(), sc.z())
-  );
-  
+  sclTSOS = mtsTransform.extrapolatedState(innTSOS, GlobalPoint(sc.x(), sc.y(), sc.z()));
+
   multiTrajectoryStateMode::momentumFromModeCartesian(innTSOS, innMom);
   multiTrajectoryStateMode::positionFromModeCartesian(innTSOS, innPos);
   multiTrajectoryStateMode::momentumFromModeCartesian(sclTSOS, sclMom);
   multiTrajectoryStateMode::positionFromModeCartesian(sclTSOS, sclPos);
   multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS, outMom);
   multiTrajectoryStateMode::positionFromModeCartesian(outTSOS, outPos);
-  
- 
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -58,11 +58,9 @@ public:
   explicit EgammaHLTGsfTrackVarProducer(const edm::ParameterSet&);
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  float fillAbsAbleVar(float& existVal, const float newVal) const {
+  void fillAbsAbleVar(float& existVal, const float newVal) const {
     if (std::abs(newVal) < existVal) {
-      return produceAbsValues_ ? std::abs(newVal) : newVal;
-    } else {
-      return existVal;
+      existVal = produceAbsValues_ ? std::abs(newVal) : newVal;
     }
   }
 


### PR DESCRIPTION
#### PR description:

This a copy of https://github.com/cms-sw/cmssw/pull/43748 (AR is away from email right now so I will take over and I dont have access to his branch so I have to make a new one)

It has the fbrem variable missing in the orginal PR and then also has the requested change from Martin that we only store the signed values

As such, it adjusts all downstream filters to std::abs their variables on request and adds a customisation function to set it to those variables that need it. 

Original PR text here for convenience 

We plan to store the values of dEtaSigned, dPhi and 1/E-1/p for the best GSF track in the scouting electron collection. The default implementation is the absolute value. Hence, I named the new variable collections as signed parameters. The output of this HLT producer will now have three more variable collections. The corresponding change to computation time is expected to be negligible, as there is no additional computation required for these variables.

More details can be found in the following [Scouting Meeting Presentation](https://indico.cern.ch/event/1366361/#8-scouting-2024-egamma-updates).

PR validation:
 * Standard set of code checks and code-formatting done.
 * Suggested test in [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) passed successfully.
 * An HLT configuration was re-run on 100 events on a single thread and the output was manually verified. As expected the new collections had different signs (+ or -) compared to the previous collections. However, the absolute value was identical. The test configuration and output files are on AFS at /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/CMSSW_14_0_0_pre2/src/TestSignedOutput_scoutingPFMC.py and /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/CMSSW_14_0_0_pre2/src/TestSignedOutput_outputScoutingPF.root respectively.







