### PR TITLE
silence CPP20 warnings about `maybe-uninitialized` variables in `momentumBiasValidation.C`

### DIFF
--- a/Alignment/OfflineValidation/macros/momentumBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumBiasValidation.C
@@ -40,8 +40,8 @@ namespace eop {
     double mean = f1->GetParameter(1);
     double deviation = f1->GetParameter(2);
 
-    double lowLim;
-    double upLim;
+    double lowLim{mean - (2.0 * deviation)};
+    double upLim{mean + (2.0 * deviation)};
     double newmean;
 
     double degrade = 0.05;


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/43775

#### PR description:

As per https://github.com/cms-sw/cmssw/issues/43775#issuecomment-1906439896, technically no-op (for reasons explained at https://github.com/cms-sw/cmssw/issues/43775#issuecomment-1906374470).

#### PR validation:

`cmssw` compiles.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A