### PR TITLE
add necessary changes to run the uploads of the Combined High Granularity SiPixel alignment in the PCL

### DIFF
--- a/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
+++ b/Calibration/TkAlCaRecoProducers/test/parseFwkJobReport.py
@@ -18,7 +18,8 @@ TARGET_LIST_OF_TAGS=['BeamSpotObject_ByLumi',           # beamspot
                      'SiStripBadStripRcdHitEff_pcl',
                      'SiStripLA_pcl',
                      'SiPixelAli_pcl',                  # Alignment
-                     'SiPixelAliHG_pcl']                  
+                     'SiPixelAliHG_pcl',
+                     'SiPixelAliHGCombined_pcl']
 TARGET_DQM_FILES=1
 TARGET_DQM_FILENAME='./DQM_V0001_R000325022__Express__PCLTest__ALCAPROMPT.root'
 TARGET_DB_FILES=len(TARGET_LIST_OF_TAGS)

--- a/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
+++ b/Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py
@@ -83,6 +83,7 @@ process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripGainsAAG_dbOu
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripHitEff_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAli_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAliHG_dbOutput)
+process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelAliHGCombined_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelLA_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiPixelLAMCS_dbOutput)
 process.PoolDBOutputService.toPut.append(process.ALCAHARVESTSiStripLA_dbOutput)
@@ -106,6 +107,7 @@ process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripGainsAAG
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripHitEff_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAli_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAliHG_metadata)
+process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelAliHGCombined_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelLA_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiPixelLAMCS_metadata)
 process.pclMetadataWriter.recordsToMap.append(process.ALCAHARVESTSiStripLA_metadata)
@@ -164,6 +166,7 @@ process.schedule = cms.Schedule(process.SiStripQuality,
                                 process.SiStripHitEff,
                                 process.SiPixelAli,
                                 process.SiPixelAliHG,
+                                process.SiPixelAliHGCombined,
                                 process.SiPixelLA,
                                 process.SiPixelLAMCS,
                                 process.SiStripLA,

--- a/CondFormats/Common/data/SiPixelAliHGCombRcd_prep.json
+++ b/CondFormats/Common/data/SiPixelAliHGCombRcd_prep.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcoff_prep/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelAliHGCombined_PCL_v0_hlt": {},
+        "SiPixelAliHGCombined_PCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelAliHGCombined_pcl", 
+    "since": null, 
+    "userText": "T0 PCL Upload for SiPixel HG Combined (MiBias + Z->mm) Ali. (prep)"
+}

--- a/CondFormats/Common/data/SiPixelAliHGCombRcd_prod.json
+++ b/CondFormats/Common/data/SiPixelAliHGCombRcd_prod.json
@@ -1,0 +1,10 @@
+{
+    "destinationDatabase": "oracle://cms_orcon_prod/CMS_CONDITIONS", 
+    "destinationTags": {
+        "SiPixelAliHGCombined_PCL_v0_hlt": {}, 
+        "SiPixelAliHGCombined_PCL_v0_prompt": {}
+    }, 
+    "inputTag": "SiPixelAliHGCombined_pcl", 
+    "since": null, 
+    "userText": "T0 PCL Upload for SiPixel HG Combined (MinBias + Z->mm) Ali. (prod)"
+}

--- a/CondFormats/Common/test/DropBoxMetadataReader.py
+++ b/CondFormats/Common/test/DropBoxMetadataReader.py
@@ -38,6 +38,7 @@ process.myReader = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                     'SiStripApvGainRcd',
                                     'TrackerAlignmentRcd',
                                     'TrackerAlignmentHGRcd',
+                                    'TrackerAlignmentHGCombinedRcd',
                                     'SiStripApvGainRcdAAG',
                                     'EcalPedestalsRcd',
                                     "LumiCorrectionsRcd",
@@ -49,7 +50,7 @@ process.myReader = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                     "CTPPSRPAlignmentCorrectionsDataRcd",
                                     "PPSTimingCalibrationRcd_HPTDC",
                                     "PPSTimingCalibrationRcd_SAMPIC",
-                                    "SiStripLorentzAngleRcd",
+                                    "SiStripLorentzAngleRcd",                                      
                                     ) # same strings as fType
                                   )
 

--- a/CondFormats/Common/test/ProduceDropBoxMetadata.py
+++ b/CondFormats/Common/test/ProduceDropBoxMetadata.py
@@ -69,6 +69,10 @@ SiPixelAliRcd_prep_str = encodeJsonInString("SiPixelAliRcd_prep.json")
 SiPixelAliHGRcd_prod_str = encodeJsonInString("SiPixelAliHGRcd_prod.json")
 SiPixelAliHGRcd_prep_str = encodeJsonInString("SiPixelAliHGRcd_prep.json")
 
+#SiPixelAliHGComb
+SiPixelAliHGCombRcd_prod_str = encodeJsonInString("SiPixelAliHGCombRcd_prod.json")
+SiPixelAliHGCombRcd_prep_str = encodeJsonInString("SiPixelAliHGCombRcd_prep.json")
+
 #EcalPedestalsRcd
 EcalPedestalsRcd_prod_str = encodeJsonInString("EcalPedestal_prod.json")
 EcalPedestalsRcd_prep_str = encodeJsonInString("EcalPedestal_prep.json")
@@ -173,6 +177,12 @@ process.mywriter = cms.EDAnalyzer("ProduceDropBoxMetadata",
                                                                FileClass           = cms.untracked.string("ALCA"),
                                                                prodMetaData        = cms.untracked.string(SiPixelAliHGRcd_prod_str),
                                                                prepMetaData        = cms.untracked.string(SiPixelAliHGRcd_prep_str),
+                                                               ),
+                                                      cms.PSet(record              = cms.untracked.string('TrackerAlignmentHGCombinedRcd'),
+                                                               Source              = cms.untracked.string("AlcaHarvesting"),
+                                                               FileClass           = cms.untracked.string("ALCA"),
+                                                               prodMetaData        = cms.untracked.string(SiPixelAliHGCombRcd_prod_str),
+                                                               prepMetaData        = cms.untracked.string(SiPixelAliHGCombRcd_prep_str),
                                                                ),
                                                       cms.PSet(record              = cms.untracked.string('SiStripApvGainRcdAAG'),
                                                                Source              = cms.untracked.string("AlcaHarvesting"),


### PR DESCRIPTION
#### PR description:

This is a minimal follow-up to https://github.com/cms-sw/cmssw/pull/43721 in order to be able to support uploads from the High Granularity Tracker Alignment Prompt Calibration Loop with Z → µµ:
   * updated `DropBoxMetaData` writer and reader configuration files;
   * provided steering meta-data for upload to prod / prep
   * added `SiPixelAliHGCombined` workflow to `Calibration/TkAlCaRecoProducers/test/testPCLAlCaHarvesting.py`

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A