### PR TITLE
ECAL - Set correct CC tag labels for ECAL RecHit producer

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -60,6 +60,8 @@ process.ecalMultiFitUncalibRecHitCPU.algoPSet.outOfTimeThresholdGain61pEB = 5.
 process.ecalMultiFitUncalibRecHitCPU.algoPSet.outOfTimeThresholdGain61mEB = 5.
 process.ecalMultiFitUncalibRecHitCPU.algoPSet.timeCalibTag = ':'
 process.ecalMultiFitUncalibRecHitCPU.algoPSet.timeOffsetTag = ':'
+process.ecalRecHit.cpu.timeCalibTag = ':'
+process.ecalRecHit.cpu.timeOffsetTag = ':'
 
 process.ecalPhysicsFilter = cms.EDFilter("EcalMonitorPrescaler",
     cosmics = cms.untracked.uint32(1),

--- a/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py
@@ -183,6 +183,8 @@ process.ecalTestPulseMonitorTask.commonParameters.onlineMode = True
 
 process.ecalRecHit.EEuncalibRecHitCollection = "ecalGlobalUncalibRecHit:EcalUncalibRecHitsEE"
 process.ecalRecHit.EBuncalibRecHitCollection = "ecalGlobalUncalibRecHit:EcalUncalibRecHitsEB"
+process.ecalRecHit.timeCalibTag = ':'
+process.ecalRecHit.timeOffsetTag = ':'
 
 process.ecalPNDiodeMonitorTask.verbosity = 0
 process.ecalPNDiodeMonitorTask.commonParameters.onlineMode = True

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -99,6 +99,20 @@ fastSim.toModify(ecalRecHit,
                  recoverEBIsolatedChannels = False
                 )
 
+# use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
+from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
+run3_ecal.toModify(ecalRecHit,
+    timeCalibTag = ':CC',
+    timeOffsetTag = ':CC'
+)
+
+# this overrides the modifications made by run3_ecal if both modifiers are active
+from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
+gpuValidationEcal.toModify(ecalRecHit,
+    timeCalibTag = ':',
+    timeOffsetTag = ':'
+)
+
 # Phase 2 modifications
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
 phase2_ecal_devel.toModify(ecalRecHit,


### PR DESCRIPTION
#### PR description:

While the ECAL uncalibrated RecHit producer is set up to use the timing calibrations and offsets from the `CC` labelled records in the GT for Run 3 and beyond (because the cross correlation timing algorithm is used in the time reconstruction), the RecHit producer has until now not picked the calibrations from the record with those labels. This mismatch in conditions used for the two producers is fixed with this PR.
The RecHit producer needs to use the conditions matching the reconstruction algorithm running in the uncalibrated REcHit producer.

In the online DQM the ratio timing is used and the record labels are explicitly set to be empty.

#### PR validation:

Passes the limited matrix tests.
