### PR TITLE
Update CICADA emulator templates and update model version to pattern testing model

### DIFF
--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -342,13 +342,13 @@ typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8>> L1TCaloSummary_CICADA_v2p0
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v1p0p0);
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v2p0p0);
 // X.1.0 version input.output typing
-typedef L1TCaloSummary<ap_ufixed<10,10>, ap_fixed<11,5>> L1TCaloSummary_CICADA_v1p1p0;
-typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8>> L1TCaloSummary_CICADA_v2p1p0;
+typedef L1TCaloSummary<ap_ufixed<10, 10>, ap_fixed<11, 5>> L1TCaloSummary_CICADA_v1p1p0;
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8>> L1TCaloSummary_CICADA_v2p1p0;
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v1p1p0);
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v2p1p0);
 // X.1.1 version input/output typing
-typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8,AP_RND,AP_SAT,AP_SAT>> L1TCaloSummary_CICADA_vXp1p1;
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8, AP_RND, AP_SAT, AP_SAT>> L1TCaloSummary_CICADA_vXp1p1;
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_vXp1p1);
 // X.1.2 version input/output typing
-typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8,AP_RND_CONV,AP_SAT>> L1TCaloSummary_CICADA_vXp1p2;
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8, AP_RND_CONV, AP_SAT>> L1TCaloSummary_CICADA_vXp1p2;
 DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_vXp1p2);

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloSummary.cc
@@ -336,8 +336,19 @@ void L1TCaloSummary<INPUT, OUTPUT>::fillDescriptions(edm::ConfigurationDescripti
   descriptions.addDefault(desc);
 }
 
-typedef L1TCaloSummary<ap_ufixed<10, 10>, ap_fixed<11, 5>> L1TCaloSummaryCICADAv1;
-typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8>> L1TCaloSummaryCICADAv2;
-//define type version plugins
-DEFINE_FWK_MODULE(L1TCaloSummaryCICADAv1);
-DEFINE_FWK_MODULE(L1TCaloSummaryCICADAv2);
+// Initial version, X.0.0, input/output typing
+typedef L1TCaloSummary<ap_ufixed<10, 10>, ap_fixed<11, 5>> L1TCaloSummary_CICADA_v1p0p0;
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16, 8>> L1TCaloSummary_CICADA_v2p0p0;
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v1p0p0);
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v2p0p0);
+// X.1.0 version input.output typing
+typedef L1TCaloSummary<ap_ufixed<10,10>, ap_fixed<11,5>> L1TCaloSummary_CICADA_v1p1p0;
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8>> L1TCaloSummary_CICADA_v2p1p0;
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v1p1p0);
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_v2p1p0);
+// X.1.1 version input/output typing
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8,AP_RND,AP_SAT,AP_SAT>> L1TCaloSummary_CICADA_vXp1p1;
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_vXp1p1);
+// X.1.2 version input/output typing
+typedef L1TCaloSummary<ap_uint<10>, ap_ufixed<16,8,AP_RND_CONV,AP_SAT>> L1TCaloSummary_CICADA_vXp1p2;
+DEFINE_FWK_MODULE(L1TCaloSummary_CICADA_vXp1p2);

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1TCaloLayer1.CICADATestPatterns import standardCICADATestPatterns
 
-simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummaryCICADAv2',
+simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p1',
     nPumBins = cms.uint32(18),
     pumLUT00n=  cms.vdouble(0.43, 0.32, 0.29, 0.36, 0.33, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25),
     pumLUT00p=  cms.vdouble(0.45, 0.32, 0.29, 0.35, 0.31, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25),
@@ -50,7 +50,7 @@ simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummaryCICADAv2',
     verbose = cms.bool(False),
     # See UCTLayer1.hh for firmware version
     firmwareVersion = cms.int32(1),
-    CICADAModelVersion = cms.string("CICADAModel_v2p1"),
+    CICADAModelVersion = cms.string("CICADA_v1p1p1"),
     useTestPatterns = cms.bool(False),
     testPatterns = standardCICADATestPatterns
 )

--- a/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
+++ b/L1Trigger/L1TCaloLayer1/python/simCaloStage2Layer1Summary_cfi.py
@@ -50,7 +50,7 @@ simCaloStage2Layer1Summary = cms.EDProducer('L1TCaloSummary_CICADA_vXp1p1',
     verbose = cms.bool(False),
     # See UCTLayer1.hh for firmware version
     firmwareVersion = cms.int32(1),
-    CICADAModelVersion = cms.string("CICADA_v1p1p1"),
+    CICADAModelVersion = cms.string("CICADAModel_v1p1p1"),
     useTestPatterns = cms.bool(False),
     testPatterns = standardCICADATestPatterns
 )


### PR DESCRIPTION
#### PR description:

This PR updates the CICADA emulator to have templates for more recent models, and updates the model in the L1 emulation path to v1.1.1, currently in use for pattern test commissioning.

#### PR validation:

All code compiles and has had formatting applied.

Ran ntuplization configuration designed to run all current models at once with no crashing, input mismatches, or other assorted segfaults.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and is not expected to be backported.