### PR TITLE
Remove uses of deprecated std::random_shuffle

### DIFF
--- a/DataFormats/Common/test/DataFrame_t.cpp
+++ b/DataFormats/Common/test/DataFrame_t.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <numeric>
 #include <cstring>
+#include <random>
 
 class TestDataFrame : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestDataFrame);
@@ -121,7 +122,9 @@ void TestDataFrame::sort() {
   std::vector<unsigned int> ids(100, 1);
   ids[0] = 2001;
   std::partial_sum(ids.begin(), ids.end(), ids.begin());
-  std::random_shuffle(ids.begin(), ids.end());
+  std::random_device rd;
+  std::mt19937 g(rd());
+  std::shuffle(ids.begin(), ids.end(), g);
 
   for (int n = 0; n < 100; ++n) {
     frames.push_back(ids[n]);

--- a/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
+++ b/DataFormats/GeometrySurface/test/gpuFrameTransformTest.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <numeric>
+#include <random>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
@@ -41,6 +42,9 @@ int main(void) {
 
   constexpr uint32_t size = 10000;
   constexpr uint32_t size32 = size * sizeof(float);
+
+  std::random_device rd;
+  std::mt19937 g(rd());
 
   float xl[size], yl[size];
   float x[size], y[size], z[size];
@@ -79,8 +83,8 @@ int main(void) {
     le[3 * i + 2] = (i > size / 2) ? 1.f : 0.04f;
     le[2 * i + 1] = 0.;
   }
-  std::random_shuffle(xl, xl + size);
-  std::random_shuffle(yl, yl + size);
+  std::shuffle(xl, xl + size, g);
+  std::shuffle(yl, yl + size, g);
 
   cudaCheck(cudaMemcpy(d_xl.get(), xl, size32, cudaMemcpyHostToDevice));
   cudaCheck(cudaMemcpy(d_yl.get(), yl, size32, cudaMemcpyHostToDevice));

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneRadixSort.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneRadixSort.dev.cc
@@ -168,6 +168,9 @@ int main() {
     return 0;
   }
 
+  std::random_device rd;
+  std::mt19937 g(rd());
+
   // run the test on each device
   for (auto const& device : devices) {
     Queue queue(device);
@@ -232,7 +235,7 @@ int main() {
     //cudaCheck(cudaMemcpy(gpu_input, input, sizeof(FLOAT) * nmax, cudaMemcpyHostToDevice));
 
     for (int k = 2; k <= nmax; k++) {
-      std::random_shuffle(input, input + k);
+      std::shuffle(input, input + k, g);
       printf("Test with %d items\n", k);
       // sort  on the GPU
       testWrapper(queue, gpu_input_d.data(), gpu_product_d.data(), k, false);

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testRadixSort.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testRadixSort.dev.cc
@@ -135,7 +135,7 @@ void go(Queue& queue, bool useShared) {
       offsets_h[10] = 3297 + offsets_h[9];
     }
 
-    std::random_shuffle(v_h.data(), v_h.data() + N);
+    std::shuffle(v_h.data(), v_h.data() + N, eng);
 
     auto v_d = cms::alpakatools::make_device_buffer<U[]>(queue, N);
     auto ind_d = cms::alpakatools::make_device_buffer<uint16_t[]>(queue, N);

--- a/HeterogeneousCore/CUDAUtilities/test/oneRadixSort_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/oneRadixSort_t.cu
@@ -5,6 +5,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/radixSort.h"
 #include <algorithm>
+#include <random>
 
 using FLOAT = double;
 
@@ -140,6 +141,9 @@ namespace {
 int main() {
   cms::cudatest::requireDevices();
 
+  std::random_device rd;
+  std::mt19937 g(rd());
+
   FLOAT* gpu_input;
   int* gpu_product;
 
@@ -189,7 +193,7 @@ int main() {
   cudaCheck(cudaMemcpy(gpu_input, input, sizeof(FLOAT) * nmax, cudaMemcpyHostToDevice));
 
   for (int k = 2; k <= nmax; k++) {
-    std::random_shuffle(input, input + k);
+    std::shuffle(input, input + k, g);
     printf("Test with %d items\n", k);
     // sort  on the GPU
     testWrapper(gpu_input, gpu_product, k, false);

--- a/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
+++ b/HeterogeneousCore/CUDAUtilities/test/radixSort_t.cu
@@ -135,7 +135,7 @@ void go(bool useShared) {
       offsets[10] = 3297 + offsets[9];
     }
 
-    std::random_shuffle(v, v + N);
+    std::shuffle(v, v + N, eng);
 
     auto v_d = cms::cuda::make_device_unique<U[]>(N, nullptr);
     auto ind_d = cms::cuda::make_device_unique<uint16_t[]>(N, nullptr);


### PR DESCRIPTION
#### PR description:

`std::random_shuffle` is deprecated since C++14, and removed in C++17. Fixes compilation warnings in DEVEL_X: [link](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_0_DEVEL_X_2024-01-28-2300/HeterogeneousCore/AlpakaInterface)

#### PR validation:

Bot tests