### PR TITLE
Update skim configs for full ReReco 2022/2023

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -21,8 +21,13 @@ hltDisappTrk = _hltHighLevel.hltHighLevel.clone(
       "HLT_IsoMu*_v*",
       "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*",
       "HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1_v*",
+      # 2023
       "HLT_DoubleMediumDeepTauPFTauHPS*_L2NN_eta2p1_*",
-      "HLT_LooseDeepTauPFTauHPS*_L2NN_eta2p1_v*"
+      "HLT_LooseDeepTauPFTauHPS*_L2NN_eta2p1_v*",
+      # 2022
+      "HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*",
+      "HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*",
+      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*",
    ]
 )
 

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -348,7 +348,7 @@ SKIMStreamEXODisappTrk = cms.FilteredStream(
     paths = (EXODisappTrkPath),
     content = EXODisappTrkSkimContent.outputCommands, 
     selectEvents = cms.untracked.PSet(), 
-    dataTier = cms.untracked.string('AOD')
+    dataTier = cms.untracked.string('USER')
     )
 
 from Configuration.Skimming.PDWG_EXODisappMuon_cff import *

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -2,9 +2,9 @@ autoSkim = {
 
  # Skim 2023
  'BTagMu' : 'LogError+LogErrorMonitor',
- 'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOLLPJetHCAL+LogError+LogErrorMonitor',
- 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+LogError+LogErrorMonitor',
- 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+LogError+LogErrorMonitor',
+ 'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+EXOLLPJetHCAL+LogError+LogErrorMonitor',
+ 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
  'EGamma0':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'EGamma1':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Tau' : 'EXODisappTrk+LogError+LogErrorMonitor',
@@ -28,14 +28,13 @@ autoSkim = {
 
  # These should be uncommented when 2022 data reprocessing
  # Dedicated skim for 2022
- 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+LogError+LogErrorMonitor',
- 'EGamma':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+LogError+LogErrorMonitor',
+ 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
+ 'EGamma':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Muon' : 'MUOJME+ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
- 'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+EXOLLPJetHCAL+LogError+LogErrorMonitor',
- 'JetHT' : 'JetHTJetPlusHOFilter+LogError+LogErrorMonitor',
- 'MET' : 'EXOHighMET+EXODelayedJetMET+EXODisappTrk+LogError+LogErrorMonitor',
+ 'JetHT' : 'JetHTJetPlusHOFilter+TeVJet+LogError+LogErrorMonitor',
+ 'MET' : 'EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
  'SingleMuon' : 'ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
- 'DoubleMuon' : 'LogError+LogErrorMonitor',
+ 'DoubleMuon' : 'MUOJME+LogError+LogErrorMonitor',
 
  # Used in unit test scenario ppEra_Run2_2018
  #'SingleMuon': 'LogError+LogErrorMonitor',

--- a/DPGAnalysis/Skims/python/TopMuEGSkim_cff.py
+++ b/DPGAnalysis/Skims/python/TopMuEGSkim_cff.py
@@ -21,6 +21,10 @@ from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 hltBtagTopMuEGSelection = cms.EDFilter("HLTHighLevel",
      TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
      HLTPaths = cms.vstring(
+    # 2022
+    'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5_v*',
+    'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5_v*',
+    # 2023
     'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepJet_1p5_v*',  # DeepCSV paths not available anymore. See https://its.cern.ch/jira/browse/CMSHLT-2592 
     'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PNet2BTagMean0p50_v*',  # Taken from HLTrigger/Configuration/python/HLTrigger_Datasets_GRun_cff.py
      ), 


### PR DESCRIPTION
#### PR description:

* Put all relevant 2022/2023 triggers together for ```EXODisappTrk``` and ```TopMuEG``` skims as they have different HLTs between 2022 and 2023.
* Update autoskim.py.
* Modify ```EXODisappTrk``` skim data tier from ```AOD``` to ```USER``` (discussed in #42893)

**Still check with EXO PAG about if ```EXODisappTrk``` HLT path is correct.**


#### PR validation:

```runTheMatrix.py -w "standard" -l 141.101,141.102,141.103,141.104,141.105,141.106,141.107,141.108,141.109,141.110,141.111,141.112,141.113,141.114 --dryRun```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport
