### PR TITLE
SkipEvent is removed [issue#43793]

### DIFF
--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -240,11 +240,11 @@ process.p = cms.Path(
 print("Final Source settings:", process.source)
 process.options = cms.untracked.PSet(
 		Rethrow = cms.untracked.vstring(
-#			"ProductNotFound",
+			"ProductNotFound",
 			"TooManyProducts",
 			"TooFewProducts"
-		),
-		SkipEvent = cms.untracked.vstring(
-			'ProductNotFound'
 		)
+#		SkipEvent = cms.untracked.vstring(
+#			'ProductNotFound'
+#		)
 )


### PR DESCRIPTION
#### PR description:
  - Issue was: SkipEvent not available in process.options from 13_3_X? #43793
  - The solution is to remove SkipEvent option. 
  -  SkipEvent is removed hcalcalib_dqm_sourceclient-live_cfg.py  
 

