### PR TITLE
cmsTriton bug fixes and improvements

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2501,7 +2501,7 @@ class UpgradeWorkflow_SonicTriton(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
         stepDict[stepName][k] = merge([{'--procModifiers': 'allSonicTriton'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=='TTbar_13' and '2021' in key) \
+        return ((fragment=='TTbar_13' or fragment=='TTbar_14TeV') and '2021' in key) \
             or (fragment=='TTbar_14TeV' and '2026' in key)
 upgradeWFs['SonicTriton'] = UpgradeWorkflow_SonicTriton(
     steps = [

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -35,7 +35,7 @@ def runSelected(opt):
     ret = 0
     if opt.show:
         mrd.show(opt.testList, opt.extended, opt.cafVeto)
-        if opt.testList : print('testListected items:', opt.testList)
+        if opt.testList : print('selected items:', opt.testList)
     else:
         mRunnerHi = MatrixRunner(mrd.workFlows, opt.nProcs, opt.nThreads)
         ret = mRunnerHi.runTests(opt)

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -29,6 +29,7 @@ The model information from the server can be printed by enabling `verbose` outpu
 * `modelConfigPath`: path to `config.pbtxt` file for the model (using `edm::FileInPath`)
 * `preferredServer`: name of preferred server, for testing (see [Services](#services) below)
 * `timeout`: maximum allowed time for a request (disabled with 0)
+* `timeoutUnit`: seconds, milliseconds, or microseconds (default: seconds)
 * `outputs`: optional, specify which output(s) the server should send
 * `verbose`: enable verbose printouts (default: false)
 * `useSharedMemory`: enable use of shared memory (see [below](#shared-memory)) with local servers (default: true)

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -132,6 +132,7 @@ The script has three operations (`start`, `stop`, `check`) and the following opt
 * `-C [dir]`: directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)
 * `-D`: dry run: print container commands rather than executing them
 * `-d`: use Docker instead of Apptainer
+* `-E [path]`: include extra path(s) for executables (default: /cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin)
 * `-f`: force reuse of (possibly) existing container instance
 * `-g`: use GPU instead of CPU
 * `-i` [name]`: server image name (default: fastml/triton-torchgeo:22.07-py3-geometric)

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -48,6 +48,7 @@ public:
   void resetBatchMode();
   void reset() override;
   TritonServerType serverType() const { return serverType_; }
+  bool isLocal() const { return isLocal_; }
 
   //for fillDescriptions
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
@@ -78,6 +79,7 @@ protected:
   bool verbose_;
   bool useSharedMemory_;
   TritonServerType serverType_;
+  bool isLocal_;
   grpc_compression_algorithm compressionAlgo_;
   triton::client::Headers headers_;
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonException.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonException.h
@@ -9,9 +9,6 @@ class TritonException : public cms::Exception {
 public:
   explicit TritonException(std::string const& aCategory, bool signal = false);
   void convertToWarning() const;
-
-protected:
-  bool signal_;
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonException.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonException.h
@@ -7,8 +7,11 @@
 
 class TritonException : public cms::Exception {
 public:
-  explicit TritonException(std::string const& aCategory);
+  explicit TritonException(std::string const& aCategory, bool signal = false);
   void convertToWarning() const;
+
+protected:
+  bool signal_;
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonMemResource.h
@@ -19,6 +19,7 @@ public:
   uint8_t* addr() { return addr_; }
   size_t size() const { return size_; }
   virtual void close() {}
+  void closeSafe();
   //used for input
   virtual void copyInput(const void* values, size_t offset, unsigned entry) {}
   //used for output

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -134,7 +134,7 @@ private:
   unsigned currentModuleId_;
   bool allowAddModel_;
   bool startedFallback_;
-  CMS_SA_ALLOW mutable std::atomic<int> callFails_;
+  mutable std::atomic<int> callFails_;
   std::string pid_;
   std::unordered_map<std::string, Model> unservedModels_;
   //this represents a many:many:many map

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <functional>
 #include <utility>
+#include <atomic>
 
 #include "grpc_client.h"
 
@@ -112,6 +113,7 @@ public:
   void addModel(const std::string& modelName, const std::string& path);
   Server serverInfo(const std::string& model, const std::string& preferred = "") const;
   const std::string& pid() const { return pid_; }
+  void notifyCallStatus(bool status) const;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -132,6 +134,7 @@ private:
   unsigned currentModuleId_;
   bool allowAddModel_;
   bool startedFallback_;
+  CMS_SA_ALLOW mutable std::atomic<int> callFails_;
   std::string pid_;
   std::unordered_map<std::string, Model> unservedModels_;
   //this represents a many:many:many map

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -1,6 +1,7 @@
 #ifndef HeterogeneousCore_SonicTriton_triton_utils
 #define HeterogeneousCore_SonicTriton_triton_utils
 
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/Span.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonException.h"
 
@@ -19,6 +20,8 @@ namespace triton_utils {
   bool checkType(inference::DataType dtype) {
     return false;
   }
+  //turn CMS exceptions into warnings
+  void convertToWarning(const cms::Exception& e);
 }  // namespace triton_utils
 
 //explicit specializations (inlined)

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -72,11 +72,11 @@ inline bool triton_utils::checkType<double>(inference::DataType dtype) {
 
 //helper to turn triton error into exception
 //implemented as a macro to avoid constructing the MSG string for successful function calls
-#define TRITON_THROW_IF_ERROR(X, MSG)                                                                         \
-  {                                                                                                           \
-    triton::client::Error err = (X);                                                                          \
-    if (!err.IsOk())                                                                                          \
-      throw TritonException("TritonFailure") << (MSG) << (err.Message().empty() ? "" : ": " + err.Message()); \
+#define TRITON_THROW_IF_ERROR(X, MSG)                                                                               \
+  {                                                                                                                 \
+    triton::client::Error err = (X);                                                                                \
+    if (!err.IsOk())                                                                                                \
+      throw TritonException("TritonFailure", true) << (MSG) << (err.Message().empty() ? "" : ": " + err.Message()); \
   }
 
 extern template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -72,11 +72,11 @@ inline bool triton_utils::checkType<double>(inference::DataType dtype) {
 
 //helper to turn triton error into exception
 //implemented as a macro to avoid constructing the MSG string for successful function calls
-#define TRITON_THROW_IF_ERROR(X, MSG)                                                                               \
-  {                                                                                                                 \
-    triton::client::Error err = (X);                                                                                \
-    if (!err.IsOk())                                                                                                \
-      throw TritonException("TritonFailure", true) << (MSG) << (err.Message().empty() ? "" : ": " + err.Message()); \
+#define TRITON_THROW_IF_ERROR(X, MSG, NOTIFY)                                                                         \
+  {                                                                                                                   \
+    triton::client::Error err = (X);                                                                                  \
+    if (!err.IsOk())                                                                                                  \
+      throw TritonException("TritonFailure", NOTIFY) << (MSG) << (err.Message().empty() ? "" : ": " + err.Message()); \
   }
 
 extern template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -5,7 +5,7 @@ USEDOCKER=""
 GPU=""
 VERBOSE=""
 VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-warning=1 --log-info=1"
-WTIME=300
+WTIME=600
 SERVER=triton_server_instance
 RETRIES=3
 REPOS=()

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -23,6 +23,7 @@ NPORTS=3
 IMAGE=fastml/triton-torchgeo:22.07-py3-geometric
 SANDBOX=""
 COMPAT_USR=""
+EXTRAPATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin
 
 get_sandbox(){
 	if [ -z "$SANDBOX" ]; then
@@ -41,6 +42,7 @@ usage() {
 	$ECHO "-C [dir]    \t directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)"
 	$ECHO "-D          \t dry run: print container commands rather than executing them"
 	$ECHO "-d          \t use Docker instead of Apptainer"
+	$ECHO "-E [path]   \t include extra path(s) for executables (default: ${EXTRAPATH})"
 	$ECHO "-f          \t force reuse of (possibly) existing container instance"
 	$ECHO "-g          \t use GPU instead of CPU"
 	$ECHO "-i [name]   \t server image name (default: ${IMAGE})"
@@ -131,6 +133,11 @@ else
 	TMPDIR=$(readlink -f $TMPDIR)
 fi
 
+# update path
+if [ -n "$EXTRAPATH" ]; then
+	export PATH="${EXTRAPATH}:${PATH}"
+fi
+
 # find executables
 if [ -n "$USEDOCKER" ]; then
 	if [ -z "$DOCKER" ]; then
@@ -148,7 +155,6 @@ else
 		fi
 	fi
 fi
-
 
 SANDBOX=$(get_sandbox)
 SANDBOX=$(readlink -f ${SANDBOX})

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -580,11 +580,16 @@ elif [ "$OP" == start ]; then
 	START_EXIT=0
 	for ((counter=0; counter < ${RETRIES}; counter++)); do
 		make_tmp
-		#If we plan on editing model configs, must repull files into /tmp/local_model_repo, which is deleted upon retry
+
+		# if we plan on editing model configs, must copy files into /tmp/local_model_repo, which is deleted upon retry
 		if [ "$counter" -eq 0 ] || [ -n "$THREADCONTROL" ]; then list_models; fi
-		check_drivers
-		DRIVER_EXIT=$?
-		if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
+
+		# only need to check drivers if using GPU
+		if [ -n "$GPU" ]; then
+			check_drivers
+			DRIVER_EXIT=$?
+			if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi
+		fi
 
 		$START_FN
 		START_EXIT=$?

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -406,6 +406,7 @@ auto_stop(){
 		fi
 		PCOUNTER=0
 		PMAX=5
+		# builtin wait is not used here because it can only monitor a child process, not a parent process
 		while [ "$PCOUNTER" -le "$PMAX" ]; do
 			if ! kill -0 $PARENTPID >& /dev/null; then
 				PCOUNTER=$((PCOUNTER+1))
@@ -427,13 +428,11 @@ auto_stop(){
 	$STOP_FN
 
 	# move logs out of tmp dir
-	if [ -z "$DRYRUN" ]; then
-		if [ -n "$VERBOSE" ]; then
-			mv "$LOG" "$TOPDIR"
-			# only keep non-empty log
-			if [ -s "$STOPLOG" ]; then
-				mv "$STOPLOG" "$TOPDIR"
-			fi
+	if [ -z "$DRYRUN" ] && [ -n "$VERBOSE" ]; then
+		mv "$LOG" "$TOPDIR"
+		# only keep non-empty log
+		if [ -s "$STOPLOG" ]; then
+			mv "$STOPLOG" "$TOPDIR"
 		fi
 	fi
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -160,6 +160,12 @@ SEGFAULT_INDICATOR="Address already in use"
 EXTRA=""
 COMPAT_SCRIPT=/etc/shinit_v2
 
+THREADCONTROL=""
+# do not apply thread control settings if GPU use is requested
+if [ "$INSTANCES" -gt 0 ] && [ -z "$GPU" ]; then
+	THREADCONTROL=true
+fi
+
 compute_ports(){
 	# compute derived port numbers
 	export HTTPPORT=$BASEPORT
@@ -341,7 +347,7 @@ wait_server(){
 list_models(){
 	# make list of model repositories
 	LOCALMODELREPO="local_model_repo"
-	if [ "$INSTANCES" -gt 0 ]; then
+	if [ -n "$THREADCONTROL" ]; then
 		if [ -d "$TMPDIR/$LOCALMODELREPO" ]; then
 			#Want to start with a fresh copy of model files in case this directory already exists with local edits
 			rm -rf $TMPDIR/$LOCALMODELREPO
@@ -359,7 +365,7 @@ list_models(){
 		if [ -f "$MODEL" ]; then
 			MODEL="$(dirname "$MODEL")"
 		fi
-		if [ "$INSTANCES" -gt 0 ]; then
+		if [ -n "$THREADCONTROL" ]; then
 			$DRYRUN cmsTritonConfigTool threadcontrol -c ${MODEL}/config.pbtxt --copy $TMPDIR/$LOCALMODELREPO --nThreads $INSTANCES
 			TOOL_EXIT=$?
 			if [ "$TOOL_EXIT" -ne 0 ]; then
@@ -370,7 +376,7 @@ list_models(){
 			REPOS+=("$(dirname "$MODEL")")
 		fi
 	done
-	if [ "$INSTANCES" -gt 0 ]; then
+	if [ -n "$THREADCONTROL" ]; then
 		REPOS=$TMPDIR/$LOCALMODELREPO
 	else
 		for ((r=0; r < ${#REPOS[@]}; r++)); do
@@ -570,7 +576,7 @@ elif [ "$OP" == start ]; then
 	for ((counter=0; counter < ${RETRIES}; counter++)); do
 		make_tmp
 		#If we plan on editing model configs, must repull files into /tmp/local_model_repo, which is deleted upon retry
-		if [ "$counter" -eq 0 ] || [ "$INSTANCES" -gt 0 ]; then list_models; fi
+		if [ "$counter" -eq 0 ] || [ -n "$THREADCONTROL" ]; then list_models; fi
 		check_drivers
 		DRIVER_EXIT=$?
 		if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
@@ -263,7 +263,8 @@ def cfg_checksum(args):
     from glob import glob
     config_dir = os.path.dirname(args.config)
     for filename in glob(os.path.join(config_dir,"*/*")):
-        if os.path.islink(os.path.dirname(filename)): continue
+        # evaluate symbolic links
+        filename = os.path.realpath(filename)
         checksum = get_checksum(filename)
         # key = algorithm:[filename relative to config.pbtxt dir]
         filename = os.path.relpath(filename, config_dir)
@@ -324,10 +325,12 @@ def cfg_versioncheck(args):
     missing = []
 
     for path in os.environ['CMSSW_SEARCH_PATH'].split(':'):
-        for dirpath, dirnames, filenames in os.walk(path):
+        if args.verbose: print("Checking: "+path)
+        for dirpath, dirnames, filenames in os.walk(path, followlinks=True):
             for filename in filenames:
                 if filename=="config.pbtxt":
                     filepath = os.path.join(dirpath,filename)
+                    if args.verbose: print(filepath)
                     checksum_args = Namespace(
                         config=filepath, should_return=True,
                         copy=False, json=False, defaults=False, view=False,
@@ -435,6 +438,7 @@ if __name__=="__main__":
     parser_checksum.set_defaults(func=cfg_checksum)
 
     parser_versioncheck = subparsers.add_parser("versioncheck", parents=[_parser_checksum_update], help="check all model checksums")
+    parser_versioncheck.add_argument("--verbose", default=False, action="store_true", help="verbose output (show all files checked)")
     parser_versioncheck.set_defaults(func=cfg_versioncheck)
 
     _parser_copy_req = ArgumentParser(add_help=False, parents=[_parser_copy_view])

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
@@ -261,9 +261,10 @@ def cfg_checksum(args):
     missing = []
 
     from glob import glob
-    config_dir = os.path.dirname(args.config)
+    # evaluate symbolic links
+    config_dir = os.path.realpath(os.path.dirname(args.config))
     for filename in glob(os.path.join(config_dir,"*/*")):
-        # evaluate symbolic links
+        # evaluate symbolic links again
         filename = os.path.realpath(filename)
         checksum = get_checksum(filename)
         # key = algorithm:[filename relative to config.pbtxt dir]

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -71,11 +71,13 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   //todo: could enforce async mode otherwise (unless mode was specified by user?)
   if (serverType_ == TritonServerType::LocalCPU)
     setMode(SonicMode::Sync);
+  isLocal_ = serverType_ == TritonServerType::LocalCPU or serverType_ == TritonServerType::LocalGPU;
 
   //connect to the server
   TRITON_THROW_IF_ERROR(
       tc::InferenceServerGrpcClient::Create(&client_, server.url, false, server.useSsl, server.sslOptions),
-      "TritonClient(): unable to create inference context");
+      "TritonClient(): unable to create inference context",
+      isLocal_);
 
   //set options
   options_[0].model_version_ = params.getParameter<std::string>("modelVersion");
@@ -110,7 +112,8 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   //compare model checksums to remote config to enforce versioning
   inference::ModelConfigResponse modelConfigResponse;
   TRITON_THROW_IF_ERROR(client_->ModelConfig(&modelConfigResponse, options_[0].model_name_, options_[0].model_version_),
-                        "TritonClient(): unable to get model config");
+                        "TritonClient(): unable to get model config",
+                        isLocal_);
   inference::ModelConfig remoteModelConfig(modelConfigResponse.config());
 
   std::map<std::string, std::array<std::string, 2>> checksums;
@@ -140,7 +143,8 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   //get model info
   inference::ModelMetadataResponse modelMetadata;
   TRITON_THROW_IF_ERROR(client_->ModelMetadata(&modelMetadata, options_[0].model_name_, options_[0].model_version_),
-                        "TritonClient(): unable to get model metadata");
+                        "TritonClient(): unable to get model metadata",
+                        isLocal_);
 
   //get input and output (which know their sizes)
   const auto& nicInputs = modelMetadata.inputs();
@@ -329,8 +333,8 @@ void TritonClient::getResults(const std::vector<std::shared_ptr<tc::InferResult>
       //set shape here before output becomes const
       if (output.variableDims()) {
         std::vector<int64_t> tmp_shape;
-        TRITON_THROW_IF_ERROR(result->Shape(oname, &tmp_shape),
-                              "getResults(): unable to get output shape for " + oname);
+        TRITON_THROW_IF_ERROR(
+            result->Shape(oname, &tmp_shape), "getResults(): unable to get output shape for " + oname, false);
         if (!noOuterDim_)
           tmp_shape.erase(tmp_shape.begin());
         output.setShape(tmp_shape, i);
@@ -406,43 +410,45 @@ void TritonClient::evaluate() {
   if (mode_ == SonicMode::Async) {
     //non-blocking call
     success = handle_exception([&]() {
-      TRITON_THROW_IF_ERROR(
-          client_->AsyncInferMulti(
-              [start_status, this](std::vector<tc::InferResult*> resultsTmp) {
-                //immediately convert to shared_ptr
-                const auto& results = convertToShared(resultsTmp);
-                //check results
-                for (auto ptr : results) {
-                  auto success = handle_exception(
-                      [&]() { TRITON_THROW_IF_ERROR(ptr->RequestStatus(), "evaluate(): unable to get result(s)"); });
-                  if (!success)
-                    return;
-                }
+      TRITON_THROW_IF_ERROR(client_->AsyncInferMulti(
+                                [start_status, this](std::vector<tc::InferResult*> resultsTmp) {
+                                  //immediately convert to shared_ptr
+                                  const auto& results = convertToShared(resultsTmp);
+                                  //check results
+                                  for (auto ptr : results) {
+                                    auto success = handle_exception([&]() {
+                                      TRITON_THROW_IF_ERROR(
+                                          ptr->RequestStatus(), "evaluate(): unable to get result(s)", isLocal_);
+                                    });
+                                    if (!success)
+                                      return;
+                                  }
 
-                if (verbose()) {
-                  inference::ModelStatistics end_status;
-                  auto success = handle_exception([&]() { end_status = getServerSideStatus(); });
-                  if (!success)
-                    return;
+                                  if (verbose()) {
+                                    inference::ModelStatistics end_status;
+                                    auto success = handle_exception([&]() { end_status = getServerSideStatus(); });
+                                    if (!success)
+                                      return;
 
-                  const auto& stats = summarizeServerStats(start_status, end_status);
-                  reportServerSideStats(stats);
-                }
+                                    const auto& stats = summarizeServerStats(start_status, end_status);
+                                    reportServerSideStats(stats);
+                                  }
 
-                //check result
-                auto success = handle_exception([&]() { getResults(results); });
-                if (!success)
-                  return;
+                                  //check result
+                                  auto success = handle_exception([&]() { getResults(results); });
+                                  if (!success)
+                                    return;
 
-                //finish
-                finish(true);
-              },
-              options_,
-              inputsTriton,
-              outputsTriton,
-              headers_,
-              compressionAlgo_),
-          "evaluate(): unable to launch async run");
+                                  //finish
+                                  finish(true);
+                                },
+                                options_,
+                                inputsTriton,
+                                outputsTriton,
+                                headers_,
+                                compressionAlgo_),
+                            "evaluate(): unable to launch async run",
+                            isLocal_);
     });
     if (!success)
       return;
@@ -452,7 +458,8 @@ void TritonClient::evaluate() {
     success = handle_exception([&]() {
       TRITON_THROW_IF_ERROR(
           client_->InferMulti(&resultsTmp, options_, inputsTriton, outputsTriton, headers_, compressionAlgo_),
-          "evaluate(): unable to run and/or get result");
+          "evaluate(): unable to run and/or get result",
+          isLocal_);
     });
     //immediately convert to shared_ptr
     const auto& results = convertToShared(resultsTmp);
@@ -539,7 +546,8 @@ inference::ModelStatistics TritonClient::getServerSideStatus() const {
   if (verbose_) {
     inference::ModelStatisticsResponse resp;
     TRITON_THROW_IF_ERROR(client_->ModelInferenceStatistics(&resp, options_[0].model_name_, options_[0].model_version_),
-                          "getServerSideStatus(): unable to get model statistics");
+                          "getServerSideStatus(): unable to get model statistics",
+                          isLocal_);
     return *(resp.model_stats().begin());
   }
   return inference::ModelStatistics{};

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -346,6 +346,12 @@ void TritonClient::getResults(const std::vector<std::shared_ptr<tc::InferResult>
 
 //default case for sync and pseudo async
 void TritonClient::evaluate() {
+  //undo previous signal from TritonException
+  if (tries_ > 0) {
+    edm::Service<TritonService> ts;
+    ts->notifyCallStatus(true);
+  }
+
   //in case there is nothing to process
   if (batchSize() == 0) {
     //call getResults on an empty vector

--- a/HeterogeneousCore/SonicTriton/src/TritonException.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonException.cc
@@ -1,6 +1,22 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonException.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
 
-TritonException::TritonException(std::string const& aCategory) : cms::Exception(aCategory) {}
+TritonException::TritonException(std::string const& aCategory, bool signal)
+    : cms::Exception(aCategory), signal_(signal) {
+  if (signal_) {
+    edm::Service<TritonService> ts;
+    ts->notifyCallStatus(false);
+  }
+}
 
-void TritonException::convertToWarning() const { edm::LogWarning(category()) << explainSelf(); }
+void TritonException::convertToWarning() const {
+  //undo the previous signal
+  if (signal_) {
+    edm::Service<TritonService> ts;
+    ts->notifyCallStatus(true);
+  }
+
+  edm::LogWarning(category()) << explainSelf();
+}

--- a/HeterogeneousCore/SonicTriton/src/TritonException.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonException.cc
@@ -3,20 +3,11 @@
 #include "HeterogeneousCore/SonicTriton/interface/TritonException.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonService.h"
 
-TritonException::TritonException(std::string const& aCategory, bool signal)
-    : cms::Exception(aCategory), signal_(signal) {
-  if (signal_) {
+TritonException::TritonException(std::string const& aCategory, bool signal) : cms::Exception(aCategory) {
+  if (signal) {
     edm::Service<TritonService> ts;
     ts->notifyCallStatus(false);
   }
 }
 
-void TritonException::convertToWarning() const {
-  //undo the previous signal
-  if (signal_) {
-    edm::Service<TritonService> ts;
-    ts->notifyCallStatus(true);
-  }
-
-  edm::LogWarning(category()) << explainSelf();
-}
+void TritonException::convertToWarning() const { edm::LogWarning(category()) << explainSelf(); }

--- a/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonMemResource.cc
@@ -25,6 +25,19 @@ void TritonMemResource<IO>::set() {
 }
 
 template <typename IO>
+void TritonMemResource<IO>::closeSafe() {
+  CMS_SA_ALLOW try { close(); } catch (TritonException& e) {
+    e.convertToWarning();
+  } catch (cms::Exception& e) {
+    triton_utils::convertToWarning(e);
+  } catch (std::exception& e) {
+    edm::LogWarning("UnknownFailure") << e.what();
+  } catch (...) {
+    edm::LogWarning("UnknownFailure") << "An unknown exception was thrown";
+  }
+}
+
+template <typename IO>
 TritonHeapResource<IO>::TritonHeapResource(TritonData<IO>* data, const std::string& name, size_t size)
     : TritonMemResource<IO>(data, name, size) {}
 
@@ -96,7 +109,7 @@ TritonCpuShmResource<IO>::TritonCpuShmResource(TritonData<IO>* data, const std::
 
 template <typename IO>
 TritonCpuShmResource<IO>::~TritonCpuShmResource() {
-  close();
+  this->closeSafe();
 }
 
 template <typename IO>
@@ -154,7 +167,7 @@ TritonGpuShmResource<IO>::TritonGpuShmResource(TritonData<IO>* data, const std::
 
 template <typename IO>
 TritonGpuShmResource<IO>::~TritonGpuShmResource() {
-  close();
+  this->closeSafe();
 }
 
 template <typename IO>

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -325,13 +325,14 @@ void TritonService::postEndJob() {
     edm::LogError("TritonService") << output;
     printFallbackServerLog<edm::LogError>();
     if (rv != 0) {
-      cms::Exception stopException("FallbackFailed");
-      stopException << "TritonService: Stopping the fallback server failed with exit code " << rv;
+      std::string stopCat("FallbackFailed");
+      std::stringstream stopMsg;
+      stopMsg << "TritonService: Stopping the fallback server failed with exit code " << rv;
       //avoid throwing if the stack is already unwinding
       if (callFails_ > 0)
-        edm::LogWarning(stopException.category()) << stopException.explainSelf();
+        edm::LogWarning(stopCat) << stopMsg.str();
       else
-        throw stopException;
+        throw cms::Exception(stopCat) << stopMsg.str();
     }
   } else if (verbose_) {
     edm::LogInfo("TritonService") << output;

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -105,20 +105,22 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
     std::unique_ptr<tc::InferenceServerGrpcClient> client;
     TRITON_THROW_IF_ERROR(
         tc::InferenceServerGrpcClient::Create(&client, server.url, false, server.useSsl, server.sslOptions),
-        "TritonService(): unable to create inference context for " + serverName + " (" + server.url + ")");
+        "TritonService(): unable to create inference context for " + serverName + " (" + server.url + ")",
+        false);
 
     if (verbose_) {
       inference::ServerMetadataResponse serverMetaResponse;
       TRITON_THROW_IF_ERROR(client->ServerMetadata(&serverMetaResponse),
-                            "TritonService(): unable to get metadata for " + serverName + " (" + server.url + ")");
+                            "TritonService(): unable to get metadata for " + serverName + " (" + server.url + ")",
+                            false);
       edm::LogInfo("TritonService") << "Server " << serverName << ": url = " << server.url
                                     << ", version = " << serverMetaResponse.version();
     }
 
     inference::RepositoryIndexResponse repoIndexResponse;
-    TRITON_THROW_IF_ERROR(
-        client->ModelRepositoryIndex(&repoIndexResponse),
-        "TritonService(): unable to get repository index for " + serverName + " (" + server.url + ")");
+    TRITON_THROW_IF_ERROR(client->ModelRepositoryIndex(&repoIndexResponse),
+                          "TritonService(): unable to get repository index for " + serverName + " (" + server.url + ")",
+                          false);
 
     //servers keep track of models and vice versa
     if (verbose_)

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -326,13 +326,12 @@ void TritonService::postEndJob() {
     printFallbackServerLog<edm::LogError>();
     if (rv != 0) {
       std::string stopCat("FallbackFailed");
-      std::stringstream stopMsg;
-      stopMsg << "TritonService: Stopping the fallback server failed with exit code " << rv;
+      std::string stopMsg = fmt::format("TritonService: Stopping the fallback server failed with exit code {}", rv);
       //avoid throwing if the stack is already unwinding
       if (callFails_ > 0)
-        edm::LogWarning(stopCat) << stopMsg.str();
+        edm::LogWarning(stopCat) << stopMsg;
       else
-        throw cms::Exception(stopCat) << stopMsg.str();
+        throw cms::Exception(stopCat) << stopMsg;
     }
   } else if (verbose_) {
     edm::LogInfo("TritonService") << output;

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -1,3 +1,4 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
 
 #include <sstream>
@@ -15,6 +16,7 @@ namespace triton_utils {
     return msg.str();
   }
 
+  void convertToWarning(const cms::Exception& e) { edm::LogWarning(e.category()) << e.explainSelf(); }
 }  // namespace triton_utils
 
 template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -16,17 +16,17 @@ The local server will use Apptainer with CPU by default; if a local Nvidia GPU i
 
 Run the image test:
 ```
-cmsRun tritonTest_cfg.py maxEvents=1 modules=TritonImageProducer,TritonImageProducer models=inception_graphdef,densenet_onnx
+cmsRun tritonTest_cfg.py --maxEvents 1 --modules TritonImageProducer TritonImageProducer --models inception_graphdef densenet_onnx
 ```
 
 Run the identity test with ragged batching:
 ```
-cmsRun tritonTest_cfg.py maxEvents=1 modules=TritonIdentityProducer models=ragged_io
+cmsRun tritonTest_cfg.py --maxEvents 1 --modules TritonIdentityProducer --models ragged_io
 ```
 
 Run the graph test:
 ```
-cmsRun tritonTest_cfg.py maxEvents=1 modules=TritonGraphProducer
+cmsRun tritonTest_cfg.py --maxEvents 1 --modules TritonGraphProducer
 ```
 
 ## Caveats

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -29,7 +29,10 @@ options.register("streams", 0, VarParsing.multiplicity.singleton, VarParsing.var
 options.register("modules", "TritonGraphProducer", VarParsing.multiplicity.list, VarParsing.varType.string, "list of modules to run (choices: {})".format(', '.join(models)))
 options.register("models","gat_test", VarParsing.multiplicity.list, VarParsing.varType.string, "list of models (same length as modules, or just 1 entry if all modules use same model)")
 options.register("mode","Async", VarParsing.multiplicity.singleton, VarParsing.varType.string, "mode for client (choices: {})".format(', '.join(allowed_modes)))
-options.register("verbose", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output")
+options.register("verbose", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable all verbose output")
+options.register("verboseClient", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for clients")
+options.register("verboseServer", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for server")
+options.register("verboseService", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for TritonService")
 options.register("brief", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "briefer output for graph modules")
 options.register("fallbackName", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "name for fallback server")
 options.register("unittest", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "unit test mode: reduce input sizes")
@@ -83,8 +86,8 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 
 process.source = cms.Source("EmptySource")
 
-process.TritonService.verbose = options.verbose
-process.TritonService.fallback.verbose = options.verbose
+process.TritonService.verbose = options.verbose or options.verboseService
+process.TritonService.fallback.verbose = options.verbose or options.verboseServer
 process.TritonService.fallback.useDocker = options.docker
 if len(options.fallbackName)>0:
     process.TritonService.fallback.instanceBaseName = options.fallbackName
@@ -127,7 +130,7 @@ for im,module in enumerate(options.modules):
                 modelName = cms.string(model),
                 modelVersion = cms.string(""),
                 modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/{}/config.pbtxt".format(model)),
-                verbose = cms.untracked.bool(options.verbose),
+                verbose = cms.untracked.bool(options.verbose or options.verboseClient),
                 allowedTries = cms.untracked.uint32(options.tries),
                 useSharedMemory = cms.untracked.bool(options.shm),
                 compression = cms.untracked.string(options.compression),

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -1,6 +1,6 @@
-from FWCore.ParameterSet.VarParsing import VarParsing
 import FWCore.ParameterSet.Config as cms
 import os, sys, json
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 # module/model correspondence
 models = {
@@ -16,34 +16,34 @@ allowed_modes = ["Async","PseudoAsync","Sync"]
 allowed_compression = ["none","deflate","gzip"]
 allowed_devices = ["auto","cpu","gpu"]
 
-options = VarParsing()
-options.register("maxEvents", -1, VarParsing.multiplicity.singleton, VarParsing.varType.int, "Number of events to process (-1 for all)")
-options.register("serverName", "default", VarParsing.multiplicity.singleton, VarParsing.varType.string, "name for server (used internally)")
-options.register("address", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "server address")
-options.register("port", 8001, VarParsing.multiplicity.singleton, VarParsing.varType.int, "server port")
-options.register("timeout", 30, VarParsing.multiplicity.singleton, VarParsing.varType.int, "timeout for requests")
-options.register("timeoutUnit", "seconds", VarParsing.multiplicity.singleton, VarParsing.varType.string, "unit for timeout")
-options.register("params", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "json file containing server address/port")
-options.register("threads", 1, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of threads")
-options.register("streams", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of streams")
-options.register("modules", "TritonGraphProducer", VarParsing.multiplicity.list, VarParsing.varType.string, "list of modules to run (choices: {})".format(', '.join(models)))
-options.register("models","gat_test", VarParsing.multiplicity.list, VarParsing.varType.string, "list of models (same length as modules, or just 1 entry if all modules use same model)")
-options.register("mode","Async", VarParsing.multiplicity.singleton, VarParsing.varType.string, "mode for client (choices: {})".format(', '.join(allowed_modes)))
-options.register("verbose", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable all verbose output")
-options.register("verboseClient", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for clients")
-options.register("verboseServer", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for server")
-options.register("verboseService", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable verbose output for TritonService")
-options.register("brief", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "briefer output for graph modules")
-options.register("fallbackName", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "name for fallback server")
-options.register("unittest", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "unit test mode: reduce input sizes")
-options.register("testother", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "also test gRPC communication if shared memory enabled, or vice versa")
-options.register("shm", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable shared memory")
-options.register("compression", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "enable I/O compression (choices: {})".format(', '.join(allowed_compression)))
-options.register("ssl", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "enable SSL authentication for server communication")
-options.register("device","auto", VarParsing.multiplicity.singleton, VarParsing.varType.string, "specify device for fallback server (choices: {})".format(', '.join(allowed_devices)))
-options.register("docker", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "use Docker for fallback server")
-options.register("tries", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of retries for failed request")
-options.parseArguments()
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+parser.add_argument("--maxEvents", default=-1, type=int, help="Number of events to process (-1 for all)")
+parser.add_argument("--serverName", default="default", type=str, help="name for server (used internally)")
+parser.add_argument("--address", default="", type=str, help="server address")
+parser.add_argument("--port", default=8001, type=int, help="server port")
+parser.add_argument("--timeout", default=30, type=int, help="timeout for requests")
+parser.add_argument("--timeoutUnit", default="seconds", type=str, help="unit for timeout")
+parser.add_argument("--params", default="", type=str, help="json file containing server address/port")
+parser.add_argument("--threads", default=1, type=int, help="number of threads")
+parser.add_argument("--streams", default=0, type=int, help="number of streams")
+parser.add_argument("--modules", metavar=("MODULES"), default=["TritonGraphProducer"], nargs='+', type=str, choices=list(models), help="list of modules to run (choices: %(choices)s)")
+parser.add_argument("--models", default=["gat_test"], nargs='+', type=str, help="list of models (same length as modules, or just 1 entry if all modules use same model)")
+parser.add_argument("--mode", default="Async", type=str, choices=allowed_modes, help="mode for client")
+parser.add_argument("--verbose", default=False, action="store_true", help="enable all verbose output")
+parser.add_argument("--verboseClient", default=False, action="store_true", help="enable verbose output for clients")
+parser.add_argument("--verboseServer", default=False, action="store_true", help="enable verbose output for server")
+parser.add_argument("--verboseService", default=False, action="store_true", help="enable verbose output for TritonService")
+parser.add_argument("--brief", default=False, action="store_true", help="briefer output for graph modules")
+parser.add_argument("--fallbackName", default="", type=str, help="name for fallback server")
+parser.add_argument("--unittest", default=False, action="store_true", help="unit test mode: reduce input sizes")
+parser.add_argument("--testother", default=False, action="store_true", help="also test gRPC communication if shared memory enabled, or vice versa")
+parser.add_argument("--noShm", default=False, action="store_true", help="disable shared memory")
+parser.add_argument("--compression", default="", type=str, choices=allowed_compression, help="enable I/O compression")
+parser.add_argument("--ssl", default=False, action="store_true", help="enable SSL authentication for server communication")
+parser.add_argument("--device", default="auto", type=str.lower, choices=allowed_devices, help="specify device for fallback server")
+parser.add_argument("--docker", default=False, action="store_true", help="use Docker for fallback server")
+parser.add_argument("--tries", default=0, type=int, help="number of retries for failed request")
+options = parser.parse_args()
 
 if len(options.params)>0:
     with open(options.params,'r') as pfile:
@@ -55,27 +55,12 @@ if len(options.params)>0:
 # check models and modules
 if len(options.modules)!=len(options.models):
     # assigning to VarParsing.multiplicity.list actually appends to existing value(s)
-    if len(options.models)==1: options.models = [options.models[0]]*(len(options.modules)-1)
+    if len(options.models)==1: options.models = [options.models[0]]*(len(options.modules))
     else: raise ValueError("Arguments for modules and models must have same length")
 for im,module in enumerate(options.modules):
-    if module not in models:
-        raise ValueError("Unknown module: {}".format(module))
     model = options.models[im]
     if model not in models[module]:
         raise ValueError("Unsupported model {} for module {}".format(model,module))
-
-# check modes
-if options.mode not in allowed_modes:
-    raise ValueError("Unknown mode: {}".format(options.mode))
-
-# check compression
-if len(options.compression)>0 and options.compression not in allowed_compression:
-    raise ValueError("Unknown compression setting: {}".format(options.compression))
-
-# check devices
-options.device = options.device.lower()
-if options.device not in allowed_devices:
-	raise ValueError("Unknown device: {}".format(options.device))
 
 from Configuration.ProcessModifiers.enableSonicTriton_cff import enableSonicTriton
 process = cms.Process('tritonTest',enableSonicTriton)
@@ -132,7 +117,7 @@ for im,module in enumerate(options.modules):
                 modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/{}/config.pbtxt".format(model)),
                 verbose = cms.untracked.bool(options.verbose or options.verboseClient),
                 allowedTries = cms.untracked.uint32(options.tries),
-                useSharedMemory = cms.untracked.bool(options.shm),
+                useSharedMemory = cms.untracked.bool(not options.noShm),
                 compression = cms.untracked.string(options.compression),
             )
         )

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -22,6 +22,7 @@ options.register("serverName", "default", VarParsing.multiplicity.singleton, Var
 options.register("address", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "server address")
 options.register("port", 8001, VarParsing.multiplicity.singleton, VarParsing.varType.int, "server port")
 options.register("timeout", 30, VarParsing.multiplicity.singleton, VarParsing.varType.int, "timeout for requests")
+options.register("timeoutUnit", "seconds", VarParsing.multiplicity.singleton, VarParsing.varType.string, "unit for timeout")
 options.register("params", "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "json file containing server address/port")
 options.register("threads", 1, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of threads")
 options.register("streams", 0, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of streams")
@@ -122,6 +123,7 @@ for im,module in enumerate(options.modules):
                 mode = cms.string(options.mode),
                 preferredServer = cms.untracked.string(""),
                 timeout = cms.untracked.uint32(options.timeout),
+                timeoutUnit = cms.untracked.string(options.timeoutUnit),
                 modelName = cms.string(model),
                 modelVersion = cms.string(""),
                 modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/{}/config.pbtxt".format(model)),

--- a/HeterogeneousCore/SonicTriton/test/unittest.sh
+++ b/HeterogeneousCore/SonicTriton/test/unittest.sh
@@ -50,7 +50,7 @@ fi
 
 fallbackName=triton_server_instance_${DEVICE}
 tmpFile=$(mktemp -p ${LOCALTOP} SonicTritonTestXXXXXXXX.log)
-cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py modules=TritonGraphProducer,TritonGraphFilter,TritonGraphAnalyzer maxEvents=2 unittest=1 verbose=1 device=${DEVICE} testother=1 fallbackName=${fallbackName} >& $tmpFile
+cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py --modules TritonGraphProducer TritonGraphFilter TritonGraphAnalyzer --maxEvents 2 --unittest --verbose --device ${DEVICE} --testother --fallbackName ${fallbackName} >& $tmpFile
 CMSEXIT=$?
 
 cat $tmpFile


### PR DESCRIPTION
#### PR description:

Rollup of several pending bug fixes and improvements, primarily aimed at the `cmsTriton` server management script:
1. Some relval jobs have been seeing timeouts when starting the local fallback server if the server image (hosted on `/cvms/unpacked.cern.ch`) is not already loaded in the worker node's cache. It does not appear to be possible for a non-privileged user to check if something is in the cvmfs cache or not, so the default server start timeout is just extended to minimize these failures.
2. Thread control settings for the local fallback server are only used in the CPU case, not the GPU case.
3. The OSG apptainer version is used by default if available. This avoids the need to propagate updated apptainer versions through a slew of different containers.
4. The SONIC special workflows are extended to 14 TeV processes for Run 3.
5. The `TritonService` will print the local fallback server log if the process is terminated because of an exception that could be related to the local fallback server. (This is denoted by a third argument in the `TRITON_THROW_IF_ERROR` macro.) During inference requests, which can be retried, an exception does not necessarily lead to process termination, so the notification to the `TritonService` can be undone in that case.
6. The unit of the inference request timeout can now be selected. (This was useful for testing the above feature.)
7. More granular verbosity control in the unit test script is now available; clients, the fallback server, and the `TritonService` itself can all be targeted separately.
8. The unit test script is migrated from `VarParsing` to `argparse`, now that the latter works properly with `cmsRun`.
9. The GPU driver check is skipped if the local fallback server is not using GPU.
10. Fix handling of symbolic links in `checksum` and `versioncheck` modes of `cmsTritonConfigTool`
11. Avoid throwing exceptions in `TritonMemResource` destructors (addresses #38260)

#### PR validation:

Unit tests pass.

The following command was used to test item 5:
```
cmsRun test/tritonTest_cfg.py --modules TritonGraphProducer --maxEvents 10 --timeout 1 --timeoutUnit microseconds --verboseService --device CPU --noShm
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not intended to be backported.
