### PR TITLE
Fix loop in vertexFinder::splitVertices(acc, ...)

### DIFF
--- a/RecoTracker/PixelVertexFinding/plugins/alpaka/splitVertices.h
+++ b/RecoTracker/PixelVertexFinding/plugins/alpaka/splitVertices.h
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         alpaka::syncBlockThreads(acc);
 
         // copy to local
-        for (auto k : cms::alpakatools::elements_with_stride(acc, nt)) {
+        for (auto k : cms::alpakatools::independent_group_elements(acc, nt)) {
           if (iv[k] == int(kv)) {
             auto old = alpaka::atomicInc(acc, &nq, MAXTK, alpaka::hierarchy::Threads{});
             zz[old] = zt[k] - zv[kv];


### PR DESCRIPTION
#### PR description:

Fix loop in `vertexFinder::splitVertices(acc, ...)`.

The correct loop should be over all tracks of a given vertex, not all tracks of all vertices.

#### PR validation:

Enabling device-side asserts in `RecoTracker/PixelVertexFinding/plugins/alpaka/splitVertices.h` shows the problem:
```
$ $CMSSW_BASE/test/el8_amd64_gcc12/deviceVertexFinderByDensity_tSerialSync
M eps, pset 2 0.1 0
nt,nv 297 0,0
nt,nv 297 17,17
after fit nv, min max chi2 17 0.399816 16.1201
before splitting nv, min max chi2 17 0.399816 11.9221
deviceVertexFinderByDensity_tSerialSync: /data/user/fwyzard/CMSSW_14_0_X_2024-01-23-2300/src/RecoTracker/PixelVertexFinding/plugins/alpaka/splitVertices.h:85: void alpaka_serial_sync::vertexFinder::splitVertices(const TAcc&, VtxSoAView&, WsSoAView&, float) [with TAcc = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, unsigned int>; VtxSoAView = reco::ZVertexLayout<>::ViewTemplateFreeParams<128, false, true, false>; WsSoAView = vertexFinder::PixelVertexWSSoALayout<>::ViewTemplateFreeParams<128, false, true, false>]: Assertion `int(nq) == nn[kv] + 1' failed.
Aborted (core dumped)
```

With the fix, the tests run to completion:
```
$ $CMSSW_BASE/test/el8_amd64_gcc12/deviceVertexFinderByDensity_tSerialSync
M eps, pset 2 0.1 0
nt,nv 297 0,0
nt,nv 297 17,17
after fit nv, min max chi2 17 0.399816 16.1201
before splitting nv, min max chi2 17 0.399816 11.9221
after split 17
nv, min max chi2 17 0.399816 11.3424
min max error 0.0115278 0.00197312
min max ptv2 17.8624 130.467
min max ptv2 17.8624 130.467 at 4 0
min max rms 0.000147343 0.00674829 0.000665088
...
```