### PR TITLE
    Phase-2 L1T Correlator: Rewrite linpuppi emulator with ap_fixed

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -21,7 +21,7 @@ namespace l1ct {
   typedef ap_int<10> z0_t;         // 40cm / 0.1
   typedef ap_int<8> dxy_t;         // tbd
   typedef ap_uint<3> tkquality_t;  // tbd
-  typedef ap_uint<9> puppiWgt_t;   // 256 = 1.0
+  typedef ap_ufixed<9, 1, AP_RND_CONV, AP_WRAP> puppiWgt_t;
   typedef ap_uint<6> emid_t;
   typedef ap_uint<14> tk2em_dr_t;
   typedef ap_uint<14> tk2calo_dr_t;
@@ -169,7 +169,7 @@ namespace l1ct {
     inline float floatPhi(glbphi_t phi) { return phi.to_float() * ETAPHI_LSB; }
     inline float floatZ0(z0_t z0) { return z0.to_float() * Z0_LSB; }
     inline float floatDxy(dxy_t dxy) { return dxy.to_float() * DXY_LSB; }
-    inline float floatPuppiW(puppiWgt_t puppiw) { return puppiw.to_float() * PUPPIW_LSB; }
+    inline float floatPuppiW(puppiWgt_t puppiw) { return puppiw.to_float(); }
     inline float floatIso(iso_t iso) { return iso.to_float(); }
     inline float floatSrrTot(srrtot_t srrtot) { return srrtot.to_float() / SRRTOT_SCALE; };
     inline float floatMeanZ(meanz_t meanz) { return meanz + MEANZ_OFFSET; };

--- a/DataFormats/L1TParticleFlow/interface/puppi.h
+++ b/DataFormats/L1TParticleFlow/interface/puppi.h
@@ -74,7 +74,9 @@ namespace l1ct {
 #ifndef __SYNTHESIS__
       assert(hwId.neutral());
 #endif
-      return puppiWgt_t(hwData(BITS_PUPPIW_START + puppiWgt_t::width - 1, BITS_PUPPIW_START));
+      puppiWgt_t ret;
+      ret(puppiWgt_t::width - 1, 0) = hwData(BITS_PUPPIW_START + puppiWgt_t::width - 1, BITS_PUPPIW_START);
+      return ret;
     }
 
     inline void setHwPuppiW(puppiWgt_t w) {
@@ -84,11 +86,11 @@ namespace l1ct {
       hwData(BITS_PUPPIW_START + puppiWgt_t::width - 1, BITS_PUPPIW_START) = w(puppiWgt_t::width - 1, 0);
     }
 
-    inline puppiWgt_t hwEmID() const {
+    inline emid_t hwEmID() const {
 #ifndef __SYNTHESIS__
       assert(hwId.neutral());
 #endif
-      return puppiWgt_t(hwData(BITS_EMID_START + emid_t::width - 1, BITS_EMID_START));
+      return emid_t(hwData(BITS_EMID_START + emid_t::width - 1, BITS_EMID_START));
     }
 
     inline void setHwEmID(emid_t w) {

--- a/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_bits.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_bits.h
@@ -1,17 +1,19 @@
-#ifndef FIRMWARE_LINPUPPI_BITS_H
-#define FIRMWARE_LINPUPPI_BITS_H
+#ifndef L1Trigger_Phase2L1ParticleFlow_LINPUPPI_BITS_H
+#define L1Trigger_Phase2L1ParticleFlow_LINPUPPI_BITS_H
 
-#define LINPUPPI_ptLSB 0.25
-#define LINPUPPI_DR2LSB 1.9e-5
-#define LINPUPPI_dzLSB 0.05
-#define LINPUPPI_pt2LSB LINPUPPI_ptLSB* LINPUPPI_ptLSB
-#define LINPUPPI_pt2DR2_scale LINPUPPI_ptLSB* LINPUPPI_ptLSB / LINPUPPI_DR2LSB
+#include "DataFormats/L1TParticleFlow/interface/datatypes.h"
 
-#define LINPUPPI_sum_bitShift 15
-#define LINPUPPI_x2_bits 6          // decimal bits the discriminator values
-#define LINPUPPI_alpha_bits 5       // decimal bits of the alpha values
-#define LINPUPPI_alphaSlope_bits 5  // decimal bits of the alphaSlope values
-#define LINPUPPI_ptSlope_bits 6     // decimal bits of the ptSlope values
-#define LINPUPPI_weight_bits 8
+namespace linpuppi {
+  typedef ap_ufixed<12, 6, AP_TRN, AP_SAT> sumTerm_t;
+  typedef ap_ufixed<16, 0, AP_RND, AP_SAT> dr2inv_t;
+  typedef ap_fixed<12, 7, AP_TRN, AP_SAT> x2_t;
+  typedef ap_ufixed<7, 2, AP_RND, AP_WRAP> alphaSlope_t;
+  typedef ap_fixed<12, 8, AP_RND, AP_WRAP> alpha_t;
+  typedef ap_ufixed<6, 0, AP_TRN, AP_WRAP> ptSlope_t;
+
+  constexpr float DR2_LSB = l1ct::Scales::ETAPHI_LSB * l1ct::Scales::ETAPHI_LSB;
+  constexpr float PT2DR2_LSB = l1ct::Scales::INTPT_LSB * l1ct::Scales::INTPT_LSB / DR2_LSB;
+  constexpr int SUM_BITSHIFT = sumTerm_t::width - sumTerm_t::iwidth;
+}  // namespace linpuppi
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/puppi/linpuppi_ref.h
@@ -2,6 +2,7 @@
 #define LINPUPPI_REF_H
 
 #include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
+#include "linpuppi_bits.h"
 
 #include <vector>
 
@@ -217,7 +218,8 @@ namespace l1ct {
     bool fakePuppi_;
     // utility
     unsigned int find_ieta(const PFRegionEmu &region, eta_t eta) const;
-    std::pair<pt_t, puppiWgt_t> sum2puppiPt_ref(uint64_t sum, pt_t pt, unsigned int ieta, bool isEM, int icand) const;
+    std::pair<pt_t, puppiWgt_t> sum2puppiPt_ref(
+        linpuppi::sumTerm_t sum, pt_t pt, unsigned int ieta, bool isEM, int icand) const;
     std::pair<float, float> sum2puppiPt_flt(float sum, float pt, unsigned int ieta, bool isEM, int icand) const;
   };
 


### PR DESCRIPTION
#### PR description:

The old emulator was written long time ago using ap_uint and implementing bit shifts by hand.

This new version uses ap_fixed types, resulting in cleaner code, and also better agreement with the floating point expectations (roundings are handled better) and the associated firmware is also a bit better as it uses less bits in the accumulation part.

Physics performance is expected to be essentially identical. 

The corresponding PR to cms-l1t-offline is https://github.com/cms-l1t-offline/cmssw/pull/1201

#### PR validation:

 * Usual code-checks, code-format, etc.
 * `runTheMatrix.py -l 24834.0` which runs TTbar_14TeV_TuneCP5_2026D98_GenSimHLBeamSpot14INPUT + DigiTrigger_2026D98 + RecoGlobal_2026D98 + HARVESTGlobal_2026D98+ALCAPhase2_2026D98
 * `L1Trigger/Phase2L1ParticleFlow/test/cmsRun make_l1ct_binaryFiles_cfg.py`

In CMSSW 13_3_X, as used in the cms-l1t-offline PR, some occupancy plots for Puppi candidates from TTbar events at PU200 were made, showing only small differences between the new and the old code. The new code was also validated against an updated version of the firmware.
