### PR TITLE
Declare InvariantMassError as transient data product

### DIFF
--- a/L1Trigger/Phase2L1GT/src/classes_def.xml
+++ b/L1Trigger/Phase2L1GT/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
-  <class name="l1t::InvariantMassError"/>
-  <class name="l1t::InvariantMassErrorCollection"/>
-  <class name="edm::Wrapper<l1t::InvariantMassErrorCollection>"/>
+  <class name="l1t::InvariantMassError" persistent="false"/>
+  <class name="l1t::InvariantMassErrorCollection" persistent="false"/>
+  <class name="edm::Wrapper<l1t::InvariantMassErrorCollection>" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
#### PR description:

Came across while investigating https://github.com/cms-sw/cmssw/issues/43823. Data products defined in non-DataFormat packages must be transient. These slipped through in https://github.com/cms-sw/cmssw/pull/41808.

An alternative would be to move the `InvariantMassError` to a DataFormat package.

#### PR validation:

None