### PR TITLE
update input file for `testG4Refitter` to avoid backward compatibility issue due to not storing `TStreamerInfo`

### DIFF
--- a/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py
+++ b/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py
@@ -28,7 +28,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20) )
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-      '/store/relval/CMSSW_12_5_0_pre3/RelValSingleMuPt10/GEN-SIM-RECO/124X_mcRun3_2022_realistic_v8-v2/10000/6a6528c0-9d66-4358-bacc-158c40b439cf.root'
+        '/store/relval/CMSSW_14_0_0_pre2/RelValSingleMuPt10/GEN-SIM-RECO/133X_mcRun3_2023_realistic_v3_STD-v2/2590000/da5cf255-2d65-41ec-ac89-45daf33c66d3.root',
     ),
 )
 


### PR DESCRIPTION
#### PR description:

Title says it, addresses part of https://github.com/cms-sw/cmssw/pull/43758#issuecomment-1918368879. 
The input files of this test were written with 12_4_X, where we know ROOT had a bug in not storing `TStreamerInfo` in some cases (see #41246). This circumvents the unit test failures occurring after updating the `Run3ScoutingVertex`  data format in https://github.com/cms-sw/cmssw/pull/43758.

#### PR validation:

`scram b runtests` works now.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A