### PR TITLE
Fix NanoAOD workflow reading 12_4_X file

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -195,7 +195,8 @@ steps['NANO_mcRun3ScoutingPF13.X']=merge([{'-s':'NANO:PhysicsTools/NanoAOD/custo
                          '--datatier':'NANOAOD',
                          '--eventcontent':'NANOAOD',
                          '--filein':'/store/mc/Run3Summer22MiniAODv3/BulkGravitonToHH_MX1120_MH121_TuneCP5_13p6TeV_madgraph-pythia8/MINIAODSIM/124X_mcRun3_2022_realistic_v12-v3/2810000/f9cdd76c-faac-4f24-bf0c-2496c8fffe54.root',
-                         '--secondfilein':'/store/mc/Run3Summer22DRPremix/BulkGravitonToHH_MX1120_MH121_TuneCP5_13p6TeV_madgraph-pythia8/AODSIM/124X_mcRun3_2022_realistic_v12-v3/2810000/ab09fc5d-859c-407f-b7ce-74b0bae9bb96.root'}])
+                         '--secondfilein':'/store/mc/Run3Summer22DRPremix/BulkGravitonToHH_MX1120_MH121_TuneCP5_13p6TeV_madgraph-pythia8/AODSIM/124X_mcRun3_2022_realistic_v12-v3/2810000/ab09fc5d-859c-407f-b7ce-74b0bae9bb96.root',
+                         '--customise':'IOPool/Input/fixReading_12_4_X_Files.fixReading_12_4_X_Files'}])
 
 _wfn=WFN(2500)
 ################

--- a/IOPool/Input/python/fixReading_12_4_X_Files.py
+++ b/IOPool/Input/python/fixReading_12_4_X_Files.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+# ROOT version used in 12_4_X (2022 data taking), and in 13_0_X up to
+# 13_0_3 had a bug where TStreamerInfo was missing in some cases. This
+# customize function adds a Service to include the TStreamerInfo for
+# the affected classes so that the old files can be read now that some
+# of the affected data format classes have evolved.
+def fixReading_12_4_X_Files(process):
+    process.add_(cms.Service("FixMissingStreamerInfos",
+        fileInPath = cms.untracked.FileInPath("IOPool/Input/data/fileContainingStreamerInfos_13_0_0.root")
+    ))
+    return process


### PR DESCRIPTION
#### PR description:

The input file contains Scouting data formats, whose evolution causes read failure because of `TStreamerInfo` being missing from the file because of a ROOT bug at the time.

The problems were reported in https://github.com/cms-sw/cmssw/pull/43758#issuecomment-1918368879.

For more information of the cause, see https://github.com/cms-sw/cmssw/issues/41246 and https://github.com/cms-sw/cmssw/issues/41348.


#### PR validation:

Workflow 2500.51 ~~and `testG4Refitter` unit test~~ succeeds.