### PR TITLE
Migrate last geometry legacy type module

### DIFF
--- a/Geometry/CSCGeometry/test/stubs/CSCDetIdAnalyzer.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCDetIdAnalyzer.cc
@@ -1,6 +1,6 @@
 // Test CSCDetId & CSCIndexer 13.11.2007 ptc
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-class CSCDetIdAnalyzer : public edm::EDAnalyzer {
+class CSCDetIdAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit CSCDetIdAnalyzer(const edm::ParameterSet&);
   ~CSCDetIdAnalyzer() override = default;


### PR DESCRIPTION
#### PR description:

This is part of a Core campaign to eliminate all references to legacy type modules from CMSSW. This is the last one in geometry packages.

Converted the test module CSCDetIdAnalyzer from a legacy type module to a ```one``` type module. A trivial 2 line change.

Note that I migrated this one rather than deleting it, because other than being legacy it looks like the module might still work and there has been activity to maintain this module as recently as 2022. As far as I can tell, this module has always been excluded from compilation in the BuildFile. Compilation has been broken since January 2023 because it is legacy. If you would prefer I delete the module, let me know and I will gladly do that instead.

#### PR validation:

If I temporarily add it into the BuildFile only as a test, then it compiles successfully with the change. There are no tests to run this module and I didn't think it worth the effort to add new ones.
