### PR TITLE
ROOT6 changes needed for RNTupleModel

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -74,20 +74,20 @@ private:
   class CommonEventFields {
   public:
     void createFields(RNTupleModel& model) {
-      model.AddField<UInt_t>("run", &m_run);
-      model.AddField<UInt_t>("luminosityBlock", &m_luminosityBlock);
-      model.AddField<std::uint64_t>("event", &m_event);
+      m_run = model.MakeField<UInt_t>("run");
+      m_luminosityBlock = model.MakeField<UInt_t>("luminosityBlock");
+      m_event = model.MakeField<std::uint64_t>("event");
     }
     void fill(const edm::EventID& id) {
-      m_run = id.run();
-      m_luminosityBlock = id.luminosityBlock();
-      m_event = id.event();
+      *m_run = id.run();
+      *m_luminosityBlock = id.luminosityBlock();
+      *m_event = id.event();
     }
 
   private:
-    UInt_t m_run;
-    UInt_t m_luminosityBlock;
-    std::uint64_t m_event;
+    std::shared_ptr<UInt_t> m_run;
+    std::shared_ptr<UInt_t> m_luminosityBlock;
+    std::shared_ptr<std::uint64_t> m_event;
   } m_commonFields;
 
   LumiNTuple m_lumi;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -123,7 +123,7 @@ void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& trigger
 
 void TriggerOutputFields::makeUniqueFieldName(RNTupleModel& model, std::string& name) {
   // Could also use a cache of names in a higher-level object, don't ask the RNTupleModel each time
-#if ROOT_VERSION_CODE < ROOT_VERSION(6,31,0)
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
   auto existing_field = model.Get<bool>(name);
 #else
   auto existing_field = model.GetDefaultEntry().GetPtr<bool>(name);

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TriggerOutputFields.cc
@@ -123,7 +123,11 @@ void TriggerOutputFields::updateTriggerFields(const edm::TriggerResults& trigger
 
 void TriggerOutputFields::makeUniqueFieldName(RNTupleModel& model, std::string& name) {
   // Could also use a cache of names in a higher-level object, don't ask the RNTupleModel each time
-  const auto* existing_field = model.Get<bool>(name);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6,31,0)
+  auto existing_field = model.Get<bool>(name);
+#else
+  auto existing_field = model.GetDefaultEntry().GetPtr<bool>(name);
+#endif
   if (!existing_field) {
     return;
   }


### PR DESCRIPTION
Latest ROOT change https://github.com/root-project/root/pull/14454 has removed
- `void RUpdater::AddField(const NameWithDescription_t &fieldNameDesc, T *fromWhere)`
  As suggested https://github.com/root-project/root/pull/14454#issuecomment-1917427640 , this PR makes use of `MakeField`
-  `T *RUpdater::Get(std::string_view fieldName)`
  This is now replaced with `model.GetDefaultEntry().GetPtr<bool>(name)`.   Extra check on `ROOT_VERSION_CODE` is added to allow same code to run for all ROOT 6.26 and above IB

Local compilation works for all ROOT626 to ROOT6 (root master based)  IBs



