### PR TITLE
Primary vertex reconstruction: update configuration handling

### DIFF
--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -55,9 +55,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyMap.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h"
 #include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
@@ -3696,7 +3694,7 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
   // track filtering
   edm::ParameterSetDescription psd0;
   TrackFilterForPVFinding::fillPSetDescription(psd0);
-  HITrackFilterForPVFinding::fillPSetDescription(psd0);  // HI only
+  psd0.add<int>("numTracksThreshold", 0);  // HI only
   desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
 
   // PV Clusterization
@@ -3704,7 +3702,7 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
     edm::ParameterSetDescription psd0;
     {
       edm::ParameterSetDescription psd1;
-      DAClusterizerInZT_vect::fillPSetDescription(psd1);
+      DAClusterizerInZ_vect::fillPSetDescription(psd1);
       psd0.add<edm::ParameterSetDescription>("TkDAClusParameters", psd1);
 
       edm::ParameterSetDescription psd2;

--- a/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixelAdaptiveVertex_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 
-hiPixelAdaptiveVertex = _mod.primaryVertexProducer.clone(
+hiPixelAdaptiveVertex = offlinePrimaryVertices.clone(
     verbose = False,
     TkFilterParameters = dict(
         algorithm = 'filterWithThreshold',
@@ -11,13 +11,12 @@ hiPixelAdaptiveVertex = _mod.primaryVertexProducer.clone(
         maxD0Significance = 3.0,     ## keep most primary tracks (was 5.0)
         minPt = 0.0,                 ## better for softish events
         maxEta = 100.,
-        numTracksThreshold = 2
     ),
     # label of tracks to be used
     TrackLabel = "hiSelectedProtoTracks",
     # clustering
-    TkClusParameters = dict(
-        algorithm = "gap",
+    TkClusParameters = cms.PSet(
+        algorithm = cms.string("gap"),
         TkGapClusParameters = cms.PSet(
             zSeparation = cms.double(1.0)       ## 1 cm max separation between clusters
         )
@@ -33,3 +32,5 @@ hiPixelAdaptiveVertex = _mod.primaryVertexProducer.clone(
         )
       )
 )
+
+hiPixelAdaptiveVertex.TkFilterParameters.numTracksThreshold = cms.int32(2)

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -2,19 +2,18 @@ import FWCore.ParameterSet.Config as cms
 from RecoVertex.Configuration.RecoVertex_cff import unsortedOfflinePrimaryVertices, trackWithVertexRefSelector, trackRefsForJets, sortedPrimaryVertices, offlinePrimaryVertices, offlinePrimaryVerticesWithBS,vertexrecoTask
 
 unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone(
-    TkClusParameters = dict(
-        algorithm = "DA2D_vect", 
-        TkDAClusParameters = dict(
-            Tmin = 4.0, 
-            Tpurge = 4.0, 
-            Tstop = 2.0
-        ),
+    TkClusParameters = cms.PSet(algorithm = cms.string("DA2D_vect"),
+        TkDAClusParameters = cms.PSet(
+            Tmin = cms.double(4.0),
+            Tpurge = cms.double(4.0),
+            Tstop = cms.double(2.0),
+        )
     ),
     TrackTimesLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),
     TrackTimeResosLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),
     vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D'))),
                          1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D')))}
-)
+    )
 trackWithVertexRefSelectorBeforeSorting4D = trackWithVertexRefSelector.clone(
     vertexTag = "unsortedOfflinePrimaryVertices4D",
     ptMax = 9e99,
@@ -68,8 +67,7 @@ tofPID3D=tofPIDProducer.clone(vtxsSrc='unsortedOfflinePrimaryVertices')
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing_layer.toModify(tofPID, vtxsSrc='unsortedOfflinePrimaryVertices4D', vertexReassignment=False)
 phase2_timing_layer.toModify(tofPID3D, vertexReassignment=False)
-phase2_timing_layer.toModify(unsortedOfflinePrimaryVertices, 
+phase2_timing_layer.toModify(unsortedOfflinePrimaryVertices,
     vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID'))),
                          1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID')))}
 )
-

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -39,6 +39,7 @@ public:
   }
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
+    TrackFilterForPVFinding::fillPSetDescription(desc);
     desc.add<int>("numTracksThreshold", 0);  // HI only
     desc.add<int>("maxNumTracksThreshold", std::numeric_limits<int>::max());
     desc.add<double>("minPtTight", 0.0);

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -421,8 +421,7 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<bool>("verbose", false);
   {
     edm::ParameterSetDescription psd0;
-    TrackFilterForPVFinding::fillPSetDescription(psd0);
-    HITrackFilterForPVFinding::fillPSetDescription(psd0);  // HI only
+    HITrackFilterForPVFinding::fillPSetDescription(psd0);  // extension of TrackFilterForPVFinding
     desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
   }
   desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("offlineBeamSpot"));
@@ -435,14 +434,21 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
     edm::ParameterSetDescription psd0;
     {
       edm::ParameterSetDescription psd1;
-      DAClusterizerInZT_vect::fillPSetDescription(psd1);
-      psd0.add<edm::ParameterSetDescription>("TkDAClusParameters", psd1);
+      DAClusterizerInZ_vect::fillPSetDescription(psd1);
 
       edm::ParameterSetDescription psd2;
-      GapClusterizerInZ::fillPSetDescription(psd2);
-      psd0.add<edm::ParameterSetDescription>("TkGapClusParameters", psd2);
+      DAClusterizerInZT_vect::fillPSetDescription(psd2);
+
+      edm::ParameterSetDescription psd3;
+      GapClusterizerInZ::fillPSetDescription(psd3);
+
+      psd0.ifValue(
+          edm::ParameterDescription<std::string>("algorithm", "DA_vect", true),
+          "DA_vect" >> edm::ParameterDescription<edm::ParameterSetDescription>("TkDAClusParameters", psd1, true) or
+              "DA2D_vect" >>
+                  edm::ParameterDescription<edm::ParameterSetDescription>("TkDAClusParameters", psd2, true) or
+              "gap" >> edm::ParameterDescription<edm::ParameterSetDescription>("TkGapClusParameters", psd3, true));
     }
-    psd0.add<std::string>("algorithm", "DA_vect");
     desc.add<edm::ParameterSetDescription>("TkClusParameters", psd0);
   }
 
@@ -451,7 +457,7 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<bool>("useMVACut", false);
   desc.add<double>("minTrackTimeQuality", 0.8);
 
-  descriptions.add("primaryVertexProducer", desc);
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 
-pixelVertices = _mod.primaryVertexProducer.clone(
+pixelVertices = offlinePrimaryVertices.clone(
     TrackLabel = "pixelTracks",
 
     TkFilterParameters = dict(

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVerticesFromCosmicTracks_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
-import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
 
-offlinePrimaryVerticesFromCosmicTracks = _mod.primaryVertexProducer.clone(
+offlinePrimaryVerticesFromCosmicTracks = offlinePrimaryVertices.clone(
     TrackLabel    = "ctfWithMaterialTracksP5",
     beamSpotLabel = "offlineBeamSpot",
-                                        
+
     TkFilterParameters = dict(
         maxNormalizedChi2 = 5.0,
         minSiliconLayersWithHits = 7, ## hits > 7
@@ -15,11 +15,11 @@ offlinePrimaryVerticesFromCosmicTracks = _mod.primaryVertexProducer.clone(
         minPixelLayersWithHits = 2, ## hits > 2
     ),
 
-    TkClusParameters = dict(
-        algorithm   = "gap",
-        TkGapClusParameters = dict( 
-            zSeparation = 0.1 ## 1 mm max separation betw. clusters
-        )
+    TkClusParameters = cms.PSet(
+      algorithm = cms.string("gap"),
+      TkGapClusParameters = cms.PSet(
+        zSeparation = cms.double(0.1) ## 1 mm max separation betw. clusters
+      )
     ),
 
     vertexCollections = cms.VPSet(

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -1,29 +1,90 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi import primaryVertexProducer
+offlinePrimaryVertices = cms.EDProducer(
+    "PrimaryVertexProducer",
 
-offlinePrimaryVertices = primaryVertexProducer.clone()
+    verbose = cms.untracked.bool(False),
+    TrackLabel = cms.InputTag("generalTracks"),
+    beamSpotLabel = cms.InputTag("offlineBeamSpot"),
 
-DA_vectParameters = cms.PSet(primaryVertexProducer.TkClusParameters.clone())
+    TkFilterParameters = cms.PSet(
+        algorithm=cms.string('filter'),
+        maxNormalizedChi2 = cms.double(10.0),
+        minPixelLayersWithHits=cms.int32(2),
+        minSiliconLayersWithHits = cms.int32(5),
+        maxD0Significance = cms.double(4.0),
+        maxD0Error = cms.double(1.0),
+        maxDzError = cms.double(1.0),
+        minPt = cms.double(0.0),
+        maxEta = cms.double(2.4),
+        trackQuality = cms.string("any")
+    ),
+
+    TkClusParameters = cms.PSet(
+        algorithm   = cms.string("DA_vect"),
+        TkDAClusParameters = cms.PSet(
+            coolingFactor = cms.double(0.6),  # moderate annealing speed
+            zrange = cms.double(4.),          # consider only clusters within 4 sigma*sqrt(T) of a track
+            delta_highT = cms.double(1.e-2),  # convergence requirement at high T
+            delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
+            convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
+            Tmin = cms.double(2.0),           # end of vertex splitting
+            Tpurge = cms.double(2.0),         # cleaning
+            Tstop = cms.double(0.5),          # end of annealing
+            vertexSize = cms.double(0.006),   # added in quadrature to track-z resolutions
+            d0CutOff = cms.double(3.),        # downweight high IP tracks
+            dzCutOff = cms.double(3.),        # outlier rejection after freeze-out (T<Tmin)
+            zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
+            uniquetrkweight = cms.double(0.8),# require at least two tracks with this weight at T=Tpurge
+            uniquetrkminp = cms.double(0.0),  # minimal a priori track weight for counting unique tracks
+            runInBlocks = cms.bool(False),    # activate the DA running in blocks of z sorted tracks
+            block_size = cms.uint32(10000),   # block size in tracks
+            overlap_frac = cms.double(0.0)    # overlap between consecutive blocks (blocks_size*overlap_frac)
+        )
+    ),
+
+    vertexCollections = cms.VPSet(
+     [cms.PSet(label=cms.string(""),
+               algorithm=cms.string("AdaptiveVertexFitter"),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(0.0),
+               useBeamConstraint = cms.bool(False),
+               maxDistanceToBeam = cms.double(1.0)
+               ),
+      cms.PSet(label=cms.string("WithBS"),
+               algorithm = cms.string('AdaptiveVertexFitter'),
+               chi2cutoff = cms.double(2.5),
+               minNdof=cms.double(2.0),
+               useBeamConstraint = cms.bool(True),
+               maxDistanceToBeam = cms.double(1.0),
+               )
+      ]
+    ),
+
+    isRecoveryIteration = cms.bool(False),
+    recoveryVtxCollection = cms.InputTag("")
+
+
+)
 
 from Configuration.ProcessModifiers.vertexInBlocks_cff import vertexInBlocks
 vertexInBlocks.toModify(offlinePrimaryVertices,
     TkClusParameters = dict(
         TkDAClusParameters = dict(
-        runInBlocks = True,
-        block_size = 128,
-        overlap_frac = 0.5
+            runInBlocks = True,
+            block_size = 128,
+            overlap_frac = 0.5
         )
     )
 )
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 (phase2_tracker & vertexInBlocks).toModify(offlinePrimaryVertices,
-    TkClusParameters = dict(
-        TkDAClusParameters = dict(
-        block_size = 512,
-        overlap_frac = 0.5)
-    )
+     TkClusParameters = dict(
+         TkDAClusParameters = dict(
+             block_size = 512,
+             overlap_frac = 0.5)
+         )
 )
 
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
@@ -38,9 +99,11 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
             dzCutOff = 5.,
             zmerge = 2.e-2,
             uniquetrkweight = 0.9
-        )
+       )
     )
 )
+
+DA_vectParameters = cms.PSet(offlinePrimaryVertices.TkClusParameters.clone())
 
 from Configuration.ProcessModifiers.weightedVertexing_cff import weightedVertexing
 weightedVertexing.toModify(offlinePrimaryVertices,
@@ -72,8 +135,8 @@ trackingLowPU.toModify(offlinePrimaryVertices,
 
 
 # higher eta cut for the phase 2 tracker
-from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker 
-phase2_tracker.toModify(offlinePrimaryVertices, 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(offlinePrimaryVertices,
                         TkFilterParameters = dict(maxEta = 4.0))
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
@@ -82,8 +145,8 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                TkFilterParameters = dict(
                    algorithm="filterWithThreshold",
                    maxD0Significance = 2.0,
-                   maxD0Error = 10.0, 
-                   maxDzError = 10.0, 
+                   maxD0Error = 10.0,
+                   maxDzError = 10.0,
                    minPixelLayersWithHits=3,
                    minPt = 0.7,
                    trackQuality = "highPurity",
@@ -91,11 +154,14 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
                    maxNumTracksThreshold = cms.int32(1000),
                    minPtTight = cms.double(1.0)
                ),
-               TkClusParameters = dict(
-                 algorithm = "gap"
+               TkClusParameters = cms.PSet(
+                 algorithm = cms.string("gap"),
+                 TkGapClusParameters = cms.PSet(
+                   zSeparation = cms.double(1.0)
+                 )
                )
 )
-    
+
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(offlinePrimaryVertices,
      TkFilterParameters = dict(
@@ -103,8 +169,8 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          minPixelLayersWithHits = 1,
          minSiliconLayersWithHits = 3,
          maxD0Significance = 7.0,
-         maxD0Error = 10.0, 
-         maxDzError = 10.0, 
+         maxD0Error = 10.0,
+         maxDzError = 10.0,
          maxEta = 2.5
      ),
      vertexCollections = {
@@ -112,3 +178,4 @@ highBetaStar_2018.toModify(offlinePrimaryVertices,
          1: dict(chi2cutoff = 4.0, minNdof = -2.0),
      }
 )
+

--- a/Validation/RecoVertex/python/pvRecoSequence_cff.py
+++ b/Validation/RecoVertex/python/pvRecoSequence_cff.py
@@ -7,8 +7,8 @@ from Configuration.StandardSequences.Reconstruction_cff import *
 #from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
 
 # 2010-like PV reconstruction 
-import RecoVertex.PrimaryVertexProducer.primaryVertexProducer_cfi as _mod
-offlinePrimaryVerticesGAP = _mod.primaryVertexProducer.clone(
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices
+offlinePrimaryVerticesGAP = offlinePrimaryVertices.clone(
        TrackLabel = "generalTracks",             # label of tracks to be used
        TkFilterParameters = dict(
                     maxNormalizedChi2 = 20.0,    #
@@ -53,7 +53,7 @@ offlinePrimaryVerticesD0s51mm = offlinePrimaryVerticesGAP.clone(
     )
 )
 
-offlinePrimaryVerticesDA100um = _mod.primaryVertexProducer.clone(
+offlinePrimaryVerticesDA100um = offlinePrimaryVertices.clone(
     TrackLabel = "generalTracks",
     TkFilterParameters = dict(
         maxNormalizedChi2 = 20.0,


### PR DESCRIPTION
#### PR description:

This PR addresses issue #43787 following the primary vertex code reorganization made in https://github.com/cms-sw/cmssw/pull/43592 . In particular:

- the previous python master definitions are restored;
- the fillDescription of ```PrimaryVertexProducer``` is updated to provide a default, but no explicit cfi python at runtime;
- conditional statements are introduced for the definition of ```TkClusParameters``` and ~~logical alternatives for ```TkFilterParameters```~~* in order to prevent the need for all possible versions always present in the PSet definition.

```RecoHI/HiTracking``` code is neglected, as obsolete and anyway not properly working.

*: as ```HITrackFilterForPVFinding``` is just an extension of ```TrackFilterForPVFinding``` and the output ```PSet``` has always the same name ```TkFilterParameters```, the use of logical statements for ```PSet``` like ```xor``` does not really works correctly. Using the extended version to provide the overall default seems the cleanest and safest solution.

#### PR validation:

Several benchmark reco configurations are expanded and compared to previous version. FWK calidation of parameters is tested at runtime for a number of benchmark cases.