### PR TITLE
Implement quick fix for eta going out of scope

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -298,10 +298,10 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
       //This is a quick fix to eta going outside of scope - also including protection against phi going outside
-      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins 
-      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins 
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins
+      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins
       //minus one).
-      if ((j < 0) || (j > (etaBins_-1)) || (i < 0) || (i > (phiBins_-1)))
+      if ((j < 0) || (j > (etaBins_ - 1)) || (i < 0) || (i > (phiBins_ - 1)))
         continue;
 
       if (trkpt < pt_intern(trkPtMax_))

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -298,9 +298,10 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
       //This is a quick fix to eta going outside of scope - also including protection against phi going outside
-      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins).
-      //The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins).
-      if ((j < 0) || (j > 23) || (i < 0) || (i > 26))
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins 
+      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins 
+      //minus one).
+      if ((j < 0) || (j > (etaBins_-1)) || (i < 0) || (i > (phiBins_-1)))
         continue;
 
       if (trkpt < pt_intern(trkPtMax_))

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -297,6 +297,12 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       // Eta bin
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
+      //This is a quick fix to eta going outside of scope - also including protection against phi going outside
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins).
+      //The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins).
+      if ((j < 0) || (j > 23) || (i < 0) || (i > 26))
+        continue;
+
       if (trkpt < pt_intern(trkPtMax_))
         epbins[i][j].pTtot += trkpt;
       else


### PR DESCRIPTION
#### PR description:

Added quick fix to eta bin indices going out of scope. [cms-sw/cmssw#43723](https://github.com/cms-sw/cmssw/issues/43723) shows that in CMSSW_14_0_0_pre2, a problem emerges when tracks with |eta| > 2.4 are put through the emulator, causing the resultant bin index to have a negative value. The quick fix is to simply discard tracks outside of the allowed eta region for the track jet emulator. There should be no change to the output jets. 

#### PR validation:

https://github.com/cms-sw/cmssw/issues/43723#issuecomment-1920655663 this comment shows a specific event that causes a segfault. With the implemented changes, there is no segfault at this event. 
