### PR TITLE
Update `TestRun3ScoutingFormats.sh` for CMSSW_14_0_0_pre3 Scouting DataFormat updates

### DIFF
--- a/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
+++ b/DataFormats/Scouting/test/TestRun3ScoutingFormats.sh
@@ -27,6 +27,10 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py || die "Failure using test
 #     minor conflicts or issues in test/BuildFile.xml that need to
 #     be resolved.
 #
+#     testRun3Scouting_v3_v7_v3_v4_v5_v3_v6_v3_v4_CMSSW_14_0_0_pre3.root:
+#     Check out the 14_0_0_pre3 pre-release, no additional commits
+#     will be neeeded.
+#
 # Run the create_Run3Scouting_test_file_cfg.py configuration and
 # rename the file it creates.
 #
@@ -54,6 +58,11 @@ cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die
 file=testRun3Scouting_v3_v6_v3_v4_v5_v3_v5_v3_v3_CMSSW_13_0_3.root
 inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
 argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_13_0_3.root --electronVersion 6 --photonVersion 5 --vertexVersion 3"
+cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
+
+file=testRun3Scouting_v3_v7_v3_v4_v5_v3_v6_v3_v4_CMSSW_14_0_0_pre3.root
+inputfile=$(edmFileInPath DataFormats/Scouting/data/$file) || die "Failure edmFileInPath DataFormats/Scouting/data/$file" $?
+argsPassedToPython="--inputFile $inputfile --outputFileName testRun3Scouting2_CMSSW_14_0_0_pre3.root --electronVersion 7 --photonVersion 6 --vertexVersion 4"
 cmsRun ${LOCAL_TEST_DIR}/test_readRun3Scouting_cfg.py $argsPassedToPython || die "Failed to read old file $file" $?
 
 exit 0


### PR DESCRIPTION
#### PR description:

Title says it all, to address https://github.com/cms-sw/cmssw/issues/43755.

Update includes: 
 - `Run3ScoutingElectron` (version 7)
 - `Run3ScoutingPhoton` (version 6)
 - `Run3ScoutingVertex` (version 4)

#### PR validation:

`scram b runtests` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A