### PR TITLE
Migrate dqm & validation  plugins from Sioutertracker to Sitrackerphase2

### DIFF
--- a/DQM/SiTrackerPhase2/plugins/BuildFile.xml
+++ b/DQM/SiTrackerPhase2/plugins/BuildFile.xml
@@ -1,9 +1,11 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="CommonTools/Statistics"/>
 <use name="DataFormats/SiPixelDigi"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/L1TrackTrigger"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
@@ -190,8 +190,8 @@ void Phase2OTMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::Even
 // ------------ method called once each job just before starting event loop
 // ------------
 void Phase2OTMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
-                                                  edm::Run const &run,
-                                                  edm::EventSetup const &es) {
+                                              edm::Run const &run,
+                                              edm::EventSetup const &es) {
   std::string HistoName;
   const int numDiscs = 5;
 

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTCluster.cc
@@ -1,0 +1,489 @@
+// -*- C++ -*-
+//
+// Package:    SiOuterTracker
+// Class:      SiOuterTracker
+//
+/**\class SiOuterTracker Phase2OTMonitorTTCluster.cc
+ DQM/SiOuterTracker/plugins/Phase2OTMonitorTTCluster.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+ [Notes on implementation]
+ */
+//
+// Original Author:  Isabelle Helena J De Bruyn
+//         Created:  Mon, 10 Feb 2014 13:57:08 GMT
+//
+
+// system include files
+#include <memory>
+#include <numeric>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+class Phase2OTMonitorTTCluster : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTMonitorTTCluster(const edm::ParameterSet &);
+  ~Phase2OTMonitorTTCluster() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  // TTCluster stacks
+  MonitorElement *Cluster_IMem_Barrel = nullptr;
+  MonitorElement *Cluster_IMem_Endcap_Disc = nullptr;
+  MonitorElement *Cluster_IMem_Endcap_Ring = nullptr;
+  MonitorElement *Cluster_IMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_IMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_OMem_Barrel = nullptr;
+  MonitorElement *Cluster_OMem_Endcap_Disc = nullptr;
+  MonitorElement *Cluster_OMem_Endcap_Ring = nullptr;
+  MonitorElement *Cluster_OMem_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_OMem_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
+  MonitorElement *Cluster_W = nullptr;
+  MonitorElement *Cluster_Phi = nullptr;
+  MonitorElement *Cluster_R = nullptr;
+  MonitorElement *Cluster_Eta = nullptr;
+
+  MonitorElement *Cluster_Barrel_XY = nullptr;
+  MonitorElement *Cluster_Endcap_Fw_XY = nullptr;
+  MonitorElement *Cluster_Endcap_Bw_XY = nullptr;
+  MonitorElement *Cluster_RZ = nullptr;
+
+private:
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tagTTClustersToken_;
+  std::string topFolderName_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry *tkGeom_ = nullptr;
+  const TrackerTopology *tTopo_ = nullptr;
+};
+
+//
+// constructors and destructor
+//
+Phase2OTMonitorTTCluster::Phase2OTMonitorTTCluster(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  tagTTClustersToken_ = consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
+      conf_.getParameter<edm::InputTag>("TTClusters"));
+}
+
+Phase2OTMonitorTTCluster::~Phase2OTMonitorTTCluster() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+void Phase2OTMonitorTTCluster::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+  tkGeom_ = &(iSetup.getData(geomToken_));
+  tTopo_ = &(iSetup.getData(topoToken_));
+}
+
+// ------------ method called for each event  ------------
+void Phase2OTMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  /// Track Trigger Clusters
+  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTClusterHandle;
+  iEvent.getByToken(tagTTClustersToken_, Phase2TrackerDigiTTClusterHandle);
+
+  /// Loop over the input Clusters
+  typename edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
+
+  // Adding protection
+  if (!Phase2TrackerDigiTTClusterHandle.isValid())
+    return;
+
+  for (inputIter = Phase2TrackerDigiTTClusterHandle->begin(); inputIter != Phase2TrackerDigiTTClusterHandle->end();
+       ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
+      // Make reference cluster
+      edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>> tempCluRef =
+          edmNew::makeRefTo(Phase2TrackerDigiTTClusterHandle, contentIter);
+
+      DetId detIdClu = tkGeom_->idToDet(tempCluRef->getDetId())->geographicalId();
+      unsigned int memberClu = tempCluRef->getStackMember();
+      unsigned int widClu = tempCluRef->findWidth();
+
+      MeasurementPoint mp = tempCluRef->findAverageLocalCoordinates();
+      const GeomDet *theGeomDet = tkGeom_->idToDet(detIdClu);
+      Global3DPoint posClu = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
+
+      double r = posClu.perp();
+      double z = posClu.z();
+
+      Cluster_W->Fill(widClu, memberClu);
+      Cluster_Eta->Fill(posClu.eta());
+      Cluster_Phi->Fill(posClu.phi());
+      Cluster_R->Fill(r);
+      Cluster_RZ->Fill(z, r);
+
+      if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TOB))  // Phase 2 Outer Tracker Barrel
+      {
+        if (memberClu == 0)
+          Cluster_IMem_Barrel->Fill(tTopo_->layer(detIdClu));
+        else
+          Cluster_OMem_Barrel->Fill(tTopo_->layer(detIdClu));
+
+        Cluster_Barrel_XY->Fill(posClu.x(), posClu.y());
+
+      }                                                                         // end if isBarrel
+      else if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TID))  // Phase 2 Outer Tracker Endcap
+      {
+        if (memberClu == 0) {
+          Cluster_IMem_Endcap_Disc->Fill(tTopo_->layer(detIdClu));  // returns wheel
+          Cluster_IMem_Endcap_Ring->Fill(tTopo_->tidRing(detIdClu));
+        } else {
+          Cluster_OMem_Endcap_Disc->Fill(tTopo_->layer(detIdClu));  // returns wheel
+          Cluster_OMem_Endcap_Ring->Fill(tTopo_->tidRing(detIdClu));
+        }
+
+        if (posClu.z() > 0) {
+          Cluster_Endcap_Fw_XY->Fill(posClu.x(), posClu.y());
+          if (memberClu == 0)
+            Cluster_IMem_Endcap_Ring_Fw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
+          else
+            Cluster_OMem_Endcap_Ring_Fw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
+        } else {
+          Cluster_Endcap_Bw_XY->Fill(posClu.x(), posClu.y());
+          if (memberClu == 0)
+            Cluster_IMem_Endcap_Ring_Bw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
+          else
+            Cluster_OMem_Endcap_Ring_Bw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
+        }
+
+      }  // end if isEndcap
+    }    // end loop contentIter
+  }      // end loop inputIter
+}  // end of method
+
+// ------------ method called once each job just before starting event loop
+// ------------
+void Phase2OTMonitorTTCluster::bookHistograms(DQMStore::IBooker &iBooker,
+                                                  edm::Run const &run,
+                                                  edm::EventSetup const &es) {
+  std::string HistoName;
+  const int numDiscs = 5;
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Clusters/NClusters");
+
+  // NClusters
+  edm::ParameterSet psTTCluster_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Barrel");
+  HistoName = "NClusters_IMem_Barrel";
+  Cluster_IMem_Barrel = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+                                       psTTCluster_Barrel.getParameter<double>("xmin"),
+                                       psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_IMem_Barrel->setAxisTitle("Barrel Layer", 1);
+  Cluster_IMem_Barrel->setAxisTitle("# L1 Clusters", 2);
+
+  HistoName = "NClusters_OMem_Barrel";
+  Cluster_OMem_Barrel = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTCluster_Barrel.getParameter<int32_t>("Nbinsx"),
+                                       psTTCluster_Barrel.getParameter<double>("xmin"),
+                                       psTTCluster_Barrel.getParameter<double>("xmax"));
+  Cluster_OMem_Barrel->setAxisTitle("Barrel Layer", 1);
+  Cluster_OMem_Barrel->setAxisTitle("# L1 Clusters", 2);
+
+  edm::ParameterSet psTTCluster_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECDiscs");
+  HistoName = "NClusters_IMem_Endcap_Disc";
+  Cluster_IMem_Endcap_Disc = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
+  Cluster_IMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
+
+  HistoName = "NClusters_OMem_Endcap_Disc";
+  Cluster_OMem_Endcap_Disc = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmin"),
+                                            psTTCluster_ECDisc.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
+  Cluster_OMem_Endcap_Disc->setAxisTitle("# L1 Clusters", 2);
+
+  edm::ParameterSet psTTCluster_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_ECRings");
+  HistoName = "NClusters_IMem_Endcap_Ring";
+  Cluster_IMem_Endcap_Ring = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECRing.getParameter<double>("xmin"),
+                                            psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_IMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
+  Cluster_IMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
+
+  HistoName = "NClusters_OMem_Endcap_Ring";
+  Cluster_OMem_Endcap_Ring = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTCluster_ECRing.getParameter<double>("xmin"),
+                                            psTTCluster_ECRing.getParameter<double>("xmax"));
+  Cluster_OMem_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
+  Cluster_OMem_Endcap_Ring->setAxisTitle("# L1 Clusters", 2);
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NClusters_IMem_Disc+" + std::to_string(i + 1);
+    Cluster_IMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
+    Cluster_IMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NClusters_IMem_Disc-" + std::to_string(i + 1);
+    Cluster_IMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
+    Cluster_IMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NClusters_OMem_Disc+" + std::to_string(i + 1);
+    Cluster_OMem_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
+    Cluster_OMem_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Clusters ", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NClusters_OMem_Disc-" + std::to_string(i + 1);
+    Cluster_OMem_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                                    HistoName,
+                                                    psTTCluster_ECRing.getParameter<int32_t>("Nbinsx"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmin"),
+                                                    psTTCluster_ECRing.getParameter<double>("xmax"));
+    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
+    Cluster_OMem_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Clusters ", 2);
+  }
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Clusters");
+
+  // Cluster Width
+  edm::ParameterSet psTTClusterWidth = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Width");
+  HistoName = "Cluster_W";
+  Cluster_W = iBooker.book2D(HistoName,
+                             HistoName,
+                             psTTClusterWidth.getParameter<int32_t>("Nbinsx"),
+                             psTTClusterWidth.getParameter<double>("xmin"),
+                             psTTClusterWidth.getParameter<double>("xmax"),
+                             psTTClusterWidth.getParameter<int32_t>("Nbinsy"),
+                             psTTClusterWidth.getParameter<double>("ymin"),
+                             psTTClusterWidth.getParameter<double>("ymax"));
+  Cluster_W->setAxisTitle("L1 Cluster Width", 1);
+  Cluster_W->setAxisTitle("Stack Member", 2);
+
+  // Cluster eta distribution
+  edm::ParameterSet psTTClusterEta = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Eta");
+  HistoName = "Cluster_Eta";
+  Cluster_Eta = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTClusterEta.getParameter<int32_t>("Nbinsx"),
+                               psTTClusterEta.getParameter<double>("xmin"),
+                               psTTClusterEta.getParameter<double>("xmax"));
+  Cluster_Eta->setAxisTitle("#eta", 1);
+  Cluster_Eta->setAxisTitle("# L1 Clusters ", 2);
+
+  // Cluster phi distribution
+  edm::ParameterSet psTTClusterPhi = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_Phi");
+  HistoName = "Cluster_Phi";
+  Cluster_Phi = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTClusterPhi.getParameter<int32_t>("Nbinsx"),
+                               psTTClusterPhi.getParameter<double>("xmin"),
+                               psTTClusterPhi.getParameter<double>("xmax"));
+  Cluster_Phi->setAxisTitle("#phi", 1);
+  Cluster_Phi->setAxisTitle("# L1 Clusters", 2);
+
+  // Cluster R distribution
+  edm::ParameterSet psTTClusterR = conf_.getParameter<edm::ParameterSet>("TH1TTCluster_R");
+  HistoName = "Cluster_R";
+  Cluster_R = iBooker.book1D(HistoName,
+                             HistoName,
+                             psTTClusterR.getParameter<int32_t>("Nbinsx"),
+                             psTTClusterR.getParameter<double>("xmin"),
+                             psTTClusterR.getParameter<double>("xmax"));
+  Cluster_R->setAxisTitle("R [cm]", 1);
+  Cluster_R->setAxisTitle("# L1 Clusters", 2);
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Clusters/Position");
+
+  // Position plots
+  edm::ParameterSet psTTCluster_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Barrel_XY";
+  Cluster_Barrel_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("xmin"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("xmax"),
+                                     psTTCluster_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("ymin"),
+                                     psTTCluster_Barrel_XY.getParameter<double>("ymax"));
+  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position x [cm]", 1);
+  Cluster_Barrel_XY->setAxisTitle("L1 Cluster Barrel position y [cm]", 2);
+
+  edm::ParameterSet psTTCluster_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Endcap_Fw_XY";
+  Cluster_Endcap_Fw_XY = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmin"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("xmax"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymin"),
+                                        psTTCluster_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position x [cm]", 1);
+  Cluster_Endcap_Fw_XY->setAxisTitle("L1 Cluster Forward Endcap position y [cm]", 2);
+
+  edm::ParameterSet psTTCluster_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_Position");
+  HistoName = "Cluster_Endcap_Bw_XY";
+  Cluster_Endcap_Bw_XY = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmin"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("xmax"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymin"),
+                                        psTTCluster_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position x [cm]", 1);
+  Cluster_Endcap_Bw_XY->setAxisTitle("L1 Cluster Backward Endcap position y [cm]", 2);
+
+  // TTCluster #rho vs. z
+  edm::ParameterSet psTTCluster_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTCluster_RZ");
+  HistoName = "Cluster_RZ";
+  Cluster_RZ = iBooker.book2D(HistoName,
+                              HistoName,
+                              psTTCluster_RZ.getParameter<int32_t>("Nbinsx"),
+                              psTTCluster_RZ.getParameter<double>("xmin"),
+                              psTTCluster_RZ.getParameter<double>("xmax"),
+                              psTTCluster_RZ.getParameter<int32_t>("Nbinsy"),
+                              psTTCluster_RZ.getParameter<double>("ymin"),
+                              psTTCluster_RZ.getParameter<double>("ymax"));
+  Cluster_RZ->setAxisTitle("L1 Cluster position z [cm]", 1);
+  Cluster_RZ->setAxisTitle("L1 Cluster position #rho [cm]", 2);
+
+}  // end of method
+void Phase2OTMonitorTTCluster::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // OuterTrackerMonitorTTCluster
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 7);
+    psd0.add<double>("xmax", 7.5);
+    psd0.add<double>("xmin", 0.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Barrel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 6);
+    psd0.add<double>("xmax", 6.5);
+    psd0.add<double>("xmin", 0.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_ECDiscs", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 16);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<double>("xmax", 16.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_ECRings", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<double>("xmin", -5.0);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 60);
+    psd0.add<double>("xmax", 3.5);
+    psd0.add<double>("xmin", -3.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_Phi", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmax", 120);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1TTCluster_R", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 7);
+    psd0.add<double>("xmax", 6.5);
+    psd0.add<double>("xmin", -0.5);
+    psd0.add<int>("Nbinsy", 2);
+    psd0.add<double>("ymax", 1.5);
+    psd0.add<double>("ymin", -0.5);
+    desc.add<edm::ParameterSetDescription>("TH2TTCluster_Width", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 960);
+    psd0.add<double>("xmax", 120);
+    psd0.add<double>("xmin", -120);
+    psd0.add<int>("Nbinsy", 960);
+    psd0.add<double>("ymax", 120);
+    psd0.add<double>("ymin", -120);
+    desc.add<edm::ParameterSetDescription>("TH2TTCluster_Position", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 900);
+    psd0.add<double>("xmax", 300);
+    psd0.add<double>("xmin", -300);
+    psd0.add<int>("Nbinsy", 900);
+    psd0.add<double>("ymax", 120);
+    psd0.add<double>("ymin", 0);
+    desc.add<edm::ParameterSetDescription>("TH2TTCluster_RZ", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2TTCluster");
+  desc.add<edm::InputTag>("TTClusters", edm::InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"));
+  descriptions.add("Phase2OTMonitorTTCluster", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+DEFINE_FWK_MODULE(Phase2OTMonitorTTCluster);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -200,9 +200,7 @@ void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSe
 }  // end of method
 
 // ------------ method called when starting to processes a run  ------------
-void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
-                                               edm::Run const &run,
-                                               edm::EventSetup const &es) {
+void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const &run, edm::EventSetup const &es) {
   std::string HistoName;
   const int numDiscs = 5;
   iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Position");

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTStub.cc
@@ -1,0 +1,657 @@
+// -*- C++ -*-
+//
+// Package:    SiOuterTracker
+// Class:      SiOuterTracker
+//
+/**\class SiOuterTracker Phase2OTMonitorTTStub.cc
+ DQM/SiOuterTracker/plugins/Phase2OTMonitorTTStub.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Isis Marina Van Parijs
+//         Created:  Fri, 24 Oct 2014 12:31:31 GMT
+//
+//
+
+// system include files
+#include <memory>
+#include <numeric>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+class Phase2OTMonitorTTStub : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTMonitorTTStub(const edm::ParameterSet &);
+  ~Phase2OTMonitorTTStub() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  // TTStub stacks
+  // Global position of the stubs
+  MonitorElement *Stub_Barrel_XY = nullptr;     // TTStub barrel y vs x
+  MonitorElement *Stub_Endcap_Fw_XY = nullptr;  // TTStub Forward Endcap y vs. x
+  MonitorElement *Stub_Endcap_Bw_XY = nullptr;  // TTStub Backward Endcap y vs. x
+  MonitorElement *Stub_RZ = nullptr;            // TTStub #rho vs. z
+
+  // Number of stubs
+  MonitorElement *Stub_Barrel = nullptr;                                                   // TTStub per layer
+  MonitorElement *Stub_Endcap_Disc = nullptr;                                              // TTStubs per disc
+  MonitorElement *Stub_Endcap_Disc_Fw = nullptr;                                           // TTStub per disc
+  MonitorElement *Stub_Endcap_Disc_Bw = nullptr;                                           // TTStub per disc
+  MonitorElement *Stub_Endcap_Ring = nullptr;                                              // TTStubs per ring
+  MonitorElement *Stub_Endcap_Ring_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStubs per EC ring
+  MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub per EC ring
+
+  // Stub distribution
+  MonitorElement *Stub_Eta = nullptr;     // TTstub eta distribution
+  MonitorElement *Stub_Phi = nullptr;     // TTstub phi distribution
+  MonitorElement *Stub_R = nullptr;       // TTstub r distribution
+  MonitorElement *Stub_bendFE = nullptr;  // TTstub trigger bend
+  MonitorElement *Stub_bendBE = nullptr;  // TTstub hardware bend
+  MonitorElement *Stub_isPS = nullptr;    // is this stub a PS module?
+
+  // STUB Displacement - offset
+  MonitorElement *Stub_Barrel_W = nullptr;       // TTstub Pos-Corr Displacement (layer)
+  MonitorElement *Stub_Barrel_O = nullptr;       // TTStub Offset (layer)
+  MonitorElement *Stub_Endcap_Disc_W = nullptr;  // TTstub Pos-Corr Displacement (disc)
+  MonitorElement *Stub_Endcap_Disc_O = nullptr;  // TTStub Offset (disc)
+  MonitorElement *Stub_Endcap_Ring_W = nullptr;  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O = nullptr;  // TTStub Offset (EC ring)
+  MonitorElement *Stub_Endcap_Ring_W_Fw[5] = {
+      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Fw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
+  MonitorElement *Stub_Endcap_Ring_W_Bw[5] = {
+      nullptr, nullptr, nullptr, nullptr, nullptr};  // TTstub Pos-Corr Displacement (EC ring)
+  MonitorElement *Stub_Endcap_Ring_O_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub Offset (EC ring)
+
+private:
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> tagTTStubsToken_;
+  std::string topFolderName_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry *tkGeom_ = nullptr;
+  const TrackerTopology *tTopo_ = nullptr;
+};
+
+// constructors and destructor
+Phase2OTMonitorTTStub::Phase2OTMonitorTTStub(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  // now do what ever initialization is needed
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  tagTTStubsToken_ =
+      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
+}
+
+Phase2OTMonitorTTStub::~Phase2OTMonitorTTStub() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+void Phase2OTMonitorTTStub::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+  tkGeom_ = &(iSetup.getData(geomToken_));
+  tTopo_ = &(iSetup.getData(topoToken_));
+}
+// member functions
+
+// ------------ method called for each event  ------------
+void Phase2OTMonitorTTStub::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  /// Track Trigger Stubs
+  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTStubHandle;
+  iEvent.getByToken(tagTTStubsToken_, Phase2TrackerDigiTTStubHandle);
+
+  /// Loop over input Stubs
+  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
+  // Adding protection
+  if (!Phase2TrackerDigiTTStubHandle.isValid())
+    return;
+
+  for (inputIter = Phase2TrackerDigiTTStubHandle->begin(); inputIter != Phase2TrackerDigiTTStubHandle->end();
+       ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
+      /// Make reference stub
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
+          edmNew::makeRefTo(Phase2TrackerDigiTTStubHandle, contentIter);
+
+      /// Get det ID (place of the stub)
+      //  tempStubRef->getDetId() gives the stackDetId, not rawId
+      DetId detIdStub = tkGeom_->idToDet((tempStubRef->clusterRef(0))->getDetId())->geographicalId();
+
+      /// Get trigger displacement/offset
+      double rawBend = tempStubRef->rawBend();
+      double bendOffset = tempStubRef->bendOffset();
+
+      /// Define position stub by position inner cluster
+      MeasurementPoint mp = (tempStubRef->clusterRef(0))->findAverageLocalCoordinates();
+      const GeomDet *theGeomDet = tkGeom_->idToDet(detIdStub);
+      Global3DPoint posStub = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
+
+      Stub_Eta->Fill(posStub.eta());
+      Stub_Phi->Fill(posStub.phi());
+      Stub_R->Fill(posStub.perp());
+      Stub_RZ->Fill(posStub.z(), posStub.perp());
+      Stub_bendFE->Fill(tempStubRef->bendFE());
+      Stub_bendBE->Fill(tempStubRef->bendBE());
+      Stub_isPS->Fill(tempStubRef->moduleTypePS());
+
+      if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
+        Stub_Barrel->Fill(tTopo_->layer(detIdStub));
+        Stub_Barrel_XY->Fill(posStub.x(), posStub.y());
+        Stub_Barrel_W->Fill(tTopo_->layer(detIdStub), rawBend - bendOffset);
+        Stub_Barrel_O->Fill(tTopo_->layer(detIdStub), bendOffset);
+      } else if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID)) {  // Phase 2 Outer Tracker Endcap
+        int disc = tTopo_->layer(detIdStub);                                         // returns wheel
+        int ring = tTopo_->tidRing(detIdStub);
+        Stub_Endcap_Disc->Fill(disc);
+        Stub_Endcap_Ring->Fill(ring);
+        Stub_Endcap_Disc_W->Fill(disc, rawBend - bendOffset);
+        Stub_Endcap_Ring_W->Fill(ring, rawBend - bendOffset);
+        Stub_Endcap_Disc_O->Fill(disc, bendOffset);
+        Stub_Endcap_Ring_O->Fill(ring, bendOffset);
+
+        if (posStub.z() > 0) {
+          Stub_Endcap_Fw_XY->Fill(posStub.x(), posStub.y());
+          Stub_Endcap_Disc_Fw->Fill(disc);
+          Stub_Endcap_Ring_Fw[disc - 1]->Fill(ring);
+          Stub_Endcap_Ring_W_Fw[disc - 1]->Fill(ring, rawBend - bendOffset);
+          Stub_Endcap_Ring_O_Fw[disc - 1]->Fill(ring, bendOffset);
+        } else {
+          Stub_Endcap_Bw_XY->Fill(posStub.x(), posStub.y());
+          Stub_Endcap_Disc_Bw->Fill(disc);
+          Stub_Endcap_Ring_Bw[disc - 1]->Fill(ring);
+          Stub_Endcap_Ring_W_Bw[disc - 1]->Fill(ring, rawBend - bendOffset);
+          Stub_Endcap_Ring_O_Bw[disc - 1]->Fill(ring, bendOffset);
+        }
+      }
+    }
+  }
+}  // end of method
+
+// ------------ method called when starting to processes a run  ------------
+void Phase2OTMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
+                                               edm::Run const &run,
+                                               edm::EventSetup const &es) {
+  std::string HistoName;
+  const int numDiscs = 5;
+  iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Position");
+
+  edm::ParameterSet psTTStub_Barrel_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Barrel_XY";
+  Stub_Barrel_XY = iBooker.book2D(HistoName,
+                                  HistoName,
+                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsx"),
+                                  psTTStub_Barrel_XY.getParameter<double>("xmin"),
+                                  psTTStub_Barrel_XY.getParameter<double>("xmax"),
+                                  psTTStub_Barrel_XY.getParameter<int32_t>("Nbinsy"),
+                                  psTTStub_Barrel_XY.getParameter<double>("ymin"),
+                                  psTTStub_Barrel_XY.getParameter<double>("ymax"));
+  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position x [cm]", 1);
+  Stub_Barrel_XY->setAxisTitle("L1 Stub Barrel position y [cm]", 2);
+
+  edm::ParameterSet psTTStub_Endcap_Fw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Endcap_Fw_XY";
+  Stub_Endcap_Fw_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmin"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("xmax"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymin"),
+                                     psTTStub_Endcap_Fw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
+  Stub_Endcap_Fw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
+
+  edm::ParameterSet psTTStub_Endcap_Bw_XY = conf_.getParameter<edm::ParameterSet>("TH2TTStub_Position");
+  HistoName = "Stub_Endcap_Bw_XY";
+  Stub_Endcap_Bw_XY = iBooker.book2D(HistoName,
+                                     HistoName,
+                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsx"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmin"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("xmax"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<int32_t>("Nbinsy"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymin"),
+                                     psTTStub_Endcap_Bw_XY.getParameter<double>("ymax"));
+  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position x [cm]", 1);
+  Stub_Endcap_Bw_XY->setAxisTitle("L1 Stub Endcap position y [cm]", 2);
+
+  // TTStub #rho vs. z
+  edm::ParameterSet psTTStub_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
+  HistoName = "Stub_RZ";
+  Stub_RZ = iBooker.book2D(HistoName,
+                           HistoName,
+                           psTTStub_RZ.getParameter<int32_t>("Nbinsx"),
+                           psTTStub_RZ.getParameter<double>("xmin"),
+                           psTTStub_RZ.getParameter<double>("xmax"),
+                           psTTStub_RZ.getParameter<int32_t>("Nbinsy"),
+                           psTTStub_RZ.getParameter<double>("ymin"),
+                           psTTStub_RZ.getParameter<double>("ymax"));
+  Stub_RZ->setAxisTitle("L1 Stub position z [cm]", 1);
+  Stub_RZ->setAxisTitle("L1 Stub position #rho [cm]", 2);
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Stubs");
+  // TTStub eta
+  edm::ParameterSet psTTStub_Eta = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Eta");
+  HistoName = "Stub_Eta";
+  Stub_Eta = iBooker.book1D(HistoName,
+                            HistoName,
+                            psTTStub_Eta.getParameter<int32_t>("Nbinsx"),
+                            psTTStub_Eta.getParameter<double>("xmin"),
+                            psTTStub_Eta.getParameter<double>("xmax"));
+  Stub_Eta->setAxisTitle("#eta", 1);
+  Stub_Eta->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub phi
+  edm::ParameterSet psTTStub_Phi = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Phi");
+  HistoName = "Stub_Phi";
+  Stub_Phi = iBooker.book1D(HistoName,
+                            HistoName,
+                            psTTStub_Phi.getParameter<int32_t>("Nbinsx"),
+                            psTTStub_Phi.getParameter<double>("xmin"),
+                            psTTStub_Phi.getParameter<double>("xmax"));
+  Stub_Phi->setAxisTitle("#phi", 1);
+  Stub_Phi->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub R
+  edm::ParameterSet psTTStub_R = conf_.getParameter<edm::ParameterSet>("TH1TTStub_R");
+  HistoName = "Stub_R";
+  Stub_R = iBooker.book1D(HistoName,
+                          HistoName,
+                          psTTStub_R.getParameter<int32_t>("Nbinsx"),
+                          psTTStub_R.getParameter<double>("xmin"),
+                          psTTStub_R.getParameter<double>("xmax"));
+  Stub_R->setAxisTitle("R", 1);
+  Stub_R->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub trigger bend
+  edm::ParameterSet psTTStub_bend = conf_.getParameter<edm::ParameterSet>("TH1TTStub_bend");
+  HistoName = "Stub_bendFE";
+  Stub_bendFE = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                               psTTStub_bend.getParameter<double>("xmin"),
+                               psTTStub_bend.getParameter<double>("xmax"));
+  Stub_bendFE->setAxisTitle("Trigger bend", 1);
+  Stub_bendFE->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub hardware bend
+  HistoName = "Stub_bendBE";
+  Stub_bendBE = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTStub_bend.getParameter<int32_t>("Nbinsx"),
+                               psTTStub_bend.getParameter<double>("xmin"),
+                               psTTStub_bend.getParameter<double>("xmax"));
+  Stub_bendBE->setAxisTitle("Hardware bend", 1);
+  Stub_bendBE->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub, is PS?
+  edm::ParameterSet psTTStub_isPS = conf_.getParameter<edm::ParameterSet>("TH1TTStub_isPS");
+  HistoName = "Stub_isPS";
+  Stub_isPS = iBooker.book1D(HistoName,
+                             HistoName,
+                             psTTStub_isPS.getParameter<int32_t>("Nbinsx"),
+                             psTTStub_isPS.getParameter<double>("xmin"),
+                             psTTStub_isPS.getParameter<double>("xmax"));
+  Stub_isPS->setAxisTitle("Is PS?", 1);
+  Stub_isPS->setAxisTitle("# L1 Stubs ", 2);
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Stubs/NStubs");
+  // TTStub barrel stack
+  edm::ParameterSet psTTStub_Barrel = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Layers");
+  HistoName = "NStubs_Barrel";
+  Stub_Barrel = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTTStub_Barrel.getParameter<int32_t>("Nbinsx"),
+                               psTTStub_Barrel.getParameter<double>("xmin"),
+                               psTTStub_Barrel.getParameter<double>("xmax"));
+  Stub_Barrel->setAxisTitle("Barrel Layer", 1);
+  Stub_Barrel->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub Endcap stack
+  edm::ParameterSet psTTStub_ECDisc = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Discs");
+  HistoName = "NStubs_Endcap_Disc";
+  Stub_Endcap_Disc = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                    psTTStub_ECDisc.getParameter<double>("xmin"),
+                                    psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc->setAxisTitle("Endcap Disc", 1);
+  Stub_Endcap_Disc->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub Endcap stack
+  HistoName = "NStubs_Endcap_Disc_Fw";
+  Stub_Endcap_Disc_Fw = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                       psTTStub_ECDisc.getParameter<double>("xmin"),
+                                       psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Fw->setAxisTitle("Forward Endcap Disc", 1);
+  Stub_Endcap_Disc_Fw->setAxisTitle("# L1 Stubs ", 2);
+
+  // TTStub Endcap stack
+  HistoName = "NStubs_Endcap_Disc_Bw";
+  Stub_Endcap_Disc_Bw = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psTTStub_ECDisc.getParameter<int32_t>("Nbinsx"),
+                                       psTTStub_ECDisc.getParameter<double>("xmin"),
+                                       psTTStub_ECDisc.getParameter<double>("xmax"));
+  Stub_Endcap_Disc_Bw->setAxisTitle("Backward Endcap Disc", 1);
+  Stub_Endcap_Disc_Bw->setAxisTitle("# L1 Stubs ", 2);
+
+  edm::ParameterSet psTTStub_ECRing = conf_.getParameter<edm::ParameterSet>("TH1TTStub_Rings");
+  HistoName = "NStubs_Endcap_Ring";
+  Stub_Endcap_Ring = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                    psTTStub_ECRing.getParameter<double>("xmin"),
+                                    psTTStub_ECRing.getParameter<double>("xmax"));
+  Stub_Endcap_Ring->setAxisTitle("Endcap Ring", 1);
+  Stub_Endcap_Ring->setAxisTitle("# L1 Stubs ", 2);
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NStubs_Disc+" + std::to_string(i + 1);
+    // TTStub Endcap stack
+    Stub_Endcap_Ring_Fw[i] = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTStub_ECRing.getParameter<double>("xmin"),
+                                            psTTStub_ECRing.getParameter<double>("xmax"));
+    Stub_Endcap_Ring_Fw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_Fw[i]->setAxisTitle("# L1 Stubs ", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "NStubs_Disc-" + std::to_string(i + 1);
+    // TTStub Endcap stack
+    Stub_Endcap_Ring_Bw[i] = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psTTStub_ECRing.getParameter<int32_t>("Nbinsx"),
+                                            psTTStub_ECRing.getParameter<double>("xmin"),
+                                            psTTStub_ECRing.getParameter<double>("xmax"));
+    Stub_Endcap_Ring_Bw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_Bw[i]->setAxisTitle("# L1 Stubs ", 2);
+  }
+
+  // TTStub displ/offset
+  edm::ParameterSet psTTStub_Barrel_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Layer");
+  edm::ParameterSet psTTStub_ECDisc_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Disc");
+  edm::ParameterSet psTTStub_ECRing_2D = conf_.getParameter<edm::ParameterSet>("TH2TTStub_DisOf_Ring");
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Width");
+  HistoName = "Stub_Width_Barrel";
+  Stub_Barrel_W = iBooker.book2D(HistoName,
+                                 HistoName,
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_W->setAxisTitle("Barrel Layer", 1);
+  Stub_Barrel_W->setAxisTitle("Displacement - Offset", 2);
+
+  HistoName = "Stub_Width_Endcap_Disc";
+  Stub_Endcap_Disc_W = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_W->setAxisTitle("Endcap Disc", 1);
+  Stub_Endcap_Disc_W->setAxisTitle("Displacement - Offset", 2);
+
+  HistoName = "Stub_Width_Endcap_Ring";
+  Stub_Endcap_Ring_W = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_W->setAxisTitle("Endcap Ring", 1);
+  Stub_Endcap_Ring_W->setAxisTitle("Trigger Offset", 2);
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "Stub_Width_Disc+" + std::to_string(i + 1);
+    Stub_Endcap_Ring_W_Fw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_W_Fw[i]->setAxisTitle("Displacement - Offset", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "Stub_Width_Disc-" + std::to_string(i + 1);
+    Stub_Endcap_Ring_W_Bw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_W_Bw[i]->setAxisTitle("Displacement - Offset", 2);
+  }
+
+  iBooker.setCurrentFolder(topFolderName_ + "/Stubs/Offset");
+  HistoName = "Stub_Offset_Barrel";
+  Stub_Barrel_O = iBooker.book2D(HistoName,
+                                 HistoName,
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsx"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("xmax"),
+                                 psTTStub_Barrel_2D.getParameter<int32_t>("Nbinsy"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymin"),
+                                 psTTStub_Barrel_2D.getParameter<double>("ymax"));
+  Stub_Barrel_O->setAxisTitle("Barrel Layer", 1);
+  Stub_Barrel_O->setAxisTitle("Trigger Offset", 2);
+
+  HistoName = "Stub_Offset_Endcap_Disc";
+  Stub_Endcap_Disc_O = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECDisc_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECDisc_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Disc_O->setAxisTitle("Endcap Disc", 1);
+  Stub_Endcap_Disc_O->setAxisTitle("Trigger Offset", 2);
+
+  HistoName = "Stub_Offset_Endcap_Ring";
+  Stub_Endcap_Ring_O = iBooker.book2D(HistoName,
+                                      HistoName,
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                      psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                      psTTStub_ECRing_2D.getParameter<double>("ymax"));
+  Stub_Endcap_Ring_O->setAxisTitle("Endcap Ring", 1);
+  Stub_Endcap_Ring_O->setAxisTitle("Trigger Offset", 2);
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "Stub_Offset_Disc+" + std::to_string(i + 1);
+    Stub_Endcap_Ring_O_Fw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_O_Fw[i]->setAxisTitle("Trigger Offset", 2);
+  }
+
+  for (int i = 0; i < numDiscs; i++) {
+    HistoName = "Stub_Offset_Disc-" + std::to_string(i + 1);
+    Stub_Endcap_Ring_O_Bw[i] = iBooker.book2D(HistoName,
+                                              HistoName,
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsx"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("xmax"),
+                                              psTTStub_ECRing_2D.getParameter<int32_t>("Nbinsy"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymin"),
+                                              psTTStub_ECRing_2D.getParameter<double>("ymax"));
+    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Endcap Ring", 1);
+    Stub_Endcap_Ring_O_Bw[i]->setAxisTitle("Trigger Offset", 2);
+  }
+}
+void Phase2OTMonitorTTStub::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // Phase2OTMonitorTTStub
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 960);
+    psd0.add<double>("xmax", 120);
+    psd0.add<double>("xmin", -120);
+    psd0.add<int>("Nbinsy", 960);
+    psd0.add<double>("ymax", 120);
+    psd0.add<double>("ymin", -120);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_Position", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 900);
+    psd0.add<double>("xmax", 300);
+    psd0.add<double>("xmin", -300);
+    psd0.add<int>("Nbinsy", 900);
+    psd0.add<double>("ymax", 120);
+    psd0.add<double>("ymin", 0);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_RZ", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmin", -5);
+    psd0.add<double>("xmax", 5);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_Eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 60);
+    psd0.add<double>("xmin", -3.5);
+    psd0.add<double>("xmax", 3.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_Phi", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmin", 0);
+    psd0.add<double>("xmax", 120);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_R", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 69);
+    psd0.add<double>("xmin", -8.625);
+    psd0.add<double>("xmax", 8.625);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_bend", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 2);
+    psd0.add<double>("xmin", 0.0);
+    psd0.add<double>("xmax", 2.0);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_isPS", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 7);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<double>("xmax", 7.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_Layers", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 6);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<double>("xmax", 6.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_Discs", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 16);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<double>("xmax", 16.5);
+    desc.add<edm::ParameterSetDescription>("TH1TTStub_Rings", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 6);
+    psd0.add<double>("xmax", 6.5);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<int>("Nbinsy", 43);
+    psd0.add<double>("ymax", 10.75);
+    psd0.add<double>("ymin", -10.75);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Layer", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 5);
+    psd0.add<double>("xmax", 5.5);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<int>("Nbinsy", 43);
+    psd0.add<double>("ymax", 10.75);
+    psd0.add<double>("ymin", -10.75);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Disc", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 16);
+    psd0.add<double>("xmax", 16.5);
+    psd0.add<double>("xmin", 0.5);
+    psd0.add<int>("Nbinsy", 43);
+    psd0.add<double>("ymax", 10.75);
+    psd0.add<double>("ymin", -10.75);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_DisOf_Ring", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTStub");
+  desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis", "StubAccepted"));
+  descriptions.add("Phase2OTMonitorTTStub", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(Phase2OTMonitorTTStub);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -1,0 +1,807 @@
+// Package:    SiOuterTracker
+// Class:      SiOuterTracker
+//
+// Original Author:  Isis Marina Van Parijs
+// Modified by: Emily MacDonald (emily.kaelyn.macdonald@cern.ch)
+
+// system include files
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+#include <bitset>
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+class Phase2OTMonitorTTTrack : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTMonitorTTTrack(const edm::ParameterSet &);
+  ~Phase2OTMonitorTTTrack() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  /// Low-quality TTTracks (All tracks)
+  MonitorElement *Track_All_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_All_NStubs = nullptr;            // Number of stubs per track
+  MonitorElement *Track_All_NLayersMissed = nullptr;     // Number of layers missed per track
+  MonitorElement *Track_All_Eta_NStubs = nullptr;        // Number of stubs per track vs eta
+  MonitorElement *Track_All_Pt = nullptr;                // pT distrubtion for tracks
+  MonitorElement *Track_All_Eta = nullptr;               // eta distrubtion for tracks
+  MonitorElement *Track_All_Phi = nullptr;               // phi distrubtion for tracks
+  MonitorElement *Track_All_D0 = nullptr;                // d0 distrubtion for tracks
+  MonitorElement *Track_All_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_All_BendChi2 = nullptr;          // Bendchi2 distrubtion for tracks
+  MonitorElement *Track_All_Chi2 = nullptr;              // chi2 distrubtion for tracks
+  MonitorElement *Track_All_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_All_Chi2RZ = nullptr;            // chi2 r-phi distrubtion for tracks
+  MonitorElement *Track_All_Chi2RPhi = nullptr;          // chi2 r-z distrubtion for tracks
+  MonitorElement *Track_All_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
+  MonitorElement *Track_All_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
+  MonitorElement *Track_All_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
+  MonitorElement *Track_All_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
+  MonitorElement *Track_All_Chi2_Probability = nullptr;  // chi2 probability
+  MonitorElement *Track_All_MVA1 = nullptr;              // MVA1 (prompt quality) distribution
+
+  /// High-quality TTTracks; different depending on prompt vs displaced tracks
+  // Quality cuts: chi2/dof<10, bendchi2<2.2 (Prompt), default in config
+  // Quality cuts: chi2/dof<40, bendchi2<2.4 (Extended/Displaced tracks)
+  MonitorElement *Track_HQ_N = nullptr;                 // Number of tracks per event
+  MonitorElement *Track_HQ_NStubs = nullptr;            // Number of stubs per track
+  MonitorElement *Track_HQ_NLayersMissed = nullptr;     // Number of layers missed per track
+  MonitorElement *Track_HQ_Eta_NStubs = nullptr;        // Number of stubs per track vs eta
+  MonitorElement *Track_HQ_Pt = nullptr;                // pT distrubtion for tracks
+  MonitorElement *Track_HQ_Eta = nullptr;               // eta distrubtion for tracks
+  MonitorElement *Track_HQ_Phi = nullptr;               // phi distrubtion for tracks
+  MonitorElement *Track_HQ_D0 = nullptr;                // d0 distrubtion for tracks
+  MonitorElement *Track_HQ_VtxZ = nullptr;              // z0 distrubtion for tracks
+  MonitorElement *Track_HQ_BendChi2 = nullptr;          // Bendchi2 distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2 = nullptr;              // chi2 distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2Red = nullptr;           // chi2/dof distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2RZ = nullptr;            // chi2 r-z distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2RPhi = nullptr;          // chi2 r-phi distrubtion for tracks
+  MonitorElement *Track_HQ_Chi2Red_NStubs = nullptr;    // chi2/dof vs number of stubs
+  MonitorElement *Track_HQ_Chi2Red_Eta = nullptr;       // chi2/dof vs eta of track
+  MonitorElement *Track_HQ_Eta_BarrelStubs = nullptr;   // eta vs number of stubs in barrel
+  MonitorElement *Track_HQ_Eta_ECStubs = nullptr;       // eta vs number of stubs in end caps
+  MonitorElement *Track_HQ_Chi2_Probability = nullptr;  // chi2 probability
+  MonitorElement *Track_HQ_MVA1 = nullptr;              // MVA1 (prompt quality) distribution
+
+private:
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> ttTrackToken_;
+
+  unsigned int HQNStubs_;
+  double HQChi2dof_;
+  double HQBendChi2_;
+  std::string topFolderName_;
+};
+
+// constructors and destructor
+Phase2OTMonitorTTTrack::Phase2OTMonitorTTTrack(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  ttTrackToken_ =
+      consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTTracksTag"));
+  HQNStubs_ = conf_.getParameter<int>("HQNStubs");
+  HQChi2dof_ = conf_.getParameter<double>("HQChi2dof");
+  HQBendChi2_ = conf_.getParameter<double>("HQBendChi2");
+}
+
+Phase2OTMonitorTTTrack::~Phase2OTMonitorTTTrack() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+// ------------ method called for each event  ------------
+void Phase2OTMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  // L1 Primaries
+  edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> TTTrackHandle;
+  iEvent.getByToken(ttTrackToken_, TTTrackHandle);
+
+  /// Track Trigger Tracks
+  unsigned int numAllTracks = 0;
+  unsigned int numHQTracks = 0;
+
+  // Adding protection
+  if (!TTTrackHandle.isValid())
+    return;
+
+  /// Loop over TTTracks
+  unsigned int tkCnt = 0;
+  for (const auto &iterTTTrack : *TTTrackHandle) {
+    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> tempTrackPtr(TTTrackHandle, tkCnt++);  /// Make the pointer
+
+    unsigned int nStubs = tempTrackPtr->getStubRefs().size();
+    int nBarrelStubs = 0;
+    int nECStubs = 0;
+
+    float track_eta = tempTrackPtr->momentum().eta();
+    float track_d0 = tempTrackPtr->d0();
+    float track_bendchi2 = tempTrackPtr->stubPtConsistency();
+    float track_chi2 = tempTrackPtr->chi2();
+    float track_chi2dof = tempTrackPtr->chi2Red();
+    float track_chi2rz = tempTrackPtr->chi2Z();
+    float track_chi2rphi = tempTrackPtr->chi2XY();
+    float track_MVA1 = tempTrackPtr->trkMVA1();
+    int nLayersMissed = 0;
+    unsigned int hitPattern_ = (unsigned int)tempTrackPtr->hitPattern();
+
+    int nbits = floor(log2(hitPattern_)) + 1;
+    int lay_i = 0;
+    bool seq = false;
+    for (int i = 0; i < nbits; i++) {
+      lay_i = ((1 << i) & hitPattern_) >> i;  //0 or 1 in ith bit (right to left)
+      if (lay_i && !seq)
+        seq = true;  //sequence starts when first 1 found
+      if (!lay_i && seq)
+        nLayersMissed++;
+    }
+
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+        theStubs = iterTTTrack.getStubRefs();
+    for (const auto &istub : theStubs) {
+      bool inBarrel = false;
+      bool inEC = false;
+
+      if (istub->getDetId().subdetId() == StripSubdetector::TOB)
+        inBarrel = true;
+      else if (istub->getDetId().subdetId() == StripSubdetector::TID)
+        inEC = true;
+      if (inBarrel)
+        nBarrelStubs++;
+      else if (inEC)
+        nECStubs++;
+    }  // end loop over stubs
+
+    // HQ tracks: bendchi2<2.2 and chi2/dof<10
+    if (nStubs >= HQNStubs_ && track_chi2dof <= HQChi2dof_ && track_bendchi2 <= HQBendChi2_) {
+      numHQTracks++;
+
+      Track_HQ_NStubs->Fill(nStubs);
+      Track_HQ_NLayersMissed->Fill(nLayersMissed);
+      Track_HQ_Eta_NStubs->Fill(track_eta, nStubs);
+      Track_HQ_Pt->Fill(tempTrackPtr->momentum().perp());
+      Track_HQ_Eta->Fill(track_eta);
+      Track_HQ_Phi->Fill(tempTrackPtr->momentum().phi());
+      Track_HQ_D0->Fill(track_d0);
+      Track_HQ_VtxZ->Fill(tempTrackPtr->z0());
+      Track_HQ_BendChi2->Fill(track_bendchi2);
+      Track_HQ_Chi2->Fill(track_chi2);
+      Track_HQ_Chi2RZ->Fill(track_chi2rz);
+      Track_HQ_Chi2RPhi->Fill(track_chi2rphi);
+      Track_HQ_Chi2Red->Fill(track_chi2dof);
+      Track_HQ_Chi2Red_NStubs->Fill(nStubs, track_chi2dof);
+      Track_HQ_Chi2Red_Eta->Fill(track_eta, track_chi2dof);
+      Track_HQ_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
+      Track_HQ_Eta_ECStubs->Fill(track_eta, nECStubs);
+      Track_HQ_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
+      Track_HQ_MVA1->Fill(track_MVA1);
+    }
+
+    // All tracks (including HQ tracks)
+    numAllTracks++;
+    Track_All_NStubs->Fill(nStubs);
+    Track_All_NLayersMissed->Fill(nLayersMissed);
+    Track_All_Eta_NStubs->Fill(track_eta, nStubs);
+    Track_All_Pt->Fill(tempTrackPtr->momentum().perp());
+    Track_All_Eta->Fill(track_eta);
+    Track_All_Phi->Fill(tempTrackPtr->momentum().phi());
+    Track_All_D0->Fill(track_d0);
+    Track_All_VtxZ->Fill(tempTrackPtr->z0());
+    Track_All_BendChi2->Fill(track_bendchi2);
+    Track_All_Chi2->Fill(track_chi2);
+    Track_All_Chi2RZ->Fill(track_chi2rz);
+    Track_All_Chi2RPhi->Fill(track_chi2rphi);
+    Track_All_Chi2Red->Fill(track_chi2dof);
+    Track_All_Chi2Red_NStubs->Fill(nStubs, track_chi2dof);
+    Track_All_Chi2Red_Eta->Fill(track_eta, track_chi2dof);
+    Track_All_Eta_BarrelStubs->Fill(track_eta, nBarrelStubs);
+    Track_All_Eta_ECStubs->Fill(track_eta, nECStubs);
+    Track_All_Chi2_Probability->Fill(ChiSquaredProbability(track_chi2, nStubs));
+    Track_All_MVA1->Fill(track_MVA1);
+  }  // End of loop over TTTracks
+
+  Track_HQ_N->Fill(numHQTracks);
+  Track_All_N->Fill(numAllTracks);
+}  // end of method
+
+// ------------ method called once each job just before starting event loop
+// ------------
+// Creating all histograms for DQM file output
+void Phase2OTMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
+                                                edm::Run const &run,
+                                                edm::EventSetup const &es) {
+  std::string HistoName;
+
+  /// Low-quality tracks (All tracks, including HQ tracks)
+  iBooker.setCurrentFolder(topFolderName_ + "/Tracks/All");
+  // Nb of L1Tracks
+  HistoName = "Track_All_N";
+  edm::ParameterSet psTrack_N = conf_.getParameter<edm::ParameterSet>("TH1_NTracks");
+  Track_All_N = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTrack_N.getParameter<int32_t>("Nbinsx"),
+                               psTrack_N.getParameter<double>("xmin"),
+                               psTrack_N.getParameter<double>("xmax"));
+  Track_All_N->setAxisTitle("# L1 Tracks", 1);
+  Track_All_N->setAxisTitle("# Events", 2);
+
+  // Number of stubs
+  edm::ParameterSet psTrack_NStubs = conf_.getParameter<edm::ParameterSet>("TH1_NStubs");
+  HistoName = "Track_All_NStubs";
+  Track_All_NStubs = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_NStubs.getParameter<double>("xmin"),
+                                    psTrack_NStubs.getParameter<double>("xmax"));
+  Track_All_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
+  Track_All_NStubs->setAxisTitle("# L1 Tracks", 2);
+
+  // Number of layers missed
+  HistoName = "Track_All_NLayersMissed";
+  Track_All_NLayersMissed = iBooker.book1D(HistoName,
+                                           HistoName,
+                                           psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_NStubs.getParameter<double>("xmin"),
+                                           psTrack_NStubs.getParameter<double>("xmax"));
+  Track_All_NLayersMissed->setAxisTitle("# Layers missed", 1);
+  Track_All_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
+
+  edm::ParameterSet psTrack_Eta_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Eta_NStubs");
+  HistoName = "Track_All_Eta_NStubs";
+  Track_All_Eta_NStubs = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_All_Eta_NStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
+
+  // Pt of the tracks
+  edm::ParameterSet psTrack_Pt = conf_.getParameter<edm::ParameterSet>("TH1_Track_Pt");
+  HistoName = "Track_All_Pt";
+  Track_All_Pt = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_Pt.getParameter<int32_t>("Nbinsx"),
+                                psTrack_Pt.getParameter<double>("xmin"),
+                                psTrack_Pt.getParameter<double>("xmax"));
+  Track_All_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  Track_All_Pt->setAxisTitle("# L1 Tracks", 2);
+
+  // Phi
+  edm::ParameterSet psTrack_Phi = conf_.getParameter<edm::ParameterSet>("TH1_Track_Phi");
+  HistoName = "Track_All_Phi";
+  Track_All_Phi = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_Phi.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_Phi.getParameter<double>("xmin"),
+                                 psTrack_Phi.getParameter<double>("xmax"));
+  Track_All_Phi->setAxisTitle("#phi", 1);
+  Track_All_Phi->setAxisTitle("# L1 Tracks", 2);
+
+  // D0
+  edm::ParameterSet psTrack_D0 = conf_.getParameter<edm::ParameterSet>("TH1_Track_D0");
+  HistoName = "Track_All_D0";
+  Track_All_D0 = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_D0.getParameter<int32_t>("Nbinsx"),
+                                psTrack_D0.getParameter<double>("xmin"),
+                                psTrack_D0.getParameter<double>("xmax"));
+  Track_All_D0->setAxisTitle("Track D0", 1);
+  Track_All_D0->setAxisTitle("# L1 Tracks", 2);
+
+  // Eta
+  edm::ParameterSet psTrack_Eta = conf_.getParameter<edm::ParameterSet>("TH1_Track_Eta");
+  HistoName = "Track_All_Eta";
+  Track_All_Eta = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_Eta.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_Eta.getParameter<double>("xmin"),
+                                 psTrack_Eta.getParameter<double>("xmax"));
+  Track_All_Eta->setAxisTitle("#eta", 1);
+  Track_All_Eta->setAxisTitle("# L1 Tracks", 2);
+
+  // VtxZ
+  edm::ParameterSet psTrack_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1_Track_VtxZ");
+  HistoName = "Track_All_VtxZ";
+  Track_All_VtxZ = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_VtxZ.getParameter<double>("xmin"),
+                                  psTrack_VtxZ.getParameter<double>("xmax"));
+  Track_All_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
+  Track_All_VtxZ->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2
+  edm::ParameterSet psTrack_Chi2 = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2");
+  HistoName = "Track_All_Chi2";
+  Track_All_Chi2 = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_Chi2.getParameter<double>("xmin"),
+                                  psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_All_Chi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-z
+  HistoName = "Track_All_Chi2RZ";
+  Track_All_Chi2RZ = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2.getParameter<double>("xmin"),
+                                    psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
+  Track_All_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-phi
+  HistoName = "Track_All_Chi2RPhi";
+  Track_All_Chi2RPhi = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                      psTrack_Chi2.getParameter<double>("xmin"),
+                                      psTrack_Chi2.getParameter<double>("xmax"));
+  Track_All_Chi2RPhi->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_All_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
+
+  // Bendchi2
+  edm::ParameterSet psTrack_Chi2R = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  HistoName = "Track_All_BendChi2";
+  Track_All_BendChi2 = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                      psTrack_Chi2R.getParameter<double>("xmin"),
+                                      psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_All_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
+  Track_All_BendChi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2Red
+  edm::ParameterSet psTrack_Chi2Red = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2R");
+  HistoName = "Track_All_Chi2Red";
+  Track_All_Chi2Red = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2R.getParameter<double>("xmin"),
+                                     psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_All_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
+  Track_All_Chi2Red->setAxisTitle("# L1 Tracks", 2);
+
+  // Chi2 prob
+  edm::ParameterSet psTrack_Chi2_Probability = conf_.getParameter<edm::ParameterSet>("TH1_Track_Chi2_Probability");
+  HistoName = "Track_All_Chi2_Probability";
+  Track_All_Chi2_Probability = iBooker.book1D(HistoName,
+                                              HistoName,
+                                              psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
+                                              psTrack_Chi2_Probability.getParameter<double>("xmin"),
+                                              psTrack_Chi2_Probability.getParameter<double>("xmax"));
+  Track_All_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
+  Track_All_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
+
+  // MVA1 (prompt quality)
+  edm::ParameterSet psTrack_MVA1 = conf_.getParameter<edm::ParameterSet>("TH1_Track_MVA1");
+  HistoName = "Track_All_MVA1";
+  Track_All_MVA1 = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+                                  psTrack_MVA1.getParameter<double>("xmin"),
+                                  psTrack_MVA1.getParameter<double>("xmax"));
+  Track_All_MVA1->setAxisTitle("MVA1", 1);
+  Track_All_MVA1->setAxisTitle("# L1 Tracks", 2);
+
+  // Reduced chi2 vs #stubs
+  edm::ParameterSet psTrack_Chi2R_NStubs = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_NStubs");
+  HistoName = "Track_All_Chi2Red_NStubs";
+  Track_All_Chi2Red_NStubs = iBooker.book2D(HistoName,
+                                            HistoName,
+                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
+                                            psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
+                                            psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
+  Track_All_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_All_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // chi2/dof vs eta
+  edm::ParameterSet psTrack_Chi2R_Eta = conf_.getParameter<edm::ParameterSet>("TH2_Track_Chi2R_Eta");
+  HistoName = "Track_All_Chi2Red_Eta";
+  Track_All_Chi2Red_Eta = iBooker.book2D(HistoName,
+                                         HistoName,
+                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("xmin"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("xmax"),
+                                         psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("ymin"),
+                                         psTrack_Chi2R_Eta.getParameter<double>("ymax"));
+  Track_All_Chi2Red_Eta->setAxisTitle("#eta", 1);
+  Track_All_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // Eta vs #stubs in barrel
+  HistoName = "Track_All_Eta_BarrelStubs";
+  Track_All_Eta_BarrelStubs = iBooker.book2D(HistoName,
+                                             HistoName,
+                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                             psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                             psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                             psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                             psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                             psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_All_Eta_BarrelStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
+
+  // Eta vs #stubs in EC
+  HistoName = "Track_LQ_Eta_ECStubs";
+  Track_All_Eta_ECStubs = iBooker.book2D(HistoName,
+                                         HistoName,
+                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                         psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                         psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                         psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                         psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                         psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_All_Eta_ECStubs->setAxisTitle("#eta", 1);
+  Track_All_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
+
+  /// High-quality tracks (Bendchi2 < 2.2 and chi2/dof < 10)
+  iBooker.setCurrentFolder(topFolderName_ + "/Tracks/HQ");
+  // Nb of L1Tracks
+  HistoName = "Track_HQ_N";
+  Track_HQ_N = iBooker.book1D(HistoName,
+                              HistoName,
+                              psTrack_N.getParameter<int32_t>("Nbinsx"),
+                              psTrack_N.getParameter<double>("xmin"),
+                              psTrack_N.getParameter<double>("xmax"));
+  Track_HQ_N->setAxisTitle("# L1 Tracks", 1);
+  Track_HQ_N->setAxisTitle("# Events", 2);
+
+  // Number of stubs
+  HistoName = "Track_HQ_NStubs";
+  Track_HQ_NStubs = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                   psTrack_NStubs.getParameter<double>("xmin"),
+                                   psTrack_NStubs.getParameter<double>("xmax"));
+  Track_HQ_NStubs->setAxisTitle("# L1 Stubs per L1 Track", 1);
+  Track_HQ_NStubs->setAxisTitle("# L1 Tracks", 2);
+
+  // Number of layers missed
+  HistoName = "Track_HQ_NLayersMissed";
+  Track_HQ_NLayersMissed = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psTrack_NStubs.getParameter<int32_t>("Nbinsx"),
+                                          psTrack_NStubs.getParameter<double>("xmin"),
+                                          psTrack_NStubs.getParameter<double>("xmax"));
+  Track_HQ_NLayersMissed->setAxisTitle("# Layers missed", 1);
+  Track_HQ_NLayersMissed->setAxisTitle("# L1 Tracks", 2);
+
+  // Track eta vs #stubs
+  HistoName = "Track_HQ_Eta_NStubs";
+  Track_HQ_Eta_NStubs = iBooker.book2D(HistoName,
+                                       HistoName,
+                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                       psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                       psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                       psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                       psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                       psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_NStubs->setAxisTitle("#eta", 1);
+  Track_HQ_Eta_NStubs->setAxisTitle("# L1 Stubs", 2);
+
+  // Pt of the tracks
+  HistoName = "Track_HQ_Pt";
+  Track_HQ_Pt = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTrack_Pt.getParameter<int32_t>("Nbinsx"),
+                               psTrack_Pt.getParameter<double>("xmin"),
+                               psTrack_Pt.getParameter<double>("xmax"));
+  Track_HQ_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  Track_HQ_Pt->setAxisTitle("# L1 Tracks", 2);
+
+  // Phi
+  HistoName = "Track_HQ_Phi";
+  Track_HQ_Phi = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_Phi.getParameter<int32_t>("Nbinsx"),
+                                psTrack_Phi.getParameter<double>("xmin"),
+                                psTrack_Phi.getParameter<double>("xmax"));
+  Track_HQ_Phi->setAxisTitle("#phi", 1);
+  Track_HQ_Phi->setAxisTitle("# L1 Tracks", 2);
+
+  // D0
+  HistoName = "Track_HQ_D0";
+  Track_HQ_D0 = iBooker.book1D(HistoName,
+                               HistoName,
+                               psTrack_D0.getParameter<int32_t>("Nbinsx"),
+                               psTrack_D0.getParameter<double>("xmin"),
+                               psTrack_D0.getParameter<double>("xmax"));
+  Track_HQ_D0->setAxisTitle("Track D0", 1);
+  Track_HQ_D0->setAxisTitle("# L1 Tracks", 2);
+
+  // Eta
+  HistoName = "Track_HQ_Eta";
+  Track_HQ_Eta = iBooker.book1D(HistoName,
+                                HistoName,
+                                psTrack_Eta.getParameter<int32_t>("Nbinsx"),
+                                psTrack_Eta.getParameter<double>("xmin"),
+                                psTrack_Eta.getParameter<double>("xmax"));
+  Track_HQ_Eta->setAxisTitle("#eta", 1);
+  Track_HQ_Eta->setAxisTitle("# L1 Tracks", 2);
+
+  // VtxZ
+  HistoName = "Track_HQ_VtxZ";
+  Track_HQ_VtxZ = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_VtxZ.getParameter<double>("xmin"),
+                                 psTrack_VtxZ.getParameter<double>("xmax"));
+  Track_HQ_VtxZ->setAxisTitle("L1 Track vertex position z [cm]", 1);
+  Track_HQ_VtxZ->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2
+  HistoName = "Track_HQ_Chi2";
+  Track_HQ_Chi2 = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_Chi2.getParameter<double>("xmin"),
+                                 psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2->setAxisTitle("L1 Track #chi^{2}", 1);
+  Track_HQ_Chi2->setAxisTitle("# L1 Tracks", 2);
+
+  // Bendchi2
+  HistoName = "Track_HQ_BendChi2";
+  Track_HQ_BendChi2 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2R.getParameter<double>("xmin"),
+                                     psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_HQ_BendChi2->setAxisTitle("L1 Track Bend #chi^{2}", 1);
+  Track_HQ_BendChi2->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2 r-z
+  HistoName = "Track_HQ_Chi2RZ";
+  Track_HQ_Chi2RZ = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                   psTrack_Chi2.getParameter<double>("xmin"),
+                                   psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2RZ->setAxisTitle("L1 Track #chi^{2} r-z", 1);
+  Track_HQ_Chi2RZ->setAxisTitle("# L1 Tracks", 2);
+
+  HistoName = "Track_HQ_Chi2RPhi";
+  Track_HQ_Chi2RPhi = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psTrack_Chi2.getParameter<int32_t>("Nbinsx"),
+                                     psTrack_Chi2.getParameter<double>("xmin"),
+                                     psTrack_Chi2.getParameter<double>("xmax"));
+  Track_HQ_Chi2RPhi->setAxisTitle("L1 Track #chi^{2} r-phi", 1);
+  Track_HQ_Chi2RPhi->setAxisTitle("# L1 Tracks", 2);
+
+  // chi2Red
+  HistoName = "Track_HQ_Chi2Red";
+  Track_HQ_Chi2Red = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psTrack_Chi2R.getParameter<int32_t>("Nbinsx"),
+                                    psTrack_Chi2R.getParameter<double>("xmin"),
+                                    psTrack_Chi2R.getParameter<double>("xmax"));
+  Track_HQ_Chi2Red->setAxisTitle("L1 Track #chi^{2}/ndf", 1);
+  Track_HQ_Chi2Red->setAxisTitle("# L1 Tracks", 2);
+
+  // Chi2 prob
+  HistoName = "Track_HQ_Chi2_Probability";
+  Track_HQ_Chi2_Probability = iBooker.book1D(HistoName,
+                                             HistoName,
+                                             psTrack_Chi2_Probability.getParameter<int32_t>("Nbinsx"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmin"),
+                                             psTrack_Chi2_Probability.getParameter<double>("xmax"));
+  Track_HQ_Chi2_Probability->setAxisTitle("#chi^{2} probability", 1);
+  Track_HQ_Chi2_Probability->setAxisTitle("# L1 Tracks", 2);
+
+  // MVA1 (prompt quality)
+  HistoName = "Track_HQ_MVA1";
+  Track_HQ_MVA1 = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrack_MVA1.getParameter<int32_t>("Nbinsx"),
+                                 psTrack_MVA1.getParameter<double>("xmin"),
+                                 psTrack_MVA1.getParameter<double>("xmax"));
+  Track_HQ_MVA1->setAxisTitle("MVA1", 1);
+  Track_HQ_MVA1->setAxisTitle("# L1 Tracks", 2);
+
+  // Reduced chi2 vs #stubs
+  HistoName = "Track_HQ_Chi2Red_NStubs";
+  Track_HQ_Chi2Red_NStubs = iBooker.book2D(HistoName,
+                                           HistoName,
+                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsx"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("xmin"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("xmax"),
+                                           psTrack_Chi2R_NStubs.getParameter<int32_t>("Nbinsy"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("ymin"),
+                                           psTrack_Chi2R_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Chi2Red_NStubs->setAxisTitle("# L1 Stubs", 1);
+  Track_HQ_Chi2Red_NStubs->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // chi2/dof vs eta
+  HistoName = "Track_HQ_Chi2Red_Eta";
+  Track_HQ_Chi2Red_Eta = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("xmax"),
+                                        psTrack_Chi2R_Eta.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymin"),
+                                        psTrack_Chi2R_Eta.getParameter<double>("ymax"));
+  Track_HQ_Chi2Red_Eta->setAxisTitle("#eta", 1);
+  Track_HQ_Chi2Red_Eta->setAxisTitle("L1 Track #chi^{2}/ndf", 2);
+
+  // eta vs #stubs in barrel
+  HistoName = "Track_HQ_Eta_BarrelStubs";
+  Track_HQ_Eta_BarrelStubs = iBooker.book2D(HistoName,
+                                            HistoName,
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                            psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                            psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_BarrelStubs->setAxisTitle("#eta", 1);
+  Track_HQ_Eta_BarrelStubs->setAxisTitle("# L1 Barrel Stubs", 2);
+
+  // eta vs #stubs in EC
+  HistoName = "Track_HQ_Eta_ECStubs";
+  Track_HQ_Eta_ECStubs = iBooker.book2D(HistoName,
+                                        HistoName,
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsx"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("xmax"),
+                                        psTrack_Eta_NStubs.getParameter<int32_t>("Nbinsy"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymin"),
+                                        psTrack_Eta_NStubs.getParameter<double>("ymax"));
+  Track_HQ_Eta_ECStubs->setAxisTitle("#eta", 1);
+  Track_HQ_Eta_ECStubs->setAxisTitle("# L1 EC Stubs", 2);
+
+}  // end of method
+
+void Phase2OTMonitorTTTrack::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // Phase2OTMonitorTTTrack
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 8);
+    psd0.add<double>("xmax", 8);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_NStubs", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 399);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_NTracks", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 100);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Pt", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 60);
+    psd0.add<double>("xmax", 3.5);
+    psd0.add<double>("xmin", -3.5);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Phi", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 5.0);
+    psd0.add<double>("xmin", -5.0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_D0", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmax", 3.0);
+    psd0.add<double>("xmin", -3.0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 41);
+    psd0.add<double>("xmax", 20);
+    psd0.add<double>("xmin", -20);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_VtxZ", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 50);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 10);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2R", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 1);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_Chi2_Probability", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 1);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1_Track_MVA1", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 5);
+    psd0.add<double>("xmax", 8);
+    psd0.add<double>("xmin", 3);
+    psd0.add<int>("Nbinsy", 15);
+    psd0.add<double>("ymax", 10);
+    psd0.add<double>("ymin", 0);
+    desc.add<edm::ParameterSetDescription>("TH2_Track_Chi2R_NStubs", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 15);
+    psd0.add<double>("xmax", 3.0);
+    psd0.add<double>("xmin", -3.0);
+    psd0.add<int>("Nbinsy", 15);
+    psd0.add<double>("ymax", 10);
+    psd0.add<double>("ymin", 0);
+    desc.add<edm::ParameterSetDescription>("TH2_Track_Chi2R_Eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 15);
+    psd0.add<double>("xmax", 3.0);
+    psd0.add<double>("xmin", -3.0);
+    psd0.add<int>("Nbinsy", 5);
+    psd0.add<double>("ymax", 8);
+    psd0.add<double>("ymin", 3);
+    desc.add<edm::ParameterSetDescription>("TH2_Track_Eta_NStubs", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1Track");
+  desc.add<edm::InputTag>("TTTracksTag", edm::InputTag("l1tTTTracksFromTrackletEmulation", "Level1TTTracks"));
+  desc.add<int>("HQNStubs", 4);
+  desc.add<double>("HQChi2dof", 10.0);
+  desc.add<double>("HQBendChi2", 2.2);
+  descriptions.add("Phase2OTMonitorTTTrack", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+DEFINE_FWK_MODULE(Phase2OTMonitorTTTrack);

--- a/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
+++ b/DQM/SiTrackerPhase2/plugins/Phase2OTMonitorTTTrack.cc
@@ -232,8 +232,8 @@ void Phase2OTMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventS
 // ------------
 // Creating all histograms for DQM file output
 void Phase2OTMonitorTTTrack::bookHistograms(DQMStore::IBooker &iBooker,
-                                                edm::Run const &run,
-                                                edm::EventSetup const &es) {
+                                            edm::Run const &run,
+                                            edm::EventSetup const &es) {
   std::string HistoName;
 
   /// Low-quality tracks (All tracks, including HQ tracks)

--- a/DQM/SiTrackerPhase2/python/Phase2TrackerDQMFirstStep_cff.py
+++ b/DQM/SiTrackerPhase2/python/Phase2TrackerDQMFirstStep_cff.py
@@ -4,12 +4,19 @@ from DQM.SiTrackerPhase2.Phase2ITMonitorRecHit_cff import *
 from DQM.SiTrackerPhase2.Phase2ITMonitorCluster_cff import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorCluster_cff import *
 from DQM.SiTrackerPhase2.Phase2OTMonitorVectorHits_cff import *
+#L1 
+from DQM.SiTrackerPhase2.Phase2OTMonitorTTTrack_cfi import *
+from DQM.SiTrackerPhase2.Phase2OTMonitorTTStub_cfi import *
+from DQM.SiTrackerPhase2.Phase2OTMonitorTTCluster_cfi import *
 
 trackerphase2DQMSource = cms.Sequence( pixDigiMon 
                                        + otDigiMon
                                        +rechitMonitorIT
                                        + clusterMonitorIT
                                        + clusterMonitorOT
+                                       + Phase2OTMonitorTTCluster
+                                       + Phase2OTMonitorTTStub
+                                       + Phase2OTMonitorTTTrack
 )
 
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -208,7 +208,6 @@ DQMOfflinePOGMC = cms.Sequence( DQMOfflinePrePOGMC *
 #DQMOfflineCommon
 from DQM.TrackingMonitorSource.pixelTracksMonitoring_cff import *
 from DQMOffline.RecoB.PixelVertexMonitor_cff import *
-from DQM.SiOuterTracker.OuterTrackerSourceConfig_cff import *
 from Validation.RecoTau.DQMSequences_cfi import *
 
 DQMOfflinePixelTracking = cms.Sequence( pixelTracksMonitoring *
@@ -216,7 +215,6 @@ DQMOfflinePixelTracking = cms.Sequence( pixelTracksMonitoring *
                                         monitorpixelSoASource )
 
 DQMOuterTracker = cms.Sequence( DQMOfflineDCS *
-                                OuterTrackerSource *
                                 DQMMessageLogger *
                                 DQMOfflinePhysics *
                                 DQMOfflineVertex

--- a/Validation/Configuration/python/autoValidation.py
+++ b/Validation/Configuration/python/autoValidation.py
@@ -19,12 +19,11 @@ autoValidation = { 'liteTracking' : ['prevalidationLiteTracking','validationLite
                    'standardValidationNoHLTHiMix' : ['prevalidationNoHLT','validationNoHLTHiMix','validationHarvestingNoHLT'],
                    'HGCalValidation' : ['globalPrevalidationHGCal', 'globalValidationHGCal', 'hgcalValidatorPostProcessor'],
                    'MTDValidation' : ['', 'globalValidationMTD', 'mtdValidationPostProcessor'],
-                   'OuterTrackerValidation' : ['', 'globalValidationOuterTracker', 'postValidationOuterTracker'],
                    'ecalValidation_phase2' : ['', 'validationECALPhase2', ''],
                    'TrackerPhase2Validation' : ['', 'trackerphase2ValidationSource', 'trackerphase2ValidationHarvesting'],
                  }
 
-_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'OuterTrackerValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation', 'standardValidation']
+_phase2_allowed = ['baseValidation','trackingValidation','muonOnlyValidation','JetMETOnlyValidation', 'electronOnlyValidation', 'photonOnlyValidation','bTagOnlyValidation', 'tauOnlyValidation', 'hcalValidation', 'HGCalValidation', 'MTDValidation', 'ecalValidation_phase2', 'TrackerPhase2Validation', 'standardValidation']
 autoValidation['phase2Validation'] = ['','','']
 for i in range(0,3):
     autoValidation['phase2Validation'][i] = '+'.join([_f for _f in [autoValidation[m][i] for m in _phase2_allowed] if _f])

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -44,7 +44,6 @@ from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from Validation.RecoB.BDHadronTrackValidation_cff import *
 from Validation.Configuration.hgcalSimValid_cff import *
 from Validation.Configuration.mtdSimValid_cff import *
-from Validation.SiOuterTrackerV.OuterTrackerSourceConfigV_cff import *
 from Validation.Configuration.ecalSimValid_cff import *
 from Validation.SiTrackerPhase2V.Phase2TrackerValidationFirstStep_cff import *
 
@@ -202,8 +201,6 @@ globalValidationHGCal = cms.Sequence(hgcalValidation)
 globalPrevalidationHGCal = cms.Sequence(hgcalAssociators, ticlSimTrackstersTask)
 
 globalValidationMTD = cms.Sequence()
-
-globalValidationOuterTracker = cms.Sequence(OuterTrackerSourceV)
 
 globalPrevalidationMuons = cms.Sequence(
       gemSimValid

--- a/Validation/SiTrackerPhase2V/plugins/BuildFile.xml
+++ b/Validation/SiTrackerPhase2V/plugins/BuildFile.xml
@@ -11,6 +11,8 @@
 <use name="SimDataFormats/TrackingHit"/>
 <use name="SimDataFormats/Vertex"/>
 <use name="SimDataFormats/TrackerDigiSimLink"/>
+<use name="SimDataFormats/TrackingAnalysis"/>
+<use name="SimTracker/TrackTriggerAssociation"/>
 <use name="SimTracker/TrackerHitAssociation"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTHarvestTrackingParticles.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTHarvestTrackingParticles.cc
@@ -12,17 +12,16 @@ public:
   explicit Phase2OTHarvestTrackingParticles(const edm::ParameterSet &);
   ~Phase2OTHarvestTrackingParticles() override;
   void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
 private:
   // ----------member data ---------------------------
   DQMStore *dbe;
   std::string topFolderName_;
 };
 
-
-Phase2OTHarvestTrackingParticles::Phase2OTHarvestTrackingParticles(const edm::ParameterSet &iConfig) :
-  topFolderName_(iConfig.getParameter<std::string>("TopFolderName"))
-{}
+Phase2OTHarvestTrackingParticles::Phase2OTHarvestTrackingParticles(const edm::ParameterSet &iConfig)
+    : topFolderName_(iConfig.getParameter<std::string>("TopFolderName")) {}
 
 Phase2OTHarvestTrackingParticles::~Phase2OTHarvestTrackingParticles() {}
 
@@ -67,8 +66,7 @@ void Phase2OTHarvestTrackingParticles::dqmEndJob(DQMStore::IBooker &ibooker, DQM
     MonitorElement *merespt_eta0to0p7_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta0to0p7_pt8toInf");
     MonitorElement *merespt_eta0p7to1_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta0p7to1_pt8toInf");
     MonitorElement *merespt_eta1to1p2_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta1to1p2_pt8toInf");
-    MonitorElement *merespt_eta1p2to1p6_pt8toInf =
-        dbe->get(topFolderName_ + "/Resolution/respt_eta1p2to1p6_pt8toInf");
+    MonitorElement *merespt_eta1p2to1p6_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta1p2to1p6_pt8toInf");
     MonitorElement *merespt_eta1p6to2_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta1p6to2_pt8toInf");
     MonitorElement *merespt_eta2to2p4_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta2to2p4_pt8toInf");
 
@@ -502,7 +500,7 @@ void Phase2OTHarvestTrackingParticles::dqmEndJob(DQMStore::IBooker &ibooker, DQM
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-void Phase2OTHarvestTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void Phase2OTHarvestTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1TrackV");
   descriptions.add("Phase2OTHarvestTrackingParticles", desc);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTHarvestTrackingParticles.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTHarvestTrackingParticles.cc
@@ -1,0 +1,510 @@
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+class Phase2OTHarvestTrackingParticles : public DQMEDHarvester {
+public:
+  explicit Phase2OTHarvestTrackingParticles(const edm::ParameterSet &);
+  ~Phase2OTHarvestTrackingParticles() override;
+  void dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  // ----------member data ---------------------------
+  DQMStore *dbe;
+  std::string topFolderName_;
+};
+
+
+Phase2OTHarvestTrackingParticles::Phase2OTHarvestTrackingParticles(const edm::ParameterSet &iConfig) :
+  topFolderName_(iConfig.getParameter<std::string>("TopFolderName"))
+{}
+
+Phase2OTHarvestTrackingParticles::~Phase2OTHarvestTrackingParticles() {}
+
+// ------------ method called once each job just after ending the event loop
+// ------------
+void Phase2OTHarvestTrackingParticles::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  using namespace edm;
+
+  float eta_bins[] = {0.0, 0.7, 1.0, 1.2, 1.6, 2.0, 2.4};
+  int eta_binnum = 6;
+
+  dbe = nullptr;
+  dbe = edm::Service<DQMStore>().operator->();
+
+  if (dbe) {
+    // Find all monitor elements for histograms
+    MonitorElement *meN_eta = dbe->get(topFolderName_ + "/Efficiency/match_tp_eta");
+    MonitorElement *meD_eta = dbe->get(topFolderName_ + "/Efficiency/tp_eta");
+    MonitorElement *meN_pt = dbe->get(topFolderName_ + "/Efficiency/match_tp_pt");
+    MonitorElement *meD_pt = dbe->get(topFolderName_ + "/Efficiency/tp_pt");
+    MonitorElement *meN_pt_zoom = dbe->get(topFolderName_ + "/Efficiency/match_tp_pt_zoom");
+    MonitorElement *meD_pt_zoom = dbe->get(topFolderName_ + "/Efficiency/tp_pt_zoom");
+    MonitorElement *meN_d0 = dbe->get(topFolderName_ + "/Efficiency/match_tp_d0");
+    MonitorElement *meD_d0 = dbe->get(topFolderName_ + "/Efficiency/tp_d0");
+    MonitorElement *meN_VtxR = dbe->get(topFolderName_ + "/Efficiency/match_tp_VtxR");
+    MonitorElement *meD_VtxR = dbe->get(topFolderName_ + "/Efficiency/tp_VtxR");
+    MonitorElement *meN_VtxZ = dbe->get(topFolderName_ + "/Efficiency/match_tp_VtxZ");
+    MonitorElement *meD_VtxZ = dbe->get(topFolderName_ + "/Efficiency/tp_VtxZ");
+
+    MonitorElement *merespt_eta0to0p7_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta0to0p7_pt2to3");
+    MonitorElement *merespt_eta0p7to1_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta0p7to1_pt2to3");
+    MonitorElement *merespt_eta1to1p2_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta1to1p2_pt2to3");
+    MonitorElement *merespt_eta1p2to1p6_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta1p2to1p6_pt2to3");
+    MonitorElement *merespt_eta1p6to2_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta1p6to2_pt2to3");
+    MonitorElement *merespt_eta2to2p4_pt2to3 = dbe->get(topFolderName_ + "/Resolution/respt_eta2to2p4_pt2to3");
+    MonitorElement *merespt_eta0to0p7_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta0to0p7_pt3to8");
+    MonitorElement *merespt_eta0p7to1_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta0p7to1_pt3to8");
+    MonitorElement *merespt_eta1to1p2_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta1to1p2_pt3to8");
+    MonitorElement *merespt_eta1p2to1p6_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta1p2to1p6_pt3to8");
+    MonitorElement *merespt_eta1p6to2_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta1p6to2_pt3to8");
+    MonitorElement *merespt_eta2to2p4_pt3to8 = dbe->get(topFolderName_ + "/Resolution/respt_eta2to2p4_pt3to8");
+    MonitorElement *merespt_eta0to0p7_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta0to0p7_pt8toInf");
+    MonitorElement *merespt_eta0p7to1_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta0p7to1_pt8toInf");
+    MonitorElement *merespt_eta1to1p2_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta1to1p2_pt8toInf");
+    MonitorElement *merespt_eta1p2to1p6_pt8toInf =
+        dbe->get(topFolderName_ + "/Resolution/respt_eta1p2to1p6_pt8toInf");
+    MonitorElement *merespt_eta1p6to2_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta1p6to2_pt8toInf");
+    MonitorElement *merespt_eta2to2p4_pt8toInf = dbe->get(topFolderName_ + "/Resolution/respt_eta2to2p4_pt8toInf");
+
+    MonitorElement *mereseta_eta0to0p7 = dbe->get(topFolderName_ + "/Resolution/reseta_eta0to0p7");
+    MonitorElement *mereseta_eta0p7to1 = dbe->get(topFolderName_ + "/Resolution/reseta_eta0p7to1");
+    MonitorElement *mereseta_eta1to1p2 = dbe->get(topFolderName_ + "/Resolution/reseta_eta1to1p2");
+    MonitorElement *mereseta_eta1p2to1p6 = dbe->get(topFolderName_ + "/Resolution/reseta_eta1p2to1p6");
+    MonitorElement *mereseta_eta1p6to2 = dbe->get(topFolderName_ + "/Resolution/reseta_eta1p6to2");
+    MonitorElement *mereseta_eta2to2p4 = dbe->get(topFolderName_ + "/Resolution/reseta_eta2to2p4");
+
+    MonitorElement *meresphi_eta0to0p7 = dbe->get(topFolderName_ + "/Resolution/resphi_eta0to0p7");
+    MonitorElement *meresphi_eta0p7to1 = dbe->get(topFolderName_ + "/Resolution/resphi_eta0p7to1");
+    MonitorElement *meresphi_eta1to1p2 = dbe->get(topFolderName_ + "/Resolution/resphi_eta1to1p2");
+    MonitorElement *meresphi_eta1p2to1p6 = dbe->get(topFolderName_ + "/Resolution/resphi_eta1p2to1p6");
+    MonitorElement *meresphi_eta1p6to2 = dbe->get(topFolderName_ + "/Resolution/resphi_eta1p6to2");
+    MonitorElement *meresphi_eta2to2p4 = dbe->get(topFolderName_ + "/Resolution/resphi_eta2to2p4");
+
+    MonitorElement *meresVtxZ_eta0to0p7 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta0to0p7");
+    MonitorElement *meresVtxZ_eta0p7to1 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta0p7to1");
+    MonitorElement *meresVtxZ_eta1to1p2 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta1to1p2");
+    MonitorElement *meresVtxZ_eta1p2to1p6 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta1p2to1p6");
+    MonitorElement *meresVtxZ_eta1p6to2 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta1p6to2");
+    MonitorElement *meresVtxZ_eta2to2p4 = dbe->get(topFolderName_ + "/Resolution/resVtxZ_eta2to2p4");
+
+    MonitorElement *meresd0_eta0to0p7 = dbe->get(topFolderName_ + "/Resolution/resd0_eta0to0p7");
+    MonitorElement *meresd0_eta0p7to1 = dbe->get(topFolderName_ + "/Resolution/resd0_eta0p7to1");
+    MonitorElement *meresd0_eta1to1p2 = dbe->get(topFolderName_ + "/Resolution/resd0_eta1to1p2");
+    MonitorElement *meresd0_eta1p2to1p6 = dbe->get(topFolderName_ + "/Resolution/resd0_eta1p2to1p6");
+    MonitorElement *meresd0_eta1p6to2 = dbe->get(topFolderName_ + "/Resolution/resd0_eta1p6to2");
+    MonitorElement *meresd0_eta2to2p4 = dbe->get(topFolderName_ + "/Resolution/resd0_eta2to2p4");
+
+    if (meN_eta && meD_eta) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator = meN_eta->getTH1F();
+      TH1F *denominator = meD_eta->getTH1F();
+      numerator->Sumw2();
+      denominator->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_eta = ibooker.book1D("EtaEfficiency",
+                                                    "#eta efficiency",
+                                                    numerator->GetNbinsX(),
+                                                    numerator->GetXaxis()->GetXmin(),
+                                                    numerator->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_eta->getTH1F()->Divide(numerator, denominator, 1., 1., "B");
+      me_effic_eta->setAxisTitle("tracking particle #eta");
+      me_effic_eta->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_eta->getTH1F()->SetMaximum(1.0);
+      me_effic_eta->getTH1F()->SetMinimum(0.0);
+      me_effic_eta->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for eta efficiency cannot be found!\n";
+    }
+
+    if (meN_pt && meD_pt) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator2 = meN_pt->getTH1F();
+      numerator2->Sumw2();
+      TH1F *denominator2 = meD_pt->getTH1F();
+      denominator2->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_pt = ibooker.book1D("PtEfficiency",
+                                                   "p_{T} efficiency",
+                                                   numerator2->GetNbinsX(),
+                                                   numerator2->GetXaxis()->GetXmin(),
+                                                   numerator2->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_pt->getTH1F()->Divide(numerator2, denominator2, 1., 1., "B");
+      me_effic_pt->setAxisTitle("Tracking particle p_{T} [GeV]");
+      me_effic_pt->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_pt->getTH1F()->SetMaximum(1.0);
+      me_effic_pt->getTH1F()->SetMinimum(0.0);
+      me_effic_pt->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT efficiency cannot be found!\n";
+    }
+
+    if (meN_pt_zoom && meD_pt_zoom) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator2_zoom = meN_pt_zoom->getTH1F();
+      numerator2_zoom->Sumw2();
+      TH1F *denominator2_zoom = meD_pt_zoom->getTH1F();
+      denominator2_zoom->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_pt_zoom = ibooker.book1D("PtEfficiency_zoom",
+                                                        "p_{T} efficiency",
+                                                        numerator2_zoom->GetNbinsX(),
+                                                        numerator2_zoom->GetXaxis()->GetXmin(),
+                                                        numerator2_zoom->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_pt_zoom->getTH1F()->Divide(numerator2_zoom, denominator2_zoom, 1., 1., "B");
+      me_effic_pt_zoom->setAxisTitle("Tracking particle p_{T} [GeV]");
+      me_effic_pt_zoom->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_pt_zoom->getTH1F()->SetMaximum(1.0);
+      me_effic_pt_zoom->getTH1F()->SetMinimum(0.0);
+      me_effic_pt_zoom->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for zoom pT efficiency cannot be found!\n";
+    }
+
+    if (meN_d0 && meD_d0) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator5 = meN_d0->getTH1F();
+      numerator5->Sumw2();
+      TH1F *denominator5 = meD_d0->getTH1F();
+      denominator5->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_d0 = ibooker.book1D("d0Efficiency",
+                                                   "d_{0} efficiency",
+                                                   numerator5->GetNbinsX(),
+                                                   numerator5->GetXaxis()->GetXmin(),
+                                                   numerator5->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_d0->getTH1F()->Divide(numerator5, denominator5, 1., 1., "B");
+      me_effic_d0->setAxisTitle("Tracking particle d_{0} [cm]");
+      me_effic_d0->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_d0->getTH1F()->SetMaximum(1.0);
+      me_effic_d0->getTH1F()->SetMinimum(0.0);
+      me_effic_d0->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for d0 efficiency cannot be found!\n";
+    }
+
+    if (meN_VtxR && meD_VtxR) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator6 = meN_VtxR->getTH1F();
+      numerator6->Sumw2();
+      TH1F *denominator6 = meD_VtxR->getTH1F();
+      denominator6->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_VtxR = ibooker.book1D("VtxREfficiency",
+                                                     "Vtx R efficiency",
+                                                     numerator6->GetNbinsX(),
+                                                     numerator6->GetXaxis()->GetXmin(),
+                                                     numerator6->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_VtxR->getTH1F()->Divide(numerator6, denominator6, 1., 1., "B");
+      me_effic_VtxR->setAxisTitle("Tracking particle VtxR [cm]");
+      me_effic_VtxR->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_VtxR->getTH1F()->SetMaximum(1.0);
+      me_effic_VtxR->getTH1F()->SetMinimum(0.0);
+      me_effic_VtxR->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxR efficiency cannot be found!\n";
+    }
+
+    if (meN_VtxZ && meD_VtxZ) {
+      // Get the numerator and denominator histograms
+      TH1F *numerator7 = meN_VtxZ->getTH1F();
+      numerator7->Sumw2();
+      TH1F *denominator7 = meD_VtxZ->getTH1F();
+      denominator7->Sumw2();
+
+      // Set the current directory
+      dbe->setCurrentFolder(topFolderName_ + "/FinalEfficiency");
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_effic_VtxZ = ibooker.book1D("VtxZEfficiency",
+                                                     "Vtx Z efficiency",
+                                                     numerator7->GetNbinsX(),
+                                                     numerator7->GetXaxis()->GetXmin(),
+                                                     numerator7->GetXaxis()->GetXmax());
+
+      // Calculate the efficiency
+      me_effic_VtxZ->getTH1F()->Divide(numerator7, denominator7, 1., 1., "B");
+      me_effic_VtxZ->setAxisTitle("Tracking particle VtxZ [cm]");
+      me_effic_VtxZ->getTH1F()->GetYaxis()->SetTitle("Efficiency");
+      me_effic_VtxZ->getTH1F()->SetMaximum(1.0);
+      me_effic_VtxZ->getTH1F()->SetMinimum(0.0);
+      me_effic_VtxZ->getTH1F()->SetStats(false);
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxZ efficiency cannot be found!\n";
+    }
+
+    if (merespt_eta0to0p7_pt2to3 && merespt_eta0p7to1_pt2to3 && merespt_eta1to1p2_pt2to3 &&
+        merespt_eta1p2to1p6_pt2to3 && merespt_eta1p6to2_pt2to3 && merespt_eta2to2p4_pt2to3) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resPt1a = merespt_eta0to0p7_pt2to3->getTH1F();
+      TH1F *resPt2a = merespt_eta0p7to1_pt2to3->getTH1F();
+      TH1F *resPt3a = merespt_eta1to1p2_pt2to3->getTH1F();
+      TH1F *resPt4a = merespt_eta1p2to1p6_pt2to3->getTH1F();
+      TH1F *resPt5a = merespt_eta1p6to2_pt2to3->getTH1F();
+      TH1F *resPt6a = merespt_eta2to2p4_pt2to3->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_pt1 =
+          ibooker.book1D("pTResVsEta_2-3", "p_{T} resolution vs |#eta|, for p_{T}: 2-3 GeV", eta_binnum, eta_bins);
+      TH1F *resPt1 = me_res_pt1->getTH1F();
+      resPt1->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resPt1->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
+      resPt1->SetMinimum(0.0);
+      resPt1->SetStats(false);
+
+      std::vector<TH1F *> vResPt1 = {resPt1a, resPt2a, resPt3a, resPt4a, resPt5a, resPt6a};
+      for (int i = 0; i < 6; i++) {
+        resPt1->SetBinContent(i + 1, vResPt1[i]->GetStdDev());
+        resPt1->SetBinError(i + 1, vResPt1[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (2-3) cannot be found!\n";
+    }
+
+    if (merespt_eta0to0p7_pt3to8 && merespt_eta0p7to1_pt3to8 && merespt_eta1to1p2_pt3to8 &&
+        merespt_eta1p2to1p6_pt3to8 && merespt_eta1p6to2_pt3to8 && merespt_eta2to2p4_pt3to8) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resPt1b = merespt_eta0to0p7_pt3to8->getTH1F();
+      TH1F *resPt2b = merespt_eta0p7to1_pt3to8->getTH1F();
+      TH1F *resPt3b = merespt_eta1to1p2_pt3to8->getTH1F();
+      TH1F *resPt4b = merespt_eta1p2to1p6_pt3to8->getTH1F();
+      TH1F *resPt5b = merespt_eta1p6to2_pt3to8->getTH1F();
+      TH1F *resPt6b = merespt_eta2to2p4_pt3to8->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_pt2 =
+          ibooker.book1D("pTResVsEta_3-8", "p_{T} resolution vs |#eta|, for p_{T}: 3-8 GeV", eta_binnum, eta_bins);
+      TH1F *resPt2 = me_res_pt2->getTH1F();
+      resPt2->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resPt2->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
+      resPt2->SetMinimum(0.0);
+      resPt2->SetStats(false);
+
+      std::vector<TH1F *> vResPt2 = {resPt1b, resPt2b, resPt3b, resPt4b, resPt5b, resPt6b};
+      for (int i = 0; i < 6; i++) {
+        resPt2->SetBinContent(i + 1, vResPt2[i]->GetStdDev());
+        resPt2->SetBinError(i + 1, vResPt2[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (3-8) cannot be found!\n";
+    }
+
+    if (merespt_eta0to0p7_pt8toInf && merespt_eta0p7to1_pt8toInf && merespt_eta1to1p2_pt8toInf &&
+        merespt_eta1p2to1p6_pt8toInf && merespt_eta1p6to2_pt8toInf && merespt_eta2to2p4_pt8toInf) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resPt1c = merespt_eta0to0p7_pt8toInf->getTH1F();
+      TH1F *resPt2c = merespt_eta0p7to1_pt8toInf->getTH1F();
+      TH1F *resPt3c = merespt_eta1to1p2_pt8toInf->getTH1F();
+      TH1F *resPt4c = merespt_eta1p2to1p6_pt8toInf->getTH1F();
+      TH1F *resPt5c = merespt_eta1p6to2_pt8toInf->getTH1F();
+      TH1F *resPt6c = merespt_eta2to2p4_pt8toInf->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_pt3 =
+          ibooker.book1D("pTResVsEta_8-inf", "p_{T} resolution vs |#eta|, for p_{T}: >8 GeV", eta_binnum, eta_bins);
+      TH1F *resPt3 = me_res_pt3->getTH1F();
+      resPt3->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resPt3->GetYaxis()->SetTitle("#sigma(#Deltap_{T}/p_{T})");
+      resPt3->SetMinimum(0.0);
+      resPt3->SetStats(false);
+
+      std::vector<TH1F *> vResPt3 = {resPt1c, resPt2c, resPt3c, resPt4c, resPt5c, resPt6c};
+      for (int i = 0; i < 6; i++) {
+        resPt3->SetBinContent(i + 1, vResPt3[i]->GetStdDev());
+        resPt3->SetBinError(i + 1, vResPt3[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for pT resolution (8-inf) cannot be found!\n";
+    }
+
+    if (mereseta_eta0to0p7 && mereseta_eta0p7to1 && mereseta_eta1to1p2 && mereseta_eta1p2to1p6 && mereseta_eta1p6to2 &&
+        mereseta_eta2to2p4) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resEta1 = mereseta_eta0to0p7->getTH1F();
+      TH1F *resEta2 = mereseta_eta0p7to1->getTH1F();
+      TH1F *resEta3 = mereseta_eta1to1p2->getTH1F();
+      TH1F *resEta4 = mereseta_eta1p2to1p6->getTH1F();
+      TH1F *resEta5 = mereseta_eta1p6to2->getTH1F();
+      TH1F *resEta6 = mereseta_eta2to2p4->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_eta = ibooker.book1D("EtaResolution", "#eta resolution vs |#eta|", eta_binnum, eta_bins);
+      TH1F *resEta = me_res_eta->getTH1F();
+      resEta->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resEta->GetYaxis()->SetTitle("#sigma(#Delta#eta)");
+      resEta->SetMinimum(0.0);
+      resEta->SetStats(false);
+
+      std::vector<TH1F *> vResEta = {resEta1, resEta2, resEta3, resEta4, resEta5, resEta6};
+      for (int i = 0; i < 6; i++) {
+        resEta->SetBinContent(i + 1, vResEta[i]->GetStdDev());
+        resEta->SetBinError(i + 1, vResEta[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for eta resolution cannot be found!\n";
+    }
+
+    if (meresphi_eta0to0p7 && meresphi_eta0p7to1 && meresphi_eta1to1p2 && meresphi_eta1p2to1p6 && meresphi_eta1p6to2 &&
+        meresphi_eta2to2p4) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resPhi1 = meresphi_eta0to0p7->getTH1F();
+      TH1F *resPhi2 = meresphi_eta0p7to1->getTH1F();
+      TH1F *resPhi3 = meresphi_eta1to1p2->getTH1F();
+      TH1F *resPhi4 = meresphi_eta1p2to1p6->getTH1F();
+      TH1F *resPhi5 = meresphi_eta1p6to2->getTH1F();
+      TH1F *resPhi6 = meresphi_eta2to2p4->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_phi = ibooker.book1D("PhiResolution", "#phi resolution vs |#eta|", eta_binnum, eta_bins);
+      TH1F *resPhi = me_res_phi->getTH1F();
+      resPhi->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resPhi->GetYaxis()->SetTitle("#sigma(#Delta#phi)");
+      resPhi->SetMinimum(0.0);
+      resPhi->SetStats(false);
+
+      std::vector<TH1F *> vResPhi = {resPhi1, resPhi2, resPhi3, resPhi4, resPhi5, resPhi6};
+      for (int i = 0; i < 6; i++) {
+        resPhi->SetBinContent(i + 1, vResPhi[i]->GetStdDev());
+        resPhi->SetBinError(i + 1, vResPhi[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for phi resolution cannot be found!\n";
+    }
+
+    if (meresVtxZ_eta0to0p7 && meresVtxZ_eta0p7to1 && meresVtxZ_eta1to1p2 && meresVtxZ_eta1p2to1p6 &&
+        meresVtxZ_eta1p6to2 && meresVtxZ_eta2to2p4) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resVtxZ_1 = meresVtxZ_eta0to0p7->getTH1F();
+      TH1F *resVtxZ_2 = meresVtxZ_eta0p7to1->getTH1F();
+      TH1F *resVtxZ_3 = meresVtxZ_eta1to1p2->getTH1F();
+      TH1F *resVtxZ_4 = meresVtxZ_eta1p2to1p6->getTH1F();
+      TH1F *resVtxZ_5 = meresVtxZ_eta1p6to2->getTH1F();
+      TH1F *resVtxZ_6 = meresVtxZ_eta2to2p4->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_VtxZ = ibooker.book1D("VtxZResolution", "VtxZ resolution vs |#eta|", eta_binnum, eta_bins);
+      TH1F *resVtxZ = me_res_VtxZ->getTH1F();
+      resVtxZ->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resVtxZ->GetYaxis()->SetTitle("#sigma(#DeltaVtxZ) [cm]");
+      resVtxZ->SetMinimum(0.0);
+      resVtxZ->SetStats(false);
+
+      std::vector<TH1F *> vResVtxZ = {resVtxZ_1, resVtxZ_2, resVtxZ_3, resVtxZ_4, resVtxZ_5, resVtxZ_6};
+      for (int i = 0; i < 6; i++) {
+        resVtxZ->SetBinContent(i + 1, vResVtxZ[i]->GetStdDev());
+        resVtxZ->SetBinError(i + 1, vResVtxZ[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for VtxZ resolution cannot be found!\n";
+    }
+
+    if (meresd0_eta0to0p7 && meresd0_eta0p7to1 && meresd0_eta1to1p2 && meresd0_eta1p2to1p6 && meresd0_eta1p6to2 &&
+        meresd0_eta2to2p4) {
+      // Set the current directoy
+      dbe->setCurrentFolder(topFolderName_ + "/FinalResolution");
+
+      // Grab the histograms
+      TH1F *resd0_1 = meresd0_eta0to0p7->getTH1F();
+      TH1F *resd0_2 = meresd0_eta0p7to1->getTH1F();
+      TH1F *resd0_3 = meresd0_eta1to1p2->getTH1F();
+      TH1F *resd0_4 = meresd0_eta1p2to1p6->getTH1F();
+      TH1F *resd0_5 = meresd0_eta1p6to2->getTH1F();
+      TH1F *resd0_6 = meresd0_eta2to2p4->getTH1F();
+
+      // Book the new histogram to contain the results
+      MonitorElement *me_res_d0 = ibooker.book1D("d0Resolution", "d_{0} resolution vs |#eta|", eta_binnum, eta_bins);
+      TH1F *resd0 = me_res_d0->getTH1F();
+      resd0->GetXaxis()->SetTitle("tracking particle |#eta|");
+      resd0->GetYaxis()->SetTitle("#sigma(#Deltad_{0}) [cm]");
+      resd0->SetMinimum(0.0);
+      resd0->SetStats(false);
+
+      std::vector<TH1F *> vResD0 = {resd0_1, resd0_2, resd0_3, resd0_4, resd0_5, resd0_6};
+      for (int i = 0; i < 6; i++) {
+        resd0->SetBinContent(i + 1, vResD0[i]->GetStdDev());
+        resd0->SetBinError(i + 1, vResD0[i]->GetStdDevError());
+      }
+    }  // if ME found
+    else {
+      edm::LogWarning("DataNotFound") << "Monitor elements for d0 resolution cannot be found!\n";
+    }
+
+  }  // if dbe found
+  else {
+    edm::LogWarning("DataNotFound") << "Cannot find valid DQM back end \n";
+  }
+}  // end dqmEndJob
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+void Phase2OTHarvestTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1TrackV");
+  descriptions.add("Phase2OTHarvestTrackingParticles", desc);
+}
+DEFINE_FWK_MODULE(Phase2OTHarvestTrackingParticles);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTTStub.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTTStub.cc
@@ -1,0 +1,165 @@
+// -*- C++ -*-
+//
+/**\class SiOuterTracker Phase2OTValidateTTStub.cc
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  
+//
+
+// system include files
+#include <memory>
+#include <numeric>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+class Phase2OTValidateTTStub : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTValidateTTStub(const edm::ParameterSet &);
+  ~Phase2OTValidateTTStub() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  // TTStub stacks
+  // Global position of the stubs
+  MonitorElement *Stub_RZ = nullptr;            // TTStub #rho vs. z
+
+
+private:
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> tagTTStubsToken_;
+  std::string topFolderName_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry *tkGeom_ = nullptr;
+  const TrackerTopology *tTopo_ = nullptr;
+};
+
+// constructors and destructor
+Phase2OTValidateTTStub::Phase2OTValidateTTStub(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+  // now do what ever initialization is needed
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  tagTTStubsToken_ =
+      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
+}
+
+Phase2OTValidateTTStub::~Phase2OTValidateTTStub() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+void Phase2OTValidateTTStub::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+  tkGeom_ = &(iSetup.getData(geomToken_));
+  tTopo_ = &(iSetup.getData(topoToken_));
+}
+// member functions
+
+// ------------ method called for each event  ------------
+void Phase2OTValidateTTStub::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  /// Track Trigger Stubs
+  edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTStubHandle;
+  iEvent.getByToken(tagTTStubsToken_, Phase2TrackerDigiTTStubHandle);
+
+  /// Loop over input Stubs
+  typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
+  typename edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator contentIter;
+  // Adding protection
+  if (!Phase2TrackerDigiTTStubHandle.isValid())
+    return;
+
+  for (inputIter = Phase2TrackerDigiTTStubHandle->begin(); inputIter != Phase2TrackerDigiTTStubHandle->end();
+       ++inputIter) {
+    for (contentIter = inputIter->begin(); contentIter != inputIter->end(); ++contentIter) {
+      /// Make reference stub
+      edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
+          edmNew::makeRefTo(Phase2TrackerDigiTTStubHandle, contentIter);
+
+      /// Get det ID (place of the stub)
+      //  tempStubRef->getDetId() gives the stackDetId, not rawId
+      DetId detIdStub = tkGeom_->idToDet((tempStubRef->clusterRef(0))->getDetId())->geographicalId();
+
+      /// Get trigger displacement/offset
+      //double rawBend = tempStubRef->rawBend();
+      //double bendOffset = tempStubRef->bendOffset();
+
+      /// Define position stub by position inner cluster
+      MeasurementPoint mp = (tempStubRef->clusterRef(0))->findAverageLocalCoordinates();
+      const GeomDet *theGeomDet = tkGeom_->idToDet(detIdStub);
+      Global3DPoint posStub = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
+
+      Stub_RZ->Fill(posStub.z(), posStub.perp());
+    }
+  }
+}  // end of method
+
+// ------------ method called when starting to processes a run  ------------
+void Phase2OTValidateTTStub::bookHistograms(DQMStore::IBooker &iBooker,
+                                               edm::Run const &run,
+                                               edm::EventSetup const &es) {
+  std::string HistoName;
+  iBooker.setCurrentFolder(topFolderName_);
+  edm::ParameterSet psTTStub_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
+  HistoName = "Stub_RZ";
+  Stub_RZ = iBooker.book2D(HistoName,
+                           HistoName,
+                           psTTStub_RZ.getParameter<int32_t>("Nbinsx"),
+                           psTTStub_RZ.getParameter<double>("xmin"),
+                           psTTStub_RZ.getParameter<double>("xmax"),
+                           psTTStub_RZ.getParameter<int32_t>("Nbinsy"),
+                           psTTStub_RZ.getParameter<double>("ymin"),
+                           psTTStub_RZ.getParameter<double>("ymax"));
+}
+
+void Phase2OTValidateTTStub::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // Phase2OTValidateTTStub
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 900);
+    psd0.add<double>("xmax", 300);
+    psd0.add<double>("xmin", -300);
+    psd0.add<int>("Nbinsy", 900);
+    psd0.add<double>("ymax", 120);
+    psd0.add<double>("ymin", 0);
+    desc.add<edm::ParameterSetDescription>("TH2TTStub_RZ", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTStubV");
+  desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"));
+  descriptions.add("Phase2OTValidateTTStub", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+DEFINE_FWK_MODULE(Phase2OTValidateTTStub);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTTStub.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTTStub.cc
@@ -7,7 +7,7 @@
      [Notes on implementation]
 */
 //
-// Original Author:  
+// Original Author:
 //
 
 // system include files
@@ -49,11 +49,10 @@ public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   // TTStub stacks
   // Global position of the stubs
-  MonitorElement *Stub_RZ = nullptr;            // TTStub #rho vs. z
-
+  MonitorElement *Stub_RZ = nullptr;  // TTStub #rho vs. z
 
 private:
   edm::ParameterSet conf_;
@@ -127,8 +126,8 @@ void Phase2OTValidateTTStub::analyze(const edm::Event &iEvent, const edm::EventS
 
 // ------------ method called when starting to processes a run  ------------
 void Phase2OTValidateTTStub::bookHistograms(DQMStore::IBooker &iBooker,
-                                               edm::Run const &run,
-                                               edm::EventSetup const &es) {
+                                            edm::Run const &run,
+                                            edm::EventSetup const &es) {
   std::string HistoName;
   iBooker.setCurrentFolder(topFolderName_);
   edm::ParameterSet psTTStub_RZ = conf_.getParameter<edm::ParameterSet>("TH2TTStub_RZ");
@@ -143,7 +142,7 @@ void Phase2OTValidateTTStub::bookHistograms(DQMStore::IBooker &iBooker,
                            psTTStub_RZ.getParameter<double>("ymax"));
 }
 
-void Phase2OTValidateTTStub::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void Phase2OTValidateTTStub::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // Phase2OTValidateTTStub
   edm::ParameterSetDescription desc;
   {
@@ -157,7 +156,7 @@ void Phase2OTValidateTTStub::fillDescriptions(edm::ConfigurationDescriptions& de
     desc.add<edm::ParameterSetDescription>("TH2TTStub_RZ", psd0);
   }
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTStubV");
-  desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"));
+  desc.add<edm::InputTag>("TTStubs", edm::InputTag("TTStubsFromPhase2TrackerDigis", "StubAccepted"));
   descriptions.add("Phase2OTValidateTTStub", desc);
   // or use the following to generate the label from the module's C++ type
   //descriptions.addWithDefaultLabel(desc);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingParticles.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingParticles.cc
@@ -1,0 +1,1226 @@
+// Package:    SiOuterTrackerV
+// Class:      SiOuterTrackerV
+
+// Original Author:  Emily MacDonald
+
+// system include files
+#include <memory>
+#include <numeric>
+#include <vector>
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/StackedTrackerGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
+#include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
+#include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
+
+class Phase2OTValidateTrackingParticles : public DQMEDAnalyzer {
+public:
+  explicit Phase2OTValidateTrackingParticles(const edm::ParameterSet &);
+  ~Phase2OTValidateTrackingParticles() override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  // Tracking particle distributions
+  MonitorElement *trackParts_Eta = nullptr;
+  MonitorElement *trackParts_Phi = nullptr;
+  MonitorElement *trackParts_Pt = nullptr;
+
+  // pT and eta for efficiency plots
+  MonitorElement *tp_pt = nullptr;             // denominator
+  MonitorElement *tp_pt_zoom = nullptr;        // denominator
+  MonitorElement *tp_eta = nullptr;            // denominator
+  MonitorElement *tp_d0 = nullptr;             // denominator
+  MonitorElement *tp_VtxR = nullptr;           // denominator (also known as vxy)
+  MonitorElement *tp_VtxZ = nullptr;           // denominator
+  MonitorElement *match_tp_pt = nullptr;       // numerator
+  MonitorElement *match_tp_pt_zoom = nullptr;  // numerator
+  MonitorElement *match_tp_eta = nullptr;      // numerator
+  MonitorElement *match_tp_d0 = nullptr;       // numerator
+  MonitorElement *match_tp_VtxR = nullptr;     // numerator (also known as vxy)
+  MonitorElement *match_tp_VtxZ = nullptr;     // numerator
+
+  // 1D intermediate resolution plots (pT and eta)
+  MonitorElement *res_eta = nullptr;    // for all eta and pT
+  MonitorElement *res_pt = nullptr;     // for all eta and pT
+  MonitorElement *res_ptRel = nullptr;  // for all eta and pT (delta(pT)/pT)
+  MonitorElement *respt_eta0to0p7_pt2to3 = nullptr;
+  MonitorElement *respt_eta0p7to1_pt2to3 = nullptr;
+  MonitorElement *respt_eta1to1p2_pt2to3 = nullptr;
+  MonitorElement *respt_eta1p2to1p6_pt2to3 = nullptr;
+  MonitorElement *respt_eta1p6to2_pt2to3 = nullptr;
+  MonitorElement *respt_eta2to2p4_pt2to3 = nullptr;
+  MonitorElement *respt_eta0to0p7_pt3to8 = nullptr;
+  MonitorElement *respt_eta0p7to1_pt3to8 = nullptr;
+  MonitorElement *respt_eta1to1p2_pt3to8 = nullptr;
+  MonitorElement *respt_eta1p2to1p6_pt3to8 = nullptr;
+  MonitorElement *respt_eta1p6to2_pt3to8 = nullptr;
+  MonitorElement *respt_eta2to2p4_pt3to8 = nullptr;
+  MonitorElement *respt_eta0to0p7_pt8toInf = nullptr;
+  MonitorElement *respt_eta0p7to1_pt8toInf = nullptr;
+  MonitorElement *respt_eta1to1p2_pt8toInf = nullptr;
+  MonitorElement *respt_eta1p2to1p6_pt8toInf = nullptr;
+  MonitorElement *respt_eta1p6to2_pt8toInf = nullptr;
+  MonitorElement *respt_eta2to2p4_pt8toInf = nullptr;
+  MonitorElement *reseta_eta0to0p7 = nullptr;
+  MonitorElement *reseta_eta0p7to1 = nullptr;
+  MonitorElement *reseta_eta1to1p2 = nullptr;
+  MonitorElement *reseta_eta1p2to1p6 = nullptr;
+  MonitorElement *reseta_eta1p6to2 = nullptr;
+  MonitorElement *reseta_eta2to2p4 = nullptr;
+  MonitorElement *resphi_eta0to0p7 = nullptr;
+  MonitorElement *resphi_eta0p7to1 = nullptr;
+  MonitorElement *resphi_eta1to1p2 = nullptr;
+  MonitorElement *resphi_eta1p2to1p6 = nullptr;
+  MonitorElement *resphi_eta1p6to2 = nullptr;
+  MonitorElement *resphi_eta2to2p4 = nullptr;
+  MonitorElement *resVtxZ_eta0to0p7 = nullptr;
+  MonitorElement *resVtxZ_eta0p7to1 = nullptr;
+  MonitorElement *resVtxZ_eta1to1p2 = nullptr;
+  MonitorElement *resVtxZ_eta1p2to1p6 = nullptr;
+  MonitorElement *resVtxZ_eta1p6to2 = nullptr;
+  MonitorElement *resVtxZ_eta2to2p4 = nullptr;
+
+  // For d0
+  MonitorElement *resd0_eta0to0p7 = nullptr;
+  MonitorElement *resd0_eta0p7to1 = nullptr;
+  MonitorElement *resd0_eta1to1p2 = nullptr;
+  MonitorElement *resd0_eta1p2to1p6 = nullptr;
+  MonitorElement *resd0_eta1p6to2 = nullptr;
+  MonitorElement *resd0_eta2to2p4 = nullptr;
+private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticleToken_;
+  edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> ttClusterMCTruthToken_;  // MC truth association map for clusters
+  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> ttStubMCTruthToken_;  // MC truth association map for stubs
+  edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>  ttTrackMCTruthToken_;  // MC truth association map for tracks
+  int L1Tk_minNStub;
+  double L1Tk_maxChi2dof;
+  int TP_minNStub;
+  int TP_minNLayersStub;
+  double TP_minPt;
+  double TP_maxEta;
+  double TP_maxVtxZ;
+  std::string topFolderName_;
+};
+
+//
+// constructors and destructor
+//
+Phase2OTValidateTrackingParticles::Phase2OTValidateTrackingParticles(const edm::ParameterSet &iConfig)
+    : m_topoToken(esConsumes()), conf_(iConfig) {
+  topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
+  trackingParticleToken_ =
+      consumes<std::vector<TrackingParticle>>(conf_.getParameter<edm::InputTag>("trackingParticleToken"));
+  ttStubMCTruthToken_ =
+      consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>(conf_.getParameter<edm::InputTag>("MCTruthStubInputTag"));
+  ttClusterMCTruthToken_ = consumes<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>(
+      conf_.getParameter<edm::InputTag>("MCTruthClusterInputTag"));
+  ttTrackMCTruthToken_ = consumes<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>(
+      conf_.getParameter<edm::InputTag>("MCTruthTrackInputTag"));
+  L1Tk_minNStub = conf_.getParameter<int>("L1Tk_minNStub");         // min number of stubs in the track
+  L1Tk_maxChi2dof = conf_.getParameter<double>("L1Tk_maxChi2dof");  // maximum chi2/dof of the track
+  TP_minNStub = conf_.getParameter<int>("TP_minNStub");             // min number of stubs in the tracking particle to
+  //min number of layers with stubs in the tracking particle to consider matching
+  TP_minNLayersStub = conf_.getParameter<int>("TP_minNLayersStub");
+  TP_minPt = conf_.getParameter<double>("TP_minPt");      // min pT to consider matching
+  TP_maxEta = conf_.getParameter<double>("TP_maxEta");    // max eta to consider matching
+  TP_maxVtxZ = conf_.getParameter<double>("TP_maxVtxZ");  // max vertZ (or z0) to consider matching
+}
+
+Phase2OTValidateTrackingParticles::~Phase2OTValidateTrackingParticles() = default;
+
+// member functions
+
+// ------------ method called for each event  ------------
+void Phase2OTValidateTrackingParticles::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  // Tracking Particles
+  edm::Handle<std::vector<TrackingParticle>> trackingParticleHandle;
+  iEvent.getByToken(trackingParticleToken_, trackingParticleHandle);
+
+  // Truth Association Maps
+  edm::Handle<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTTrackHandle;
+  iEvent.getByToken(ttTrackMCTruthToken_, MCTruthTTTrackHandle);
+  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTClusterHandle;
+  iEvent.getByToken(ttClusterMCTruthToken_, MCTruthTTClusterHandle);
+  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTStubHandle;
+  iEvent.getByToken(ttStubMCTruthToken_, MCTruthTTStubHandle);
+
+  // Geometries
+  const TrackerTopology *const tTopo = &iSetup.getData(m_topoToken);
+
+  // Loop over tracking particles
+  int this_tp = 0;
+  for (const auto &iterTP : *trackingParticleHandle) {
+    edm::Ptr<TrackingParticle> tp_ptr(trackingParticleHandle, this_tp);
+    this_tp++;
+
+    // int tmp_eventid = iterTP.eventId().event();
+    float tmp_tp_pt = iterTP.pt();
+    float tmp_tp_phi = iterTP.phi();
+    float tmp_tp_eta = iterTP.eta();
+
+    //Calculate nLayers variable
+    std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+        theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
+
+    int hasStubInLayer[11] = {0};
+    for (unsigned int is = 0; is < theStubRefs.size(); is++) {
+      DetId detid(theStubRefs.at(is)->getDetId());
+      int layer = -1;
+      if (detid.subdetId() == StripSubdetector::TOB)
+        layer = static_cast<int>(tTopo->layer(detid)) - 1;  //fill in array as entries 0-5
+      else if (detid.subdetId() == StripSubdetector::TID)
+        layer = static_cast<int>(tTopo->layer(detid)) + 5;  //fill in array as entries 6-10
+
+      //treat genuine stubs separately (==2 is genuine, ==1 is not)
+      if (MCTruthTTStubHandle->findTrackingParticlePtr(theStubRefs.at(is)).isNull() && hasStubInLayer[layer] < 2)
+        hasStubInLayer[layer] = 1;
+      else
+        hasStubInLayer[layer] = 2;
+    }
+
+    int nStubLayerTP = 0;
+    for (int isum = 0; isum < 11; isum++) {
+      if (hasStubInLayer[isum] >= 1)
+        nStubLayerTP += 1;
+    }
+
+    if (std::fabs(tmp_tp_eta) > TP_maxEta)
+      continue;
+    // Fill the 1D distribution plots for tracking particles, to monitor change in stub definition
+    if (tmp_tp_pt > TP_minPt && nStubLayerTP >= TP_minNLayersStub) {
+      trackParts_Pt->Fill(tmp_tp_pt);
+      trackParts_Eta->Fill(tmp_tp_eta);
+      trackParts_Phi->Fill(tmp_tp_phi);
+    }
+
+    // if (TP_select_eventid == 0 && tmp_eventid != 0)
+    //   continue;  //only care about tracking particles from the primary interaction for efficiency/resolution
+    int nStubTP = -1;
+    if (MCTruthTTStubHandle.isValid()) {
+      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+          theStubRefs = MCTruthTTStubHandle->findTTStubRefs(tp_ptr);
+      nStubTP = (int)theStubRefs.size();
+    }
+    if (MCTruthTTClusterHandle.isValid() && MCTruthTTClusterHandle->findTTClusterRefs(tp_ptr).empty())
+      continue;
+
+    float tmp_tp_vz = iterTP.vz();
+    float tmp_tp_vx = iterTP.vx();
+    float tmp_tp_vy = iterTP.vy();
+    float tmp_tp_charge = tp_ptr->charge();
+    int tmp_tp_pdgid = iterTP.pdgId();
+
+    // ----------------------------------------------------------------------------------------------
+    // calculate d0 and VtxZ propagated back to the IP, pass if greater than max
+    // VtxZ
+    float tmp_tp_t = tan(2.0 * atan(1.0) - 2.0 * atan(exp(-tmp_tp_eta)));
+    float delx = -tmp_tp_vx;
+    float dely = -tmp_tp_vy;
+    float K = 0.01 * 0.5696 / tmp_tp_pt * tmp_tp_charge;  // curvature correction
+    float A = 1. / (2. * K);
+    float tmp_tp_x0p = delx - A * sin(tmp_tp_phi);
+    float tmp_tp_y0p = dely + A * cos(tmp_tp_phi);
+    float tmp_tp_rp = sqrt(tmp_tp_x0p * tmp_tp_x0p + tmp_tp_y0p * tmp_tp_y0p);
+    static double pi = 4.0 * atan(1.0);
+    float delphi = tmp_tp_phi - atan2(-K * tmp_tp_x0p, K * tmp_tp_y0p);
+    if (delphi < -pi)
+      delphi += 2.0 * pi;
+    if (delphi > pi)
+      delphi -= 2.0 * pi;
+
+    float tmp_tp_VtxZ = tmp_tp_vz + tmp_tp_t * delphi / (2.0 * K);
+    float tmp_tp_VtxR = sqrt(tmp_tp_vx * tmp_tp_vx + tmp_tp_vy * tmp_tp_vy);
+    float tmp_tp_d0 = tmp_tp_charge * tmp_tp_rp - (1. / (2. * K));
+
+    // simpler formula for d0, in cases where the charge is zero:
+    // https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackReco/interface/TrackBase.h
+    float other_d0 = -tmp_tp_vx * sin(tmp_tp_phi) + tmp_tp_vy * cos(tmp_tp_phi);
+    tmp_tp_d0 = tmp_tp_d0 * (-1);  // fix d0 sign
+    if (K == 0) {
+      tmp_tp_d0 = other_d0;
+      tmp_tp_VtxZ = tmp_tp_vz;
+    }
+    if (std::fabs(tmp_tp_VtxZ) > TP_maxVtxZ)
+      continue;
+
+    // To make efficiency plots where the denominator has NO stub cuts
+    if (tmp_tp_VtxR < 1.0) {
+      tp_pt->Fill(tmp_tp_pt);  //pT effic, no cut on pT, but VtxR cut
+      if (tmp_tp_pt <= 10)
+        tp_pt_zoom->Fill(tmp_tp_pt);  //pT effic, no cut on pT, but VtxR cut
+    }
+    if (tmp_tp_pt < TP_minPt)
+      continue;
+    tp_VtxR->Fill(tmp_tp_VtxR);  // VtxR efficiency has no cut on VtxR
+    if (tmp_tp_VtxR > 1.0)
+      continue;
+    tp_eta->Fill(tmp_tp_eta);
+    tp_d0->Fill(tmp_tp_d0);
+    tp_VtxZ->Fill(tmp_tp_VtxZ);
+
+    if (nStubTP < TP_minNStub || nStubLayerTP < TP_minNLayersStub)
+      continue;  //nStub cut not included in denominator of efficiency plots
+
+    // ----------------------------------------------------------------------------------------------
+    // look for L1 tracks matched to the tracking particle
+    int tp_nMatch = 0;
+    int i_track = -1;
+    float i_chi2dof = 99999;
+    if (MCTruthTTTrackHandle.isValid()) {
+      std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> matchedTracks =
+          MCTruthTTTrackHandle->findTTTrackPtrs(tp_ptr);
+
+      // ----------------------------------------------------------------------------------------------
+      // loop over matched L1 tracks
+      // here, "match" means tracks that can be associated to a TrackingParticle
+      // with at least one hit of at least one of its clusters
+      // https://twiki.cern.ch/twiki/bin/viewauth/CMS/SLHCTrackerTriggerSWTools#MC_truth_for_TTTrack
+      int trkCounter = 0;
+      for (const auto &thisTrack : matchedTracks) {
+        if (!MCTruthTTTrackHandle->isGenuine(thisTrack))
+          continue;
+        // ----------------------------------------------------------------------------------------------
+        // further require L1 track to be (loosely) genuine, that there is only
+        // one TP matched to the track
+        // + have >= L1Tk_minNStub stubs for it to be a valid match
+        int tmp_trk_nstub = thisTrack->getStubRefs().size();
+        if (tmp_trk_nstub < L1Tk_minNStub)
+          continue;
+        float dmatch_pt = 999;
+        float dmatch_eta = 999;
+        float dmatch_phi = 999;
+        int match_id = 999;
+
+        edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(thisTrack);
+        dmatch_pt = std::fabs(my_tp->p4().pt() - tmp_tp_pt);
+        dmatch_eta = std::fabs(my_tp->p4().eta() - tmp_tp_eta);
+        dmatch_phi = std::fabs(my_tp->p4().phi() - tmp_tp_phi);
+        match_id = my_tp->pdgId();
+        float tmp_trk_chi2dof = thisTrack->chi2Red();
+
+        // ensure that track is uniquely matched to the TP we are looking at!
+        if (dmatch_pt < 0.1 && dmatch_eta < 0.1 && dmatch_phi < 0.1 && tmp_tp_pdgid == match_id) {
+          tp_nMatch++;
+          if (i_track < 0 || tmp_trk_chi2dof < i_chi2dof) {
+            i_track = trkCounter;
+            i_chi2dof = tmp_trk_chi2dof;
+          }
+        }
+        trkCounter++;
+      }  // end loop over matched L1 tracks
+
+      if (tp_nMatch < 1)
+        continue;
+      // Get information on the matched tracks
+      float tmp_matchtrk_pt = -999;
+      float tmp_matchtrk_eta = -999;
+      float tmp_matchtrk_phi = -999;
+      float tmp_matchtrk_VtxZ = -999;
+      float tmp_matchtrk_chi2dof = -999;
+      int tmp_matchTrk_nStub = -999;
+      float tmp_matchtrk_d0 = -999;
+
+      tmp_matchtrk_pt = matchedTracks[i_track]->momentum().perp();
+      tmp_matchtrk_eta = matchedTracks[i_track]->momentum().eta();
+      tmp_matchtrk_phi = matchedTracks[i_track]->momentum().phi();
+      tmp_matchtrk_VtxZ = matchedTracks[i_track]->z0();
+      tmp_matchtrk_chi2dof = matchedTracks[i_track]->chi2Red();
+      tmp_matchTrk_nStub = (int)matchedTracks[i_track]->getStubRefs().size();
+
+      //for d0
+      float tmp_matchtrk_x0 = matchedTracks[i_track]->POCA().x();
+      float tmp_matchtrk_y0 = matchedTracks[i_track]->POCA().y();
+      tmp_matchtrk_d0 = -tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) + tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
+
+      //Add cuts for the matched tracks, numerator
+      if (tmp_matchTrk_nStub < L1Tk_minNStub || tmp_matchtrk_chi2dof > L1Tk_maxChi2dof)
+        continue;
+
+      // fill matched track histograms (if passes all criteria)
+      match_tp_pt->Fill(tmp_tp_pt);
+      if (tmp_tp_pt > 0 && tmp_tp_pt <= 10)
+        match_tp_pt_zoom->Fill(tmp_tp_pt);
+      match_tp_eta->Fill(tmp_tp_eta);
+      match_tp_d0->Fill(tmp_tp_d0);
+      match_tp_VtxR->Fill(tmp_tp_VtxR);
+      match_tp_VtxZ->Fill(tmp_tp_VtxZ);
+
+      // Eta and pT histograms for resolution
+      float pt_diff = tmp_matchtrk_pt - tmp_tp_pt;
+      float pt_res = pt_diff / tmp_tp_pt;
+      float eta_res = tmp_matchtrk_eta - tmp_tp_eta;
+      float phi_res = tmp_matchtrk_phi - tmp_tp_phi;
+      float VtxZ_res = tmp_matchtrk_VtxZ - tmp_tp_VtxZ;
+      float d0_res = tmp_matchtrk_d0 - tmp_tp_d0;
+
+      // fill total resolution histograms
+      res_pt->Fill(pt_diff);
+      res_ptRel->Fill(pt_res);
+      res_eta->Fill(eta_res);
+
+      // Fill resolution plots for different abs(eta) bins:
+      // (0, 0.7), (0.7, 1.0), (1.0, 1.2), (1.2, 1.6), (1.6, 2.0), (2.0, 2.4)
+      if (std::fabs(tmp_tp_eta) >= 0 && std::fabs(tmp_tp_eta) < 0.7) {
+        reseta_eta0to0p7->Fill(eta_res);
+        resphi_eta0to0p7->Fill(phi_res);
+        resVtxZ_eta0to0p7->Fill(VtxZ_res);
+        resd0_eta0to0p7->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta0to0p7_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta0to0p7_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta0to0p7_pt8toInf->Fill(pt_res);
+      } else if (std::fabs(tmp_tp_eta) >= 0.7 && std::fabs(tmp_tp_eta) < 1.0) {
+        reseta_eta0p7to1->Fill(eta_res);
+        resphi_eta0p7to1->Fill(phi_res);
+        resVtxZ_eta0p7to1->Fill(VtxZ_res);
+        resd0_eta0p7to1->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta0p7to1_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta0p7to1_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta0p7to1_pt8toInf->Fill(pt_res);
+      } else if (std::fabs(tmp_tp_eta) >= 1.0 && std::fabs(tmp_tp_eta) < 1.2) {
+        reseta_eta1to1p2->Fill(eta_res);
+        resphi_eta1to1p2->Fill(phi_res);
+        resVtxZ_eta1to1p2->Fill(VtxZ_res);
+        resd0_eta1to1p2->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta1to1p2_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta1to1p2_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta1to1p2_pt8toInf->Fill(pt_res);
+      } else if (std::fabs(tmp_tp_eta) >= 1.2 && std::fabs(tmp_tp_eta) < 1.6) {
+        reseta_eta1p2to1p6->Fill(eta_res);
+        resphi_eta1p2to1p6->Fill(phi_res);
+        resVtxZ_eta1p2to1p6->Fill(VtxZ_res);
+        resd0_eta1p2to1p6->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta1p2to1p6_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta1p2to1p6_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta1p2to1p6_pt8toInf->Fill(pt_res);
+      } else if (std::fabs(tmp_tp_eta) >= 1.6 && std::fabs(tmp_tp_eta) < 2.0) {
+        reseta_eta1p6to2->Fill(eta_res);
+        resphi_eta1p6to2->Fill(phi_res);
+        resVtxZ_eta1p6to2->Fill(VtxZ_res);
+        resd0_eta1p6to2->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta1p6to2_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta1p6to2_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta1p6to2_pt8toInf->Fill(pt_res);
+      } else if (std::fabs(tmp_tp_eta) >= 2.0 && std::fabs(tmp_tp_eta) <= 2.4) {
+        reseta_eta2to2p4->Fill(eta_res);
+        resphi_eta2to2p4->Fill(phi_res);
+        resVtxZ_eta2to2p4->Fill(VtxZ_res);
+        resd0_eta2to2p4->Fill(d0_res);
+        if (tmp_tp_pt >= 2 && tmp_tp_pt < 3)
+          respt_eta2to2p4_pt2to3->Fill(pt_res);
+        else if (tmp_tp_pt >= 3 && tmp_tp_pt < 8)
+          respt_eta2to2p4_pt3to8->Fill(pt_res);
+        else if (tmp_tp_pt >= 8)
+          respt_eta2to2p4_pt8toInf->Fill(pt_res);
+      }
+    }  //if MC TTTrack handle is valid
+  }    //end loop over tracking particles
+}  // end of method
+
+// ------------ method called once each job just before starting event loop
+// ------------
+void Phase2OTValidateTrackingParticles::bookHistograms(DQMStore::IBooker &iBooker,
+                                                          edm::Run const &run,
+                                                          edm::EventSetup const &es) {
+  // Histogram setup and definitions
+  std::string HistoName;
+  iBooker.setCurrentFolder(topFolderName_ + "/trackParticles");
+
+  // 1D: pT
+  edm::ParameterSet psTrackParts_Pt = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Pt");
+  HistoName = "trackParts_Pt";
+  trackParts_Pt = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psTrackParts_Pt.getParameter<int32_t>("Nbinsx"),
+                                 psTrackParts_Pt.getParameter<double>("xmin"),
+                                 psTrackParts_Pt.getParameter<double>("xmax"));
+  trackParts_Pt->setAxisTitle("p_{T} [GeV]", 1);
+  trackParts_Pt->setAxisTitle("# tracking particles", 2);
+
+  // 1D: eta
+  edm::ParameterSet psTrackParts_Eta = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Eta");
+  HistoName = "trackParts_Eta";
+  trackParts_Eta = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrackParts_Eta.getParameter<int32_t>("Nbinsx"),
+                                  psTrackParts_Eta.getParameter<double>("xmin"),
+                                  psTrackParts_Eta.getParameter<double>("xmax"));
+  trackParts_Eta->setAxisTitle("#eta", 1);
+  trackParts_Eta->setAxisTitle("# tracking particles", 2);
+
+  // 1D: phi
+  edm::ParameterSet psTrackParts_Phi = conf_.getParameter<edm::ParameterSet>("TH1TrackParts_Phi");
+  HistoName = "trackParts_Phi";
+  trackParts_Phi = iBooker.book1D(HistoName,
+                                  HistoName,
+                                  psTrackParts_Phi.getParameter<int32_t>("Nbinsx"),
+                                  psTrackParts_Phi.getParameter<double>("xmin"),
+                                  psTrackParts_Phi.getParameter<double>("xmax"));
+  trackParts_Phi->setAxisTitle("#phi", 1);
+  trackParts_Phi->setAxisTitle("# tracking particles", 2);
+
+  // 1D plots for efficiency
+  iBooker.setCurrentFolder(topFolderName_ + "/Efficiency");
+  // pT
+  edm::ParameterSet psEffic_pt = conf_.getParameter<edm::ParameterSet>("TH1Effic_pt");
+  HistoName = "tp_pt";
+  tp_pt = iBooker.book1D(HistoName,
+                         HistoName,
+                         psEffic_pt.getParameter<int32_t>("Nbinsx"),
+                         psEffic_pt.getParameter<double>("xmin"),
+                         psEffic_pt.getParameter<double>("xmax"));
+  tp_pt->setAxisTitle("p_{T} [GeV]", 1);
+  tp_pt->setAxisTitle("# tracking particles", 2);
+
+  // Matched TP's pT
+  HistoName = "match_tp_pt";
+  match_tp_pt = iBooker.book1D(HistoName,
+                               HistoName,
+                               psEffic_pt.getParameter<int32_t>("Nbinsx"),
+                               psEffic_pt.getParameter<double>("xmin"),
+                               psEffic_pt.getParameter<double>("xmax"));
+  match_tp_pt->setAxisTitle("p_{T} [GeV]", 1);
+  match_tp_pt->setAxisTitle("# matched tracking particles", 2);
+
+  // pT zoom (0-10 GeV)
+  edm::ParameterSet psEffic_pt_zoom = conf_.getParameter<edm::ParameterSet>("TH1Effic_pt_zoom");
+  HistoName = "tp_pt_zoom";
+  tp_pt_zoom = iBooker.book1D(HistoName,
+                              HistoName,
+                              psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
+                              psEffic_pt_zoom.getParameter<double>("xmin"),
+                              psEffic_pt_zoom.getParameter<double>("xmax"));
+  tp_pt_zoom->setAxisTitle("p_{T} [GeV]", 1);
+  tp_pt_zoom->setAxisTitle("# tracking particles", 2);
+
+  // Matched pT zoom (0-10 GeV)
+  HistoName = "match_tp_pt_zoom";
+  match_tp_pt_zoom = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psEffic_pt_zoom.getParameter<int32_t>("Nbinsx"),
+                                    psEffic_pt_zoom.getParameter<double>("xmin"),
+                                    psEffic_pt_zoom.getParameter<double>("xmax"));
+  match_tp_pt_zoom->setAxisTitle("p_{T} [GeV]", 1);
+  match_tp_pt_zoom->setAxisTitle("# matched tracking particles", 2);
+
+  // eta
+  edm::ParameterSet psEffic_eta = conf_.getParameter<edm::ParameterSet>("TH1Effic_eta");
+  HistoName = "tp_eta";
+  tp_eta = iBooker.book1D(HistoName,
+                          HistoName,
+                          psEffic_eta.getParameter<int32_t>("Nbinsx"),
+                          psEffic_eta.getParameter<double>("xmin"),
+                          psEffic_eta.getParameter<double>("xmax"));
+  tp_eta->setAxisTitle("#eta", 1);
+  tp_eta->setAxisTitle("# tracking particles", 2);
+
+  // Matched eta
+  HistoName = "match_tp_eta";
+  match_tp_eta = iBooker.book1D(HistoName,
+                                HistoName,
+                                psEffic_eta.getParameter<int32_t>("Nbinsx"),
+                                psEffic_eta.getParameter<double>("xmin"),
+                                psEffic_eta.getParameter<double>("xmax"));
+  match_tp_eta->setAxisTitle("#eta", 1);
+  match_tp_eta->setAxisTitle("# matched tracking particles", 2);
+
+  // d0
+  edm::ParameterSet psEffic_d0 = conf_.getParameter<edm::ParameterSet>("TH1Effic_d0");
+  HistoName = "tp_d0";
+  tp_d0 = iBooker.book1D(HistoName,
+                         HistoName,
+                         psEffic_d0.getParameter<int32_t>("Nbinsx"),
+                         psEffic_d0.getParameter<double>("xmin"),
+                         psEffic_d0.getParameter<double>("xmax"));
+  tp_d0->setAxisTitle("d_{0} [cm]", 1);
+  tp_d0->setAxisTitle("# tracking particles", 2);
+
+  // Matched d0
+  HistoName = "match_tp_d0";
+  match_tp_d0 = iBooker.book1D(HistoName,
+                               HistoName,
+                               psEffic_d0.getParameter<int32_t>("Nbinsx"),
+                               psEffic_d0.getParameter<double>("xmin"),
+                               psEffic_d0.getParameter<double>("xmax"));
+  match_tp_d0->setAxisTitle("d_{0} [cm]", 1);
+  match_tp_d0->setAxisTitle("# matched tracking particles", 2);
+
+  // VtxR (also known as vxy)
+  edm::ParameterSet psEffic_VtxR = conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxR");
+  HistoName = "tp_VtxR";
+  tp_VtxR = iBooker.book1D(HistoName,
+                           HistoName,
+                           psEffic_VtxR.getParameter<int32_t>("Nbinsx"),
+                           psEffic_VtxR.getParameter<double>("xmin"),
+                           psEffic_VtxR.getParameter<double>("xmax"));
+  tp_VtxR->setAxisTitle("d_{xy} [cm]", 1);
+  tp_VtxR->setAxisTitle("# tracking particles", 2);
+
+  // Matched VtxR
+  HistoName = "match_tp_VtxR";
+  match_tp_VtxR = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psEffic_VtxR.getParameter<int32_t>("Nbinsx"),
+                                 psEffic_VtxR.getParameter<double>("xmin"),
+                                 psEffic_VtxR.getParameter<double>("xmax"));
+  match_tp_VtxR->setAxisTitle("d_{xy} [cm]", 1);
+  match_tp_VtxR->setAxisTitle("# matched tracking particles", 2);
+
+  // VtxZ
+  edm::ParameterSet psEffic_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1Effic_VtxZ");
+  HistoName = "tp_VtxZ";
+  tp_VtxZ = iBooker.book1D(HistoName,
+                           HistoName,
+                           psEffic_VtxZ.getParameter<int32_t>("Nbinsx"),
+                           psEffic_VtxZ.getParameter<double>("xmin"),
+                           psEffic_VtxZ.getParameter<double>("xmax"));
+  tp_VtxZ->setAxisTitle("z_{0} [cm]", 1);
+  tp_VtxZ->setAxisTitle("# tracking particles", 2);
+
+  // Matched d0
+  HistoName = "match_tp_VtxZ";
+  match_tp_VtxZ = iBooker.book1D(HistoName,
+                                 HistoName,
+                                 psEffic_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                 psEffic_VtxZ.getParameter<double>("xmin"),
+                                 psEffic_VtxZ.getParameter<double>("xmax"));
+  match_tp_VtxZ->setAxisTitle("z_{0} [cm]", 1);
+  match_tp_VtxZ->setAxisTitle("# matched tracking particles", 2);
+
+  // 1D plots for resolution
+  iBooker.setCurrentFolder(topFolderName_ + "/Resolution");
+  // full pT
+  edm::ParameterSet psRes_pt = conf_.getParameter<edm::ParameterSet>("TH1Res_pt");
+  HistoName = "res_pt";
+  res_pt = iBooker.book1D(HistoName,
+                          HistoName,
+                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                          psRes_pt.getParameter<double>("xmin"),
+                          psRes_pt.getParameter<double>("xmax"));
+  res_pt->setAxisTitle("p_{T} [GeV]", 1);
+  res_pt->setAxisTitle("# tracking particles", 2);
+
+  // Full eta
+  edm::ParameterSet psRes_eta = conf_.getParameter<edm::ParameterSet>("TH1Res_eta");
+  HistoName = "res_eta";
+  res_eta = iBooker.book1D(HistoName,
+                           HistoName,
+                           psRes_eta.getParameter<int32_t>("Nbinsx"),
+                           psRes_eta.getParameter<double>("xmin"),
+                           psRes_eta.getParameter<double>("xmax"));
+  res_eta->setAxisTitle("#eta", 1);
+  res_eta->setAxisTitle("# tracking particles", 2);
+
+  // Relative pT
+  edm::ParameterSet psRes_ptRel = conf_.getParameter<edm::ParameterSet>("TH1Res_ptRel");
+  HistoName = "res_ptRel";
+  res_ptRel = iBooker.book1D(HistoName,
+                             HistoName,
+                             psRes_ptRel.getParameter<int32_t>("Nbinsx"),
+                             psRes_ptRel.getParameter<double>("xmin"),
+                             psRes_ptRel.getParameter<double>("xmax"));
+  res_ptRel->setAxisTitle("Relative p_{T} [GeV]", 1);
+  res_ptRel->setAxisTitle("# tracking particles", 2);
+
+  // Eta parts (for resolution)
+  // Eta 1 (0 to 0.7)
+  HistoName = "reseta_eta0to0p7";
+  reseta_eta0to0p7 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                    psRes_eta.getParameter<double>("xmin"),
+                                    psRes_eta.getParameter<double>("xmax"));
+  reseta_eta0to0p7->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta0to0p7->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "reseta_eta0p7to1";
+  reseta_eta0p7to1 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                    psRes_eta.getParameter<double>("xmin"),
+                                    psRes_eta.getParameter<double>("xmax"));
+  reseta_eta0p7to1->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta0p7to1->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "reseta_eta1to1p2";
+  reseta_eta1to1p2 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                    psRes_eta.getParameter<double>("xmin"),
+                                    psRes_eta.getParameter<double>("xmax"));
+  reseta_eta1to1p2->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta1to1p2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "reseta_eta1p2to1p6";
+  reseta_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                      psRes_eta.getParameter<double>("xmin"),
+                                      psRes_eta.getParameter<double>("xmax"));
+  reseta_eta1p2to1p6->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta1p2to1p6->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "reseta_eta1p6to2";
+  reseta_eta1p6to2 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                    psRes_eta.getParameter<double>("xmin"),
+                                    psRes_eta.getParameter<double>("xmax"));
+  reseta_eta1p6to2->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta1p6to2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "reseta_eta2to2p4";
+  reseta_eta2to2p4 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_eta.getParameter<int32_t>("Nbinsx"),
+                                    psRes_eta.getParameter<double>("xmin"),
+                                    psRes_eta.getParameter<double>("xmax"));
+  reseta_eta2to2p4->setAxisTitle("#eta_{trk} - #eta_{tp}", 1);
+  reseta_eta2to2p4->setAxisTitle("# tracking particles", 2);
+
+  // pT parts for resolution (pT res vs eta)
+  // pT a (2 to 3 GeV)
+  // Eta 1 (0 to 0.7)
+  HistoName = "respt_eta0to0p7_pt2to3";
+  respt_eta0to0p7_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0to0p7_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "respt_eta0p7to1_pt2to3";
+  respt_eta0p7to1_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0p7to1_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "respt_eta1to1p2_pt2to3";
+  respt_eta1to1p2_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1to1p2_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "respt_eta1p2to1p6_pt2to3";
+  respt_eta1p2to1p6_pt2to3 = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p2to1p6_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "respt_eta1p6to2_pt2to3";
+  respt_eta1p6to2_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p6to2_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "respt_eta2to2p4_pt2to3";
+  respt_eta2to2p4_pt2to3 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt2to3->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta2to2p4_pt2to3->setAxisTitle("# tracking particles", 2);
+
+  // pT b (3 to 8 GeV)
+  // Eta 1 (0 to 0.7)
+  HistoName = "respt_eta0to0p7_pt3to8";
+  respt_eta0to0p7_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0to0p7_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "respt_eta0p7to1_pt3to8";
+  respt_eta0p7to1_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0p7to1_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "respt_eta1to1p2_pt3to8";
+  respt_eta1to1p2_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1to1p2_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "respt_eta1p2to1p6_pt3to8";
+  respt_eta1p2to1p6_pt3to8 = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p2to1p6_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "respt_eta1p6to2_pt3to8";
+  respt_eta1p6to2_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p6to2_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "respt_eta2to2p4_pt3to8";
+  respt_eta2to2p4_pt3to8 = iBooker.book1D(HistoName,
+                                          HistoName,
+                                          psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                          psRes_pt.getParameter<double>("xmin"),
+                                          psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt3to8->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta2to2p4_pt3to8->setAxisTitle("# tracking particles", 2);
+
+  // pT c (>8 GeV)
+  // Eta 1 (0 to 0.7)
+  HistoName = "respt_eta0to0p7_pt8toInf";
+  respt_eta0to0p7_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta0to0p7_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0to0p7_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "respt_eta0p7to1_pt8toInf";
+  respt_eta0p7to1_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta0p7to1_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta0p7to1_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "respt_eta1to1p2_pt8toInf";
+  respt_eta1to1p2_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1to1p2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1to1p2_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "respt_eta1p2to1p6_pt8toInf";
+  respt_eta1p2to1p6_pt8toInf = iBooker.book1D(HistoName,
+                                              HistoName,
+                                              psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                              psRes_pt.getParameter<double>("xmin"),
+                                              psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p2to1p6_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p2to1p6_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "respt_eta1p6to2_pt8toInf";
+  respt_eta1p6to2_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta1p6to2_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta1p6to2_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "respt_eta2to2p4_pt8toInf";
+  respt_eta2to2p4_pt8toInf = iBooker.book1D(HistoName,
+                                            HistoName,
+                                            psRes_pt.getParameter<int32_t>("Nbinsx"),
+                                            psRes_pt.getParameter<double>("xmin"),
+                                            psRes_pt.getParameter<double>("xmax"));
+  respt_eta2to2p4_pt8toInf->setAxisTitle("(p_{T}(trk) - p_{T}(tp))/p_{T}(tp)", 1);
+  respt_eta2to2p4_pt8toInf->setAxisTitle("# tracking particles", 2);
+
+  // Phi parts (for resolution)
+  // Eta 1 (0 to 0.7)
+  edm::ParameterSet psRes_phi = conf_.getParameter<edm::ParameterSet>("TH1Res_phi");
+  HistoName = "resphi_eta0to0p7";
+  resphi_eta0to0p7 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                    psRes_phi.getParameter<double>("xmin"),
+                                    psRes_phi.getParameter<double>("xmax"));
+  resphi_eta0to0p7->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta0to0p7->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "resphi_eta0p7to1";
+  resphi_eta0p7to1 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                    psRes_phi.getParameter<double>("xmin"),
+                                    psRes_phi.getParameter<double>("xmax"));
+  resphi_eta0p7to1->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta0p7to1->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "resphi_eta1to1p2";
+  resphi_eta1to1p2 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                    psRes_phi.getParameter<double>("xmin"),
+                                    psRes_phi.getParameter<double>("xmax"));
+  resphi_eta1to1p2->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta1to1p2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "resphi_eta1p2to1p6";
+  resphi_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                      HistoName,
+                                      psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                      psRes_phi.getParameter<double>("xmin"),
+                                      psRes_phi.getParameter<double>("xmax"));
+  resphi_eta1p2to1p6->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta1p2to1p6->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "resphi_eta1p6to2";
+  resphi_eta1p6to2 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                    psRes_phi.getParameter<double>("xmin"),
+                                    psRes_phi.getParameter<double>("xmax"));
+  resphi_eta1p6to2->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta1p6to2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "resphi_eta2to2p4";
+  resphi_eta2to2p4 = iBooker.book1D(HistoName,
+                                    HistoName,
+                                    psRes_phi.getParameter<int32_t>("Nbinsx"),
+                                    psRes_phi.getParameter<double>("xmin"),
+                                    psRes_phi.getParameter<double>("xmax"));
+  resphi_eta2to2p4->setAxisTitle("#phi_{trk} - #phi_{tp}", 1);
+  resphi_eta2to2p4->setAxisTitle("# tracking particles", 2);
+
+  // VtxZ parts (for resolution)
+  // Eta 1 (0 to 0.7)
+  edm::ParameterSet psRes_VtxZ = conf_.getParameter<edm::ParameterSet>("TH1Res_VtxZ");
+  HistoName = "resVtxZ_eta0to0p7";
+  resVtxZ_eta0to0p7 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                     psRes_VtxZ.getParameter<double>("xmin"),
+                                     psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta0to0p7->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta0to0p7->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "resVtxZ_eta0p7to1";
+  resVtxZ_eta0p7to1 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                     psRes_VtxZ.getParameter<double>("xmin"),
+                                     psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta0p7to1->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta0p7to1->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "resVtxZ_eta1to1p2";
+  resVtxZ_eta1to1p2 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                     psRes_VtxZ.getParameter<double>("xmin"),
+                                     psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta1to1p2->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta1to1p2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "resVtxZ_eta1p2to1p6";
+  resVtxZ_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                       HistoName,
+                                       psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                       psRes_VtxZ.getParameter<double>("xmin"),
+                                       psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta1p2to1p6->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta1p2to1p6->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "resVtxZ_eta1p6to2";
+  resVtxZ_eta1p6to2 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                     psRes_VtxZ.getParameter<double>("xmin"),
+                                     psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta1p6to2->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta1p6to2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "resVtxZ_eta2to2p4";
+  resVtxZ_eta2to2p4 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_VtxZ.getParameter<int32_t>("Nbinsx"),
+                                     psRes_VtxZ.getParameter<double>("xmin"),
+                                     psRes_VtxZ.getParameter<double>("xmax"));
+  resVtxZ_eta2to2p4->setAxisTitle("VtxZ_{trk} - VtxZ_{tp} [cm]", 1);
+  resVtxZ_eta2to2p4->setAxisTitle("# tracking particles", 2);
+
+  // d0 parts (for resolution)
+  // Eta 1 (0 to 0.7)
+  edm::ParameterSet psRes_d0 = conf_.getParameter<edm::ParameterSet>("TH1Res_d0");
+  HistoName = "resd0_eta0to0p7";
+  resd0_eta0to0p7 = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                   psRes_d0.getParameter<double>("xmin"),
+                                   psRes_d0.getParameter<double>("xmax"));
+  resd0_eta0to0p7->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta0to0p7->setAxisTitle("# tracking particles", 2);
+
+  // Eta 2 (0.7 to 1.0)
+  HistoName = "resd0_eta0p7to1";
+  resd0_eta0p7to1 = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                   psRes_d0.getParameter<double>("xmin"),
+                                   psRes_d0.getParameter<double>("xmax"));
+  resd0_eta0p7to1->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta0p7to1->setAxisTitle("# tracking particles", 2);
+
+  // Eta 3 (1.0 to 1.2)
+  HistoName = "resd0_eta1to1p2";
+  resd0_eta1to1p2 = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                   psRes_d0.getParameter<double>("xmin"),
+                                   psRes_d0.getParameter<double>("xmax"));
+  resd0_eta1to1p2->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta1to1p2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 4 (1.2 to 1.6)
+  HistoName = "resd0_eta1p2to1p6";
+  resd0_eta1p2to1p6 = iBooker.book1D(HistoName,
+                                     HistoName,
+                                     psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                     psRes_d0.getParameter<double>("xmin"),
+                                     psRes_d0.getParameter<double>("xmax"));
+  resd0_eta1p2to1p6->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta1p2to1p6->setAxisTitle("# tracking particles", 2);
+
+  // Eta 5 (1.6 to 2.0)
+  HistoName = "resd0_eta1p6to2";
+  resd0_eta1p6to2 = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                   psRes_d0.getParameter<double>("xmin"),
+                                   psRes_d0.getParameter<double>("xmax"));
+  resd0_eta1p6to2->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta1p6to2->setAxisTitle("# tracking particles", 2);
+
+  // Eta 6 (2.0 to 2.4)
+  HistoName = "resd0_eta2to2p4";
+  resd0_eta2to2p4 = iBooker.book1D(HistoName,
+                                   HistoName,
+                                   psRes_d0.getParameter<int32_t>("Nbinsx"),
+                                   psRes_d0.getParameter<double>("xmin"),
+                                   psRes_d0.getParameter<double>("xmax"));
+  resd0_eta2to2p4->setAxisTitle("d0_{trk} - d0_{tp} [cm]", 1);
+  resd0_eta2to2p4->setAxisTitle("# tracking particles", 2);
+
+}  // end of method
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+void Phase2OTValidateTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // OuterTrackerMonitorTrackingParticles
+  edm::ParameterSetDescription desc;
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmax", 3);
+    psd0.add<double>("xmin", -3);
+    desc.add<edm::ParameterSetDescription>("TH1TrackParts_Eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 60);
+    psd0.add<double>("xmax", 3.141592653589793);
+    psd0.add<double>("xmin", -3.141592653589793);
+    desc.add<edm::ParameterSetDescription>("TH1TrackParts_Phi", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 45);
+    psd0.add<double>("xmax", 100);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1TrackParts_Pt", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 200);
+    psd0.add<double>("xmax", 0.5);
+    psd0.add<double>("xmin", -0.5);
+    desc.add<edm::ParameterSetDescription>("TH1Res_ptRel", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 100);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_pt", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 10);
+    psd0.add<double>("xmin", 0);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_pt_zoom", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 2.5);
+    psd0.add<double>("xmin", -2.5);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 2);
+    psd0.add<double>("xmin", -2);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_d0", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 5);
+    psd0.add<double>("xmin", -5);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_VtxR", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 50);
+    psd0.add<double>("xmax", 30);
+    psd0.add<double>("xmin", -30);
+    desc.add<edm::ParameterSetDescription>("TH1Effic_VtxZ", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 0.2);
+    psd0.add<double>("xmin", -0.2);
+    desc.add<edm::ParameterSetDescription>("TH1Res_pt", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 0.01);
+    psd0.add<double>("xmin", -0.01);
+    desc.add<edm::ParameterSetDescription>("TH1Res_eta", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 0.01);
+    psd0.add<double>("xmin", -0.01);
+    desc.add<edm::ParameterSetDescription>("TH1Res_phi", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 1.0);
+    psd0.add<double>("xmin", -1.0);
+    desc.add<edm::ParameterSetDescription>("TH1Res_VtxZ", psd0);
+  }
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<int>("Nbinsx", 100);
+    psd0.add<double>("xmax", 0.05);
+    psd0.add<double>("xmin", -0.05);
+    desc.add<edm::ParameterSetDescription>("TH1Res_d0", psd0);
+  }
+  desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1TrackV");
+  desc.add<edm::InputTag>("trackingParticleToken", edm::InputTag("mix","MergedTrackTruth"));
+  desc.add<edm::InputTag>("MCTruthStubInputTag", edm::InputTag("TTStubAssociatorFromPixelDigis","StubAccepted"));
+  desc.add<edm::InputTag>("MCTruthTrackInputTag", edm::InputTag("TTTrackAssociatorFromPixelDigis","Level1TTTracks"));
+  desc.add<edm::InputTag>("MCTruthClusterInputTag", edm::InputTag("TTClusterAssociatorFromPixelDigis","ClusterAccepted"));
+  desc.add<int>("L1Tk_minNStub", 4);
+  desc.add<double>("L1Tk_maxChi2dof", 25.0);
+  desc.add<int>("TP_minNStub", 4);
+  desc.add<int>("TP_minNLayersStub", 4);
+  desc.add<double>("TP_minPt", 2.0);
+  desc.add<double>("TP_maxEta", 2.4);
+  desc.add<double>("TP_maxVtxZ", 15.0);
+  descriptions.add("Phase2OTValidateTrackingParticles", desc);
+  // or use the following to generate the label from the module's C++ type
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(Phase2OTValidateTrackingParticles);

--- a/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingParticles.cc
+++ b/Validation/SiTrackerPhase2V/plugins/Phase2OTValidateTrackingParticles.cc
@@ -44,7 +44,7 @@ public:
   ~Phase2OTValidateTrackingParticles() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   // Tracking particle distributions
   MonitorElement *trackParts_Eta = nullptr;
   MonitorElement *trackParts_Phi = nullptr;
@@ -112,13 +112,17 @@ public:
   MonitorElement *resd0_eta1p2to1p6 = nullptr;
   MonitorElement *resd0_eta1p6to2 = nullptr;
   MonitorElement *resd0_eta2to2p4 = nullptr;
+
 private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_topoToken;
   edm::ParameterSet conf_;
   edm::EDGetTokenT<std::vector<TrackingParticle>> trackingParticleToken_;
-  edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> ttClusterMCTruthToken_;  // MC truth association map for clusters
-  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> ttStubMCTruthToken_;  // MC truth association map for stubs
-  edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>  ttTrackMCTruthToken_;  // MC truth association map for tracks
+  edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>
+      ttClusterMCTruthToken_;  // MC truth association map for clusters
+  edm::EDGetTokenT<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>
+      ttStubMCTruthToken_;  // MC truth association map for stubs
+  edm::EDGetTokenT<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>
+      ttTrackMCTruthToken_;  // MC truth association map for tracks
   int L1Tk_minNStub;
   double L1Tk_maxChi2dof;
   int TP_minNStub;
@@ -461,8 +465,8 @@ void Phase2OTValidateTrackingParticles::analyze(const edm::Event &iEvent, const 
 // ------------ method called once each job just before starting event loop
 // ------------
 void Phase2OTValidateTrackingParticles::bookHistograms(DQMStore::IBooker &iBooker,
-                                                          edm::Run const &run,
-                                                          edm::EventSetup const &es) {
+                                                       edm::Run const &run,
+                                                       edm::EventSetup const &es) {
   // Histogram setup and definitions
   std::string HistoName;
   iBooker.setCurrentFolder(topFolderName_ + "/trackParticles");
@@ -1098,7 +1102,7 @@ void Phase2OTValidateTrackingParticles::bookHistograms(DQMStore::IBooker &iBooke
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-void Phase2OTValidateTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void Phase2OTValidateTrackingParticles::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // OuterTrackerMonitorTrackingParticles
   edm::ParameterSetDescription desc;
   {
@@ -1207,10 +1211,11 @@ void Phase2OTValidateTrackingParticles::fillDescriptions(edm::ConfigurationDescr
     desc.add<edm::ParameterSetDescription>("TH1Res_d0", psd0);
   }
   desc.add<std::string>("TopFolderName", "TrackerPhase2OTL1TrackV");
-  desc.add<edm::InputTag>("trackingParticleToken", edm::InputTag("mix","MergedTrackTruth"));
-  desc.add<edm::InputTag>("MCTruthStubInputTag", edm::InputTag("TTStubAssociatorFromPixelDigis","StubAccepted"));
-  desc.add<edm::InputTag>("MCTruthTrackInputTag", edm::InputTag("TTTrackAssociatorFromPixelDigis","Level1TTTracks"));
-  desc.add<edm::InputTag>("MCTruthClusterInputTag", edm::InputTag("TTClusterAssociatorFromPixelDigis","ClusterAccepted"));
+  desc.add<edm::InputTag>("trackingParticleToken", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("MCTruthStubInputTag", edm::InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"));
+  desc.add<edm::InputTag>("MCTruthTrackInputTag", edm::InputTag("TTTrackAssociatorFromPixelDigis", "Level1TTTracks"));
+  desc.add<edm::InputTag>("MCTruthClusterInputTag",
+                          edm::InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"));
   desc.add<int>("L1Tk_minNStub", 4);
   desc.add<double>("L1Tk_maxChi2dof", 25.0);
   desc.add<int>("TP_minNStub", 4);

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerMCHarvesting_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from Validation.SiTrackerPhase2V.Phase2ITRechitHarvester_cfi import *
-
+from Validation.SiTrackerPhase2V.Phase2OTHarvestTrackingParticles_cfi import *
 #ITTracking rechit
 #clone the rechit harvester for tracking rechit
 Phase2ITtrackingrechitHarvester=Phase2ITRechitHarvester.clone(
@@ -76,4 +76,5 @@ trackerphase2ValidationHarvesting_standalone = cms.Sequence(Phase2ITRechitHarves
                                                             * Phase2OTRechitHarvester_2S
                                                             * Phase2OTTrackingRechitHarvester_PS
                                                             * Phase2OTTrackingRechitHarvester_2S
+                                                            * Phase2OTHarvestTrackingParticles
 )

--- a/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2TrackerValidationFirstStep_cff.py
@@ -5,6 +5,7 @@ from Validation.SiTrackerPhase2V.Phase2ITValidateTrackingRecHit_cff import *
 from Validation.SiTrackerPhase2V.Phase2ITValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateCluster_cff import *
 from Validation.SiTrackerPhase2V.Phase2OTValidateTrackingRecHit_cff import *
+from Validation.SiTrackerPhase2V.Phase2ValidateL1TTObjects_cff import *
 
 trackerphase2ValidationSource = cms.Sequence(pixDigiValid  
                                              + otDigiValid 
@@ -13,6 +14,8 @@ trackerphase2ValidationSource = cms.Sequence(pixDigiValid
                                              + clusterValidIT
                                              + clusterValidOT
                                              + trackingRechitValidOT
+                                             + trackingParticleValidOT
+                                             + stubValidOT
 )
 
 from Configuration.ProcessModifiers.vectorHits_cff import vectorHits

--- a/Validation/SiTrackerPhase2V/python/Phase2ValidateL1TTObjects_cff.py
+++ b/Validation/SiTrackerPhase2V/python/Phase2ValidateL1TTObjects_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.SiTrackerPhase2V.Phase2OTValidateTrackingParticles_cfi import * 
+from Validation.SiTrackerPhase2V.Phase2OTValidateTTStub_cfi import *
+
+trackingParticleValidOT = Phase2OTValidateTrackingParticles.clone()
+
+stubValidOT = Phase2OTValidateTTStub.clone()


### PR DESCRIPTION
#### PR description:
The motivation for the PR can be found in this [talk](https://indico.cern.ch/event/1242120/contributions/5230280/attachments/2579402/4449460/DQM_Tracker.pdf).
The basic idea is to move the plugins form
- ```DQM/SiOuterTracker```  to ```DQM/SiTrackerPhase2V```
- ```Validation/SiOuterTrackerV```   to ```Validation/SiTrackerPhase2V```
The  top level DQM folders have been renamed accordingly.

#### PR validation:
Wf 24834.0 runs.
#### If this PR is a backport please specify the original PR and why you need to 
Not a backport