### PR TITLE
add phase2 customizations to `TkAlMuonSelectors` to increase selection efficiency

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
@@ -16,3 +16,16 @@ TkAlRelCombIsoMuonSelector = cms.EDFilter("MuonSelector",
     cut = cms.string('(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.15'),
     filter = cms.bool(True)
 )
+
+## FIXME: these are needed for ALCARECO production in CMSSW_14_0_X
+## to avoid loosing in efficiency. To be reviewed after muon reco is fixed
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(TkAlGoodIdMuonSelector,
+                       cut = '(abs(eta) < 2.5 & isGlobalMuon & isTrackerMuon & numberOfMatches > 1 & globalTrack.hitPattern.numberOfValidMuonHits > 0 &  globalTrack.normalizedChi2 < 20.) ||'  # regular selection
+                       '(abs(eta) > 2.3 & abs(eta) < 3.0 & numberOfMatches >= 0 & isTrackerMuon)'   # to recover GE0 tracks
+                       )
+
+phase2_common.toModify(TkAlRelCombIsoMuonSelector,
+                       cut = '(isolationR03().sumPt)/pt < 0.1' # only tracker isolation
+                       )


### PR DESCRIPTION
#### PR description:

While studying the Phase2 TkAl ALCARECO events produced in the `Phase2Fall22DRMiniAOD` campaign, a peculiar feature was noticed in the ϕ distribution of the tracks from Z → µµ decays selected from alignment (see [here](https://indico.cern.ch/event/1363142/contributions/5787810/attachments/2789909/4865144/cmsal_240130.pdf#page=12) for more details).
Upon dedicated check at the level of ALCARECO sample, it was observed that the feature was already present in the tracks persisted in the input sample, but also in the muon tracks from W → μν decays . Additionally the pseudo-rapidity of tracks from muons was limited to around 2.5 while in the upgrade detector the acceptance should be extended to higher values.
These features were not observed in the tracks from MinimumBias selection:
| Track ϕ  | Track 𝜂  |
| --- | ----------- |
|  ![image](https://github.com/cms-sw/cmssw/assets/5082376/c2ac84e2-e877-4a64-8e7b-802c6583c30d) | ![image](https://github.com/cms-sw/cmssw/assets/5082376/ac32db93-31b0-4088-b74b-201be295837e) |

Checking on the input muons, the reason of the ϕ-dependent inefficiency was spotted in an abnormal distribution of the muon electromagnetic relative isolation distribution as a function of the muon azimuth. This quantity is used together with the tracker and hadronic relative isolation to select the muons entering the alignment samples. For more details look at https://github.com/cms-sw/cmssw/issues/43858.

 https://github.com/cms-sw/cmssw/blob/f2ffd7b3c9b926a2db457de7749d4fca2183ba53/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py#L16

Additionally it was found that no Global Muons were available above 2.5. This is expected as a to created global muon a standalone muon fit and this is not possible with only one station. Also the number of matches in that region is nearly always 0.

| Muon EG isolation | IsGlobal Muon | Muon Number of matches |   
 | --- | ----------- |------|
 | ![canvas_hIsoEmEtOverPt](https://github.com/cms-sw/cmssw/assets/5082376/8a95e826-5b72-415a-bf9f-d039dee25184) | ![canvas_hIsGlobalMuon](https://github.com/cms-sw/cmssw/assets/5082376/bdb49b82-6244-4d95-8a05-c4cd65c77e1a)  | ![canvas_hNumberOfMatches](https://github.com/cms-sw/cmssw/assets/5082376/b886920b-fd6c-4ed2-8df3-d037eef38024) |

The selections are therefore adjusted in the Phase-2 case in order to recover in efficiency, by adding a dedicated selection for the high rapidity region and to apply only the tracker relative isolation. 

#### PR validation:

I have re-run the ALCARECO production out of the sample [*] via the following command:
```bash
cmsDriver.py step5 \
    -s ALCA:TkAlMuonIsolated \
    --conditions auto:phase2_realistic_T25 \
    --datatier ALCARECO \
    -n -1 \
    --eventcontent ALCARECO \
    --geometry Extended2026D98 \
    --era Phase2C17I13M9 \
    --fileout file:step5.root \
    --nThreads 4 \
    --dasquery='file dataset=/RelValSingleMuFlatPt2To100/CMSSW_14_0_0_pre2-133X_mcRun4_realistic_v1_STD_2026D98_noPU_RV229-v1/GEN-SIM-RECO'
```
with and without these changes and I have obtained the [following results](http://musich.web.cern.ch/musich/display/checkPhase2AlCaRecoSamples/RECOvsALCA_fix/).
In particular the track ϕ  and tack 𝜂 distributions look as expected after the fix:

| Track ϕ  | Track 𝜂  |
| --- | ----------- |
| ![image](https://github.com/cms-sw/cmssw/assets/5082376/892bd757-548a-4537-9ffa-d31bdaf158fa) |  ![image](https://github.com/cms-sw/cmssw/assets/5082376/48292e72-4dd2-423f-b019-c3a4e6581008) |

Additionally I have re-run the sequence also on a recent `RelValZMM_14` sample [*] and haven't observed adverse effects (see [link](http://musich.web.cern.ch/musich/display/checkPhase2AlCaRecoSamples/RECOvsALCA_fix_ZMuMu/).  

[*] 
`/RelValSingleMuFlatPt2To100/CMSSW_14_0_0_pre2-133X_mcRun4_realistic_v1_STD_2026D98_noPU_RV229-v1/GEN-SIM-RECO `

[**] 
```
cmsDriver.yp stepTkAlZMuMu -s ALCA:TkAlZMuMu --conditions auto:phase2_realistic_T25 --datatier ALCARECO -n -1 --eventcontent ALCARECO --geometry Extended2026D98 --era Phase2C17I13M9 -n -1
 --fileout file:step5.root --nThreads 4 --dasquery=file dataset=/RelValZMM_14/CMSSW_14_0_0_pre2-133X_mcRun4_realistic_v1_STD_2026D98_noPU-v2/GEN-SIM-RECO'
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A