### PR TITLE
extend histograms to the Run3 range in CTPPSLHCInfoPlotter

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSLHCInfoPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSLHCInfoPlotter.cc
@@ -71,8 +71,8 @@ CTPPSLHCInfoPlotter::CTPPSLHCInfoPlotter(const edm::ParameterSet &iConfig)
                                       -0.005,
                                       1.005)),
 
-      h_fill_(new TH1D("h_fill", ";fill", 4001, 3999.5, 8000.5)),
-      h_run_(new TH1D("h_run", ";run", 6000, 270E3, 330E3)) {}
+      h_fill_(new TH1D("h_fill", ";fill", 6001, 3999.5, 10000.5)),
+      h_run_(new TH1D("h_run", ";run", 6000, 270E3, 430E3)) {}
 
 //----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
#### PR description:

This PR updates the validation scripts used with Proton Object to plot the LHCInfo. The range of the output histograms produced by the code was extended to account for the Run3 fill and run numbers

#### PR validation:

tested using cmsRun on https://github.com/cms-sw/cmssw/blob/master/CondTools/RunInfo/test/xangleBetaStarFilter_test_cfg.py from https://github.com/cms-sw/cmssw/pull/43854
with CMSSW_14_0_0_pre3

