### PR TITLE
Add low pt muon fix objects into phase 2 L1 event content.

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -231,6 +231,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tTkStubsGmt_*_*',
         'keep *_l1tTkMuonsGmt_*_*',
         'keep *_l1tSAMuonsGmt_*_*',
+        'keep *_l1tTkMuonsGmtLowPtFix_*_*', # in the long run this should be removed, but these fix objects will be used for now.
         ]
     obj.outputCommands += l1Phase2Digis
 


### PR DESCRIPTION
#### PR description:

This PR adds the low pt muon fix objects that are temporarily an input into the phase 2 GT emulator into L1 FEVTDEBUG content to have all emulator objects available. This _should_ be temporary until the full kBMTF/GMT muon objects are available with all fixes.

@cbotta, @artlbv, just FYI that this PR has been opened. With your approval I will tag Soham on this PR as well.

#### PR validation:

New FEVTDEBUG has the required objects.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We are sort of hoping for this content to make it into the scheduled HLT MC production for CMSSW_14_0. Therefore, this PR may need to be backported based on whether or not it can be quickly included in the final build of CMSSW_14_0.