### PR TITLE
Add l1tPhase2L1CaloEGammaEmulator to the phase 2 L1 event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -231,6 +231,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tTkStubsGmt_*_*',
         'keep *_l1tTkMuonsGmt_*_*',
         'keep *_l1tSAMuonsGmt_*_*',
+	'keep *_l1tPhase2L1CaloEGammaEmulator_*_*',
         ]
     obj.outputCommands += l1Phase2Digis
 


### PR DESCRIPTION
This PR adds a new collection to the phase-2 L1 event content.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
As for https://github.com/cms-sw/cmssw/pull/43869, we are sort of hoping for this content to make it into the scheduled HLT MC production for CMSSW_14_0. Therefore, this PR may need to be backported based on whether or not it can be quickly included in the final build of CMSSW_14_0.
