### PR TITLE
fix `DAClusterizerInZ_vect` for ASAN_X build

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -1313,7 +1313,8 @@ vector<TransientVertex> DAClusterizerInZ_vect::fill_vertices(double beta, double
         zerror_squared = sumwp / (sumw * sumw);
         y.zvtx[k] = sumwz / sumw;
       }
-      const auto& bs = vertexTracks[0].stateAtBeamLine().beamSpot();
+
+      reco::BeamSpot bs = vertexTracks[0].stateAtBeamLine().beamSpot();
       GlobalPoint pos(bs.x(y.zvtx[k]), bs.y(y.zvtx[k]), y.zvtx[k]);
       const float xerror_squared = pow(bs.BeamWidthX(), 2);
       const float yerror_squared = pow(bs.BeamWidthY(), 2);


### PR DESCRIPTION
#### PR description:

This is a simple follow-up to https://github.com/cms-sw/cmssw/pull/43592 and it's supposed to fix the massive failures observed in the ASAN_X build after that PR was merged (see https://github.com/cms-sw/cmssw/pull/43592#issuecomment-1921783489).
 This is achieved by making a copy of the object returned from another temporary object avoid holding ref to released memory.

#### PR validation:

In `CMSSW_14_0_ASAN_X_2024-02-05-2300` run `runTheMatrix.py -l 1.0 --ibeos` with this branch and seen it succeed (it is currently failing, see [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_0_ASAN_X_2024-02-05-2300/pyRelValMatrixLogs/run/1.0_ProdMinBias/step3_ProdMinBias.log#/) ).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

Cc: @werdmann @fabiocos @kdeleo 