### PR TITLE
Do not redefine twice in CMSSW the TkAl muon selectors

### DIFF
--- a/Alignment/APEEstimation/python/AlcaRecoSelection_cff.py
+++ b/Alignment/APEEstimation/python/AlcaRecoSelection_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 
 
 ##
@@ -7,26 +8,12 @@ import FWCore.ParameterSet.Config as cms
 ##
 
 ## First select goodId + isolated muons
-TkAlGoodIdMuonSelector = cms.EDFilter("MuonSelector",
-    src = cms.InputTag('muons'),
-    cut = cms.string('isGlobalMuon &'
-                     'isTrackerMuon &'
-                     'numberOfMatches > 1 &'
-                     'globalTrack.hitPattern.numberOfValidMuonHits > 0 &'
-                     'abs(eta) < 2.5 &'
-                     'globalTrack.normalizedChi2 < 20.'),
-    filter = cms.bool(True)
+ALCARECOTkAlMuonIsolatedGoodMuons = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.TkAlGoodIdMuonSelector.clone()
+ALCARECOTkAlMuonIsolatedRelCombIsoMuons = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.TkAlRelCombIsoMuonSelector.clone(
+    src = 'ALCARECOTkAlMuonIsolatedGoodMuons'
 )
-TkAlRelCombIsoMuonSelector = cms.EDFilter("MuonSelector",
-    src = cms.InputTag(''),
-    cut = cms.string('(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.15'),
-    filter = cms.bool(True)
-)
-ALCARECOTkAlMuonIsolatedGoodMuons = TkAlGoodIdMuonSelector.clone()
-ALCARECOTkAlMuonIsolatedRelCombIsoMuons = TkAlRelCombIsoMuonSelector.clone(src = 'ALCARECOTkAlMuonIsolatedGoodMuons')
 
 ## Then select their tracks with additional cuts
-import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
 ALCARECOTkAlMuonIsolated = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
     filter = True, ##do not store empty events
     applyBasicCuts = True,


### PR DESCRIPTION
#### PR description:

The config in Alignment/APEEstimation/python/AlcaRecoSelection_cff.py redefines the two selectors:
- `TkAlGoodIdMuonSelector`
- `TkAlRelCombIsoMuonSelector`

already defined in Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py

This could insert unwanted mistakes in case the two python configs are imported in the same workflow.

Those two selectors in the file touched here are not even needed themselves, because are just meant to get cloned into the actual selectors to be used in the `mySeqALCARECOTkAlMuonIsolated` sequence.

An objection raised by @mmusich in https://github.com/cms-sw/cmssw/pull/43859#issuecomment-1929308917 is that importing those selectors from Alignment/CommonAlignmentProducer could make the `ALCARECOTkAlMuonIsolated*` sequences depend on some other confinguration not fully under control of the APE team. (At the moment the selections are coded identically in the two python files).

My impression is that, if so, one should rather explicitly define all relevant parameters into the `clone()` function and avoid as such redefining the same module in two different places. Of course, if the TkAl people does not agree with me I will remove this PR.


#### PR validation:

At this moment the configurations and the sequences in Alignment/APEEstimation/python/AlcaRecoSelection_cff.py end up being identical to the previous ones. No further validation was attempted.