### PR TITLE
Implement the GSF Track fBrem Variable Filling for Scouting Electrons: 14_0

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
@@ -56,6 +56,7 @@ HLTScoutingEgammaProducer::HLTScoutingEgammaProducer(const edm::ParameterSet& iC
       DphiMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("DphiMap"))),
       MissingHitsMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("MissingHitsMap"))),
       OneOEMinusOneOPMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("OneOEMinusOneOPMap"))),
+      fBremMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("fBremMap"))),
       EcalPFClusterIsoMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("EcalPFClusterIsoMap"))),
       EleGsfTrackIsoMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("EleGsfTrackIsoMap"))),
       HcalPFClusterIsoMap_(consumes<RecoEcalCandMap>(iConfig.getParameter<edm::InputTag>("HcalPFClusterIsoMap"))),
@@ -174,6 +175,14 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
   // Get 1/E - 1/p Map
   Handle<RecoEcalCandMap> OneOEMinusOneOPMap;
   if (!iEvent.getByToken(OneOEMinusOneOPMap_, OneOEMinusOneOPMap)) {
+    iEvent.put(std::move(outElectrons));
+    iEvent.put(std::move(outPhotons));
+    return;
+  }
+
+  // Get fBrem Map
+  Handle<RecoEcalCandMap> fBremMap;
+  if (!iEvent.getByToken(fBremMap_, fBremMap)) {
     iEvent.put(std::move(outElectrons));
     iEvent.put(std::move(outPhotons));
     return;
@@ -365,7 +374,7 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
                                  (*OneOEMinusOneOPMap)[candidateRef],
                                  (*MissingHitsMap)[candidateRef],
                                  trkcharge,
-                                 0.0 /* waiting implementation of the track fbrem producer*/,
+                                 (*fBremMap)[candidateRef],
                                  (*EcalPFClusterIsoMap)[candidateRef],
                                  (*HcalPFClusterIsoMap)[candidateRef],
                                  (*EleGsfTrackIsoMap)[candidateRef],
@@ -395,10 +404,11 @@ void HLTScoutingEgammaProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("SigmaIEtaIEtaMap", edm::InputTag("hltEgammaClusterShape:sigmaIEtaIEta5x5"));
   desc.add<edm::InputTag>("r9Map", edm::InputTag("hltEgammaR9ID:r95x5"));
   desc.add<edm::InputTag>("HoverEMap", edm::InputTag("hltEgammaHoverE"));
-  desc.add<edm::InputTag>("DetaMap", edm::InputTag("hltEgammaGsfTrackVars:DetaSeed"));
-  desc.add<edm::InputTag>("DphiMap", edm::InputTag("hltEgammaGsfTrackVars:Dphi"));
-  desc.add<edm::InputTag>("MissingHitsMap", edm::InputTag("hltEgammaGsfTrackVars:MissingHits"));
-  desc.add<edm::InputTag>("OneOEMinusOneOPMap", edm::InputTag("hltEgammaGsfTrackVars:OneOESuperMinusOneOP"));
+  desc.add<edm::InputTag>("DetaMap", edm::InputTag("hltEgammaGsfTrackVarsUnseeded:DetaSeed"));
+  desc.add<edm::InputTag>("DphiMap", edm::InputTag("hltEgammaGsfTrackVarsUnseeded:Dphi"));
+  desc.add<edm::InputTag>("MissingHitsMap", edm::InputTag("hltEgammaGsfTrackVarsUnseeded:MissingHits"));
+  desc.add<edm::InputTag>("OneOEMinusOneOPMap", edm::InputTag("hltEgammaGsfTrackVarsUnseeded:OneOESuperMinusOneOP"));
+  desc.add<edm::InputTag>("fBremMap", edm::InputTag("hltEgammaGsfTrackVarsUnseeded:fbrem"));
   desc.add<edm::InputTag>("EcalPFClusterIsoMap", edm::InputTag("hltEgammaEcalPFClusterIso"));
   desc.add<edm::InputTag>("EleGsfTrackIsoMap", edm::InputTag("hltEgammaEleGsfTrackIso"));
   desc.add<edm::InputTag>("HcalPFClusterIsoMap", edm::InputTag("hltEgammaHcalPFClusterIso"));

--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
@@ -73,6 +73,7 @@ private:
   const edm::EDGetTokenT<RecoEcalCandMap> DphiMap_;
   const edm::EDGetTokenT<RecoEcalCandMap> MissingHitsMap_;
   const edm::EDGetTokenT<RecoEcalCandMap> OneOEMinusOneOPMap_;
+  const edm::EDGetTokenT<RecoEcalCandMap> fBremMap_;
   const edm::EDGetTokenT<RecoEcalCandMap> EcalPFClusterIsoMap_;
   const edm::EDGetTokenT<RecoEcalCandMap> EleGsfTrackIsoMap_;
   const edm::EDGetTokenT<RecoEcalCandMap> HcalPFClusterIsoMap_;


### PR DESCRIPTION
#### PR description:

 - The fBrem variable is reconstructed at the HLT with [PR43774](https://github.com/cms-sw/cmssw/pull/43774).
 - This PR enables its accessibility to the Scouting Egamma Producer and fills the electron collection appropriately.
 - The default values in ```HLTScoutingEgammaProducer::fillDescriptions``` changed to reflect the values as expected in the path that uses the producer.
 - Backport of [PR43873](https://github.com/cms-sw/cmssw/pull/43873) in the 14_1_X release cycle.

#### PR validation:

 - The standards code check and formatting have been completed successfully.
 - I re-ran the recommended HLT config - /dev/CMSSW_13_3_0/GRun - with the changes in this PR on the Double Electron Gun MC and checked the variable fill. Screenshot is attached below and shows that the variable is correctly filled. The config and the output can be found in CERN AFS at the path /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/TestSecondRoundOfCommits/CMSSW_14_0_0_pre3/src and are named as configHLT1330V22Fbrem_ScoutingPF.py and outputHLT1330V22Fbrem_ScoutingPF.root respectively. 
 - The relevant for the customisation for the menu is at the path /afs/cern.ch/work/a/asahasra/public/ScoutingStudy/For2024ScoutingEGUpdate/TestSecondRoundOfCommits/CMSSW_14_0_0_pre3/src/HLTrigger/Configuration/python/customizeHLTforScouting.py.

<img width="1510" alt="image" src="https://github.com/cms-sw/cmssw/assets/32368439/c3f55f61-31d5-49a0-a71e-4374361b935d">
