### PR TITLE
 HLT development: add unit test for online vs dev tables consistency [14.0.X]

### DIFF
--- a/HLTrigger/Configuration/tables/online_grun.txt
+++ b/HLTrigger/Configuration/tables/online_grun.txt
@@ -427,7 +427,6 @@ HLT_IsoMu24_TwoProngs35_v*	#	CMSHLT-1885
 HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_v*	#	CMSHLT-1796
 HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_v*	#	CMSHLT-1796
 HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1_v*         # CMSHLT-2289
-HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v* # CMSHLT-2349
 HLT_ZeroBias_Alignment_v*	#	CMSHLT-1892
 HLT_CDC_L2cosmic_5p5_er1p0_v*	#	CMSHLT-1896
 HLT_Ele30_WPTight_Gsf_v*	#	CMSHLT-1921

--- a/HLTrigger/Configuration/test/BuildFile.xml
+++ b/HLTrigger/Configuration/test/BuildFile.xml
@@ -14,3 +14,6 @@
 
 <!-- test script hltFindDuplicates -->
 <test name="test_hltFindDuplicates" command="test_hltFindDuplicates.sh"/>
+
+<!-- test script testOnlineVsDevTablesConsistency -->
+<test name="test_OnlineVsDevTablesConsistency" command="test_OnlineVsDevTablesConsistency.sh"/>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43865

#### PR description:

Title says it all, add a script to test the consistency of the paths added in the `online_<...>.txt` sub-tables w.r.t to the development subtables `<...>.txt` (excluding the elements known to differ (`"HLTAnalyzerEndpath" "RatesMonitoring" "DQMHistograms"`).
A corresponding unit test run on all the sub-tables supported by TSG / STORM is added
Additionally a mistake in the integration of [CMSHLT-3019](https://its.cern.ch/jira/browse/CMSHLT-3019), introduced in PR https://github.com/cms-sw/cmssw/pull/43842 is corrected (the path `HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v` removed from the `GRun` table should be removed also from `online_grun` one.

#### PR validation:

`scram b runtests_test_OnlineVsDevTablesConsistency`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/43865