### PR TITLE
Produce sMajor, sMinor in EgammaHLTClusterShapeProducer

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaClusterShapeL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaClusterShapeL1Seeded_cfi.py
@@ -3,6 +3,5 @@ import FWCore.ParameterSet.Config as cms
 hltEgammaClusterShapeL1Seeded = cms.EDProducer("EgammaHLTClusterShapeProducer",
     ecalRechitEB = cms.InputTag("hltRechitInRegionsECAL","EcalRecHitsEB"),
     ecalRechitEE = cms.InputTag("hltRechitInRegionsECAL","EcalRecHitsEE"),
-    isIeta = cms.bool(True),
     recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesL1Seeded")
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaClusterShapeUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaClusterShapeUnseeded_cfi.py
@@ -3,6 +3,5 @@ import FWCore.ParameterSet.Config as cms
 hltEgammaClusterShapeUnseeded = cms.EDProducer("EgammaHLTClusterShapeProducer",
     ecalRechitEB = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
     ecalRechitEE = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
-    isIeta = cms.bool(True),
     recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded")
 )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -234,6 +234,12 @@ def customiseForOffline(process):
     return process
 
 
+def customizeHLTfor43885(process):
+    for producer in producers_by_type(process, "EgammaHLTClusterShapeProducer"):
+        if hasattr(producer, 'isIeta'):
+            delattr(producer, 'isIeta')
+    return process
+    
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -247,5 +253,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customizeHLTfor43885(process)
 
     return process

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -128,11 +128,11 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
     double sigmaee;
     double sigmapp;  //sigmaIphiIphi, needed in e/gamma HLT regression setup
-    
+
     const auto& vCov = lazyTools.localCovariances(*(recoecalcandref->superCluster()->seed()));
     sigmaee = sqrt(vCov[0]);
     sigmapp = sqrt(vCov[2]);
-    
+
     //this is full5x5 showershape
     auto const ecalCandLocalCov = lazyTools5x5.localCovariances(*(recoecalcandref->superCluster()->seed()));
     auto const sigmaee5x5 = sqrt(ecalCandLocalCov[0]);


### PR DESCRIPTION
#### PR description:
Produce sMajor, sMinor via EgammaHLTClusterShapeProducer in ECAL. These variables are useful for displaced e/gamma HLT path. In phase2, we would like to add some displaced e/gamma paths where we would like to cut on these variables. This PR is to enable such studies easily for Phase2 HLT. 

#### PR validation:
`runTheMatrix.py -l 24834.0` worked fine.

Additionally, checked that we are getting reasonable values for sMajor, sMinor. This check was done from Phase2 EGamma HLT setup, using this root file:  
```
/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-10To50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/noPU_131X_mcRun4_realistic_v5-v1/30000/66eea162-e0cd-4752-a295-5bbca4bd8363.root (1000 events)
```
These are the histograms for sMajor and sMinor, for barrel, at HLT
<img src="https://github.com/cms-sw/cmssw/assets/5052706/90475bb6-80e7-4cfb-9b7c-406ff8e2c1bc" width="350"> <img src="https://github.com/cms-sw/cmssw/assets/5052706/7da10d61-dad6-44b2-a786-797fc40b5162" width="350">

PS: Took this opportunity to do some cleanup. Removed sigmaEtaEta type variables as they are obsolete.