### PR TITLE
Send full quality scale from uGMT to uGT

### DIFF
--- a/L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h
+++ b/L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h
@@ -44,7 +44,7 @@ namespace l1t {
 
     static int calcGlobalPhi(int locPhi, tftype t, int proc);
 
-    static int setOutputMuonQuality(int muQual, tftype type, int haloBit);
+    static int setOutputMuonQuality(int muQual, tftype type, int haloBit, unsigned fwVersion);
 
     static int calcMuonHwEtaExtra(const l1t::Muon& mu);
     static int calcMuonHwPhiExtra(const l1t::Muon& mu);

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -329,7 +329,8 @@ void L1TMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         math::PtEtaPhiMLorentzVector vec{
             (mu->hwPt() - 1) * 0.5, mu->hwEta() * 0.010875, mu->hwGlobalPhi() * 0.010908, 0.0};
         int iso = mu->hwAbsIso() + (mu->hwRelIso() << 1);
-        int outMuQual = MicroGMTConfiguration::setOutputMuonQuality(mu->hwQual(), mu->trackFinderType(), mu->hwHF());
+        int outMuQual = MicroGMTConfiguration::setOutputMuonQuality(
+            mu->hwQual(), mu->trackFinderType(), mu->hwHF(), microGMTParamsHelper->fwVersion());
         Muon outMu{vec,
                    mu->hwPt(),
                    mu->hwEta(),
@@ -434,7 +435,8 @@ void L1TMuonProducer::addMuonsToCollections(MicroGMTConfiguration::InterMuonList
   for (auto& mu : coll) {
     interout.push_back(mu);
     math::PtEtaPhiMLorentzVector vec{(mu->hwPt() - 1) * 0.5, mu->hwEta() * 0.010875, mu->hwGlobalPhi() * 0.010908, 0.0};
-    int outMuQual = MicroGMTConfiguration::setOutputMuonQuality(mu->hwQual(), mu->trackFinderType(), mu->hwHF());
+    int outMuQual = MicroGMTConfiguration::setOutputMuonQuality(
+        mu->hwQual(), mu->trackFinderType(), mu->hwHF(), microGMTParamsHelper->fwVersion());
     // set tfMuonIndex and iso to 0 like in the FW
     Muon outMu{vec,
                mu->hwPt(),

--- a/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
+++ b/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
@@ -98,15 +98,15 @@ gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     BONegMatchQualLUTfEtaCoarse   = cms.double(1),
     BONegMatchQualLUTfPhi         = cms.double(6),
 
-    FOPosMatchQualLUTMaxDR        = cms.double(0.075),
+    FOPosMatchQualLUTMaxDR        = cms.double(0.2),
     FOPosMatchQualLUTfEta         = cms.double(1),
     FOPosMatchQualLUTfEtaCoarse   = cms.double(1),
-    FOPosMatchQualLUTfPhi         = cms.double(3),
+    FOPosMatchQualLUTfPhi         = cms.double(2),
 
-    FONegMatchQualLUTMaxDR        = cms.double(0.075),
+    FONegMatchQualLUTMaxDR        = cms.double(0.2),
     FONegMatchQualLUTfEta         = cms.double(1),
     FONegMatchQualLUTfEtaCoarse   = cms.double(1),
-    FONegMatchQualLUTfPhi         = cms.double(3),
+    FONegMatchQualLUTfPhi         = cms.double(2),
 
     # parameters for SortRank LUT if no path to an external LUT is defined
     # If a path to an external LUT is defined these parameters have no effect

--- a/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
+++ b/L1Trigger/L1TMuon/python/fakeGmtParams_cff.py
@@ -29,7 +29,7 @@ gmtParams = cms.ESProducer('L1TMuonGlobalParamsESProducer',
     # uGMT FW version to be set
     # Format: 0xMMmmvvpp for major.minor.very_minor.patch
     # E.g.: 2.1.0.patch1 translates to 0x02010001
-    fwVersion = cms.uint32(0x4010000),
+    fwVersion = cms.uint32(0x8010000),
 
     # uGMT inputs to disable
     # disabled inputs are not used in the algo but are still in the readout

--- a/L1Trigger/L1TMuon/src/MicroGMTConfiguration.cc
+++ b/L1Trigger/L1TMuon/src/MicroGMTConfiguration.cc
@@ -12,28 +12,31 @@ int l1t::MicroGMTConfiguration::calcGlobalPhi(int locPhi, tftype t, int proc) {
   int globPhi = 0;
   if (t == bmtf) {
     // each BMTF processor corresponds to a 30 degree wedge = 48 in int-scale
-    globPhi = (proc)*48 + locPhi;
+    globPhi = (proc) * 48 + locPhi;
     // first processor starts at CMS phi = -15 degrees...
     globPhi += 576 - 24;
     // handle wrap-around (since we add the 576-24, the value will never be negative!)
     globPhi = globPhi % 576;
   } else {
     // all others correspond to 60 degree sectors = 96 in int-scale
-    globPhi = (proc)*96 + locPhi;
+    globPhi = (proc) * 96 + locPhi;
     // first processor starts at CMS phi = 15 degrees (24 in int)... Handle wrap-around with %. Add 576 to make sure the number is positive
     globPhi = (globPhi + 600) % 576;
   }
   return globPhi;
 }
 
-int l1t::MicroGMTConfiguration::setOutputMuonQuality(int muQual, tftype type, int haloBit) {
-  // use only the two MSBs for the muon to the uGT
-  int outQual = muQual & 0xC;
-  if (haloBit == 1 && (type == tftype::emtf_neg || type == tftype::emtf_pos)) {
+int l1t::MicroGMTConfiguration::setOutputMuonQuality(int muQual, tftype type, int haloBit, unsigned fwVersion) {
+  if (fwVersion >= 0x8010000) {
+    // From 2024 uGMT sends the full quality on to uGT
+    return muQual;
+  } else if (haloBit == 1 && (type == tftype::emtf_neg || type == tftype::emtf_pos)) {
     // set quality to 0xF if the halo bit is set
-    outQual = 0xF;
+    return 0xF;
+  } else {
+    // use only the two MSBs for the muon to the uGT
+    return muQual & 0xC;
   }
-  return outQual;
 }
 
 int l1t::MicroGMTConfiguration::calcMuonHwEtaExtra(const l1t::Muon& mu) { return mu.hwEta() + mu.hwDEtaExtra(); }


### PR DESCRIPTION
#### PR description:

From the 2024 running period uGMT will send the full quality scale instead of a truncated one to uGT. This PR implements this in the uGMT emulator.

Also updated the values of the matching windows for the ghost busting unit in the fakeParams. These parameters aren't used by the normal machinery, but only when overriding the standard workflows for studies.

#### PR validation:

Ran standard tests, currently comparing with the firmware.
