### PR TITLE
Avoid holding ref to released memory in DAClusterizerInZ_vect

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZ_vect.cc
@@ -1313,7 +1313,7 @@ vector<TransientVertex> DAClusterizerInZ_vect::fill_vertices(double beta, double
         zerror_squared = sumwp / (sumw * sumw);
         y.zvtx[k] = sumwz / sumw;
       }
-      const auto& bs = vertexTracks[0].stateAtBeamLine().beamSpot();
+      const auto bs = vertexTracks[0].stateAtBeamLine().beamSpot();
       GlobalPoint pos(bs.x(y.zvtx[k]), bs.y(y.zvtx[k]), y.zvtx[k]);
       const float xerror_squared = pow(bs.BeamWidthX(), 2);
       const float yerror_squared = pow(bs.BeamWidthY(), 2);


### PR DESCRIPTION
#### PR description:

Make a copy of the object returned from another temporary object.

#### PR validation:

Fixes the compiler warning in CMSSW_14_1_NONLTO_X_2024-02-06-2300.