### PR TITLE
[14.0.X] add phase2 customizations to `TkAlMuonSelectors` to increase selection efficiency

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/TkAlMuonSelectors_cfi.py
@@ -16,3 +16,16 @@ TkAlRelCombIsoMuonSelector = cms.EDFilter("MuonSelector",
     cut = cms.string('(isolationR03().sumPt + isolationR03().emEt + isolationR03().hadEt)/pt  < 0.15'),
     filter = cms.bool(True)
 )
+
+## FIXME: these are needed for ALCARECO production in CMSSW_14_0_X
+## to avoid loosing in efficiency. To be reviewed after muon reco is fixed
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(TkAlGoodIdMuonSelector,
+                       cut = '(abs(eta) < 2.5 & isGlobalMuon & isTrackerMuon & numberOfMatches > 1 & globalTrack.hitPattern.numberOfValidMuonHits > 0 &  globalTrack.normalizedChi2 < 20.) ||'  # regular selection
+                       '(abs(eta) > 2.3 & abs(eta) < 3.0 & numberOfMatches >= 0 & isTrackerMuon)'   # to recover GE0 tracks
+                       )
+
+phase2_common.toModify(TkAlRelCombIsoMuonSelector,
+                       cut = '(isolationR03().sumPt)/pt < 0.1' # only tracker isolation
+                       )


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43859

#### PR description:

See description at https://github.com/cms-sw/cmssw/pull/43859

#### PR validation:

See description at https://github.com/cms-sw/cmssw/pull/43859

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/43859 (same branch is used).