### PR TITLE
[14.0.X]  miscellaneous updates to improve validation of phase-2 Tracker Alignment samples

### DIFF
--- a/Alignment/OfflineValidation/macros/loopAndPlot.C
+++ b/Alignment/OfflineValidation/macros/loopAndPlot.C
@@ -32,12 +32,12 @@ void MakeNiceProfile(TProfile *prof);
 //void MakeNicePlotStyle(TH1 *hist);
 void plot2Histograms(TH1 *h1, TH1 *h2, const TString &label1, const TString &label2);
 void plot2Profiles(TProfile *h1, TProfile *h2, const TString &label1, const TString &label2);
-void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels);
+void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels, bool isNorm);
 void recurseOverKeys(TDirectory *target1, const TString &label1, const TString &label2);
-void plotHistograms(std::vector<TH1 *> histos, const std::vector<TString> &labels);
+void plotHistograms(std::vector<TH1 *> histos, const std::vector<TString> &labels, bool isNormalized = false);
 
 /************************************************/
-void loopAndPlot(TString namesandlabels)
+void loopAndPlot(TString namesandlabels, bool doNormalize = false)
 /************************************************/
 {
   std::vector<TString> labels;
@@ -56,7 +56,7 @@ void loopAndPlot(TString namesandlabels)
     }
   }
 
-  recurseOverKeys(sourceFiles[0], labels);
+  recurseOverKeys(sourceFiles[0], labels, doNormalize);
 
   for (const auto &file : sourceFiles) {
     file->Close();
@@ -64,7 +64,7 @@ void loopAndPlot(TString namesandlabels)
 }
 
 /************************************************/
-void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels)
+void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels, bool isNorm)
 /************************************************/
 {
   // Figure out where we are
@@ -107,7 +107,7 @@ void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels)
 
       //outputFilename=histName;
       //plot2Histograms(htemp1, htemp2, outputFolder+path+"/"+outputFilename+"."+imageType);
-      plotHistograms(histos, labels);
+      plotHistograms(histos, labels, isNorm);
 
     } else if (obj->IsA()->InheritsFrom("TDirectory")) {
       // it's a subdirectory
@@ -122,14 +122,14 @@ void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels)
       if ((TString(obj->GetName())).Contains("Residuals"))
         continue;
 
-      recurseOverKeys((TDirectory *)obj, labels);
+      recurseOverKeys((TDirectory *)obj, labels, isNorm);
 
     }  // end of IF a TDriectory
   }
 }
 
 /************************************************/
-void plotHistograms(std::vector<TH1 *> histos, const std::vector<TString> &labels) {
+void plotHistograms(std::vector<TH1 *> histos, const std::vector<TString> &labels, bool isNormalized) {
   /************************************************/
 
   TGaxis::SetMaxDigits(3);
@@ -142,6 +142,11 @@ void plotHistograms(std::vector<TH1 *> histos, const std::vector<TString> &label
   int index = 0;
   for (const auto &histo : histos) {
     MakeNicePlotStyle<TH1>(histo);
+
+    if (isNormalized) {
+      Double_t scale = 1. / histo->Integral();
+      histo->Scale(scale);
+    }
 
     histo->SetLineColor(def_colors[index]);
     histo->SetMarkerColor(def_colors[index]);

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -869,7 +869,7 @@ private:
     hEta = book<TH1D>("h_Eta", "Track pseudorapidity; track #eta;tracks", 100, -etaMax_, etaMax_);
     hPhi = book<TH1D>("h_Phi", "Track azimuth; track #phi;tracks", 100, -M_PI, M_PI);
 
-    hPhiBarrel = book<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #Phi;tracks", 100, -M_PI, M_PI);
+    hPhiBarrel = book<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #phi;tracks", 100, -M_PI, M_PI);
     hPhiOverlapPlus =
         book<TH1D>("h_PhiOverlapPlus", "hPhiOverlapPlus (0.8<#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
     hPhiOverlapMinus =
@@ -880,7 +880,7 @@ private:
     h_BSx0 = book<TH1F>("h_BSx0", "x-coordinate of reco beamspot;x^{BS}_{0};n_{events}", 100, -0.1, 0.1);
     h_BSy0 = book<TH1F>("h_BSy0", "y-coordinate of reco beamspot;y^{BS}_{0};n_{events}", 100, -0.1, 0.1);
     h_BSz0 = book<TH1F>("h_BSz0", "z-coordinate of reco beamspot;z^{BS}_{0};n_{events}", 100, -1., 1.);
-    h_Beamsigmaz = book<TH1F>("h_Beamsigmaz", "z-coordinate beam width;#sigma_{Z}^{beam};n_{events}", 100, 0., 1.);
+    h_Beamsigmaz = book<TH1F>("h_Beamsigmaz", "z-coordinate beam width;#sigma_{Z}^{beam};n_{events}", 100, 0., 7.);
     h_BeamWidthX = book<TH1F>("h_BeamWidthX", "x-coordinate beam width;#sigma_{X}^{beam};n_{events}", 100, 0., 0.01);
     h_BeamWidthY = book<TH1F>("h_BeamWidthY", "y-coordinate beam width;#sigma_{Y}^{beam};n_{events}", 100, 0., 0.01);
     h_BSdxdz = book<TH1F>("h_BSdxdz", "BeamSpot dxdz;beamspot dx/dz;n_{events}", 100, -0.0003, 0.0003);
@@ -1125,6 +1125,12 @@ private:
       modeByRun_->GetXaxis()->SetBinLabel((the_r - theRuns_.front()) + 1, std::to_string(the_r).c_str());
       fieldByRun_->GetXaxis()->SetBinLabel((the_r - theRuns_.front()) + 1, std::to_string(the_r).c_str());
     }
+
+    static const int kappadiffindex = this->index(vTrackHistos_, "h_diff_curvature");
+    vTrackHistos_[kappadiffindex]->Add(vTrackHistos_[this->index(vTrackHistos_, "h_curvature_neg")],
+                                       vTrackHistos_[this->index(vTrackHistos_, "h_curvature_pos")],
+                                       -1,
+                                       1);
 
     if (phase_ < SiPixelPI::phase::two) {
       if (phase_ == SiPixelPI::phase::zero) {

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -18,6 +18,8 @@ filesDefaultMC_MinBiasPUPhase2 = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/ALCARECO/TkAlMinBias-125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/27b7ab93-1d2b-4f4a-a98e-68386c314b5e.root',
 )
 
+filesDefaultMC_DoubleMuonPUPhase_string = '/store/mc/Phase2Fall22DRMiniAOD/DYJetsToMuMu_M-50_TuneCP5_14TeV-madgraphMLM-pythia8/ALCARECO/TkAlZMuMu-PU200ALCA_TkAlPU200_125X_mcRun4_realistic_v5-v1/60000/9382696c-70fd-4b37-8a0f-24bd02aeda5f.root'
+
 filesDefaultMC_MinBiasPUPhase2RECO = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_3/RelValMinBias_14TeV/GEN-SIM-RECO/125X_mcRun4_realistic_v5_2026D88PU-v1/2590000/22e22ae6-a353-4f2e-815e-cc5efee37af9.root',
 )

--- a/Alignment/OfflineValidation/test/inspectData_cfg.py
+++ b/Alignment/OfflineValidation/test/inspectData_cfg.py
@@ -1,6 +1,8 @@
+import math
 import glob
+import importlib
 import FWCore.ParameterSet.Config as cms
-from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_Comissioning2022_Cosmics_string
+from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultData_Comissioning2022_Cosmics_string,filesDefaultMC_DoubleMuonPUPhase_string
 
 ###################################################################
 # Setup 'standard' options
@@ -31,6 +33,18 @@ options.register('unitTest',
                  VarParsing.VarParsing.varType.bool, # string, int, or float
                  "is it a unit test?")
 
+options.register('isDiMuonData',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "is it running on DiMuon data?")
+
+options.register('isCosmics',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "is it running on cosmics data?")
+
 options.register('inputData',
                  "/eos/cms/store/express/Commissioning2022/ExpressCosmics/FEVT/Express-v1/000/350/010/00000/*",
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -43,9 +57,33 @@ options.register('maxEvents',
                  VarParsing.VarParsing.varType.int, # string, int, or float
                  "num. events to run")
 
+options.register('Detector',
+                 '2023',
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list                 
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "Detector to run upon")
+
 options.parseArguments()
 
-process = cms.Process("AlCaRECOAnalysis")
+
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import upgradeProperties
+ConditionsInfo = {}
+if 'D' in options.Detector:
+    ConditionsInfo = upgradeProperties[2026][options.Detector] # so if the default changes, change wf only here
+else:
+    ConditionsInfo = upgradeProperties[2017][options.Detector]
+    
+era_value = ConditionsInfo['Era']
+era_module_name = f'Configuration.Eras.Era_{era_value}_cff'
+config_name = f'{era_value}'
+era_module = importlib.import_module(era_module_name)
+era_config = getattr(era_module, config_name, None)
+
+if era_config is not None:
+    # Use the configurations from the imported module in the process setup
+    process = cms.Process("AlCaRECOAnalysis", era_config)
+else:
+    print(f"Error: Could not find configuration {config_name} in module {era_module_name}.")
 
 ###################################################################
 # Message logger service
@@ -71,7 +109,12 @@ process.MessageLogger.cout = cms.untracked.PSet(
 ###################################################################
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+if 'D' in options.Detector:
+    geom = options.Detector  # Replace with your actual dynamic part
+    process.load(f'Configuration.Geometry.GeometryExtended{geom}Reco_cff')
+else:
+    process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+
 process.load('Configuration.StandardSequences.MagneticField_cff')
 #process.load("Configuration.StandardSequences.MagneticField_0T_cff")
 process.load("CondCore.CondDB.CondDB_cfi")
@@ -81,7 +124,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag if (options.globalTag != '') else ConditionsInfo['GT'], '')
 
 ###################################################################
 # Source
@@ -91,11 +134,19 @@ process.source = cms.Source("PoolSource",fileNames = readFiles)
 the_files=[]
 if(options.unitTest):
     ## fixed input for the unit test
-    readFiles.extend([filesDefaultData_Comissioning2022_Cosmics_string]) 
+    if('D' in options.Detector) :
+        # it's for phase-2
+        readFiles.extend([filesDefaultMC_DoubleMuonPUPhase_string])
+    else:
+        # it's for phase-1
+        readFiles.extend([filesDefaultData_Comissioning2022_Cosmics_string])
 else:
     file_list = glob.glob(options.inputData)
     for f in file_list:
-        the_files.append(f.replace("/eos/cms",""))
+        if '/eos/cms' in f:
+            the_files.append(f.replace("/eos/cms",""))
+        else: 
+            the_files.append(f.replace("./","file:"))
     print(the_files)
     readFiles.extend(the_files)
 
@@ -135,13 +186,21 @@ process.MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelecto
 ###################################################################
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 import RecoTracker.TrackProducer.TrackRefitters_cff
-process.TrackRefitter1 = process.TrackRefitterP5.clone(
-    src =  options.trackCollection, #'AliMomConstraint',
-    TrajectoryInEvent = True,
-    TTRHBuilder = "WithAngleAndTemplate", #"WithTrackAngle"
-    NavigationSchool = "",
-    #constraint = 'momentum', ### SPECIFIC FOR CRUZET
-    #srcConstr='AliMomConstraint' ### SPECIFIC FOR CRUZET$works only with tag V02-10-02 TrackingTools/PatternTools / or CMSSW >=31X
+if options.isCosmics:
+    process.TrackRefitter1 = process.TrackRefitterP5.clone(
+        src =  options.trackCollection, #'AliMomConstraint',
+        TrajectoryInEvent = True,
+        TTRHBuilder = "WithAngleAndTemplate", #"WithTrackAngle"
+        NavigationSchool = "",
+        #constraint = 'momentum', ### SPECIFIC FOR CRUZET
+        #srcConstr='AliMomConstraint' ### SPECIFIC FOR CRUZET$works only with tag V02-10-02 TrackingTools/PatternTools / or CMSSW >=31X
+    )
+else:
+    process.TrackRefitter1 = RecoTracker.TrackProducer.TrackRefitter_cfi.TrackRefitter.clone(
+        src =  options.trackCollection, #'AliMomConstraint',
+        TrajectoryInEvent = True,
+        TTRHBuilder = "WithAngleAndTemplate", #"WithTrackAngle"
+        NavigationSchool = "",
     )
 
 ###################################################################
@@ -161,11 +220,12 @@ if(options.unitTest):
 ###################################################################
 process.myanalysis = cms.EDAnalyzer("GeneralPurposeTrackAnalyzer",
                                     TkTag  = cms.InputTag('TrackRefitter1'),
-                                    isCosmics = cms.bool(True))
+                                    #TkTag  = cms.InputTag(options.trackCollection),
+                                    isCosmics = cms.bool(options.isCosmics))
 
 process.fastdmr = cms.EDAnalyzer("DMRChecker",
                                  TkTag  = cms.InputTag('TrackRefitter1'),
-                                 isCosmics = cms.bool(True))
+                                 isCosmics = cms.bool(options.isCosmics))
 
 ###################################################################
 # Output name
@@ -173,17 +233,88 @@ process.fastdmr = cms.EDAnalyzer("DMRChecker",
 process.TFileService = cms.Service("TFileService",
                                    fileName = cms.string(options.outFileName))
 
+
+###################################################################
+# TransientTrack from https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTransientTracks
+###################################################################
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+process.load('TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi')
+process.load('TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi')
+process.load('TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff')
+
+process.DiMuonVertexValidation = cms.EDAnalyzer("DiMuonVertexValidation",
+                                                useReco = cms.bool(False),
+                                                muonTracks = cms.InputTag('TrackRefitter1'),
+                                                tracks = cms.InputTag(''),
+                                                vertices = cms.InputTag('offlinePrimaryVertices'))
+
+from Alignment.OfflineValidation.diMuonValidation_cfi import diMuonValidation as _diMuonValidation
+process.DiMuonMassValidation = _diMuonValidation.clone(
+    #TkTag = 'refittedMuons',
+    TkTag = 'TrackRefitter1',
+    # mu mu mass
+    Pair_mass_min   = 80.,
+    Pair_mass_max   = 120.,
+    Pair_mass_nbins = 80,
+    Pair_etaminpos  = -2.4,
+    Pair_etamaxpos  = 2.4,
+    Pair_etaminneg  = -2.4,
+    Pair_etamaxneg  = 2.4,
+    # cosTheta CS
+    Variable_CosThetaCS_xmin  = -1.,
+    Variable_CosThetaCS_xmax  =  1.,
+    Variable_CosThetaCS_nbins = 20,
+    # DeltaEta
+    Variable_DeltaEta_xmin  = -4.8,
+    Variable_DeltaEta_xmax  = 4.8,
+    Variable_DeltaEta_nbins = 20,
+    # EtaMinus
+    Variable_EtaMinus_xmin  = -2.4,
+    Variable_EtaMinus_xmax  =  2.4,
+    Variable_EtaMinus_nbins = 12,
+    # EtaPlus
+    Variable_EtaPlus_xmin  = -2.4,
+    Variable_EtaPlus_xmax  =  2.4,
+    Variable_EtaPlus_nbins = 12,
+    # Phi CS
+    Variable_PhiCS_xmin  = -math.pi/2.,
+    Variable_PhiCS_xmax  =  math.pi/2.,
+    Variable_PhiCS_nbins = 20,
+    # Phi Minus
+    Variable_PhiMinus_xmin  = -math.pi,
+    Variable_PhiMinus_xmax  =  math.pi,
+    Variable_PhiMinus_nbins = 16,
+    # Phi Plus
+    Variable_PhiPlus_xmin  = -math.pi,
+    Variable_PhiPlus_xmax  =  math.pi,
+    Variable_PhiPlus_nbins = 16,
+    # mu mu pT
+    Variable_PairPt_xmin  = 0.,
+    Variable_PairPt_xmax  = 100.,
+    Variable_PairPt_nbins = 100)
+
 ###################################################################
 # Path
 ###################################################################
 process.p1 = cms.Path(process.offlineBeamSpot
                       #*process.AliMomConstraint  # for 0T
-                      *process.TrackRefitter1
-                      *process.myanalysis
-                      *process.fastdmr)
+                      * process.TrackRefitter1
+                      * process.myanalysis
+                      * process.fastdmr)
 
 ###################################################################
-# preprend the filter
+# append di muon analysis
 ###################################################################
-if(options.unitTest):
+if(options.isDiMuonData):
+    process.p1.insert(5,process.DiMuonVertexValidation)
+    process.p1.insert(6,process.DiMuonMassValidation)
+
+###################################################################
+# preprend the filter for unit tests
+###################################################################
+if(options.unitTest and not options.isDiMuonData):
     process.p1.insert(0, process.preAnaSeq)
+
+
+
+    

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitMiscellanea.sh
@@ -2,7 +2,10 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING inspect ALCARECO data ..."
-cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True trackCollection=ALCARECOTkAlCosmicsCTF0T || die "Failure running inspectData_cfg.py" $?
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=True trackCollection=ALCARECOTkAlCosmicsCTF0T || die "Failure running inspectData_cfg.py" $?
+
+echo "TESTING inspect Phase2 ALCARECO data ..."
+cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/inspectData_cfg.py unitTest=True isCosmics=False globalTag='' trackCollection=ALCARECOTkAlZMuMu isDiMuonData=True Detector='2026D98' || die "Failure running inspectData_cfg.py on Phase-2 input" $?
 
 echo "TESTING G4e refitter ..."
 cmsRun ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testG4Refitter_cfg.py maxEvents=10  || die "Failure running testG4Refitter_cfg.py" $?


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43870

#### PR description:

This PR contains a bunch of small updates to various plugins and configuration files that were useful for the debugging of phase-2 ALCARECO samples that lead to PR https://github.com/cms-sw/cmssw/pull/43859.

#### PR validation:

The following tests:
   * `scram b runtests_Miscellanea` 
   * `scram b runtests_DiMuonVertex`
   * `scram b runtests_PrimaryVertex`
    
run fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/43870 to CMSSW_14_0_X to examine the samples produced in this release.