### PR TITLE
Issue exception for ROOT file forward incompatiblity problem

### DIFF
--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -414,8 +414,9 @@ namespace edm {
       }
       default: {
         // We should never get here.
-        assert("Invalid type code" == nullptr);
-        //throw EntryError(std::string("invalid type code ") + type);
+        throw edm::Exception(edm::errors::Configuration) << "Unknown ParameterSet Entry type encoding: '" << type_
+                                                         << "'.\n This could be caused by reading a file which was "
+                                                            "written using a newer incompatible software release.";
         break;
       }
     }  // switch(type)


### PR DESCRIPTION
#### PR description:

Throw an exception if the ParameterSet parsing finds an unknown entry type. This problem is occurring presently in older releases if they try to read files which contain the new string encoding for ParameterSets.

#### PR validation:

This same code was tested in CMSSW_12_6 and properly throws the proper exception type containing the proper information when reading a file generated in CMSSW_13_3.

#### Backporting
This is meant to be back ported to all active releases before CMSSW_13_3:  13_2, 13_1, 13_0, 12_6, 12_4 and 10_6.

part of makortel/framework#804 