### PR TITLE
Issue exception for ROOT file forward incompatiblity problem [12_6]

### DIFF
--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -391,8 +391,9 @@ namespace edm {
       }
       default: {
         // We should never get here.
-        assert("Invalid type code" == nullptr);
-        //throw EntryError(std::string("invalid type code ") + type);
+        throw edm::Exception(edm::errors::Configuration) << "Unknown ParameterSet Entry type encoding: '" << type
+                                                         << "'.\n This could be caused by reading a file which was "
+                                                            "written using a newer incompatible software release.";
         break;
       }
     }  // switch(type)


### PR DESCRIPTION
#### PR description:

Throw an exception if the ParameterSet parsing finds an unknown entry type. This problem is occurring presently in older releases if they try to read files which contain the new string encoding for ParameterSets.

#### PR validation:

This same code was tested in CMSSW_12_6 and properly throws the proper exception type containing the proper information when reading a file generated in CMSSW_13_3.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #43894 . This change is needed by all open releases before we changed the string encoding done in ParameterSets in CMSSW_13_3 in order to give meaningful error messages when trying to read a file from a newer release.

fixed makortel/framework#804