### PR TITLE
Issue exception for ROOT file forward incompatiblity problem [13_1]

### DIFF
--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -391,8 +391,9 @@ namespace edm {
       }
       default: {
         // We should never get here.
-        assert("Invalid type code" == nullptr);
-        //throw EntryError(std::string("invalid type code ") + type);
+        throw edm::Exception(edm::errors::Configuration) << "Unknown ParameterSet Entry type encoding: '" << type
+                                                         << "'.\n This could be caused by reading a file which was "
+                                                            "written using a newer incompatible software release.";
         break;
       }
     }  // switch(type)


### PR DESCRIPTION
#### PR description:

Throw an exception if the ParameterSet parsing finds an unknown entry type. This problem is occurring presently in older releases if they try to read files which contain the new string encoding for ParameterSets.

#### PR validation:

This same code was tested in CMSSW_13_1_4 and properly throws the proper exception type containing the proper information when reading a file generated in CMSSW_13_3.

#### If this PR is a backport please specify the original PR and why you need to backport that PR.

Part of large scale backport of https://github.com/cms-sw/cmssw/pull/43894

fixes https://github.com/makortel/framework/issues/804