### PR TITLE
Update Run3 CSC conditions in 2022, 2023, 2024 realistic MC GTs and offline data GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -37,9 +37,9 @@ autoCond = {
     'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
     'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-01-19 05:46:14 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v1',
-    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-01-19 05:46:14 (UTC)
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-02-07 16:38:59 (UTC)
+    'run3_data'                    :    '140X_dataRun3_v3',
+    # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
     'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v3',
@@ -66,35 +66,35 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           :    '140X_mcRun3_2022_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v1',
+    'phase1_2022_realistic'        :    '140X_mcRun3_2022_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 post-EE+ leak
-    'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v1',
+    'phase1_2022_realistic_postEE' :    '140X_mcRun3_2022_realistic_postEE_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics'          :    '140X_mcRun3_2022cosmics_realistic_deco_v1',
+    'phase1_2022_cosmics'          :    '140X_mcRun3_2022cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   :    '140X_mcRun3_2022cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v1',
+    'phase1_2022_realistic_hi'     :    '140X_mcRun3_2022_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2023
     'phase1_2023_design'           :    '140X_mcRun3_2023_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v1',
+    'phase1_2023_realistic'        :    '140X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 postBPix issue 2023
-    'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v1',
+    'phase1_2023_realistic_postBPix'  : '140X_mcRun3_2023_realistic_postBPix_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 preBPix 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics'          :    '140X_mcRun3_2023cosmics_realistic_deco_v1',
+    'phase1_2023_cosmics'          :    '140X_mcRun3_2023cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 postBPix 2023, Strip tracker in DECO mode
-    'phase1_2023_cosmics_postBPix' :    '140X_mcRun3_2023cosmics_realistic_postBPix_deco_v1',
+    'phase1_2023_cosmics_postBPix' :    '140X_mcRun3_2023cosmics_realistic_postBPix_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2023, Strip tracker in DECO mode
     'phase1_2023_cosmics_design'   :    '140X_mcRun3_2023cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
-    'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v1',
+    'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
     'phase1_2024_design'           :    '140X_mcRun3_2024_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v1',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v1',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase2


### PR DESCRIPTION
#### PR description:

This PR updates the Run3 CSC conditions in the following GTs:
- 2022, 2023, 2024 realistic MC GTs
- Run3 offline data GT for future ReReco 

requested in [1] and [2] respectively. More details and internal validations can be found in [3]. The tag updates are as follows:

**For MC GTs**:

|Rcd | Label | Tag |
| -- | -- | -- | 
| CSCDBGainsRcd | - | CSCDBGains_Dec_2023_v1 | 
| CSCDBPedestalsRcd | - | CSCDBPedestals_Dec_2023_v1 |  
| CSCDBCrosstalkRcd | - | CSCDBCrosstalk_Dec_2023_v1 |
  
**For Run3 Offline Data GT** :

|Rcd | Label | Tag |
| -- | -- | -- | 
| CSCDBGainsRcd | - | CSCDBGains_v3_offline | 
| CSCDBPedestalsRcd | - | CSCDBPedestals_v3_offline |  
| CSCDBCrosstalkRcd | - | CSCDBCrosstalk_v4_offline |

the new conditions are effective from [Run 347687](https://cmsoms.cern.ch/cms/runs/report?cms_run=347687) (2022-02-15)

[1] https://cms-talk.web.cern.ch/t/mc-gt-update-csc-conditions-for-run3-mc-gts/33583
[2] https://cms-talk.web.cern.ch/t/full-track-validation-hlt-express-prompt-offline-csc-run3-condition-updates-for-2024-data-taking/33776 
[3] https://indico.cern.ch/event/1358549/#9-csc-conditions-update-for-20

**GT Differences with the last ones are here**:

- **Run3 data Offline**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v1/140X_dataRun3_v3 

- **Phase1 2022 realistic**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_v1/140X_mcRun3_2022_realistic_v3 

- **Phase1 2022 realistic postEE**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_postEE_v1/140X_mcRun3_2022_realistic_postEE_v3 

- **Phase1 2022 cosmics realistic**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022cosmics_realistic_deco_v1/140X_mcRun3_2022cosmics_realistic_deco_v3

- **Phase1 2022 realistic hi**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2022_realistic_HI_v1/140X_mcRun3_2022_realistic_HI_v3

- **Phase1 2023 realistic**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_v1/140X_mcRun3_2023_realistic_v3
	
- **Phase1 2023 realistic postBPix**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_postBPix_v1/140X_mcRun3_2023_realistic_postBPix_v3

- **Phase1 2023 cosmics reaslistic**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023cosmics_realistic_deco_v1/140X_mcRun3_2023cosmics_realistic_deco_v3 

- **Phase1 2023 cosmics reaslistic postBPix**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023cosmics_realistic_postBPix_deco_v1/140X_mcRun3_2023cosmics_realistic_postBPix_deco_v3

- **Phase1 2023 realistic hi**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_HI_v1/140X_mcRun3_2023_realistic_HI_v3

- **Phase1 2024 realistic**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v1/140X_mcRun3_2024_realistic_v3

- **Phase1 2024 cosmics realistic**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v1/140X_mcRun3_2024cosmics_realistic_deco_v3


#### PR validation:
Tested successfully with 
- `runTheMatrix.py -l 7.23,141.001,141.044,140.022,140.069,159.1,160.1,312.0,12834.0, -j 8 --ibeos`
- `runTheMatrix.py -l 12401.0,12404.0,12412.0,12423.0,12425.0,12430.0,12431.0,12444.0,12447.0,12450.0,12504.0,12634.586,12650.0,12737.0, --what upgrade -j 8 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport. But backport will be followed up for 140X (considering the Full 2022+2023 ReReco campaign)


