### PR TITLE
Issue exception for ROOT file forward incompatiblity problem [10_6]

### DIFF
--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -260,8 +260,9 @@ namespace edm {
       }
       default: {
         // We should never get here.
-        assert("Invalid type code" == nullptr);
-        //throw EntryError(std::string("invalid type code ") + type);
+        throw edm::Exception(edm::errors::Configuration) << "Unknown ParameterSet Entry type encoding: '" << type
+                                                         << "'.\n This could be caused by reading a file which was "
+                                                            "written using a newer incompatible software release.";
         break;
       }
     }  // switch(type)

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -34,11 +34,10 @@ namespace edm {
       std::rethrow_exception(e);
     }
     if (!file_) {
-      return;
+      throw edm::Exception(errors::FileOpenError) << "TFile::Open failed.";
     }
     if (file_->IsZombie()) {
-      file_ = nullptr;  // propagate_const<T> has no reset() function
-      return;
+      throw edm::Exception(errors::FileOpenError) << "TFile::Open returned zombie.";
     }
 
     logFileAction("  Successfully opened file ", fileName);

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -391,12 +391,23 @@ namespace edm {
     } else {
       // Merge into the parameter set registry.
       pset::Registry& psetRegistry = *pset::Registry::instance();
-      for (auto const& psetEntry : psetMap) {
-        ParameterSet pset(psetEntry.second.pset());
-        pset.setID(psetEntry.first);
-        // For thread safety, don't update global registries when a secondary source opens a file.
-        if (inputType != InputType::SecondarySource) {
-          psetRegistry.insertMapped(pset);
+      try {
+        for (auto const& psetEntry : psetMap) {
+          ParameterSet pset(psetEntry.second.pset());
+          pset.setID(psetEntry.first);
+          // For thread safety, don't update global registries when a secondary source opens a file.
+          if (inputType != InputType::SecondarySource) {
+            psetRegistry.insertMapped(pset);
+          }
+        }
+      } catch (edm::Exception const& iExcept) {
+        if (iExcept.categoryCode() == edm::errors::Configuration) {
+          edm::Exception exception(edm::errors::FormatIncompatibility);
+          exception << iExcept.message();
+          exception.addContext("Creating ParameterSets from file");
+          throw exception;
+        } else {
+          throw;
         }
       }
     }


### PR DESCRIPTION
#### PR description:

- Throw an exception if the ParameterSet parsing finds an unknown entry type. This problem is occurring presently in older releases if they try to read files which contain the new string encoding for ParameterSets.
- Throw exception if TFile::Open returns nullptr.

#### PR validation:

This code was tested in CMSSW_10_6_30 and even with the backport seg faulted when reading a file generated in CMSSW_13_3. The problem was traced down to ROOT silently ignoring a failure while unzipping StreamerInfo. Added additional check on nullptr from TFile::Open gives a graceful exit to the job from an exception.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. 

Part of large scale backport of https://github.com/cms-sw/cmssw/pull/43894

fixes https://github.com/makortel/framework/issues/804