### PR TITLE
Implementation of TauWPThreshold without need to catch exceptions [14_0_X]

### DIFF
--- a/RecoTauTag/RecoTau/interface/TauWPThreshold.h
+++ b/RecoTauTag/RecoTau/interface/TauWPThreshold.h
@@ -3,20 +3,22 @@
 
 #include "DataFormats/TauReco/interface/BaseTau.h"
 #include "DataFormats/PatCandidates/interface/Tau.h"
+
 #include <TF1.h>
+
+#include <cmath>
+#include <cstdlib>
 
 namespace tau {
   class TauWPThreshold {
   public:
     explicit TauWPThreshold(const std::string& cut_str) {
       bool simple_value = false;
-      try {
-        size_t pos = 0;
-        value_ = std::stod(cut_str, &pos);
-        simple_value = (pos == cut_str.size());
-      } catch (std::invalid_argument&) {
-      } catch (std::out_of_range&) {
-      }
+      const char* cut_cstr = cut_str.c_str();
+      char* end_cstr{};
+      value_ = std::strtod(cut_cstr, &end_cstr);
+      // simple number if end_cstr is empty and not equal to initial string (cut_cstr), and returned value is finite
+      simple_value = !*end_cstr && cut_cstr != end_cstr && std::isfinite(value_);
       if (!simple_value) {
         static const std::string prefix =
             "[&](double *x, double *p) { const int decayMode = p[0];"


### PR DESCRIPTION
#### PR description:

As title says, this PR implements parsing of threshold values in the `TauWPThreshold` class using function which does not require catching exceptions. Namely, it replaces usage of `std::stod` by `std::strtod`.
It addresses #39627 independently raised also here https://github.com/cms-sw/cmssw/pull/43100#discussion_r1480963009.

Backport of #43890

#### PR validation:

Identical to #43890 and validated for it.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #43890 to 14_0_X release series; it is needed for 2024 operations.
