### PR TITLE
[MTD simulation, validation]: implementation of MTD clusters association maps

### DIFF
--- a/Geometry/MTDGeometryBuilder/interface/MTDGeomUtil.h
+++ b/Geometry/MTDGeometryBuilder/interface/MTDGeomUtil.h
@@ -43,6 +43,8 @@ namespace mtd {
     std::pair<uint8_t, uint8_t> pixelInModule(const DetId& id, const LocalPoint& local_point) const;
     int crystalInModule(const DetId&) const;
 
+    uint32_t sensorModuleId(const DetId& id) const;
+
     // 4-vector helper functions using GlobalPoint
     float eta(const GlobalPoint& position, const float& vertex_z = 0.) const;
     float phi(const GlobalPoint& position) const;

--- a/Geometry/MTDGeometryBuilder/src/MTDGeomUtil.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeomUtil.cc
@@ -159,6 +159,19 @@ int MTDGeomUtil::crystalInModule(const DetId& id) const {
   return hid.crystal();
 }
 
+// returns the sensor module id
+uint32_t MTDGeomUtil::sensorModuleId(const DetId& id) const {
+  if (isBTL(id)) {
+    BTLDetId detId(id);
+    DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology_->getMTDTopologyMode()));
+    return (geoId.rawId());
+  } else {
+    ETLDetId detId(id);
+    DetId geoId = detId.geographicalId();
+    return (geoId.rawId());
+  }
+}
+
 float MTDGeomUtil::eta(const GlobalPoint& position, const float& vertex_z) const {
   GlobalPoint corrected_position = GlobalPoint(position.x(), position.y(), position.z() - vertex_z);
   return corrected_position.eta();

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
@@ -1,0 +1,49 @@
+#ifndef SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociationMap_h
+#define SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociationMap_h
+
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Common/interface/HandleBase.h"
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h"
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+/**
+ * Maps FTLCluserRef to SimLayerClusterRef
+ *
+ */
+class MtdRecoClusterToSimLayerClusterAssociationMap {
+public:
+  using key_type = FTLClusterRef;
+  using mapped_type = MtdSimLayerClusterRef;
+  //  using value_type = std::pair<key_type, mapped_type>;
+  using value_type = std::pair<key_type, std::vector<mapped_type>>;
+  using map_type = std::vector<value_type>;
+  using const_iterator = typename map_type::const_iterator;
+
+  /// Constructor
+  MtdRecoClusterToSimLayerClusterAssociationMap();
+  /// Destructor
+  ~MtdRecoClusterToSimLayerClusterAssociationMap();
+
+  void emplace_back(const FTLClusterRef& recoClus, std::vector<MtdSimLayerClusterRef>& simClusVect) {
+    map_.emplace_back(recoClus, simClusVect);
+  }
+
+  bool empty() const { return map_.empty(); }
+  size_t size() const { return map_.size(); }
+
+  const_iterator begin() const { return map_.begin(); }
+  const_iterator cbegin() const { return map_.cbegin(); }
+  const_iterator end() const { return map_.end(); }
+  const_iterator cend() const { return map_.cend(); }
+
+  const map_type& map() const { return map_; }
+
+private:
+  map_type map_;
+};
+
+#endif

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
@@ -32,7 +32,7 @@ public:
     map_.emplace_back(recoClus, simClusVect);
   }
 
-  void sort() { std::sort(map_.begin(), map_.end(), compare); }
+  void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
 
   bool empty() const { return map_.empty(); }
   size_t size() const { return map_.size(); }

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h
@@ -18,10 +18,10 @@ class MtdRecoClusterToSimLayerClusterAssociationMap {
 public:
   using key_type = FTLClusterRef;
   using mapped_type = MtdSimLayerClusterRef;
-  //  using value_type = std::pair<key_type, mapped_type>;
   using value_type = std::pair<key_type, std::vector<mapped_type>>;
   using map_type = std::vector<value_type>;
   using const_iterator = typename map_type::const_iterator;
+  using range = std::pair<const_iterator, const_iterator>;
 
   /// Constructor
   MtdRecoClusterToSimLayerClusterAssociationMap();
@@ -32,6 +32,8 @@ public:
     map_.emplace_back(recoClus, simClusVect);
   }
 
+  void sort() { std::sort(map_.begin(), map_.end(), compare); }
+
   bool empty() const { return map_.empty(); }
   size_t size() const { return map_.size(); }
 
@@ -40,9 +42,15 @@ public:
   const_iterator end() const { return map_.end(); }
   const_iterator cend() const { return map_.cend(); }
 
+  range equal_range(const FTLClusterRef& key) const {
+    return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<MtdSimLayerClusterRef>()), compare);
+  }
+
   const map_type& map() const { return map_; }
 
 private:
+  static bool compare(const value_type& i, const value_type& j) { return (i.first < j.first); }
+
   map_type map_;
 };
 

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h
@@ -1,0 +1,49 @@
+#ifndef SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociator_h
+#define SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociator_h
+// Original Author:  Martina Malberti
+
+// system include files
+#include <memory>
+
+// user include files
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.h"
+
+// forward declarations
+
+namespace reco {
+
+  class MtdRecoClusterToSimLayerClusterAssociator {
+  public:
+    MtdRecoClusterToSimLayerClusterAssociator(std::unique_ptr<reco::MtdRecoClusterToSimLayerClusterAssociatorBaseImpl>);
+    MtdRecoClusterToSimLayerClusterAssociator() = default;
+    MtdRecoClusterToSimLayerClusterAssociator(MtdRecoClusterToSimLayerClusterAssociator &&) = default;
+    MtdRecoClusterToSimLayerClusterAssociator &operator=(MtdRecoClusterToSimLayerClusterAssociator &&) = default;
+    MtdRecoClusterToSimLayerClusterAssociator(const MtdRecoClusterToSimLayerClusterAssociator &) =
+        delete;  // stop default
+
+    ~MtdRecoClusterToSimLayerClusterAssociator() = default;
+    const MtdRecoClusterToSimLayerClusterAssociator &operator=(const MtdRecoClusterToSimLayerClusterAssociator &) =
+        delete;  // stop default
+
+    // ---------- const member functions ---------------------
+    /// Associate RecoCluster to MtdSimLayerCluster
+    reco::RecoToSimCollectionMtd associateRecoToSim(const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+                                                    const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+                                                    const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const {
+      return m_impl->associateRecoToSim(btlRecoClusH, etlRecoClusH, simClusH);
+    };
+
+    /// Associate MtdSimLayerCluster to RecoCluster
+    reco::SimToRecoCollectionMtd associateSimToReco(const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+                                                    const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+                                                    const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const {
+      return m_impl->associateSimToReco(btlRecoClusH, etlRecoClusH, simClusH);
+    };
+
+  private:
+    // ---------- member data --------------------------------
+    std::unique_ptr<MtdRecoClusterToSimLayerClusterAssociatorBaseImpl> m_impl;
+  };
+}  // namespace reco
+
+#endif

--- a/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.h
@@ -1,0 +1,37 @@
+#ifndef SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociatorBaseImpl_h
+#define SimDataFormats_Associations_MtdRecoClusterToSimLayerClusterAssociatorBaseImpl_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h"
+
+namespace reco {
+
+  using RecoToSimCollectionMtd = MtdRecoClusterToSimLayerClusterAssociationMap;
+  using SimToRecoCollectionMtd = MtdSimLayerClusterToRecoClusterAssociationMap;
+
+  class MtdRecoClusterToSimLayerClusterAssociatorBaseImpl {
+  public:
+    /// Constructor
+    MtdRecoClusterToSimLayerClusterAssociatorBaseImpl();
+    /// Destructor
+    virtual ~MtdRecoClusterToSimLayerClusterAssociatorBaseImpl();
+
+    /// Associate a MtdRecoCluster to MtdSimLayerClusters
+    virtual reco::RecoToSimCollectionMtd associateRecoToSim(
+        const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+        const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+        const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const;
+
+    /// Associate a MtdSimLayerClusters to MtdRecoClusters
+    virtual reco::SimToRecoCollectionMtd associateSimToReco(
+        const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+        const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+        const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const;
+  };
+}  // namespace reco
+
+#endif

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
@@ -21,6 +21,7 @@ public:
   using value_type = std::pair<key_type, std::vector<mapped_type>>;
   using map_type = std::vector<value_type>;
   using const_iterator = typename map_type::const_iterator;
+  using range = std::pair<const_iterator, const_iterator>;
 
   /// Constructor
   MtdSimLayerClusterToRecoClusterAssociationMap();
@@ -31,6 +32,8 @@ public:
     map_.emplace_back(simClus, recoClusVect);
   }
 
+  void sort() { std::sort(map_.begin(), map_.end(), compare); }
+
   bool empty() const { return map_.empty(); }
   size_t size() const { return map_.size(); }
 
@@ -39,9 +42,31 @@ public:
   const_iterator end() const { return map_.end(); }
   const_iterator cend() const { return map_.cend(); }
 
+  range equal_range(const MtdSimLayerClusterRef& key) const {
+    return std::equal_range(map_.begin(), map_.end(), value_type(key, std::vector<FTLClusterRef>()), compare);
+  }
+
   const map_type& map() const { return map_; }
 
 private:
+  static bool compare(const value_type& i, const value_type& j) {
+    auto i_hAndE = (i.first)->hits_and_energies();
+    std::vector<uint64_t> i_ids(i_hAndE.size());
+    std::transform(i_hAndE.begin(), i_hAndE.end(), i_ids.begin(), [](const std::pair<uint64_t, float>& pair) {
+      return pair.first;
+    });
+
+    auto j_hAndE = (j.first)->hits_and_energies();
+    std::vector<uint64_t> j_ids(j_hAndE.size());
+    std::transform(j_hAndE.begin(), j_hAndE.end(), j_ids.begin(), [](const std::pair<uint64_t, float>& pair) {
+      return pair.first;
+    });
+
+    uint64_t imin = *(std::min_element(i_ids.begin(), i_ids.end()));
+    uint64_t jmin = *(std::min_element(j_ids.begin(), j_ids.end()));
+    return (imin < jmin);
+  }
+
   map_type map_;
 };
 

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
@@ -1,0 +1,48 @@
+#ifndef SimDataFormats_Associations_MtdSimLayerClusterToRecoClusterAssociationMap_h
+#define SimDataFormats_Associations_MtdSimLayerClusterToRecoClusterAssociationMap_h
+
+#include "DataFormats/Provenance/interface/ProductID.h"
+#include "DataFormats/Common/interface/HandleBase.h"
+#include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h"
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+
+/**
+ * Maps MtdSimLayerCluserRef to FTLClusterRef
+ *
+ */
+class MtdSimLayerClusterToRecoClusterAssociationMap {
+public:
+  using key_type = MtdSimLayerClusterRef;
+  using mapped_type = FTLClusterRef;
+  using value_type = std::pair<key_type, std::vector<mapped_type>>;
+  using map_type = std::vector<value_type>;
+  using const_iterator = typename map_type::const_iterator;
+
+  /// Constructor
+  MtdSimLayerClusterToRecoClusterAssociationMap();
+  /// Destructor
+  ~MtdSimLayerClusterToRecoClusterAssociationMap();
+
+  void emplace_back(const MtdSimLayerClusterRef& simClus, std::vector<FTLClusterRef>& recoClusVect) {
+    map_.emplace_back(simClus, recoClusVect);
+  }
+
+  bool empty() const { return map_.empty(); }
+  size_t size() const { return map_.size(); }
+
+  const_iterator begin() const { return map_.begin(); }
+  const_iterator cbegin() const { return map_.cbegin(); }
+  const_iterator end() const { return map_.end(); }
+  const_iterator cend() const { return map_.cend(); }
+
+  const map_type& map() const { return map_; }
+
+private:
+  map_type map_;
+};
+
+#endif

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h
@@ -32,7 +32,7 @@ public:
     map_.emplace_back(simClus, recoClusVect);
   }
 
-  void sort() { std::sort(map_.begin(), map_.end(), compare); }
+  void post_insert() { std::sort(map_.begin(), map_.end(), compare); }
 
   bool empty() const { return map_.empty(); }
   size_t size() const { return map_.size(); }
@@ -50,21 +50,18 @@ public:
 
 private:
   static bool compare(const value_type& i, const value_type& j) {
-    auto i_hAndE = (i.first)->hits_and_energies();
-    std::vector<uint64_t> i_ids(i_hAndE.size());
-    std::transform(i_hAndE.begin(), i_hAndE.end(), i_ids.begin(), [](const std::pair<uint64_t, float>& pair) {
-      return pair.first;
-    });
+    const auto& i_hAndE = (i.first)->hits_and_energies();
+    const auto& j_hAndE = (j.first)->hits_and_energies();
 
-    auto j_hAndE = (j.first)->hits_and_energies();
-    std::vector<uint64_t> j_ids(j_hAndE.size());
-    std::transform(j_hAndE.begin(), j_hAndE.end(), j_ids.begin(), [](const std::pair<uint64_t, float>& pair) {
-      return pair.first;
-    });
+    auto imin = std::min_element(i_hAndE.begin(),
+                                 i_hAndE.end(),
+                                 [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
 
-    uint64_t imin = *(std::min_element(i_ids.begin(), i_ids.end()));
-    uint64_t jmin = *(std::min_element(j_ids.begin(), j_ids.end()));
-    return (imin < jmin);
+    auto jmin = std::min_element(j_hAndE.begin(),
+                                 j_hAndE.end(),
+                                 [](std::pair<uint64_t, float> a, std::pair<uint64_t, float> b) { return a < b; });
+
+    return (*imin < *jmin);
   }
 
   map_type map_;

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h
@@ -1,0 +1,46 @@
+#ifndef SimDataFormats_Associations_MtdSimLayerClusterToTPAssociator_h
+#define SimDataFormats_Associations_MtdSimLayerClusterToTPAssociator_h
+// Author:  M. Malberti
+
+// system include files
+#include <memory>
+
+// user include files
+
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociatorBaseImpl.h"
+
+// forward declarations
+
+namespace reco {
+  class MtdSimLayerClusterToTPAssociator {
+  public:
+    MtdSimLayerClusterToTPAssociator(std::unique_ptr<reco::MtdSimLayerClusterToTPAssociatorBaseImpl>);
+    MtdSimLayerClusterToTPAssociator() = default;
+    MtdSimLayerClusterToTPAssociator(MtdSimLayerClusterToTPAssociator &&) = default;
+    MtdSimLayerClusterToTPAssociator &operator=(MtdSimLayerClusterToTPAssociator &&) = default;
+    MtdSimLayerClusterToTPAssociator(const MtdSimLayerClusterToTPAssociator &) = delete;  // stop default
+    const MtdSimLayerClusterToTPAssociator &operator=(const MtdSimLayerClusterToTPAssociator &) =
+        delete;  // stop default
+
+    ~MtdSimLayerClusterToTPAssociator() = default;
+
+    // ---------- const member functions ---------------------
+    /// Associate MtdSimLayerCluster to TrackingParticle
+    reco::SimToTPCollectionMtd associateSimToTP(const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+                                                const edm::Handle<TrackingParticleCollection> &trackingParticleH) const {
+      return m_impl->associateSimToTP(simClusH, trackingParticleH);
+    };
+
+    /// Associate TrackingParticle to MtdSimLayerCluster
+    reco::TPToSimCollectionMtd associateTPToSim(const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+                                                const edm::Handle<TrackingParticleCollection> &trackingParticleH) const {
+      return m_impl->associateTPToSim(simClusH, trackingParticleH);
+    };
+
+  private:
+    // ---------- member data --------------------------------
+    std::unique_ptr<MtdSimLayerClusterToTPAssociatorBaseImpl> m_impl;
+  };
+}  // namespace reco
+
+#endif

--- a/SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociatorBaseImpl.h
@@ -1,0 +1,48 @@
+#ifndef SimDataFormats_Associations_MtdSimLayerClusterToTPAssociatorBaseImpl_h
+#define SimDataFormats_Associations_MtdSimLayerClusterToTPAssociatorBaseImpl_h
+
+/** \class MtdSimLayerClusterToTPAssociatorBaseImpl
+ *
+ * Base class for MtdSimLayerClusterToTPAssociator. Methods take as input
+ * the handles of MtdSimLayerCluster and TrackingParticle collections and return an
+ * AssociationMap (oneToMany)
+ *
+ *  \author M. Malberti
+ */
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
+#include "DataFormats/Common/interface/OneToMany.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+
+namespace reco {
+
+  typedef edm::AssociationMap<edm::OneToMany<MtdSimLayerClusterCollection, TrackingParticleCollection> >
+      SimToTPCollectionMtd;
+  typedef edm::AssociationMap<edm::OneToMany<TrackingParticleCollection, MtdSimLayerClusterCollection> >
+      TPToSimCollectionMtd;
+
+  class MtdSimLayerClusterToTPAssociatorBaseImpl {
+  public:
+    /// Constructor
+    MtdSimLayerClusterToTPAssociatorBaseImpl();
+    /// Destructor
+    virtual ~MtdSimLayerClusterToTPAssociatorBaseImpl();
+
+    /// Associate a MtdSimLayerCluster to TrackingParticle
+    virtual SimToTPCollectionMtd associateSimToTP(
+        const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+        const edm::Handle<TrackingParticleCollection> &trackingParticleH) const;
+
+    /// Associate a TrackingParticle to MtdSimLayerCluster
+    virtual TPToSimCollectionMtd associateTPToSim(
+        const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+        const edm::Handle<TrackingParticleCollection> &trackingParticleH) const;
+  };
+}  // namespace reco
+
+#endif

--- a/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociationMap.cc
+++ b/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociationMap.cc
@@ -1,0 +1,5 @@
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
+
+MtdRecoClusterToSimLayerClusterAssociationMap::MtdRecoClusterToSimLayerClusterAssociationMap() {}
+
+MtdRecoClusterToSimLayerClusterAssociationMap::~MtdRecoClusterToSimLayerClusterAssociationMap() {}

--- a/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociator.cc
+++ b/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociator.cc
@@ -1,0 +1,5 @@
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h"
+
+reco::MtdRecoClusterToSimLayerClusterAssociator::MtdRecoClusterToSimLayerClusterAssociator(
+    std::unique_ptr<reco::MtdRecoClusterToSimLayerClusterAssociatorBaseImpl> ptr)
+    : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.cc
@@ -1,0 +1,21 @@
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociatorBaseImpl.h"
+
+namespace reco {
+  MtdRecoClusterToSimLayerClusterAssociatorBaseImpl::MtdRecoClusterToSimLayerClusterAssociatorBaseImpl(){};
+  MtdRecoClusterToSimLayerClusterAssociatorBaseImpl::~MtdRecoClusterToSimLayerClusterAssociatorBaseImpl(){};
+
+  reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorBaseImpl::associateRecoToSim(
+      const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+      const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const {
+    return reco::RecoToSimCollectionMtd();
+  }
+
+  reco::SimToRecoCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorBaseImpl::associateSimToReco(
+      const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+      const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const {
+    return reco::SimToRecoCollectionMtd();
+  }
+
+}  // namespace reco

--- a/SimDataFormats/Associations/src/MtdSimLayerClusterToRecoClusterAssociationMap.cc
+++ b/SimDataFormats/Associations/src/MtdSimLayerClusterToRecoClusterAssociationMap.cc
@@ -1,0 +1,5 @@
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h"
+
+MtdSimLayerClusterToRecoClusterAssociationMap::MtdSimLayerClusterToRecoClusterAssociationMap() {}
+
+MtdSimLayerClusterToRecoClusterAssociationMap::~MtdSimLayerClusterToRecoClusterAssociationMap() {}

--- a/SimDataFormats/Associations/src/MtdSimLayerClusterToTPAssociator.cc
+++ b/SimDataFormats/Associations/src/MtdSimLayerClusterToTPAssociator.cc
@@ -1,0 +1,5 @@
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h"
+
+reco::MtdSimLayerClusterToTPAssociator::MtdSimLayerClusterToTPAssociator(
+    std::unique_ptr<reco::MtdSimLayerClusterToTPAssociatorBaseImpl> ptr)
+    : m_impl(std::move(ptr)) {}

--- a/SimDataFormats/Associations/src/MtdSimLayerClusterToTPAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/MtdSimLayerClusterToTPAssociatorBaseImpl.cc
@@ -1,0 +1,19 @@
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociatorBaseImpl.h"
+
+namespace reco {
+  MtdSimLayerClusterToTPAssociatorBaseImpl::MtdSimLayerClusterToTPAssociatorBaseImpl(){};
+  MtdSimLayerClusterToTPAssociatorBaseImpl::~MtdSimLayerClusterToTPAssociatorBaseImpl(){};
+
+  reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorBaseImpl::associateSimToTP(
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+      const edm::Handle<TrackingParticleCollection> &trackingParticleH) const {
+    return reco::SimToTPCollectionMtd();
+  }
+
+  reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorBaseImpl::associateTPToSim(
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+      const edm::Handle<TrackingParticleCollection> &trackingParticleH) const {
+    return reco::TPToSimCollectionMtd();
+  }
+
+}  // namespace reco

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -20,49 +20,47 @@
 #include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h"
 #include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h"
 
-namespace SimDataFormats_Associations {
-  struct SimDataFormats_Associations {
-    // add 'dummy' Wrapper variable for each class type you put into the Event
-    edm::Wrapper<reco::TrackToTrackingParticleAssociator> dummy1;
-    edm::Wrapper<reco::TrackToGenParticleAssociator> dummy2;
-    edm::Wrapper<reco::MuonToTrackingParticleAssociator> dummy3;
+struct SimDataFormats_Associations {
+  // add 'dummy' Wrapper variable for each class type you put into the Event
+  edm::Wrapper<reco::TrackToTrackingParticleAssociator> dummy1;
+  edm::Wrapper<reco::TrackToGenParticleAssociator> dummy2;
+  edm::Wrapper<reco::MuonToTrackingParticleAssociator> dummy3;
 
-    edm::Wrapper<reco::VertexToTrackingVertexAssociator> dummy4;
+  edm::Wrapper<reco::VertexToTrackingVertexAssociator> dummy4;
 
-    edm::Wrapper<hgcal::LayerClusterToCaloParticleAssociator> dummy5;
+  edm::Wrapper<hgcal::LayerClusterToCaloParticleAssociator> dummy5;
 
-    edm::Wrapper<hgcal::LayerClusterToSimClusterAssociator> dummy6;
+  edm::Wrapper<hgcal::LayerClusterToSimClusterAssociator> dummy6;
 
-    edm::Wrapper<hgcal::TracksterToSimClusterAssociator> dummy7;
+  edm::Wrapper<hgcal::TracksterToSimClusterAssociator> dummy7;
 
-    edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator> dummy8;
+  edm::Wrapper<hgcal::MultiClusterToCaloParticleAssociator> dummy8;
 
-    edm::Wrapper<hgcal::TracksterToSimTracksterAssociator> dummy9;
+  edm::Wrapper<hgcal::TracksterToSimTracksterAssociator> dummy9;
 
-    edm::Wrapper<hgcal::TracksterToSimTracksterHitLCAssociator> dummy10;
+  edm::Wrapper<hgcal::TracksterToSimTracksterHitLCAssociator> dummy10;
 
-    edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator> dummy11;
+  edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator> dummy11;
 
-    edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator> dummy12;
+  edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator> dummy12;
 
-    reco::VertexSimToRecoCollection vstrc;
-    reco::VertexSimToRecoCollection::const_iterator vstrci;
-    edm::Wrapper<reco::VertexSimToRecoCollection> wvstrc;
+  reco::VertexSimToRecoCollection vstrc;
+  reco::VertexSimToRecoCollection::const_iterator vstrci;
+  edm::Wrapper<reco::VertexSimToRecoCollection> wvstrc;
 
-    reco::VertexRecoToSimCollection vrtsc;
-    reco::VertexRecoToSimCollection::const_iterator vrtsci;
-    edm::Wrapper<reco::VertexRecoToSimCollection> wvrtsci;
+  reco::VertexRecoToSimCollection vrtsc;
+  reco::VertexRecoToSimCollection::const_iterator vrtsci;
+  edm::Wrapper<reco::VertexRecoToSimCollection> wvrtsci;
 
-    std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>> dummy13;
-    edm::Wrapper<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>> dummy14;
-    MtdRecoClusterToSimLayerClusterAssociationMap dummy15;
-    edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap> dummy16;
+  std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>> dummy13;
+  edm::Wrapper<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>> dummy14;
+  MtdRecoClusterToSimLayerClusterAssociationMap dummy15;
+  edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap> dummy16;
 
-    std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>> dummy17;
-    edm::Wrapper<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>>> dummy18;
-    MtdSimLayerClusterToRecoClusterAssociationMap dummy19;
-    edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap> dummy20;
+  std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>> dummy17;
+  edm::Wrapper<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>>> dummy18;
+  MtdSimLayerClusterToRecoClusterAssociationMap dummy19;
+  edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap> dummy20;
 
-    edm::Wrapper<reco::MtdSimLayerClusterToTPAssociator> dummy21;
-  };
-}  // namespace SimDataFormats_Associations
+  edm::Wrapper<reco::MtdSimLayerClusterToTPAssociator> dummy21;
+};

--- a/SimDataFormats/Associations/src/classes.h
+++ b/SimDataFormats/Associations/src/classes.h
@@ -15,6 +15,10 @@
 #include "SimDataFormats/Associations/interface/TracksterToSimTracksterHitLCAssociator.h"
 #include "SimDataFormats/Associations/interface/TTTrackTruthPair.h"
 #include "SimDataFormats/Associations/interface/LayerClusterToSimTracksterAssociator.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToRecoClusterAssociationMap.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h"
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h"
 
 namespace SimDataFormats_Associations {
   struct SimDataFormats_Associations {
@@ -39,6 +43,8 @@ namespace SimDataFormats_Associations {
 
     edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator> dummy11;
 
+    edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator> dummy12;
+
     reco::VertexSimToRecoCollection vstrc;
     reco::VertexSimToRecoCollection::const_iterator vstrci;
     edm::Wrapper<reco::VertexSimToRecoCollection> wvstrc;
@@ -46,5 +52,17 @@ namespace SimDataFormats_Associations {
     reco::VertexRecoToSimCollection vrtsc;
     reco::VertexRecoToSimCollection::const_iterator vrtsci;
     edm::Wrapper<reco::VertexRecoToSimCollection> wvrtsci;
+
+    std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>> dummy13;
+    edm::Wrapper<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>> dummy14;
+    MtdRecoClusterToSimLayerClusterAssociationMap dummy15;
+    edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap> dummy16;
+
+    std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>> dummy17;
+    edm::Wrapper<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef>>> dummy18;
+    MtdSimLayerClusterToRecoClusterAssociationMap dummy19;
+    edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap> dummy20;
+
+    edm::Wrapper<reco::MtdSimLayerClusterToTPAssociator> dummy21;
   };
 }  // namespace SimDataFormats_Associations

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <lcgdict>
   <class name="reco::TrackToTrackingParticleAssociator" persistent="false"/>
   <class name="edm::Wrapper<reco::TrackToTrackingParticleAssociator>" persistent="false"/>
@@ -29,7 +30,6 @@
 
   <class name="hgcal::LayerClusterToSimTracksterAssociator" persistent="false"/>
   <class name="edm::Wrapper<hgcal::LayerClusterToSimTracksterAssociator>" persistent="false"/>
-
 
   <class name="reco::VertexSimToRecoCollection" >
     <field name="transientMap_" transient="true"/>
@@ -141,4 +141,39 @@
 
   <class name="edm::Ref<std::vector<TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > >" />
   <class name="edm::Wrapper<std::vector<TTTrackTruthPair<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>,Phase2TrackerDigi,edm::refhelper::FindForDetSetVector<Phase2TrackerDigi> > > > >" />
+
+
+  
+  <class name="std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> >" persistent="true" />
+  <class name="std::vector<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> > >" />
+  <class name="MtdRecoClusterToSimLayerClusterAssociationMap" persistent="true" />
+  <class name="edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap>" />
+  <class name="std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> >" persistent="true" />
+  <class name="std::vector<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> > >" />
+  <class name="MtdSimLayerClusterToRecoClusterAssociationMap" persistent="true" />
+  <class name="edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap>" />
+  <class name="reco::MtdRecoClusterToSimLayerClusterAssociator" persistent="false"/>
+  <class name="edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator>" persistent="false"/>
+
+
+
+
+  <class name="reco::MtdSimLayerClusterToTPAssociator" persistent="false"/>
+  <class name="edm::Wrapper<reco::MtdSimLayerClusterToTPAssociator>" persistent="false"/>
+
+  <class name="edm::Wrapper<reco::SimToTPCollectionMtd>" />
+  <class name="edm::Wrapper<reco::TPToSimCollectionMtd>" />
+
+  <class name="reco::SimToTPCollectionMtd" >
+   <field name="transientMap_" transient="true"/>
+  </class>
+  <class name="reco::TPToSimCollectionMtd" >
+   <field name="transientMap_" transient="true"/>
+  </class>
+
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<MtdSimLayerCluster> >, edm::RefProd<std::vector<TrackingParticle> > >" />
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >, edm::RefProd<std::vector<MtdSimLayerCluster> > >" />
+  
+
+  
 </lcgdict>

--- a/SimDataFormats/Associations/src/classes_def.xml
+++ b/SimDataFormats/Associations/src/classes_def.xml
@@ -144,14 +144,17 @@
 
 
   
-  <class name="std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> >" persistent="true" />
+  <class name="std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> >" />
   <class name="std::vector<std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef> > >" />
-  <class name="MtdRecoClusterToSimLayerClusterAssociationMap" persistent="true" />
+  <class name="MtdRecoClusterToSimLayerClusterAssociationMap" ClassVersion="3">
+    <version ClassVersion="3" checksum="3711078147"/>
+  </class>
   <class name="edm::Wrapper<MtdRecoClusterToSimLayerClusterAssociationMap>" />
-  <class name="std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> >" persistent="true" />
+  <class name="std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> >" />
   <class name="std::vector<std::pair<MtdSimLayerClusterRef, std::vector<FTLClusterRef> > >" />
-  <class name="MtdSimLayerClusterToRecoClusterAssociationMap" persistent="true" />
-  <class name="edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap>" />
+  <class name="MtdSimLayerClusterToRecoClusterAssociationMap" ClassVersion="3">
+    <version ClassVersion="3" checksum="4259123457"/>
+  </class><class name="edm::Wrapper<MtdSimLayerClusterToRecoClusterAssociationMap>" />
   <class name="reco::MtdRecoClusterToSimLayerClusterAssociator" persistent="false"/>
   <class name="edm::Wrapper<reco::MtdRecoClusterToSimLayerClusterAssociator>" persistent="false"/>
 

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimCluster.h
@@ -4,6 +4,7 @@
 #ifndef SimDataFormats_CaloAnalysis_MtdSimCluster_h
 #define SimDataFormats_CaloAnalysis_MtdSimCluster_h
 
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include <vector>
@@ -30,6 +31,9 @@ public:
     mtdHits_.emplace_back(hit);
     fractions_.emplace_back(fraction);
   }
+
+  /** @brief add hit position*/
+  void addHitPosition(LocalPoint pos) { positions_.emplace_back(pos); }
 
   /** @brief Returns list of hit IDs and fractions for this SimCluster */
   std::vector<std::pair<uint64_t, float>> hits_and_fractions() const {
@@ -70,6 +74,17 @@ public:
     return result;
   }
 
+  /** @brief Returns list of hit IDs and times for this SimCluster */
+  std::vector<std::pair<uint64_t, LocalPoint>> hits_and_positions() const {
+    assert(mtdHits_.size() == times_.size());
+    std::vector<std::pair<uint64_t, LocalPoint>> result;
+    result.reserve(mtdHits_.size());
+    for (size_t i = 0; i < mtdHits_.size(); ++i) {
+      result.emplace_back(mtdHits_[i], positions_[i]);
+    }
+    return result;
+  }
+
   /** @brief Returns list of detIds, rows and columns for this SimCluster */
   std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIds_and_rows() const {
     std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> result;
@@ -85,10 +100,14 @@ public:
   /** @brief clear the times list */
   void clearHitsTime() { std::vector<float>().swap(times_); }
 
+  /** @brief clear the positions list */
+  void clearHitsPosition() { std::vector<LocalPoint>().swap(positions_); }
+
   void clear() {
     clearHitsAndFractions();
     clearHitsEnergy();
     clearHitsTime();
+    clearHitsPosition();
   }
 
   /** @brief add simhit's energy to cluster */
@@ -97,9 +116,15 @@ public:
     ++nsimhits_;
   }
 
+  void setTrackIdOffset(unsigned int offset) { idOffset_ = offset; }
+
+  unsigned int trackIdOffset() const { return idOffset_; }
+
 protected:
   std::vector<uint64_t> mtdHits_;
   std::vector<float> times_;
+  std::vector<LocalPoint> positions_;
+  unsigned int idOffset_{0};
 };
 
 #endif

--- a/SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h
+++ b/SimDataFormats/CaloAnalysis/interface/MtdSimLayerClusterFwd.h
@@ -5,7 +5,8 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-class MtdSimLayerCluster;
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
+//class MtdSimLayerCluster;
 typedef std::vector<MtdSimLayerCluster> MtdSimLayerClusterCollection;
 typedef edm::Ref<MtdSimLayerClusterCollection> MtdSimLayerClusterRef;
 typedef edm::RefVector<MtdSimLayerClusterCollection> MtdSimLayerClusterRefVector;

--- a/SimDataFormats/CaloAnalysis/src/classes_def.xml
+++ b/SimDataFormats/CaloAnalysis/src/classes_def.xml
@@ -28,13 +28,17 @@
   <class name="SimClusterRefProd"/>
   <class name="SimClusterContainer"/>
 
-  <class name="MtdSimCluster"/>
+  <class name="MtdSimCluster" ClassVersion="4">
+    <version ClassVersion="4" checksum="3803328692"/>
+    <version ClassVersion="3" checksum="1001786642"/>
+  </class>
   <class name="MtdSimClusterCollection"/>
   <class name="edm::Wrapper<MtdSimClusterCollection>"/>
   <class name="MtdSimClusterRef"/>
   <class name="MtdSimClusterRefVector"/>
   <class name="MtdSimClusterRefProd"/>
   <class name="MtdSimClusterContainer"/>
+
 
   <class name="MtdSimLayerCluster"/>
   <class name="MtdSimLayerClusterCollection"/>

--- a/SimFastTiming/MtdAssociatorProducers/plugins/BuildFile.xml
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/BuildFile.xml
@@ -1,0 +1,13 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="SimDataFormats/Associations"/>
+<use name="DataFormats/FTLRecHit"/>
+<use name="DataFormats/Common"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Utilities"/>
+<use name="SimDataFormats/CaloAnalysis"/>
+<use name="SimDataFormats/TrackingHit"/>
+<use name="Geometry/MTDGeometryBuilder"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/MTDCommonData"/>
+<flags EDM_PLUGIN="1"/>  

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
@@ -134,7 +134,7 @@ reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
     }    // -- end loop over detsetclus
   }
 
-  outputCollection.sort();
+  outputCollection.post_insert();
   return outputCollection;
 }
 
@@ -240,6 +240,6 @@ reco::SimToRecoCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
 
   }  // -- end loop over sim clusters
 
-  outputCollection.sort();
+  outputCollection.post_insert();
   return outputCollection;
 }

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
@@ -27,7 +27,7 @@ reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
 
   const auto& simClusters = *simClusH.product();
 
-  // -- create temporary map  DetId, SimClusterRef (praticamente ... il DetSetVector dei poveri)
+  // -- create temporary map  DetId, SimClusterRef
   std::map<uint32_t, std::vector<MtdSimLayerClusterRef>> simClusIdsMap;
   for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
     const auto& simClus = *simClusIt;
@@ -134,6 +134,7 @@ reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
     }    // -- end loop over detsetclus
   }
 
+  outputCollection.sort();
   return outputCollection;
 }
 
@@ -239,5 +240,6 @@ reco::SimToRecoCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
 
   }  // -- end loop over sim clusters
 
+  outputCollection.sort();
   return outputCollection;
 }

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
@@ -1,0 +1,243 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.h"
+#include "DataFormats/ForwardDetId/interface/BTLDetId.h"
+
+using namespace reco;
+using namespace std;
+
+/* Constructor */
+
+MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl::MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl(
+    edm::EDProductGetter const& productGetter, double energyCut, double timeCut, mtd::MTDGeomUtil& geomTools)
+    : productGetter_(&productGetter), energyCut_(energyCut), timeCut_(timeCut), geomTools_(geomTools) {}
+
+//
+//---member functions
+//
+
+reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl::associateRecoToSim(
+    const edm::Handle<FTLClusterCollection>& btlRecoClusH,
+    const edm::Handle<FTLClusterCollection>& etlRecoClusH,
+    const edm::Handle<MtdSimLayerClusterCollection>& simClusH) const {
+  RecoToSimCollectionMtd outputCollection;
+
+  // -- get the collections
+  std::array<edm::Handle<FTLClusterCollection>, 2> inputRecoClusH{{btlRecoClusH, etlRecoClusH}};
+
+  const auto& simClusters = *simClusH.product();
+
+  // -- create temporary map  DetId, SimClusterRef (praticamente ... il DetSetVector dei poveri)
+  std::map<uint32_t, std::vector<MtdSimLayerClusterRef>> simClusIdsMap;
+  for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
+    const auto& simClus = *simClusIt;
+
+    edm::Ref<MtdSimLayerClusterCollection> simClusterRef =
+        edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
+
+    std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIdsAndRows = simClus.detIds_and_rows();
+    std::vector<uint32_t> detIds(detIdsAndRows.size());
+    std::transform(detIdsAndRows.begin(),
+                   detIdsAndRows.end(),
+                   detIds.begin(),
+                   [](const std::pair<uint32_t, std::pair<uint8_t, uint8_t>>& pair) { return pair.first; });
+
+    // -- get the sensor module id from the first hit id of the MtdSimCluster
+    DetId id(detIds[0]);
+    uint32_t modId = geomTools_.sensorModuleId(id);
+    simClusIdsMap[modId].push_back(simClusterRef);
+
+    LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl") << "Sim cluster  detId = " << modId << std::endl;
+  }
+
+  for (auto const& recoClusH : inputRecoClusH) {
+    // -- loop over detSetVec
+    for (const auto& detSet : *recoClusH) {
+      // -- loop over reco clusters
+      for (const auto& recoClus : detSet) {
+        MTDDetId clusId = recoClus.id();
+
+        LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl") << "Reco cluster : " << clusId;
+
+        std::vector<uint64_t> recoClusHitIds;
+
+        // -- loop over hits in the reco cluster and find their unique ids
+        for (int ihit = 0; ihit < recoClus.size(); ++ihit) {
+          int hit_row = recoClus.minHitRow() + recoClus.hitOffset()[ihit * 2];
+          int hit_col = recoClus.minHitCol() + recoClus.hitOffset()[ihit * 2 + 1];
+
+          // -- Get an unique id from sensor module detId , row, column
+          uint64_t uniqueId = static_cast<uint64_t>(clusId.rawId()) << 32;
+          uniqueId |= hit_row << 16;
+          uniqueId |= hit_col;
+          recoClusHitIds.push_back(uniqueId);
+
+          LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+              << " ======= cluster raw Id : " << clusId.rawId() << "  row : " << hit_row << "   column: " << hit_col
+              << " recHit uniqueId : " << uniqueId;
+        }
+
+        // -- loop over sim clusters and check if this reco clus shares some hits
+        std::vector<MtdSimLayerClusterRef> simClusterRefs;
+
+        for (const auto& simClusterRef : simClusIdsMap[clusId.rawId()]) {
+          const auto& simClus = *simClusterRef;
+
+          // get the hit ids of hits in the SimCluster
+          std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIdsAndRows = simClus.detIds_and_rows();
+          std::vector<uint64_t> simClusHitIds(detIdsAndRows.size());
+          for (unsigned int i = 0; i < detIdsAndRows.size(); i++) {
+            DetId id(detIdsAndRows[i].first);
+            uint32_t modId = geomTools_.sensorModuleId(id);
+            // build the unique id from sensor module detId , row, column
+            uint64_t uniqueId = static_cast<uint64_t>(modId) << 32;
+            uniqueId |= detIdsAndRows[i].second.first << 16;
+            uniqueId |= detIdsAndRows[i].second.second;
+            simClusHitIds.push_back(uniqueId);
+          }
+
+          // -- Get shared hits
+          std::vector<uint64_t> sharedHitIds;
+          std::set_intersection(recoClusHitIds.begin(),
+                                recoClusHitIds.end(),
+                                simClusHitIds.begin(),
+                                simClusHitIds.end(),
+                                std::back_inserter(sharedHitIds));
+
+          if (sharedHitIds.empty())
+            continue;
+
+          float dE = recoClus.energy() * 0.001 / simClus.simLCEnergy();  // reco cluster energy is in MeV!
+          float dtSig = std::abs((recoClus.time() - simClus.simLCTime()) / recoClus.timeError());
+
+          // -- If the sim and reco clusters have common hits, fill the std:vector of sim clusters refs
+          if (!sharedHitIds.empty() && dE < energyCut_ &&
+              dtSig < timeCut_) {  // at least one hit in common + requirement on energy and time compatibility
+
+            simClusterRefs.push_back(simClusterRef);
+
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "RecoToSim --> Found " << sharedHitIds.size() << " shared hits";
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "E_recoClus = " << recoClus.energy() << "   E_simClus = " << simClus.simLCEnergy()
+                << "   E_recoClus/E_simClus = " << dE;
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "(t_recoClus-t_simClus)/sigma_t = " << dtSig;
+          }
+        }  // -- end loop over sim clus refs
+
+        // -- Now fill the output collection
+        edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> recoClusterRef = edmNew::makeRefTo(recoClusH, &recoClus);
+        outputCollection.emplace_back(recoClusterRef, simClusterRefs);
+
+      }  // -- end loop over reco clus
+    }    // -- end loop over detsetclus
+  }
+
+  return outputCollection;
+}
+
+reco::SimToRecoCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl::associateSimToReco(
+    const edm::Handle<FTLClusterCollection>& btlRecoClusH,
+    const edm::Handle<FTLClusterCollection>& etlRecoClusH,
+    const edm::Handle<MtdSimLayerClusterCollection>& simClusH) const {
+  SimToRecoCollectionMtd outputCollection;
+
+  // -- get the collections
+  const auto& simClusters = *simClusH.product();
+
+  std::array<edm::Handle<FTLClusterCollection>, 2> inputH{{btlRecoClusH, etlRecoClusH}};
+
+  // -- loop over MtdSimLayerClusters
+  for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
+    const auto& simClus = *simClusIt;
+
+    // get the hit ids of hits in the SimCluster
+    std::vector<std::pair<uint32_t, std::pair<uint8_t, uint8_t>>> detIdsAndRows = simClus.detIds_and_rows();
+    std::vector<uint64_t> simClusHitIds(detIdsAndRows.size());
+    uint32_t modId = 0;
+    for (unsigned int i = 0; i < detIdsAndRows.size(); i++) {
+      DetId id(detIdsAndRows[i].first);
+      modId = geomTools_.sensorModuleId(id);
+      // build the unique id from sensor module detId , row, column
+      uint64_t uniqueId = static_cast<uint64_t>(modId) << 32;
+      uniqueId |= detIdsAndRows[i].second.first << 16;
+      uniqueId |= detIdsAndRows[i].second.second;
+      simClusHitIds.push_back(uniqueId);
+    }
+
+    DetId simClusId(modId);
+
+    std::vector<FTLClusterRef> recoClusterRefs;
+
+    // -- loop over reco clusters
+    for (auto const& recoClusH : inputH) {
+      // -- loop over detSetVec
+      for (const auto& detSet : *recoClusH) {
+        if (detSet.id() != simClusId.rawId())
+          continue;
+
+        // -- loop over reco clusters
+        for (const auto& recoClus : detSet) {
+          MTDDetId clusId = recoClus.id();
+
+          std::vector<uint64_t> recoClusHitIds;
+
+          // -- loop over hits in the reco cluster and find their ids
+          for (int ihit = 0; ihit < recoClus.size(); ++ihit) {
+            int hit_row = recoClus.minHitRow() + recoClus.hitOffset()[ihit * 2];
+            int hit_col = recoClus.minHitCol() + recoClus.hitOffset()[ihit * 2 + 1];
+
+            // -- Get an unique id from sensor module detId , row, column
+            uint64_t uniqueId = static_cast<uint64_t>(clusId.rawId()) << 32;
+            uniqueId |= hit_row << 16;
+            uniqueId |= hit_col;
+            recoClusHitIds.push_back(uniqueId);
+
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << " ======= cluster raw Id : " << clusId.rawId() << "  row : " << hit_row << "   column: " << hit_col
+                << " recHit uniqueId : " << uniqueId;
+          }
+
+          // -- Get shared hits
+          std::vector<uint64_t> sharedHitIds;
+          std::set_intersection(simClusHitIds.begin(),
+                                simClusHitIds.end(),
+                                recoClusHitIds.begin(),
+                                recoClusHitIds.end(),
+                                std::back_inserter(sharedHitIds));
+          if (sharedHitIds.empty())
+            continue;
+
+          float dE = recoClus.energy() * 0.001 / simClus.simLCEnergy();  // reco cluster energy is in MeV
+          float dtSig = std::abs((recoClus.time() - simClus.simLCTime()) / recoClus.timeError());
+
+          // -- If the sim and reco clusters have common hits, fill the std:vector of reco clusters refs
+          if (!sharedHitIds.empty() && dE < energyCut_ && dtSig < timeCut_) {
+            // Create a persistent edm::Ref to the cluster
+            edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> recoClusterRef =
+                edmNew::makeRefTo(recoClusH, &recoClus);
+            recoClusterRefs.push_back(recoClusterRef);
+
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "SimToReco --> Found " << sharedHitIds.size() << " shared hits";
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "E_recoClus = " << recoClus.energy() << "   E_simClus = " << simClus.simLCEnergy()
+                << "   E_recoClus/E_simClus = " << dE;
+            LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
+                << "(t_recoClus-t_simClus)/sigma_t = " << dtSig;
+          }
+
+        }  // end loop ove reco clus
+      }    // end loop over detsets
+    }
+
+    // -- Now fill the output collection
+    edm::Ref<MtdSimLayerClusterCollection> simClusterRef =
+        edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
+    outputCollection.emplace_back(simClusterRef, recoClusterRefs);
+
+  }  // -- end loop over sim clusters
+
+  return outputCollection;
+}

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.h
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.h
@@ -1,0 +1,34 @@
+#include <vector>
+#include <memory>
+
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeomUtil.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+class MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
+    : public reco::MtdRecoClusterToSimLayerClusterAssociatorBaseImpl {
+public:
+  explicit MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl(edm::EDProductGetter const &,
+                                                               double,
+                                                               double,
+                                                               mtd::MTDGeomUtil &);
+
+  reco::RecoToSimCollectionMtd associateRecoToSim(
+      const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+      const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const override;
+
+  reco::SimToRecoCollectionMtd associateSimToReco(
+      const edm::Handle<FTLClusterCollection> &btlRecoClusH,
+      const edm::Handle<FTLClusterCollection> &etlRecoClusH,
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH) const override;
+
+private:
+  edm::EDProductGetter const *productGetter_;
+  const double energyCut_;
+  const double timeCut_;
+  mtd::MTDGeomUtil geomTools_;
+};

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer.cc
@@ -1,0 +1,79 @@
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
+#include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+
+#include "MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.h"
+
+//
+// Class declaration
+//
+
+class MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer : public edm::global::EDProducer<> {
+public:
+  explicit MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer(const edm::ParameterSet &);
+  ~MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+  const double energyCut_;
+  const double timeCut_;
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<MTDTopology, MTDTopologyRcd> topoToken_;
+};
+
+MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer::MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer(
+    const edm::ParameterSet &ps)
+    : energyCut_(ps.getParameter<double>("energyCut")), timeCut_(ps.getParameter<double>("timeCut")) {
+  geomToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
+  topoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
+
+  // Register the product
+  produces<reco::MtdRecoClusterToSimLayerClusterAssociator>();
+}
+
+MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer::~MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer() {}
+
+void MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer::produce(edm::StreamID,
+                                                                      edm::Event &iEvent,
+                                                                      const edm::EventSetup &es) const {
+  auto geometryHandle = es.getTransientHandle(geomToken_);
+  const MTDGeometry *geom = geometryHandle.product();
+
+  auto topologyHandle = es.getTransientHandle(topoToken_);
+  const MTDTopology *topology = topologyHandle.product();
+
+  mtd::MTDGeomUtil geomTools_;
+  geomTools_.setGeometry(geom);
+  geomTools_.setTopology(topology);
+
+  auto impl = std::make_unique<MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl>(
+      iEvent.productGetter(), energyCut_, timeCut_, geomTools_);
+  auto toPut = std::make_unique<reco::MtdRecoClusterToSimLayerClusterAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("energyCut", 5.);
+  desc.add<double>("timeCut", 10.);
+
+  cfg.add("mtdRecoClusterToSimLayerClusterAssociatorByHits", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(MtdRecoClusterToSimLayerClusterAssociatorByHitsProducer);

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorEDProducer.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorEDProducer.cc
@@ -1,0 +1,85 @@
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociator.h"
+
+//
+// class decleration
+//
+
+class MtdRecoClusterToSimLayerClusterAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit MtdRecoClusterToSimLayerClusterAssociatorEDProducer(const edm::ParameterSet &);
+  ~MtdRecoClusterToSimLayerClusterAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<FTLClusterCollection> btlRecoClustersToken_;
+  edm::EDGetTokenT<FTLClusterCollection> etlRecoClustersToken_;
+  edm::EDGetTokenT<MtdSimLayerClusterCollection> simClustersToken_;
+
+  edm::EDGetTokenT<reco::MtdRecoClusterToSimLayerClusterAssociator> associatorToken_;
+};
+
+MtdRecoClusterToSimLayerClusterAssociatorEDProducer::MtdRecoClusterToSimLayerClusterAssociatorEDProducer(
+    const edm::ParameterSet &pset) {
+  produces<reco::SimToRecoCollectionMtd>();
+  produces<reco::RecoToSimCollectionMtd>();
+
+  btlRecoClustersToken_ = consumes<FTLClusterCollection>(pset.getParameter<edm::InputTag>("btlRecoClustersTag"));
+  etlRecoClustersToken_ = consumes<FTLClusterCollection>(pset.getParameter<edm::InputTag>("etlRecoClustersTag"));
+  simClustersToken_ = consumes<MtdSimLayerClusterCollection>(pset.getParameter<edm::InputTag>("mtdSimClustersTag"));
+  associatorToken_ =
+      consumes<reco::MtdRecoClusterToSimLayerClusterAssociator>(pset.getParameter<edm::InputTag>("associator"));
+}
+
+MtdRecoClusterToSimLayerClusterAssociatorEDProducer::~MtdRecoClusterToSimLayerClusterAssociatorEDProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void MtdRecoClusterToSimLayerClusterAssociatorEDProducer::produce(edm::StreamID,
+                                                                  edm::Event &iEvent,
+                                                                  const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<reco::MtdRecoClusterToSimLayerClusterAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  edm::Handle<FTLClusterCollection> btlRecoClusters;
+  iEvent.getByToken(btlRecoClustersToken_, btlRecoClusters);
+
+  edm::Handle<FTLClusterCollection> etlRecoClusters;
+  iEvent.getByToken(etlRecoClustersToken_, etlRecoClusters);
+
+  edm::Handle<MtdSimLayerClusterCollection> simClusters;
+  iEvent.getByToken(simClustersToken_, simClusters);
+
+  // associate reco clus to sim layer clus
+  reco::RecoToSimCollectionMtd recoToSimColl =
+      theAssociator->associateRecoToSim(btlRecoClusters, etlRecoClusters, simClusters);
+  reco::SimToRecoCollectionMtd simToRecoColl =
+      theAssociator->associateSimToReco(btlRecoClusters, etlRecoClusters, simClusters);
+
+  auto r2s = std::make_unique<reco::RecoToSimCollectionMtd>(recoToSimColl);
+  auto s2r = std::make_unique<reco::SimToRecoCollectionMtd>(simToRecoColl);
+
+  iEvent.put(std::move(r2s));
+  iEvent.put(std::move(s2r));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(MtdRecoClusterToSimLayerClusterAssociatorEDProducer);

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.cc
@@ -1,0 +1,133 @@
+//
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "MtdSimLayerClusterToTPAssociatorByTrackIdImpl.h"
+
+using namespace reco;
+using namespace std;
+
+/* Constructor */
+MtdSimLayerClusterToTPAssociatorByTrackIdImpl::MtdSimLayerClusterToTPAssociatorByTrackIdImpl(
+    edm::EDProductGetter const& productGetter)
+    : productGetter_(&productGetter) {}
+
+//
+//---member functions
+//
+
+reco::SimToTPCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associateSimToTP(
+    const edm::Handle<MtdSimLayerClusterCollection>& simClusH,
+    const edm::Handle<TrackingParticleCollection>& trackingParticleH) const {
+  SimToTPCollectionMtd outputCollection(productGetter_);
+
+  // -- get the collections
+  const auto& simClusters = *simClusH.product();
+  const auto& trackingParticles = *trackingParticleH.product();
+
+  // -- Loop over tracking particles and build a temporary map of trackId, eventId  --> tpRef
+  std::map<std::pair<unsigned int, uint32_t>, TrackingParticleRef> tpIdMap;
+  for (auto tpIt = trackingParticles.begin(); tpIt != trackingParticles.end(); tpIt++) {
+    const auto& tp = *tpIt;
+    unsigned int tpTrackId = tp.g4Tracks()[0].trackId();
+    EncodedEventId tpEventId = tp.eventId();
+    TrackingParticleRef tpRef =
+        edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIt - trackingParticles.begin());
+    tpIdMap[std::make_pair(tpTrackId, tpEventId.rawId())] = tpRef;
+  }
+
+  // -- loop over sim clusters and get the trackId, eventId
+
+  LogDebug("MtdSimLayerClusterToTPAssociator")
+      << " Found " << simClusters.size() << " MtdSimLayerClusters in the event";
+
+  for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
+    const auto& simClus = *simClusIt;
+    size_t simClusIndex = simClusIt - simClusters.begin();
+    MtdSimLayerClusterRef simClusterRef = edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIndex);
+    unsigned int simClusTrackId = simClus.g4Tracks()[0].trackId();
+    EncodedEventId simClusEventId = simClus.eventId();
+
+    // -- Check the trackId offset of the sim hits and keep only clusters with "direct" hits (offset == 0)
+    /* 
+       if (simClus.trackIdOffset() != 0 ) continue; 
+    */
+
+    std::pair uniqueId = std::make_pair(simClusTrackId, simClusEventId.rawId());
+    auto it = tpIdMap.find(uniqueId);
+
+    if (it != tpIdMap.end()) {
+      TrackingParticleRef tpRef = tpIdMap[uniqueId];
+      outputCollection.insert(simClusterRef, tpRef);
+
+      LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
+          << "MtdSimLayerCluster: index = " << simClusIndex << "   simClus TrackId = " << simClusTrackId
+          << " simClus EventId = " << simClusEventId.rawId() << " simClus Eta = " << simClus.eta()
+          << " simClus Phi = " << simClus.phi() << "  simClus Time = " << simClus.simLCTime()
+          << "  simClus Energy = " << simClus.simLCEnergy() << std::endl;
+      LogDebug("MtdSimLayerClusterToTPAssociator::associateSimToTP")
+          << "  --> Found associated tracking particle:  tp TrackId = " << (*tpRef).g4Tracks()[0].trackId()
+          << " tp EventId = " << (*tpRef).eventId().rawId() << std::endl;
+    }
+
+  }  // -- end loop over sim clus
+
+  return outputCollection;
+}
+
+reco::TPToSimCollectionMtd MtdSimLayerClusterToTPAssociatorByTrackIdImpl::associateTPToSim(
+    const edm::Handle<MtdSimLayerClusterCollection>& simClusH,
+    const edm::Handle<TrackingParticleCollection>& trackingParticleH) const {
+  TPToSimCollectionMtd outputCollection(productGetter_);
+
+  // -- get the collections
+  const auto& simClusters = *simClusH.product();
+  const auto& trackingParticles = *trackingParticleH.product();
+
+  // -- Loop over MtdSimLayerClusters and build a temporary map of trackId, eventId --> simClusterRef
+  std::map<std::pair<unsigned int, uint32_t>, std::vector<MtdSimLayerClusterRef>> simClusIdMap;
+  for (auto simClusIt = simClusters.begin(); simClusIt != simClusters.end(); simClusIt++) {
+    const auto& simClus = *simClusIt;
+    unsigned int simClusTrackId = simClus.g4Tracks()[0].trackId();
+    EncodedEventId simClusEventId = simClus.eventId();
+    MtdSimLayerClusterRef simClusterRef =
+        edm::Ref<MtdSimLayerClusterCollection>(simClusH, simClusIt - simClusters.begin());
+    simClusIdMap[std::make_pair(simClusTrackId, simClusEventId.rawId())].push_back(simClusterRef);
+  }
+
+  // -- Loop over the tracking particles
+  for (auto tpIt = trackingParticles.begin(); tpIt != trackingParticles.end(); tpIt++) {
+    const auto& tp = *tpIt;
+    size_t tpIndex = tpIt - trackingParticles.begin();
+    TrackingParticleRef tpRef = edm::Ref<TrackingParticleCollection>(trackingParticleH, tpIndex);
+    unsigned int tpTrackId = tp.g4Tracks()[0].trackId();
+    EncodedEventId tpEventId = tp.eventId();
+
+    std::pair uniqueId = std::make_pair(tpTrackId, tpEventId.rawId());
+    auto it = simClusIdMap.find(uniqueId);
+
+    if (it != simClusIdMap.end()) {
+      for (unsigned int i = 0; i < simClusIdMap[uniqueId].size(); i++) {
+        MtdSimLayerClusterRef simClusterRef = simClusIdMap[uniqueId][i];
+        // -- Check the trackId offset of the sim hits and keep only clusters with "direct" hits (offset == 0)
+        /*
+	  if (simClus.trackIdOffset() != 0 ) continue; 
+	*/
+
+        outputCollection.insert(tpRef, simClusterRef);
+
+        LogDebug("MtdSimLayerClusterToTPAssociator")
+            << "Tracking particle:  index = " << tpIndex << "  tp TrackId = " << tpTrackId
+            << "  tp EventId = " << tpEventId.rawId();
+        LogDebug("MtdSimLayerClusterToTPAssociator")
+            << " --> Found associated MtdSimLayerCluster:  simClus TrackId = "
+            << (*simClusterRef).g4Tracks()[0].trackId() << " simClus EventId = " << (*simClusterRef).eventId().rawId()
+            << " simClus Eta = " << (*simClusterRef).eta() << " simClus Phi = " << (*simClusterRef).phi()
+            << "  simClus Time = " << (*simClusterRef).simLCTime()
+            << "  simClus Energy = " << (*simClusterRef).simLCEnergy() << std::endl;
+      }
+    }
+  }
+
+  return outputCollection;
+}

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.h
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdImpl.h
@@ -1,0 +1,24 @@
+#include <vector>
+#include <memory>
+
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h"
+
+namespace edm {
+  class EDProductGetter;
+}
+
+class MtdSimLayerClusterToTPAssociatorByTrackIdImpl : public reco::MtdSimLayerClusterToTPAssociatorBaseImpl {
+public:
+  explicit MtdSimLayerClusterToTPAssociatorByTrackIdImpl(edm::EDProductGetter const &);
+
+  reco::SimToTPCollectionMtd associateSimToTP(
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+      const edm::Handle<TrackingParticleCollection> &trackingParticleH) const override;
+
+  reco::TPToSimCollectionMtd associateTPToSim(
+      const edm::Handle<MtdSimLayerClusterCollection> &simClusH,
+      const edm::Handle<TrackingParticleCollection> &trackingParticleH) const override;
+
+private:
+  edm::EDProductGetter const *productGetter_;
+};

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdProducer.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorByTrackIdProducer.cc
@@ -1,0 +1,56 @@
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "MtdSimLayerClusterToTPAssociatorByTrackIdImpl.h"
+
+//
+// Class declaration
+//
+
+class MtdSimLayerClusterToTPAssociatorByTrackIdProducer : public edm::global::EDProducer<> {
+public:
+  explicit MtdSimLayerClusterToTPAssociatorByTrackIdProducer(const edm::ParameterSet &);
+  ~MtdSimLayerClusterToTPAssociatorByTrackIdProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+};
+
+MtdSimLayerClusterToTPAssociatorByTrackIdProducer::MtdSimLayerClusterToTPAssociatorByTrackIdProducer(
+    const edm::ParameterSet &pset) {
+  // Register the product
+  produces<reco::MtdSimLayerClusterToTPAssociator>();
+}
+
+MtdSimLayerClusterToTPAssociatorByTrackIdProducer::~MtdSimLayerClusterToTPAssociatorByTrackIdProducer() {}
+
+void MtdSimLayerClusterToTPAssociatorByTrackIdProducer::produce(edm::StreamID,
+                                                                edm::Event &iEvent,
+                                                                const edm::EventSetup &es) const {
+  auto impl = std::make_unique<MtdSimLayerClusterToTPAssociatorByTrackIdImpl>(iEvent.productGetter());
+  auto toPut = std::make_unique<reco::MtdSimLayerClusterToTPAssociator>(std::move(impl));
+  iEvent.put(std::move(toPut));
+}
+
+void MtdSimLayerClusterToTPAssociatorByTrackIdProducer::fillDescriptions(edm::ConfigurationDescriptions &cfg) {
+  edm::ParameterSetDescription desc;
+
+  cfg.add("mtdSimLayerClusterToTPAssociatorByTrackId", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(MtdSimLayerClusterToTPAssociatorByTrackIdProducer);

--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorEDProducer.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdSimLayerClusterToTPAssociatorEDProducer.cc
@@ -1,0 +1,78 @@
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/Associations/interface/MtdSimLayerClusterToTPAssociator.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+//
+// class decleration
+//
+
+class MtdSimLayerClusterToTPAssociatorEDProducer : public edm::global::EDProducer<> {
+public:
+  explicit MtdSimLayerClusterToTPAssociatorEDProducer(const edm::ParameterSet &);
+  ~MtdSimLayerClusterToTPAssociatorEDProducer() override;
+
+private:
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
+
+  edm::EDGetTokenT<MtdSimLayerClusterCollection> simClustersToken_;
+  edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+  edm::EDGetTokenT<reco::MtdSimLayerClusterToTPAssociator> associatorToken_;
+};
+
+MtdSimLayerClusterToTPAssociatorEDProducer::MtdSimLayerClusterToTPAssociatorEDProducer(const edm::ParameterSet &pset) {
+  produces<reco::SimToTPCollectionMtd>();
+  produces<reco::TPToSimCollectionMtd>();
+
+  simClustersToken_ = consumes<MtdSimLayerClusterCollection>(pset.getParameter<edm::InputTag>("mtdSimClustersTag"));
+  tpToken_ = consumes<TrackingParticleCollection>(pset.getParameter<edm::InputTag>("trackingParticlesTag"));
+  associatorToken_ = consumes<reco::MtdSimLayerClusterToTPAssociator>(pset.getParameter<edm::InputTag>("associator"));
+}
+
+MtdSimLayerClusterToTPAssociatorEDProducer::~MtdSimLayerClusterToTPAssociatorEDProducer() {}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void MtdSimLayerClusterToTPAssociatorEDProducer::produce(edm::StreamID,
+                                                         edm::Event &iEvent,
+                                                         const edm::EventSetup &iSetup) const {
+  using namespace edm;
+
+  edm::Handle<reco::MtdSimLayerClusterToTPAssociator> theAssociator;
+  iEvent.getByToken(associatorToken_, theAssociator);
+
+  edm::Handle<MtdSimLayerClusterCollection> simClusters;
+  iEvent.getByToken(simClustersToken_, simClusters);
+
+  edm::Handle<TrackingParticleCollection> trackingParticles;
+  iEvent.getByToken(tpToken_, trackingParticles);
+
+  reco::SimToTPCollectionMtd simToTPColl = theAssociator->associateSimToTP(simClusters, trackingParticles);
+  reco::TPToSimCollectionMtd tpToSimColl = theAssociator->associateTPToSim(simClusters, trackingParticles);
+
+  auto s2tp = std::make_unique<reco::SimToTPCollectionMtd>(simToTPColl);
+  auto tp2s = std::make_unique<reco::TPToSimCollectionMtd>(tpToSimColl);
+
+  iEvent.put(std::move(s2tp));
+  iEvent.put(std::move(tp2s));
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(MtdSimLayerClusterToTPAssociatorEDProducer);

--- a/SimFastTiming/MtdAssociatorProducers/python/mtdRecoClusterToSimLayerClusterAssociation_cfi.py
+++ b/SimFastTiming/MtdAssociatorProducers/python/mtdRecoClusterToSimLayerClusterAssociation_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+mtdRecoClusterToSimLayerClusterAssociation = cms.EDProducer("MtdRecoClusterToSimLayerClusterAssociatorEDProducer",
+    associator = cms.InputTag('mtdRecoClusterToSimLayerClusterAssociatorByHits'),
+    mtdSimClustersTag = cms.InputTag('mix','MergedMtdTruthLC'),
+    btlRecoClustersTag = cms.InputTag('mtdClusters', 'FTLBarrel'),
+    etlRecoClustersTag = cms.InputTag('mtdClusters', 'FTLEndcap'),
+)

--- a/SimFastTiming/MtdAssociatorProducers/python/mtdSimLayerClusterToTPAssociation_cfi.py
+++ b/SimFastTiming/MtdAssociatorProducers/python/mtdSimLayerClusterToTPAssociation_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+mtdSimLayerClusterToTPAssociation = cms.EDProducer("MtdSimLayerClusterToTPAssociatorEDProducer",
+    associator = cms.InputTag('mtdSimLayerClusterToTPAssociatorByTrackId'),
+    mtdSimClustersTag = cms.InputTag('mix','MergedMtdTruthLC'),
+    trackingParticlesTag = cms.InputTag('mix', 'MergedTrackTruth')
+)

--- a/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
@@ -1,8 +1,7 @@
 // Author: Aurora Perego, Fabio Cossutti - aurora.perego@cern.ch, fabio.cossutti@ts.infn.it
 // Date: 05/2023
 
-//#define DEBUG false
-#define DEBUG true
+#define DEBUG false
 #define PRINT_DEBUG true
 
 #if DEBUG

--- a/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
+++ b/SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc
@@ -1,7 +1,9 @@
 // Author: Aurora Perego, Fabio Cossutti - aurora.perego@cern.ch, fabio.cossutti@ts.infn.it
 // Date: 05/2023
 
-#define DEBUG false
+//#define DEBUG false
+#define DEBUG true
+#define PRINT_DEBUG true
 
 #if DEBUG
 #pragma GCC diagnostic pop
@@ -83,8 +85,7 @@ private:
    * for bad modules if required */
   template <class T>
   void fillSimHits(std::vector<std::pair<uint64_t, const PSimHit *>> &returnValue,
-                   std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdEnergyMap,
-                   std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdTimeMap,
+                   std::unordered_map<int, std::map<uint64_t, std::tuple<float, float, LocalPoint>>> &simTrackDetIdMap,
                    const T &event,
                    const edm::EventSetup &setup);
 
@@ -163,18 +164,17 @@ private:
 namespace {
   class CaloParticle_dfs_visitor : public boost::default_dfs_visitor {
   public:
-    CaloParticle_dfs_visitor(MtdTruthAccumulator::OutputCollections &output,
-                             MtdTruthAccumulator::calo_particles &caloParticles,
-                             std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex,
-                             std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdEnergyMap,
-                             std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdTimeMap,
-                             std::unordered_map<uint32_t, float> &vertex_time_map,
-                             Selector selector)
+    CaloParticle_dfs_visitor(
+        MtdTruthAccumulator::OutputCollections &output,
+        MtdTruthAccumulator::calo_particles &caloParticles,
+        std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex,
+        std::unordered_map<int, std::map<uint64_t, std::tuple<float, float, LocalPoint>>> &simTrackDetIdMap,
+        std::unordered_map<uint32_t, float> &vertex_time_map,
+        Selector selector)
         : output_(output),
           caloParticles_(caloParticles),
           simHitBarcodeToIndex_(simHitBarcodeToIndex),
-          simTrackDetIdEnergyMap_(simTrackDetIdEnergyMap),
-          simTrackDetIdTimeMap_(simTrackDetIdTimeMap),
+          simTrackDetIdMap_(simTrackDetIdMap),
           vertex_time_map_(vertex_time_map),
           selector_(selector) {}
     template <typename Vertex, typename Graph>
@@ -186,23 +186,34 @@ namespace {
       auto const vertex_property = get(vertex_name, g, u);
       if (!vertex_property.simTrack)
         return;
-      auto trackIdx = vertex_property.simTrack->trackId();
-      IfLogDebug(DEBUG, messageCategoryGraph_)
-          << " Found " << simHitBarcodeToIndex_.count(trackIdx) << " associated simHits" << std::endl;
-      if (simHitBarcodeToIndex_.count(trackIdx)) {
-        output_.pSimClusters->emplace_back(*vertex_property.simTrack);
-        auto &simcluster = output_.pSimClusters->back();
-        std::unordered_map<uint64_t, float> acc_energy;
-        for (auto const &hit_and_energy : simTrackDetIdEnergyMap_[trackIdx]) {
-          acc_energy[hit_and_energy.first] += hit_and_energy.second;
-        }
-        for (auto const &hit_and_energy : acc_energy) {
-          simcluster.addHitAndFraction(hit_and_energy.first, hit_and_energy.second);
-          simcluster.addHitEnergy(hit_and_energy.second);
-          simcluster.addHitTime(simTrackDetIdTimeMap_[simcluster.g4Tracks()[0].trackId()][hit_and_energy.first]);
+      // -- loop over possible trackIdOffsets to save also sim clusters from non-direct hits
+      for (unsigned int offset = 0; offset < 4; offset++) {
+        auto trackIdx = vertex_property.simTrack->trackId();
+        trackIdx += offset * (static_cast<int>(PSimHit::k_tidOffset));
+        IfLogDebug(DEBUG, messageCategoryGraph_)
+            << " Found " << simHitBarcodeToIndex_.count(trackIdx) << " associated simHits" << std::endl;
+        if (simHitBarcodeToIndex_.count(trackIdx)) {
+          output_.pSimClusters->emplace_back(*vertex_property.simTrack);
+          auto &simcluster = output_.pSimClusters->back();
+          std::unordered_map<uint64_t, float> acc_energy;
+          for (auto const &hit_and_energy : simTrackDetIdMap_[trackIdx]) {
+            acc_energy[hit_and_energy.first] += std::get<0>(hit_and_energy.second);
+          }
+          for (auto const &hit_and_energy : acc_energy) {
+            simcluster.addHitAndFraction(hit_and_energy.first, hit_and_energy.second);
+            simcluster.addHitEnergy(hit_and_energy.second);
+            simcluster.addHitTime(std::get<1>(
+                simTrackDetIdMap_[simcluster.g4Tracks()[0].trackId() +
+                                  offset * (static_cast<int>(PSimHit::k_tidOffset))][hit_and_energy.first]));
+            simcluster.addHitPosition(std::get<2>(
+                simTrackDetIdMap_[simcluster.g4Tracks()[0].trackId() +
+                                  offset * (static_cast<int>(PSimHit::k_tidOffset))][hit_and_energy.first]));
+            simcluster.setTrackIdOffset(offset);
+          }
         }
       }
     }
+
     template <typename Edge, typename Graph>
     void examine_edge(Edge e, const Graph &g) {
       auto src = source(e, g);
@@ -235,12 +246,11 @@ namespace {
     MtdTruthAccumulator::OutputCollections &output_;
     MtdTruthAccumulator::calo_particles &caloParticles_;
     std::unordered_multimap<Barcode_t, Index_t> &simHitBarcodeToIndex_;
-    std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdEnergyMap_;
-    std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdTimeMap_;
+    std::unordered_map<int, std::map<uint64_t, std::tuple<float, float, LocalPoint>>> &simTrackDetIdMap_;
     std::unordered_map<uint32_t, float> &vertex_time_map_;
     Selector selector_;
   };
-}  // namespace
+}  // Namespace
 
 MtdTruthAccumulator::MtdTruthAccumulator(const edm::ParameterSet &config,
                                          edm::ProducesCollector producesCollector,
@@ -406,6 +416,7 @@ void MtdTruthAccumulator::finalizeEvent(edm::Event &event, edm::EventSetup const
     auto const &hAndF = sc.hits_and_fractions();
     auto const &hAndE = sc.hits_and_energies();
     auto const &hAndT = sc.hits_and_times();
+    auto const &hAndP = sc.hits_and_positions();
     auto const &hAndR = sc.detIds_and_rows();
     // create a vector with the indices of the hits in the simCluster
     std::vector<int> indices(hAndF.size());
@@ -429,12 +440,21 @@ void MtdTruthAccumulator::finalizeEvent(edm::Event &event, edm::EventSetup const
       tmpLC.addHitAndFraction(hAndF[ind].first, hAndF[ind].second);
       tmpLC.addHitEnergy(hAndE[ind].second);
       tmpLC.addHitTime(hAndT[ind].second);
+      tmpLC.addHitPosition(hAndP[ind].second);
     };
 
     auto update_clu_info = [&](const int &ind) {
       double energy = hAndE[ind].second;
-      auto position =
-          geomTools_.position((DetId)hAndR[ind].first, (hAndR[ind].second).first, (hAndR[ind].second).second).first;
+      auto position = hAndP[ind].second;
+      if (geomTools_.isBTL((DetId)hAndR[ind].first)) {
+        BTLDetId detId{(DetId)hAndR[ind].first};
+        DetId geoId = detId.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topology->getMTDTopologyMode()));
+        const MTDGeomDet *thedet = geom->idToDet(geoId);
+        const ProxyMTDTopology &topoproxy = static_cast<const ProxyMTDTopology &>(thedet->topology());
+        const RectangularMTDTopology &topo = static_cast<const RectangularMTDTopology &>(topoproxy.specificTopology());
+        position =
+            topo.pixelToModuleLocalPoint(hAndP[ind].second, (hAndR[ind].second).first, (hAndR[ind].second).second);
+      }
       SimLCenergy += energy;
       SimLCx += position.x() * energy;
       SimLCy += position.y() * energy;
@@ -451,6 +471,7 @@ void MtdTruthAccumulator::finalizeEvent(edm::Event &event, edm::EventSetup const
       SimLCz = 0.;
       tmpLC.addCluIndex(SC_index);
       tmpLC.computeClusterTime();
+      tmpLC.setTrackIdOffset(sc.trackIdOffset());  // add trackIdoffset
       output_.pMtdSimLayerClusters->push_back(tmpLC);
       LC_indices.push_back(LC_index);
       LC_index++;
@@ -583,9 +604,8 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
   event.getByLabel(genParticleLabel_, hGenParticleIndices);
 
   std::vector<std::pair<uint64_t, const PSimHit *>> simHitPointers;
-  std::unordered_map<int, std::map<uint64_t, float>> simTrackDetIdEnergyMap;
-  std::unordered_map<int, std::map<uint64_t, float>> simTrackDetIdTimeMap;
-  fillSimHits(simHitPointers, simTrackDetIdEnergyMap, simTrackDetIdTimeMap, event, setup);
+  std::unordered_map<int, std::map<uint64_t, std::tuple<float, float, LocalPoint>>> simTrackDetIdMap;
+  fillSimHits(simHitPointers, simTrackDetIdMap, event, setup);
 
   // Clear maps from previous event fill them for this one
   m_simHitBarcodeToIndex.clear();
@@ -600,7 +620,7 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
   DecayChain decay;
 
   for (uint32_t i = 0; i < vertices.size(); i++) {
-    vertex_time_map[i] = vertices[i].position().t() * 1e9 + event.bunchCrossing() * bunchSpacing_;
+    vertex_time_map[i] = vertices[i].position().t() * 1e9 + event.bunchCrossing() * static_cast<int>(bunchSpacing_);
   }
 
   IfLogDebug(DEBUG, messageCategory_) << " TRACKS" << std::endl;
@@ -656,10 +676,8 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
       // Perform the actual vertex collapsing, if needed.
       if (collapsed_vertices[origin_vtx])
         origin_vtx = collapsed_vertices[origin_vtx];
-      add_edge(origin_vtx,
-               v.vertexId(),
-               EdgeProperty(&tracks[trk_idx], simTrackDetIdEnergyMap[v.parentIndex()].size(), 0),
-               decay);
+      add_edge(
+          origin_vtx, v.vertexId(), EdgeProperty(&tracks[trk_idx], simTrackDetIdMap[v.parentIndex()].size(), 0), decay);
       used_sim_tracks[trk_idx] = v.vertexId();
     }
   }
@@ -674,8 +692,7 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
       // Perform the actual vertex collapsing, if needed.
       if (collapsed_vertices[origin_vtx])
         origin_vtx = collapsed_vertices[origin_vtx];
-      add_edge(
-          origin_vtx, offset, EdgeProperty(&tracks[i], simTrackDetIdEnergyMap[tracks[i].trackId()].size(), 0), decay);
+      add_edge(origin_vtx, offset, EdgeProperty(&tracks[i], simTrackDetIdMap[tracks[i].trackId()].size(), 0), decay);
       // The properties for "fake" vertices associated to stable particles have
       // to be set inside this loop, since they do not belong to the vertices
       // collection and would be skipped by that loop (coming next)
@@ -697,8 +714,7 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
       output_,
       m_caloParticles,
       m_simHitBarcodeToIndex,
-      simTrackDetIdEnergyMap,
-      simTrackDetIdTimeMap,
+      simTrackDetIdMap,
       vertex_time_map,
       [&](EdgeProperty &edge_property) -> bool {
         // Apply selection on SimTracks in order to promote them to be
@@ -720,11 +736,11 @@ void MtdTruthAccumulator::accumulateEvent(const T &event,
 }
 
 template <class T>
-void MtdTruthAccumulator::fillSimHits(std::vector<std::pair<uint64_t, const PSimHit *>> &returnValue,
-                                      std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdEnergyMap,
-                                      std::unordered_map<int, std::map<uint64_t, float>> &simTrackDetIdTimeMap,
-                                      const T &event,
-                                      const edm::EventSetup &setup) {
+void MtdTruthAccumulator::fillSimHits(
+    std::vector<std::pair<uint64_t, const PSimHit *>> &returnValue,
+    std::unordered_map<int, std::map<uint64_t, std::tuple<float, float, LocalPoint>>> &simTrackDetIdMap,
+    const T &event,
+    const edm::EventSetup &setup) {
   using namespace geant_units::operators;
   using namespace angle_units::operators;
   for (auto const &collectionTag : collectionTags_) {
@@ -755,6 +771,7 @@ void MtdTruthAccumulator::fillSimHits(std::vector<std::pair<uint64_t, const PSim
       // also row and column are needed. An unique number is created from detId, row, col
       // Get row and column
       const auto &position = simHit.localPosition();
+
       LocalPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
       std::pair<uint8_t, uint8_t> pixel = geomTools_.pixelInModule(id, simscaled);
       // create the unique id
@@ -762,13 +779,19 @@ void MtdTruthAccumulator::fillSimHits(std::vector<std::pair<uint64_t, const PSim
       uniqueId |= pixel.first << 16;
       uniqueId |= pixel.second;
 
-      simTrackDetIdEnergyMap[simHit.trackId()][uniqueId] += simHit.energyLoss();
+      std::get<0>(simTrackDetIdMap[simHit.trackId()][uniqueId]) += simHit.energyLoss();
       m_detIdToTotalSimEnergy[uniqueId] += simHit.energyLoss();
       // --- Get the time of the first SIM hit in the cell
-      if (simTrackDetIdTimeMap[simHit.trackId()][uniqueId] == 0. ||
-          simHit.tof() < simTrackDetIdTimeMap[simHit.trackId()][uniqueId]) {
-        simTrackDetIdTimeMap[simHit.trackId()][uniqueId] = simHit.tof();
+      if (std::get<1>(simTrackDetIdMap[simHit.trackId()][uniqueId]) == 0. ||
+          simHit.tof() < std::get<1>(simTrackDetIdMap[simHit.trackId()][uniqueId])) {
+        std::get<1>(simTrackDetIdMap[simHit.trackId()][uniqueId]) = simHit.tof();
       }
+
+      float xSim = std::get<2>(simTrackDetIdMap[simHit.trackId()][uniqueId]).x() + simscaled.x() * simHit.energyLoss();
+      float ySim = std::get<2>(simTrackDetIdMap[simHit.trackId()][uniqueId]).y() + simscaled.y() * simHit.energyLoss();
+      float zSim = std::get<2>(simTrackDetIdMap[simHit.trackId()][uniqueId]).z() + simscaled.z() * simHit.energyLoss();
+      LocalPoint posSim(xSim, ySim, zSim);
+      std::get<2>(simTrackDetIdMap[simHit.trackId()][uniqueId]) = posSim;
 
 #ifdef PRINT_DEBUG
       IfLogDebug(DEBUG, messageCategory_)
@@ -779,7 +802,19 @@ void MtdTruthAccumulator::fillSimHits(std::vector<std::pair<uint64_t, const PSim
           << convertUnitsTo(0.001_MeV, simHit.energyLoss()) << std::endl;
 #endif
     }  // end of loop over simHits
-  }    // end of loop over InputTags
+
+  }  // End of loop over InputTags
+
+  for (auto &tkIt : simTrackDetIdMap) {
+    for (auto &uIt : tkIt.second) {
+      float accEnergy = std::get<0>(uIt.second);
+      float xSim = std::get<2>(uIt.second).x() / accEnergy;
+      float ySim = std::get<2>(uIt.second).y() / accEnergy;
+      float zSim = std::get<2>(uIt.second).z() / accEnergy;
+      LocalPoint posSim(xSim, ySim, zSim);
+      std::get<2>(uIt.second) = posSim;
+    }
+  }
 }
 
 // Register with the framework

--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -32,7 +32,7 @@ typedefsDict = \
 equivDict = \
      [
          {'SelectorUtils': ['VersionedSelector']},
-         {'Associations': ['TTTrackTruthPair', 'edm::Wrapper.+edm::AssociationMap.+TrackingParticle']},
+         {'Associations': ['TTTrackTruthPair', 'edm::Wrapper.+edm::AssociationMap.+TrackingParticle', 'MtdSimLayerCluster.+TrackingParticle', 'TrackingParticle.+MtdSimLayerCluster']},
          {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
          {'TrackTriggerAssociation' : ['(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap|TrackingParticle).*Phase2TrackerDigi',
                                        '(TTStub|TTCluster|TTTrack).*Phase2TrackerDigi.*TrackingParticle']},

--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+# --- Cluster associations maps producers
+from SimFastTiming.MtdAssociatorProducers.mtdRecoClusterToSimLayerClusterAssociatorByHits_cfi import mtdRecoClusterToSimLayerClusterAssociatorByHits
+from SimFastTiming.MtdAssociatorProducers.mtdRecoClusterToSimLayerClusterAssociation_cfi import mtdRecoClusterToSimLayerClusterAssociation
+from SimFastTiming.MtdAssociatorProducers.mtdSimLayerClusterToTPAssociatorByTrackId_cfi import mtdSimLayerClusterToTPAssociatorByTrackId
+from SimFastTiming.MtdAssociatorProducers.mtdSimLayerClusterToTPAssociation_cfi import mtdSimLayerClusterToTPAssociation
+mtdAssociationProducers = cms.Sequence( mtdRecoClusterToSimLayerClusterAssociatorByHits +
+                                        mtdRecoClusterToSimLayerClusterAssociation +
+                                        mtdSimLayerClusterToTPAssociatorByTrackId +
+                                        mtdSimLayerClusterToTPAssociation
+                                       )
+
 # MTD validation sequences
 from Validation.MtdValidation.btlSimHitsValid_cfi import btlSimHitsValid
 from Validation.MtdValidation.btlDigiHitsValid_cfi import btlDigiHitsValid
@@ -13,5 +24,5 @@ from Validation.MtdValidation.mtdEleIsoValid_cfi import mtdEleIsoValid
 
 mtdSimValid  = cms.Sequence(btlSimHitsValid  + etlSimHitsValid )
 mtdDigiValid = cms.Sequence(btlDigiHitsValid + etlDigiHitsValid)
-mtdRecoValid = cms.Sequence(btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid + mtdEleIsoValid)
+mtdRecoValid = cms.Sequence(mtdAssociationProducers + btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid + mtdEleIsoValid)
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -181,6 +181,8 @@ private:
   MonitorElement* meCluYLocalErr_;
 
   // resolution wrt to MtdSimLayerClusters
+  MonitorElement* meCluTrackIdOffset_;
+
   MonitorElement* meCluTimeRes_simLC_;
   MonitorElement* meCluEnergyRes_simLC_;
   MonitorElement* meCluTResvsE_simLC_;
@@ -684,6 +686,8 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           float xlocal_res = local_point.x() - simClusLocalPos.x();
           float ylocal_res = local_point.y() - simClusLocalPos.y();
 
+          meCluTrackIdOffset_->Fill(float(idOffset));
+
           // -- Fill for direct hits
           if (idOffset == 0) {
             meCluTimeRes_simLC_->Fill(time_res);
@@ -1185,6 +1189,9 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   }
 
   // with MtdSimLayerCluster as truth
+
+  meCluTrackIdOffset_ =
+      ibook.book1D("BtlCluTrackIdOffset", "BTL cluster category (trackId offset); trackId offset", 4, 0.0, 4.0);
   meCluTimeRes_simLC_ = ibook.book1D("BtlCluTimeRes_simLC",
                                      "BTL cluster time resolution (wrt MtdSimLayerClusters);T_{RECO}-T_{SIM} [ns]",
                                      100,

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -1345,7 +1345,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                                  -5.,
                                                  5.);
   meCluLocalYPullZGlobMinus_simLC_ =
-      ibook.book1D("BtlCluLocalYPullZGlobMinus",
+      ibook.book1D("BtlCluLocalYPullZGlobMinus_simLC",
                    "BTL cluster local Y pull (wrt MtdSimLayerClusters, glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
                    100,
                    -5.,
@@ -1555,7 +1555,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                    -5.,
                    5.);
   meCluLocalYPullZGlobMinus_simLC_fromIndirectHits_ = ibook.book1D(
-      "BtlCluLocalYPullZGlobMinus",
+      "BtlCluLocalYPullZGlobMinus_simLC_fromIndirectHits",
       "BTL cluster local Y pull (wrt MtdSimLayerClusters, non-direct hits, glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
       100,
       -5.,

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -662,13 +662,10 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       // --- Fill the cluster resolution histograms using MtdSimLayerClusters as mtd truth
       edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> clusterRef = edmNew::makeRefTo(btlRecCluHandle, &cluster);
-      auto it = std::find_if(
-          r2sAssociationMap.begin(),
-          r2sAssociationMap.end(),
-          [&](const std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>& p) { return p.first == clusterRef; });
-
-      if (it != r2sAssociationMap.end()) {
-        std::vector<MtdSimLayerClusterRef> simClustersRefs = (*it).second;
+      auto itp = r2sAssociationMap.equal_range(clusterRef);
+      if (itp.first != itp.second) {
+        std::vector<MtdSimLayerClusterRef> simClustersRefs =
+            (*itp.first).second;  // the range of itp.first, itp.second should be always 1
         for (unsigned int i = 0; i < simClustersRefs.size(); i++) {
           auto simClusterRef = simClustersRefs[i];
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -28,6 +28,8 @@
 #include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
 #include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
+#include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -71,9 +73,10 @@ private:
 
   edm::EDGetTokenT<FTLRecHitCollection> btlRecHitsToken_;
   edm::EDGetTokenT<FTLUncalibratedRecHitCollection> btlUncalibRecHitsToken_;
-  edm::EDGetTokenT<CrossingFrame<PSimHit> > btlSimHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> btlSimHitsToken_;
   edm::EDGetTokenT<FTLClusterCollection> btlRecCluToken_;
   edm::EDGetTokenT<MTDTrackingDetSetVector> mtdTrackingHitToken_;
+  edm::EDGetTokenT<MtdRecoClusterToSimLayerClusterAssociationMap> r2sAssociationMapToken_;
 
   const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
   const edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
@@ -177,6 +180,83 @@ private:
   MonitorElement* meCluXLocalErr_;
   MonitorElement* meCluYLocalErr_;
 
+  // resolution wrt to MtdSimLayerClusters
+  MonitorElement* meCluTimeRes_simLC_;
+  MonitorElement* meCluEnergyRes_simLC_;
+  MonitorElement* meCluTResvsE_simLC_;
+  MonitorElement* meCluTResvsEta_simLC_;
+  MonitorElement* meCluTPullvsE_simLC_;
+  MonitorElement* meCluTPullvsEta_simLC_;
+  MonitorElement* meCluRhoRes_simLC_;
+  MonitorElement* meCluPhiRes_simLC_;
+  MonitorElement* meCluLocalXRes_simLC_;
+
+  MonitorElement* meCluLocalYResZGlobPlus_simLC_;
+  MonitorElement* meCluLocalYResZGlobMinus_simLC_;
+
+  MonitorElement* meCluZRes_simLC_;
+  MonitorElement* meCluLocalXPull_simLC_;
+
+  MonitorElement* meCluLocalYPullZGlobPlus_simLC_;
+  MonitorElement* meCluLocalYPullZGlobMinus_simLC_;
+
+  MonitorElement* meCluSingCrystalLocalYRes_simLC_;
+  MonitorElement* meCluSingCrystalLocalYResZGlobPlus_simLC_;
+  MonitorElement* meCluSingCrystalLocalYResZGlobMinus_simLC_;
+
+  MonitorElement* meCluMultiCrystalLocalYRes_simLC_;
+  MonitorElement* meCluMultiCrystalLocalYResZGlobPlus_simLC_;
+  MonitorElement* meCluMultiCrystalLocalYResZGlobMinus_simLC_;
+
+  MonitorElement* meCluCentralLocalYRes_simLC_;
+  MonitorElement* meCluCentralLocalYResZGlobPlus_simLC_;
+  MonitorElement* meCluCentralLocalYResZGlobMinus_simLC_;
+
+  MonitorElement* meCluForwardLocalYRes_simLC_;
+  MonitorElement* meCluForwardPlusLocalYRes_simLC_;
+  MonitorElement* meCluForwardMinusLocalYRes_simLC_;
+
+  MonitorElement* meCluZPull_simLC_;
+  MonitorElement* meCluYXLocalSim_simLC_;
+
+  MonitorElement* meCluTimeRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluEnergyRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluTResvsE_simLC_fromIndirectHits_;
+  MonitorElement* meCluTResvsEta_simLC_fromIndirectHits_;
+  MonitorElement* meCluTPullvsE_simLC_fromIndirectHits_;
+  MonitorElement* meCluTPullvsEta_simLC_fromIndirectHits_;
+  MonitorElement* meCluRhoRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluPhiRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluLocalXRes_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluLocalYResZGlobPlus_simLC_fromIndirectHits_;
+  MonitorElement* meCluLocalYResZGlobMinus_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluZRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluLocalXPull_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluLocalYPullZGlobPlus_simLC_fromIndirectHits_;
+  MonitorElement* meCluLocalYPullZGlobMinus_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluSingCrystalLocalYRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluSingCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_;
+  MonitorElement* meCluSingCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluMultiCrystalLocalYRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluMultiCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_;
+  MonitorElement* meCluMultiCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluCentralLocalYRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluCentralLocalYResZGlobPlus_simLC_fromIndirectHits_;
+  MonitorElement* meCluCentralLocalYResZGlobMinus_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluForwardLocalYRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluForwardPlusLocalYRes_simLC_fromIndirectHits_;
+  MonitorElement* meCluForwardMinusLocalYRes_simLC_fromIndirectHits_;
+
+  MonitorElement* meCluZPull_simLC_fromIndirectHits_;
+  MonitorElement* meCluYXLocalSim_simLC_fromIndirectHits_;
+
   MonitorElement* meUnmatchedCluEnergy_;
 
   // --- UncalibratedRecHits histograms
@@ -221,9 +301,11 @@ BtlLocalRecoValidation::BtlLocalRecoValidation(const edm::ParameterSet& iConfig)
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
   btlUncalibRecHitsToken_ =
       consumes<FTLUncalibratedRecHitCollection>(iConfig.getParameter<edm::InputTag>("uncalibRecHitsTag"));
-  btlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
+  btlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("simHitsTag"));
   btlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
   mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
+  r2sAssociationMapToken_ = consumes<MtdRecoClusterToSimLayerClusterAssociationMap>(
+      iConfig.getParameter<edm::InputTag>("r2sAssociationMapTag"));
 }
 
 BtlLocalRecoValidation::~BtlLocalRecoValidation() {}
@@ -246,6 +328,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
   auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
   auto mtdTrkHitHandle = makeValid(iEvent.getHandle(mtdTrackingHitToken_));
+  const auto& r2sAssociationMap = iEvent.get(r2sAssociationMapToken_);
   MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
 
 #ifdef EDM_ML_DEBUG
@@ -573,6 +656,173 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
       else {
         meUnmatchedCluEnergy_->Fill(std::log10(cluster.energy()));
+      }
+
+      // --- Fill the cluster resolution histograms using MtdSimLayerClusters as mtd truth
+      edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> clusterRef = edmNew::makeRefTo(btlRecCluHandle, &cluster);
+      auto it = std::find_if(
+          r2sAssociationMap.begin(),
+          r2sAssociationMap.end(),
+          [&](const std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>& p) { return p.first == clusterRef; });
+
+      if (it != r2sAssociationMap.end()) {
+        std::vector<MtdSimLayerClusterRef> simClustersRefs = (*it).second;
+        for (unsigned int i = 0; i < simClustersRefs.size(); i++) {
+          auto simClusterRef = simClustersRefs[i];
+
+          float simClusEnergy = convertUnitsTo(0.001_MeV, (*simClusterRef).simLCEnergy());  // GeV --> MeV
+          float simClusTime = (*simClusterRef).simLCTime();
+          LocalPoint simClusLocalPos = (*simClusterRef).simLCPos();
+          const auto& simClusGlobalPos = genericDet->toGlobal(simClusLocalPos);
+          unsigned int idOffset = (*simClusterRef).trackIdOffset();
+
+          float time_res = cluster.time() - simClusTime;
+          float energy_res = cluster.energy() - simClusEnergy;
+          float rho_res = global_point.perp() - simClusGlobalPos.perp();
+          float phi_res = global_point.phi() - simClusGlobalPos.phi();
+          float z_res = global_point.z() - simClusGlobalPos.z();
+          float xlocal_res = local_point.x() - simClusLocalPos.x();
+          float ylocal_res = local_point.y() - simClusLocalPos.y();
+
+          // -- Fill for direct hits
+          if (idOffset == 0) {
+            meCluTimeRes_simLC_->Fill(time_res);
+            meCluEnergyRes_simLC_->Fill(energy_res);
+            meCluRhoRes_simLC_->Fill(rho_res);
+            meCluPhiRes_simLC_->Fill(phi_res);
+            meCluZRes_simLC_->Fill(z_res);
+
+            if (matchClu && comp != nullptr) {
+              meCluLocalXRes_simLC_->Fill(xlocal_res);
+
+              if (global_point.z() > 0) {
+                meCluLocalYResZGlobPlus_simLC_->Fill(ylocal_res);
+                meCluLocalYPullZGlobPlus_simLC_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+              } else {
+                meCluLocalYResZGlobMinus_simLC_->Fill(ylocal_res);
+                meCluLocalYPullZGlobMinus_simLC_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+              }
+              if (optionalPlots_) {
+                if (cluster.size() == 1) {  // single-crystal clusters
+                  meCluSingCrystalLocalYRes_simLC_->Fill(ylocal_res);
+                  if (global_point.z() > 0) {
+                    meCluSingCrystalLocalYResZGlobPlus_simLC_->Fill(ylocal_res);
+                  } else {
+                    meCluSingCrystalLocalYResZGlobMinus_simLC_->Fill(ylocal_res);
+                  }
+                }  // end of single-crystal clusters
+                else {
+                  if (cluster.size() > 1) {  // multi-crystal clusters
+                    meCluMultiCrystalLocalYRes_simLC_->Fill(ylocal_res);
+                    if (global_point.z() > 0) {
+                      meCluMultiCrystalLocalYResZGlobPlus_simLC_->Fill(ylocal_res);
+                    } else {
+                      meCluMultiCrystalLocalYResZGlobMinus_simLC_->Fill(ylocal_res);
+                    }
+                  }
+                }  // end of multi-crystal clusters
+
+                if (abs(global_point.eta()) < 0.3) {
+                  meCluCentralLocalYRes_simLC_->Fill(ylocal_res);
+                  if (global_point.z() > 0) {
+                    meCluCentralLocalYResZGlobPlus_simLC_->Fill(ylocal_res);
+                  } else {
+                    meCluCentralLocalYResZGlobMinus_simLC_->Fill(ylocal_res);
+                  }
+                } else {
+                  if (abs(global_point.eta()) > 1) {
+                    meCluForwardLocalYRes_simLC_->Fill(ylocal_res);
+                    if (global_point.z() > 0) {
+                      meCluForwardPlusLocalYRes_simLC_->Fill(ylocal_res);
+                    } else {
+                      meCluForwardMinusLocalYRes_simLC_->Fill(ylocal_res);
+                    }
+                  }
+                }
+              }  //end of optional plots
+
+              meCluLocalXPull_simLC_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+              meCluZPull_simLC_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            }
+
+            meCluTResvsEta_simLC_->Fill(std::abs(simClusGlobalPos.eta()), time_res);
+            meCluTResvsE_simLC_->Fill(simClusEnergy, time_res);
+
+            meCluTPullvsEta_simLC_->Fill(std::abs(simClusGlobalPos.eta()), time_res / cluster.timeError());
+            meCluTPullvsE_simLC_->Fill(simClusEnergy, time_res / cluster.timeError());
+
+          }  // if idOffset == 0
+          else {
+            meCluTimeRes_simLC_fromIndirectHits_->Fill(time_res);
+            meCluEnergyRes_simLC_fromIndirectHits_->Fill(energy_res);
+            meCluRhoRes_simLC_fromIndirectHits_->Fill(rho_res);
+            meCluPhiRes_simLC_fromIndirectHits_->Fill(phi_res);
+            meCluZRes_simLC_fromIndirectHits_->Fill(z_res);
+
+            if (matchClu && comp != nullptr) {
+              meCluLocalXRes_simLC_fromIndirectHits_->Fill(xlocal_res);
+
+              if (global_point.z() > 0) {
+                meCluLocalYResZGlobPlus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                meCluLocalYPullZGlobPlus_simLC_fromIndirectHits_->Fill(ylocal_res /
+                                                                       std::sqrt(comp->localPositionError().yy()));
+              } else {
+                meCluLocalYResZGlobMinus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                meCluLocalYPullZGlobMinus_simLC_fromIndirectHits_->Fill(ylocal_res /
+                                                                        std::sqrt(comp->localPositionError().yy()));
+              }
+              if (optionalPlots_) {
+                if (cluster.size() == 1) {  // single-crystal clusters
+                  meCluSingCrystalLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  if (global_point.z() > 0) {
+                    meCluSingCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  } else {
+                    meCluSingCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  }
+                }  // end of single-crystal clusters
+                else {
+                  if (cluster.size() > 1) {  // multi-crystal clusters
+                    meCluMultiCrystalLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    if (global_point.z() > 0) {
+                      meCluMultiCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    } else {
+                      meCluMultiCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    }
+                  }
+                }  // end of multi-crystal clusters
+
+                if (abs(global_point.eta()) < 0.3) {
+                  meCluCentralLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  if (global_point.z() > 0) {
+                    meCluCentralLocalYResZGlobPlus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  } else {
+                    meCluCentralLocalYResZGlobMinus_simLC_fromIndirectHits_->Fill(ylocal_res);
+                  }
+                } else {
+                  if (abs(global_point.eta()) > 1) {
+                    meCluForwardLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    if (global_point.z() > 0) {
+                      meCluForwardPlusLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    } else {
+                      meCluForwardMinusLocalYRes_simLC_fromIndirectHits_->Fill(ylocal_res);
+                    }
+                  }
+                }
+              }  //end of optional plots
+
+              meCluLocalXPull_simLC_fromIndirectHits_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+              meCluZPull_simLC_fromIndirectHits_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            }
+
+            meCluTResvsEta_simLC_fromIndirectHits_->Fill(std::abs(simClusGlobalPos.eta()), time_res);
+            meCluTResvsE_simLC_fromIndirectHits_->Fill(simClusEnergy, time_res);
+
+            meCluTPullvsEta_simLC_fromIndirectHits_->Fill(std::abs(simClusGlobalPos.eta()),
+                                                          time_res / cluster.timeError());
+            meCluTPullvsE_simLC_fromIndirectHits_->Fill(simClusEnergy, time_res / cluster.timeError());
+          }
+
+        }  // simLayerClusterRefs loop
       }
 
     }  // cluster loop
@@ -933,6 +1183,411 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     -2.8,
                                     2.8);
   }
+
+  // with MtdSimLayerCluster as truth
+  meCluTimeRes_simLC_ = ibook.book1D("BtlCluTimeRes_simLC",
+                                     "BTL cluster time resolution (wrt MtdSimLayerClusters);T_{RECO}-T_{SIM} [ns]",
+                                     100,
+                                     -0.5,
+                                     0.5);
+  meCluEnergyRes_simLC_ = ibook.book1D("BtlCluEnergyRes_simLC",
+                                       "BTL cluster energy resolution (wrt MtdSimLayerClusters);E_{RECO}-E_{SIM} [MeV]",
+                                       100,
+                                       -0.5,
+                                       0.5);
+  meCluTResvsE_simLC_ = ibook.bookProfile(
+      "BtlCluTResvsE_simLC",
+      "BTL cluster time resolution (wrt MtdSimLayerClusters) vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM}) [ns]",
+      20,
+      0.,
+      20.,
+      -0.5,
+      0.5,
+      "S");
+  meCluTResvsEta_simLC_ = ibook.bookProfile(
+      "BtlCluTResvsEta_simLC",
+      "BTL cluster time resolution (wrt MtdSimLayerClusters) vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM}) [ns]",
+      30,
+      0,
+      1.55,
+      -0.5,
+      0.5,
+      "S");
+  meCluTPullvsE_simLC_ = ibook.bookProfile(
+      "BtlCluTPullvsE_simLC",
+      "BTL cluster time pull (wrt MtdSimLayerClusters) vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+      20,
+      0.,
+      20.,
+      -5.,
+      5.,
+      "S");
+  meCluTPullvsEta_simLC_ = ibook.bookProfile(
+      "BtlCluTPullvsEta_simLC",
+      "BTL cluster time pull (wrt MtdSimLayerClusters) vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+      30,
+      0,
+      1.55,
+      -5.,
+      5.,
+      "S");
+  meCluRhoRes_simLC_ = ibook.book1D("BtlCluRhoRes_simLC",
+                                    "BTL cluster #rho resolution (wrt MtdSimLayerClusters);#rho_{RECO}-#rho_{SIM} [cm]",
+                                    100,
+                                    -0.5,
+                                    0.5);
+  meCluPhiRes_simLC_ =
+      ibook.book1D("BtlCluPhiRes_simLC",
+                   "BTL cluster #phi resolution (wrt MtdSimLayerClusters);#phi_{RECO}-#phi_{SIM} [rad]",
+                   100,
+                   -0.03,
+                   0.03);
+  meCluZRes_simLC_ = ibook.book1D(
+      "BtlCluZRes_simLC", "BTL cluster Z resolution (wrt MtdSimLayerClusters);Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
+  meCluLocalXRes_simLC_ = ibook.book1D("BtlCluLocalXRes_simLC",
+                                       "BTL cluster local X resolution (wrt MtdSimLayerClusters);X_{RECO}-X_{SIM} [cm]",
+                                       100,
+                                       -3.1,
+                                       3.1);
+  meCluLocalYResZGlobPlus_simLC_ =
+      ibook.book1D("BtlCluLocalYResZGlobPlus_simLC",
+                   "BTL cluster local Y resolution (wrt MtdSimLayerClusters, glob Z > 0);Y_{RECO}-Y_{SIM} [cm]",
+                   100,
+                   -0.2,
+                   0.2);
+  meCluLocalYResZGlobMinus_simLC_ =
+      ibook.book1D("BtlCluLocalYResZGlobMinus_simLC",
+                   "BTL cluster local Y resolution (wrt MtdSimLayerClusters, glob Z < 0);Y_{RECO}-Y_{SIM} [cm]",
+                   100,
+                   -0.2,
+                   0.2);
+  if (optionalPlots_) {
+    meCluSingCrystalLocalYRes_simLC_ = ibook.book1D(
+        "BtlCluSingCrystalLocalYRes_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, single Crystal clusters);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluSingCrystalLocalYResZGlobPlus_simLC_ =
+        ibook.book1D("BtlCluSingCrystalLocalYResZGlobPlus_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, single Crystal clusters, Z glob > "
+                     "0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluSingCrystalLocalYResZGlobMinus_simLC_ =
+        ibook.book1D("BtlCluSingCrystalLocalYResZGlobMinus_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, single Crystal clusters, Z glob < "
+                     "0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluMultiCrystalLocalYRes_simLC_ = ibook.book1D(
+        "BtlCluMultiCrystalLocalYRes_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, Multi-Crystal clusters);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluMultiCrystalLocalYResZGlobPlus_simLC_ =
+        ibook.book1D("BtlCluMultiCrystalLocalYResZGlobPlus_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, Multi-Crystal clusters, Z glob > "
+                     "0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluMultiCrystalLocalYResZGlobMinus_simLC_ =
+        ibook.book1D("BtlCluMultiCrystalLocalYResZGlobMinus_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, Multi-Crystal clusters, Z glob < "
+                     "0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluCentralLocalYRes_simLC_ =
+        ibook.book1D("BtlCluCentralLocalYRes_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, central region);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluCentralLocalYResZGlobPlus_simLC_ = ibook.book1D(
+        "BtlCluCentralLocalYResZGlobPlus_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, central region, Z glob > 0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluCentralLocalYResZGlobMinus_simLC_ = ibook.book1D(
+        "BtlCluCentralLocalYResZGlobMinus_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, central region, Z glob < 0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluForwardLocalYRes_simLC_ =
+        ibook.book1D("BtlCluForwardLocalYRes_simLC",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, forward region);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluForwardPlusLocalYRes_simLC_ = ibook.book1D(
+        "BtlCluForwardPlusLocalYRes_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, forward region, Z glob > 0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluForwardMinusLocalYRes_simLC_ = ibook.book1D(
+        "BtlCluForwardMinusLocalYRes_simLC",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, forward region, Z glob < 0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+  }
+  meCluLocalYPullZGlobPlus_simLC_ = ibook.book1D("BtlCluLocalYPullZGlobPlus_simLC",
+                                                 "BTL cluster local Y pull (glob Z > 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+                                                 100,
+                                                 -5.,
+                                                 5.);
+  meCluLocalYPullZGlobMinus_simLC_ =
+      ibook.book1D("BtlCluLocalYPullZGlobMinus",
+                   "BTL cluster local Y pull (wrt MtdSimLayerClusters, glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+                   100,
+                   -5.,
+                   5.);
+
+  meCluLocalXPull_simLC_ =
+      ibook.book1D("BtlCluLocalXPull_simLC",
+                   "BTL cluster local X pull (wrt MtdSimLayerClusters);X_{RECO}-X_{SIM}/sigmaX_[RECO]",
+                   100,
+                   -5.,
+                   5.);
+
+  meCluZPull_simLC_ = ibook.book1D(
+      "BtlCluZPull_simLC", "BTL cluster Z pull (wrt MtdSimLayerClusters);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]", 100, -5., 5.);
+  if (optionalPlots_) {
+    meCluYXLocalSim_simLC_ =
+        ibook.book2D("BtlCluYXLocalSim_simLC",
+                     "BTL cluster local Y vs X (MtdSimLayerClusters);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                     200,
+                     -9.5,
+                     9.5,
+                     200,
+                     -2.8,
+                     2.8);
+  }
+
+  ///
+
+  meCluTimeRes_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluTimeRes_simLC_fromIndirectHits",
+                   "BTL cluster time resolution (wrt MtdSimLayerClusters, non-direct hits);T_{RECO}-T_{SIM} [ns]",
+                   100,
+                   -0.5,
+                   0.5);
+  meCluEnergyRes_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluEnergyRes_simLC_fromIndirectHits",
+                   "BTL cluster energy resolution (wrt MtdSimLayerClusters, non-direct hits);E_{RECO}-E_{SIM} [MeV]",
+                   100,
+                   -0.5,
+                   0.5);
+  meCluTResvsE_simLC_fromIndirectHits_ =
+      ibook.bookProfile("BtlCluTResvsE_simLC_fromIndirectHits",
+                        "BTL cluster time resolution (wrt MtdSimLayerClusters, non-direct hits) vs E;E_{SIM} "
+                        "[MeV];(T_{RECO}-T_{SIM}) [ns]",
+                        20,
+                        0.,
+                        20.,
+                        -0.5,
+                        0.5,
+                        "S");
+  meCluTResvsEta_simLC_fromIndirectHits_ =
+      ibook.bookProfile("BtlCluTResvsEta_simLC_fromIndirectHits",
+                        "BTL cluster time resolution (wrt MtdSimLayerClusters, non-direct hits) vs "
+                        "#eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM}) [ns]",
+                        30,
+                        0,
+                        1.55,
+                        -0.5,
+                        0.5,
+                        "S");
+  meCluTPullvsE_simLC_fromIndirectHits_ =
+      ibook.bookProfile("BtlCluTPullvsE_simLC_fromIndirectHits",
+                        "BTL cluster time pull (wrt MtdSimLayerClusters, non-direct hits) vs E;E_{SIM} "
+                        "[MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        20,
+                        0.,
+                        20.,
+                        -5.,
+                        5.,
+                        "S");
+  meCluTPullvsEta_simLC_fromIndirectHits_ =
+      ibook.bookProfile("BtlCluTPullvsEta_simLC_fromIndirectHits",
+                        "BTL cluster time pull (wrt MtdSimLayerClusters, non-direct hits) vs "
+                        "#eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
+                        30,
+                        0,
+                        1.55,
+                        -5.,
+                        5.,
+                        "S");
+  meCluRhoRes_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluRhoRes_simLC_fromIndirectHits",
+                   "BTL cluster #rho resolution (wrt MtdSimLayerClusters, non-direct hits);#rho_{RECO}-#rho_{SIM} [cm]",
+                   100,
+                   -0.5,
+                   0.5);
+  meCluPhiRes_simLC_fromIndirectHits_ = ibook.book1D(
+      "BtlCluPhiRes_simLC_fromIndirectHits",
+      "BTL cluster #phi resolution (wrt MtdSimLayerClusters, non-direct hits);#phi_{RECO}-#phi_{SIM} [rad]",
+      100,
+      -0.03,
+      0.03);
+  meCluZRes_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluZRes_simLC_fromIndirectHits",
+                   "BTL cluster Z resolution (wrt MtdSimLayerClusters, non-direct hits);Z_{RECO}-Z_{SIM} [cm]",
+                   100,
+                   -0.2,
+                   0.2);
+  meCluLocalXRes_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluLocalXRes_simLC_fromIndirectHits",
+                   "BTL cluster local X resolution (wrt MtdSimLayerClusters, non-direct hits);X_{RECO}-X_{SIM} [cm]",
+                   100,
+                   -3.1,
+                   3.1);
+  meCluLocalYResZGlobPlus_simLC_fromIndirectHits_ = ibook.book1D(
+      "BtlCluLocalYResZGlobPlus_simLC_fromIndirectHits",
+      "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, glob Z > 0);Y_{RECO}-Y_{SIM} [cm]",
+      100,
+      -0.2,
+      0.2);
+  meCluLocalYResZGlobMinus_simLC_fromIndirectHits_ = ibook.book1D(
+      "BtlCluLocalYResZGlobMinus_simLC_fromIndirectHits",
+      "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, glob Z < 0);Y_{RECO}-Y_{SIM} [cm]",
+      100,
+      -0.2,
+      0.2);
+  if (optionalPlots_) {
+    meCluSingCrystalLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluSingCrystalLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, single Crystal "
+                     "clusters);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluSingCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_ = ibook.book1D(
+        "BtlCluSingCrystalLocalYResZGlobPlus_simLC_fromIndirectHits",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, single Crystal clusters, Z glob > "
+        "0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluSingCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_ = ibook.book1D(
+        "BtlCluSingCrystalLocalYResZGlobMinus_simLC_fromIndirectHits",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, single Crystal clusters, Z glob < "
+        "0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluMultiCrystalLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluMultiCrystalLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, Multi-Crystal "
+                     "clusters);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluMultiCrystalLocalYResZGlobPlus_simLC_fromIndirectHits_ = ibook.book1D(
+        "BtlCluMultiCrystalLocalYResZGlobPlus_simLC_fromIndirectHits",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, Multi-Crystal clusters, Z glob > "
+        "0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluMultiCrystalLocalYResZGlobMinus_simLC_fromIndirectHits_ = ibook.book1D(
+        "BtlCluMultiCrystalLocalYResZGlobMinus_simLC_fromIndirectHits",
+        "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, Multi-Crystal clusters, Z glob < "
+        "0);Y_{RECO}-Y_{SIM} [cm]",
+        100,
+        -0.2,
+        0.2);
+    meCluCentralLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluCentralLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, central "
+                     "region);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluCentralLocalYResZGlobPlus_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluCentralLocalYResZGlobPlus_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, central region, Z glob "
+                     "> 0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluCentralLocalYResZGlobMinus_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluCentralLocalYResZGlobMinus_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, central region, Z glob "
+                     "< 0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluForwardLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluForwardLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, forward "
+                     "region);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluForwardPlusLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluForwardPlusLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, forward region, Z glob "
+                     "> 0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+    meCluForwardMinusLocalYRes_simLC_fromIndirectHits_ =
+        ibook.book1D("BtlCluForwardMinusLocalYRes_simLC_fromIndirectHits",
+                     "BTL cluster local Y resolution (wrt MtdSimLayerClusters, non-direct hits, forward region, Z glob "
+                     "< 0);Y_{RECO}-Y_{SIM} [cm]",
+                     100,
+                     -0.2,
+                     0.2);
+  }
+  meCluLocalYPullZGlobPlus_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluLocalYPullZGlobPlus_simLC_fromIndirectHits",
+                   "BTL cluster local Y pull (glob Z > 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+                   100,
+                   -5.,
+                   5.);
+  meCluLocalYPullZGlobMinus_simLC_fromIndirectHits_ = ibook.book1D(
+      "BtlCluLocalYPullZGlobMinus",
+      "BTL cluster local Y pull (wrt MtdSimLayerClusters, non-direct hits, glob Z < 0);Y_{RECO}-Y_{SIM}/sigmaY_[RECO]",
+      100,
+      -5.,
+      5.);
+
+  meCluLocalXPull_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluLocalXPull_simLC_fromIndirectHits",
+                   "BTL cluster local X pull (wrt MtdSimLayerClusters, non-direct hits);X_{RECO}-X_{SIM}/sigmaX_[RECO]",
+                   100,
+                   -5.,
+                   5.);
+
+  meCluZPull_simLC_fromIndirectHits_ =
+      ibook.book1D("BtlCluZPull_simLC_fromIndirectHits",
+                   "BTL cluster Z pull (wrt MtdSimLayerClusters, non-direct hits);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]",
+                   100,
+                   -5.,
+                   5.);
+  if (optionalPlots_) {
+    meCluYXLocalSim_simLC_fromIndirectHits_ =
+        ibook.book2D("BtlCluYXLocalSim_simLC_fromIndirectHits",
+                     "BTL cluster local Y vs X (MtdSimLayerClusters);X^{local}_{SIM} [cm];Y^{local}_{SIM} [cm]",
+                     200,
+                     -9.5,
+                     9.5,
+                     200,
+                     -2.8,
+                     2.8);
+  }
+
+  ///
+
   meUnmatchedCluEnergy_ =
       ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster log10(energy);log10(E_{RECO} [MeV])", 5, -3, 2);
 
@@ -1013,6 +1668,7 @@ void BtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLBarrel"));
   desc.add<edm::InputTag>("trkHitTag", edm::InputTag("mtdTrackingRecHits"));
+  desc.add<edm::InputTag>("r2sAssociationMapTag", edm::InputTag("mtdRecoClusterToSimLayerClusterAssociation"));
   desc.add<double>("HitMinimumEnergy", 1.);  // [MeV]
   desc.add<bool>("optionalPlots", false);
   desc.add<bool>("UncalibRecHitsPlots", false);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -510,13 +510,10 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       // --- Fill the cluster resolution histograms using MtdSimLayerClusters as mtd truth
       edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> clusterRef = edmNew::makeRefTo(etlRecCluHandle, &cluster);
-      auto it = std::find_if(
-          r2sAssociationMap.begin(),
-          r2sAssociationMap.end(),
-          [&](const std::pair<FTLClusterRef, std::vector<MtdSimLayerClusterRef>>& p) { return p.first == clusterRef; });
-
-      if (it != r2sAssociationMap.end()) {
-        std::vector<MtdSimLayerClusterRef> simClustersRefs = (*it).second;
+      auto itp = r2sAssociationMap.equal_range(clusterRef);
+      if (itp.first != itp.second) {
+        std::vector<MtdSimLayerClusterRef> simClustersRefs =
+            (*itp.first).second;  // the range of itp.first, itp.second should be always 1
         for (unsigned int i = 0; i < simClustersRefs.size(); i++) {
           auto simClusterRef = simClustersRefs[i];
 


### PR DESCRIPTION
#### PR description:
This pull request implements association maps for MTD reco clusters to MtdSimLayerClusters and MtdSimLayerClusters to Tracking Particles. A summary was given at the last MTD DPG meeting [1].

The MTD clusters associations maps are implemented in the following packages:
SimDataFormats/Associations
SimFastTiming/MtdAssociationProducers
and used in the Validation/MtdValidation package.

Some changes were made also to the following packages:
- SimDataFormats/CaloAnalysis: addition of new members (positions_, idOffset_ ) and methods to the MtdSimCluster class. Class version updated accordingly.
- SimGeneral/CaloAnalysis/plugins/MtdTruthAccumulator.cc updated to:  
   1) produce all the MTD sim clusters, not only those from direct hits in the MTD, relying on the BTL sim hits categorization implemented by F. Cossutti in https://github.com/cms-sw/cmssw/blob/master/SimG4CMS/Forward/interface/MtdSD.h;   
   2) store the local position of the MTD sim cluster estimated from the true position of the sim hits.
- Geometry/MTDGeometryBuilder: added a new method to the MTDGeomUtil class to return the sensor module DetId starting from the crystal BTLDetId. 

[1] https://indico.cern.ch/event/1376660/#6-mtd-clusters-association-map

#### PR validation:
The code was tested on the workflows:
24807.0 (SingleMuPt10)
24906.0 (SinglePiFlatPt0p7To10) 
and produces the expected results.
