### PR TITLE
Throw exception if TFile::Open returns nullptr

### DIFF
--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -34,11 +34,10 @@ namespace edm {
       std::rethrow_exception(e);
     }
     if (!file_) {
-      return;
+      throw edm::Exception(errors::FileOpenError) << "TFile::Open failed.";
     }
     if (file_->IsZombie()) {
-      file_ = nullptr;  // propagate_const<T> has no reset() function
-      return;
+      throw edm::Exception(errors::FileOpenError) << "TFile::Open returned zombie.";
     }
 
     logFileAction("  Successfully opened file ", fileName);


### PR DESCRIPTION
#### PR description:

The InputFile does not function properly if TFile::Open returns nullptr.

#### PR validation:

A case where TFile::Open returned nullptr was seen in CMSSW_10_6 in case where we tested reading a file generated in CMSSW_13_3 in that older release.
