### PR TITLE
Backport track jet eta quick fix

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -228,9 +228,10 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
       //This is a quick fix to eta going outside of scope - also including protection against phi going outside
-      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins).
-      //The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins).
-      if ((j < 0) || (j > 23) || (i < 0) || (i > 26))
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins 
+      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins 
+      //minus one).
+      if ((j < 0) || (j > (etaBins_-1)) || (i < 0) || (i > (phiBins_-1)))
         continue;
 
       if (trkpt < pt_intern(trkPtMax_))

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -228,10 +228,10 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
       //This is a quick fix to eta going outside of scope - also including protection against phi going outside
-      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins 
-      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins 
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins
+      //minus one). The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins
       //minus one).
-      if ((j < 0) || (j > (etaBins_-1)) || (i < 0) || (i > (phiBins_-1)))
+      if ((j < 0) || (j > (etaBins_ - 1)) || (i < 0) || (i > (phiBins_ - 1)))
         continue;
 
       if (trkpt < pt_intern(trkPtMax_))

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -227,6 +227,12 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
       // Eta bin
       int j = eta_bin_firmwareStyle(L1TrkPtrs_[k]->getTanlWord());  //Function defined in L1TrackJetClustering.h
 
+      //This is a quick fix to eta going outside of scope - also including protection against phi going outside
+      //of scope as well. The eta index, j, cannot be less than zero or greater than 23 (the number of eta bins).
+      //The phi index, i, cannot be less than zero or greater than 26 (the number of phi bins).
+      if ((j < 0) || (j > 23) || (i < 0) || (i > 26))
+        continue;
+
       if (trkpt < pt_intern(trkPtMax_))
         epbins[i][j].pTtot += trkpt;
       else


### PR DESCRIPTION
#### PR description:

Backport of 
https://github.com/cms-sw/cmssw/pull/43852#issuecomment-1927781592

Bug fix needed for production of simulation samples. Error was in track jet emulator - tracks outside of the acceptable geometry were causing bin indexing to go out of scope. This resulted in a segmentation fault. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR: 
https://github.com/cms-sw/cmssw/pull/43852#issuecomment-1927781592

Release cycle:
CMSSW_14_0_X

Need:
Requested by @srimanob 

