### PR TITLE
Backport [14_0]: Add low pt muon fix objects into phase 2 L1 event content.

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -231,6 +231,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tTkStubsGmt_*_*',
         'keep *_l1tTkMuonsGmt_*_*',
         'keep *_l1tSAMuonsGmt_*_*',
+        'keep *_l1tTkMuonsGmtLowPtFix_*_*', # in the long run this should be removed, but these fix objects will be used for now.
         ]
     obj.outputCommands += l1Phase2Digis
 


### PR DESCRIPTION
#### PR description:
Taken from https://github.com/cms-sw/cmssw/pull/43869
> This PR adds the low pt muon fix objects that are temporarily an input into the phase 2 GT emulator into L1 FEVTDEBUG content to have all emulator objects available. This should be temporary until the full kBMTF/GMT muon objects are available with all fixes.


#### PR validation:

Taken from https://github.com/cms-sw/cmssw/pull/43869
> New FEVTDEBUG has the required objects.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/43869. It is being backported in the hopes that HLT can include these objects in their Phase 2 MC production cycle, to be performed on CMSSW_14_0

@artlbv @cbotta @epalencia FYI. Let me know if you would like me to tag Soham as well.