### PR TITLE
Correction of MTD ETL Validation: hits accumulation on a pixel-basis

### DIFF
--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -80,7 +80,6 @@ private:
   MonitorElement* meHitQvsEta_[4];
   MonitorElement* meHitTvsPhi_[4];
   MonitorElement* meHitTvsEta_[4];
-
 };
 
 // ------------ constructor and destructor --------------
@@ -104,13 +103,13 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
   // Struct to  identify the pixel
   struct ETLPixelId {
     const uint32_t detid_;
-    const uint8_t row_; 
+    const uint8_t row_;
     const uint8_t col_;
     ETLPixelId() : detid_(0), row_(0), col_(0) {}
     ETLPixelId(const ETLDetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
     bool operator==(const ETLPixelId& other) const {
       return detid_ == other.detid_ && row_ == other.row_ && col_ == other.col_;
-    }    
+    }
   };
 
   struct PixelKey_hash {
@@ -119,8 +118,6 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     }
   };
 
-
-  
   auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
   const MTDGeometry* geom = geometryHandle.product();
 
@@ -130,7 +127,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   std::array<std::unordered_map<ETLPixelId, uint32_t, PixelKey_hash>, 4> ndigiPerLGAD_;
   MTDGeomUtil geomUtil;
-  
+
   unsigned int n_digi_etl[4] = {0, 0, 0, 0};
   for (size_t i = 0; i < 4; i++) {
     ndigiPerLGAD_[i].clear();

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -340,23 +340,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitTvsEta_[idet]->Fill(global_point.eta(), recHit.time());
 
     // Resolution histograms
-    /*
-    if (m_etlSimHits[idet].count(detId.rawId()) == 1) {
-      if (m_etlSimHits[idet][detId.rawId()].energy > hitMinEnergy2Dis_) {
-        float time_res = recHit.time() - m_etlSimHits[idet][detId.rawId()].time;
-        float energy_res = recHit.energy() - m_etlSimHits[idet][detId.rawId()].energy;
-
-        meTimeRes_->Fill(time_res);
-        meEnergyRes_->Fill(energy_res);
-
-        meTPullvsEta_->Fill(std::abs(global_point.eta()), time_res / recHit.timeError());
-        meTPullvsE_->Fill(m_etlSimHits[idet][detId.rawId()].energy, time_res / recHit.timeError());
-      }
-    }
-
-    n_reco_etl[idet]++;
-  }  // recHit loop
-    */
     std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
     ETLPixelId pixelId(detId.rawId(), pixel.first, pixel.second);
 
@@ -474,11 +457,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             continue;
 
           // SIM hit's position in the module reference frame
-	  /*
-          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].x),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].y),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].z));
-	  */
 	  Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
                                        convertMmToCm(m_etlSimHits[idet][pixelId].y),
                                        convertMmToCm(m_etlSimHits[idet][pixelId].z));
@@ -577,10 +555,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       ETLPixelId pixelId(detId.rawId(), pixel.first, pixel.second);
 
       // --- Skip UncalibratedRecHits not matched to SimHits
-      /*
-      if (m_etlSimHits[idet].count(detId.rawId()) != 1)
-        continue;
-      */
       if (m_etlSimHits[idet].count(pixelId) == 0)
 	continue;
 
@@ -588,19 +562,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
                                                        << detId.rawId() << ") is invalid!" << std::dec << std::endl;
 
-      /*//moving it up
-
-      DetId geoId = detId.geographicalId();
-      const MTDGeomDet* thedet = geom->idToDet(geoId);
-      if (thedet == nullptr)
-        throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                       << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-      const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-      const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
-
-      Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
-      const auto& global_point = thedet->toGlobal(local_point);
-      */
       // --- Fill the histograms
 
       if (uRecHit.amplitude().first < hitMinAmplitude_)

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -181,14 +181,13 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   // Struct to  identify the pixel
   struct ETLPixelId {
     const uint32_t detid_;
-    const uint8_t row_; 
+    const uint8_t row_;
     const uint8_t col_;
     ETLPixelId() : detid_(0), row_(0), col_(0) {}
     ETLPixelId(const ETLDetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
     bool operator==(const ETLPixelId& other) const {
       return detid_ == other.detid_ && row_ == other.row_ && col_ == other.col_;
-    }    
-
+    }
   };
 
   struct PixelKey_hash {
@@ -226,7 +225,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   // --- Loop over the ETL SIM hits
   //std::unordered_map<uint32_t, MTDHit> m_etlSimHits[4];
-  std::unordered_map< ETLPixelId, MTDHit, PixelKey_hash> m_etlSimHits[4];
+  std::unordered_map<ETLPixelId, MTDHit, PixelKey_hash> m_etlSimHits[4];
   for (auto const& simHit : etlSimHits) {
     // --- Use only hits compatible with the in-time bunch-crossing
     if (simHit.tof() < 0 || simHit.tof() > 25.)
@@ -253,7 +252,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(id, simHit.localPosition());
     ETLPixelId pixelId(id.rawId(), pixel.first, pixel.second);
     auto simHitIt = m_etlSimHits[idet].emplace(pixelId, MTDHit()).first;
-
 
     // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
@@ -432,17 +430,17 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
         // Match the RECO hit to the corresponding SIM hit
         for (const auto& recHit : *etlRecHitsHandle) {
-	  ETLDetId detId(recHit.id().rawId());
+          ETLDetId detId(recHit.id().rawId());
 
-	  DetId geoId = detId.geographicalId();
-	  const MTDGeomDet* thedet = geom->idToDet(geoId);
-	  const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
-	  const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+          DetId geoId = detId.geographicalId();
+          const MTDGeomDet* thedet = geom->idToDet(geoId);
+          const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+          const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
-	  Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
+          Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
 
-	  std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
-	  ETLPixelId pixelId(detId.rawId(), pixel.first, pixel.second);
+          std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+          ETLPixelId pixelId(detId.rawId(), pixel.first, pixel.second);
 
           if (m_etlSimHits[idet].count(pixelId) == 0)
             continue;
@@ -457,7 +455,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             continue;
 
           // SIM hit's position in the module reference frame
-	  Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
+          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
                                        convertMmToCm(m_etlSimHits[idet][pixelId].y),
                                        convertMmToCm(m_etlSimHits[idet][pixelId].z));
 
@@ -550,13 +548,13 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
       const auto& global_point = thedet->toGlobal(local_point);
-      
+
       std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
       ETLPixelId pixelId(detId.rawId(), pixel.first, pixel.second);
 
       // --- Skip UncalibratedRecHits not matched to SimHits
       if (m_etlSimHits[idet].count(pixelId) == 0)
-	continue;
+        continue;
 
       if (thedet == nullptr)
         throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -112,9 +112,7 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     const uint8_t row_; 
     const uint8_t col_;
     ETLPixelId() : detid_(0), row_(0), col_(0) {}
-    //ETLPixelId(const DetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
     ETLPixelId(const ETLDetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
-    // Eventually add some member func else
     bool operator==(const ETLPixelId& other) const {
       return detid_ == other.detid_ && row_ == other.row_ && col_ == other.col_;
     }    

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -109,14 +109,13 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   // Struct to  identify the pixel
   struct ETLPixelId {
     const uint32_t detid_;
-    const uint8_t row_; 
+    const uint8_t row_;
     const uint8_t col_;
     ETLPixelId() : detid_(0), row_(0), col_(0) {}
     ETLPixelId(const ETLDetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
     bool operator==(const ETLPixelId& other) const {
       return detid_ == other.detid_ && row_ == other.row_ && col_ == other.col_;
-    }    
-
+    }
   };
 
   struct PixelKey_hash {
@@ -124,7 +123,7 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       return std::hash<uint32_t>{}(key.detid_) ^ std::hash<uint8_t>{}(key.row_) ^ std::hash<uint8_t>{}(key.col_);
     }
   };
-  
+
   auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
   const MTDGeometry* geom = geometryHandle.product();
 
@@ -133,8 +132,8 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
 
-  std::unordered_map< ETLPixelId, MTDHit, PixelKey_hash> m_etlHits[4];
-  std::unordered_map< ETLPixelId, std::set<int>, PixelKey_hash > m_etlTrkPerCell[4];
+  std::unordered_map<ETLPixelId, MTDHit, PixelKey_hash> m_etlHits[4];
+  std::unordered_map<ETLPixelId, std::set<int>, PixelKey_hash> m_etlTrkPerCell[4];
 
   // --- Loop over the ETL SIM hits
 
@@ -205,7 +204,7 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       // --- Get the SIM hit global position
 
       ETLDetId detId;
-      detId=hit.first.detid_;
+      detId = hit.first.detid_;
       DetId geoId = detId.geographicalId();
       const MTDGeomDet* thedet = geom->idToDet(geoId);
       if (thedet == nullptr)

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -302,14 +302,13 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   // Struct to  identify the pixel
   struct ETLPixelId {
     const uint32_t detid_;
-    const uint8_t row_; 
+    const uint8_t row_;
     const uint8_t col_;
     ETLPixelId() : detid_(0), row_(0), col_(0) {}
     ETLPixelId(const ETLDetId& id, uint8_t row, uint8_t col) : detid_(id.rawId()), row_(row), col_(col) {}
     bool operator==(const ETLPixelId& other) const {
       return detid_ == other.detid_ && row_ == other.row_ && col_ == other.col_;
-    }    
-
+    }
   };
 
   struct PixelKey_hash {
@@ -326,7 +325,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::unordered_map<uint32_t, MTDHit> m_btlHits;
   std::unordered_map<ETLPixelId, MTDHit, PixelKey_hash> m_etlHits;
   std::unordered_map<uint32_t, std::set<unsigned long int>> m_btlTrkPerCell;
-  std::unordered_map<ETLPixelId, std::set<unsigned long int>, PixelKey_hash > m_etlTrkPerCell;
+  std::unordered_map<ETLPixelId, std::set<unsigned long int>, PixelKey_hash> m_etlTrkPerCell;
   std::map<TrackingParticleRef, std::vector<uint32_t>> m_tp2detid;
 
   const auto& tMtd = iEvent.get(tmtdToken_);
@@ -414,12 +413,12 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
           }
         }
         for (auto const& cell : m_etlTrkPerCell) {
- 	  if (m_etlHits[cell.first].energy < depositETLthreshold_) {
+          if (m_etlHits[cell.first].energy < depositETLthreshold_) {
             continue;
           }
           for (auto const& simtrack : cell.second) {
             if (thisTId == simtrack) {
-	      m_tp2detid[tpref].emplace_back(cell.first.detid_);
+              m_tp2detid[tpref].emplace_back(cell.first.detid_);
               break;
             }
           }


### PR DESCRIPTION
#### PR description:

The proposed correction of the validation involves adjusting the accumulation process to be pixel-level during SimHits processing, aligning it with the digitization.

As it stands, LGAD pixels collect signals and it is imperative that SimHits be accumulated on a per-pixel basis. This pixel-level accumulation is consistent with the digitization [1].

Contrary to this, in the validation, the accumulation is currently performed solely based on modules (DetId), as in the BTL. 
While this may not significantly impact processes without pile-up due to the relatively low occupancy, it becomes a critical concern under high pile-up conditions.

In order to consistently test changes in the ETL digitization [2] it is crucial to rectify this discrepancy. 

[1] https://github.com/cms-sw/cmssw/blob/master/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc#L78
[2] https://github.com/cms-sw/cmssw/pull/43762