### PR TITLE
Exo soft displaced vertices skim

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXOSoftDisplacedVertices_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOSoftDisplacedVertices_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.EventContent.EventContent_cff import AODSIMEventContent
+EXOSoftDisplacedVerticesSkimContent = AODSIMEventContent.clone()
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi as _hltHighLevel
+
+hltSoftDV = _hltHighLevel.hltHighLevel.clone(
+   throw = False,
+   andOr = True,
+   HLTPaths = [
+    "HLT_PFHT*_PFMET*_PFMHT*_IDTight_v*",
+    "HLT_PFMET*_PFMHT*_IDTight_v*",
+    "HLT_PFMET*_PFMHT*_IDTight_PFHT*_v*",
+    "HLT_PFMETTypeOne*_PFMHT*_IDTight_v*",
+    "HLT_PFMETTypeOne*_PFMHT*_IDTight_PFHT*_v*",
+    "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_v*",
+    "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_PFHT*_v*",
+    "HLT_MonoCentralPFJet*_PFMETNoMu*_PFMHTNoMu*_IDTight_v*",
+    "HLT_PFMET*_*Cleaned_v*"
+   ]
+)
+
+softDVSelection=cms.EDFilter("CandViewSelector",
+    src = cms.InputTag("pfMet"),
+    cut = cms.string( "pt()>140" ),
+    filter = cms.bool(True)
+)
+
+EXOSoftDisplacedVerticesSkimSequence = cms.Sequence(
+    hltSoftDV * softDVSelection
+    )

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -362,6 +362,17 @@ SKIMStreamEXODisappMuon = cms.FilteredStream(
     dataTier = cms.untracked.string('USER')
     )
 
+from Configuration.Skimming.PDWG_EXOSoftDisplacedVertices_cff import *
+EXOSoftDisplacedVerticesPath = cms.Path(EXOSoftDisplacedVerticesSkimSequence)
+SKIMStreamEXOSoftDisplacedVertices = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXOSoftDisplacedVertices',
+    paths = (EXOSoftDisplacedVerticesPath ),
+    content = EXOSoftDisplacedVerticesSkimContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('AOD')
+)
+
 #####################
 # For the Data on Data Mixing in TSG
 from HLTrigger.Configuration.HLT_Fake1_cff import fragment as _fragment

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -3,8 +3,8 @@ autoSkim = {
  # Skim 2023
  'BTagMu' : 'LogError+LogErrorMonitor',
  'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+EXOLLPJetHCAL+LogError+LogErrorMonitor',
- 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
- 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'EGamma0':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'EGamma1':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Tau' : 'EXODisappTrk+LogError+LogErrorMonitor',
@@ -28,11 +28,11 @@ autoSkim = {
 
  # These should be uncommented when 2022 data reprocessing
  # Dedicated skim for 2022
- 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'EGamma':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Muon' : 'MUOJME+ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
- 'JetHT' : 'JetHTJetPlusHOFilter+TeVJet+LogError+LogErrorMonitor',
- 'MET' : 'EXOHighMET+EXODelayedJetMET+EXODisappTrk+TeVJet+LogError+LogErrorMonitor',
+ 'JetHT' : 'JetHTJetPlusHOFilter+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'MET' : 'EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'SingleMuon' : 'ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
  'DoubleMuon' : 'MUOJME+LogError+LogErrorMonitor',
 


### PR DESCRIPTION
#### PR description:

This PR introduces a new skim called EXOSoftDisplacedVertices, the passing rate has been tested and is around 20%.  
The skim works on a selection of MET HLT paths and a requirement on pfMET > 140 GeV

#### PR validation:

The code has been compiled and tested locally

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
