### PR TITLE
Backport changes in BaseMVAValueMapProducer to 10_6_X

### DIFF
--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -18,7 +18,6 @@
 <use   name="PhysicsTools/PatUtils"/>
 <use   name="PhysicsTools/Utilities"/>
 <use   name="PhysicsTools/IsolationAlgos"/>
-<use   name="PhysicsTools/PatUtils"/>
 <use   name="PhysicsTools/TensorFlow"/>
 <use   name="PhysicsTools/ONNXRuntime"/>
 <use   name="Geometry/CaloTopology"/>

--- a/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
+++ b/PhysicsTools/PatAlgos/interface/BaseMVAValueMapProducer.h
@@ -166,43 +166,45 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
     v.reserve(src->size());
 
   if (batch_eval_) {
-    std::vector<float> data;
-    data.reserve(src->size() * positions_.size());
-    for (auto const& o : *src) {
-      for (auto const& p : funcs_) {
-        setValue(p.first, p.second(o));
+    if (!src->empty()) {
+      std::vector<float> data;
+      data.reserve(src->size() * positions_.size());
+      for (auto const& o : *src) {
+        for (auto const& p : funcs_) {
+          setValue(p.first, p.second(o));
+        }
+        fillAdditionalVariables(o);
+        data.insert(data.end(), values_.begin(), values_.end());
       }
-      fillAdditionalVariables(o);
-      data.insert(data.end(), values_.begin(), values_.end());
-    }
 
-    std::vector<float> outputs;
-    if (tf_) {
-      //currently support only one input sensor to reuse the TMVA like config
-      tensorflow::TensorShape input_size{(long long int)src->size(), (long long int)positions_.size()};
-      tensorflow::NamedTensorList input_tensors;
-      input_tensors.resize(1);
-      input_tensors[0] =
-          tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
+      std::vector<float> outputs;
+      if (tf_) {
+        //currently support only one input sensor to reuse the TMVA like config
+        tensorflow::TensorShape input_size{(long long int)src->size(), (long long int)positions_.size()};
+        tensorflow::NamedTensorList input_tensors;
+        input_tensors.resize(1);
+        input_tensors[0] =
+            tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
 
-      for (unsigned i = 0; i < data.size(); ++i) {
-        input_tensors[0].second.flat<float>()(i) = data[i];
+        for (unsigned i = 0; i < data.size(); ++i) {
+          input_tensors[0].second.flat<float>()(i) = data[i];
+        }
+        std::vector<tensorflow::Tensor> output_tensors;
+        tensorflow::run(session_, input_tensors, {outputTensorName_}, &output_tensors);
+        for (unsigned i = 0; i < output_tensors.at(0).NumElements(); ++i) {
+          outputs.push_back(output_tensors.at(0).flat<float>()(i));
+        }
+      } else if (onnx_) {
+        cms::Ort::FloatArrays inputs{data};
+        outputs = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_}, src->size())[0];
       }
-      std::vector<tensorflow::Tensor> output_tensors;
-      tensorflow::run(session_, input_tensors, {outputTensorName_}, &output_tensors);
-      for (unsigned i = 0; i < output_tensors.at(0).NumElements(); ++i) {
-        outputs.push_back(output_tensors.at(0).flat<float>()(i));
-      }
-    } else if (onnx_) {
-      cms::Ort::FloatArrays inputs{data};
-      outputs = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_}, src->size())[0];
-    }
 
-    const unsigned outdim = outputs.size() / src->size();
-    for (unsigned i = 0; i < src->size(); ++i) {
-      std::vector<float> tmpOut(outputs.begin() + i * outdim, outputs.begin() + (i + 1) * outdim);
-      for (size_t k = 0; k < output_names_.size(); k++) {
-        mvaOut[k].push_back(output_formulas_[k](tmpOut));
+      const unsigned outdim = outputs.size() / src->size();
+      for (unsigned i = 0; i < src->size(); ++i) {
+        std::vector<float> tmpOut(outputs.begin() + i * outdim, outputs.begin() + (i + 1) * outdim);
+        for (size_t k = 0; k < output_names_.size(); k++) {
+          mvaOut[k].push_back(output_formulas_[k](tmpOut));
+        }
       }
     }
   } else {
@@ -213,32 +215,33 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
       fillAdditionalVariables(o);
       if (tmva_) {
         mvaOut[0].push_back(isClassifier_ ? reader_->EvaluateMVA(name_) : reader_->EvaluateRegression(name_)[0]);
-      }
-
-      std::vector<float> tmpOut;
-      if (tf_) {
-        //currently support only one input sensor to reuse the TMVA like config
-        tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
-        tensorflow::NamedTensorList input_tensors;
-        input_tensors.resize(1);
-        input_tensors[0] =
-            tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
-        for (size_t j = 0; j < values_.size(); j++) {
-          input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+      } else {
+        std::vector<float> tmpOut;
+        if (tf_) {
+          //currently support only one input sensor to reuse the TMVA like config
+          tensorflow::TensorShape input_size{1, (long long int)positions_.size()};
+          tensorflow::NamedTensorList input_tensors;
+          input_tensors.resize(1);
+          input_tensors[0] =
+              tensorflow::NamedTensor(inputTensorName_, tensorflow::Tensor(tensorflow::DT_FLOAT, input_size));
+          for (size_t j = 0; j < values_.size(); j++) {
+            input_tensors[0].second.matrix<float>()(0, j) = values_[j];
+          }
+          std::vector<tensorflow::Tensor> outputs;
+          tensorflow::run(session_, input_tensors, {outputTensorName_}, &outputs);
+          for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
+            tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
+        } else if (onnx_) {
+          cms::Ort::FloatArrays inputs{values_};
+          tmpOut = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_})[0];
         }
-        std::vector<tensorflow::Tensor> outputs;
-        tensorflow::run(session_, input_tensors, {outputTensorName_}, &outputs);
-        for (int k = 0; k < outputs.at(0).matrix<float>().dimension(1); k++)
-          tmpOut.push_back(outputs.at(0).matrix<float>()(0, k));
-      } else if (onnx_) {
-        cms::Ort::FloatArrays inputs{values_};
-        tmpOut = ort_->run({inputTensorName_}, inputs, {}, {outputTensorName_})[0];
-      }
 
-      for (size_t k = 0; k < output_names_.size(); k++)
-        mvaOut[k].push_back(output_formulas_[k](tmpOut));
+        for (size_t k = 0; k < output_names_.size(); k++)
+          mvaOut[k].push_back(output_formulas_[k](tmpOut));
+      }
     }
   }
+
   size_t k = 0;
   for (auto& m : mvaOut) {
     std::unique_ptr<edm::ValueMap<float>> mvaV(new edm::ValueMap<float>());
@@ -249,7 +252,6 @@ void BaseMVAValueMapProducer<T>::produce(edm::Event& iEvent, const edm::EventSet
     k++;
   }
 }
-
 
 template <typename T>
 edm::ParameterSetDescription BaseMVAValueMapProducer<T>::getDescription() {


### PR DESCRIPTION
#### PR description:

This PR backports two changes in `BaseMVAValueMapProducer` that have already been in the master branch to 10_6_X to avoid crash on empty `src`. This should fix https://github.com/cms-sw/cmssw/issues/43863.

#### PR validation:

Tested locally and it fixes the crash reported in https://github.com/cms-sw/cmssw/issues/43863.