### PR TITLE
[ROOT6] RNTuple API change: RNTupleWriter is private

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -19,8 +19,13 @@
 #include <ROOT/RPageStorageFile.hxx>
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::RNTupleWriter;
 using ROOT::Experimental::Detail::RPageSinkFile;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
+using ROOT::Experimental::RNTupleWriter;
+#define MakeRNTupleWriter std::make_unique<RNTupleWriter>
+#else
+#define MakeRNTupleWriter ROOT::Experimental::Internal::CreateRNTupleWriter
+#endif
 
 #include "TObjString.h"
 
@@ -206,8 +211,7 @@ void NanoAODRNTupleOutputModule::initializeNTuple(edm::EventForOutput const& iEv
   // TODO use Append
   RNTupleWriteOptions options;
   options.SetCompression(m_file->GetCompressionSettings());
-  m_ntuple =
-      std::make_unique<RNTupleWriter>(std::move(model), std::make_unique<RPageSinkFile>("Events", *m_file, options));
+  m_ntuple = MakeRNTupleWriter(std::move(model), std::make_unique<RPageSinkFile>("Events", *m_file, options));
 }
 
 void NanoAODRNTupleOutputModule::write(edm::EventForOutput const& iEvent) {


### PR DESCRIPTION
RNTupleWriter(std::unique_ptr<RNTupleModel> model, std::unique_ptr<Detail::RPageSink> sink); is private now (see https://github.com/jblomer/root/commit/cac8467f6f134c6d064c41235dded7cb000f128f). This PR proposes to use new CreateRNTupleWriter.  This change is needed to integrate the latest ROOT master changes in ROOT6 IBs ( https://github.com/cms-sw/cmsdist/pull/8999 )