### PR TITLE
CTPPS update HLTPPSJetComparisonFilter to use LHCInfoCombined

### DIFF
--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/EcalObjects"/>
 <use name="CondFormats/RunInfo"/>
+<use name="CondTools/RunInfo"/>
 <use name="DataFormats/CSCDigi"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="DataFormats/CTPPSDetId"/>


### PR DESCRIPTION
this PR updates `HLTPPSJetComparisonFilter` to be able to use both old `LHCInfo` (for `Run 2` & `Direct Simulation` calculations) and new `LHCInfoPer*` records (`Run 3`).
record types. The update is a follow-up to https://github.com/cms-sw/cmssw/pull/42515 and https://github.com/cms-sw/cmssw/pull/42890