### PR TITLE
[14.0.X] update `HLTPPSJetComparisonFilter` to use `LHCInfoCombined`

### DIFF
--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/EcalObjects"/>
 <use name="CondFormats/RunInfo"/>
+<use name="CondTools/RunInfo"/>
 <use name="DataFormats/CSCDigi"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="DataFormats/CTPPSDetId"/>


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/43951

#### PR description:

This PR updates `HLTPPSJetComparisonFilter` to be able to use both old `LHCInfo` (for Run 2 & Direct Simulation calculations) and new `LHCInfoPer*` records (Run 3) record types. The update is a follow-up to https://github.com/cms-sw/cmssw/pull/42515 and https://github.com/cms-sw/cmssw/pull/42890

#### PR validation:

Private TSG tests.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/43951