### PR TITLE
Alternative module configuration syntax

### DIFF
--- a/FWCore/Integration/test/check_empty_event_cfg.py
+++ b/FWCore/Integration/test/check_empty_event_cfg.py
@@ -1,14 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.Modules.modules import EventContentAnalyzer, EmptySource
 
 process = cms.Process("EMPTY")
 
-process.test = cms.EDAnalyzer("EventContentAnalyzer", listPathStatus = cms.untracked.bool(True))
+process.test = EventContentAnalyzer(listPathStatus = True)
 
 process.e = cms.EndPath(process.test)
 
 #process.out = cms.OutputModule("AsciiOutputModule")
 #process.e2 = cms.EndPath(process.out)
 
-process.source = cms.Source("EmptySource")
+process.source = EmptySource()
 
 process.maxEvents.input = 1

--- a/FWCore/Integration/test/delayedreader_throw_cfg.py
+++ b/FWCore/Integration/test/delayedreader_throw_cfg.py
@@ -1,27 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.Framework.modules import AddIntsProducer, IntProductFilter
+from FWCore.Modules.modules import AsciiOutputModule
+from FWCore.Integration.modules import DelayedReaderThrowingSource
 
 process = cms.Process("TEST")
 
-process.source = cms.Source("DelayedReaderThrowingSource", labels = cms.untracked.vstring("test", "test2", "test3"))
+process.source = DelayedReaderThrowingSource( labels = ["test", "test2", "test3"])
 
-process.getter = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("test","","INPUTTEST")))
-process.onPath = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("test2", "", "INPUTTEST"), cms.InputTag("getter", "other")))
-process.f1 = cms.EDFilter("IntProductFilter", label = cms.InputTag("onPath"), shouldProduce = cms.bool(True))
-process.f2 = cms.EDFilter("IntProductFilter", label = cms.InputTag("onPath"), shouldProduce = cms.bool(True))
-process.inFront = cms.EDFilter("IntProductFilter", label = cms.InputTag("test3"))
+process.getter = AddIntsProducer(labels = [("test","","INPUTTEST")])
+process.onPath = AddIntsProducer(labels = [("test2", "", "INPUTTEST"), ("getter", "other")])
+process.f1 = IntProductFilter( label = "onPath", shouldProduce = True)
+process.f2 = IntProductFilter( label = "onPath", shouldProduce = True)
+process.inFront = IntProductFilter( label = "test3")
 
 process.p1 = cms.Path(process.inFront+process.onPath+process.f1+process.f2)
 process.p3 = cms.Path(process.onPath+process.f1, cms.Task(process.getter))
 
 process.p2 = cms.Path(process.onPath+process.f2)
 
-
-#process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+#from FWCore.Modules.modules import EventContentAnalyzer import *
+#process.dump = EventContentAnalyzer()
 #process.p = cms.Path(process.dump)
 
-process.out = cms.OutputModule("AsciiOutputModule")
+process.out = AsciiOutputModule()
 process.e = cms.EndPath(process.out, cms.Task(process.getter))
 
 process.maxEvents.input = 1
 
-#process.add_(cms.Service("Tracer"))
+#from FWCore.Services.modules import Tracer
+#process.add_(Tracer())

--- a/FWCore/ParameterSet/interface/ConfigurationDescriptions.h
+++ b/FWCore/ParameterSet/interface/ConfigurationDescriptions.h
@@ -87,6 +87,8 @@ namespace edm {
                                  std::string const& pluginName,
                                  std::set<std::string>& usedCfiFileNames);
 
+    void writeClassFile(ParameterSetDescription const&) const;
+
     void printForLabel(std::pair<std::string, ParameterSetDescription> const& labelAndDesc,
                        std::ostream& os,
                        std::string const& moduleLabel,

--- a/FWCore/ParameterSet/python/ModulesProxy.py
+++ b/FWCore/ParameterSet/python/ModulesProxy.py
@@ -1,0 +1,24 @@
+import os
+from os.path import sep, join
+import importlib
+
+class _ModuleProxy (object):
+    def __init__(self, package, name):
+        self._package = package
+        self._name = name
+        self._caller = None
+    def __call__(self,**kwargs):
+        if not self._caller:
+            self._caller = getattr(importlib.import_module(self._package+'.'+self._name),self._name)
+        return self._caller(**kwargs)
+
+
+def _setupProxies(fullName):
+    _cmssw_package_name='.'.join(fullName.split(sep)[-3:-1])
+    basename = fullName.split(sep)[-1]
+    pathname = fullName[:-1*len(basename)]
+    proxies = dict()
+    for filename in ( x for x in os.listdir(pathname) if (len(x) > 3 and x[-3:] == '.py' and x != basename and ((len(x) < 6) or (x[-6:] != 'cfi.py')))):
+        name = filename[:-3]
+        proxies[name] = _ModuleProxy(_cmssw_package_name, name)
+    return proxies

--- a/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/ParameterDescriptionBase.cc
@@ -120,6 +120,9 @@ namespace edm {
 
   void ParameterDescriptionBase::writeCfi_(
       std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
+    if (label().empty() or label()[0] == '@') {
+      return;
+    }
     wroteSomething = true;
     if (startWithComma)
       os << ",";


### PR DESCRIPTION
#### PR description:

Uses the default C++ configuration description to generate a new python file that knows the module
- class name
- type
- default parameters names and types
By importing the file (directly or indirectly through the new 'modules' python module) the developer no longer needs
to specify those information with declaring a module for use.

#### PR validation:

Framework unit tests all pass, including the two that were modified to use the new syntax.