### PR TITLE
graphical fixes for `L1TUtmTriggerMenuPayloadInspectorHelper`

### DIFF
--- a/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
+++ b/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
@@ -125,12 +125,12 @@ namespace L1TUtmTriggerMenuInspectorHelper {
       std::vector<std::string> s_x1, s_x2, s_x3;
       y = 1.0;
       x1 = 0.02;
-      x2 = x1 + 0.45;
+      x2 = x1 + 0.37;
       y -= pitch;
 
       // title for plot
       y_x1.push_back(y);
-      s_x1.push_back("#scale[1.1]{Key}");
+      s_x1.push_back("#scale[1.1]{Algo Name}");
       y_x2.push_back(y);
       s_x2.push_back("#scale[1.1]{Target tag / IOV: #color[2]{" + m_tagName + "} / " + m_IOVsinceDisplay + "}");
 
@@ -147,7 +147,7 @@ namespace L1TUtmTriggerMenuInspectorHelper {
       for (const auto& ref : vec_only_in_other) {
         y -= pitch;
         y_x1.push_back(y);
-        s_x1.push_back(ref);
+        s_x1.push_back("#scale[0.7]{" + ref + "}");
         y_x2.push_back(y);
         s_x2.push_back("#color[4]{#bf{Only in reference, not in target.}}");
         y_line.push_back(y - (pitch / 2.));
@@ -157,7 +157,7 @@ namespace L1TUtmTriggerMenuInspectorHelper {
       for (const auto& tar : vec_only_in_this) {
         y -= pitch;
         y_x1.push_back(y);
-        s_x1.push_back(tar);
+        s_x1.push_back("#scale[0.7]{" + tar + "}");
         y_x2.push_back(y);
         s_x2.push_back("#color[2]{#bf{Only in target, not in reference.}}");
         y_line.push_back(y - (pitch / 2.));


### PR DESCRIPTION
#### PR description:

Minor graphical improvements for better readability of the output of `plot_L1TUtmTriggerMenu_CompareAlgosTwoTags`.

#### PR validation:

Run `getPayloadData.py` script locally

```bash
getPayloadData.py \
    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
    --plot plot_L1TUtmTriggerMenu_CompareAlgosTwoTags \
    --tag L1Menu_Collisions2023_v1_3_0_xml \
    --tagtwo L1Menu_Collisions2024_v0_0_0_xml \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;
```

and obtained the following plot:

![image](https://github.com/cms-sw/cmssw/assets/5082376/161d40f5-1bca-48c5-a03f-8d1a4dc1f3e9)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A