### PR TITLE
Updates DT Calibration to 14_0_X and includes fixes for the HI workflow

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigWriter.cc
@@ -104,7 +104,7 @@ void DTTTrigWriter::endJob() {
   string tTrigRecord = "DTTtrigRcd";
 
   // Write the object to DB
-  DTCalibDBUtils::writeToDB(tTrigRecord, tTrig);
+  DTCalibDBUtils::writeToDB(tTrigRecord, *tTrig);
 }
 
 // Compute the name of the time box histo

--- a/CalibMuon/DTCalibration/python/Workflow/CLIHelper.py
+++ b/CalibMuon/DTCalibration/python/Workflow/CLIHelper.py
@@ -99,6 +99,8 @@ class CLIHelper(object):
             help="Number of lumi sections to process for RAW / Comsics grid jobs")
         submission_opts_group.add_argument("--preselection", dest="preselection",
             help="configuration fragment and sequence name, separated by a ':', defining a pre-selection filter")
+        submission_opts_group.add_argument("--raw-data-label", dest="raw_data_label", default="rawDataCollector",
+            help="RAW Data label as in the sample file.")
         submission_opts_group.add_argument("--output-site", default = "T2_DE_RWTH",
             help="Site used for stage out of results")
         submission_opts_group.add_argument("--ce-black-list", default = [], nargs="+",

--- a/CalibMuon/DTCalibration/python/Workflow/CrabHelper.py
+++ b/CalibMuon/DTCalibration/python/Workflow/CrabHelper.py
@@ -5,6 +5,7 @@ import sys
 import os
 from importlib import import_module
 import subprocess
+import shutil
 import time
 from . import tools
 
@@ -94,8 +95,7 @@ class CrabHelper(object):
 
     def voms_proxy_time_left(self):
         process = subprocess.Popen(['voms-proxy-info', '-timeleft'],
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT)
+                                   stdout=subprocess.PIPE)
         stdout = process.communicate()[0]
         if process.returncode != 0:
             return 0
@@ -105,14 +105,15 @@ class CrabHelper(object):
     def voms_proxy_create(self, passphrase = None):
         voms = 'cms'
         if passphrase:
-            p = subprocess.Popen(['voms-proxy-init', '--voms', voms, '--valid', '192:00'],
+            p = subprocess.Popen([shutil.which('voms-proxy-init'), '--voms', voms, '--valid', '192:00'],
+                                 executable = '/bin/bash',
                                  stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT)
             stdout = p.communicate(input=passphrase+'\n')[0]
             retcode = p.returncode
             if not retcode == 0:
                 raise ProxyError('Proxy initialization command failed: %s'%stdout)
         else:
-            retcode = subprocess.call(['voms-proxy-init', '--voms', voms, '--valid', '192:00'])
+            retcode = subprocess.call([shutil.which('voms-proxy-init'), '--voms', voms, '--valid', '192:00'])
         if not retcode == 0:
             raise ProxyError('Proxy initialization command failed.')
 

--- a/CalibMuon/DTCalibration/python/Workflow/CrabHelper.py
+++ b/CalibMuon/DTCalibration/python/Workflow/CrabHelper.py
@@ -52,6 +52,7 @@ class CrabHelper(object):
         print(self.crab_config_filepath)
         task = self.crabFunctions.CrabTask(crab_config = self.crab_config_filepath,
                                             initUpdate = False)
+        
         if self.options.no_exec:
             log.info("Nothing to check in no-exec mode")
             return True

--- a/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabConfigParser.py
+++ b/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabConfigParser.py
@@ -4,17 +4,17 @@
 # This module extends the python configparser to create crab3 config files.
 
 
-from ConfigParser import *
+from configparser import RawConfigParser
 
 ## The CrabConfigParser class
 #
 # This class extends the python ConfigParser class and adds functions to
 # output crab3 config files
-class CrabConfigParser(ConfigParser):
+class CrabConfigParser(RawConfigParser):
 
     ## The constructor.
     def __init__(self):
-        ConfigParser.__init__(self)
+        RawConfigParser.__init__(self)
         self.optionxform = str
     ## Write CrabConfigParser object to file
     # @type self: CrabConfigParser
@@ -37,8 +37,9 @@ class CrabConfigParser(ConfigParser):
         for section in sections:
             outlines.extend(self.getSectionLines(section))
         #print filename
-        with open(filename,'wb') as outfile:
-            outfile.write('\n'.join(outlines) + '\n')
+        with open(filename,'w') as outfile:
+            for line in outlines:
+                outfile.write(f"{line}\n")
     ## Helper function to retrieve crab config output lines for one section
     # @type self: CrabConfigParser
     # @param self:The object pointer.

--- a/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabFunctions.py
+++ b/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabFunctions.py
@@ -16,7 +16,7 @@ import logging
 import datetime
 import uuid
 import time
-from  httplib import HTTPException
+from http.client import HTTPException
 from multiprocessing import Process, Queue
 
 from CRABAPI.RawCommand import crabCommand
@@ -353,10 +353,10 @@ class CertInfo:
             self.voGroup = ""
             self.voRole = ""
         else:
-            lines = stdout.split("\n")
-            splitline = lines[0].split("/")
+            lines = stdout.split(b"\n")
+            splitline = lines[0].split(b"/")
             if len(splitline) < 4:
-                splitline = lines[1].split("/")
+                splitline = lines[1].split(b"/")
             self.vo = splitline[1]
             self.voGroup = splitline[2]
             try:
@@ -404,7 +404,7 @@ class CrabTask:
         #~ self.lock = multiprocessing.Lock()
         #setup logging
         self.log = logging.getLogger( 'crabTask' )
-        self.log.setLevel(logging._levelNames[ debuglevel ])
+        self.log.setLevel(logging.getLevelName(debuglevel))
         self.jobs = {}
         self.localDir = localDir
         self.outlfn = outlfn

--- a/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabFunctions.py
+++ b/CalibMuon/DTCalibration/python/Workflow/Crabtools/crabFunctions.py
@@ -168,7 +168,6 @@ class CrabController():
                 else:
                     callname = name
                 res = self.callCrabCommand( ('status', '--long', callname) )
-                #print res
                 if 'taskFailureMsg' in res and 'jobs' in res:
                     return res['status'], res['jobs'], res['taskFailureMsg']
                 elif 'jobs' in res and 'taskFailureMsg' not in res:

--- a/CalibMuon/DTCalibration/python/Workflow/DTCalibrationWorker.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTCalibrationWorker.py
@@ -6,6 +6,7 @@ from .tools import loadCmsProcess
 from .DTWorkflow import DTWorkflow
 from .DTTtrigWorkflow import DTttrigWorkflow
 from .DTVdriftWorkflow import DTvdriftWorkflow
+from .DTT0WireWorkflow import DTT0WireWorkflow
 import logging
 # setup logging
 log = logging.getLogger(__name__)
@@ -40,12 +41,12 @@ class DTCalibrationWorker(object):
         # following
         #http://.com/questions/3503719/emulating-bash-source-in-python
         command = ['bash', '-c', 'unset module;source /cvmfs/cms.cern.ch/crab3/crab.sh && env']
-        proc = subprocess.Popen(command, stdout = subprocess.PIPE)
+        proc = subprocess.Popen(command, executable = '/bin/bash', stdout = subprocess.PIPE)
 
         print('setting up crab')
         for line in proc.stdout:
-          (key, _, value) = line.partition("=")
-          os.environ[key] = value.replace("\n","")
+          (key, _, value) = line.partition(b"=")
+          os.environ[key.decode()] = value.decode().replace("\n","")
         for path in os.environ['PYTHONPATH'].split(':'):
             sys.path.append(path)
         proc.communicate()
@@ -59,7 +60,7 @@ class DTCalibrationWorker(object):
                 workflow_class = eval( class_name )
                 workflow_class.add_parser_options(workflow_parser)
             except:
-                log.error("No class with name: %s exists bot workflow exists in %s" %
+                log.error("No class with name: %s exists but workflow exists in %s" %
                             (class_name, DTCalibrationWorker)
                          )
 

--- a/CalibMuon/DTCalibration/python/Workflow/DTT0WireWorkflow.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTT0WireWorkflow.py
@@ -1,9 +1,9 @@
 import os
 import logging
 
-import tools
+from . import tools
 import FWCore.ParameterSet.Config as cms
-from DTWorkflow import DTWorkflow
+from .DTWorkflow import DTWorkflow
 
 log = logging.getLogger(__name__)
 

--- a/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
@@ -6,7 +6,7 @@ import logging
 import argparse
 import subprocess
 import time, datetime
-import urllib2
+import urllib
 import json
 
 from . import tools

--- a/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
@@ -98,6 +98,7 @@ class DTWorkflow(CLIHelper, CrabHelper):
         """
         self.run_all_command = True
         for command in self.all_commands:
+            log.info(f"Will run command: {command}")
             self.options.command = command
             self.run()
 
@@ -127,9 +128,7 @@ class DTWorkflow(CLIHelper, CrabHelper):
         tools.prependPaths(self.process, seqname)
 
     def add_raw_option(self):
-        # getattr(self.process, self.digilabel).inputLabel = 'rawDataCollector'
-        # HI CHANGES
-        getattr(self.process, self.digilabel).inputLabel = 'rawDataRepacker'
+        getattr(self.process, self.digilabel).inputLabel = self.options.raw_data_label
         tools.prependPaths(self.process,self.digilabel)
 
     def add_local_t0_db(self, local=False):
@@ -220,6 +219,10 @@ class DTWorkflow(CLIHelper, CrabHelper):
                                                initUpdate = False)
         if not (self.options.skip_stageout or self.files_reveived or self.options.no_exec):
             output_files =  self.get_output_files(crabtask, output_path)
+            if "xrootd" not in output_files.keys():
+                raise RuntimeError("Could not get output files. No xrootd key found.")
+            if len(output_files["xrootd"]) == 0:
+                raise RuntimeError("Could not get output files. Output file list is empty.")
             log.info("Received files from storage element")
             log.info("Using hadd to merge output files")
         if not self.options.no_exec and do_hadd:

--- a/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
@@ -127,7 +127,9 @@ class DTWorkflow(CLIHelper, CrabHelper):
         tools.prependPaths(self.process, seqname)
 
     def add_raw_option(self):
-        getattr(self.process, self.digilabel).inputLabel = 'rawDataCollector'
+        # getattr(self.process, self.digilabel).inputLabel = 'rawDataCollector'
+        # HI CHANGES
+        getattr(self.process, self.digilabel).inputLabel = 'rawDataRepacker'
         tools.prependPaths(self.process,self.digilabel)
 
     def add_local_t0_db(self, local=False):

--- a/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
+++ b/CalibMuon/DTCalibration/python/Workflow/DTWorkflow.py
@@ -217,11 +217,11 @@ class DTWorkflow(CLIHelper, CrabHelper):
         crabtask = self.crabFunctions.CrabTask(crab_config = self.crab_config_filepath,
                                                initUpdate = False)
         if not (self.options.skip_stageout or self.files_reveived or self.options.no_exec):
-            self.get_output_files(crabtask, output_path)
+            output_files =  self.get_output_files(crabtask, output_path)
             log.info("Received files from storage element")
             log.info("Using hadd to merge output files")
         if not self.options.no_exec and do_hadd:
-            returncode = tools.haddLocal(output_path, merged_file)
+            returncode = tools.haddLocal(output_files["xrootd"], merged_file)
             if returncode != 0:
                 raise RuntimeError("Failed to merge files with hadd")
         return crabtask.crabConfig.Data.outputDatasetTag
@@ -268,10 +268,12 @@ class DTWorkflow(CLIHelper, CrabHelper):
                                                                 )
 
     def get_output_files(self, crabtask, output_path):
-        self.crab.callCrabCommand( ["getoutput",
-                                    "--outputpath",
-                                    output_path,
+        res = self.crab.callCrabCommand( ["getoutput",
+                                    "--dump",
+                                    "--xrootd",
                                     crabtask.crabFolder ] )
+        
+        return res
 
     def runCMSSWtask(self, pset_path=""):
         """ Run a cmsRun job locally. The member variable self.pset_path is used

--- a/CalibMuon/DTCalibration/python/Workflow/tools.py
+++ b/CalibMuon/DTCalibration/python/Workflow/tools.py
@@ -40,7 +40,7 @@ def listFilesLocal(paths, extension = '.root'):
 
 def haddLocal(localdir,result_file,extension = 'root'):
     if not os.path.exists( localdir ):
-        raise ValueError("localdir for hadd operation does not exist" )
+        raise ValueError(f"localdir {localdir} for hadd operation does not exist")
 
     files = listFilesLocal([localdir],extension)
     process = subprocess.Popen( ['hadd','-f', result_file] + files,

--- a/CalibMuon/DTCalibration/python/Workflow/tools.py
+++ b/CalibMuon/DTCalibration/python/Workflow/tools.py
@@ -38,11 +38,11 @@ def listFilesLocal(paths, extension = '.root'):
                 file_paths.append( os.path.join( root, filename ) )
     return file_paths
 
-def haddLocal(localdir,result_file,extension = 'root'):
-    if not os.path.exists( localdir ):
-        raise ValueError(f"localdir {localdir} for hadd operation does not exist")
+def haddLocal(files,result_file,extension = 'root'):
+    # if not os.path.exists( localdir ):
+    #    raise ValueError(f"localdir {localdir} for hadd operation does not exist")
 
-    files = listFilesLocal([localdir],extension)
+    # files = listFilesLocal([localdir],extension)
     process = subprocess.Popen( ['hadd','-f', result_file] + files,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)

--- a/CalibMuon/DTCalibration/python/Workflow/tools.py
+++ b/CalibMuon/DTCalibration/python/Workflow/tools.py
@@ -39,14 +39,12 @@ def listFilesLocal(paths, extension = '.root'):
     return file_paths
 
 def haddLocal(files,result_file,extension = 'root'):
-    # if not os.path.exists( localdir ):
-    #    raise ValueError(f"localdir {localdir} for hadd operation does not exist")
-
-    # files = listFilesLocal([localdir],extension)
+    log.info("hadd command: {}".format(" ".join(['hadd','-f', result_file] + files)))
     process = subprocess.Popen( ['hadd','-f', result_file] + files,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
     stdout = process.communicate()[0]
+    log.info(f"hadd output: {stdout}")
     return process.returncode
 
 def loadCmsProcessFile(psetName):

--- a/CalibMuon/DTCalibration/python/dtCalibOfflineSelection_cff.py
+++ b/CalibMuon/DTCalibration/python/dtCalibOfflineSelection_cff.py
@@ -16,8 +16,12 @@ hltDTCalibration = copy.deepcopy(hltHighLevel)
 hltDTCalibration.HLTPaths = ['HLT_DTCalibration_v*']
 
 ALCARECODtCalibHIHLTFilter = copy.deepcopy(hltHighLevel)
-ALCARECODtCalibHIHLTFilter.throw = False
-ALCARECODtCalibHIHLTFilter.eventSetupPathsKey = 'MuAlcaDtCalibHI'
+
+# HI CHANGES
+# ALCARECODtCalibHIHLTFilter.throw = False
+# ALCARECODtCalibHIHLTFilter.eventSetupPathsKey = 'MuAlcaDtCalibHI'
+ALCARECODtCalibHIHLTFilter.HLTPaths = ['HLT_HIL2SingleMu*']
+
 
 from HLTrigger.HLTfilters.hltLevel1GTSeed_cfi import *
 l1tech = hltLevel1GTSeed.clone()
@@ -108,7 +112,10 @@ offlineSelectionALCARECOPt15 = cms.Sequence(muonSelectionPt15)
 offlineSelectionPt5 = cms.Sequence(scrapingEvtFilter + primaryVertexFilter + muonSelectionPt5)
 offlineSelectionALCARECOPt5 = cms.Sequence(muonSelectionPt5)
 offlineSelectionCosmicsPt5 = cms.Sequence(hltL1SingleMuOpen + goodCosmicTracksPt5)
-offlineSelectionHIPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter + primaryVertexFilterHI + muonSelectionPt5)
+# HI CHANGES
+# offlineSelectionHIPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter + primaryVertexFilterHI + muonSelectionPt5)
+offlineSelectionHIPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter + primaryVertexFilter + muonSelectionPt5)
+
 offlineSelectionHIALCARECOPt5 = cms.Sequence(primaryVertexFilterHI + muonSelectionPt5)
 offlineSelectionHIRAWPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter)
 

--- a/CalibMuon/DTCalibration/python/dtCalibOfflineSelection_cff.py
+++ b/CalibMuon/DTCalibration/python/dtCalibOfflineSelection_cff.py
@@ -17,9 +17,6 @@ hltDTCalibration.HLTPaths = ['HLT_DTCalibration_v*']
 
 ALCARECODtCalibHIHLTFilter = copy.deepcopy(hltHighLevel)
 
-# HI CHANGES
-# ALCARECODtCalibHIHLTFilter.throw = False
-# ALCARECODtCalibHIHLTFilter.eventSetupPathsKey = 'MuAlcaDtCalibHI'
 ALCARECODtCalibHIHLTFilter.HLTPaths = ['HLT_HIL2SingleMu*']
 
 
@@ -112,8 +109,6 @@ offlineSelectionALCARECOPt15 = cms.Sequence(muonSelectionPt15)
 offlineSelectionPt5 = cms.Sequence(scrapingEvtFilter + primaryVertexFilter + muonSelectionPt5)
 offlineSelectionALCARECOPt5 = cms.Sequence(muonSelectionPt5)
 offlineSelectionCosmicsPt5 = cms.Sequence(hltL1SingleMuOpen + goodCosmicTracksPt5)
-# HI CHANGES
-# offlineSelectionHIPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter + primaryVertexFilterHI + muonSelectionPt5)
 offlineSelectionHIPt5 = cms.Sequence(ALCARECODtCalibHIHLTFilter + primaryVertexFilter + muonSelectionPt5)
 
 offlineSelectionHIALCARECOPt5 = cms.Sequence(primaryVertexFilterHI + muonSelectionPt5)

--- a/CalibMuon/DTCalibration/python/dtCalibValidationFromMuons_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtCalibValidationFromMuons_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Validation")
+process = cms.Process("Validation",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtCalibValidation_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtCalibValidation_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Validation")
+process = cms.Process("Validation",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtCalibValidation_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtCalibValidation_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Validation")
+process = cms.Process("Validation",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtDQMAlca_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMAlca_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DQM")
+process = cms.Process("DQM",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtDQMAlca_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMAlca_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DQM")
+process = cms.Process("DQM",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtDQMClientAlca_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMClientAlca_cfg.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 class config: pass
 config.dqmAtRunEnd = True
 if config.dqmAtRunEnd: config.fileMode = 'FULLMERGE'
 else: config.fileMode = 'NOMERGE'
 
-process = cms.Process("HARVESTING")
+process = cms.Process("HARVESTING",eras.Run3)
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtDQMClient_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMClient_cfg.py
@@ -1,11 +1,12 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
 class config: pass
 config.dqmAtRunEnd = False
 if config.dqmAtRunEnd: config.fileMode = 'FULLMERGE'
 else: config.fileMode = 'NOMERGE'
 
-process = cms.Process("DQMClient")
+process = cms.Process("DQMClient",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.debugModules = cms.untracked.vstring('')

--- a/CalibMuon/DTCalibration/python/dtDQMMerge_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMMerge_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('MERGEDQM')
+process = cms.Process('MERGEDQM',eras.Run3)
 
 process.load('Configuration.EventContent.EventContent_cff')
 

--- a/CalibMuon/DTCalibration/python/dtNoiseCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtNoiseCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = ['dtNoiseCalibration']

--- a/CalibMuon/DTCalibration/python/dtResidualCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtResidualCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtResidualCalibration')

--- a/CalibMuon/DTCalibration/python/dtResidualCalibration_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtResidualCalibration_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtResidualCalibration')

--- a/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Correction")
+process = cms.Process("DTT0Correction",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0AbsoluteReferenceCorrection')

--- a/CalibMuon/DTCalibration/python/dtT0Analyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0Analyzer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Analyzer")
+process = cms.Process("DTT0Analyzer",eras.Run3)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond

--- a/CalibMuon/DTCalibration/python/dtT0FEBPathCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FEBPathCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Correction")
+process = cms.Process("DTT0Correction",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FEBPathCorrection')

--- a/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Correction")
+process = cms.Process("DTT0Correction",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillChamberFromDBCorrection')

--- a/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Correction")
+process = cms.Process("DTT0Correction",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillDefaultFromDBCorrection')

--- a/CalibMuon/DTCalibration/python/dtT0WireCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0WireCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("PROD")
+process = cms.Process("PROD",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.debugModules = cms.untracked.vstring('*')

--- a/CalibMuon/DTCalibration/python/dtT0WireInChamberReferenceCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0WireInChamberReferenceCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTT0Correction")
+process = cms.Process("DTT0Correction",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0WireInChamberReferenceCorrection')

--- a/CalibMuon/DTCalibration/python/dtTPAnalyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPAnalyzer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTPAnalyzer")
+process = cms.Process("DTTPAnalyzer",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTPDQM_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPDQM_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DQM")
+process = cms.Process("DQM",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.debugModules = cms.untracked.vstring('*')

--- a/CalibMuon/DTCalibration/python/dtTPDeadWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPDeadWriter_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTPDeadWriter")
+process = cms.Process("DTTPDeadWriter",eras.Run3)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond

--- a/CalibMuon/DTCalibration/python/dtTTrigAnalyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigAnalyzer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTTrigAnalyzer")
+process = cms.Process("DTTTrigAnalyzer",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTTrigCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtTTrigCalibration_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCalibration_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/CalibMuon/DTCalibration/python/dtTTrigConstantShiftCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigConstantShiftCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTTrigCorrection")
+process = cms.Process("DTTTrigCorrection",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtTTrigConstantShiftCorrection')

--- a/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTTrigCorrection")
+process = cms.Process("DTTTrigCorrection",eras.Run3)
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtTTrigResidualCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigResidualCorrection_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTTTrigCorrection")
+process = cms.Process("DTTTrigCorrection",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtTTrigResidualCorrection')

--- a/CalibMuon/DTCalibration/python/dtTTrigValidSummary_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigValidSummary_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Validation")
+process = cms.Process("Validation",eras.Run3)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.debugModules = cms.untracked.vstring('')

--- a/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
@@ -7,9 +7,8 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag=autoCond['run3_data']
 
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-process.load("Geometry.DTGeometry.dtGeometry_cfi")
+process.load('Configuration/StandardSequences/GeometryRecoDB_cff')
+process.load("Configuration.StandardSequences.MagneticField_cff")
 process.DTGeometryESModule.applyAlignment = False
 process.DTGeometryESModule.fromDDD = False
 

--- a/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("PROD")
+process = cms.Process("PROD",eras.Run3)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond

--- a/CalibMuon/DTCalibration/python/dtVDriftAnalyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftAnalyzer_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTVDriftAnalyzer")
+process = cms.Process("DTVDriftAnalyzer",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftMeanTimerCalibration')

--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftMeanTimerCalibration')

--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerWriter_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTVDriftWriter")
+process = cms.Process("DTVDriftWriter",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftMeanTimerWriter')

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentCalibration_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftSegmentCalibration')

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentCalibration_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentCalibration_cosmics_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Calibration")
+process = cms.Process("Calibration",eras.Run3)
 
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftSegmentCalibration')

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DTVDriftWriter")
+process = cms.Process("DTVDriftWriter",eras.Run3)
 
 ### Set to true to switch to writing constants in the new DB format.
 NEWDBFORMAT = False 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_GT_ttrig_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_GT_ttrig_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_GT_vdrift_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_GT_vdrift_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_noise_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_noise_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_t0Wire_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_t0Wire_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_tpDead_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_tpDead_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_ttrig_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_ttrig_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_vdrift_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_vdrift_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("DumpDBToFile")
+process = cms.Process("DumpDBToFile",eras.Run3)
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/scripts/dtCalibration
+++ b/CalibMuon/DTCalibration/scripts/dtCalibration
@@ -1,6 +1,8 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import sys,os,time,datetime,logging
 import argparse
+from termcolor import colored
+
 from CalibMuon.DTCalibration.Workflow.DTCalibrationWorker import DTCalibrationWorker
 
 
@@ -16,12 +18,12 @@ def main():
     setupLogging(options)
 
     # echo the command line used to run calibration to the log file
-    log.info("DT Calibration started with command: ")
+    log.info("DT Calibration started with command:")
     log.info(" ".join(sys.argv))
 
     start = time.time()
-    print "DT Calibration starting "
-    print "Running at",options.working_dir
+    print(colored("[DT Calibration starting]", 'cyan', attrs = ["bold"]))
+    print(f"Running at {options.working_dir}")
 
     #stdout_original = sys.stdout
     #sys.stdout = logOut
@@ -30,21 +32,21 @@ def main():
     local_path = dtCalibWorker.run()
 
     # move the log file to the working directory to avoid cluttering up the base directory
-    print "Job dir is",local_path
-    print "Log file is",log_file_name
+    print(f"Job dir is {local_path}")
+    print(f"Log file is {log_file_name}")
     os.rename(log_file_name,local_path+log_file_name)
 
     #sys.stdout = stdout_original
     stop = time.time()
-    print "DT Calibration finished"
-    print "Time elapsed was %.1f seconds"%(stop-start)
+    print(colored("[DT Calibration finished]", 'green', attrs = ["bold"]))
+    print(f"Time elapsed was {stop-start:.2f} seconds")
 
 def setupLogging(options):
     #setup logging
     format = '%(levelname)s (%(name)s) [%(asctime)s]: %(message)s'
-    #logging.basicConfig( level=logging._levelNames[ options.debug ], format=format, datefmt=date )
+    #logging.basicConfig( level=logging.getLevelName(options.debug), format=format, datefmt=date )
     logging.basicConfig(filename=log_file_name, level=logging.DEBUG, format=format, datefmt=date )
-    log.setLevel(logging._levelNames[ options.debug ])
+    log.setLevel(logging.getLevelName(options.debug))
     #formatter = logging.Formatter( format )
     #hdlr = logging.FileHandler( log_file_name, mode='w' )
     #hdlr.setFormatter( formatter )


### PR DESCRIPTION
#### PR description: 

Following the discussion from [1], this PR updates the DT Calibration code to CMSSW_14_0_X and includes fixes for the HI workflow (available trigger paths + "rawDataCollector" --> "rawDataRepacker").

[1] - https://indico.cern.ch/event/1339792/#80-dt-calibration-results-with

#### PR validation:

##### pp - Run2023

```bash
dtCalibration \
       ttrig \
       residuals \
       all \
       --run=370175 \
       --trial=3 \
       --label=PPtest \
       --runselection=370175 \
       --datasetpath=/ExpressPhysics/Run2023D-Express-v1/FEVT \
       --globaltag=130X_dataRun3_HLT_v2 \
       --lumisPerJob 50 \
       --preselection=CalibMuon.DTCalibration.dtCalibOfflineSelection_cff:dtCalibOfflineSelection \
       --output-site T2_CH_CERN \
       --user YOUR_CERN_USERNAME \
       --run-on-RAW \
       --max-checks 100000
```

##### HI - Run2023

```bash
dtCalibration \ 
       ttrig \
       residuals\
       all\
       --run=375831\
       --trial=6\
       --label=HItest\
       --runselection=375823\
       --datasetpath=/HIExpressPhysics/HIRun2023A-Express-v2/FEVT\
       --globaltag=132X_dataRun3_Express_v4\
       --lumisPerJob 50\
       --preselection=CalibMuon.DTCalibration.dtCalibOfflineSelection_cff:dtCalibOfflineSelectionHI
       --raw-data-label=rawDataRepacker
       --output-site T2_CH_CERN
       --user YOUR_CERN_USERNAME
       --run-on-RAW
       --max-checks 100000
       --ce-white-list=T2_FR_IPHC
```

##### Cosmics - Run2023

```bash
dtCalibration \
        ttrig \
        timeboxes \
        all \
        --run=366296  \
        --trial=3 \
        --label=Cosmicstest \
        --runselection=366296 \
        --datasetpath=/ExpressCosmics/Run2023A-Express-v2/FEVT \
        --globaltag=130X_dataRun3_Express_v2 \
        --lumisPerJob 50 \
        --preselection=CalibMuon.DTCalibration.dtCalibOfflineSelection_cff:dtCalibOfflineSelectionCosmics \
        --output-site T2_CH_CERN \
        --user YOUR_CERN_USERNAME \
        --run-on-RAW \
       --max-checks 100000
```

No significant difference was observed.

@battibass @fcavallo @valesark 
