### PR TITLE
Adapt ParticleLevelProducer for Rivet 3.1.10

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -102,18 +102,17 @@ namespace Rivet {
       // useDecayPhotons=true allows for photons with tau ancestor,
       // photons from hadrons are vetoed by the PromptFinalState;
       // will be default DressedLeptons behaviour for Rivet >= 2.5.4
-      DressedLeptons dressed_leptons(
+      DressedLeptons prompt_dressed_leptons(
           prompt_photons, prompt_leptons, _lepConeSize, lepton_cut, /*useDecayPhotons*/ true);
-      if (not _usePromptFinalStates)
-        dressed_leptons = DressedLeptons(photons, charged_leptons, _lepConeSize, lepton_cut, /*useDecayPhotons*/ true);
-      declare(dressed_leptons, "DressedLeptons");
+      DressedLeptons dressed_leptons(photons, charged_leptons, _lepConeSize, lepton_cut, /*useDecayPhotons*/ true);
+      declare(_usePromptFinalStates ? prompt_dressed_leptons : dressed_leptons, "DressedLeptons");
 
       declare(photons, "Photons");
 
       // Jets
       VetoedFinalState fsForJets(fs);
       if (_usePromptFinalStates and _excludePromptLeptonsFromJetClustering)
-        fsForJets.addVetoOnThisFinalState(dressed_leptons);
+        fsForJets.addVetoOnThisFinalState(prompt_dressed_leptons);
       JetAlg::Invisibles invisiblesStrategy = JetAlg::Invisibles::DECAY;
       if (_excludeNeutrinosFromJetClustering)
         invisiblesStrategy = JetAlg::Invisibles::NONE;

--- a/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
@@ -4,11 +4,10 @@ process = cms.Process("TQAF")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
-from TopQuarkAnalysis.TopEventProducers.tqafInputFiles_cff import relValTTbar
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-            #relValTTbar
-            '/store/relval/CMSSW_11_0_0/RelValTTbar_14TeV/GEN-SIM/110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/22BAADDB-EE84-794F-9A5D-812F341D8075.root'
+            #UL18 MiniAODv2
+            '/store/mc/RunIISummer20UL18MiniAODv2/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v16_L1v1-v1/00000/04A0B676-D63A-6D41-B47F-F4CF8CBE7DB8.root'
         )
 )
 
@@ -23,10 +22,13 @@ process.options = cms.untracked.PSet(
 )
 
 process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("GeneratorInterface.RivetInterface.mergedGenParticles_cfi")
 process.load("GeneratorInterface.RivetInterface.genParticles2HepMC_cfi")
 process.load("GeneratorInterface.RivetInterface.particleLevel_cfi")
+process.genParticles2HepMC.genParticles = cms.InputTag("mergedGenParticles")
+process.particleLevel.src = cms.InputTag("genParticles2HepMC:unsmeared")
 
-process.path = cms.Path(process.genParticles2HepMC*process.particleLevel)
+process.path = cms.Path(process.mergedGenParticles*process.genParticles2HepMC*process.particleLevel)
 
 process.out = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string("particleLevel.root"),


### PR DESCRIPTION
#### PR description:

Fixing `error: use of deleted function 'Rivet::DressedLeptons& Rivet::DressedLeptons::operator=(Rivet::DressedLeptons&&)'` from https://github.com/cms-sw/cmsdist/pull/9006#issuecomment-1941177826

#### PR validation:

Running updated ParticleLevelProducer test successfully.