### PR TITLE
Fix on muon_mvaID in NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -65,15 +65,13 @@ slimmedMuonsWithUserData = cms.EDProducer("PATMuonUserDataEmbedder",
         ptRel = cms.InputTag("ptRatioRelForMu:ptRel"),
         jetNDauChargedMVASel = cms.InputTag("ptRatioRelForMu:jetNDauChargedMVASel"),
         mvaIDMuon_wpMedium = cms.InputTag("muonMVAID:wpMedium"),
-        mvaIDMuon_wpTight = cms.InputTag("muonMVAID:wpTight")
+        mvaIDMuon_wpTight = cms.InputTag("muonMVAID:wpTight"),
+        mvaIDMuon = cms.InputTag("muonMVAID:probGOOD")
      ),
      userCands = cms.PSet(
         jetForLepJetVar = cms.InputTag("ptRatioRelForMu:jetForLepJetVar") # warning: Ptr is null if no match is found
      ),
 )
-
-(run2_nanoAOD_106Xv2 | run3_nanoAOD_122 ).toModify(slimmedMuonsWithUserData.userFloats,
-                                           mvaIDMuon = cms.InputTag("muonMVAID:probGOOD"))
 
 
 finalMuons = cms.EDFilter("PATMuonRefSelector",
@@ -169,7 +167,7 @@ muonTable = simpleCandidateFlatTableProducer.clone(
         pfIsoId = Var("passed('PFIsoVeryLoose')+passed('PFIsoLoose')+passed('PFIsoMedium')+passed('PFIsoTight')+passed('PFIsoVeryTight')+passed('PFIsoVeryVeryTight')","uint8",doc="PFIso ID from miniAOD selector (1=PFIsoVeryLoose, 2=PFIsoLoose, 3=PFIsoMedium, 4=PFIsoTight, 5=PFIsoVeryTight, 6=PFIsoVeryVeryTight)"),
         tkIsoId = Var("?passed('TkIsoTight')?2:passed('TkIsoLoose')","uint8",doc="TkIso ID (1=TkIsoLoose, 2=TkIsoTight)"),
         miniIsoId = Var("passed('MiniIsoLoose')+passed('MiniIsoMedium')+passed('MiniIsoTight')+passed('MiniIsoVeryTight')","uint8",doc="MiniIso ID from miniAOD selector (1=MiniIsoLoose, 2=MiniIsoMedium, 3=MiniIsoTight, 4=MiniIsoVeryTight)"),
-        mvaMuID = Var("mvaIDValue()",float,doc="MVA-based ID score ",precision=6),
+        mvaMuID = Var("userFloat('mvaIDMuon')", float, doc="MVA-based ID score",precision=6),
         mvaMuID_WP = Var("userFloat('mvaIDMuon_wpMedium') + userFloat('mvaIDMuon_wpTight')","uint8",doc="MVA-based ID selector WPs (1=MVAIDwpMedium,2=MVAIDwpTight)"),
         multiIsoId = Var("?passed('MultiIsoMedium')?2:passed('MultiIsoLoose')","uint8",doc="MultiIsoId from miniAOD selector (1=MultiIsoLoose, 2=MultiIsoMedium)"),
         puppiIsoId = Var("passed('PuppiIsoLoose')+passed('PuppiIsoMedium')+passed('PuppiIsoTight')", "uint8", doc="PuppiIsoId from miniAOD selector (1=Loose, 2=Medium, 3=Tight)"),
@@ -190,9 +188,6 @@ muonTable = simpleCandidateFlatTableProducer.clone(
 # Increase precision of eta and phi
 muonTable.variables.eta.precision = 16
 muonTable.variables.phi.precision = 16
-
-(run2_nanoAOD_106Xv2 | run3_nanoAOD_122).toModify(muonTable.variables,mvaMuID=None).toModify(
-     muonTable.variables, mvaMuID = Var("userFloat('mvaIDMuon')", float, doc="MVA-based ID score",precision=6))
 
 
 # Revert back to AK4 CHS jets for Run 2


### PR DESCRIPTION
#### PR description:

This PR is a fix to the previous implementation of the muon MVA ID in nanoAOD [1]. 

In this fix the score of the MVA ID  (mvaIDMuon) is computed on the fly when producing the nanoAOD. In the current implementation this is read from the miniAOD which has a non final version of the training. With this fix we make sure the  training that has been published in CMS-PAS-MUO-22-001 enters the following nanoAOD versions. 

Note: the WP variables (mvaIDMuon_wpTight and mvaIDMuon_wpMedium ) were computed in nanoAOD already. 

[1] https://github.com/cms-sw/cmssw/pull/41903

#### PR validation:

- The code changes have passed most of the standard runTheMatrix test workflows. There was only one failure when running 1000.0_RunMinBias2011A step 3. The error [2] seems unrealted with the changes in this PR. 
- We execute the basic tests suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).

[2] [a] Calling RootInputFileSequence::initTheFile(): fail to open the file with name root://eoscms.cern.ch//eos/cms/store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/18E0AF9F-BA7F-E011-AC1C-001D09F24259.root
      [b] Input file root://xrootd-cms.infn.it//store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/18E0AF9F-BA7F-E011-AC1C-001D09F24259.root could not be opened.
      [c] XrdCl::File::Open(name='root://xrootd-cms.infn.it//store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/18E0AF9F-BA7F-E011-AC1C-001D09F24259.root', flags=0x10, permissions=0660) => error '[ERROR] Server responded with an error: [3011] No servers are available to read the file.
' (errno=3011, code=400). No additional data servers were found.
      [d] Last URL tried: root://cms-xrd-global.cern.ch:1094//store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/18E0AF9F-BA7F-E011-AC1C-001D09F24259.root?tried=+1213llrxrd-redir.in2p3.fr,&xrdcl.requuid=43b88d64-2f45-401b-b96d-41b1aa1d7c12
      [e] Problematic data server: cms-xrd-global.cern.ch:1094
      [f] Disabled source: cms-xrd-global.cern.ch:1094

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We would like to have this backported to  14_0_X, so this enters in NanoAODv14. 