### PR TITLE
Remove unpackLayer1 option from L1REPACK:Full

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_Full_cff.py
@@ -71,10 +71,6 @@ import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
 unpackHcal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone(
     InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
 
-import EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi
-unpackLayer1 = EventFilter.L1TXRawToDigi.caloLayer1Stage2Digis_cfi.l1tCaloLayer1Digis.clone(
-    fedRawDataLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess()))
-
 # Second, Re-Emulate the entire L1T
 
 from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import *
@@ -129,7 +125,7 @@ simEmtfDigis.CSCInput            = "unpackEmtf"
 simEmtfDigis.RPCInput            = 'unpackRPC'
 
 simCaloStage2Layer1Digis.ecalToken = 'unpackEcal:EcalTriggerPrimitives'
-simCaloStage2Layer1Digis.hcalToken = 'unpackLayer1'
+simCaloStage2Layer1Digis.hcalToken = 'unpackHcal'
 
 
 ## GT
@@ -160,7 +156,6 @@ rawDataCollector = EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi.rawD
 
 SimL1EmulatorTask = cms.Task()
 stage2L1Trigger.toReplaceWith(SimL1EmulatorTask, cms.Task(unpackEcal,unpackHcal,unpackCSC,unpackDT,unpackRPC,unpackRPCTwinMux,unpackTwinMux,unpackOmtf,unpackEmtf,unpackCsctf,unpackBmtf
-                                                          ,unpackLayer1
                                                           ,unpackTcds
                                                           ,SimL1EmulatorCoreTask,packCaloStage2
                                                           ,packGmtStage2,packGtStage2,rawDataCollector))


### PR DESCRIPTION
#### PR description:

This PR removes the `unpackLayer1` from `L1REPACK:Full`. This was brought into our attention by TSG colleagues and it was causing unrealistic rates when re-emulating data after 2023A. 

There might be an underlying reason to why this problem started happening, but for the time being we prefer to remove this option and use `unpackHcal` directly. This is more in line with how ECAL TPs are used. The `unpackLayer1` step was probably an artifact from Run 2, which is not needed anymore.

#### PR validation:

Validated that the `L1REPACK:Full` workflows still work after the change and the rates obtained are as expected.

FYI @missirol @savarghe @caruta @aloeliger @epalencia 