### PR TITLE
Update L1Scouting Data Format tests and minor code fixes 

### DIFF
--- a/DataFormats/L1Scouting/interface/OrbitCollection.h
+++ b/DataFormats/L1Scouting/interface/OrbitCollection.h
@@ -78,7 +78,7 @@ public:
   }
 
   // get number of objects stored in a BX
-  int getBxSize(unsigned bx) const {
+  unsigned getBxSize(unsigned bx) const {
     if (bx >= orbitBufferSize_) {
       cms::Exception("OrbitCollection") << "Called getBxSize() of a bx out of the orbit range."
                                         << " BX = " << bx;

--- a/DataFormats/L1Scouting/src/classes_def.xml
+++ b/DataFormats/L1Scouting/src/classes_def.xml
@@ -1,40 +1,43 @@
 <lcgdict>
-  <class name="l1ScoutingRun3::Muon" ClassVersion="3">
-    <version ClassVersion="3" checksum="3886315831"/>
-  </class>
-  <class name="std::vector<l1ScoutingRun3::Muon>"/>
-  <class name="l1ScoutingRun3::MuonOrbitCollection"/>
-  <class name="edm::Wrapper<l1ScoutingRun3::MuonOrbitCollection>"/>
-
-  <class name="l1ScoutingRun3::CaloObject"/>
-  <class name="std::vector<l1ScoutingRun3::CaloObject>"/>
-
-  <class name="l1ScoutingRun3::Jet" ClassVersion="3">
-    <version ClassVersion="3" checksum="1391509699"/>
-  </class>
-  <class name="std::vector<l1ScoutingRun3::Jet>"/>
-  <class name="l1ScoutingRun3::JetOrbitCollection"/>
-  <class name="edm::Wrapper<l1ScoutingRun3::JetOrbitCollection>"/>
-
-  <class name="l1ScoutingRun3::EGamma" ClassVersion="3">
-    <version ClassVersion="3" checksum="1578240696"/>
-  </class>
-  <class name="std::vector<l1ScoutingRun3::EGamma>"/>
-  <class name="l1ScoutingRun3::EGammaOrbitCollection"/>
-  <class name="edm::Wrapper<l1ScoutingRun3::EGammaOrbitCollection>"/>
-
-  <class name="l1ScoutingRun3::Tau" ClassVersion="3">
-    <version ClassVersion="3" checksum="2889952120"/>
-  </class>
-  <class name="std::vector<l1ScoutingRun3::Tau>"/>
-  <class name="l1ScoutingRun3::TauOrbitCollection"/>
-  <class name="edm::Wrapper<l1ScoutingRun3::TauOrbitCollection>"/>
 
   <class name="l1ScoutingRun3::BxSums" ClassVersion="3">
     <version ClassVersion="3" checksum="1112955969"/>
   </class>
+
+  <class name="l1ScoutingRun3::CaloObject"/>
+
+  <class name="l1ScoutingRun3::EGamma" ClassVersion="3">
+    <version ClassVersion="3" checksum="1578240696"/>
+  </class>
+
+  <class name="l1ScoutingRun3::Jet" ClassVersion="3">
+    <version ClassVersion="3" checksum="1391509699"/>
+  </class>
+
+  <class name="l1ScoutingRun3::Muon" ClassVersion="3">
+    <version ClassVersion="3" checksum="3886315831"/>
+  </class>
+  
+  <class name="l1ScoutingRun3::Tau" ClassVersion="3">
+    <version ClassVersion="3" checksum="2889952120"/>
+  </class>
+
   <class name="std::vector<l1ScoutingRun3::BxSums>"/>
+  <class name="std::vector<l1ScoutingRun3::EGamma>"/>
+  <class name="std::vector<l1ScoutingRun3::Jet>"/>
+  <class name="std::vector<l1ScoutingRun3::Muon>"/>
+  <class name="std::vector<l1ScoutingRun3::Tau>"/>
+
   <class name="l1ScoutingRun3::BxSumsOrbitCollection"/>
+  <class name="l1ScoutingRun3::EGammaOrbitCollection"/>
+  <class name="l1ScoutingRun3::JetOrbitCollection"/>
+  <class name="l1ScoutingRun3::MuonOrbitCollection"/>
+  <class name="l1ScoutingRun3::TauOrbitCollection"/>
+
   <class name="edm::Wrapper<l1ScoutingRun3::BxSumsOrbitCollection>"/>
+  <class name="edm::Wrapper<l1ScoutingRun3::EGammaOrbitCollection>"/>
+  <class name="edm::Wrapper<l1ScoutingRun3::JetOrbitCollection>"/>
+  <class name="edm::Wrapper<l1ScoutingRun3::MuonOrbitCollection>"/>
+  <class name="edm::Wrapper<l1ScoutingRun3::TauOrbitCollection>"/>
   
 </lcgdict>

--- a/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
+++ b/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
@@ -9,3 +9,9 @@ cmsRun ${LOCAL_TEST_DIR}/create_L1Scouting_test_file_cfg.py || die 'Failure usin
 file=testL1Scouting.root
 
 cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py "$file" || die "Failure using read_L1Scouting_cfg.py $file" $?
+
+oldFile="testL1Scouting_v3_v3_v3_v3_v3_13_3_0_pre5.root"
+inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$oldFile) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$oldFile" $?
+cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py "$inputfile" || die "Failed to read old file $oldFile" $?
+
+exit 0

--- a/DataFormats/L1ScoutingRawData/interface/SDSNumbering.h
+++ b/DataFormats/L1ScoutingRawData/interface/SDSNumbering.h
@@ -19,6 +19,8 @@ public:
   static constexpr int GtSDSID = 4;
   static constexpr int BmtfMinSDSID = 10;
   static constexpr int BmtfMaxSDSID = 21;
+  static constexpr int CaloTCPMinSDSID = 22;
+  static constexpr int CaloTCPMaxSDSID = 29;
 };
 
 #endif  // L1ScoutingRawData_SDSNumbering_h

--- a/DataFormats/L1ScoutingRawData/test/TestSDSRawDataCollectionFormat.sh
+++ b/DataFormats/L1ScoutingRawData/test/TestSDSRawDataCollectionFormat.sh
@@ -9,3 +9,9 @@ cmsRun ${LOCAL_TEST_DIR}/create_SDSRawDataCollection_test_file_cfg.py || die 'Fa
 file=testSDSRawDataCollection.root
 
 cmsRun ${LOCAL_TEST_DIR}/read_SDSRawDataCollection_cfg.py "$file" || die "Failure using read_SDSRawDataCollection_cfg.py $file" $?
+
+oldFile="testSDSRawDataCollection_v3_CMSSW_13_3_0_pre5.root"
+inputfile=$(edmFileInPath DataFormats/L1ScoutingRawData/data/$oldFile) || die "Failure edmFileInPath DataFormats/L1ScoutingRawData/data/$oldFile" $?
+cmsRun ${LOCAL_TEST_DIR}/read_SDSRawDataCollection_cfg.py "$inputfile" || die "Failed to read old file $oldFile" $?
+
+exit 0

--- a/DataFormats/L1ScoutingRawData/test/read_SDSRawDataCollection_cfg.py
+++ b/DataFormats/L1ScoutingRawData/test/read_SDSRawDataCollection_cfg.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("READ")
+process = cms.Process("READRAW")
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
 process.maxEvents.input = 1

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -101,9 +101,6 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
         continue;
       }
       uint32_t qual = (bl->mu[i].f >> ugmt::shiftsMuon::qual) & ugmt::masksMuon::qual;
-      if (qual == 0) {
-        continue;
-      }
 
       // extract integer value for extrapolated phi
       int32_t iphiext = ((bl->mu[i].f >> ugmt::shiftsMuon::phiext) & ugmt::masksMuon::phiext);
@@ -157,7 +154,6 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
 
   }  // end orbit while loop
 
-  //muons->flatten();
 }
 
 void ScGMTRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -153,7 +153,6 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
     }  // end of bx
 
   }  // end orbit while loop
-
 }
 
 void ScGMTRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+ScCaloUnpacker = cms.EDProducer("ScCaloRawToDigi",
+  srcInputTag = cms.InputTag("rawDataCollector"),
+  # print all objects
+  debug = cms.untracked.bool(False)
+)

--- a/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+ScGmtUnpacker = cms.EDProducer('ScGMTRawToDigi',
+  srcInputTag = cms.InputTag('rawDataCollector'),
+  # print all objects
+  debug = cms.untracked.bool(False)
+)

--- a/L1TriggerScouting/Utilities/interface/scales.h
+++ b/L1TriggerScouting/Utilities/interface/scales.h
@@ -20,7 +20,7 @@ namespace l1ScoutingRun3 {
 
   namespace demux {
     struct scales {
-      static constexpr float phi_scale = 2. * M_PI / 144.;
+      static constexpr float phi_scale = 0.0435;
       static constexpr float eta_scale = 0.0435;
       static constexpr float et_scale = 0.5;
     };


### PR DESCRIPTION
#### PR description:

The aim of this PR is to add test files to `DataFormats/L1Scouting` and `DataFormats/L1ScoutingRawData`, as requested in https://github.com/cms-sw/cmssw/pull/43467#discussion_r1431614179. Test files have been added to cms-data in these two PRs:
* https://github.com/cms-data/DataFormats-L1Scouting/pull/2
* https://github.com/cms-data/DataFormats-L1ScoutingRawData/pull/2

Additionally, I've taken the opportunity to introduce minor changes in other modules, most notably:
* Using an approximate value for the phi LSB of caloL2 trigger objects to match the current usage by caloL2 trigger emulator.
* New set of ScoutingDataSourceIDs for TCP/IP-based readout of calo primitives. Calo Unpacker  will be reformated in a future PR.
* Fixing a bug in `OrbitCollection` data format

#### PR validation:

Validated files produced with this new version files against a set of reference data.
