### PR TITLE
Make test_ExtractMassConstraint to depend on roothistmatrix

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -17,5 +17,5 @@
 <test name="test_ZMuMuMassConstraintParameterFinder" command="test_ZMuMuMassConstraintParameterFinder.sh"/>
 <bin file="testFindMassContraintParameters.cpp" name="test_ExtractMassConstraint">
   <flags PRE_TEST="test_ZMuMuMassConstraintParameterFinder"/>
-  <use name="rootcore"/>
+  <use name="roothistmatrix"/>
 </bin>


### PR DESCRIPTION
#### PR description:

This hopefully fixes UBSAN build failure
```
>> Building binary test_ExtractMassConstraint
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++17 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-deprecated-copy -Wno-deprecated -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=builtin -fsanitize=pointer-overflow -DBOOST_DISABLE_ASSERTS -g -fPIC  tmp/el8_amd64_gcc12/src/Alignment/MillePedeAlignmentAlgorithm/test/test_ExtractMassConstraint/testFindMassContraintParameters.cpp.o -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a455c7a5b724be894a663904dad922/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_UBSAN_X_2024-02-14-2300/biglib/el8_amd64_gcc12 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a455c7a5b724be894a663904dad922/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_UBSAN_X_2024-02-14-2300/lib/el8_amd64_gcc12 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a455c7a5b724be894a663904dad922/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_UBSAN_X_2024-02-14-2300/external/el8_amd64_gcc12/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/c0a455c7a5b724be894a663904dad922/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_UBSAN_X_2024-02-14-2300/static/el8_amd64_gcc12 -lTree -lNet -lThread -lMathCore -lRIO -lCore -lpcre -lbz2 -llzma -lz -lcrypt -ldl -lrt -o tmp/el8_amd64_gcc12/src/Alignment/MillePedeAlignmentAlgorithm/test/test_ExtractMassConstraint/test_ExtractMassConstraint
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el8_amd64_gcc12/src/Alignment/MillePedeAlignmentAlgorithm/test/test_ExtractMassConstraint/testFindMassContraintParameters.cpp.o:(.data.rel+0xd8): undefined reference to `typeinfo for TH1'
   /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el8_amd64_gcc12/src/Alignment/MillePedeAlignmentAlgorithm/test/test_ExtractMassConstraint/testFindMassContraintParameters.cpp.o:(.data.rel+0x198): undefined reference to `typeinfo for TH1'
   /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el8_amd64_gcc12/src/Alignment/MillePedeAlignmentAlgorithm/test/test_ExtractMassConstraint/testFindMassContraintParameters.cpp.o:(.data.rel+0x218): undefined reference to `typeinfo for TH1F'
 collect2: error: ld returned 1 exit status
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_UBSAN_X_2024-02-14-2300/Alignment/MillePedeAlignmentAlgorithm

#### PR validation:

None