### PR TITLE
Remove or replace ```OwnVector<SiStripMatchedRecHit2D>```

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h
@@ -2,15 +2,8 @@
 #define DATAFORMATS_SISTRIPMATCHEDRECHIT2DCOLLECTION_H
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/Common/interface/RangeMap.h"
-#include "DataFormats/Common/interface/ClonePolicy.h"
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/Common/interface/OwnVector.h"
-#include <vector>
-
-typedef edm::RangeMap<DetId, edm::OwnVector<SiStripMatchedRecHit2D> > SiStripMatchedRecHit2DCollectionOld;
-
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
+
 typedef edmNew::DetSetVector<SiStripMatchedRecHit2D> SiStripMatchedRecHit2DCollection;
 typedef SiStripMatchedRecHit2DCollection SiStripMatchedRecHit2DCollectionNew;
 

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -60,17 +60,8 @@
    <version ClassVersion="10" checksum="414205262"/>
   </class>
 
-  <class name="std::vector<SiStripMatchedRecHit2D*>"/>
-  <class name="edm::OwnVector<SiStripMatchedRecHit2D,edm::ClonePolicy<SiStripMatchedRecHit2D> >"/>
-  <class name="edm::OwnVector<SiStripMatchedRecHit2D,edm::ClonePolicy<SiStripMatchedRecHit2D> >::const_iterator"/>
-
   <class name="edm::OwnVector<BaseTrackerRecHit>" persistent="false"/>
   <class name="edm::Wrapper<edm::OwnVector<BaseTrackerRecHit> >" persistent="false"/>
-
-  <class name="edm::RangeMap<DetId, edm::OwnVector<SiStripMatchedRecHit2D, edm::ClonePolicy<SiStripMatchedRecHit2D> >, edm::ClonePolicy<SiStripMatchedRecHit2D> >"/>
-  <class name="edm::RangeMap<DetId, edm::OwnVector<SiStripMatchedRecHit2D, edm::ClonePolicy<SiStripMatchedRecHit2D> >, edm::ClonePolicy<SiStripMatchedRecHit2D> >::id_iterator"/>
-
-  <class name="edm::Wrapper<edm::RangeMap<DetId, edm::OwnVector<SiStripMatchedRecHit2D, edm::ClonePolicy<SiStripMatchedRecHit2D> >, edm::ClonePolicy<SiStripMatchedRecHit2D> > >"/>
 
   <class name="std::vector<SiPixelRecHit>"/>
 

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitConverterAlgorithm.h
@@ -12,6 +12,8 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
+#include <memory>
+
 namespace edm {
   class ConsumesCollector;
   class ParameterSet;

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -20,6 +20,7 @@ class GluedGeomDet;
 #include <cfloat>
 #include <functional>
 #include <memory>
+#include <vector>
 
 class SiStripRecHitMatcher {
 public:
@@ -88,7 +89,7 @@ public:
   void match(const SiStripRecHit2D* monoRH,
              SimpleHitIterator begin,
              SimpleHitIterator end,
-             edm::OwnVector<SiStripMatchedRecHit2D>& collector,
+             std::vector<std::unique_ptr<SiStripMatchedRecHit2D>>& collector,
              const GluedGeomDet* gluedDet,
              LocalVector trackdirection) const;
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -29,14 +29,14 @@ namespace {
 void SiStripRecHitMatcher::match(const SiStripRecHit2D* monoRH,
                                  SimpleHitIterator begin,
                                  SimpleHitIterator end,
-                                 edm::OwnVector<SiStripMatchedRecHit2D>& collector,
+                                 std::vector<std::unique_ptr<SiStripMatchedRecHit2D>>& collector,
                                  const GluedGeomDet* gluedDet,
                                  LocalVector trackdirection) const {
   std::vector<SiStripMatchedRecHit2D*> result;
   result.reserve(end - begin);
   match(monoRH, begin, end, result, gluedDet, trackdirection);
   for (std::vector<SiStripMatchedRecHit2D*>::iterator p = result.begin(); p != result.end(); p++)
-    collector.push_back(*p);
+    collector.emplace_back(*p);
 }
 
 void SiStripRecHitMatcher::match(const SiStripRecHit2D* monoRH,

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
@@ -19,7 +19,6 @@
 // USER INCLUDES
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
@@ -635,9 +634,6 @@ void StdHitNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es) {
   // now matched hits
   if (rechitsmatched.product()->dataSize() > 0) {
     //Loop over all rechits in RPHI collection (can also loop only over DetId)
-    //SiStripMatchedRecHit2DCollectionOld::const_iterator theRecHitRangeIteratorBegin = rechitsmatched->begin();
-    //SiStripMatchedRecHit2DCollectionOld::const_iterator theRecHitRangeIteratorEnd   = rechitsmatched->end();
-    //SiStripMatchedRecHit2DCollectionOld::const_iterator iterRecHit;
     SiStripMatchedRecHit2DCollection::const_iterator recHitIdIterator = (rechitsmatched.product())->begin();
     SiStripMatchedRecHit2DCollection::const_iterator recHitIdIteratorEnd = (rechitsmatched.product())->end();
 


### PR DESCRIPTION
#### PR description:

This is part of a campaign to remove code related to OwnVector. This is in preparation for a possible move to RNTuple from TTree as a persistence mechanism. RNTuple does not support OwnVector because it allows polymorphism. Issue #42734 discusses this in more detail.

In this PR, ```OwnVector<SiStripMatchedRecHit2D>``` is removed or replaced. This is one of the classes on Matti's list in the issue.

The dictionaries in classes_def.xml are removed and also an unused typedef.

The other usage in SiStripRecHitMatcher and SiStripRecHitConverterAlgorithm is replaced by a ```std::vector<std::unique_ptr<SiStripMatchedRecHit2D>>```. As used in that part of the code, the object is not persistent so there aren't any backward compatibility issues and the replacement should work exactly the same as the OwnVector.

It appears that the OwnVector dictionaries were originally introduced in 2006 and new DetSetVector containers replaced them in 2007. Probably the OwnVector code was kept for backward compatibility originally and no one ever had time or remembered to clean it up when backward compatibility to 2007 was no longer needed.

#### PR validation:

This relies on existing tests for the part that was converted to a ```vector<unique_ptr>```.  It should work identically to the way it worked before.

To test the deletion of the dictionaries, I added this in OwnVector.h and built
```
class OwnVector {
    static_assert(!std::is_same_v<T, SiStripRecHitMatcher>,
        "foo does not support Bar1");
```
This demonstrates nothing could be using this or writing this type persistently. I did that for a 14_1_X IB and also for 10_6_39. I suspect nothing has written products of this type since 2007, but didn't verify that with a test. 10_6_X is what we need for the legacy release work.

FYI @makortel 
