### PR TITLE
Fix ESProducerExternalWork::setWhatAcquiredProducedWithLambda()

### DIFF
--- a/FWCore/Framework/interface/ESProducerExternalWork.h
+++ b/FWCore/Framework/interface/ESProducerExternalWork.h
@@ -108,10 +108,9 @@ namespace edm {
                                            TProduceFunc&& produceFunc,
                                            const es::Label& iLabel = {}) {
       using AcquireTypes = eventsetup::impl::ReturnArgumentTypes<TAcquireFunc>;
+      using TRecord = typename AcquireTypes::argument_type;
       using TAcquireReturn = typename AcquireTypes::return_type;
-      using ProduceTypes = eventsetup::impl::ReturnArgumentTypes<TProduceFunc>;
-      using TProduceReturn = typename ProduceTypes::return_type;
-      using TRecord = typename ProduceTypes::argument_type;
+      using TProduceReturn = std::invoke_result_t<TProduceFunc, TRecord const&, TAcquireReturn>;
       using DecoratorType = eventsetup::CallbackSimpleDecorator<TRecord>;
 
       return setWhatAcquiredProducedWithLambda<TAcquireReturn, TProduceReturn, TRecord>(

--- a/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
+++ b/FWCore/Framework/interface/es_impl/ReturnArgumentTypes.h
@@ -1,45 +1,67 @@
 #ifndef FWCore_Framework_interface_es_impl_ReturnArgumentTypes_h
 #define FWCore_Framework_interface_es_impl_ReturnArgumentTypes_h
 
-namespace edm::eventsetup::impl {
-  template <typename F>
-  struct ReturnArgumentTypesImpl;
+namespace edm {
+  class WaitingTaskWithArenaHolder;
 
-  // function pointer
-  template <typename R, typename T>
-  struct ReturnArgumentTypesImpl<R (*)(T const&)> {
-    using argument_type = T;
-    using return_type = R;
-  };
+  namespace eventsetup::impl {
+    template <typename F>
+    struct ReturnArgumentTypesImpl;
 
-  // mutable functor/lambda
-  template <typename R, typename T, typename O>
-  struct ReturnArgumentTypesImpl<R (O::*)(T const&)> {
-    using argument_type = T;
-    using return_type = R;
-  };
+    // function pointer
+    template <typename R, typename T>
+    struct ReturnArgumentTypesImpl<R (*)(T const&)> {
+      using argument_type = T;
+      using return_type = R;
+    };
+    template <typename R, typename T>
+    struct ReturnArgumentTypesImpl<R (*)(T const&, WaitingTaskWithArenaHolder)> {
+      using argument_type = T;
+      using return_type = R;
+    };
 
-  // const functor/lambda
-  template <typename R, typename T, typename O>
-  struct ReturnArgumentTypesImpl<R (O::*)(T const&) const> {
-    using argument_type = T;
-    using return_type = R;
-  };
+    // mutable functor/lambda
+    template <typename R, typename T, typename O>
+    struct ReturnArgumentTypesImpl<R (O::*)(T const&)> {
+      using argument_type = T;
+      using return_type = R;
+    };
+    template <typename R, typename T, typename O>
+    struct ReturnArgumentTypesImpl<R (O::*)(T const&, WaitingTaskWithArenaHolder)> {
+      using argument_type = T;
+      using return_type = R;
+    };
 
-  template <typename F, typename = void>
-  struct ReturnArgumentTypes;
+    // const functor/lambda
+    template <typename R, typename T, typename O>
+    struct ReturnArgumentTypesImpl<R (O::*)(T const&) const> {
+      using argument_type = T;
+      using return_type = R;
+    };
+    template <typename R, typename T, typename O>
+    struct ReturnArgumentTypesImpl<R (O::*)(T const&, WaitingTaskWithArenaHolder) const> {
+      using argument_type = T;
+      using return_type = R;
+    };
 
-  template <typename F>
-  struct ReturnArgumentTypes<F, std::enable_if_t<std::is_class_v<F>>> {
-    using argument_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::argument_type;
-    using return_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::return_type;
-  };
+    //////////
 
-  template <typename F>
-  struct ReturnArgumentTypes<F, std::enable_if_t<std::is_pointer_v<F>>> {
-    using argument_type = typename ReturnArgumentTypesImpl<F>::argument_type;
-    using return_type = typename ReturnArgumentTypesImpl<F>::return_type;
-  };
-}  // namespace edm::eventsetup::impl
+    template <typename F, typename = void>
+    struct ReturnArgumentTypes;
+
+    template <typename F>
+    struct ReturnArgumentTypes<F, std::enable_if_t<std::is_class_v<F>>> {
+      using argument_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::argument_type;
+      using return_type = typename ReturnArgumentTypesImpl<decltype(&F::operator())>::return_type;
+    };
+
+    template <typename F>
+    struct ReturnArgumentTypes<F, std::enable_if_t<std::is_pointer_v<F>>> {
+      using argument_type = typename ReturnArgumentTypesImpl<F>::argument_type;
+      using return_type = typename ReturnArgumentTypesImpl<F>::return_type;
+    };
+
+  }  // namespace eventsetup::impl
+}  // namespace edm
 
 #endif

--- a/FWCore/Integration/plugins/AcquireIntESProducer.cc
+++ b/FWCore/Integration/plugins/AcquireIntESProducer.cc
@@ -84,6 +84,8 @@ namespace edmtest {
     const unsigned int secondsToWaitForWork_;
     std::vector<TestValue*> uniqueTestPointers_;
     std::vector<TestValue*> optionalTestPointers_;
+    std::vector<TestValue*> lambdaUniqueTestPointers_;
+    std::vector<TestValue*> lambdaOptionalTestPointers_;
   };
 
   AcquireIntESProducer::AcquireIntESProducer(edm::ParameterSet const& pset)
@@ -103,6 +105,42 @@ namespace edmtest {
                             &AcquireIntESProducer::acquireOptional,
                             &AcquireIntESProducer::produceOptional,
                             edm::es::Label("optional"));
+
+    setWhatAcquiredProducedWithLambda(
+        [this](ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
+          usleep(200000);
+          auto returnValue = std::make_unique<TestValue>(kAcquireTestValueUniquePtr1);
+          lambdaUniqueTestPointers_[record.iovIndex()] = returnValue.get();
+          return returnValue;
+        },
+        [this](ESTestRecordI const& record, auto testValue) {
+          usleep(200000);
+          if (testValue.get() != lambdaUniqueTestPointers_[record.iovIndex()]) {
+            throw cms::Exception("TestFailure") << "AcquireIntESProducer::<lambda produceUniquePtr>"
+                                                << " unexpected value passed in as argument";
+          }
+          return std::make_unique<ESTestDataI>(kAcquireTestValueUniquePtr2);
+        },
+        edm::es::Label("uniquePtrLambda"));
+
+    setWhatAcquiredProducedWithLambda(
+        [this](ESTestRecordI const& record, edm::WaitingTaskWithArenaHolder holder) {
+          usleep(200000);
+          std::vector<TestValue> testVector;
+          testVector.push_back(kAcquireTestValueOptional1);
+          auto returnValue = std::make_optional<std::vector<TestValue>>(std::move(testVector));
+          lambdaOptionalTestPointers_[record.iovIndex()] = &returnValue.value()[0];
+          return returnValue;
+        },
+        [this](ESTestRecordI const& record, std::optional<std::vector<TestValue>> testValue) {
+          usleep(200000);
+          if (&testValue.value()[0] != lambdaOptionalTestPointers_[record.iovIndex()]) {
+            throw cms::Exception("TestFailure") << "AcquireIntESProducer::<lambda produceOptional>"
+                                                << " unexpected value passed in as argument";
+          }
+          return std::make_unique<ESTestDataI>(kAcquireTestValueOptional2);
+        },
+        edm::es::Label("optionalLambda"));
   }
 
   AcquireIntESProducer::~AcquireIntESProducer() {
@@ -120,6 +158,8 @@ namespace edmtest {
       server_->start();
       uniqueTestPointers_.resize(nConcurrentIOVs);
       optionalTestPointers_.resize(nConcurrentIOVs);
+      lambdaUniqueTestPointers_.resize(nConcurrentIOVs);
+      lambdaOptionalTestPointers_.resize(nConcurrentIOVs);
     }
   }
 

--- a/FWCore/Integration/plugins/ConcurrentIOVAnalyzer.cc
+++ b/FWCore/Integration/plugins/ConcurrentIOVAnalyzer.cc
@@ -46,8 +46,10 @@ namespace edmtest {
     edm::ESGetToken<ESTestDataI, ESTestRecordI> esTokenFromAcquireIntESProducer_;
     std::vector<int> expectedESAcquireTestResults_;
     edm::ESGetToken<ESTestDataI, ESTestRecordI> esTokenUniquePtrTestValue_;
+    edm::ESGetToken<ESTestDataI, ESTestRecordI> esTokenLambdaUniquePtrTestValue_;
     int expectedUniquePtrTestValue_;
     edm::ESGetToken<ESTestDataI, ESTestRecordI> esTokenOptionalTestValue_;
+    edm::ESGetToken<ESTestDataI, ESTestRecordI> esTokenLambdaOptionalTestValue_;
     int expectedOptionalTestValue_;
   };
 
@@ -63,9 +65,11 @@ namespace edmtest {
     }
     if (expectedUniquePtrTestValue_ != 0) {
       esTokenUniquePtrTestValue_ = esConsumes(edm::ESInputTag("", "uniquePtr"));
+      esTokenLambdaUniquePtrTestValue_ = esConsumes(edm::ESInputTag("", "uniquePtrLambda"));
     }
     if (expectedOptionalTestValue_ != 0) {
       esTokenOptionalTestValue_ = esConsumes(edm::ESInputTag("", "optional"));
+      esTokenLambdaOptionalTestValue_ = esConsumes(edm::ESInputTag("", "optionalLambda"));
     }
   }
 
@@ -113,12 +117,22 @@ namespace edmtest {
             << "ConcurrentIOVAnalyzer::analyze,"
             << " value for unique_ptr test from EventSetup does not match expected value";
       }
+      if (eventSetup.getData(esTokenLambdaUniquePtrTestValue_).value() != expectedUniquePtrTestValue_) {
+        throw cms::Exception("TestFailure")
+            << "ConcurrentIOVAnalyzer::analyze,"
+            << " value for lambda unique_ptr test from EventSetup does not match expected value";
+      }
     }
 
     if (expectedOptionalTestValue_ != 0) {
       if (eventSetup.getData(esTokenOptionalTestValue_).value() != expectedOptionalTestValue_) {
         throw cms::Exception("TestFailure") << "ConcurrentIOVAnalyzer::analyze,"
                                             << " value for optional test from EventSetup does not match expected value";
+      }
+      if (eventSetup.getData(esTokenLambdaOptionalTestValue_).value() != expectedOptionalTestValue_) {
+        throw cms::Exception("TestFailure")
+            << "ConcurrentIOVAnalyzer::analyze,"
+            << " value for lambda optional test from EventSetup does not match expected value";
       }
     }
 


### PR DESCRIPTION
#### PR description:

While trying to make Alpaka ESProducers asynchronous, I encountered the type-deducing overload of `ESProducerExternalWork::setWhatAcquiredProducedWithLambda()` didn't compile, and we didn't have tests for it. This PR fixes the problem by adding necessary partial specializations of `edm::eventsetup::impl::ReturnArgumentTypesImpl` to account for the second argument to `acquire()`/`produce()` (`edm::WaitingTaskWithArenaHolder` / return type of the `acquire()`), and extends the tests.

#### PR validation:

Unit tests run.