### PR TITLE
[Phase-2 L1T 14_0_X] small fixes for RCT cluster emulation

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -59,9 +59,9 @@ namespace p2eg {
   static constexpr float c0_ss = 0.94, c1_ss = 0.052, c2_ss = 0.044;                     // passes_ss
   static constexpr float d0 = 0.96, d1 = 0.0003;                                         // passes_photon
   static constexpr float e0_looseTkss = 0.944, e1_looseTkss = 0.65, e2_looseTkss = 0.4;  // passes_looseTkss
-  static constexpr float loose_ss_offset = 0.89;                                         // loosen ss requirement in two eta bins
+  static constexpr float loose_ss_offset = 0.89;  // loosen ss requirement in two eta bins
   static constexpr float eta0_loose_ss = 0.4, eta1_loose_ss = 0.5, eta2_loose_ss = 0.75, eta3_loose_ss = 0.85;
-  static constexpr float high_pt_threshold = 130.;                                       // apply iso and ss requirements below this threshold
+  static constexpr float high_pt_threshold = 130.;  // apply iso and ss requirements below this threshold
   static constexpr float cut_500_MeV = 0.5;
 
   static constexpr float ECAL_LSB = 0.5;  // to convert from int to float (GeV) multiply by LSB
@@ -928,7 +928,8 @@ namespace p2eg {
     bool is_ss;
     if (pt > high_pt_threshold)
       is_ss = true;
-    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) || (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
+    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) ||
+             (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
       is_ss = ((loose_ss_offset + c1_ss * std::exp(-c2_ss * pt)) <= ss);
     else
       is_ss = ((c0_ss + c1_ss * std::exp(-c2_ss * pt)) <= ss);
@@ -939,7 +940,8 @@ namespace p2eg {
     bool is_ss;
     if (pt > high_pt_threshold)
       is_ss = true;
-    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) || (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
+    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) ||
+             (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
       is_ss = ((loose_ss_offset - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
     else
       is_ss = ((e0_looseTkss - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -59,6 +59,7 @@ namespace p2eg {
   static constexpr float c0_ss = 0.94, c1_ss = 0.052, c2_ss = 0.044;                     // passes_ss
   static constexpr float d0 = 0.96, d1 = 0.0003;                                         // passes_photon
   static constexpr float e0_looseTkss = 0.944, e1_looseTkss = 0.65, e2_looseTkss = 0.4;  // passes_looseTkss
+  static constexpr float loose_ss_offset = 0.89;
   static constexpr float cut_500_MeV = 0.5;
 
   static constexpr float ECAL_LSB = 0.5;  // to convert from int to float (GeV) multiply by LSB
@@ -90,14 +91,6 @@ namespace p2eg {
   static constexpr int GCTCARD_2_TOWER_IPHI_OFFSET = 68;
 
   static constexpr int N_GCTTOWERS_CLUSTER_ISO_ONESIDE = 5;  // window size of isolation sum (5x5 in towers)
-
-  /*
-    * Convert HCAL ET to ECAL ET convention 
-    */
-  inline ap_uint<12> convertHcalETtoEcalET(ap_uint<12> HCAL) {
-    float hcalEtAsFloat = HCAL * HCAL_LSB;
-    return (ap_uint<12>(hcalEtAsFloat / ECAL_LSB));
-  }
 
   //////////////////////////////////////////////////////////////////////////
   // RCT: indexing helper functions
@@ -773,7 +766,8 @@ namespace p2eg {
             int clusterRegionIdx = 0) {
       data = (clusterEnergy) | (((ap_uint<32>)towerEta) << 12) | (((ap_uint<32>)towerPhi) << 17) |
              (((ap_uint<32>)clusterEta) << 19) | (((ap_uint<32>)clusterPhi) << 22) | (((ap_uint<32>)satur) << 25);
-      regionIdx = clusterRegionIdx, et5x5 = clusterEt5x5;
+      regionIdx = clusterRegionIdx;
+      et5x5 = clusterEt5x5;
       et2x5 = clusterEt2x5;
       brems = clusterBrems;
       calib = clusterCalib;
@@ -928,19 +922,23 @@ namespace p2eg {
     return is_iso;
   }
 
-  inline bool passes_ss(float pt, float ss) {
+  inline bool passes_ss(float pt, float eta, float ss) {
     bool is_ss;
     if (pt > 130)
       is_ss = true;
+    else if ((abs(eta) > 0.4 && abs(eta) < 0.5) || (abs(eta) > 0.75 && abs(eta) < 0.85))  // temporary adjustment
+      is_ss = ((loose_ss_offset + c1_ss * std::exp(-c2_ss * pt)) <= ss);
     else
       is_ss = ((c0_ss + c1_ss * std::exp(-c2_ss * pt)) <= ss);
     return is_ss;
   }
 
-  inline bool passes_looseTkss(float pt, float ss) {
+  inline bool passes_looseTkss(float pt, float eta, float ss) {
     bool is_ss;
     if (pt > 130)
       is_ss = true;
+    else if ((abs(eta) > 0.4 && abs(eta) < 0.5) || (abs(eta) > 0.75 && abs(eta) < 0.85))  // temporary adjustment
+      is_ss = ((loose_ss_offset - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
     else
       is_ss = ((e0_looseTkss - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
     return is_ss;

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloEGammaUtils.h
@@ -59,7 +59,9 @@ namespace p2eg {
   static constexpr float c0_ss = 0.94, c1_ss = 0.052, c2_ss = 0.044;                     // passes_ss
   static constexpr float d0 = 0.96, d1 = 0.0003;                                         // passes_photon
   static constexpr float e0_looseTkss = 0.944, e1_looseTkss = 0.65, e2_looseTkss = 0.4;  // passes_looseTkss
-  static constexpr float loose_ss_offset = 0.89;
+  static constexpr float loose_ss_offset = 0.89;                                         // loosen ss requirement in two eta bins
+  static constexpr float eta0_loose_ss = 0.4, eta1_loose_ss = 0.5, eta2_loose_ss = 0.75, eta3_loose_ss = 0.85;
+  static constexpr float high_pt_threshold = 130.;                                       // apply iso and ss requirements below this threshold
   static constexpr float cut_500_MeV = 0.5;
 
   static constexpr float ECAL_LSB = 0.5;  // to convert from int to float (GeV) multiply by LSB
@@ -901,7 +903,7 @@ namespace p2eg {
   /*******************************************************************/
   inline bool passes_iso(float pt, float iso) {
     bool is_iso = true;
-    if (pt > 130)
+    if (pt > high_pt_threshold)
       is_iso = true;
     else if (pt < slideIsoPtThreshold) {
       if (!((a0_80 - a1_80 * pt) > iso))
@@ -915,7 +917,7 @@ namespace p2eg {
 
   inline bool passes_looseTkiso(float pt, float iso) {
     bool is_iso;
-    if (pt > 130)
+    if (pt > high_pt_threshold)
       is_iso = true;
     else
       is_iso = (b0 + b1 * std::exp(-b2 * pt) > iso);
@@ -924,9 +926,9 @@ namespace p2eg {
 
   inline bool passes_ss(float pt, float eta, float ss) {
     bool is_ss;
-    if (pt > 130)
+    if (pt > high_pt_threshold)
       is_ss = true;
-    else if ((abs(eta) > 0.4 && abs(eta) < 0.5) || (abs(eta) > 0.75 && abs(eta) < 0.85))  // temporary adjustment
+    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) || (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
       is_ss = ((loose_ss_offset + c1_ss * std::exp(-c2_ss * pt)) <= ss);
     else
       is_ss = ((c0_ss + c1_ss * std::exp(-c2_ss * pt)) <= ss);
@@ -935,9 +937,9 @@ namespace p2eg {
 
   inline bool passes_looseTkss(float pt, float eta, float ss) {
     bool is_ss;
-    if (pt > 130)
+    if (pt > high_pt_threshold)
       is_ss = true;
-    else if ((abs(eta) > 0.4 && abs(eta) < 0.5) || (abs(eta) > 0.75 && abs(eta) < 0.85))  // temporary adjustment
+    else if ((abs(eta) > eta0_loose_ss && abs(eta) < eta1_loose_ss) || (abs(eta) > eta2_loose_ss && abs(eta) < eta3_loose_ss))  // temporary adjustment
       is_ss = ((loose_ss_offset - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);
     else
       is_ss = ((e0_looseTkss - e1_looseTkss * std::exp(-e2_looseTkss * pt)) <= ss);

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1GCT.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1GCT.h
@@ -68,22 +68,15 @@ inline void p2eg::doProximityAndBremsStitching(const p2eg::RCTcard_t (&inputCard
             }
 
             // Next, check for brems correction: clusters need to be next to each other in TOWERS only (not crystals) across an RCT card boundary.
-            // And the sub-leading cluster must have a significant (>10%) energy of the larger cluster, in order for them to be combined.
             if (towerPhi1 == topTowerPhi) {
               if (towerPhi2 == botTowerPhi) {
                 if ((dPhi <= 5) && (dEta < 2)) {
                   if (one > two) {
-                    if (two >
-                        (0.10 * one)) {  // Only stitch if the sub-leading cluster has a significant amount of energy
-                      outputCards[i].RCTtoGCTfiber[j].RCTclusters[k].et = one + two;
-                      outputCards[i + 1].RCTtoGCTfiber[j1].RCTclusters[k1].et = 0;
-                    }
+                    outputCards[i].RCTtoGCTfiber[j].RCTclusters[k].et = one + two;
+                    outputCards[i + 1].RCTtoGCTfiber[j1].RCTclusters[k1].et = 0;
                   } else {
-                    if (one >
-                        (0.10 * two)) {  // Only stitch if the sub-leading cluster has a significant amount of energy
-                      outputCards[i].RCTtoGCTfiber[j].RCTclusters[k].et = 0;
-                      outputCards[i + 1].RCTtoGCTfiber[j1].RCTclusters[k1].et = one + two;
-                    }
+                    outputCards[i].RCTtoGCTfiber[j].RCTclusters[k].et = 0;
+                    outputCards[i + 1].RCTtoGCTfiber[j1].RCTclusters[k1].et = one + two;
                   }
                 }
               }

--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1RCT.h
@@ -1041,7 +1041,7 @@ inline void p2eg::getECALTowersEt(p2eg::crystal tempX[p2eg::CRYSTAL_IN_ETA][p2eg
       int index = j + 4 * i;
       towerEt[index] = 0;
       for (int k = 0; k < 5; k++) {
-        towerEt[index] += (towerEtN[i][j][k] >> 2);
+        towerEt[index] += towerEtN[i][j][k];
       }
     }
   }
@@ -1223,7 +1223,7 @@ inline p2eg::clusterInfo p2eg::getBremsValuesPos(p2eg::crystal tempX[p2eg::CRYST
   for (int i = 0; i < 3; i++) {
     eta_slice[i] = phi0eta[i] + phi1eta[i] + phi2eta[i] + phi3eta[i] + phi4eta[i];
   }
-  cluster_tmp.energy = (eta_slice[0] + eta_slice[1] + eta_slice[2]) >> 2;
+  cluster_tmp.energy = (eta_slice[0] + eta_slice[1] + eta_slice[2]);
 
   return cluster_tmp;
 }
@@ -1298,7 +1298,7 @@ inline p2eg::clusterInfo p2eg::getBremsValuesNeg(p2eg::crystal tempX[p2eg::CRYST
   for (int i = 0; i < 3; i++) {
     eta_slice[i] = phi0eta[i] + phi1eta[i] + phi2eta[i] + phi3eta[i] + phi4eta[i];
   }
-  cluster_tmp.energy = (eta_slice[0] + eta_slice[1] + eta_slice[2]) >> 2;
+  cluster_tmp.energy = (eta_slice[0] + eta_slice[1] + eta_slice[2]);
 
   return cluster_tmp;
 }
@@ -1389,7 +1389,7 @@ inline p2eg::clusterInfo p2eg::getClusterValues(p2eg::crystal tempX[p2eg::CRYSTA
     eta_slice[i] = phi0eta[i] + phi1eta[i] + phi2eta[i] + phi3eta[i] + phi4eta[i];
   }
 
-  cluster_tmp.energy = (eta_slice[1] + eta_slice[2] + eta_slice[3]) >> 2;
+  cluster_tmp.energy = (eta_slice[1] + eta_slice[2] + eta_slice[3]);
 
   // Get the energy totals in the 5x5 and also in two 2x5
   et5x5Tot = (eta_slice[0] + eta_slice[1] + eta_slice[2] + eta_slice[3] + eta_slice[4]);
@@ -1401,8 +1401,8 @@ inline p2eg::clusterInfo p2eg::getClusterValues(p2eg::crystal tempX[p2eg::CRYSTA
   else
     etSum2x5 = et2x5_2Tot;
 
-  cluster_tmp.et5x5 = et5x5Tot >> 2;
-  cluster_tmp.et2x5 = etSum2x5 >> 2;
+  cluster_tmp.et5x5 = et5x5Tot;
+  cluster_tmp.et2x5 = etSum2x5;
 
   return cluster_tmp;
 }
@@ -1503,7 +1503,7 @@ inline void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>& cluster_
           dPhi = (phi1 > phi2) ? (phi1 - phi2) : (phi2 - phi1);
 
           if (dPhi < 2) {
-            ap_uint<15> totalEnergy = c1.clusterEnergy() + c2.clusterEnergy();
+            ap_uint<12> totalEnergy = c1.clusterEnergy() + c2.clusterEnergy();
             ap_uint<15> totalEt2x5 = c1.uint_et2x5() + c2.uint_et2x5();
             ap_uint<15> totalEt5x5 = c1.uint_et5x5() + c2.uint_et5x5();
 
@@ -1521,6 +1521,7 @@ inline void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>& cluster_
                                     totalEt5x5,
                                     totalEt2x5,
                                     c1.getBrems(),
+                                    c1.getCalib(),
                                     c1.getIsSS(),
                                     c1.getIsLooseTkss(),
                                     rct_is_iso,
@@ -1535,6 +1536,7 @@ inline void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>& cluster_
                                     0,
                                     0,
                                     0,
+                                    1.0,
                                     false,
                                     false,
                                     rct_is_iso,
@@ -1553,6 +1555,7 @@ inline void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>& cluster_
                                     0,
                                     0,
                                     0,
+                                    1.0,
                                     false,
                                     false,
                                     rct_is_iso,
@@ -1567,6 +1570,7 @@ inline void p2eg::stitchClusterOverRegionBoundary(std::vector<Cluster>& cluster_
                                     totalEt5x5,
                                     totalEt2x5,
                                     c2.getBrems(),
+                                    c2.getCalib(),
                                     c2.getIsSS(),
                                     c2.getIsLooseTkss(),
                                     rct_is_iso,


### PR DESCRIPTION
#### PR description:

Small changes to correctly use ECAL LSB = 0.5 in firmware based code. A fix in RCT cluster stitching function and shower shape flag is implemented.

#### PR validation:

Passes local validation checks with efficiency and rate plots, to be presented in a DP note.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR: https://github.com/cms-sw/cmssw/pull/43950
We need the backport for 14_0_X 