### PR TITLE
[GEM][backport] GEMGeometryBuilder update for the 2024 geometry

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -8,6 +8,8 @@
               Updated:  7 August 2020 
               Updated by Ian J. Watson (ian.james.watson@cern.ch) to allow GE2/1 demonstrator to be built
               Updated: 7 December 2021
+              Updated by Yechan Kang (yechan.kang@cern.ch) to allow GE2/1 demonstrator to be built while 2 GE2/1 layers are in the other region during 2024
+              Updated : 13 Feburary 2024
 */
 #include "Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
@@ -74,7 +76,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     fvGE2.parent();
     doSuper = fvGE2.nextSibling();
   }
-  bool demonstratorGeometry = nGE21 == 1;
+  bool demonstratorGeometry = nGE21 % 2 == 1;
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
@@ -369,7 +371,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     }
   }
 
-  bool demonstratorGeometry = nGE21 == 1;
+  bool demonstratorGeometry = nGE21 % 2 == 1;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
                                << demonstratorGeometry;
@@ -585,8 +587,7 @@ void GEMGeometryBuilder::buildRegions(GEMGeometry& theGeometry,
             auto chamber = theGeometry.chamber(chId);
             if (!chamber) {
               // this particular layer 1 chamber *should* be missing in the demonstrator geometry (we only have layer 2)
-              if (!demonstratorGeometry or
-                  not(chId.region() == 1 and chId.station() == 2 and chId.chamber() == 16 and chId.layer() == 1)) {
+              if (!demonstratorGeometry or not(chId.station() == 2)) {
                 edm::LogWarning("GEMGeometryBuilder") << "Missing chamber " << chId;
               }
             } else {

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -81,7 +81,7 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
       edm::LogError("GEMGeometryParsFromDD") << "Failed to find next child volume. Cannot determine presence of GE 2/1";
     }
   }
-  bool demonstratorGeometry = nGE21 == 1;
+  bool demonstratorGeometry = nGE21 % 2 == 1;
 
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
@@ -296,7 +296,7 @@ void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
       nGE21++;
     }
   }
-  bool demonstratorGeometry = nGE21 == 1;
+  bool demonstratorGeometry = nGE21 % 2 == 1;
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
                                << demonstratorGeometry;


### PR DESCRIPTION
#### PR description:

* The GE2/1 demonstrator was installed at the beginning of Run 3.
* At the beginning of the year, we installed the 2 GE 2/1 production chambers on the other region of the demonstrator.
* @bsunanda made the GEM geometry for 2024. (#43876).
* On the testing for the new geometry, the demonstrator is not built with the new 2 production chambers.
* This PR allows the building of the demonstrator with the 2 new chambers.

#### PR validation:

* `scram b code-format` and `scram b code-checks` are applied
* The built geometry has been tested with `GEMGeometryAnalyzer`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* The original PR is #43948
* The updated is needed for 2024 data taking
