### PR TITLE
[NanoAOD] Backport of #43966 (Add EM energy fraction for CorrT1METJet) to 14_0_X

### DIFF
--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -518,6 +518,7 @@ corrT1METJetTable = simpleCandidateFlatTableProducer.clone(
         eta  = Var("eta",  float,precision=12),
         phi = Var("phi", float, precision=12),
         area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
+        EmEF = Var("chargedEmEnergyFraction()+neutralEmEnergyFraction()", float, doc="charged+neutral Electromagnetic Energy Fraction", precision=6),
     )
 )
 

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -232,6 +232,7 @@ corrT1METJetPuppiTable = simpleCandidateFlatTableProducer.clone(
         eta  = Var("eta",  float,precision=12),
         phi = Var("phi", float, precision=12),
         area = Var("jetArea()", float, doc="jet catchment area, for JECs",precision=10),
+        EmEF = Var("chargedEmEnergyFraction()+neutralEmEnergyFraction()", float, doc="charged+neutral Electromagnetic Energy Fraction", precision=6),
     )
 )
 

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -30,6 +30,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('muonSubtrFactor', 'muonSubtrFactor', 20, 0, 1, '1-(muon-subtracted raw pt)/(raw pt)'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
                 Plot1D('rawPt', 'rawPt', 20, 5, 25, "pt()*jecFactor('Uncorrected')"),
+                Plot1D('EmEF', 'EmEF', 20, 0., 1., "charged+neutral Electromagnetic Energy Fraction"),
             )
         ),
         DeepMETResolutionTune = cms.PSet(


### PR DESCRIPTION
Backport of #43966

#### Original PR description:

This PR adds the charged+neutral EM energy fraction branch for the `CorrT1METJet` table. One of the requirements of the MET Type-1 correction procedure is to only consider jets with EM energy fraction less than 0.9. The main `Jet` table has the EM energy fractions.

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`