### PR TITLE
[14_0_X] Update LHCInfoProducer to use LHCInfoCombined

### DIFF
--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusHarvester.cc
@@ -23,9 +23,6 @@
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 // Condition Format
 #include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
-// LHCinfo
-//#include "CondFormats/RunInfo/interface/LHCInfo.h"
-//#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
 
 // CondOutput
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -37,9 +37,6 @@
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 #include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 
-// #include "CondFormats/RunInfo/interface/LHCInfo.h"
-// #include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
-
 #include <string>
 
 //----------------------------------------------------------------------------------------------------
@@ -220,7 +217,6 @@ private:
 
   edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> ctppsGeometryRunToken_;
   edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> ctppsGeometryEventToken_;
-  // edm::ESGetToken<LHCInfo, LHCInfoRcd> ctppsLhcInfoToken_;
 
   bool excludeMultipleHits_;
   const bool extract_digi_info_;
@@ -594,7 +590,6 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource(const edm::ParameterSet& ps)
           ps.getUntrackedParameter<edm::InputTag>("tagDiamondLocalTracks"))),
       ctppsGeometryRunToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord, edm::Transition::BeginRun>()),
       ctppsGeometryEventToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>()),
-      // ctppsLhcInfoToken_(esConsumes<LHCInfo, LHCInfoRcd>()),
       excludeMultipleHits_(ps.getParameter<bool>("excludeMultipleHits")),
       extract_digi_info_(ps.getParameter<bool>("extractDigiInfo")),
       centralOOT_(-999),
@@ -725,7 +720,6 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
   event.getByToken(tokenDiamondTrack_, diamondLocalTracks);
 
   const CTPPSGeometry* ctppsGeometry = &iSetup.getData(ctppsGeometryEventToken_);
-  // const LHCInfo* hLhcInfo = &iSetup.getData(ctppsLhcInfoToken_);
 
   // check validity
   bool valid = true;
@@ -990,7 +984,6 @@ void CTPPSDiamondDQMSource::analyze(const edm::Event& event, const edm::EventSet
       if (plotOffline_ && !perLSsaving_) {
         // potPlots_[detId_pot].trackTimeVsLS->Fill(event.luminosityBlock(),track.time());
         potPlots_[detId_pot].trackTimeVsBX->Fill(event.bunchCrossing(), track.time());
-        //potPlots_[detId_pot].trackTimeVsXAngle->Fill(hLhcInfo->crossingAngle(), track.time());
       }
     }
   }

--- a/PhysicsTools/NanoAOD/plugins/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/plugins/BuildFile.xml
@@ -6,8 +6,8 @@
 <use name="CondFormats/BTauObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/L1TObjects"/>
-<use name="CondFormats/RunInfo"/>
 <use name="CondTools/BTau"/>
+<use name="CondTools/RunInfo"/>
 <use name="DQMServices/Core"/>
 <use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/CTPPSReco"/>

--- a/PhysicsTools/NanoAOD/plugins/LHCInfoProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/LHCInfoProducer.cc
@@ -45,12 +45,18 @@
 
 #include "FWCore/Utilities/interface/transform.h"
 
-#include "CondFormats/RunInfo/interface/LHCInfo.h"
-#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+#include "CondTools/RunInfo/interface/LHCInfoCombined.h"
 
 class LHCInfoProducer : public edm::global::EDProducer<edm::BeginLuminosityBlockProducer> {
 public:
-  LHCInfoProducer(edm::ParameterSet const&) : lhcinfoToken_(esConsumes<edm::Transition::BeginLuminosityBlock>()) {
+  LHCInfoProducer(edm::ParameterSet const& iConfig)
+      : lhcinfoToken_(esConsumes<edm::Transition::BeginLuminosityBlock>(
+            edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))),
+        lhcinfoPerLSToken_(esConsumes<edm::Transition::BeginLuminosityBlock>(
+            edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerLSLabel")))),
+        lhcinfoPerFillToken_(esConsumes<edm::Transition::BeginLuminosityBlock>(
+            edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoPerFillLabel")))),
+        useNewLHCInfo_(iConfig.getParameter<bool>("useNewLHCInfo")) {
     produces<nanoaod::MergeableCounterTable, edm::Transition::BeginLuminosityBlock>();
   }
   ~LHCInfoProducer() override {}
@@ -59,20 +65,28 @@ public:
   void produce(edm::StreamID id, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {}
 
   void globalBeginLuminosityBlockProduce(edm::LuminosityBlock& iLumi, edm::EventSetup const& iSetup) const override {
-    const auto& info = iSetup.getData(lhcinfoToken_);
+    LHCInfoCombined lhcInfoCombined(iSetup, lhcinfoPerLSToken_, lhcinfoPerFillToken_, lhcinfoToken_, useNewLHCInfo_);
     auto out = std::make_unique<nanoaod::MergeableCounterTable>();
-    out->addFloat("crossingAngle", "LHC crossing angle", info.crossingAngle());
-    out->addFloat("betaStar", "LHC beta star", info.betaStar());
-    out->addFloat("energy", "LHC beam energy", info.energy());
+    out->addFloat("crossingAngle", "LHC crossing angle", lhcInfoCombined.crossingAngle());
+    out->addFloat("betaStar", "LHC beta star", lhcInfoCombined.betaStarX);
+    out->addFloat("energy", "LHC beam energy", lhcInfoCombined.energy);
     iLumi.put(std::move(out));
   }
 
   // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
+    desc.add<std::string>("lhcInfoLabel", "")->setComment("label used for LHCInfo");
+    desc.add<std::string>("lhcInfoPerLSLabel", "")->setComment("label of the LHCInfoPerLS record");
+    desc.add<std::string>("lhcInfoPerFillLabel", "")->setComment("label of the LHCInfoPerFill record");
+    desc.add<bool>("useNewLHCInfo", true)
+        ->setComment("flag whether to use new LHCInfoPerLS/Fill records or old LHCInfo");
     descriptions.addWithDefaultLabel(desc);
   }
   edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcinfoToken_;
+  edm::ESGetToken<LHCInfoPerLS, LHCInfoPerLSRcd> lhcinfoPerLSToken_;
+  edm::ESGetToken<LHCInfoPerFill, LHCInfoPerFillRcd> lhcinfoPerFillToken_;
+  bool useNewLHCInfo_;
 };
 
 DEFINE_FWK_MODULE(LHCInfoProducer);

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -56,7 +56,11 @@ run3_nanoAOD_122.toModify(
     linkedObjects, boostedTaus=None,
 )
 
-lhcInfoTable = cms.EDProducer("LHCInfoProducer")
+from PhysicsTools.NanoAOD.lhcInfoProducer_cfi import lhcInfoProducer
+lhcInfoTable = lhcInfoProducer.clone()
+(~run3_common).toModify(
+    lhcInfoTable, useNewLHCInfo=False
+)
 
 nanoTableTaskCommon = cms.Task(
     cms.Task(nanoMetadata), 

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -14,6 +14,7 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2018_cff import run2_HLTcond
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106Xv2
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_run3_nanoAOD_122_cff import run3_nanoAOD_122
 from Configuration.Eras.Modifier_run3_nanoAOD_124_cff import run3_nanoAOD_124
 from Configuration.Eras.Modifier_run3_jme_Winter22runsBCDEprompt_cff import run3_jme_Winter22runsBCDEprompt


### PR DESCRIPTION
#### PR description:
Verbatim backport of #43956.

This PR updates the NanoAOD `LHCInfoProducer` module to be able to use both old `LHCInfo` (for Run 2) and new `LHCInfoPer*` records (for Run 3).

#### PR validation:
See master PR.

#### Backport:
Backport of #43956.