### PR TITLE
[14.0.X] Fix HLT customization for alpaka PF

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
+++ b/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
@@ -245,18 +245,26 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
 
     process.HLTPFClusterHBHECPUSerial = cms.Sequence(process.hltHBHERecHitToSoA+process.hltPFRecHitSoAProducerHCALCPUSerial+process.hltPFClusterSoAProducerCPUSerial)
 
-    # Add CPUSerial sequences to DQM_HcalReconstruction_v6 Path
-    dqmHcalRecoPathName = "DQM_HcalReconstruction_v6"
-    dqmHcalPath= getattr(process, dqmHcalRecoPathName)
-    dqmHcalRecoPathIndex = dqmHcalPath.index(process.hltHcalConsumerGPU) + 1
-    dqmHcalPath.insert(dqmHcalRecoPathIndex , process.HLTPFClusterHBHECPUSerial)
-
     # modify EventContent of DQMGPUvsCPU stream
     if hasattr(process, 'hltOutputDQMGPUvsCPU'):
         process.hltOutputDQMGPUvsCPU.outputCommands.extend([
             'keep *_hltPFClusterSoAProducer_*_*',
             'keep *_hltPFClusterSoAProducerCPUSerial_*_*',
         ])
+
+    # Add CPUSerial sequences to DQM_HcalReconstruction_v Path
+    dqmHcalRecoPathName = None
+    for pathName in process.paths_():
+        if pathName.startswith('DQM_HcalReconstruction_v'):
+            dqmHcalRecoPathName = pathName
+            break
+
+    if dqmHcalRecoPathName == None:
+        return process
+
+    dqmHcalPath = getattr(process, dqmHcalRecoPathName)
+    dqmHcalRecoPathIndex = dqmHcalPath.index(process.hltHcalConsumerGPU) + 1
+    dqmHcalPath.insert(dqmHcalRecoPathIndex , process.HLTPFClusterHBHECPUSerial)
 
     return process
 

--- a/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
+++ b/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
@@ -66,13 +66,8 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
 
     process.hltPFRecHitSoAProducerHCALCPUSerial = makeSerialClone(process.hltPFRecHitSoAProducerHCAL)
 
-
     process.hltLegacyPFRecHitProducer = cms.EDProducer("LegacyPFRecHitProducer",
             src = cms.InputTag("hltPFRecHitSoAProducerHCAL")
-            )
-
-    process.hltLegacyPFRecHitProducerCPUSerial = process.hltLegacyPFRecHitProducer.clone(
-            src = cms.InputTag("hltPFRecHitSoAProducerHCALCPUSerial")
             )
 
     process.hltPFClusterParamsESProducer = cms.ESProducer("PFClusterParamsESProducer@alpaka",
@@ -204,6 +199,7 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
             PFRecHitsLabelIn = cms.InputTag("hltPFRecHitSoAProducerHCAL")
             )
 
+
     #Same as default except change the clusterSource
     process.hltParticleFlowClusterHCAL = cms.EDProducer("PFMultiDepthClusterProducer",
             clustersSource = cms.InputTag("hltLegacyPFClusterProducer"),
@@ -217,18 +213,16 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
     process.HLTPFHcalRecHits = cms.Sequence(
             process.hltHBHERecHitToSoA+
             process.hltPFRecHitSoAProducerHCAL+
-            process.hltPFRecHitSoAProducerHCALCPUSerial+
-            process.hltLegacyPFRecHitProducer+
-            process.hltLegacyPFRecHitProducerCPUSerial
+            process.hltLegacyPFRecHitProducer
             )
 
     process.HLTPFHcalClustering = cms.Sequence(
             process.HLTPFHcalRecHits+
             process.hltPFClusterSoAProducer+
-            process.hltPFClusterSoAProducerCPUSerial+
             process.hltLegacyPFClusterProducer+
             process.hltParticleFlowClusterHCAL
             )
+
 
     #Some Sequences contain all the modules of process.HLTPFHcalClustering Sequence instead of the Sequence itself
     #find these Sequences and replace all the modules with the Sequence
@@ -248,6 +242,21 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
 
     itemsList = [process.hltParticleFlowRecHitHBHE, process.hltParticleFlowClusterHBHE,process.hltParticleFlowClusterHCAL]
     process = replaceItemsInSequence(process, itemsList, process.HLTPFHcalClustering)
+
+    process.HLTPFClusterHBHECPUSerial = cms.Sequence(process.hltHBHERecHitToSoA+process.hltPFRecHitSoAProducerHCALCPUSerial+process.hltPFClusterSoAProducerCPUSerial)
+
+    # Add CPUSerial sequences to DQM_HcalReconstruction_v6 Path
+    dqmHcalRecoPathName = "DQM_HcalReconstruction_v6"
+    dqmHcalPath= getattr(process, dqmHcalRecoPathName)
+    dqmHcalRecoPathIndex = dqmHcalPath.index(process.hltHcalConsumerGPU) + 1
+    dqmHcalPath.insert(dqmHcalRecoPathIndex , process.HLTPFClusterHBHECPUSerial)
+
+    # modify EventContent of DQMGPUvsCPU stream
+    if hasattr(process, 'hltOutputDQMGPUvsCPU'):
+        process.hltOutputDQMGPUvsCPU.outputCommands.extend([
+            'keep *_hltPFClusterSoAProducer_*_*',
+            'keep *_hltPFClusterSoAProducerCPUSerial_*_*',
+        ])
 
     return process
 


### PR DESCRIPTION
This PR is a backport of [#43999](https://github.com/cms-sw/cmssw/pull/43999)

This PR fixes the customization of Alpaka-PF introduced with [#43979](https://github.com/cms-sw/cmssw/pull/43979) with moving the CPU serial module to `DQM_HcalReconstruction_v6`

GPU vs CPU comparison at DQMOnline will follow up, currently we are only saving the needed collections

Validated running:

```
https_proxy=http://cmsproxy.cms:3128/ hltGetConfiguration /dev/CMSSW_14_0_0/GRun --unprescale --output all --globaltag auto:phase1_2024_realistic --mc --max-events 10 --input /store/mc/Run3Winter24Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/133X_mcRun3_2024_realistic_v8-v2/80000/dc984f7f-2e54-48c4-8950-5daa848b6db9.root --customise HLTrigger/Configuration/customizeHLTforAlpaka.customizeHLTforAlpaka > hlt.py 
```
