### PR TITLE
cms.allowed now accepts a dict when assigning value

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -2446,6 +2446,7 @@ if __name__=="__main__":
             self.assertRaises(ValueError, p.__setattr__, "a", EDAlias())
 
         def testProcessDumpPython(self):
+            self.maxDiff = None
             self.assertEqual(Process("test").dumpPython(),
 """import FWCore.ParameterSet.Config as cms
 

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -176,9 +176,12 @@ class _Parameterizable(object):
             #raise ValueError("unnamed arguments are not allowed. Please use the syntax 'name = value' when assigning arguments.")
             for block in arg:
                 # Allow __PSet for testing
-                if type(block).__name__ not in ["PSet", "__PSet"]:
+                if type(block).__name__ not in ["PSet", "__PSet", "dict"]:
                     raise ValueError("Only PSets can be passed as unnamed argument blocks.  This is a "+type(block).__name__)
-                self.__setParameters(block.parameters_())
+                if isinstance(block,dict):
+                    kargs = block
+                else:
+                    self.__setParameters(block.parameters_())
         self.__setParameters(kargs)
         self._isModified = False
         


### PR DESCRIPTION
#### PR description:

Extended code to also allow PSetTemplate in a cms.allowed statement.

#### PR validation:

Python unit test passes.