### PR TITLE
Add wildcards to generated _cfi.py files

### DIFF
--- a/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
+++ b/FWCore/Integration/test/unit_test_outputs/testProducerWithPsetDesc_cfi.py
@@ -240,7 +240,8 @@ testProducerWithPsetDesc = cms.EDProducer('ProducerWithPSetDesc',
     )
   ),
   wildcardPset = cms.PSet(
-    p_uint_opt = cms.uint32(0)
+    p_uint_opt = cms.uint32(0),
+    allowAnyLabel_ = cms.optional.int32
   ),
   switchPset = cms.PSet(
     iswitch = cms.int32(1),

--- a/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
+++ b/FWCore/ParameterSet/interface/ParameterDescriptionNode.h
@@ -212,6 +212,7 @@ namespace edm {
       checkAndGetLabelsAndTypes_(usedLabels, parameterTypes, wildcardTypes);
     }
 
+    virtual bool isWildcard() const { return false; }
     static void printSpaces(std::ostream& os, int n);
 
   protected:

--- a/FWCore/ParameterSet/interface/ParameterSetDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescription.h
@@ -431,7 +431,7 @@ namespace edm {
   ParameterWildcardBase* ParameterSetDescription::addWildcard(U const& pattern, bool isTracked) {
     std::unique_ptr<ParameterDescriptionNode> node =
         std::make_unique<ParameterWildcard<T>>(pattern, RequireZeroOrMore, isTracked);
-    ParameterDescriptionNode* pnode = addNode(std::move(node), true, false);
+    ParameterDescriptionNode* pnode = addNode(std::move(node), true, true);
     return static_cast<ParameterWildcardBase*>(pnode);
   }
 

--- a/FWCore/ParameterSet/interface/ParameterWildcard.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcard.h
@@ -76,6 +76,7 @@ namespace edm {
     ParameterDescriptionNode* clone() const override;
 
   private:
+    void writeTemplate(std::ostream& os, int indentation) const override;
     void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
 
     bool hasNestedContent_() const override;

--- a/FWCore/ParameterSet/interface/ParameterWildcardBase.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardBase.h
@@ -24,6 +24,8 @@ namespace edm {
     bool isTracked() const { return isTracked_; }
     WildcardValidationCriteria criteria() const { return criteria_; }
 
+    bool isWildcard() const override { return true; }
+
   protected:
     ParameterWildcardBase(ParameterTypes iType, bool isTracked, WildcardValidationCriteria criteria);
 
@@ -48,6 +50,7 @@ namespace edm {
 
     int howManyXORSubNodesExist_(ParameterSet const& pset) const override;
 
+    virtual void writeTemplate(std::ostream& os, int indentation) const;
     ParameterTypes type_;
     bool isTracked_;
     WildcardValidationCriteria criteria_;

--- a/FWCore/ParameterSet/src/ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescription.cc
@@ -129,13 +129,17 @@ namespace edm {
     using std::placeholders::_1;
     bool wroteSomething = false;
 
-    for_all(entries_,
-            std::bind(&ParameterSetDescription::writeNode,
-                      _1,
-                      std::ref(os),
-                      std::ref(startWithComma),
-                      indentation,
-                      std::ref(wroteSomething)));
+    bool seenWildcard = false;
+    for (auto const& entry : entries_) {
+      //only add the first seen wildcard to the cfi. This avoids possible ambiguities.
+      if (entry.node()->isWildcard()) {
+        if (seenWildcard == true) {
+          continue;
+        }
+        seenWildcard = true;
+      }
+      writeNode(entry, os, startWithComma, indentation, wroteSomething);
+    }
 
     if (wroteSomething) {
       char oldFill = os.fill();

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -111,6 +111,15 @@ namespace edm {
     return parameterNames.size() == 1U;
   }
 
+  void ParameterWildcard<ParameterSetDescription>::writeTemplate(std::ostream& os, int indentation) const {
+    os << "PSetTemplate(";
+    indentation += 2;
+    if (psetDesc_) {
+      psetDesc_->writeCfi(os, false, indentation);
+    }
+    os << ")";
+  }
+
   // -------------------------------------------------------------------------
 
   ParameterWildcard<std::vector<ParameterSet> >::ParameterWildcard(std::string const& pattern,

--- a/FWCore/ParameterSet/src/ParameterWildcardBase.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardBase.cc
@@ -147,9 +147,30 @@ namespace edm {
   }
 
   void ParameterWildcardBase::writeCfi_(
-      std::ostream&, bool /*optional*/, bool& /*startWithComma*/, int /*indentation*/, bool& /*wroteSomething*/) const {
-    // Until we implement default labels and values there is nothing
-    // to do here.
+      std::ostream& os, bool optional, bool& startWithComma, int indentation, bool& wroteSomething) const {
+    wroteSomething = true;
+    if (startWithComma)
+      os << ",";
+    startWithComma = true;
+
+    os << "\n";
+    printSpaces(os, indentation);
+
+    os << "allowAnyLabel_ = cms.";
+
+    if (optional) {
+      os << "optional.";
+    } else {
+      os << "required.";
+    }
+    if (!isTracked())
+      os << "untracked.";
+
+    writeTemplate(os, indentation);
+  }
+
+  void ParameterWildcardBase::writeTemplate(std::ostream& os, int indentation) const {
+    os << parameterTypeEnumToString(type());
   }
 
   bool ParameterWildcardBase::partiallyExists_(ParameterSet const& pset) const { return exists(pset); }

--- a/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
+++ b/FWCore/ParameterSet/test/test_catch_ParameterSetDescription.cc
@@ -68,6 +68,7 @@ using testParameterSetDescription::testDesc;
 
 TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
   SECTION("testWildcards") {
+    using Catch::Matchers::Equals;
     {
       edm::ParameterSetDescription set;
       edm::ParameterWildcard<int> w("*", edm::RequireZeroOrMore, true);
@@ -80,6 +81,15 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addParameter<unsigned>("z", 1);
       testDesc(w, set, pset, true, false);
+
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.int32"));
+      }
     }
 
     {
@@ -92,6 +102,15 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addUntrackedParameter<unsigned>("y", 1);
       testDesc(w, set, pset, false, false);
+
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.untracked.uint32"));
+      }
     }
 
     {
@@ -128,6 +147,15 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addParameter<double>("y", 1);
       testDesc(w, set, pset, true, true);
+
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.double"));
+      }
     }
 
     {
@@ -153,6 +181,15 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addParameter<edm::ParameterSet>("nested2", nestedPset);
       testDesc(w, set, pset, true, true);
+
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.PSetTemplate()"));
+      }
     }
 
     {
@@ -193,6 +230,16 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addParameter<edm::ParameterSet>("nested2", nestedPset);
       testDesc(w, set, pset, true, true);
+
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(),
+                     Equals("\nallowAnyLabel_ = cms.required.PSetTemplate(\n  n1 = cms.untracked.uint32(1)\n)"));
+      }
     }
 
     {
@@ -236,6 +283,14 @@ TEST_CASE("test ParameterSetDescription", "[ParameterSetDescription]") {
       testDesc(w, set, pset, true, true);
       pset.addParameter<std::vector<edm::ParameterSet>>("nested2", nestedVPset);
       testDesc(w, set, pset, true, true);
+      SECTION("cfi generation") {
+        std::ostringstream os;
+        bool startWithComma = false;
+        bool wroteSomething = false;
+        w.writeCfi(os, false, startWithComma, 0, wroteSomething);
+
+        REQUIRE_THAT(os.str(), Equals("\nallowAnyLabel_ = cms.required.VPSet"));
+      }
     }
 
     {


### PR DESCRIPTION
#### PR description:

The first wildcard denoted in a ParameterSet descriptions will be added to the _cfi.py file via the allowAnyLabel_ mechanic.

#### PR validation:

Framework unit tests pass.