### PR TITLE
Adding ZDC packer 

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CommonTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CommonTokens.h
@@ -17,6 +17,7 @@ namespace l1t {
     public:
       inline const edm::EDGetTokenT<EGammaBxCollection>& getEGammaToken() const { return egammaToken_; };
       inline const edm::EDGetTokenT<EtSumBxCollection>& getEtSumToken() const { return etSumToken_; };
+      inline const edm::EDGetTokenT<EtSumBxCollection>& getEtSumZDCToken() const { return etSumZDCToken_; };
       inline const edm::EDGetTokenT<JetBxCollection>& getJetToken() const { return jetToken_; };
       inline const edm::EDGetTokenT<TauBxCollection>& getTauToken() const { return tauToken_; };
       inline const edm::EDGetTokenT<MuonBxCollection>& getMuonToken() const { return muonToken_; };
@@ -25,6 +26,7 @@ namespace l1t {
     protected:
       edm::EDGetTokenT<EGammaBxCollection> egammaToken_;
       edm::EDGetTokenT<EtSumBxCollection> etSumToken_;
+      edm::EDGetTokenT<EtSumBxCollection> etSumZDCToken_;
       edm::EDGetTokenT<JetBxCollection> jetToken_;
       edm::EDGetTokenT<TauBxCollection> tauToken_;
       edm::EDGetTokenT<MuonBxCollection> muonToken_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -30,6 +30,7 @@ namespace l1t {
       desc.addOptional<edm::InputTag>("JetInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("TauInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("EtSumInputTag")->setComment("for stage2");
+      desc.addOptional<edm::InputTag>("EtSumZDCInputTag")->setComment("for stage2");
     }
 
     PackerMap GTSetup::getPackers(int fed, unsigned int fw) {
@@ -45,6 +46,7 @@ namespace l1t {
         res[{1, 1}] = {gt_muon_packer,
                        PackerFactory::get()->make("stage2::GTEGammaPacker"),
                        PackerFactory::get()->make("stage2::GTEtSumPacker"),
+                       PackerFactory::get()->make("stage2::GTEtSumZDCPacker"),
                        PackerFactory::get()->make("stage2::GTJetPacker"),
                        PackerFactory::get()->make("stage2::GTTauPacker"),
                        PackerFactory::get()->make("stage2::GlobalAlgBlkPacker"),

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
@@ -13,6 +13,7 @@ namespace l1t {
       auto jettag = cfg.getParameter<edm::InputTag>("JetInputTag");
       auto tautag = cfg.getParameter<edm::InputTag>("TauInputTag");
       auto etsumtag = cfg.getParameter<edm::InputTag>("EtSumInputTag");
+      auto etsumzdctag = cfg.getParameter<edm::InputTag>("EtSumZDCInputTag");
       auto muontag = cfg.getParameter<edm::InputTag>("MuonInputTag");
       auto muonshowertag = cfg.getParameter<edm::InputTag>("ShowerInputLabel");
 
@@ -22,6 +23,7 @@ namespace l1t {
       muonShowerToken_ = cc.consumes<MuonShowerBxCollection>(muonshowertag);
       egammaToken_ = cc.consumes<EGammaBxCollection>(egammatag);
       etSumToken_ = cc.consumes<EtSumBxCollection>(etsumtag);
+      etSumZDCToken_ = cc.consumes<EtSumBxCollection>(etsumzdctag);
       jetToken_ = cc.consumes<JetBxCollection>(jettag);
       tauToken_ = cc.consumes<TauBxCollection>(tautag);
       algToken_ = cc.consumes<GlobalAlgBlkBxCollection>(gttag);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/ZDCPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/ZDCPacker.cc
@@ -1,0 +1,49 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
+
+#include "CaloTokens.h"
+
+#include "L1TStage2Layer2Constants.h"
+#include "ZDCPacker.h"
+#include "GTSetup.h"
+
+namespace l1t {
+  namespace stage2 {
+    Blocks ZDCPacker::pack(const edm::Event& event, const PackerTokens* toks) {
+      edm::Handle<EtSumBxCollection> ZDCSums;
+      event.getByToken(static_cast<const CommonTokens*>(toks)->getEtSumZDCToken(), ZDCSums);
+
+      std::vector<uint32_t> load;
+      int nBx = 0;
+
+      for (int i = ZDCSums->getFirstBX(); i <= ZDCSums->getLastBX(); ++i) {
+        int zdc_mask = 0x3FF;
+        uint32_t empty_word = 0;
+        uint32_t zdcm_word = 0;
+        uint32_t zdcp_word = 0;
+
+        for (auto j = ZDCSums->begin(i); j != ZDCSums->end(i); ++j) {
+          uint32_t word = std::min(j->hwPt(), zdc_mask);
+
+          if (j->getType() == l1t::EtSum::kZDCM)
+            zdcm_word |= word;
+          if (j->getType() == l1t::EtSum::kZDCP)
+            zdcp_word |= word;
+        }
+        load.push_back(empty_word);
+        load.push_back(zdcm_word);
+        load.push_back(zdcp_word);
+
+        //pad with zeros to fill out block; must do this for each BX
+        while (load.size() - nBx * zdc::nOutputFramePerBX < zdc::nOutputFramePerBX)
+          load.push_back(0);
+        nBx++;
+      }
+
+      return {Block(b1_, load)};
+    }
+  }  // namespace stage2
+}  // namespace l1t
+
+// DEFINE_L1T_PACKER(l1t::stage2::CaloEtSumZDCPacker);
+DEFINE_L1T_PACKER(l1t::stage2::GTEtSumZDCPacker);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/ZDCPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/ZDCPacker.h
@@ -1,0 +1,26 @@
+#ifndef L1T_PACKER_STAGE2_ETSUMPACKER_H
+#define L1T_PACKER_STAGE2_ETSUMPACKER_H
+
+#include "EventFilter/L1TRawToDigi/interface/Packer.h"
+
+namespace l1t {
+  namespace stage2 {
+    class ZDCPacker : public Packer {
+    public:
+      ZDCPacker(int b1) : b1_(b1) {}
+      Blocks pack(const edm::Event&, const PackerTokens*) override;
+      int b1_;
+    };
+    class GTEtSumZDCPacker : public ZDCPacker {
+    public:
+      GTEtSumZDCPacker() : ZDCPacker(142) {}
+    };
+    // class CaloEtSumZDCPacker : public ZDCPacker {
+    // public:
+    //   CaloEtSumZDCPacker() : ZDCPacker(143) {}
+    // };
+
+  }  // namespace stage2
+}  // namespace l1t
+
+#endif

--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -12,6 +12,7 @@ gtStage2Raw = cms.EDProducer(
     TauInputTag    = cms.InputTag("simCaloStage2Digis"),
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
     EtSumInputTag  = cms.InputTag("simCaloStage2Digis"),
+    EtSumZDCInputTag  = cms.InputTag("simCaloStage2Digis"),
     FedId = cms.int32(1404),
     FWId = cms.uint32(0x1150), # FW w/ 2loose hadronic showers.
     lenSlinkHeader = cms.untracked.int32(8),

--- a/EventFilter/L1TRawToDigi/test/test_RawToDigiToRawToDigi_GT.py
+++ b/EventFilter/L1TRawToDigi/test/test_RawToDigiToRawToDigi_GT.py
@@ -1,0 +1,104 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('L1')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.Geometry.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+# Input source
+process.source = cms.Source(
+        "PoolSource",
+        fileNames = cms.untracked.vstring([
+            "/store/hidata/HIRun2023A/HIMinimumBias1/RAW/v1/000/374/345/00000/1332e7ef-bf52-4bc4-b6e2-aae1be281411.root",
+            "/store/hidata/HIRun2023A/HIMinimumBias1/RAW/v1/000/374/345/00000/6b72b001-db9b-4490-aec8-29eb1de07108.root",
+            "/store/hidata/HIRun2023A/HIMinimumBias1/RAW/v1/000/374/345/00000/1859b208-0daf-4382-a2fc-444a8e7628aa.root",
+            "/store/hidata/HIRun2023A/HIMinimumBias1/RAW/v1/000/374/345/00000/77101f68-bc1b-4ca6-a8ba-f48bef24b8de.root",
+            "/store/hidata/HIRun2023A/HIMinimumBias1/RAW/v1/000/374/345/00000/1fc90d44-5798-4eb1-a3c0-2c2e2e9a9df6.root"
+        ]),
+        eventsToProcess = cms.untracked.VEventRange('374345:1-374345:MAX')
+)
+
+process.options = cms.untracked.PSet(
+    SkipEvent = cms.untracked.vstring('ProductNotFound')
+)
+
+
+# Output definition
+
+process.output = cms.OutputModule(
+    "PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = cms.untracked.vstring("keep *",
+					   "drop *_mix_*_*"),
+    fileName = cms.untracked.string('L1T_EDM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+# # TTree output file
+# process.load("CommonTools.UtilAlgos.TFileService_cfi")
+# process.TFileService.fileName = cms.string('l1t.root')
+
+
+process.load('EventFilter.L1TRawToDigi.gtStage2Digis_cfi')
+process.gtStage2Digis.InputLabel = cms.InputTag('rawDataRepacker')
+process.gtStage2Digis.debug = cms.untracked.bool(False)
+
+process.load('EventFilter.L1TRawToDigi.gtStage2Raw_cfi')
+process.gtStage2Raw.InputLabel = cms.InputTag("gtStage2Digis","GT")
+
+process.gtStage2Raw.GtInputTag = cms.InputTag("gtStage2Digis","")
+process.gtStage2Raw.ExtInputTag = cms.InputTag("gtStage2Digis")
+process.gtStage2Raw.MuonInputTag   = cms.InputTag("gtStage2Digis","Muon")
+process.gtStage2Raw.EGammaInputTag = cms.InputTag("gtStage2Digis","EGamma")
+process.gtStage2Raw.TauInputTag    = cms.InputTag("gtStage2Digis","Tau")
+process.gtStage2Raw.JetInputTag    = cms.InputTag("gtStage2Digis","Jet")
+process.gtStage2Raw.EtSumInputTag  = cms.InputTag("gtStage2Digis","EtSum")  
+process.gtStage2Raw.EtSumZDCInputTag  = cms.InputTag("gtStage2Digis","EtSumZDC")  
+
+
+# dump raw data
+process.dumpRaw = cms.EDAnalyzer( 
+    "DumpFEDRawDataProduct",
+    token = cms.untracked.InputTag('gtStage2Raw'),
+    label = cms.untracked.InputTag('gtStage2Raw'),
+    feds = cms.untracked.vint32 ( 1404 ),
+    dumpPayload = cms.untracked.bool ( False )
+)
+process.unpackGtStage2 = process.gtStage2Digis.clone()
+process.unpackGtStage2.InputLabel = cms.InputTag('gtStage2Raw')
+process.unpackGtStage2.debug = cms.untracked.bool(False)
+
+
+# Path and EndPath definitions
+process.path = cms.Path(
+    process.gtStage2Digis
+    + process.gtStage2Raw
+    # + process.dumpRaw
+    + process.unpackGtStage2
+)
+
+process.out = cms.EndPath(
+    process.output
+)


### PR DESCRIPTION
#### PR description:
Adding a ZDC packer to EventFilter/L1TRawtoDigi

Only output change should be L1TDigitoRaw now can include EtSumZDC info.

PR has no dependencies

#### PR validation:

PR tested with EventFilter/L1TRawtoDigi/test/test_RawToDigiToRawToDigi_GT_cfi.py where the output produces 2 sets of data:
1) Raw Dataunpacked to Digis
2) Raw Data unpacked to Digis then repacked and unpacked again

These 2 data sets were compared and were identical for EtSumZDC data.

I attached the summary of the RunTheMatrix test where there were some failures 
[RunTheMatrixSummary.txt](https://github.com/cms-sw/cmssw/files/14336808/RunTheMatrixSummary.txt)
