### PR TITLE
Move relval2023 to point to Fake2 for HLT [140X]

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -11,7 +11,7 @@ autoHLT = {
   'relval2017' : 'Fake2',
   'relval2018' : 'Fake2',
   'relval2022' : 'Fake2',
-  'relval2023' : '2023v12',
+  'relval2023' : 'Fake2',
   'relval2024' : 'GRun',
   'relval2026' : '75e33',
   'test'       : 'GRun',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2830,7 +2830,7 @@ upgradeProperties[2017] = {
         'HLTmenu': '@relval2023',
         'Era' : 'Run3_2023',
         'BeamSpot': 'DBrealistic',
-        'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
+        'ScenToRun' : ['GenSim','Digi','RecoNanoFakeHLT','HARVESTNanoFakeHLT','ALCA'],
     },
     '2024' : {
         'Geom' : 'DB:Extended',


### PR DESCRIPTION
#### PR description:

Move relval2023 to point to Fake2 for HLT [141X]

The HLT menu of 2023 should be run in 13_0 or 13_2 used for 2023 data taking

#### PR validation:

TSG tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44026 

14_0/14_1 are for 2024 HLT menus and data taking
