### PR TITLE
Update Run3 HLT GT with PPS conditions for 2024 data-taking

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,8 +31,8 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v1 but with snapshot at 2024-01-20 12:00:00 (UTC)
-    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v1',
+    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v2 with snapshot at 2024-02-20 12:00:00 (UTC)
+    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v2',
     # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
     'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v1 but snapshot at 2024-01-20 12:00:00 (UTC)


### PR DESCRIPTION
#### PR description:
The PR updates the Run3 HLT GT to include the PPS conditions needed prior-to/and complementary to the HLT menu updates being integrated and tested in https://its.cern.ch/jira/browse/CMSHLT-3030. 

The updates in the GT are as follows:
- Replaces [PPSOpticalFunctions_hlt_v9](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/PPSOpticalFunctions_hlt_v9) --> [PPSOpticalFunctions_hlt_v10](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/PPSOpticalFunctions_hlt_v10)  
   - Additional IOV `2c2710a032f957718c87bcc41b44195b8a177bf9` from Run 362920 (2023-01-12) 
- Includes new tags for LHCInfoPerFillRcd and LHCInfoPerLSRcd (Not yet in production, O2O not writing to these for now)
- Removal of old LHCInfo tag from HLT as a cleanup detailed in https://github.com/cms-AlCaDB/AlCaTools/issues/87
- Replaces [CTPPSRPAlignment_real_Run3_v2_hlt](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/CTPPSRPAlignment_real_Run3_v2_hlt) --> [CTPPSRPAlignment_real_Run3_v4_hlt](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/CTPPSRPAlignment_real_Run3_v4_hlt)
  - Additional new IOVs starting Run 366396 (2023-04-21)  

**GT Difference**
- run3_hlt
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_HLT_frozen_v1/140X_dataRun3_HLT_frozen_v2


#### PR validation:
Tested successfully with `runTheMatrix.py -l 141.044,140.065,141.008,140.022 -j 10 --ibeos` 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 140X will be followed up soon after

FYI @cms-sw/hlt-l2 @cms-sw/ctpps-dpg-l2 
