### PR TITLE
Let tests fail gracefully if no devices are found [14.0.x]

### DIFF
--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.cc
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.cc
@@ -1,45 +1,50 @@
+#include <cstdlib>
+
 #include <alpaka/alpaka.hpp>
 
-#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersSoACollection.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
-
-#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "Clusters_test.h"
 
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testClusterSoA {
-
-    void runKernels(SiPixelClustersSoAView clust_view, Queue& queue);
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-
 int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
-
-  // Inner scope to deallocate memory before destroying the stream
-  {
-    // Instantiate tracks on device. PortableDeviceCollection allocates
-    // SoA on device automatically.
-    SiPixelClustersSoACollection clusters_d(100, queue);
-    testClusterSoA::runKernels(clusters_d.view(), queue);
-
-    // Instantate tracks on host. This is where the data will be
-    // copied to from device.
-    SiPixelClustersHost clusters_h(clusters_d.view().metadata().size(), queue);
-
-    std::cout << clusters_h.view().metadata().size() << std::endl;
-    alpaka::memcpy(queue, clusters_h.buffer(), clusters_d.const_buffer());
-    alpaka::wait(queue);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
-  return 0;
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
+
+    // Inner scope to deallocate memory before destroying the stream
+    {
+      // Instantiate tracks on device. PortableDeviceCollection allocates
+      // SoA on device automatically.
+      SiPixelClustersSoACollection clusters_d(100, queue);
+      testClusterSoA::runKernels(clusters_d.view(), queue);
+
+      // Instantate tracks on host. This is where the data will be
+      // copied to from device.
+      SiPixelClustersHost clusters_h(clusters_d.view().metadata().size(), queue);
+
+      std::cout << clusters_h.view().metadata().size() << std::endl;
+      alpaka::memcpy(queue, clusters_h.buffer(), clusters_d.const_buffer());
+      alpaka::wait(queue);
+    }
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.dev.cc
@@ -1,49 +1,50 @@
-#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersSoACollection.h"
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersDevice.h"
 #include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersHost.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "DataFormats/SiPixelClusterSoA/interface/alpaka/SiPixelClustersSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "Clusters_test.h"
 
 using namespace alpaka;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA {
 
-  using namespace cms::alpakatools;
-  namespace testClusterSoA {
-
-    class TestFillKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAView clust_view) const {
-        for (int32_t j : uniform_elements(acc, clust_view.metadata().size())) {
-          clust_view[j].moduleStart() = j;
-          clust_view[j].clusInModule() = j * 2;
-          clust_view[j].moduleId() = j * 3;
-          clust_view[j].clusModuleStart() = j * 4;
-        }
+  class TestFillKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAView clust_view) const {
+      for (int32_t j : cms::alpakatools::uniform_elements(acc, clust_view.metadata().size())) {
+        clust_view[j].moduleStart() = j;
+        clust_view[j].clusInModule() = j * 2;
+        clust_view[j].moduleId() = j * 3;
+        clust_view[j].clusModuleStart() = j * 4;
       }
-    };
-
-    class TestVerifyKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAConstView clust_view) const {
-        for (uint32_t j : uniform_elements(acc, clust_view.metadata().size())) {
-          assert(clust_view[j].moduleStart() == j);
-          assert(clust_view[j].clusInModule() == j * 2);
-          assert(clust_view[j].moduleId() == j * 3);
-          assert(clust_view[j].clusModuleStart() == j * 4);
-        }
-      }
-    };
-
-    void runKernels(SiPixelClustersSoAView clust_view, Queue& queue) {
-      uint32_t items = 64;
-      uint32_t groups = divide_up_by(clust_view.metadata().size(), items);
-      auto workDiv = make_workdiv<Acc1D>(groups, items);
-      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, clust_view);
-      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, clust_view);
     }
+  };
 
-  }  // namespace testClusterSoA
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+  class TestVerifyKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelClustersSoAConstView clust_view) const {
+      for (uint32_t j : cms::alpakatools::uniform_elements(acc, clust_view.metadata().size())) {
+        assert(clust_view[j].moduleStart() == j);
+        assert(clust_view[j].clusInModule() == j * 2);
+        assert(clust_view[j].moduleId() == j * 3);
+        assert(clust_view[j].clusModuleStart() == j * 4);
+      }
+    }
+  };
+
+  void runKernels(SiPixelClustersSoAView clust_view, Queue& queue) {
+    uint32_t items = 64;
+    uint32_t groups = cms::alpakatools::divide_up_by(clust_view.metadata().size(), items);
+    auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, clust_view);
+    alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, clust_view);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA

--- a/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.h
+++ b/DataFormats/SiPixelClusterSoA/test/alpaka/Clusters_test.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_SiPixelClusterSoA_test_alpaka_Clusters_test_h
+#define DataFormats_SiPixelClusterSoA_test_alpaka_Clusters_test_h
+
+#include "DataFormats/SiPixelClusterSoA/interface/SiPixelClustersSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA {
+
+  void runKernels(SiPixelClustersSoAView clust_view, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testClusterSoA
+
+#endif  // DataFormats_SiPixelClusterSoA_test_alpaka_Clusters_test_h

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.cc
@@ -1,54 +1,59 @@
-#include <alpaka/alpaka.hpp>
+#include <cstdlib>
 #include <unistd.h>
+
+#include <alpaka/alpaka.hpp>
 
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsSoACollection.h"
-
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 
+#include "DigiErrors_test.h"
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testDigisSoA {
-
-    void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue);
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-
 int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
-
-  // Inner scope to deallocate memory before destroying the stream
-  {
-    // Instantiate tracks on device. PortableDeviceCollection allocates
-    // SoA on device automatically.
-    SiPixelDigiErrorsSoACollection digiErrors_d(1000, queue);
-    testDigisSoA::runKernels(digiErrors_d.view(), queue);
-
-    // Instantate tracks on host. This is where the data will be
-    // copied to from device.
-    SiPixelDigiErrorsHost digiErrors_h(digiErrors_d.view().metadata().size(), queue);
-    alpaka::memcpy(queue, digiErrors_h.buffer(), digiErrors_d.const_buffer());
-    std::cout << "digiErrors_h.view().metadata().size(): " << digiErrors_h.view().metadata().size() << std::endl;
-    std::cout << "digiErrors_h.view()[100].pixelErrors().rawId: " << digiErrors_h.view()[100].pixelErrors().rawId
-              << std::endl;
-    std::cout << "digiErrors_h.view()[100].pixelErrors().word: " << digiErrors_h.view()[100].pixelErrors().word
-              << std::endl;
-    std::cout << "digiErrors_h.view()[100].pixelErrors().errorType: "
-              << digiErrors_h.view()[100].pixelErrors().errorType << std::endl;
-    std::cout << "digiErrors_h.view()[100].pixelErrors().fedId: " << digiErrors_h.view()[100].pixelErrors().fedId
-              << std::endl;
-    alpaka::wait(queue);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
-  return 0;
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
+
+    // Inner scope to deallocate memory before destroying the stream
+    {
+      // Instantiate tracks on device. PortableDeviceCollection allocates
+      // SoA on device automatically.
+      SiPixelDigiErrorsSoACollection digiErrors_d(1000, queue);
+      testDigisSoA::runKernels(digiErrors_d.view(), queue);
+
+      // Instantate tracks on host. This is where the data will be
+      // copied to from device.
+      SiPixelDigiErrorsHost digiErrors_h(digiErrors_d.view().metadata().size(), queue);
+      alpaka::memcpy(queue, digiErrors_h.buffer(), digiErrors_d.const_buffer());
+      std::cout << "digiErrors_h.view().metadata().size(): " << digiErrors_h.view().metadata().size() << std::endl;
+      std::cout << "digiErrors_h.view()[100].pixelErrors().rawId: " << digiErrors_h.view()[100].pixelErrors().rawId
+                << std::endl;
+      std::cout << "digiErrors_h.view()[100].pixelErrors().word: " << digiErrors_h.view()[100].pixelErrors().word
+                << std::endl;
+      std::cout << "digiErrors_h.view()[100].pixelErrors().errorType: "
+                << digiErrors_h.view()[100].pixelErrors().errorType << std::endl;
+      std::cout << "digiErrors_h.view()[100].pixelErrors().fedId: " << digiErrors_h.view()[100].pixelErrors().fedId
+                << std::endl;
+      alpaka::wait(queue);
+    }
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.dev.cc
@@ -1,50 +1,51 @@
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsSoACollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsHost.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigiErrorsSoACollection.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelErrorCompact.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+#include "DigiErrors_test.h"
 
 using namespace alpaka;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
-  using namespace cms::alpakatools;
-  namespace testDigisSoA {
-
-    class TestFillKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAView digiErrors_view) const {
-        for (uint32_t j : elements_with_stride(acc, digiErrors_view.metadata().size())) {
-          digiErrors_view[j].pixelErrors().rawId = j;
-          digiErrors_view[j].pixelErrors().word = j;
-          digiErrors_view[j].pixelErrors().errorType = j;
-          digiErrors_view[j].pixelErrors().fedId = j;
-        }
+  class TestFillKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAView digiErrors_view) const {
+      for (uint32_t j : cms::alpakatools::uniform_elements(acc, digiErrors_view.metadata().size())) {
+        digiErrors_view[j].pixelErrors().rawId = j;
+        digiErrors_view[j].pixelErrors().word = j;
+        digiErrors_view[j].pixelErrors().errorType = j;
+        digiErrors_view[j].pixelErrors().fedId = j;
       }
-    };
-
-    class TestVerifyKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAConstView digiErrors_view) const {
-        for (uint32_t j : elements_with_stride(acc, digiErrors_view.metadata().size())) {
-          assert(digiErrors_view[j].pixelErrors().rawId == j);
-          assert(digiErrors_view[j].pixelErrors().word == j);
-          assert(digiErrors_view[j].pixelErrors().errorType == j % 256);
-          assert(digiErrors_view[j].pixelErrors().fedId == j % 256);
-        }
-      }
-    };
-
-    void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue) {
-      uint32_t items = 64;
-      uint32_t groups = divide_up_by(digiErrors_view.metadata().size(), items);
-      auto workDiv = make_workdiv<Acc1D>(groups, items);
-      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, digiErrors_view);
-      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, digiErrors_view);
     }
+  };
 
-  }  // namespace testDigisSoA
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+  class TestVerifyKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigiErrorsSoAConstView digiErrors_view) const {
+      for (uint32_t j : cms::alpakatools::uniform_elements(acc, digiErrors_view.metadata().size())) {
+        assert(digiErrors_view[j].pixelErrors().rawId == j);
+        assert(digiErrors_view[j].pixelErrors().word == j);
+        assert(digiErrors_view[j].pixelErrors().errorType == j % 256);
+        assert(digiErrors_view[j].pixelErrors().fedId == j % 256);
+      }
+    }
+  };
+
+  void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue) {
+    uint32_t items = 64;
+    uint32_t groups = cms::alpakatools::divide_up_by(digiErrors_view.metadata().size(), items);
+    auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, digiErrors_view);
+    alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, digiErrors_view);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.h
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/DigiErrors_test.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_SiPixelDigiSoA_test_alpaka_DigiErrors_test_h
+#define DataFormats_SiPixelDigiSoA_test_alpaka_DigiErrors_test_h
+
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
+
+  void runKernels(SiPixelDigiErrorsSoAView digiErrors_view, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA
+
+#endif  // DataFormats_SiPixelDigiSoA_test_alpaka_DigiErrors_test_h

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.cc
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <unistd.h>
 
 #include <alpaka/alpaka.hpp>
@@ -6,43 +7,46 @@
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h"
 #include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
+#include "Digis_test.h"
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testDigisSoA {
-
-    void runKernels(SiPixelDigisSoAView digis_view, Queue& queue);
-
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-
 int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
-
-  // Inner scope to deallocate memory before destroying the stream
-  {
-    // Instantiate tracks on device. PortableDeviceCollection allocates
-    // SoA on device automatically.
-    SiPixelDigisSoACollection digis_d(1000, queue);
-    testDigisSoA::runKernels(digis_d.view(), queue);
-
-    // Instantate tracks on host. This is where the data will be
-    // copied to from device.
-    SiPixelDigisHost digis_h(digis_d.view().metadata().size(), queue);
-
-    std::cout << digis_h.view().metadata().size() << std::endl;
-    alpaka::memcpy(queue, digis_h.buffer(), digis_d.const_buffer());
-    alpaka::wait(queue);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
-  return 0;
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
+
+    // Inner scope to deallocate memory before destroying the stream
+    {
+      // Instantiate tracks on device. PortableDeviceCollection allocates
+      // SoA on device automatically.
+      SiPixelDigisSoACollection digis_d(1000, queue);
+      testDigisSoA::runKernels(digis_d.view(), queue);
+
+      // Instantate tracks on host. This is where the data will be
+      // copied to from device.
+      SiPixelDigisHost digis_h(digis_d.view().metadata().size(), queue);
+
+      std::cout << digis_h.view().metadata().size() << std::endl;
+      alpaka::memcpy(queue, digis_h.buffer(), digis_d.const_buffer());
+      alpaka::wait(queue);
+    }
+  }
+
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.dev.cc
@@ -1,49 +1,48 @@
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h"
-#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
 #include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
-using namespace alpaka;
+#include "Digis_test.h"
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
 
-  using namespace cms::alpakatools;
-  namespace testDigisSoA {
-
-    class TestFillKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAView digi_view) const {
-        for (int32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
-          digi_view[j].clus() = j;
-          digi_view[j].rawIdArr() = j * 2;
-          digi_view[j].xx() = j * 3;
-          digi_view[j].moduleId() = j * 4;
-        }
+  class TestFillKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAView digi_view) const {
+      for (int32_t j : cms::alpakatools::uniform_elements(acc, digi_view.metadata().size())) {
+        digi_view[j].clus() = j;
+        digi_view[j].rawIdArr() = j * 2;
+        digi_view[j].xx() = j * 3;
+        digi_view[j].moduleId() = j * 4;
       }
-    };
-
-    class TestVerifyKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAConstView digi_view) const {
-        for (uint32_t j : elements_with_stride(acc, digi_view.metadata().size())) {
-          assert(digi_view[j].clus() == int(j));
-          assert(digi_view[j].rawIdArr() == j * 2);
-          assert(digi_view[j].xx() == j * 3);
-          assert(digi_view[j].moduleId() == j * 4);
-        }
-      }
-    };
-
-    void runKernels(SiPixelDigisSoAView digi_view, Queue& queue) {
-      uint32_t items = 64;
-      uint32_t groups = divide_up_by(digi_view.metadata().size(), items);
-      auto workDiv = make_workdiv<Acc1D>(groups, items);
-      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, digi_view);
-      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, digi_view);
     }
+  };
 
-  }  // namespace testDigisSoA
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+  class TestVerifyKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, SiPixelDigisSoAConstView digi_view) const {
+      for (uint32_t j : cms::alpakatools::uniform_elements(acc, digi_view.metadata().size())) {
+        assert(digi_view[j].clus() == int(j));
+        assert(digi_view[j].rawIdArr() == j * 2);
+        assert(digi_view[j].xx() == j * 3);
+        assert(digi_view[j].moduleId() == j * 4);
+      }
+    }
+  };
+
+  void runKernels(SiPixelDigisSoAView digi_view, Queue& queue) {
+    uint32_t items = 64;
+    uint32_t groups = cms::alpakatools::divide_up_by(digi_view.metadata().size(), items);
+    auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, digi_view);
+    alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, digi_view);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA

--- a/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.h
+++ b/DataFormats/SiPixelDigiSoA/test/alpaka/Digis_test.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_SiPixelDigiSoA_test_alpaka_Digis_test_h
+#define DataFormats_SiPixelDigiSoA_test_alpaka_Digis_test_h
+
+#include "DataFormats/SiPixelDigiSoA/interface/SiPixelDigisSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA {
+
+  void runKernels(SiPixelDigisSoAView digis_view, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testDigisSoA
+
+#endif  // DataFormats_SiPixelDigiSoA_test_alpaka_Digis_test_h

--- a/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.cc
+++ b/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.cc
@@ -13,70 +13,74 @@
    the same Layout to access the data on host and print it.
  */
 
-#include <alpaka/alpaka.hpp>
+#include <cstdlib>
 #include <unistd.h>
-#include "DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h"
+
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/TrackSoA/interface/TracksDevice.h"
 #include "DataFormats/TrackSoA/interface/TracksHost.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "DataFormats/TrackSoA/interface/alpaka/TracksSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
-using namespace std;
-using namespace reco;
+#include "TrackSoAHeterogeneous_test.h"
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE::pixelTrack;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testTrackSoA {
-
-    template <typename TrackerTraits>
-    void runKernels(TrackSoAView<TrackerTraits> tracks_view, Queue& queue);
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-
 int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
+  }
 
-  // Inner scope to deallocate memory before destroying the stream
-  {
-    // Instantiate tracks on device. PortableDeviceCollection allocates
-    // SoA on device automatically.
-    TracksSoACollection<pixelTopology::Phase1> tracks_d(queue);
-    testTrackSoA::runKernels<pixelTopology::Phase1>(tracks_d.view(), queue);
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
 
-    // Instantate tracks on host. This is where the data will be
-    // copied to from device.
-    TracksHost<pixelTopology::Phase1> tracks_h(queue);
+    // Inner scope to deallocate memory before destroying the stream
+    {
+      // Instantiate tracks on device. PortableDeviceCollection allocates
+      // SoA on device automatically.
+      TracksSoACollection<pixelTopology::Phase1> tracks_d(queue);
+      testTrackSoA::runKernels<pixelTopology::Phase1>(tracks_d.view(), queue);
 
-    std::cout << tracks_h.view().metadata().size() << std::endl;
-    alpaka::memcpy(queue, tracks_h.buffer(), tracks_d.const_buffer());
-    alpaka::wait(queue);
+      // Instantate tracks on host. This is where the data will be
+      // copied to from device.
+      TracksHost<pixelTopology::Phase1> tracks_h(queue);
 
-    // Print results
-    std::cout << "pt"
-              << "\t"
-              << "eta"
-              << "\t"
-              << "chi2"
-              << "\t"
-              << "quality"
-              << "\t"
-              << "nLayers"
-              << "\t"
-              << "hitIndices off" << std::endl;
+      std::cout << tracks_h.view().metadata().size() << std::endl;
+      alpaka::memcpy(queue, tracks_h.buffer(), tracks_d.const_buffer());
+      alpaka::wait(queue);
 
-    for (int i = 0; i < 10; ++i) {
-      std::cout << tracks_h.view()[i].pt() << "\t" << tracks_h.view()[i].eta() << "\t" << tracks_h.view()[i].chi2()
-                << "\t" << (int)tracks_h.view()[i].quality() << "\t" << (int)tracks_h.view()[i].nLayers() << "\t"
-                << tracks_h.view().hitIndices().off[i] << std::endl;
+      // Print results
+      std::cout << "pt"
+                << "\t"
+                << "eta"
+                << "\t"
+                << "chi2"
+                << "\t"
+                << "quality"
+                << "\t"
+                << "nLayers"
+                << "\t"
+                << "hitIndices off" << std::endl;
+
+      for (int i = 0; i < 10; ++i) {
+        std::cout << tracks_h.view()[i].pt() << "\t" << tracks_h.view()[i].eta() << "\t" << tracks_h.view()[i].chi2()
+                  << "\t" << (int)tracks_h.view()[i].quality() << "\t" << (int)tracks_h.view()[i].nLayers() << "\t"
+                  << tracks_h.view().hitIndices().off[i] << std::endl;
+      }
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.dev.cc
+++ b/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.dev.cc
@@ -9,6 +9,8 @@
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
+#include "TrackSoAHeterogeneous_test.h"
+
 using namespace reco;
 
 using Quality = pixelTrack::Quality;

--- a/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.h
+++ b/DataFormats/TrackSoA/test/alpaka/TrackSoAHeterogeneous_test.h
@@ -1,0 +1,14 @@
+#ifndef DataFormats_TrackSoA_test_alpaka_TrackSoAHeterogeneous_test_h
+#define DataFormats_TrackSoA_test_alpaka_TrackSoAHeterogeneous_test_h
+
+#include "DataFormats/TrackSoA/interface/TracksSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testTrackSoA {
+
+  template <typename TrackerTraits>
+  void runKernels(reco::TrackSoAView<TrackerTraits> tracks_view, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testTrackSoA
+
+#endif  // DataFormats_TrackSoA_test_alpaka_TrackSoAHeterogeneous_test_h

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.cc
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.cc
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <unistd.h>
 
 #include <alpaka/alpaka.hpp>
@@ -5,56 +6,60 @@
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsDevice.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h"
 #include "DataFormats/TrackingRecHitSoA/interface/alpaka/TrackingRecHitsSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
+#include "Hits_test.h"
+
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testTrackingRecHitSoA {
-
-    template <typename TrackerTraits>
-    void runKernels(TrackingRecHitSoAView<TrackerTraits>& hits, Queue& queue);
-
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
-
 int main() {
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
+  }
 
-  // inner scope to deallocate memory before destroying the queue
-  {
-    uint32_t nHits = 2000;
-    int32_t offset = 100;
-    uint32_t moduleStart[pixelTopology::Phase1::numberOfModules + 1];
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
 
-    for (size_t i = 0; i < pixelTopology::Phase1::numberOfModules + 1; ++i) {
-      moduleStart[i] = i * 2;
-    }
-    TrackingRecHitsSoACollection<pixelTopology::Phase1> tkhit(queue, nHits, offset, moduleStart);
+    // inner scope to deallocate memory before destroying the queue
+    {
+      uint32_t nHits = 2000;
+      int32_t offset = 100;
+      uint32_t moduleStart[pixelTopology::Phase1::numberOfModules + 1];
 
-    testTrackingRecHitSoA::runKernels<pixelTopology::Phase1>(tkhit.view(), queue);
-    tkhit.updateFromDevice(queue);
+      for (size_t i = 0; i < pixelTopology::Phase1::numberOfModules + 1; ++i) {
+        moduleStart[i] = i * 2;
+      }
+      TrackingRecHitsSoACollection<pixelTopology::Phase1> tkhit(queue, nHits, offset, moduleStart);
+
+      testTrackingRecHitSoA::runKernels<pixelTopology::Phase1>(tkhit.view(), queue);
+      tkhit.updateFromDevice(queue);
 
 #if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED or defined ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-    // requires c++23 to make cms::alpakatools::CopyToHost compile using if constexpr
-    // see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
-    TrackingRecHitHost<pixelTopology::Phase1> const& host_collection = tkhit;
+      // requires c++23 to make cms::alpakatools::CopyToHost compile using if constexpr
+      // see https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2593r0.html
+      TrackingRecHitHost<pixelTopology::Phase1> const& host_collection = tkhit;
 #else
-    TrackingRecHitHost<pixelTopology::Phase1> host_collection =
-        cms::alpakatools::CopyToHost<TrackingRecHitDevice<pixelTopology::Phase1, Device> >::copyAsync(queue, tkhit);
+      TrackingRecHitHost<pixelTopology::Phase1> host_collection =
+          cms::alpakatools::CopyToHost<TrackingRecHitDevice<pixelTopology::Phase1, Device> >::copyAsync(queue, tkhit);
 #endif
-    // wait for the kernel and the potential copy to complete
-    alpaka::wait(queue);
-    assert(tkhit.nHits() == nHits);
-    assert(tkhit.offsetBPIX2() == 22);  // set in the kernel
-    assert(tkhit.nHits() == host_collection.nHits());
-    assert(tkhit.offsetBPIX2() == host_collection.offsetBPIX2());
+      // wait for the kernel and the potential copy to complete
+      alpaka::wait(queue);
+      assert(tkhit.nHits() == nHits);
+      assert(tkhit.offsetBPIX2() == 22);  // set in the kernel
+      assert(tkhit.nHits() == host_collection.nHits());
+      assert(tkhit.offsetBPIX2() == host_collection.offsetBPIX2());
+    }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.dev.cc
@@ -9,6 +9,8 @@
 #include "HeterogeneousCore/AlpakaInterface/interface/traits.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
+#include "Hits_test.h"
+
 using namespace alpaka;
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.h
+++ b/DataFormats/TrackingRecHitSoA/test/alpaka/Hits_test.h
@@ -1,0 +1,14 @@
+#ifndef DataFormats_TrackingRecHitSoA_test_alpaka_Hits_test_h
+#define DataFormats_TrackingRecHitSoA_test_alpaka_Hits_test_h
+
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testTrackingRecHitSoA {
+
+  template <typename TrackerTraits>
+  void runKernels(TrackingRecHitSoAView<TrackerTraits>& hits, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testTrackingRecHitSoA
+
+#endif  // DataFormats_TrackingRecHitSoA_test_alpaka_Hits_test_h

--- a/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.cc
+++ b/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.cc
@@ -13,70 +13,69 @@
    the same Layout to access the data on host and print it.
  */
 
-#include <alpaka/alpaka.hpp>
+#include <cstdlib>
 #include <unistd.h>
-#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
+
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/VertexSoA/interface/ZVertexDevice.h"
 #include "DataFormats/VertexSoA/interface/ZVertexHost.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
-using namespace std;
-using namespace ALPAKA_ACCELERATOR_NAMESPACE;
-using namespace reco;
+#include "ZVertexSoA_test.h"
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  namespace testZVertexSoAT {
-    void runKernels(ZVertexSoAView zvertex_view, Queue& queue);
-  }
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
+  // Get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
+  }
 
-  // Inner scope to deallocate memory before destroying the stream
-  {
-    // Instantiate vertices on device. PortableCollection allocates
-    // SoA on device automatically.
-    ZVertexSoACollection zvertex_d(queue);
-    testZVertexSoAT::runKernels(zvertex_d.view(), queue);
+  // Run the test on each device
+  for (const auto& device : devices) {
+    Queue queue(device);
 
-    // Instantate vertices on host. This is where the data will be
-    // copied to from device.
-    ZVertexHost zvertex_h(queue);
-    std::cout << zvertex_h.view().metadata().size() << std::endl;
-    alpaka::memcpy(queue, zvertex_h.buffer(), zvertex_d.const_buffer());
-    alpaka::wait(queue);
+    // Inner scope to deallocate memory before destroying the stream
+    {
+      // Instantiate vertices on device. PortableCollection allocates
+      // SoA on device automatically.
+      ZVertexSoACollection zvertex_d(queue);
+      testZVertexSoAT::runKernels(zvertex_d.view(), queue);
 
-    // Print results
-    std::cout << "idv"
-              << "\t"
-              << "zv"
-              << "\t"
-              << "wv"
-              << "\t"
-              << "chi2"
-              << "\t"
-              << "ptv2"
-              << "\t"
-              << "ndof"
-              << "\t"
-              << "sortInd"
-              << "\t"
-              << "nvFinal" << std::endl;
+      // Instantate vertices on host. This is where the data will be
+      // copied to from device.
+      ZVertexHost zvertex_h(queue);
+      std::cout << zvertex_h.view().metadata().size() << std::endl;
+      alpaka::memcpy(queue, zvertex_h.buffer(), zvertex_d.const_buffer());
+      alpaka::wait(queue);
 
-    for (int i = 0; i < 10; ++i) {
-      std::cout << (int)zvertex_h.view()[i].idv() << "\t" << zvertex_h.view()[i].zv() << "\t"
-                << zvertex_h.view()[i].wv() << "\t" << zvertex_h.view()[i].chi2() << "\t" << zvertex_h.view()[i].ptv2()
-                << "\t" << (int)zvertex_h.view()[i].ndof() << "\t" << (int)zvertex_h.view()[i].sortInd() << "\t"
-                << (int)zvertex_h.view().nvFinal() << std::endl;
+      // Print results
+      std::cout << "idv\t"
+                << "zv\t"
+                << "wv\t"
+                << "chi2\t"
+                << "ptv2\t"
+                << "ndof\t"
+                << "sortInd\t"
+                << "nvFinal\n";
+
+      for (int i = 0; i < 10; ++i) {
+        std::cout << (int)zvertex_h.view()[i].idv() << '\t' << zvertex_h.view()[i].zv() << '\t'
+                  << zvertex_h.view()[i].wv() << '\t' << zvertex_h.view()[i].chi2() << '\t'
+                  << zvertex_h.view()[i].ptv2() << '\t' << (int)zvertex_h.view()[i].ndof() << '\t'
+                  << (int)zvertex_h.view()[i].sortInd() << '\t' << (int)zvertex_h.view().nvFinal() << '\n';
+      }
     }
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.dev.cc
+++ b/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.dev.cc
@@ -1,62 +1,59 @@
-#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
+#include <alpaka/alpaka.hpp>
+
 #include "DataFormats/VertexSoA/interface/ZVertexDevice.h"
 #include "DataFormats/VertexSoA/interface/ZVertexHost.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"  // Check if this is really needed; code doesn't compile without it
+#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-  using namespace alpaka;
-  using namespace cms::alpakatools;
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT {
 
-  namespace testZVertexSoAT {
-
-    class TestFillKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, reco::ZVertexSoAView zvertex_view) const {
-        if (cms::alpakatools::once_per_grid(acc)) {
-          zvertex_view.nvFinal() = 420;
-        }
-
-        for (int32_t j : elements_with_stride(acc, zvertex_view.metadata().size())) {
-          zvertex_view[j].idv() = (int16_t)j;
-          zvertex_view[j].zv() = (float)j;
-          zvertex_view[j].wv() = (float)j;
-          zvertex_view[j].chi2() = (float)j;
-          zvertex_view[j].ptv2() = (float)j;
-          zvertex_view[j].ndof() = (int32_t)j;
-          zvertex_view[j].sortInd() = (uint16_t)j;
-        }
+  class TestFillKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, reco::ZVertexSoAView zvertex_view) const {
+      if (cms::alpakatools::once_per_grid(acc)) {
+        zvertex_view.nvFinal() = 420;
       }
-    };
 
-    class TestVerifyKernel {
-    public:
-      template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-      ALPAKA_FN_ACC void operator()(TAcc const& acc, reco::ZVertexSoAView zvertex_view) const {
-        if (cms::alpakatools::once_per_grid(acc)) {
-          ALPAKA_ASSERT_ACC(zvertex_view.nvFinal() == 420);
-        }
-
-        for (int32_t j : elements_with_stride(acc, zvertex_view.nvFinal())) {
-          assert(zvertex_view[j].idv() == j);
-          assert(zvertex_view[j].zv() - (float)j < 0.0001);
-          assert(zvertex_view[j].wv() - (float)j < 0.0001);
-          assert(zvertex_view[j].chi2() - (float)j < 0.0001);
-          assert(zvertex_view[j].ptv2() - (float)j < 0.0001);
-          assert(zvertex_view[j].ndof() == j);
-          assert(zvertex_view[j].sortInd() == uint32_t(j));
-        }
+      for (int32_t j : cms::alpakatools::uniform_elements(acc, zvertex_view.metadata().size())) {
+        zvertex_view[j].idv() = (int16_t)j;
+        zvertex_view[j].zv() = (float)j;
+        zvertex_view[j].wv() = (float)j;
+        zvertex_view[j].chi2() = (float)j;
+        zvertex_view[j].ptv2() = (float)j;
+        zvertex_view[j].ndof() = (int32_t)j;
+        zvertex_view[j].sortInd() = (uint16_t)j;
       }
-    };
-
-    void runKernels(reco::ZVertexSoAView zvertex_view, Queue& queue) {
-      uint32_t items = 64;
-      uint32_t groups = divide_up_by(zvertex_view.metadata().size(), items);
-      auto workDiv = make_workdiv<Acc1D>(groups, items);
-      alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, zvertex_view);
-      alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, zvertex_view);
     }
+  };
 
-  }  // namespace testZVertexSoAT
+  class TestVerifyKernel {
+  public:
+    template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, reco::ZVertexSoAView zvertex_view) const {
+      if (cms::alpakatools::once_per_grid(acc)) {
+        ALPAKA_ASSERT_ACC(zvertex_view.nvFinal() == 420);
+      }
 
-}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+      for (int32_t j : cms::alpakatools::uniform_elements(acc, zvertex_view.nvFinal())) {
+        assert(zvertex_view[j].idv() == j);
+        assert(zvertex_view[j].zv() - (float)j < 0.0001);
+        assert(zvertex_view[j].wv() - (float)j < 0.0001);
+        assert(zvertex_view[j].chi2() - (float)j < 0.0001);
+        assert(zvertex_view[j].ptv2() - (float)j < 0.0001);
+        assert(zvertex_view[j].ndof() == j);
+        assert(zvertex_view[j].sortInd() == uint32_t(j));
+      }
+    }
+  };
+
+  void runKernels(reco::ZVertexSoAView zvertex_view, Queue& queue) {
+    uint32_t items = 64;
+    uint32_t groups = cms::alpakatools::divide_up_by(zvertex_view.metadata().size(), items);
+    auto workDiv = cms::alpakatools::make_workdiv<Acc1D>(groups, items);
+    alpaka::exec<Acc1D>(queue, workDiv, TestFillKernel{}, zvertex_view);
+    alpaka::exec<Acc1D>(queue, workDiv, TestVerifyKernel{}, zvertex_view);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT

--- a/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.h
+++ b/DataFormats/VertexSoA/test/alpaka/ZVertexSoA_test.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_VertexSoA_test_alpaka_ZVertexSoA_test_h
+#define DataFormats_VertexSoA_test_alpaka_ZVertexSoA_test_h
+
+#include "DataFormats/VertexSoA/interface/ZVertexSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT {
+
+  void runKernels(reco::ZVertexSoAView zvertex_view, Queue& queue);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::testZVertexSoAT
+
+#endif  // DataFormats_VertexSoA_test_alpaka_ZVertexSoA_test_h

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testAtomicPairCounter.dev.cc
@@ -4,6 +4,9 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -43,9 +46,8 @@ TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestAtomicPair), s_
   SECTION("AtomicPairCounter") {
     auto const &devices = cms::alpakatools::devices<Platform>();
     if (devices.empty()) {
-      std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-                << ", the test will be skipped.\n";
-      REQUIRE(not devices.empty());
+      FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) "backend, "
+           "the test will be skipped.");
     }
 
     // run the test on each device

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testHistoContainer.dev.cc
@@ -7,6 +7,9 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -235,14 +238,15 @@ int go(const DevHost& host, const Device& device, Queue& queue) {
 
 TEST_CASE("Standard checks of " ALPAKA_TYPE_ALIAS_NAME(alpakaTestHistoContainer), s_tag) {
   SECTION("HistoContainerKernel") {
+    auto const& host = cms::alpakatools::host();
+
     // get the list of devices on the current platform
     auto const& devices = cms::alpakatools::devices<Platform>();
-    auto const& host = cms::alpakatools::host();
     if (devices.empty()) {
-      std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-                << ", the test will be skipped.\n";
-      return;
+      FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+           "the test will be skipped.\n");
     }
+
     // run the test on each device
     for (auto const& device : devices) {
       std::cout << "Test Histo Container on " << alpaka::getName(device) << '\n';

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testIndependentKernel.dev.cc
@@ -6,6 +6,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -122,8 +123,8 @@ TEST_CASE("Test alpaka kernels for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESP
     // get the list of devices on the current platform
     auto const& devices = cms::alpakatools::devices<Platform>();
     if (devices.empty()) {
-      INFO("No devices available on the platform " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE));
-      REQUIRE(not devices.empty());
+      FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+           "the test will be skipped.");
     }
 
     // launch the independent work kernel with a small block size and a small number of blocks;

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testKernel.dev.cc
@@ -6,6 +6,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>
 
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -378,8 +379,8 @@ TEST_CASE("Test alpaka kernels for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESP
     // get the list of devices on the current platform
     auto const& devices = cms::alpakatools::devices<Platform>();
     if (devices.empty()) {
-      INFO("No devices available on the platform " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE));
-      REQUIRE(not devices.empty());
+      FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+           "the test will be skipped.");
     }
 
     // launch the 1-dimensional kernel with a small block size and a small number of blocks;

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneHistoContainer.dev.cc
@@ -3,6 +3,9 @@
 #include <limits>
 #include <random>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -163,14 +166,15 @@ void go(const DevHost& host, const Device& device, Queue& queue) {
 }
 
 int main() {
+  auto const& host = cms::alpakatools::host();
+
+  // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
-
-  auto const& host = cms::alpakatools::host();
 
   // run the test on each device
   for (auto const& device : devices) {

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testOneToManyAssoc.dev.cc
@@ -1,10 +1,14 @@
 #include <algorithm>
 #include <array>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <memory>
 #include <random>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -146,9 +150,9 @@ int main() {
   // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
   // run the test on each device

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testPrefixScan.dev.cc
@@ -1,9 +1,13 @@
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <random>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
@@ -133,12 +137,11 @@ struct verify {
 int main() {
   // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
-  // auto const& host = cms::alpakatools::host();
 
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
   for (auto const& device : devices) {

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testRadixSort.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testRadixSort.dev.cc
@@ -3,6 +3,7 @@
 #include <chrono>
 using namespace std::chrono_literals;
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -11,6 +12,9 @@ using namespace std::chrono_literals;
 #include <set>
 #include <type_traits>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/radixSort.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -244,9 +248,9 @@ int main() {
   // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
   for (auto const& device : devices) {

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testSimpleVector.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testSimpleVector.dev.cc
@@ -1,8 +1,11 @@
-//  author: Felice Pantaleo, CERN, 2018
 #include <cassert>
+#include <cstdlib>
 #include <iostream>
 #include <new>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/SimpleVector.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
@@ -39,9 +42,9 @@ int main() {
   // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
   // run the test on each device

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testWorkDivision.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testWorkDivision.dev.cc
@@ -1,5 +1,9 @@
+#include <cstdint>
 #include <vector>
 
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
@@ -21,9 +25,9 @@ enum class LoopScope { Block, Grid };
 template <LoopScope loopScope, typename TAcc>
 bool constexpr firstInLoopRange(TAcc const& acc) {
   if constexpr (loopScope == LoopScope::Block)
-    return !alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
+    return not alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
   if constexpr (loopScope == LoopScope::Grid)
-    return !alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
+    return not alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
   assert(false);
 }
 
@@ -90,9 +94,9 @@ int main() {
   // get the list of devices on the current platform
   auto const& devices = cms::alpakatools::devices<Platform>();
   if (devices.empty()) {
-    std::cout << "No devices available on the platform " << EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE)
-              << ", the test will be skipped.\n";
-    return 0;
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
   for (auto const& device : devices) {

--- a/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.cc
+++ b/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.cc
@@ -1,33 +1,28 @@
-#include <alpaka/alpaka.hpp>
-#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include <cstdlib>
+#include <iostream>
+
+#include "FWCore/Utilities/interface/stringize.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
 
-#include "DataFormats/VertexSoA/interface/ZVertexHost.h"
-#include "DataFormats/VertexSoA/interface/alpaka/ZVertexSoACollection.h"
-#include "DataFormats/VertexSoA/interface/ZVertexDevice.h"
+#include "VertexFinder_t.h"
 
-#include "RecoTracker/PixelVertexFinding/interface/PixelVertexWorkSpaceLayout.h"
-#include "RecoTracker/PixelVertexFinding/plugins/PixelVertexWorkSpaceSoAHostAlpaka.h"
-#include "RecoTracker/PixelVertexFinding/plugins/alpaka/PixelVertexWorkSpaceSoADeviceAlpaka.h"
-
-using namespace std;
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
-namespace ALPAKA_ACCELERATOR_NAMESPACE {
-
-  namespace vertexfinder_t {
-    void runKernels(Queue& queue);
+int main() {
+  // get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    std::cerr << "No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+      "the test will be skipped.\n";
+    exit(EXIT_FAILURE);
   }
 
-};  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+  // run the test on all the available devices
+  for (auto const& device : devices) {
+    Queue queue(device);
+    vertexfinder_t::runKernels(queue);
+  }
 
-int main() {
-  const auto host = cms::alpakatools::host();
-  const auto device = cms::alpakatools::devices<Platform>()[0];
-  Queue queue(device);
-
-  vertexfinder_t::runKernels(queue);
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.dev.cc
+++ b/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.dev.cc
@@ -29,6 +29,8 @@
 #include "RecoTracker/PixelVertexFinding/plugins/alpaka/splitVertices.h"
 #include "RecoTracker/PixelVertexFinding/plugins/alpaka/vertexFinder.h"
 
+#include "VertexFinder_t.h"
+
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
   using namespace cms::alpakatools;
 

--- a/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.h
+++ b/RecoTracker/PixelVertexFinding/test/alpaka/VertexFinder_t.h
@@ -1,0 +1,14 @@
+#ifndef RecoTracker_PixelVertexFinding_test_alpaka_VertexFinder_t_h
+#define RecoTracker_PixelVertexFinding_test_alpaka_VertexFinder_t_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace vertexfinder_t {
+    void runKernels(Queue& queue);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // RecoTracker_PixelVertexFinding_test_alpaka_VertexFinder_t_h


### PR DESCRIPTION
#### PR description:

Let alpaka-based tests that require a device fail gracefully if there are no available devices on the given platform, instead of crashing or succeeding silently.

If more than one device is available, run the tests on each device.

#### PR validation:

Unit tests pass.

If there are no devices, the tests pass with an informational message instead of failing with a segmentation violation.

#### Backport status:

Backport of #44036, to make sure test failures do not go undetected in the production branch.