### PR TITLE
Migrate away from ```OwnVector<BaseTrackerRecHit>```

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -29,6 +29,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/VectorHit.h"
+#include <memory>
 #include <vector>
 
 #endif  // SISTRIPRECHIT_CLASSES_H

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -60,8 +60,8 @@
    <version ClassVersion="10" checksum="414205262"/>
   </class>
 
-  <class name="edm::OwnVector<BaseTrackerRecHit>" persistent="false"/>
-  <class name="edm::Wrapper<edm::OwnVector<BaseTrackerRecHit> >" persistent="false"/>
+  <class name="std::vector<std::unique_ptr<BaseTrackerRecHit>>" persistent="false"/>
+  <class name="edm::Wrapper<std::vector<std::unique_ptr<BaseTrackerRecHit>>>" persistent="false"/>
 
   <class name="std::vector<SiPixelRecHit>"/>
 


### PR DESCRIPTION
#### PR description:

This is part of a campaign to remove code related to OwnVector. This is in preparation for a possible move to RNTuple from TTree as a persistence mechanism. RNTuple does not support OwnVector because it allows polymorphism. Issue https://github.com/cms-sw/cmssw/issues/42734 discusses this in more detail.

In this PR, ```OwnVector<BaseTrackerRecHit>``` is replaced. This is one of the classes on Matti's list in the issue.

The dictionaries are transient so there should be no backward compatibility issues. The ```OwnVector<BaseTrackerRecHit>``` is converted to ```std::vector<std::unique_ptr<BaseTrackerRecHit>>``` in the places  where it appears.

The output and behavior of the code should be the same as before. The EDProducer that produces this also makes another product. That product has pointers to the objects in product with the OwnVector. Nothing else uses it. The only purpose of putting the  product in the event is to keep the object alive so those pointers continue to work. Nothing directly consumes it.

#### PR validation:

Several tests in runTheMatrix.py execute the affected code and those tests pass. For example, test 25.0 step 3 executes it. As a temporary test, I commented out the line putting the product in the event. When that is done, there is a seg fault when the code that dereferences the pointers accesses the object. This is expected behavior and it shows the object is getting put in the event properly when runTheMatrix tests are run and pass with object being put in the event.
