### PR TITLE
Fix `customizeHLTforAlpakaParticleFlowClustering`: insert `DQM_HcalReconstruction_v` only if present in the HLT menu

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
+++ b/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
@@ -245,18 +245,26 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
 
     process.HLTPFClusterHBHECPUSerial = cms.Sequence(process.hltHBHERecHitToSoA+process.hltPFRecHitSoAProducerHCALCPUSerial+process.hltPFClusterSoAProducerCPUSerial)
 
-    # Add CPUSerial sequences to DQM_HcalReconstruction_v6 Path
-    dqmHcalRecoPathName = "DQM_HcalReconstruction_v6"
-    dqmHcalPath= getattr(process, dqmHcalRecoPathName)
-    dqmHcalRecoPathIndex = dqmHcalPath.index(process.hltHcalConsumerGPU) + 1
-    dqmHcalPath.insert(dqmHcalRecoPathIndex , process.HLTPFClusterHBHECPUSerial)
-
     # modify EventContent of DQMGPUvsCPU stream
     if hasattr(process, 'hltOutputDQMGPUvsCPU'):
         process.hltOutputDQMGPUvsCPU.outputCommands.extend([
             'keep *_hltPFClusterSoAProducer_*_*',
             'keep *_hltPFClusterSoAProducerCPUSerial_*_*',
         ])
+
+    # Add CPUSerial sequences to DQM_HcalReconstruction_v Path
+    dqmHcalRecoPathName = None
+    for pathName in process.paths_():
+        if pathName.startswith('DQM_HcalReconstruction_v'):
+            dqmHcalRecoPathName = pathName
+            break
+
+    if dqmHcalRecoPathName == None:
+        return process
+
+    dqmHcalPath = getattr(process, dqmHcalRecoPathName)
+    dqmHcalRecoPathIndex = dqmHcalPath.index(process.hltHcalConsumerGPU) + 1
+    dqmHcalPath.insert(dqmHcalRecoPathIndex , process.HLTPFClusterHBHECPUSerial)
 
     return process
 


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/44046

#### PR description:

Title says it all, along https://github.com/cms-sw/cmssw/pull/43999#discussion_r1497986311
#### PR validation:

` runTheMatrix.py --what gpu -l 12434.402 -j 0`  runs fine in `CMSSW_14_1_GPU_X_2024-02-20-2300`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will need to be backported at https://github.com/cms-sw/cmssw/pull/44000.