### PR TITLE
MTD geometry: update pixel index definition from RectangularMTDTopology

### DIFF
--- a/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
+++ b/Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h
@@ -87,6 +87,9 @@ public:
   //check whether LocalPoint is inside the pixel active area
   bool isInPixel(const LocalPoint& p) const;
 
+  //provide pixel indices based on local module position (with protection for border positions)
+  std::pair<int, int> pixelIndex(const LocalPoint& p) const;
+
   // Errors
   // Error in local (cm) from the masurement errors
   LocalError localError(const MeasurementPoint&, const MeasurementError&) const override;

--- a/Geometry/MTDGeometryBuilder/src/MTDGeomUtil.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDGeomUtil.cc
@@ -135,8 +135,9 @@ std::pair<uint8_t, uint8_t> MTDGeomUtil::pixelInModule(const DetId& id, const Lo
                                                << detId.rawId() << ") is invalid!" << std::dec << std::endl;
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
-    const auto& thepixel = topo.pixel(local_point);
-    uint8_t row(thepixel.first), col(thepixel.second);
+    const auto& thepixel = topo.pixelIndex(local_point);
+    uint8_t row = static_cast<uint8_t>(thepixel.first);
+    uint8_t col = static_cast<uint8_t>(thepixel.second);
     return std::pair<uint8_t, uint8_t>(row, col);
   } else {
     BTLDetId detId(id);
@@ -148,8 +149,9 @@ std::pair<uint8_t, uint8_t> MTDGeomUtil::pixelInModule(const DetId& id, const Lo
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
     auto topo_point = topo.pixelToModuleLocalPoint(local_point, detId.row(topo.nrows()), detId.column(topo.nrows()));
-    const auto& thepixel = topo.pixel(topo_point);
-    uint8_t row(thepixel.first), col(thepixel.second);
+    const auto& thepixel = topo.pixelIndex(topo_point);
+    uint8_t row = static_cast<uint8_t>(thepixel.first);
+    uint8_t col = static_cast<uint8_t>(thepixel.second);
     return std::pair<uint8_t, uint8_t>(row, col);
   }
 }

--- a/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
+++ b/Geometry/MTDGeometryBuilder/src/RectangularMTDTopology.cc
@@ -16,6 +16,40 @@ std::pair<float, float> RectangularMTDTopology::pixel(const LocalPoint& p) const
   return std::pair<float, float>(newxbin, newybin);
 }
 
+//provide pixel indices based on local module position (with protection for border positions)
+std::pair<int, int> RectangularMTDTopology::pixelIndex(const LocalPoint& p) const {
+  const auto& thepixel = pixel(p);
+  bool fail(false);
+
+  static constexpr float tol = 5e-5f;  // 0.5 micron tolerance
+
+  int row = static_cast<int>(thepixel.first);
+  if (row >= m_nrows) {
+    fail = (p.x() - m_pitchx * m_nrows > tol);
+    if (!fail) {
+      row--;
+    }
+  }
+  int col = static_cast<int>(thepixel.second);
+  if (col >= m_ncols) {
+    fail = (p.y() - m_pitchy * m_ncols > tol);
+    if (!fail) {
+      col--;
+    }
+  }
+  if (fail) {
+    throw cms::Exception("RectangularMTDTopology")
+        << "Incorrect pixel id! r/c " << std::fixed << std::setw(2) << row << " / " << std::fixed << std::setw(2) << col
+        << " with max " << std::fixed << std::setw(2) << m_nrows << " / " << std::fixed << std::setw(2) << m_ncols
+        << " for LocalPoint " << std::fixed << std::setw(8) << std::setprecision(4) << p.x() << " , " << std::fixed
+        << std::setw(8) << std::setprecision(4) << p.y() << " pixel " << std::fixed << std::setw(8)
+        << std::setprecision(4) << thepixel.first << " , " << std::fixed << std::setw(8) << std::setprecision(4)
+        << thepixel.second << " deltas " << p.x() - m_pitchx * m_nrows << " , " << p.y() - m_pitchy * m_ncols;
+  }
+
+  return std::pair<int, int>(row, col);
+}
+
 //The following lines check whether the point is actually out of the active pixel area.
 bool RectangularMTDTopology::isInPixel(const LocalPoint& p) const {
   bool isInside = true;

--- a/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
+++ b/Geometry/MTDGeometryBuilder/test/DD4hep_TestBTLPixelTopology.cc
@@ -264,8 +264,9 @@ void DD4hep_TestBTLPixelTopology::analyze(const edm::Event& iEvent, const edm::E
                                 convertMmToCm(refLocalPoints[iloop].y() / dd4hep::mm),
                                 convertMmToCm(refLocalPoints[iloop].z() / dd4hep::mm));
         Local3DPoint modLocal = topo.pixelToModuleLocalPoint(cmRefLocal, origRow, origCol);
-        const auto& thepixel = topo.pixel(modLocal);
-        uint8_t recoRow(thepixel.first), recoCol(thepixel.second);
+        const auto& thepixel = topo.pixelIndex(modLocal);
+        uint8_t recoRow = static_cast<uint8_t>(thepixel.first);
+        uint8_t recoCol = static_cast<uint8_t>(thepixel.second);
 
         if (origRow != recoRow || origCol != recoCol) {
           std::stringstream warnmsg;

--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -238,6 +238,8 @@ void MTDDigiGeometryAnalyzer::checkPixelsAcceptance(const GeomDetUnit& det) {
     double ax = CLHEP::RandFlat::shoot(-width * 0.5, width * 0.5);
     double ay = CLHEP::RandFlat::shoot(-length * 0.5, length * 0.5);
     LocalPoint hit(ax, ay, 0);
+    auto const indici = topo.pixelIndex(hit);
+    assert(indici.first < topo.nrows() && indici.second < topo.ncolumns());  // sanity check on the index definition
     if (topo.isInPixel(hit)) {
       inpixel++;
     }

--- a/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
@@ -64,8 +64,10 @@ void BTLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
     Local3DPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
     // translate from crystal-local coordinates to module-local coordinates to get the row and column
     simscaled = topo.pixelToModuleLocalPoint(simscaled, btlid.row(topo.nrows()), btlid.column(topo.nrows()));
-    const auto& thepixel = topo.pixel(simscaled);
-    uint8_t row(thepixel.first), col(thepixel.second);
+
+    const auto& thepixel = topo.pixelIndex(simscaled);
+    uint8_t row = static_cast<uint8_t>(thepixel.first);
+    uint8_t col = static_cast<uint8_t>(thepixel.second);
 
     if (btlid.row(topo.nrows()) != row || btlid.column(topo.nrows()) != col) {
       edm::LogWarning("BTLDeviceSim") << "BTLDetId (row,column): (" << btlid.row(topo.nrows()) << ','

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -120,8 +120,9 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
       }
     }
 
-    const auto& thepixel = topo.pixel(simscaled);
-    const uint8_t row(thepixel.first), col(thepixel.second);
+    const auto& thepixel = topo.pixelIndex(simscaled);
+    const uint8_t row = static_cast<uint8_t>(thepixel.first);
+    const uint8_t col = static_cast<uint8_t>(thepixel.second);
     LogDebug("ETLDeviceSim") << "Processing hit in pixel # " << hitidx << " DetId " << etlid.rawId() << " row/col "
                              << (uint32_t)row << " " << (uint32_t)col << " tof " << toa;
 


### PR DESCRIPTION
#### PR description:

This PR proposes a solution to the issue https://github.com/cms-sw/cmssw/issues/43942 , or at least to the MTD-related part of it. The recent update of ETL digitization in #43762 utilizes also hits outside the active part of the pixel area, and therefore needs the computation of pixel indices also for points very close to the geometrical border of the volume. Due to numerical accuracy, they can exceed the maximum allowed value, producing a chain of problems in the downstream code.

This PR introduces a ```pixelIndex``` method in ```RectangularMTDTopology``` to correctly compute the indices based on the position in the module, introducing a safety check for border situations. The geometry test is instrumented to possibly catch problems, and this new method is used in the rest of the MTD code where applicable.

#### PR validation:

The code appears to solve the reproducible crash in recent ASAN builds within the MTD clustering algorithm, and allows the unit test of ```Geometry/MTDGeometryBuilder``` to pass smoothly.