### PR TITLE
print total number of Paths in `hltIntegrationTests`

### DIFF
--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -334,7 +334,7 @@ else
     --max-events ${SIZE} --no-prescale --no-output
     ${DATA} --input ${INPUT} ${EXTRA} ${DBPROXYOPTS}"
   HLTGETCMD=$(echo "${HLTGETCMD}" | xargs)
-  log "Creating HLT menu from ConfDB configuration:\n> ${HLTGETCMD}"
+  log "Creating HLT menu from ConfDB configuration\n> ${HLTGETCMD}"
   ${HLTGETCMD} > hlt.py
   # unset EXTRA environment variable (used later in cmsRun jobs)
   unset HLTGETCMD EXTRA
@@ -385,26 +385,41 @@ process.options.accelerators = [ "$ACCELERATOR" ]
 process.hltTriggerSummaryAOD.throw = cms.bool( True )
 @EOF
 
+# find number of cms.Paths in the HLT menu (incl. Dataset Paths)
+NUM_PATHS=$(python3 -c """
+import sys
+# redefine sys.argv (necessary to import
+# cfg file if the latter uses VarParsing)
+sys.argv = ['python3', 'hlt.py']
+from hlt import cms,process
+try:
+  print(len(process.paths_()))
+except:
+  print(0)
+""")
+log "\nThe HLT menu contains ${NUM_PATHS} Paths (incl. Dataset Paths)"
+
 # list of trigger Paths to be tested standalone (always exclude HLTriggerFinalPath)
-log "Preparing list of trigger Paths to be tested standalone (paths.txt)"
+log "\nPreparing list of Paths to be tested standalone (paths.txt)"
 [ "${PATHS}" ] || PATHS="*"
 PATHS+=",-HLTriggerFinalPath"
+log " - Path selection: \"${PATHS}\""
 TRIGGERS=$(hltListPaths hlt.py -p --no-dep --select-paths "${PATHS}")
 echo "${TRIGGERS[@]}" > paths.txt
 
 # print some info
 if [ "${SELECTION}" == "complex" ]; then
-  log "Will run full menu and $(echo $TRIGGERS | wc -w) triggers standalone over $(echo ${EVENTS} | tr ',' '\n' | wc -l) events, with ${JOBS} jobs in parallel"
+  log "\nWill run full menu and $(echo $TRIGGERS | wc -w) Paths standalone over $(echo ${EVENTS} | tr ',' '\n' | wc -l) events, with ${JOBS} jobs in parallel"
 elif [ "${SIZE}" == "-1" ]; then
-  log "Will run full menu and $(echo ${TRIGGERS} | wc -w) triggers standalone over all events, with ${JOBS} jobs in parallel"
+  log "\nWill run full menu and $(echo ${TRIGGERS} | wc -w) Paths standalone over all events, with ${JOBS} jobs in parallel"
 else
-  log "Will run full menu and $(echo ${TRIGGERS} | wc -w) triggers standalone over ${SIZE} events, with ${JOBS} jobs in parallel"
+  log "\nWill run full menu and $(echo ${TRIGGERS} | wc -w) Paths standalone over ${SIZE} events, with ${JOBS} jobs in parallel"
 fi
 
 # check the prescale modules
 hltCheckPrescaleModules -w hlt.py
 
-log "Preparing single-trigger configurations"
+log "\nPreparing single-Path configurations"
 for TRIGGER in $TRIGGERS; do
   cat > "${TRIGGER}".py << @EOF
 from hlt import *
@@ -436,7 +451,7 @@ if [ "${SETUP}" ]; then
     # this is the hltGetConfiguration behaviour and would be confusing if you had to
     # specify converter/db on the setup menu on hltIntegrationTests but not on hltGetConfiguration
     read SETUP_Vx SETUP_DB _ <<< $(parse_HLT_menu "${MENU}")
-    log "Creating setup_cff from ConfDB configuration: ${SETUP_Vx}/${SETUP_DB}:${SETUP}"
+    log "\nCreating setup_cff from ConfDB configuration: ${SETUP_Vx}/${SETUP_DB}:${SETUP}"
     hltConfigFromDB --${SETUP_Vx} --${SETUP_DB} ${DBPROXYOPTS} --cff --configName "$SETUP" \
       --nopaths --services -FUShmDQMOutputService,-PrescaleService,-EvFDaqDirector,-FastMonitoringService > setup_cff.py
     sed -i -e's/process = cms.Process(.*)/&\nprocess.load("setup_cff")/' hlt.py $(for TRIGGER in ${TRIGGERS}; do echo "${TRIGGER}".py; done)
@@ -472,7 +487,7 @@ hlt.done: hlt.py
 	@cmsRun \$*.py ${EXTRA} >& \$*.log < /dev/zero && touch \$*.done
 @EOF
 
-log "Running..."
+log "\nRunning..."
 # if the whole hlt job runs with multithreading, run it by itself
 # otherwise, run it in parallel with the single-trigger jobs
 if ((THREADS > 0)); then
@@ -483,7 +498,7 @@ else
 fi
 
 # compare HLT results
-log "Comparing the results of running each path by itself with those from the full menu"
+log "\nComparing the results of running each path by itself with those from the full menu"
 hltCompareResults
 STATUS=$?
 log "--------------------------"


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to #44005. It adds a log message to the `hltIntegrationTests` utility, stating the total number of `cms.Paths` in the HLT configuration under test.

Minor format improvements to the printouts are also included.

Merely technical. No changes expected.

#### PR validation:

Tested locally on a branch including `CMSSW_14_0_0_pre3` + #44005.
```bash
> hltIntegrationTests /dev/CMSSW_14_0_0/GRun/V7 \
 -n 100 --mc -d tmp --paths "*PFScouting*" \
 -x "--globaltag 140X_mcRun3_2024_realistic_v1" \
 -i /store/relval/CMSSW_14_0_0_pre3/RelValQCD_Pt_1800_2400_14/GEN-SIM-DIGI-RAW/PU_140X_mcRun3_2024_realistic_v1_STD_2024_PU-v1/2580000/0bf93d4d-de46-4781-bfe4-78eda3f202f6.root
----------------------------
Starting hltIntegrationTests
----------------------------
Creating HLT menu from ConfDB configuration
> hltGetConfiguration /dev/CMSSW_14_0_0/GRun/V7 --process TEST20240222081220 --max-events 100 --no-prescale --no-output --mc --input /store/relval/CMSSW_14_0_0_pre3/RelValQCD_Pt_1800_2400_14/GEN-SIM-DIGI-RAW/PU_140X_mcRun3_2024_realistic_v1_STD_2024_PU-v1/2580000/0bf93d4d-de46-4781-bfe4-78eda3f202f6.root --globaltag 140X_mcRun3_2024_realistic_v1

The HLT menu contains 844 Paths (incl. Dataset Paths)

Preparing list of Paths to be tested standalone (paths.txt)
 - Path selection: "*PFScouting*,-HLTriggerFinalPath"

Will run full menu and 7 Paths standalone over 100 events, with 4 jobs in parallel

Preparing single-Path configurations

Running...
	full menu dump
	DST_Run3_DoubleMuon_PFScoutingPixelTracking_v2
	DST_Run3_DoubleEG_PFScoutingPixelTracking_v2
	DST_Run3_EG30_PFScoutingPixelTracking_v22
	DST_Run3_JetHT_PFScoutingPixelTracking_v22
	DST_Run3_DoubleMu3_PFScoutingPixelTracking_v22
	DST_Run3_EG16_EG12_PFScoutingPixelTracking_v22
	MC_Run3_PFScoutingPixelTracking_v22

Comparing the results of running each path by itself with those from the full menu
WARNING: path DST_Run3_DoubleEG_PFScoutingPixelTracking_v2 did not accept any events
WARNING: path DST_Run3_EG16_EG12_PFScoutingPixelTracking_v22 did not accept any events
--------------------------
hltIntegrationTests PASSED
--------------------------
exit status: 0
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

To be backported to `14_0_X` for HLT-menu development in 2024.