### PR TITLE
Issue TAxis::SetRangeUser() warnings as INFO messages instead of an exception

### DIFF
--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -166,7 +166,7 @@ namespace {
   }
 
   //Contents of a message which should be reported as an INFO not a ERROR
-  constexpr std::array<const char* const, 9> in_message{
+  constexpr std::array<const char* const, 11> in_message{
       {"no dictionary for class",
        "already in TClassTable",
        "matrix not positive definite",
@@ -175,7 +175,9 @@ namespace {
        "Announced number of args different from the real number of argument passed",  // Always printed if gDebug>0 - regardless of whether warning message is real.
        "nbins is <=0 - set to nbins = 1",
        "nbinsy is <=0 - set to nbinsy = 1",
-       "oneapi::tbb::global_control is limiting"}};
+       "oneapi::tbb::global_control is limiting",
+       "ufirst < fXmin, fXmin is used",
+       "ulast > fXmax, fXmax is used"}};
 
   //Location generating messages which should be reported as an INFO not a ERROR
   constexpr std::array<const char* const, 7> in_location{{"Fit",


### PR DESCRIPTION
#### PR description:

To work around the failures reported in tests of ROOT `master` update in https://github.com/cms-sw/cmsdist/pull/9025#issuecomment-1955359251 . The condition where ROOT issues these messages does not seem to warrant job termination, even if their cause would be useful to be fixed in our code.

#### PR validation:

Code compiles