### PR TITLE
Migrate away from ```OwnVector<TrackingRegion>```

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackBuildingAnalyzer.h
@@ -60,7 +60,7 @@ public:
                const std::vector<const MVACollection*>& mvaCollections,
                const std::vector<const QualityMaskCollection*>& qualityMaskCollections);
   void analyze(const reco::CandidateView& regionCandidates);
-  void analyze(const edm::OwnVector<TrackingRegion>& regions);
+  void analyze(const std::vector<std::unique_ptr<TrackingRegion>>& regions);
   void analyze(const TrackingRegionsSeedingLayerSets& regions);
 
 private:

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -13,6 +13,8 @@ Monitoring source for general quantities related to tracks.
 
 #include <memory>
 #include <fstream>
+#include <vector>
+
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -41,7 +43,6 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/Scalers/interface/LumiScalers.h"
 #include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
 
-#include "DataFormats/Common/interface/OwnVector.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionsSeedingLayerSets.h"
 
@@ -93,12 +94,12 @@ private:
   edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
   edm::EDGetTokenT<reco::VertexCollection> pvSrcToken_;
 
-  edm::EDGetTokenT<edm::View<reco::Track> > allTrackToken_;
-  edm::EDGetTokenT<edm::View<reco::Track> > trackToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> allTrackToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> trackToken_;
   edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
-  edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
-  edm::EDGetTokenT<std::vector<SeedStopInfo> > seedStopInfoToken_;
-  edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
+  edm::EDGetTokenT<edm::View<TrajectorySeed>> seedToken_;
+  edm::EDGetTokenT<std::vector<SeedStopInfo>> seedStopInfoToken_;
+  edm::EDGetTokenT<std::vector<std::unique_ptr<TrackingRegion>>> regionToken_;
   edm::EDGetTokenT<TrackingRegionsSeedingLayerSets> regionLayerSetsToken_;
   edm::EDGetTokenT<reco::CandidateView> regionCandidateToken_;
 
@@ -107,11 +108,11 @@ private:
 
   edm::InputTag stripClusterInputTag_;
   edm::InputTag pixelClusterInputTag_;
-  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > stripClustersToken_;
-  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > pixelClustersToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> stripClustersToken_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> pixelClustersToken_;
 
-  std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection> > > mvaQualityTokens_;
-  edm::EDGetTokenT<edm::View<reco::Track> > mvaTrackToken_;
+  std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection>>> mvaQualityTokens_;
+  edm::EDGetTokenT<edm::View<reco::Track>> mvaTrackToken_;
 
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
   edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderToken_;

--- a/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackBuildingAnalyzer.cc
@@ -104,7 +104,7 @@ void TrackBuildingAnalyzer::initHisto(DQMStore::IBooker& ibooker, const edm::Par
 
   edm::InputTag seedProducer = iConfig.getParameter<edm::InputTag>("SeedProducer");
   edm::InputTag tcProducer = iConfig.getParameter<edm::InputTag>("TCProducer");
-  std::vector<std::string> mvaProducers = iConfig.getParameter<std::vector<std::string> >("MVAProducers");
+  std::vector<std::string> mvaProducers = iConfig.getParameter<std::vector<std::string>>("MVAProducers");
   edm::InputTag regionProducer = iConfig.getParameter<edm::InputTag>("RegionProducer");
 
   //    if (doAllPlots){doAllSeedPlots=true; doTCPlots=true;}
@@ -715,11 +715,13 @@ void TrackBuildingAnalyzer::analyze(const reco::CandidateView& regionCandidates)
   }
 }
 
-void TrackBuildingAnalyzer::analyze(const edm::OwnVector<TrackingRegion>& regions) { analyzeRegions(regions); }
+void TrackBuildingAnalyzer::analyze(const std::vector<std::unique_ptr<TrackingRegion>>& regions) {
+  analyzeRegions(regions);
+}
 void TrackBuildingAnalyzer::analyze(const TrackingRegionsSeedingLayerSets& regions) { analyzeRegions(regions); }
 
 namespace {
-  const TrackingRegion* regionPtr(const TrackingRegion& region) { return &region; }
+  const TrackingRegion* regionPtr(const std::unique_ptr<TrackingRegion>& region) { return region.get(); }
   const TrackingRegion* regionPtr(const TrackingRegionsSeedingLayerSets::RegionLayers& regionLayers) {
     return &(regionLayers.region());
   }

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -151,7 +151,7 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   if (doRegionPlots) {
     const auto& regionTag = iConfig.getParameter<edm::InputTag>("RegionProducer");
     if (!regionTag.label().empty()) {
-      regionToken_ = consumes<edm::OwnVector<TrackingRegion> >(regionTag);
+      regionToken_ = consumes(regionTag);
     }
     const auto& regionLayersTag = iConfig.getParameter<edm::InputTag>("RegionSeedingLayersProducer");
     if (!regionLayersTag.label().empty()) {
@@ -993,8 +993,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     // plots for tracking regions
     if (doRegionPlots) {
       if (!regionToken_.isUninitialized()) {
-        edm::Handle<edm::OwnVector<TrackingRegion> > hregions = iEvent.getHandle(regionToken_);
-        const auto& regions = *hregions;
+        auto const& regions = iEvent.get(regionToken_);
         NumberOfTrackingRegions->Fill(regions.size());
 
         theTrackBuildingAnalyzer->analyze(regions);

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -8,7 +8,6 @@
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 
 #include <vector>
@@ -20,7 +19,7 @@ public:
       : produceCollection_(conf.getParameter<bool>("produceTrackCollection")),
         produceMask_(conf.getParameter<bool>("produceMask")),
         tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))),
-        inputTrkRegionToken_(consumes<edm::OwnVector<TrackingRegion>>(conf.getParameter<edm::InputTag>("regions"))),
+        inputTrkRegionToken_(consumes(conf.getParameter<edm::InputTag>("regions"))),
         outputTracksToken_(produceCollection_ ? produces<reco::TrackCollection>()
                                               : edm::EDPutTokenT<reco::TrackCollection>{}),
         outputMaskToken_(produceMask_ ? produces<std::vector<bool>>() : edm::EDPutTokenT<std::vector<bool>>{}) {}
@@ -46,7 +45,7 @@ private:
     MaskCollection mask(tracks.size(), false);  // output mask
 
     for (auto const& region : regions) {
-      region.checkTracks(tracks, mask);
+      region->checkTracks(tracks, mask);
     }
 
     if (produceCollection_) {
@@ -71,7 +70,7 @@ private:
   const bool produceCollection_;
   const bool produceMask_;
   const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
-  const edm::EDGetTokenT<edm::OwnVector<TrackingRegion>> inputTrkRegionToken_;
+  const edm::EDGetTokenT<std::vector<std::unique_ptr<TrackingRegion>>> inputTrkRegionToken_;
   const edm::EDPutTokenT<reco::TrackCollection> outputTracksToken_;
   const edm::EDPutTokenT<std::vector<bool>> outputMaskToken_;
 };

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h
@@ -4,21 +4,18 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
-#include "DataFormats/Common/interface/OwnVector.h"
+
+#include <memory>
+#include <vector>
 
 template <typename T_TrackingRegionProducer>
 class TrackingRegionEDProducerT : public edm::stream::EDProducer<> {
 public:
-  // using OwnVector as vector<shared_ptr> and vector<unique_ptr> cause problems
-  // I can't get dictionary compiled with unique_ptr
-  // shared_ptr fails with runtime error "Class name 'TrackingRegionstdshared_ptrs' contains an underscore ('_'), which is illegal in the name of a product."
-  using ProductType = edm::OwnVector<TrackingRegion>;
-
-  TrackingRegionEDProducerT(const edm::ParameterSet& iConfig) : regionProducer_(iConfig, consumesCollector()) {
-    produces<ProductType>();
-  }
+  TrackingRegionEDProducerT(const edm::ParameterSet& iConfig)
+      : regionsPutToken_{produces()}, regionProducer_(iConfig, consumesCollector()) {}
 
   ~TrackingRegionEDProducerT() override = default;
 
@@ -28,16 +25,11 @@ public:
 
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
     auto regions = regionProducer_.regions(iEvent, iSetup);
-    auto ret = std::make_unique<ProductType>();
-    ret->reserve(regions.size());
-    for (auto& regionPtr : regions) {
-      ret->push_back(regionPtr.release());
-    }
-
-    iEvent.put(std::move(ret));
+    iEvent.emplace(regionsPutToken_, std::move(regions));
   }
 
 private:
+  edm::EDPutTokenT<std::vector<std::unique_ptr<TrackingRegion>>> regionsPutToken_;
   T_TrackingRegionProducer regionProducer_;
 };
 

--- a/RecoTracker/TkTrackingRegions/src/classes.h
+++ b/RecoTracker/TkTrackingRegions/src/classes.h
@@ -1,13 +1,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionsSeedingLayerSets.h"
-#include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace RecoTracker_TkTrackingRegions {
-  struct dictionary {
-    edm::OwnVector<TrackingRegion> ovtr;
-    edm::Wrapper<edm::OwnVector<TrackingRegion> > wovtr;
-
-    edm::Wrapper<TrackingRegionsSeedingLayerSets> wtrsls;
-  };
-}  // namespace RecoTracker_TkTrackingRegions
+#include <memory>
+#include <vector>

--- a/RecoTracker/TkTrackingRegions/src/classes_def.xml
+++ b/RecoTracker/TkTrackingRegions/src/classes_def.xml
@@ -1,7 +1,7 @@
 <lcgdict>
   <class name="TrackingRegion" persistent="false"/>
-  <class name="edm::OwnVector<TrackingRegion>" persistent="false"/>
-  <class name="edm::Wrapper<edm::OwnVector<TrackingRegion> >" persistent="false"/>
+  <class name="std::vector<std::unique_ptr<TrackingRegion>>" persistent="false"/>
+  <class name="edm::Wrapper<std::vector<std::unique_ptr<TrackingRegion>>>" persistent="false"/>
 
   <class name="TrackingRegionsSeedingLayerSets" persistent="false"/>
   <class name="edm::Wrapper<TrackingRegionsSeedingLayerSets>" persistent="false"/>


### PR DESCRIPTION
#### PR description:

This is part of a campaign to remove code related to OwnVector. This is in preparation for a possible move to RNTuple from TTree as a persistence mechanism. RNTuple does not support OwnVector because it allows polymorphism. Issue https://github.com/cms-sw/cmssw/issues/42734 discusses this in more detail.

In this PR, ```OwnVector<TrackingRegion>``` is replaced by ```std::vector<std::unique_ptr<TrackingRegion>>```. This is one of the classes on Matti's list in the issue.

The dictionaries are transient so there should be no backward compatibility issues.

The output and behavior of the code should be the same as before. There is one producer and 4 modules that consume the product.

(The code-format utility also modified the spacing in a few lines...)

#### PR validation:

runTheMatrix.py executes most of the modifed code. Test 25.0 runs the producer and 2 of the modules that consume the product. Test 5.1 executes the FastSimulation module that consumes the product and the producer. TrajectorySeedProducer seems to be only run by HLT configurations, but I temporarily forced it to run in test 25.0 (just manually added it). I verified all those tests successfully get past the point where Event::get is called and its succeeds getting the product put by the producer. All the runTheMatrix "limited" tests pass.
