### PR TITLE
Fix labels in HGCal tower customisation

### DIFF
--- a/L1Trigger/L1THGCal/python/customTowers.py
+++ b/L1Trigger/L1THGCal/python/customTowers.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from L1Trigger.L1THGCal.hgcalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
 import math
 
 def custom_towers_unclustered_tc(process):
@@ -38,7 +38,7 @@ def custom_towers_etaphi(process,
 
 def custom_towers_energySplit(process):
     parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
-    process.hgcalTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
+    process.l1tHGCalTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
     return process
 
 def custom_towers_map(process,


### PR DESCRIPTION
#### PR description:

Updating/fixing the module names for a HGCal tower customisation.  Not used by default.  Found whilst testing customisation in L1T upgrade studies.

Corresponding PR to [cms-l1t-offline #1211](https://github.com/cms-l1t-offline/cmssw/pull/1211)


#### PR validation:

Ran standard workflow but including this customisation.

@jbsauvan @indra-ehep We should also fix this in hgc-tpg if not done so already
