### PR TITLE
Erase from correct vector in PATTauHybridProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -385,7 +385,7 @@ void PATTauHybridProducer::fillTauFromJet(reco::PFTau& pfTau, const reco::JetBas
     pfTau.setleadChargedHadrCand(pfGammas[0]);
     pfTau.setleadCand(pfGammas[0]);
     pfGammasSig.push_back(pfGammas[0]);
-    pfChs.erase(pfGammas.begin());
+    pfGammas.erase(pfGammas.begin());
   }
   // Clean gamma candidates from low-pt ones
   for (CandPtrs::iterator it = pfGammas.begin(); it != pfGammas.end();) {


### PR DESCRIPTION
#### PR description:

Erasing an element from `pfChs` using an iterator from `pfGammas` is undefined behavior. Based on the surrounding code, I _guess_ the intention was to erase the element from `pfGammas`.

I came across this while investigating an UBSAN warning
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:151:22: runtime error: member call on null pointer of type 'struct Ptr'
    #0 0x14e0b6a2131e in void std::_Destroy<edm::Ptr<reco::Candidate> >(edm::Ptr<reco::Candidate>*) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:151
    #1 0x14e0b6a2131e in void std::_Destroy_aux<false>::__destroy<edm::Ptr<reco::Candidate>*>(edm::Ptr<reco::Candidate>*, edm::Ptr<reco::Candidate>*) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:163
    #2 0x14e0b6a2131e in void std::_Destroy<edm::Ptr<reco::Candidate>*>(edm::Ptr<reco::Candidate>*, edm::Ptr<reco::Candidate>*) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:196
    #3 0x14e0b6a2131e in void std::_Destroy<edm::Ptr<reco::Candidate>*, edm::Ptr<reco::Candidate> >(edm::Ptr<reco::Candidate>*, edm::Ptr<reco::Candidate>*, std::allocator<edm::Ptr<reco::Candidate> >&) /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/alloc_traits.h:850
    #4 0x14e0b6a2131e in std::vector<edm::Ptr<reco::Candidate>, std::allocator<edm::Ptr<reco::Candidate> > >::~vector() /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:730
    #5 0x14e0b6a2131e in PATTauHybridProducer::fillTauFromJet(reco::PFTau&, edm::RefToBase<reco::Jet> const&) src/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc:416
    #6 0x14e0b6a2db7e in PATTauHybridProducer::produce(edm::Event&, edm::EventSetup const&) src/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc:269
    #7 0x14e2588c290e in edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) src/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc:82
```
(e.g. in https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_UBSAN_X_2024-02-21-2300/pyRelValMatrixLogs/run/11602.0_SingleElectronPt35+2021/step3_SingleElectronPt35+2021.log#/)

I'm not fully certain if this PR would fix that warning, but this line should be fixed anyway.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

The fix impacts physics, but I don't know by how much, nor if it should be backported. I can backport it if needed.