### PR TITLE
[14_1_X SIM] Improved destruction of Geant4

### DIFF
--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -64,7 +64,7 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
         G4PhysicalVolumeStore::Clean();
         isG4Alive = false;
       } else if (m_masterThreadState == ThreadState::Destruct) {
-	// Stop master thread started
+        // Stop master thread started
         edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Breaking out of state loop";
         if (isG4Alive)
           throw cms::Exception("LogicError") << "OscarMTMasterThread: Geant4 is still alive, master thread "

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -48,7 +48,6 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
       m_masterCanProceed = false;
       edm::LogVerbatim("OscarMTMasterThread") << "Master thread: State loop, starting wait";
       m_notifyMasterCv.wait(lk2, [&] { return m_masterCanProceed; });
-      //m_notifyMasterCv.wait(lk2, [&] { return false; });
 
       // Act according to the state
       edm::LogVerbatim("OscarMTMasterThread")
@@ -62,8 +61,10 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
         // Stop Geant4
         edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Stopping Geant4";
         m_runManagerMaster->stopG4();
+        G4PhysicalVolumeStore::Clean();
         isG4Alive = false;
       } else if (m_masterThreadState == ThreadState::Destruct) {
+	// Stop master thread started
         edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Breaking out of state loop";
         if (isG4Alive)
           throw cms::Exception("LogicError") << "OscarMTMasterThread: Geant4 is still alive, master thread "
@@ -81,7 +82,6 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
 
     // must be done in this thread, segfault otherwise
     m_runManagerMaster.reset();
-    G4PhysicalVolumeStore::Clean();
 
     edm::LogVerbatim("SimG4CoreApplication") << "OscarMTMasterThread: physics and geometry are cleaned";
     lk2.unlock();


### PR DESCRIPTION
#### PR description:
In this PR the order of destruction actions end of run is performed. It should fix the issue #44009 - G4PhysicalVolumeStore is cleaned only if it is created. As a result the trace from some CMSSW crashes will be more correct. This PR should not affect any WF, the only expected result should be in trace, when a crash happens .

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO

