### PR TITLE
Fix some minor RooFit user errors

### DIFF
--- a/Alignment/OfflineValidation/bin/Zmumumerge.cc
+++ b/Alignment/OfflineValidation/bin/Zmumumerge.cc
@@ -132,7 +132,7 @@ FitOut ZMassBinFit_OldTool(TH1D* th1d_input, TString s_name = "zmumu_fitting", T
   c1->Print(Form("%s/fitResultPlot/%s_oldtool.root", output_path.Data(), s_name.Data()));
 
   FitOut fitRes(
-      fitter->mean()->getValV(), fitter->mean()->getError(), fitter->sigma()->getValV(), fitter->sigma()->getError());
+      fitter->mean()->getVal(), fitter->mean()->getError(), fitter->sigma()->getVal(), fitter->sigma()->getError());
 
   return fitRes;
 }

--- a/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
+++ b/DQMOffline/Alignment/src/DiMuonMassBiasClient.cc
@@ -494,8 +494,8 @@ diMuonMassBias::fitOutputs DiMuonMassBiasClient::fitBWTimesCB(TH1* hist) const
   }
   delete c1;
 
-  Measurement1D resultM(fitter->mean()->getValV(), fitter->mean()->getError());
-  Measurement1D resultW(fitter->sigma()->getValV(), fitter->sigma()->getError());
+  Measurement1D resultM(fitter->mean()->getVal(), fitter->mean()->getError());
+  Measurement1D resultW(fitter->sigma()->getVal(), fitter->sigma()->getError());
 
   return diMuonMassBias::fitOutputs(resultM, resultW);
 }

--- a/DQMOffline/EGamma/plugins/PhotonDataCertification.cc
+++ b/DQMOffline/EGamma/plugins/PhotonDataCertification.cc
@@ -87,9 +87,9 @@ float PhotonDataCertification::invMassZtest(string path, TString name, DQMStore:
 
   BreitWigner.fitTo(test, RooFit::Range(80, 100), RooFit::PrintLevel(-1000));
 
-  if (std::abs(mRes.getValV() - ZMass) < ZWidth) {
+  if (std::abs(mRes.getVal() - ZMass) < ZWidth) {
     return 1.0;
-  } else if (std::abs(mRes.getValV() - ZMass) < gamma.getValV()) {
+  } else if (std::abs(mRes.getVal() - ZMass) < gamma.getVal()) {
     return 0.9;
   } else {
     return 0.0;

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/FitWithRooFit.cc
@@ -118,7 +118,7 @@ public:
     // Fit with likelihood
     if (!useChi2_) {
       if (sumW2Error)
-        model->fitTo(*dh, RooFit::Save(), RooFit::SumW2Error(kTRUE));
+        model->fitTo(*dh, RooFit::SumW2Error(true));
       else
         model->fitTo(*dh);
     }

--- a/Validation/MtdValidation/macros/Pt_residuals_fit.C
+++ b/Validation/MtdValidation/macros/Pt_residuals_fit.C
@@ -114,8 +114,8 @@ void fit_to_data(TH1D* h_TrackMatchedTP, TString str) {
   // The PDF fit to that data set using an un-binned maximum likelihood fit
   // Then the data are visualized with the PDF overlaid
 
-  // Perform extended ML fit of PDF to data and save results in a pointer
-  RooFitResult* r1 = model->fitTo(*h_, Save());
+  // Perform extended ML fit of PDF to data
+  model->fitTo(*h_);
 
   // Retrieve values from the fit
   Double_t mean_fit = mean.getVal();


### PR DESCRIPTION
  * One should use `getVal()` and not `getValV()` (the latter should not be called. The "V" stands for `virtual`, and `getValV()` is the function that should be overridden if one wants to change the behavior of `getVal()`)

  * Avoid some memory leaks by not creating a leaking fit result by using the `Save()` option

  * Improve memory management with smart pointers