### PR TITLE
[14.0.X] Remove unnecessary ESProducer from LegacyPFClusterProducer

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
+++ b/HLTrigger/Configuration/python/customizeHLTforAlpaka.py
@@ -192,7 +192,6 @@ def customizeHLTforAlpakaParticleFlowClustering(process):
 
     process.hltLegacyPFClusterProducer = cms.EDProducer("LegacyPFClusterProducer",
             src = cms.InputTag("hltPFClusterSoAProducer"),
-            pfClusterParams = cms.ESInputTag("pfClusterParamsESProducer:"),
             pfClusterBuilder = process.hltParticleFlowClusterHBHE.pfClusterBuilder,
             usePFThresholdsFromDB = cms.bool(True),
             recHitsSource = cms.InputTag("hltLegacyPFRecHitProducer"),
@@ -413,7 +412,7 @@ def customizeHLTforDQMGPUvsCPUPixel(process):
 def customizeHLTforAlpakaPixelRecoLocal(process):
     '''Customisation to introduce the Local Pixel Reconstruction in Alpaka
     '''
-    process.hltESPSiPixelCablingSoA = cms.ESProducer('SiPixelCablingSoAESProducer@alpaka', 
+    process.hltESPSiPixelCablingSoA = cms.ESProducer('SiPixelCablingSoAESProducer@alpaka',
         CablingMapLabel = cms.string(''),
         UseQualityInfo = cms.bool(False),
         appendToDataLabel = cms.string(''),
@@ -429,7 +428,7 @@ def customizeHLTforAlpakaPixelRecoLocal(process):
         )
     )
 
-    process.hltESPPixelCPEFastParamsPhase1 = cms.ESProducer('PixelCPEFastParamsESProducerAlpakaPhase1@alpaka', 
+    process.hltESPPixelCPEFastParamsPhase1 = cms.ESProducer('PixelCPEFastParamsESProducerAlpakaPhase1@alpaka',
         appendToDataLabel = cms.string(''),
         alpaka = cms.untracked.PSet(
             backend = cms.untracked.string('')
@@ -729,7 +728,7 @@ def customizeHLTforAlpakaPixelRecoVertexing(process):
         process.HLTRecoPixelTracksTask,
         process.hltPixelVerticesSoA,
         process.hltPixelVertices,
-        process.hltTrimmedPixelVertices 
+        process.hltTrimmedPixelVertices
     )
 
     process.HLTRecopixelvertexingCPUSerialTask = cms.ConditionalTask(
@@ -797,7 +796,7 @@ def customizeHLTforAlpakaPixelRecoTheRest(process):
         track_pt_max = cms.double(10.0),
         track_pt_min = cms.double(1.0)
     )
-    
+
     return process
 
 def customizeHLTforAlpakaPixelReco(process):
@@ -807,7 +806,7 @@ def customizeHLTforAlpakaPixelReco(process):
     process = customizeHLTforAlpakaPixelRecoLocal(process)
     process = customizeHLTforAlpakaPixelRecoTracking(process)
     process = customizeHLTforAlpakaPixelRecoVertexing(process)
-    process = customizeHLTforDQMGPUvsCPUPixel(process)    
+    process = customizeHLTforDQMGPUvsCPUPixel(process)
     process = customizeHLTforAlpakaPixelRecoTheRest(process)
 
     return process
@@ -815,7 +814,7 @@ def customizeHLTforAlpakaPixelReco(process):
 ## ECAL HLT in Alpaka
 
 def customizeHLTforAlpakaEcalLocalReco(process):
-    
+
     if hasattr(process, 'hltEcalDigisGPU'):
         process.hltEcalDigisPortable = cms.EDProducer("EcalRawToDigiPortable@alpaka",
             FEDs = process.hltEcalDigisGPU.FEDs,
@@ -913,7 +912,7 @@ def customizeHLTforAlpaka(process):
 
     process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
     process.load('Configuration.StandardSequences.Accelerators_cff')
-    
+
     process = customizeHLTforAlpakaEcalLocalReco(process)
     process = customizeHLTforAlpakaPixelReco(process)
     process = customizeHLTforAlpakaParticleFlowClustering(process)

--- a/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
@@ -64,9 +64,9 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src");
-    desc.add<edm::InputTag>("PFRecHitsLabelIn");
-    desc.add<edm::InputTag>("recHitsSource");
+    desc.add<edm::InputTag>("src", edm::InputTag("pfClusterSoAProducer"));
+    desc.add<edm::InputTag>("PFRecHitsLabelIn", edm::InputTag("pfRecHitSoAProducerHCAL"));
+    desc.add<edm::InputTag>("recHitsSource", edm::InputTag("legacyPFRecHitProducer"));
     desc.add<bool>("usePFThresholdsFromDB", true);
     {
       edm::ParameterSetDescription pfClusterBuilder;

--- a/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
@@ -32,7 +32,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFractionHostCollection.h"
 #include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
-#include "RecoParticleFlow/PFClusterProducer/interface/PFClusterParamsHostCollection.h"
 
 class LegacyPFClusterProducer : public edm::stream::EDProducer<> {
 public:
@@ -40,7 +39,6 @@ public:
       : pfClusterSoAToken_(consumes(config.getParameter<edm::InputTag>("src"))),
         pfRecHitFractionSoAToken_(consumes(config.getParameter<edm::InputTag>("src"))),
         InputPFRecHitSoA_Token_{consumes(config.getParameter<edm::InputTag>("PFRecHitsLabelIn"))},
-        pfClusParamsToken_(esConsumes(config.getParameter<edm::ESInputTag>("pfClusterParams"))),
         legacyPfClustersToken_(produces()),
         recHitsLabel_(consumes(config.getParameter<edm::InputTag>("recHitsSource"))),
         hcalCutsToken_(esConsumes<HcalPFCuts, HcalPFCutsRcd>(edm::ESInputTag("", "withTopo"))),
@@ -68,7 +66,6 @@ public:
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("src");
     desc.add<edm::InputTag>("PFRecHitsLabelIn");
-    desc.add<edm::ESInputTag>("pfClusterParams");
     desc.add<edm::InputTag>("recHitsSource");
     desc.add<bool>("usePFThresholdsFromDB", true);
     {
@@ -183,7 +180,6 @@ private:
   const edm::EDGetTokenT<reco::PFClusterHostCollection> pfClusterSoAToken_;
   const edm::EDGetTokenT<reco::PFRecHitFractionHostCollection> pfRecHitFractionSoAToken_;
   const edm::EDGetTokenT<reco::PFRecHitHostCollection> InputPFRecHitSoA_Token_;
-  const edm::ESGetToken<reco::PFClusterParamsHostCollection, JobConfigurationGPURecord> pfClusParamsToken_;
   const edm::EDPutTokenT<reco::PFClusterCollection> legacyPfClustersToken_;
   const edm::EDGetTokenT<reco::PFRecHitCollection> recHitsLabel_;
   const edm::ESGetToken<HcalPFCuts, HcalPFCutsRcd> hcalCutsToken_;

--- a/RecoParticleFlow/PFClusterProducer/python/pfClusterHBHEAlpaka_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/pfClusterHBHEAlpaka_cff.py
@@ -72,7 +72,6 @@ pfClusterSoAProducer = _pfClusterSoAProducer.clone(
 
 legacyPFClusterProducer = _legacyPFClusterProducer.clone(
         src = 'pfClusterSoAProducer',
-        pfClusterParams = 'pfClusterParamsESProducer:',
         pfClusterBuilder = particleFlowClusterHBHE.pfClusterBuilder,
         recHitsSource = 'legacyPFRecHitProducer',
         PFRecHitsLabelIn = 'pfRecHitSoAProducerHCAL'
@@ -135,7 +134,6 @@ pfClusterSoAProducerHBHEOnly = _pfClusterSoAProducer.clone(
 
 legacyPFClusterProducerHBHEOnly = _legacyPFClusterProducer.clone(
         src = 'pfClusterSoAProducerHBHEOnly',
-        pfClusterParams = 'pfClusterParamsESProducer:',
         pfClusterBuilder = particleFlowClusterHBHE.pfClusterBuilder,
         recHitsSource = 'legacyPFRecHitProducerHBHEOnly',
         PFRecHitsLabelIn = 'pfRecHitSoAProducerHBHEOnly'


### PR DESCRIPTION
#### PR description:

This PR removes `pfClusterParamsESProducer` from `LegacyPFClusterProducer` as it is not used in the producer. Configurations for offline workflows and `customizeHLTforAlpaka.py` are updated to reflect this change.

#### PR validation:

Tested on workflow 12434.423 which uses the HLT customization and HCAL only configuration for this producer.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44070 to `14_0_X`

@hatakeyamak @fwyzard @waredjeb