### PR TITLE
Update 2024 MC GTs with the L1 menu

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -90,13 +90,13 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
-    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v1',
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v3',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v1',
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v1'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2023_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2023-06-13 14:12:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-02-21 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

Update the 2024  MC GTs with the new L1 menu as in cmsTalk https://cms-talk.web.cern.ch/t/update-of-the-2024-l1-menu-tag-l1menu-collisions2024-v1-1-0/35509

The updated tag for L1TUtmTriggerMenuRcd is
From:   **L1Menu_Collisions2023_v1_2_0_xml**
To:   	**L1Menu_Collisions2024_v1_0_0_xml**

**GT differences**

- phase1_2024_design: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v1/140X_mcRun3_2024_design_v3

- phase1_2024_realistic: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v3/140X_mcRun3_2024_realistic_v4

- phase1_2024_cosmics: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v3/140X_mcRun3_2024cosmics_realistic_deco_v4

- phase1_2024_cosmics_design: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v1/140X_mcRun3_2024cosmics_design_deco_v2

#### PR validation:

This must be tested (and merged) together with https://github.com/cms-sw/cmssw/pull/44073 once the corresponding GT updates are removed from that PR so that the ones here are picked instead

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported 

This will have to be backported in 14_0_X