### PR TITLE
[GEM][bug fix] avoid the segmentation fault caused by the 2024 GEMGeometry

### DIFF
--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -81,7 +81,7 @@ void GEMPadDigiProducer::beginRun(const edm::Run& run, const edm::EventSetup& ev
   geometry_ = &*hGeom;
   // check the number of parititions
   if (geometry_->hasGE21()) {
-    use16GE21_ = (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() ==
+    use16GE21_ = (geometry_->chamber(GEMDetId(1, 1, 2, 2, 16, 0))->nEtaPartitions() ==
                   GEMPadDigi::NumberPartitions::GE21SplitStrip);
   }
 
@@ -211,12 +211,12 @@ void GEMPadDigiProducer::checkGeometry() const {
   if (geometry_->hasGE21()) {
     if (!use16GE21_) {
       // check that GE2/1 has 8-eta partitions
-      if (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
+      if (geometry_->chamber(GEMDetId(1, 1, 2, 2, 16, 0))->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
         edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (8 partition) appears corrupted";
       }
     } else {
       // check that GE2/1 has 16-eta partitions
-      if (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() !=
+      if (geometry_->chamber(GEMDetId(1, 1, 2, 2, 16, 0))->nEtaPartitions() !=
           GEMPadDigi::NumberPartitions::GE21SplitStrip) {
         edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (16 partition) appears corrupted";
       }


### PR DESCRIPTION
#### PR description:

* With the 2024 GEMGeometry, the `GEMPadDigiProducer` trying to check the number of eta partitions from GE+2/1 chamber 1 layer 1.
* But the chamber dose not exist in the geometry. And it make a segmentation fault during the test.
* To avoid the problem, we asked the module to check GE+2/1 chamber 16 layer 2 which is in the geometry since 2022 instead of the ghost chamber.
* A backport to CMSSW_14_0_X is needed.

#### PR validation:

* The change is tested with the customized geometry which is basically 2023 geometry, but changing gem21 to 2024 scenario.
* The code format passed with `scram b code-format` and `scram b code-checks`

@watson-ij @bsunanda 