### PR TITLE
Jet phi variable in L1 correction

### DIFF
--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrectorImpl.cc
@@ -70,5 +70,6 @@ double L1FastjetCorrectorImpl::correction(const reco::Jet& fJet) const {
   values.setJetE(fJet.energy());
   values.setJetA(fJet.jetArea());
   values.setRho(rho_);
+  values.setJetPhi(fJet.phi());
   return corrector_->getCorrection(values);
 }


### PR DESCRIPTION
#### PR description:

Adding the phi variable for the L1 FastJet correction for JECs. This has application in introducing phi dependent JECs to address the "BPix issue" that appeared in 2023D era of data-taking and will be present in 2024. Main interest is the HLT PF jets but can apply for CHS jets offline too.

#### PR validation:

Tested running the latest HLT menu using this modification and applying the derived phi dependent corrections.

workflow test:
`runTheMatrix.py -l 11634.0`
passes

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Since the main target is the 2024 data-taking will backport in 14_0_X for use in HLT menu. It can potentially apply for re-reco in 2023D for offline jets, then would need also 13_X releases.