### PR TITLE
[GEM][backport] Enable masking for GEM for Run3

### DIFF
--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -14,5 +14,5 @@ gemRecHits = gemRecHitsDef.clone(
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
-run3_GEM.toModify(gemRecHits, ge21Off=True)
-phase2_GEM.toModify(gemRecHits, ge21Off=False)
+run3_GEM.toModify(gemRecHits, ge21Off=True, applyMasking=True)
+phase2_GEM.toModify(gemRecHits, ge21Off=False, applyMasking=False)


### PR DESCRIPTION
#### PR description:

* GEM strip masking was started from mid-last year
* This PR enables a clustering with considering the strip masking on the local reconstruction of GEM.
* The PR need to be hold until the `GEMMaskedStripsRcd` and `GEMDeadStripsRcd` are included in the global tags.

@watson-ij 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

* The original PR is #44085 