### PR TITLE
Fix of LumiList.py so to allow the merge of JSON files

### DIFF
--- a/FWCore/PythonUtilities/python/LumiList.py
+++ b/FWCore/PythonUtilities/python/LumiList.py
@@ -181,8 +181,8 @@ class LumiList(object):
 
     def __or__(self, other):
         result = {}
-        aruns = self.compactList.keys()
-        bruns = other.compactList.keys()
+        aruns = list(self.compactList.keys())
+        bruns = list(other.compactList.keys())
         runs = set(aruns + bruns)
         for run in runs:
             overlap = sorted(self.compactList.get(run, []) + other.compactList.get(run, []))
@@ -245,7 +245,7 @@ class LumiList(object):
         Return the list of pairs representation
         """
         theList = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList.keys())
         runs = sorted(run, key=int)
         for run in runs:
             lumis = self.compactList[run]
@@ -270,7 +270,7 @@ class LumiList(object):
         """
 
         parts = []
-        runs = self.compactList.keys()
+        runs = list(self.compactList.keys())
         runs = sorted(runs, key=int)
         for run in runs:
             lumis = self.compactList[run]


### PR DESCRIPTION
#### PR description:

While merging the JSON files with mergeJSON.py, we ran into this error: 
`  File "/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_0_0/bin/el9_amd64_gcc12/mergeJSON.py", line 44, in <module>
    finalList = finalList | localList
  File "/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_0_0/src/FWCore/PythonUtilities/python/LumiList.py", line 186, in __or__
    runs = set(aruns + bruns)
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'`

as in Python 3.x, dict.keys doesn't return a list, but instead a view object, dict_keys. Therefore, this PR converted all the runs to a list to solve this error.

#### PR validation:

The PR has been validated by copying mergeJSON.py to a local area at lxplus and point to the local LumiList.py, with this PR, two JSONs could be merged without errors. Additionally, we also use this version of LumiList.py to launch cron jobs of DCS-only JSON files at lxplus in the central DQM-DC team. The cron jobs patch the new runs with good siStrip/pixel DCS status every day on top of the previous runs (using mergeJSON.py). These cron jobs have been launched 7 days ago and produced results without error.
