### PR TITLE
Removes duplicate/unneeded entries in serialization XML of test objects.

### DIFF
--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,6 +1,5 @@
 <lcgdict>
   <class name="portabletest::TestSoA"/>
-  <class name="portabletest::TestSoA::View"/>
   <class name="portabletest::TestHostCollection"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
 
@@ -8,16 +7,9 @@
   <class name="portabletest::TestHostObject"/>
   <class name="edm::Wrapper<portabletest::TestHostObject>"/>
 
-  <class name="portabletest::TestSoA2"/>
-  <class name="portabletest::TestSoA3"/>
-
   <class name="portabletest::TestSoALayout<128,false>"/>
   <class name="portabletest::TestSoALayout2<128,false>"/>
   <class name="portabletest::TestSoALayout3<128,false>"/>
-
-  <class name="portabletest::TestSoALayout<128, false>"/>
-  <class name="portabletest::TestSoALayout2<128, false>"/>
-  <class name="portabletest::TestSoALayout3<128, false>"/>
 
   <!-- Recursive templates (with no data) ensuring we have one CollectionLeaf<index, type> for each layout in the collection -->
   <class name="portablecollection::CollectionImpl<0, portabletest::TestSoALayout<128, false>, portabletest::TestSoALayout2<128, false>>"/>

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,5 +1,4 @@
 <lcgdict>
-  <class name="portabletest::TestSoA"/>
   <class name="portabletest::TestHostCollection"/>
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
 


### PR DESCRIPTION
#### PR description:

This PR simplifies the XML for tests objects.

#### PR validation:

Unit tests plus `writer.pl` and `reader.pl` from `HeterogeneousCore/AlpakaTest/test/` ran successfully.

