### PR TITLE
Delete function warnAboutLegacyModules (no longer needed)

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -294,7 +294,6 @@ namespace edm {
 
     void throwAboutModulesRequiringLuminosityBlockSynchronization() const;
     void warnAboutModulesRequiringRunSynchronization() const;
-    void warnAboutLegacyModules() const;
 
     bool needToCallNext() const { return needToCallNext_; }
     void setNeedToCallNext(bool val) { needToCallNext_ = val; }

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -93,7 +93,7 @@ namespace edm {
   public:
     enum State { Ready, Pass, Fail, Exception };
     enum Types { kAnalyzer, kFilter, kProducer, kOutputModule };
-    enum ConcurrencyTypes { kGlobal, kLimited, kOne, kStream, kLegacy };
+    enum ConcurrencyTypes { kGlobal, kLimited, kOne, kStream };
     struct TaskQueueAdaptor {
       SerialTaskQueueChain* serial_ = nullptr;
       LimitedTaskQueue* limited_ = nullptr;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -701,7 +701,6 @@ namespace edm {
     if (preallocations_.numberOfRuns() > 1) {
       warnAboutModulesRequiringRunSynchronization();
     }
-    warnAboutLegacyModules();
 
     //NOTE:  This implementation assumes 'Job' means one call
     // the EventProcessor::run
@@ -2493,21 +2492,6 @@ namespace edm {
         if (not s) {
           s = std::make_unique<LogSystem>("ModulesSynchingOnRuns");
           (*s) << "The following modules require synchronizing on Run boundaries:";
-        }
-        (*s) << "\n  " << worker->description()->moduleName() << " " << worker->description()->moduleLabel();
-      }
-    }
-  }
-
-  void EventProcessor::warnAboutLegacyModules() const {
-    std::unique_ptr<LogSystem> s;
-    for (auto worker : schedule_->allWorkers()) {
-      if (worker->moduleConcurrencyType() == Worker::kLegacy) {
-        if (not s) {
-          s = std::make_unique<LogSystem>("LegacyModules");
-          (*s) << "The following legacy modules are configured. Support for legacy modules\n"
-                  "is going to end soon. These modules need to be converted to have type\n"
-                  "edm::global, edm::stream, edm::one, or in rare cases edm::limited.";
         }
         (*s) << "\n  " << worker->description()->moduleName() << " " << worker->description()->moduleLabel();
       }


### PR DESCRIPTION
#### PR description:

Delete function warnAboutLegacyModules. This function is no longer needed. Legacy type modules will no longer compile so there couldn't be any.

#### PR validation:

Just deletions. It compiles.