### PR TITLE
[14.0.X]  Tracker alignment offline validation tools: miscellaneous fixes to muon-related validations

### DIFF
--- a/Alignment/OfflineValidation/bin/DiMuonVmerge.cc
+++ b/Alignment/OfflineValidation/bin/DiMuonVmerge.cc
@@ -46,10 +46,14 @@ int merge(int argc, char* argv[]) {
     //   std::cout << "  Attribute: " << attr.first << " = " << attr.second.data() << std::endl;
     // }
 
-    std::cout << childTree.second.get<string>("file") << std::endl;
+    std::string file = childTree.second.get<string>("file");
+    std::cout << file << std::endl;
     std::cout << childTree.second.get<string>("title") << std::endl;
-    std::string toAdd = childTree.second.get<string>("file") +
-                        "/DiMuonVertexValidation.root=" + childTree.second.get<string>("title") + ",";
+
+    // Check if the file contains "/eos/cms/" and add the prefix accordingly
+    std::string prefixToAdd = file.find("/eos/cms/") != std::string::npos ? "root://eoscms.cern.ch/" : "";
+    std::string toAdd =
+        prefixToAdd + file + "/DiMuonVertexValidation.root=" + childTree.second.get<string>("title") + ",";
     filesAndLabels += toAdd;
   }
 

--- a/Alignment/OfflineValidation/bin/Zmumumerge.cc
+++ b/Alignment/OfflineValidation/bin/Zmumumerge.cc
@@ -75,13 +75,25 @@ public:
 };
 
 FitOut ZMassBinFit_OldTool(TH1D* th1d_input, TString s_name = "zmumu_fitting", TString output_path = "./") {
-  double xMin(75), xMax(105), xMean(91);
-  double sigma = 2;
-  double sigmaMin = 0.1;
-  double sigmaMax = 10;
+  // silence messages
+  RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
-  FitWithRooFit* fitter = new FitWithRooFit();
-  double sigma2(0.1), sigma2Min(0.), sigma2Max(10.), useChi2(false);
+  double xMean = 91.1876;
+  double xMin = th1d_input->GetXaxis()->GetXmin();
+  double xMax = th1d_input->GetXaxis()->GetXmax();
+
+  double sigma(2.);
+  double sigmaMin(0.1);
+  double sigmaMax(10.);
+
+  double sigma2(0.1);
+  double sigma2Min(0.);
+  double sigma2Max(10.);
+
+  std::unique_ptr<FitWithRooFit> fitter = std::make_unique<FitWithRooFit>();
+
+  bool useChi2(false);
+
   fitter->useChi2_ = useChi2;
   fitter->initMean(xMean, xMin, xMax);
   fitter->initSigma(sigma, sigmaMin, sigmaMax);
@@ -89,8 +101,6 @@ FitOut ZMassBinFit_OldTool(TH1D* th1d_input, TString s_name = "zmumu_fitting", T
   fitter->initAlpha(1.5, 0.05, 10.);
   fitter->initN(1, 0.01, 100.);
   fitter->initFGCB(0.4, 0., 1.);
-
-  fitter->initMean(91.1876, xMin, xMax);
   fitter->initGamma(2.4952, 0., 10.);
   fitter->gamma()->setConstant(kTRUE);
   fitter->initMean2(0., -20., 20.);
@@ -109,6 +119,7 @@ FitOut ZMassBinFit_OldTool(TH1D* th1d_input, TString s_name = "zmumu_fitting", T
   fitter->initA4(0., -10., 10.);
   fitter->initA5(0., -10., 10.);
   fitter->initA6(0., -10., 10.);
+
   TCanvas* c1 = new TCanvas();
   c1->Clear();
   c1->SetLeftMargin(0.15);
@@ -121,9 +132,10 @@ FitOut ZMassBinFit_OldTool(TH1D* th1d_input, TString s_name = "zmumu_fitting", T
 
   FitOut fitRes(
       fitter->mean()->getValV(), fitter->mean()->getError(), fitter->sigma()->getValV(), fitter->sigma()->getError());
+
   return fitRes;
 }
-void Draw_th1d(TH1D* th1d_input, TString variable_name) {
+void Draw_th1d(TH1D* th1d_input, TString variable_name, TString output_path) {
   TCanvas* c = new TCanvas();
   c->cd();
   gStyle->SetOptStat(0);
@@ -137,12 +149,13 @@ void Draw_th1d(TH1D* th1d_input, TString variable_name) {
   th1d_input->GetYaxis()->SetTitle("Mass mean (GeV)");
   th1d_input->Draw();
   tlxg->DrawLatexNDC(0.2, 0.8, Form("%s", GT.Data()));
-  c->Print(Form("%s/fitResultPlot/mass_VS_%s.pdf", GT.Data(), variable_name.Data()));
+  c->Print(Form("%s/fitResultPlot/mass_VS_%s.pdf", output_path.Data(), variable_name.Data()));
 }
 
 const static int variables_number = 8;
 const TString tstring_variables_name[variables_number] = {
     "CosThetaCS", "DeltaEta", "EtaMinus", "EtaPlus", "PhiCS", "PhiMinus", "PhiPlus", "Pt"};
+
 void Fitting_GetMassmeanVSvariables(TString inputfile_name, TString output_path) {
   TH2D* th2d_mass_variables[variables_number];
   TFile* inputfile = TFile::Open(inputfile_name.Data());
@@ -154,7 +167,7 @@ void Fitting_GetMassmeanVSvariables(TString inputfile_name, TString output_path)
 
   gSystem->Exec(Form("mkdir -p %s", output_path.Data()));
   gSystem->Exec(Form("mkdir -p %s/fitResultPlot", output_path.Data()));
-  TFile* outpufile = TFile::Open(Form("%s/fitting_output.root", output_path.Data()), "recreate");
+  TFile* outputfile = TFile::Open(Form("%s/fitting_output.root", output_path.Data()), "RECREATE");
   TH1D* th1d_variables_meanmass[variables_number];
   TH1D* th1d_variables_entries[variables_number];
   const int variables_rebin[variables_number] = {1, 1, 1, 1, 1, 1, 1, 1};
@@ -169,8 +182,8 @@ void Fitting_GetMassmeanVSvariables(TString inputfile_name, TString output_path)
       if (i == 7 and j > 25) {
         continue;
       }
-      cout << "th1d_variables_meanmass[i]->GetNbinsX()=" << th1d_variables_meanmass[i]->GetNbinsX() << endl;
-      cout << "th2d_mass_variables[i]->GetNbinsY()=" << th2d_mass_variables[i]->GetNbinsY() << endl;
+      //cout << __LINE__ << " th1d_variables_meanmass[i]->GetNbinsX()=" << th1d_variables_meanmass[i]->GetNbinsX() << endl;
+      //cout << __LINE__ << " th2d_mass_variables[i]->GetNbinsY()=" << th2d_mass_variables[i]->GetNbinsY() << endl;
       th1d_variables_meanmass[i]->SetBinContent(j, 0);
       th1d_variables_meanmass[i]->SetBinError(j, 0);
 
@@ -181,25 +194,39 @@ void Fitting_GetMassmeanVSvariables(TString inputfile_name, TString output_path)
       TString s_name = Form("%s_%d", tstring_variables_name[i].Data(), j);
 
       FitOut fitR = ZMassBinFit_OldTool(th1d_i, s_name, output_path);
+
       th1d_variables_meanmass[i]->SetBinContent(j, fitR.mean);
       th1d_variables_meanmass[i]->SetBinError(j, fitR.mean_err);
     }
+
     th1d_variables_meanmass[i]->GetXaxis()->SetRangeUser(xaxis_range[i][0], xaxis_range[i][1]);
-    Draw_th1d(th1d_variables_meanmass[i], tstring_variables_name[i]);
-    outpufile->cd();
+    Draw_th1d(th1d_variables_meanmass[i], tstring_variables_name[i], output_path);
+    outputfile->cd();
     th1d_variables_meanmass[i]->Write(th1d_name);
 
     TString th1d_name_entries = Form("th1d_entries_%s", tstring_variables_name[i].Data());
     th1d_variables_entries[i] = th2d_mass_variables[i]->ProjectionY(th1d_name_entries, 0, -1, "d");
     th1d_variables_entries[i]->GetXaxis()->SetTitle(tstring_variables_name[i].Data());
     th1d_variables_entries[i]->GetYaxis()->SetTitle("Entry");
-    outpufile->cd();
+    outputfile->cd();
     th1d_variables_entries[i]->Write(th1d_name_entries);
   }
 
-  outpufile->Write();
-  outpufile->Close();
-  delete outpufile;
+  if (outputfile->IsOpen()) {
+    // Get the path (current working directory) in which the file is going to be written
+    const char* path = outputfile->GetPath();
+
+    if (path) {
+      std::cout << "File is going to be written in the directory: " << path << " for input file: " << inputfile_name
+                << std::endl;
+    } else {
+      std::cerr << "Error: Unable to determine the path." << std::endl;
+    }
+
+    //outputfile->Write();
+    outputfile->Close();
+    delete outputfile;
+  }
 }
 
 const static int max_file_number = 10;
@@ -261,7 +288,16 @@ int Zmumumerge(int argc, char* argv[]) {
   pt::read_json(options.config, main_tree);
   pt::ptree alignments = main_tree.get_child("alignments");
   pt::ptree validation = main_tree.get_child("validation");
+
   for (const auto& childTree : alignments) {
+    // do not consider the nodes with a "file" to merge
+    if (childTree.second.find("file") == childTree.second.not_found()) {
+      std::cerr << "Ignoring alignment: " << childTree.second.get<std::string>("title") << ".\nNo file to merged found!"
+                << std::endl;
+      continue;
+    } else {
+      std::cout << "Storing alignment: " << childTree.second.get<std::string>("title") << std::endl;
+    }
     vec_single_file_path.push_back(childTree.second.get<std::string>("file"));
     vec_single_file_name.push_back(childTree.second.get<std::string>("file") + "/Zmumu.root");
     vec_color.push_back(childTree.second.get<int>("color"));
@@ -271,6 +307,7 @@ int Zmumumerge(int argc, char* argv[]) {
 
     //Fitting_GetMassmeanVSvariables(childTree.second.get<std::string>("file") + "/Zmumu.root", childTree.second.get<std::string>("file"));
   }
+
   TString merge_output = main_tree.get<std::string>("output");
   //=============================================
   vector<TString> vec_single_fittingoutput;
@@ -300,6 +337,7 @@ int Zmumumerge(int argc, char* argv[]) {
         th1d_name_entries,
         merge_output + Form("/entries_%s_GTs.pdf", tstring_variables_name[idx_variable].Data()));
   }
+
   //=============================================
   return EXIT_SUCCESS;
 }

--- a/Alignment/OfflineValidation/macros/CMS_lumi.h
+++ b/Alignment/OfflineValidation/macros/CMS_lumi.h
@@ -41,9 +41,9 @@ TString lumi_sqrtS = "";
 bool writeExraLumi = false;
 bool drawLogo = false;
 
-void CMS_lumi(TPad* pad, int iPeriod = 3, int iPosX = 10);
+void CMS_lumi(TPad* pad, int iPeriod = 3, int iPosX = 10, TString RLabel = "");
 
-inline void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
+inline void CMS_lumi(TPad* pad, int iPeriod, int iPosX, TString RLabel) {
   bool outOfFrame = false;
   if (iPosX / 10 == 0) {
     outOfFrame = true;
@@ -139,7 +139,11 @@ inline void CMS_lumi(TPad* pad, int iPeriod, int iPosX) {
   latex.SetTextFont(42);
   latex.SetTextAlign(31);
   latex.SetTextSize(lumiTextSize * t);
-  latex.DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
+  if (RLabel != "") {
+    latex.DrawLatex(1 - r, 1 - t + lumiTextOffset * t, RLabel);
+  } else {
+    latex.DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
+  }
 
   if (outOfFrame) {
     latex.SetTextFont(cmsTextFont);

--- a/Alignment/OfflineValidation/macros/loopAndPlot.C
+++ b/Alignment/OfflineValidation/macros/loopAndPlot.C
@@ -68,7 +68,15 @@ void recurseOverKeys(TDirectory *target1, const std::vector<TString> &labels, bo
 /************************************************/
 {
   // Figure out where we are
-  TString path((char *)strstr(target1->GetPath(), ":"));
+  TString fullPath = target1->GetPath();
+
+  // Check if the prefix "root://eoscms.cern.ch/" is present and remove it
+  TString prefixToRemove = "root://eoscms.cern.ch/";
+  if (fullPath.BeginsWith(prefixToRemove)) {
+    fullPath.Remove(0, prefixToRemove.Length());
+  }
+
+  TString path((char *)strstr(fullPath.Data(), ":"));
   path.Remove(0, 2);
 
   sourceFiles[0]->cd(path);

--- a/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/DiMuonVertexValidation.cc
@@ -471,7 +471,7 @@ void DiMuonVertexValidation::beginJob() {
 
   // take the range from the 2D histograms
   const auto& svDistSigRng = extractRangeValues(VtxDistSigConfiguration_);
-  hSVDistSig_ = fs->make<TH1F>("VtxDistSig", ";PV-#mu^{+}#mu^{-} vertex xy distance signficance;N(#mu#mu pairs)", 100, svDistSigRng.first, svDistRng.second);
+  hSVDistSig_ = fs->make<TH1F>("VtxDistSig", ";PV-#mu^{+}#mu^{-} vertex xy distance signficance;N(#mu#mu pairs)", 100, svDistSigRng.first, svDistSigRng.second);
 
   // take the range from the 2D histograms
   const auto& svDist3DRng = extractRangeValues(VtxDist3DConfiguration_);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/DiMuonV_cfg.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from fnmatch import fnmatch
 import FWCore.ParameterSet.Config as cms
+import FWCore.PythonUtilities.LumiList as LumiList
 import FWCore.Utilities.FileUtils as FileUtils
 from FWCore.ParameterSet.VarParsing import VarParsing
 from Alignment.OfflineValidation.TkAlAllInOneTool.defaultInputFiles_cff import filesDefaultMC_DoubleMuon_string
@@ -209,9 +210,13 @@ process.DiMuonVertexValidation = diMuonVertexValidation.clone(useReco = config["
 ## depending if RECO or ALCARECO is used
 ## the useReco flag above must be set accordingly
 if (config["validation"].get("useReco",True)):
+    print("I AM USING RECO DATA-TIER")
     process.DiMuonVertexValidation.muons  = 'muons'
     process.DiMuonVertexValidation.tracks = 'refittedVtxTracks'
 else:
+    print("I AM USING ALCARECO DATA-TIER")
+    if(hasattr(process.DiMuonVertexValidation,'muons')):
+        delattr(process.DiMuonVertexValidation,'muons')
     process.DiMuonVertexValidation.muonTracks = cms.InputTag('refittedMuons')
 
 ####################################################################

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/defaultInputFiles_cff.py
@@ -10,6 +10,8 @@ filesDefaultMC_DoubleMuon = cms.untracked.vstring(
 
 filesDefaultMC_DoubleMuon_string = '/store/relval/CMSSW_12_5_0_pre5/RelValZMM_14/GEN-SIM-RECO/125X_mcRun3_2022_realistic_v3-v1/10000/068634c7-e8e2-4e46-a68e-97ebefed4868.root'
 
+filesDefaultMC_DoubleMuonAlCa_string = '/store/relval/CMSSW_14_0_0_pre3/RelValZMM_14/ALCARECO/TkAlZMuMu-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v1/2580000/b91cfb5d-090c-4410-8c9e-ce165f4a4ef4.root'
+
 filesDefaultMC_TTBarPU = cms.untracked.vstring(
     '/store/relval/CMSSW_12_5_0_pre5/RelValTTbar_14TeV/GEN-SIM-RECO/PU_125X_mcRun3_2022_realistic_v3-v1/10000/0136c33f-3ff9-4602-8578-906ae6e0160b.root'
 )

--- a/Alignment/OfflineValidation/src/FitWithRooFit.cc
+++ b/Alignment/OfflineValidation/src/FitWithRooFit.cc
@@ -20,7 +20,7 @@ void FitWithRooFit::fit(
   reinitializeParameters();
 
   std::unique_ptr<RooDataHist> dh = importTH1(histo, xMin, xMax);
-  RooRealVar x(*static_cast<RooRealVar*>(dh->get()->find("x")));
+  RooRealVar x(*static_cast<RooRealVar*>(dh->get()->find("InvMass")));
 
   // Make plot of binned dataset showing Poisson error bars (RooFit default)
   RooPlot* frame = x.frame(RooFit::Title("di-muon mass M(#mu^{+}#mu^{-}) [GeV]"));
@@ -36,7 +36,8 @@ void FitWithRooFit::fit(
   // -----------------------
   // Fit with likelihood
   if (!useChi2_) {
-    model->fitTo(*dh, RooFit::SumW2Error(sumW2Error));
+    // use  RooFit::PrintLevel(-1) to reduce output to screen
+    model->fitTo(*dh, RooFit::SumW2Error(sumW2Error), RooFit::PrintLevel(-1));
   }
   // Fit with chi^2
   else {
@@ -46,8 +47,12 @@ void FitWithRooFit::fit(
     m.hesse();
     // RooFitResult* r_chi2_wgt = m.save();
   }
+
   model->plotOn(frame, RooFit::LineColor(kRed));
-  model->plotOn(frame, RooFit::Components(backgroundType), RooFit::LineStyle(kDashed));
+
+  // this causes segfaults when the fit causes a Warning in <ROOT::Math::Fitter::CalculateHessErrors>: Error when calculating Hessian
+  //model->plotOn(frame, RooFit::Components(backgroundType), RooFit::LineStyle(kDashed));
+
   model->paramOn(frame,
                  RooFit::Label("fit result"),
                  RooFit::Layout(0.65, 0.90, 0.90),
@@ -64,10 +69,13 @@ void FitWithRooFit::fit(
   // If histogram has custom error (i.e. its contents is does not originate from a Poisson process
   // but e.g. is a sum of weighted events) you can data with symmetric 'sum-of-weights' error instead
   // (same error bars as shown by ROOT)
+
   RooPlot* frame2 = x.frame(RooFit::Title("di-muon mass M(#mu^{+}#mu^{-}) [GeV]"));
   dh->plotOn(frame2, RooFit::DataError(RooAbsData::SumW2));
   model->plotOn(frame2, RooFit::LineColor(kRed));
-  model->plotOn(frame2, RooFit::Components(backgroundType), RooFit::LineStyle(kDashed));
+
+  // this causes segfaults when the fit causes a Warning in <ROOT::Math::Fitter::CalculateHessErrors>: Error when calculating Hessian
+  //model->plotOn(frame2, RooFit::Components(backgroundType), RooFit::LineStyle(kDashed));
   model->paramOn(frame2,
                  RooFit::Label("fit result"),
                  RooFit::Layout(0.65, 0.90, 0.90),

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -6,6 +6,9 @@
   <test name="PVall" command="testingScripts/test_unitPV.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>
+  <test name="Zmumuall" command="testingScripts/test_unitZmumu.sh">
+    <flags PRE_TEST="validateAlignments"/>
+  </test>
   <test name="SplitVall" command="testingScripts/test_unitSplitV.sh">
     <flags PRE_TEST="validateAlignments"/>
   </test>

--- a/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
+++ b/Alignment/OfflineValidation/test/DiMuonVertexValidation_cfg.py
@@ -27,13 +27,13 @@ options.register('maxEvents',
                  VarParsing.VarParsing.varType.int,
                  "number of events to process (\"-1\" for all)")
 options.register ('era',
-                  '2017', # default value
+                  '2022', # default value
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "CMS running era")
 
 options.register ('GlobalTag',
-                  '113X_mc2017_realistic_v4', # default value
+                  'auto:phase1_2022_realistic', # default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,
                   "seed number")

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitZmumu.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitZmumu.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Alignment/Zmumu single configuration with json..."
+pushd test_yaml/Zmumu/single/testSingleZMM/unitTestZmumuMCreal/1/
+./cmsRun validation_cfg.py config=validation.json || die "Failure running Zmumu first single configuration with json" $?
+popd
+
+echo "TESTING Alignment/Zmumu single configuration with json..."
+pushd test_yaml/Zmumu/single/testSingleZMM/unitTestZmumuMCdesign/1/
+./cmsRun validation_cfg.py config=validation.json || die "Failure running Zmumu second single configuration with json" $?
+
+echo "TESTING Alignment/Zmumu single configuration standalone..."
+./cmsRun validation_cfg.py || die "Failure running Zmumu single configuration standalone" $?
+popd
+
+echo "TESTING Zmumu merge step"
+pushd test_yaml/Zmumu/merge/testSingleZMM/1/
+./Zmumumerge --verbose validation.json || die "Failure running Zmumu merge step" $?
+popd

--- a/Alignment/OfflineValidation/test/unit_test.yaml
+++ b/Alignment/OfflineValidation/test/unit_test.yaml
@@ -44,6 +44,16 @@ alignments:
         globaltag: auto:phase1_2022_realistic
         style: 2101
         title: unit test
+    unitTestZmumuMCreal:
+        color: 1
+        globaltag: auto:phase1_2024_realistic
+        style: 20
+        title: realistic
+    unitTestZmumuMCdesign:
+        color: 2
+        globaltag: auto:phase1_2024_design
+        style: 21
+        title: design
     PromptNewTemplate:
         name: PromptNewTemplate
         color: 1
@@ -182,6 +192,21 @@ validations:
                 - unitTestDiMuonVMC
                 trackcollection: generalTracks
                 maxevents: 10
+
+    Zmumu:
+        merge:
+            testSingleZMM:
+                singles:
+                - testSingleZMM
+        single:
+            testSingleZMM:
+                IOV:
+                - 1
+                alignments:
+                - unitTestZmumuMCreal
+                - unitTestZmumuMCdesign
+                trackcollection: ALCARECOTkAlZMuMu
+                maxevents: 100
     MTS:
         merge:
             testSingleMTS:


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44252

#### PR description:

This PR contains a number of miscellaneous fixes / improvements in order to be able to run the `Zmumu` and `DiMuonVertex` tools in the tracker alignment all-in-one meta-tool, collecting feedback from users:
   * [minimal fixes to make Zmumumerge run in unit tests](https://github.com/cms-sw/cmssw/commit/df0dced5b39991e43a0f1ce057bb0f0ba60601ac)
   * [add unit tests for Zmumu validation](https://github.com/cms-sw/cmssw/commit/190724f9b84b1425a05b81cdb51bbd132670d1e1)
   * [fix DiMuonV_cfg.py so that it can be used with ALCARECO data-tier](https://github.com/cms-sw/cmssw/commit/859a2f4a0a1cd49e337381fb2c4a362ac9fd27c6)
   * [fixes to the DiMuonVertexValidation to work when files are on eos](https://github.com/cms-sw/cmssw/commit/1004def13a0b776a7e36813d7618aa5ca7809810)
   * [Graphical improvements to Zmumumerge](https://github.com/cms-sw/cmssw/commit/6bf8db579854c33b91764061ea8ead475760a4d9) (co-authored by @bcamaian)
   * [modify loopAndPlot.C to show inverse cosphi plots](https://github.com/cms-sw/cmssw/commit/a60e69ee05fbcf16d6c267874a499171aee34e7c) (co-authored by @phnattla)
   * [miscellaneous fixes to DiMuonVertexValidation source and configuration](https://github.com/cms-sw/cmssw/commit/54465355aeb128054103906c0cf030e8be5f80e2)

#### PR validation:

Run successfully the augmented unit tests via:
   * `scram b runtests_Zmumuall`
   * `scram b runtests_DiMuonVall`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/44252 for 2024 data operations.