### PR TITLE
Test workflows for lepton time-life customization of NanoAOD

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -177,6 +177,10 @@ steps['EGMNano_data13.0'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '10
 steps['EGMNano_mc13.0'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '1000'},
                                  steps['NANO_mc13.0']])
 
+steps['lepTimeLifeNANO_data13.0']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM',
+                                          '-n' : '1000'},
+                                         steps['NANO_data13.0']])
+
 ###current release cycle workflows : 13.2
 steps['TTBarMINIAOD13.2'] = {'INPUT':InputInfo(location='STD',
                                                ## dataset below to be replaced with a 13.2 relval sample when available
@@ -191,6 +195,10 @@ steps['muPOGNANO_mc13.2']=merge([{'-s' : 'NANO:@PHYS+@MUPOG ', '-n' : '1000'},
 
 steps['EGMNano_mc13.2'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '1000'},
                                  steps['NANO_mc13.2']])
+
+steps['lepTimeLifeNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM',
+                                        '-n' : '1000'},
+                                        steps['NANO_mc13.2']])
 
 ##13.X INPUT
 steps['RunScoutingPFRun32022D13.X']={'INPUT':InputInfo(dataSet='/ScoutingPFRun3/Run2022D-v1/RAW',label='2022D',events=100000,location='STD', ls=Run2022D)}
@@ -251,6 +259,7 @@ workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGNANO
 workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGNANOBkg_data13.0']]
 workflows[_wfn()] = ['muPOGNANO_data13.0', ['MuonEG2023MINIAOD13.0', 'muPOGNANO_data13.0']]
 workflows[_wfn()] = ['EGMNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'EGMNano_data13.0']]
+workflows[_wfn()] = ['lepTimeLifeNANO_data13.0', ['MuonEG2023MINIAOD13.0', 'lepTimeLifeNANO_data13.0']]
 
 _wfn.next()
 ################
@@ -258,6 +267,7 @@ _wfn.next()
 workflows[_wfn()] = ['NANOmc132X', ['TTBarMINIAOD13.2', 'NANO_mc13.2', 'HRV_NANO_mc']]
 workflows[_wfn()] = ['muPOGNANO_mc13.2', ['TTBarMINIAOD13.2', 'muPOGNANO_mc13.2']]
 workflows[_wfn()] = ['EGMNANOmc132X', ['TTBarMINIAOD13.2', 'EGMNano_mc13.2']]
+workflows[_wfn()] = ['lepTimeLifeNANO_mc13.2', ['TTBarMINIAOD13.2', 'lepTimeLifeNANO_mc13.2']]
 
 _wfn.next()
 ################


### PR DESCRIPTION
#### PR description:

This PR adds test workflows for lepton time-life customization of NanoAOD.
Those workflows completes inclusion of the customization into CMSSW and were requested in the original PR: https://github.com/cms-sw/cmssw/pull/43525#issuecomment-1960039636.

Backport of this PR is not foreseen.

#### PR validation:

The newly added workflows run successfully like this:
```
runTheMatrix.py -l 2500.403,2500.316 -i all --ibeos
```
