### PR TITLE
Update Run3 HLT GT to remove unused JEC tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,8 +31,8 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v2 with snapshot at 2024-02-20 12:00:00 (UTC)
-    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v2',
+    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v3 with snapshot at 2024-02-29 18:52:29 (UTC)
+    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v3',
     # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
     'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v1 but snapshot at 2024-01-20 12:00:00 (UTC)


### PR DESCRIPTION
#### PR description:
The PR updates the Run3 HLT GT to clean-up the following unused JME tags as also confirmed by HLT JME experts (@theochatzis @slehti ) 

Also FYI @mmusich @minano 

The relevant CMS Talk with details is here: https://cms-talk.web.cern.ch/t/removal-of-unused-jec-tags-from-14-0-x-online-hlt-gt/35530

|Rcd | Label | Tag |
| -- | -- | -- | 
| JetCorrectionsRecord | AK8PFchsHLT | JetCorrectorParametersCollection_AK8PFchsHLT_hlt_v1 | 
| JetCorrectionsRecord | AK4PFPuppiHLT | JetCorrectorParametersCollection_AK4PFPuppiHLT_hlt_v1 |  
| JetCorrectionsRecord | AK5PFHLT | JetCorrectorParametersCollection_AK5PF_v1_hlt |
| JetCorrectionsRecord | AK8PFPuppiHLT | JetCorrectorParametersCollection_AK8PFPuppiHLT_hlt_v1 | 
| JetCorrectionsRecord | AK5CaloHLT | JetCorrectorParametersCollection_AK5CaloHLT_v1_hlt |  
| JetCorrectionsRecord | AK8PFClusterHLT | JetCorrectorParametersCollection_AK8PFClusterHLT_hlt_v1 |
| JetCorrectionsRecord | AK4PFClusterHLT | JetCorrectorParametersCollection_AK4PFClusterHLT_hlt_v1 | 
| JetCorrectionsRecord | AK4PFchsHLT | JetCorrectorParametersCollection_AK4PFchsHLT_hlt_v1 |  
| JetCorrectionsRecord | AK5Calo | JetCorrectorParametersCollection_AK5Calo_v1_hlt |
| JetCorrectionsRecord | AK5PFchsHLT | JetCorrectorParametersCollection_AK5PFchs_v1_hlt |

**GT Differences with the last one is here**:

- **Run3 data hlt**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_HLT_frozen_v2/140X_dataRun3_HLT_frozen_v3

#### PR validation:
Successfully tested with
`runTheMatrix.py -l 140.022,140.065,140.069,141.001,141.008,141.044,141.105 -j 10 --ibeos`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport to 140X will be followed