### PR TITLE
[14_0_X] Erase from correct vector in PATTauHybridProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -385,7 +385,7 @@ void PATTauHybridProducer::fillTauFromJet(reco::PFTau& pfTau, const reco::JetBas
     pfTau.setleadChargedHadrCand(pfGammas[0]);
     pfTau.setleadCand(pfGammas[0]);
     pfGammasSig.push_back(pfGammas[0]);
-    pfChs.erase(pfGammas.begin());
+    pfGammas.erase(pfGammas.begin());
   }
   // Clean gamma candidates from low-pt ones
   for (CandPtrs::iterator it = pfGammas.begin(); it != pfGammas.end();) {


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/44067. From the original PR description
> Erasing an element from `pfChs` using an iterator from `pfGammas` is undefined behavior. Based on the surrounding code, I _guess_ the intention was to erase the element from `pfGammas`.


#### PR validation:

None beyond https://github.com/cms-sw/cmssw/pull/44067

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/44067