### PR TITLE
Fix logic in PFClusterSoAProducer kernels

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducerKernel.dev.cc
@@ -1380,17 +1380,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             clusterView[seedIdx].y() = pfRecHits[rhIdx].y();
             clusterView[seedIdx].z() = pfRecHits[rhIdx].z();
           }
-        } else if constexpr (!std::is_same_v<Device, alpaka::DevCpu>) {
           // singleSeed and multiSeedParallel functions work only for GPU backend
-          if (nSeeds == 1) {
-            // Single seed cluster
-            hcalFastCluster_singleSeed(
-                acc, pfClusParams, topology, topoId, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
-          } else if (nSeeds <= 100 && nRHTopo - nSeeds < threadsPerBlockForClustering) {
-            hcalFastCluster_multiSeedParallel(
-                acc, pfClusParams, topology, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
-          }
+        } else if ((not std::is_same_v<Device, alpaka::DevCpu>)&&nSeeds == 1) {
+          // Single seed cluster
+          hcalFastCluster_singleSeed(
+              acc, pfClusParams, topology, topoId, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
+        } else if ((not std::is_same_v<Device, alpaka::DevCpu>)&&nSeeds <= 100 &&
+                   nRHTopo - nSeeds < threadsPerBlockForClustering) {
+          hcalFastCluster_multiSeedParallel(
+              acc, pfClusParams, topology, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
         } else if (nSeeds <= 400 && nRHTopo - nSeeds <= 1500) {
+          // nSeeds value must match exotic in FastClusterExotic
           hcalFastCluster_multiSeedIterative(
               acc, pfClusParams, topology, topoId, nSeeds, nRHTopo, pfRecHits, pfClusteringVars, clusterView, fracView);
         } else {
@@ -1429,7 +1429,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         int nRHTopo = pfClusteringVars[topoId].topoRHCount();
         int nSeeds = pfClusteringVars[topoId].topoSeedCount();
 
-        if (nRHTopo > 0 && nSeeds > 400 && nRHTopo - nSeeds > 1500) {
+        // nSeeds value must match multiSeedIterative in FastCluster
+        if (nRHTopo > 0 && (nSeeds > 400 || nRHTopo - nSeeds > 1500)) {
           hcalFastCluster_exotic(acc,
                                  pfClusParams,
                                  topology,


### PR DESCRIPTION
#### PR description:

This PR fixes an issue with the clustering logic in `PFClusterSoAProducer`. The issue was highlighted by 2024 thresholds giving rise to topological clusters exceeding 100 seeds, which we had never naturally encountered in previous validations of the code in order to catch this flaw. The fall-back kernel was not being launched as intended in the previous logic, and is now changed to behave as intended.

#### PR validation:

For CPU-serial and GPU alpaka backends:
Validated  QCDPU sample on 2022, 2023, and 2024 globalTag thresholds, and validated change in Pixel+ECAL+PF Alpaka HLT test workflow.

Cluster-level validation plots can be found here: https://hep.baylor.edu/jsamudio/fixLogic/

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

**_Not a backport_**, but probably needs to be included in `14_0_0` or later `14_0_X` for HLT integration. Although I am not sure how to proceed since the `14_0_0` release is closed.

@hatakeyamak @waredjeb @fwyzard @swagata87 @stahlleiton 


