### PR TITLE
Small fix for simulation of pixel bad components

### DIFF
--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -20,7 +20,8 @@ from CalibTracker.SiPixelESProducers.siPixelQualityForDigitizerESProducer_cfi im
 # customization applies only to phase0/1 pixel.
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(pixelDigitizer,
-    AddPixelInefficiency = False # will be added in DataMixer
+    AddPixelInefficiency = False, # will be added in DataMixer
+    KillBadFEDChannels = False # will be added in DataMixer
 )
 
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer, _premixStage1ModifyDict


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the simulation of transiently bad components in the pixel detector which is at the moment enabled in both the MixingModule (configured [here](https://github.com/cms-sw/cmssw/blob/CMSSW_14_1_0_pre0/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py) and [here](https://github.com/cms-sw/cmssw/blob/CMSSW_14_1_0_pre0/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py)), where signal SimHits are digitized, and the DataMixer (configured [here](https://github.com/cms-sw/cmssw/blob/CMSSW_14_1_0_pre0/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py)) where signal and pileup Digis are mixed together (they both have the `KillBadFEDChannels` switch set to`True` in their `SiPixelSimBlock`). This PR sets this switch to `False` for the MixingModule in the `premix_stage2` modifier.

#### PR validation:

No validation done. Impact on physics should be small in standard workflows. However, the impact should be more substantial for 2023 MC where there are sizable holes in pixel L3 and L4 in the second part of the year.

#### If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to CMSSW_14_0_X needed to include this bugfix in Run 3 MC production

#### EDIT:

The severity of this PR luckily turns out to be a lot lower than it originally seemed. Since the `premix_stage2` modifier already has `AddPixelInefficiency` set to `False` in this [line](https://github.com/cms-sw/cmssw/blob/CMSSW_14_1_0_pre0/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py#L23), this switch also disables killing of transiently bad components in the MixingModule. In other words, there is no double killing of bad components (`KillBadFEDChannels = True` is a necessary but not sufficient condition to kill bad components. For this to happen, `AddPixelInefficiency`  also needs to be set to `True`). Nevertheless, what the `KillBadFEDChannels` switch still controls is the creation of the `PixelFEDChannelCollection` in the [SiPixelDigitizer](https://github.com/cms-sw/cmssw/blob/CMSSW_14_1_0_pre0/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc#L271-L278). Since this collection is not consumed by anything else, there is no point in wasting memory and computing cycles by producing it. Consequently, this PR is not critical for the Run 3 MC production so backporting it to CMSSW_14_0_X is strictly speaking not needed. Small differences observed in wf 250202.181 likely originate from a modified random number sequence (producing the `PixelFEDChannelCollection` requires calling a random number generator) which then results in some small differences in the final output.

The commit message was also modified to better reflect the actual impact of the code change.