### PR TITLE
Fix PrimaryVertexProducer::fillDescriptions to generate a cfi file [141X]

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -457,7 +457,7 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<bool>("useMVACut", false);
   desc.add<double>("minTrackTimeQuality", 0.8);
 
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

Fix PrimaryVertexProducer::fillDescriptions to generate a cfi file.
Needed for ConfDb parsing.

#### PR validation:

The cfi file is now generated!

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_0 (2024 data taking release)
