### PR TITLE
Add default values in `{CaloRecHitSoA,PFRecHitSoA,LegacyPFRecHit,PFClusterSoA}Producer::fillDescriptions` [`14_0_X`]

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -49,10 +49,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("pfRecHits");
-      desc.add<edm::ESInputTag>("pfClusterParams");
-      desc.add<edm::ESInputTag>("topology");
-      desc.add<bool>("synchronise");
+      desc.add<edm::InputTag>("pfRecHits", edm::InputTag(""));
+      desc.add<edm::ESInputTag>("pfClusterParams", edm::ESInputTag(""));
+      desc.add<edm::ESInputTag>("topology", edm::ESInputTag(""));
+      desc.add<bool>("synchronise", false);
       desc.add<int>("pfRecHitFractionAllocation", 120);
       descriptions.addWithDefaultLabel(desc);
     }

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -26,7 +26,7 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src");
+    desc.add<edm::InputTag>("src", edm::InputTag(""));
     descriptions.addWithDefaultLabel(desc);
   }
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -52,7 +52,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
-      desc.add<edm::InputTag>("src")->setComment("Input calorimeter rec hit collection");
+      desc.add<edm::InputTag>("src", edm::InputTag(""))->setComment("Input calorimeter rec hit collection");
       desc.addUntracked<bool>("synchronise", false)
           ->setComment("Add synchronisation point after execution (for benchmarking asynchronous execution)");
       descriptions.addWithDefaultLabel(desc);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -53,10 +53,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
       edm::ParameterSetDescription desc;
       edm::ParameterSetDescription producers;
-      producers.add<edm::InputTag>("src")->setComment("Input CaloRecHitSoA");
-      producers.add<edm::ESInputTag>("params")->setComment("Quality cut parameters");
-      desc.addVPSet("producers", producers)->setComment("List of inputs and quality cuts");
-      desc.add<edm::ESInputTag>("topology")->setComment("Topology information");
+      producers.add<edm::InputTag>("src", edm::InputTag(""))->setComment("Input CaloRecHitSoA");
+      producers.add<edm::ESInputTag>("params", edm::ESInputTag(""))->setComment("Quality cut parameters");
+      std::vector<edm::ParameterSet> producersDefault(1);
+      producersDefault[0].addParameter<edm::InputTag>("src", edm::InputTag(""));
+      producersDefault[0].addParameter<edm::ESInputTag>("params", edm::ESInputTag(""));
+      desc.addVPSet("producers", producers, producersDefault)->setComment("List of inputs and quality cuts");
+      desc.add<edm::ESInputTag>("topology", edm::ESInputTag(""))->setComment("Topology information");
       desc.addUntracked<bool>("synchronise", false)
           ->setComment("Add synchronisation point after execution (for benchmarking asynchronous execution)");
       descriptions.addWithDefaultLabel(desc);


### PR DESCRIPTION
backport of #44290

#### PR description:

From the description of #44290:

>This PR adds default values for parameters currently missing them in `{CaloRecHitSoA,PFRecHitSoA,LegacyPFRecHit,PFClusterSoA}Producer::fillDescriptions`.
>
>This is necessary in order to use these plugins in ConfDB for HLT-menu development (these plugins are part of the latest Alpaka developments for HLT, see [`customizeHLTforAlpakaParticleFlowClustering`](https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_1/HLTrigger/Configuration/python/customizeHLTforAlpaka.py#L928)).
>
>FYI: @cms-sw/hlt-l2

#### PR validation:

None beyond the checks done for #44290.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#44290

Necessary for the integration of Alpaka modules in the 2024 HLT menus.
