### PR TITLE
Reduce complexity of erasing elements from vectors in PATTauHybridProducer [14_0_X]

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -366,13 +366,10 @@ void PATTauHybridProducer::fillTauFromJet(reco::PFTau& pfTau, const reco::JetBas
     }
   }
   // Clean isolation candidates from low-pt and leptonic ones
-  for (CandPtrs::iterator it = pfChs.begin(); it != pfChs.end();) {
-    if ((*it)->pt() < 0.5 || std::abs((*it)->pdgId()) != 211) {
-      it = pfChs.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  pfChs.erase(std::remove_if(pfChs.begin(),
+                             pfChs.end(),
+                             [](auto const& cand) { return cand->pt() < 0.5 || std::abs(cand->pdgId()) != 211; }),
+              pfChs.end());
   // Set charged candidates
   pfTau.setsignalChargedHadrCands(pfChsSig);
   pfTau.setisolationChargedHadrCands(pfChs);
@@ -388,13 +385,8 @@ void PATTauHybridProducer::fillTauFromJet(reco::PFTau& pfTau, const reco::JetBas
     pfGammas.erase(pfGammas.begin());
   }
   // Clean gamma candidates from low-pt ones
-  for (CandPtrs::iterator it = pfGammas.begin(); it != pfGammas.end();) {
-    if ((*it)->pt() < 0.5) {
-      it = pfGammas.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  pfGammas.erase(std::remove_if(pfGammas.begin(), pfGammas.end(), [](auto const& cand) { return cand->pt() < 0.5; }),
+                 pfGammas.end());
   // if decay mode with pi0s is expected look for signal gamma candidates
   // within eta-phi strips around leading track
   if (pfTau.decayMode() % 5 != 0 && pfTau.leadChargedHadrCand().isNonnull()) {

--- a/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauHybridProducer.cc
@@ -385,7 +385,7 @@ void PATTauHybridProducer::fillTauFromJet(reco::PFTau& pfTau, const reco::JetBas
     pfTau.setleadChargedHadrCand(pfGammas[0]);
     pfTau.setleadCand(pfGammas[0]);
     pfGammasSig.push_back(pfGammas[0]);
-    pfChs.erase(pfGammas.begin());
+    pfGammas.erase(pfGammas.begin());
   }
   // Clean gamma candidates from low-pt ones
   for (CandPtrs::iterator it = pfGammas.begin(); it != pfGammas.end();) {


### PR DESCRIPTION
#### PR description:

This PR contains an update to `PATTauHybridProducer` to reduce complexity of erasing elements from vectors by using `std::remove_if` instead of looping over elements of the vectors. Originally proposed in https://github.com/cms-sw/cmssw/pull/44067#issuecomment-1964349862.
It is a technical improvement not affecting physics.

Backport of  #44266 to CMSSW 14_0 series.

#### PR validation:

Tested in the context of original CMSSW.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to 14_0 for 2024 Nano production.