### PR TITLE
fix `BPHHistoSpecificDecay::fillDescriptions`

### DIFF
--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.cc
@@ -1112,7 +1112,7 @@ void BPHHistoSpecificDecay::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<string>("lbCandsLabel", "");
   desc.add<string>("bcCandsLabel", "");
   desc.add<string>("x3872CandsLabel", "");
-  descriptions.add("process.bphHistoSpecificDecay", desc);
+  descriptions.addWithDefaultLabel(desc);
   return;
 }
 


### PR DESCRIPTION
#### PR description:

Minor fix, spotted while running a script to check release parsability in confDB.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A