### PR TITLE
Update the Run4 MC GT with the updated OMTF config

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '140X_mcRun4_realistic_v1'
+    'phase2_realistic'             :    '140X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

The mcRun4 global tags used for Phase 2 contain an obsolete OMTF configuration, taken from Run 2. The obsolete tag is L1TMuonOverlapParams_static_2016_mc. and it is changed here to L1TMuonOverlapParams_static_2023_mc. The newer configuration is already in use since a while for the most recent mcRun3 global tags.

Relevant cmsTalk with details is:
- https://cms-talk.web.cern.ch/t/omtf-configuration-in-mcrun4-global-tags-request-to-update/36201

Modified tag:

- **L1TMuonOverlapParamsRcd:** from  `L1TMuonOverlapParams_static_2016_mc` to `L1TMuonOverlapParams_static_2023_mc`

Difference with respect to the previous run4 MC GT:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun4_realistic_v1/140X_mcRun4_realistic_v2

#### PR validation:

Successfully tested with the Run4 workflows in the short matrix

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It can be backported to CMSSW_14_0_X