### PR TITLE
Updated btags and Working Points for Top Production mini AOD DQM 

### DIFF
--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc
@@ -316,9 +316,9 @@ namespace SingleTopTChannelLepton_miniAOD {
     //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
     //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
     // multiplicity for combined secondary vertex
-    hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
+    hists_["jetMultBDeepJetM_"] = ibooker.book1D("JetMultBDeepJetM", "N_{30}(DeepJetM)", 10, 0., 10.);
     // btag discriminator for combined secondary vertex
-    hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV", "BJet Disc_{CSV}(JET)", 100, -1., 2.);
+    hists_["jetBDeepJet_"] = ibooker.book1D("JetDiscDeepJet", "BJet Disc_{DeepJet}(JET)", 100, -1., 2.);
     // pt of the 1. leading jet (uncorrected)
     //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
     // pt of the 2. leading jet (uncorrected)
@@ -572,7 +572,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     pat::Jet TaggedJetCand;
     vector<double> bJetDiscVal;
 
-    unsigned int mult = 0, loosemult = 0, multBCSVM = 0;
+    unsigned int mult = 0, loosemult = 0, multBDeepJetM = 0;
 
     edm::Handle<edm::View<pat::Jet>> jets;
     if (!event.getByToken(jets_, jets)) {
@@ -604,25 +604,27 @@ namespace SingleTopTChannelLepton_miniAOD {
         correctedJets.push_back(monitorJet);
         ++loosemult;  // determine jet multiplicity
 
-        fill("jetBCSV_",
-             monitorJet.bDiscriminator(
-                 "pfCombinedInclusiveSecondaryVertexV2BJetTags"));  //hard coded discriminator and value right now.
-        if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89) {
-          if (multBCSVM == 0) {
+        double discriminator = monitorJet.bDiscriminator("pfDeepFlavourJetTags:probb") +
+                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:probbb") +
+                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:problepb");
+
+        fill("jetBDeepJet_", discriminator);  //hard coded discriminator and value right now.
+        if (discriminator > 0.2435) {
+          if (multBDeepJetM == 0) {
             TaggedJetCand = monitorJet;
-            bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
-          } else if (multBCSVM == 1) {
-            bJetDiscVal.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+            bJetDiscVal.push_back(discriminator);
+          } else if (multBDeepJetM == 1) {
+            bJetDiscVal.push_back(discriminator);
             if (bJetDiscVal[1] > bJetDiscVal[0])
               TaggedJetCand = monitorJet;
           }
 
-          ++multBCSVM;
+          ++multBDeepJetM;
         }
 
-        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
+        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: DeepJet
         // tagger
-        JetTagValues.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+        JetTagValues.push_back(discriminator);
         //    }
         // fill pt (raw or L2L3) for the leading four jets
         if (loosemult == 1) {
@@ -641,7 +643,7 @@ namespace SingleTopTChannelLepton_miniAOD {
     }
     fill("jetMult_", mult);
     fill("jetLooseMult_", loosemult);
-    fill("jetMultBCSVM_", multBCSVM);
+    fill("jetMultBDeepJetM_", multBDeepJetM);
 
     /*
   ------------------------------------------------------------
@@ -689,12 +691,12 @@ namespace SingleTopTChannelLepton_miniAOD {
       fill("massTop_", topMass);
     }
 
-    // Fill M3 with Btag (CSV Tight) requirement
+    // Fill M3 with Btag (DeepJet Tight) requirement
 
     // if (!includeBTag_) return;
     //if (correctedJets.size() != JetTagValues.size()) return;
     //double btopMass =
-    //    eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.89); //hard coded CSVv2 value
+    //    eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435); //hard coded DeepJet value
 
     //if (btopMass >= 0) fill("massBTop_", btopMass);
 
@@ -723,14 +725,14 @@ namespace SingleTopTChannelLepton_miniAOD {
       }
     }
 
-    if (multBCSVM != 0 && mTight == 1) {
+    if (multBDeepJetM != 0 && mTight == 1) {
       double mtW = eventKinematics.tmassWBoson(&mu, mET, TaggedJetCand);
       fill("MTWm_", mtW);
       double MTT = eventKinematics.tmassTopQuark(&mu, mET, TaggedJetCand);
       fill("mMTT_", MTT);
     }
 
-    if (multBCSVM != 0 && eMultIso == 1) {
+    if (multBDeepJetM != 0 && eMultIso == 1) {
       double mtW = eventKinematics.tmassWBoson(&e, mET, TaggedJetCand);
       fill("MTWe_", mtW);
       double MTT = eventKinematics.tmassTopQuark(&e, mET, TaggedJetCand);

--- a/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
+++ b/DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
@@ -17,6 +17,7 @@
 #include "DataFormats/PatCandidates/interface/MET.h"
 
 using namespace std;
+
 namespace TopSingleLepton_miniAOD {
 
   // maximal number of leading jets
@@ -305,9 +306,9 @@ namespace TopSingleLepton_miniAOD {
     //hists_["jetBDiscVtx_"] = ibooker.book1D("JetBDiscVtx",
     //    "Disc_{SSVHE}(Jet)", 35, -1., 6.);
     // multiplicity for combined secondary vertex
-    hists_["jetMultBCSVM_"] = ibooker.book1D("JetMultBCSVM", "N_{30}(CSVM)", 10, 0., 10.);
+    hists_["jetMultBDeepJetM_"] = ibooker.book1D("JetMultBDeepJetM", "N_{30}(DeepJetM)", 10, 0., 10.);
     // btag discriminator for combined secondary vertex
-    hists_["jetBCSV_"] = ibooker.book1D("JetDiscCSV", "BJet Disc_{CSV}(JET)", 100, -1., 2.);
+    hists_["jetBDeepJet_"] = ibooker.book1D("JetDiscDeepJet", "BJet Disc_{DeepJet}(JET)", 100, -1., 2.);
     // pt of the 1. leading jet (uncorrected)
     //hists_["jet1PtRaw_"] = ibooker.book1D("Jet1PtRaw", "pt_{Raw}(jet1)", 60, 0., 300.);
     // pt of the 2. leading jet (uncorrected)
@@ -550,7 +551,7 @@ namespace TopSingleLepton_miniAOD {
     // loop jet collection
     std::vector<pat::Jet> correctedJets;
     std::vector<double> JetTagValues;
-    unsigned int mult = 0, loosemult = 0, multBCSVM = 0;
+    unsigned int mult = 0, loosemult = 0, multBDeepJetM = 0;
 
     edm::Handle<edm::View<pat::Jet>> jets;
     if (!event.getByToken(jets_, jets)) {
@@ -579,15 +580,17 @@ namespace TopSingleLepton_miniAOD {
         correctedJets.push_back(monitorJet);
         ++loosemult;  // determine jet multiplicity
 
-        fill("jetBCSV_",
-             monitorJet.bDiscriminator(
-                 "pfCombinedInclusiveSecondaryVertexV2BJetTags"));  //hard coded discriminator and value right now.
-        if (monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") > 0.89)
-          ++multBCSVM;
+        double discriminator = monitorJet.bDiscriminator("pfDeepFlavourJetTags:probb") +
+                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:probbb") +
+                               monitorJet.bDiscriminator("pfDeepFlavourJetTags:problepb");
 
-        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: CSV
+        fill("jetBDeepJet_", discriminator);  //hard coded discriminator and value right now.
+        if (discriminator > 0.2435)
+          ++multBDeepJetM;
+
+        // Fill a vector with Jet b-tag WP for later M3+1tag calculation: DeepJet
         // tagger
-        JetTagValues.push_back(monitorJet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags"));
+        JetTagValues.push_back(discriminator);
         //    }
         // fill pt (raw or L2L3) for the leading four jets
         if (loosemult == 1) {
@@ -616,7 +619,7 @@ namespace TopSingleLepton_miniAOD {
     }
     fill("jetMult_", mult);
     fill("jetLooseMult_", loosemult);
-    fill("jetMultBCSVM_", multBCSVM);
+    fill("jetMultBDeepJetM_", multBDeepJetM);
 
     /*
   ------------------------------------------------------------
@@ -661,12 +664,13 @@ namespace TopSingleLepton_miniAOD {
       fill("massTop_", topMass);
     }
 
-    // Fill M3 with Btag (CSV Tight) requirement
+    // Fill M3 with Btag (DeepJet Tight) requirement
 
     // if (!includeBTag_) return;
     if (correctedJets.size() != JetTagValues.size())
       return;
-    double btopMass = eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.89);  //hard coded CSVv2 value
+
+    double btopMass = eventKinematics.massBTopQuark(correctedJets, JetTagValues, 0.2435);  //hard coded DeepJet value
 
     if (btopMass >= 0)
       fill("massBTop_", btopMass);

--- a/DQM/Physics/test/topDQM_production_miniAOD.py
+++ b/DQM/Physics/test/topDQM_production_miniAOD.py
@@ -15,7 +15,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.skipEvents = cms.untracked.uint32(0)
-process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre3/RelValTTbar_14TeV/MINIAODSIM/110X_mcRun3_2021_realistic_v8-v1/10000/65810A7D-A696-2C4A-BC49-994FCCDCF515.root'] 
+process.source.fileNames = ['/store/mc/Run3Winter24MiniAOD/TT_TuneCP5_13p6TeV_powheg-pythia8/MINIAODSIM/133X_mcRun3_2024_realistic_v8-v2/2540000/01f73297-b0d8-4458-a1c0-34a17148ca4a.root'] 
 
 #process.source.fileNames = ['/store/relval/CMSSW_11_1_0_pre2/RelValTTbar_14TeV/MINIAODSIM/110X_mcRun3_2021_realistic_v6-v1/20000/F594311A-0167-1A41-9984-753E9AFB1279.root']
 


### PR DESCRIPTION
### Description of PR 

- The main changes expected relate to the histograms on b-tagged jets for top production for miniAOD files now being filled (compared to previously being empty) after the btags were updated from the old CSV ones to the new DeepJet ones as described in the BTV Internal Wiki and also updates to the Medium Working Points used as described in the relevant BTV Internal Wiki page for 2023 Run3Summer23BPix.
- There is no dependence on other PRs or externals.
- [BTV Internal Wiki](https://btv-wiki.docs.cern.ch/ScaleFactors/)
- [BTV Internal Wiki page for 2023 Run3Summer23BPix](https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23BPix/)

### PR validation 

Changes have been made to the following files :

DQM/Physics/test/topDQM_production_miniAOD.py
DQM/Physics/src/TopSingleLeptonDQM_miniAOD.cc
DQM/Physics/src/SingleTopTChannelLeptonDQM_miniAOD.cc

Tests that have been performed to verify the correctness of the PR include running the topDQM_production_miniAOD.py file to produce a topDQM_production.root file and then the DQM/Physics/src/topDQM_harvesting_cfg.py to produce a DQM root file containing the tree with the relevant histograms that can be browsed. The correctness of the produced histograms was verified using the TBrowser root feature.

[mtopbtagmuon.pdf](https://github.com/cms-sw/cmssw/files/14482372/mtopbtagmuon.pdf)
[mtopbtagelectron.pdf](https://github.com/cms-sw/cmssw/files/14482373/mtopbtagelectron.pdf)
