### PR TITLE
edmWriteConfigs: don't use unsecure tmpnam(...)

### DIFF
--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -140,10 +140,7 @@ namespace {
 
   bool open_temp(std::string& path, std::ofstream& f) {
     path += "/XXXXXX";
-    std::vector<char> dst_path(path.begin(), path.end());
-    dst_path.push_back('\0');
-
-    int fd = mkstemp(&dst_path[0]);
+    int fd = mkstemp(path.data());
     if (fd != -1) {
       path.assign(dst_path.begin(), dst_path.end() - 1);
       f.open(path.c_str(), std::ios_base::trunc | std::ios_base::out);

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -54,7 +54,7 @@
 #include <sstream>
 #include <fstream>
 #include <filesystem>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 
 static char const* const kHelpOpt = "help";

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -144,12 +144,11 @@ namespace {
     dst_path.push_back('\0');
 
     int fd = mkstemp(&dst_path[0]);
-    if(fd != -1) {
-        path.assign(dst_path.begin(), dst_path.end() - 1);
-        f.open(path.c_str(), 
-               std::ios_base::trunc | std::ios_base::out);
-        close(fd);
-        return true;
+    if (fd != -1) {
+      path.assign(dst_path.begin(), dst_path.end() - 1);
+      f.open(path.c_str(), std::ios_base::trunc | std::ios_base::out);
+      close(fd);
+      return true;
     }
     return false;
   }

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -163,7 +163,7 @@ namespace {
       std::filesystem::copy(path.data(), "modules.py");
       std::filesystem::remove(path.data());
       return true;
-    } 
+    }
     return false;
   }
 }  // namespace


### PR DESCRIPTION
#### PR description:

Silence the following warning in UBSAN builds:

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/../lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../x86_64-redhat-linux-gnu/bin/ld.bfd: tmp/el8_amd64_gcc12/src/FWCore/ParameterSet/bin/edmWriteConfigs/edmWriteConfigs.cpp.o: in function `main':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/4bef43d043d164f5e27c46b3adf2e630/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_UBSAN_X_2024-03-04-2300/src/FWCore/ParameterSet/bin/edmWriteConfigs.cpp:143: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
 ```

#### PR validation:

Bot tests
