### PR TITLE
Retain compatibility with RooFit prior to ROOT 6.28

### DIFF
--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -558,7 +558,8 @@ void TagProbeFitter::doFitEfficiency(RooWorkspace* w, string pdfName, RooRealVar
     const RooArgSet* dataObs = data->get(0);
     // remove everything which is not a dependency of the pdf
     std::unique_ptr<RooArgSet> obs{w->pdf("simPdf")->getObservables(dataObs)};
-    w->import(RooDataHist{"data_binned", "data_binned", *obs, *data});
+    RooDataHist bdata{"data_binned", "data_binned", *obs, *data};
+    w->import(bdata);
     data = w->data("data_binned");
   }
 


### PR DESCRIPTION
Follows up on d52fed92f.

See also this commit in ROOT:
https://github.com/root-project/root/commit/0f9b90a0e41aabd690c701af753b61cf60888a3c

Closes #44312.