### PR TITLE
Kill both permanently and transiently bad pixel components in DataMixer

### DIFF
--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -136,6 +136,7 @@ premix_stage1.toModify(SiPixelSimBlock,
     AddNoisyPixels = False,
     AddPixelInefficiency = False, #done in second step
     KillBadFEDChannels = False, #done in second step
+    killModules = False #done in second step
 )
 
 # Threshold in electrons are the Official CRAFT09 numbers:

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -21,7 +21,8 @@ from CalibTracker.SiPixelESProducers.siPixelQualityForDigitizerESProducer_cfi im
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(pixelDigitizer,
     AddPixelInefficiency = False, # will be added in DataMixer
-    KillBadFEDChannels = False # will be added in DataMixer
+    KillBadFEDChannels = False, # will be added in DataMixer
+    killModules = False # will be added in DataMixer
 )
 
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer, _premixStage1ModifyDict

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -51,7 +51,6 @@ mixData = cms.EDProducer("PreMixingModule",
                 # To preserve the behaviour of copy-pasted version of premix worker
                 # All these are done in stage1 (for both signal and pileup)
                 AddNoise = False,
-                killModules = False,
                 MissCalibrate = False,
             ),
             workerType = cms.string("PreMixingSiPixelWorker"),


### PR DESCRIPTION
#### PR description:

Up to now permanently bad components were killed prior to the DataMixer and separately for signal and pileup. For pileup this was happening in the MixingModule in stage 1 premixing and for signal in the MixingModule in stage 2 premixing. Instead, killing of transiently bad components was deferred to the last step in the DataMixer where signal and pileup digis are mixed. With this commit both permanently and transiently bad pixel components are killed in one place, in the DataMixer. This way premixed pileup library can be produced even before the list of bad components has been finalized and can later be reused (within the same production campaign) even with different bad component scenarios. The proposed change was presented in the Pixel Offline Meeting on Mar. 5, 2024 and the presentation can be found [here](https://indico.cern.ch/event/1383674/#32-possible-changes-in-simulat).

#### PR validation:

Tested before and after the change using wf 250202.181 to confirm that permanently dead components are killed in both cases.

#### If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to CMSSW_14_0_X is foreseen. Since this PR had a merge conflict with https://github.com/cms-sw/cmssw/pull/44276, which had been resolved in the meantime, it might be best to backport both PRs together since they are somewhat related anyways.

@sroychow 
