### PR TITLE
[ROOTMaster] Fix include for RNTuple* (redo of #44256)

### DIFF
--- a/Alignment/OfflineValidation/bin/DiMuonVmerge.cc
+++ b/Alignment/OfflineValidation/bin/DiMuonVmerge.cc
@@ -15,6 +15,7 @@
 
 #include "TString.h"
 #include "TASImage.h"
+#include "TGraph.h"
 
 #include "Alignment/OfflineValidation/macros/loopAndPlot.C"
 #include "Alignment/OfflineValidation/interface/TkAlStyle.h"

--- a/Alignment/OfflineValidation/macros/loopAndPlot.C
+++ b/Alignment/OfflineValidation/macros/loopAndPlot.C
@@ -4,6 +4,7 @@
 #include "TDirectory.h"
 #include "TFile.h"
 #include "TGaxis.h"
+#include "TGraph.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TKey.h"

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTupleOutputModule.cc
@@ -15,17 +15,19 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::Detail::RPageSinkFile;
 #if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
 using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Detail::RPageSinkFile;
 #define MakeRNTupleWriter std::make_unique<RNTupleWriter>
+#include <ROOT/RNTupleOptions.hxx>
 #else
+using ROOT::Experimental::Internal::RPageSinkFile;
 #define MakeRNTupleWriter ROOT::Experimental::Internal::CreateRNTupleWriter
+#include <ROOT/RNTupleWriteOptions.hxx>
 #endif
+using ROOT::Experimental::RNTupleWriteOptions;
 
 #include "TObjString.h"
 

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.cc
@@ -5,17 +5,19 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
-#include <ROOT/RNTupleOptions.hxx>
 #include <ROOT/RPageStorageFile.hxx>
 using ROOT::Experimental::RNTupleModel;
-using ROOT::Experimental::RNTupleWriteOptions;
-using ROOT::Experimental::Detail::RPageSinkFile;
 #if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
 using ROOT::Experimental::RNTupleWriter;
+using ROOT::Experimental::Detail::RPageSinkFile;
 #define MakeRNTupleWriter std::make_unique<RNTupleWriter>
+#include <ROOT/RNTupleOptions.hxx>
 #else
+using ROOT::Experimental::Internal::RPageSinkFile;
 #define MakeRNTupleWriter ROOT::Experimental::Internal::CreateRNTupleWriter
+#include <ROOT/RNTupleWriteOptions.hxx>
 #endif
+using ROOT::Experimental::RNTupleWriteOptions;
 
 #include "RNTupleFieldPtr.h"
 #include "SummaryTableOutputFields.h"

--- a/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/NanoAODRNTuples.h
@@ -12,7 +12,13 @@
 
 #include "TFile.h"
 #include <ROOT/RNTuple.hxx>
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
 using ROOT::Experimental::RCollectionNTupleWriter;
+#else
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RNTupleCollectionWriter.hxx>
+using ROOT::Experimental::RNTupleCollectionWriter;
+#endif
 using ROOT::Experimental::RNTupleWriter;
 
 #include "EventStringOutputFields.h"
@@ -64,7 +70,11 @@ private:
   // https://github.com/root-project/root/issues/7861
   // RNTupleFieldPtr<edm::ParameterSetID> m_psetId;
   // RNTupleFieldPtr<edm::ParameterSetBlob> m_psetBlob;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
   std::shared_ptr<RCollectionNTupleWriter> m_collection;
+#else
+  std::shared_ptr<RNTupleCollectionWriter> m_collection;
+#endif
   RNTupleFieldPtr<std::string> m_psetId;
   RNTupleFieldPtr<std::string> m_psetBlob;
   std::unique_ptr<RNTupleWriter> m_ntuple;
@@ -78,7 +88,11 @@ public:
 
 private:
   void createFields(TFile& file);
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
   std::shared_ptr<RCollectionNTupleWriter> m_procHist;
+#else
+  std::shared_ptr<RNTupleCollectionWriter> m_procHist;
+#endif
 
   RNTupleFieldPtr<std::string> m_phId;
   std::unique_ptr<RNTupleWriter> m_ntuple;

--- a/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
+++ b/PhysicsTools/NanoAOD/plugins/rntuple/TableOutputFields.h
@@ -11,7 +11,12 @@
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
 using ROOT::Experimental::RCollectionNTupleWriter;
+#else
+#include <ROOT/RNTupleCollectionWriter.hxx>
+using ROOT::Experimental::RNTupleCollectionWriter;
+#endif
 using ROOT::Experimental::RNTupleModel;
 using ROOT::Experimental::RNTupleWriter;
 
@@ -110,7 +115,11 @@ public:
 
 private:
   std::string m_collectionName;
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 31, 0)
   std::shared_ptr<RCollectionNTupleWriter> m_collection;
+#else
+  std::shared_ptr<RNTupleCollectionWriter> m_collection;
+#endif
   TableOutputFields m_main;
   std::vector<TableOutputFields> m_extensions;
 };


### PR DESCRIPTION
#### PR description:

Redo #44256

* Fix include for RNTupleWriterOptions after root-project/root#14799;
* Fix renaming of RCollectionNTupleWriter class to RNTupleCollectionWriter, add new include (https://github.com/root-project/root/pull/14797);
* Reapply changes from https://github.com/cms-sw/cmssw/pull/44032.
* Add missing include after https://github.com/root-project/root/pull/14891

#### PR validation:

Bot tests in https://github.com/cms-sw/cmsdist/pull/9047