### PR TITLE
Adding PUPPI jets and METs to offline DQM

### DIFF
--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -108,10 +108,12 @@ private:
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtToken_;
   edm::EDGetTokenT<reco::CaloJetCollection> caloJetsToken_;
   edm::EDGetTokenT<reco::PFJetCollection> pfJetsToken_;
+  edm::EDGetTokenT<reco::PFJetCollection> puppiJetsToken_;
 
   edm::EDGetTokenT<reco::PFMETCollection> pfMetToken_;
   edm::EDGetTokenT<reco::CaloMETCollection> caloMetToken_;
   edm::EDGetTokenT<pat::METCollection> patMetToken_;
+  edm::EDGetTokenT<reco::PFMETCollection> puppiMetToken_;
 
   edm::EDGetTokenT<reco::MuonCollection> MuonsToken_;
   edm::EDGetTokenT<pat::JetCollection> patJetsToken_;
@@ -786,6 +788,7 @@ private:
   bool isCaloJet_;
   bool isPFJet_;
   bool isMiniAODJet_;
+  bool isPUPPIJet_;
 
   bool fill_jet_high_level_histo;
 

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -6,6 +6,11 @@ from DQMOffline.JetMET.jetAnalyzer_cfi import *
 
 jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
                                       *jetDQMAnalyzerAk4PFUncleaned*jetDQMAnalyzerAk4PFCleaned
+                                      *jetDQMAnalyzerAk4PFCHSCleaned
+                                   )
+
+_jetDQMAnalyzerSequenceWithPUPPI = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
+                                      *jetDQMAnalyzerAk4PFUncleaned*jetDQMAnalyzerAk4PFCleaned
                                       *jetDQMAnalyzerAk4PFCHSCleaned*jetDQMAnalizerAk4PUPPICleaned
                                    )
 
@@ -37,6 +42,7 @@ _jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMMatchAkPu4CaloAkPu4PF
         * jetDQMAnalyzerAkCs4PF
 )
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+(~pp_on_AA).toReplaceWith(jetDQMAnalyzerSequence, _jetDQMAnalyzerSequenceWithPUPPI)
 pp_on_AA.toReplaceWith( jetDQMAnalyzerSequence, _jetDQMAnalyzerSequenceHI )
 pp_on_AA.toModify( jetDQMAnalyzerAkPU4Calo, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
 pp_on_AA.toModify( jetDQMAnalyzerAkPU3PF, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -6,7 +6,7 @@ from DQMOffline.JetMET.jetAnalyzer_cfi import *
 
 jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
                                       *jetDQMAnalyzerAk4PFUncleaned*jetDQMAnalyzerAk4PFCleaned
-                                      *jetDQMAnalyzerAk4PFCHSCleaned
+                                      *jetDQMAnalyzerAk4PFCHSCleaned*jetDQMAnalizerAk4PUPPICleaned
                                    )
 
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -144,6 +144,16 @@ jetDQMAnalyzerAk4PFCHSCleaned=jetDQMAnalyzerAk4PFCleaned.clone(
     fillCHShistos = True
 )
 
+jetDQMAnalizerAk4PUPPICleaned=jetDQMAnalyzerAk4PFCleaned.clone(
+    JetType = cms.string('puppi'),
+    jetsrc = "ak4PFJetsPuppi",
+    METCollectionLabel = "pfMetPuppi",
+    JetCorrections = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    JetIDVersion = "RUN2ULPUPPI",
+    JetIDQuality = cms.string("TIGHT"),
+    fillCHShistos = True,
+)
+
 jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD=jetDQMAnalyzerAk4PFUncleaned.clone(
     filljetHighLevel = True,
     CleaningParameters = cleaningParameters.clone(

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -112,12 +112,26 @@ jetPreDQMTask = cms.Task(ak4CaloL2RelativeCorrector,
                          ak4PFCHSL2RelativeCorrector,
                          ak4PFCHSL3AbsoluteCorrector,
                          ak4PFCHSResidualCorrector,
-                         ak4PFPuppiL1FastjetCorrector,
+)
+
+_jetPreDQMTaskWithPUPPI = cms.Task(ak4CaloL2RelativeCorrector,
+                         ak4CaloL3AbsoluteCorrector,
+                         ak4CaloResidualCorrector,
+                         ak4PFL1FastjetCorrector,
+                         ak4PFL2RelativeCorrector,
+                         ak4PFL3AbsoluteCorrector,
+                         ak4PFResidualCorrector,
+                         ak4PFCHSL1FastjetCorrector,
+                         ak4PFCHSL2RelativeCorrector,
+                         ak4PFCHSL3AbsoluteCorrector,
+                         ak4PFCHSResidualCorrector,
+						 ak4PFPuppiL1FastjetCorrector,
                          ak4PFPuppiL2RelativeCorrector,
                          ak4PFPuppiL3AbsoluteCorrector,
                          ak4PFPuppiResidualCorrector,
 )
 jetPreDQMSeq=cms.Sequence(jetPreDQMTask)
+_jetPreDQMSeqWithPUPPI=cms.Sequence(_jetPreDQMTaskWithPUPPI)
 
 from JetMETCorrections.Type1MET.correctedMet_cff import pfMetT1
 from JetMETCorrections.Type1MET.correctionTermsPfMetType0PFCandidate_cff import *
@@ -133,14 +147,28 @@ pfMETT1=pfMetT1.clone(srcCorrections = (
 jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
-                                      pileupJetIdCalculatorPUPPIDQM*pileupJetIdEvaluatorPUPPIDQM*
                                       jetPreDQMSeq*
+                                      dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
+                                      cms.ignore(goodOfflinePrimaryVerticesDQM)*                                                                            
+                                      dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
+                                      cms.ignore(CSCTightHaloFilterDQM)*cms.ignore(CSCTightHalo2015FilterDQM)*cms.ignore(eeBadScFilterDQM)*cms.ignore(EcalDeadCellTriggerPrimitiveFilterDQM)*cms.ignore(EcalDeadCellBoundaryEnergyFilterDQM)*cms.ignore(HcalStripHaloFilterDQM)                                      
+                                      *METDQMAnalyzerSequence
+                                      *pfCandidateDQMAnalyzer)
+
+_jetMETDQMOfflineSourceWithPUPPI = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
+                                      pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
+                                      pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
+                                      pileupJetIdCalculatorPUPPIDQM*pileupJetIdEvaluatorPUPPIDQM*
+                                      _jetPreDQMSeqWithPUPPI*
                                       dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain*
                                       cms.ignore(goodOfflinePrimaryVerticesDQM)*                                                                            
                                       dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
                                       cms.ignore(CSCTightHaloFilterDQM)*cms.ignore(CSCTightHalo2015FilterDQM)*cms.ignore(eeBadScFilterDQM)*cms.ignore(EcalDeadCellTriggerPrimitiveFilterDQM)*cms.ignore(EcalDeadCellBoundaryEnergyFilterDQM)*cms.ignore(HcalStripHaloFilterDQM)                                      
                                       *METDQMAnalyzerSequence
                                       *pfCandidateDQMAnalyzer)
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+(~pp_on_AA).toReplaceWith(jetMETDQMOfflineSource, _jetMETDQMOfflineSourceWithPUPPI)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -92,7 +92,7 @@ dqmAk4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
     dqmAk4PFCHSL1FastL2L3Corrector
 )
 
-from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrector
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrectorChain,ak4PFPuppiL1FastL2L3ResidualCorrector,ak4PFPuppiL1FastL2L3Corrector,ak4PFPuppiResidualCorrector,ak4PFPuppiL3AbsoluteCorrector,ak4PFPuppiL2RelativeCorrector,ak4PFPuppiL1FastjetCorrector
 
 dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
 dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
@@ -112,7 +112,10 @@ jetPreDQMTask = cms.Task(ak4CaloL2RelativeCorrector,
                          ak4PFCHSL2RelativeCorrector,
                          ak4PFCHSL3AbsoluteCorrector,
                          ak4PFCHSResidualCorrector,
-                         ak4PFPuppiL1FastL2L3ResidualCorrector,
+                         ak4PFPuppiL1FastjetCorrector,
+                         ak4PFPuppiL2RelativeCorrector,
+                         ak4PFPuppiL3AbsoluteCorrector,
+                         ak4PFPuppiResidualCorrector,
 )
 jetPreDQMSeq=cms.Sequence(jetPreDQMTask)
 

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -42,6 +42,21 @@ pileupJetIdEvaluatorCHSDQM=pileupJetIdEvaluator.clone(
     inputIsCorrected = False
     )
 
+pileupJetIdCalculatorPUPPIDQM=pileupJetIdCalculator.clone(
+    jets = "ak4PFJetsPuppi",
+    jec = "AK4PFPuppi",
+    applyJec = True,
+    inputIsCorrected = False
+)
+
+pileupJetIdEvaluatorPUPPIDQM=pileupJetIdEvaluator.clone(
+    jets = "ak4PFJetsPuppi",
+    jetids = "pileupJetIdCalculatorPUPPIDQM",
+    jec = "AK4PFPuppi",
+    applyJec = True,
+    inputIsCorrected = False
+)
+
 from JetMETCorrections.Configuration.JetCorrectors_cff import ak4CaloL2L3ResidualCorrectorChain,ak4CaloL2L3ResidualCorrector,ak4CaloResidualCorrector,ak4CaloL2L3Corrector,ak4CaloL3AbsoluteCorrector,ak4CaloL2RelativeCorrector
 
 dqmAk4CaloL2L3ResidualCorrector = ak4CaloL2L3ResidualCorrector.clone()
@@ -77,6 +92,13 @@ dqmAk4PFCHSL1FastL2L3CorrectorChain = cms.Sequence(
     dqmAk4PFCHSL1FastL2L3Corrector
 )
 
+from JetMETCorrections.Configuration.JetCorrectors_cff import ak4PFPuppiL1FastL2L3ResidualCorrector
+
+dqmAk4PFPuppiL1FastL2L3ResidualCorrector = ak4PFPuppiL1FastL2L3ResidualCorrector.clone()
+dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain = cms.Sequence(
+    dqmAk4PFPuppiL1FastL2L3ResidualCorrector
+)
+
 HBHENoiseFilterResultProducerDQM=HBHENoiseFilterResultProducer.clone()
 
 jetPreDQMTask = cms.Task(ak4CaloL2RelativeCorrector,
@@ -89,7 +111,8 @@ jetPreDQMTask = cms.Task(ak4CaloL2RelativeCorrector,
                          ak4PFCHSL1FastjetCorrector,
                          ak4PFCHSL2RelativeCorrector,
                          ak4PFCHSL3AbsoluteCorrector,
-                         ak4PFCHSResidualCorrector
+                         ak4PFCHSResidualCorrector,
+                         ak4PFPuppiL1FastL2L3ResidualCorrector,
 )
 jetPreDQMSeq=cms.Sequence(jetPreDQMTask)
 
@@ -107,8 +130,9 @@ pfMETT1=pfMetT1.clone(srcCorrections = (
 jetMETDQMOfflineSource = cms.Sequence(AnalyzeSUSYDQM*QGTagger*
                                       pileupJetIdCalculatorCHSDQM*pileupJetIdEvaluatorCHSDQM*
                                       pileupJetIdCalculatorDQM*pileupJetIdEvaluatorDQM*
+                                      pileupJetIdCalculatorPUPPIDQM*pileupJetIdEvaluatorPUPPIDQM*
                                       jetPreDQMSeq*
-                                      dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*
+                                      dqmAk4CaloL2L3ResidualCorrectorChain*dqmAk4PFL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3ResidualCorrectorChain*dqmAk4PFCHSL1FastL2L3CorrectorChain*dqmAk4PFPuppiL1FastL2L3ResidualCorrectorChain*
                                       cms.ignore(goodOfflinePrimaryVerticesDQM)*                                                                            
                                       dqmCorrPfMetType1*pfMETT1*jetDQMAnalyzerSequence*HBHENoiseFilterResultProducer*
                                       cms.ignore(CSCTightHaloFilterDQM)*cms.ignore(CSCTightHalo2015FilterDQM)*cms.ignore(eeBadScFilterDQM)*cms.ignore(EcalDeadCellTriggerPrimitiveFilterDQM)*cms.ignore(EcalDeadCellBoundaryEnergyFilterDQM)*cms.ignore(HcalStripHaloFilterDQM)                                      

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.JetMET.metDQMConfig_cfi import *
 
 #correction for type 1 done in JetMETDQMOfflineSource now
-METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
+METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer*pfMetPUPPIDQMAnalyzer)
 
 METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD*pfPuppiMetDQMAnalyzerMiniAOD)
 

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -1,12 +1,17 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
 from DQMOffline.JetMET.metDQMConfig_cfi import *
 
 #correction for type 1 done in JetMETDQMOfflineSource now
-METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer*pfMetPUPPIDQMAnalyzer)
+METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
+
+_METDQMAnalyzerSequenceWithPUPPI = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer*pfMetPUPPIDQMAnalyzer)
 
 METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD*pfPuppiMetDQMAnalyzerMiniAOD)
 
 METDQMAnalyzerSequenceCosmics = cms.Sequence(caloMetDQMAnalyzer)
 
 METDQMAnalyzerSequenceHI = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer)
+
+(~pp_on_AA).toReplaceWith(METDQMAnalyzerSequence, _METDQMAnalyzerSequenceWithPUPPI)

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -207,6 +207,12 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
         Filter = True
         ),
 )
+pfMetPUPPIDQMAnalyzer = pfMetDQMAnalyzer.clone(
+    METType = 'pf',
+    METCollectionLabel     = "pfMetPuppi",
+    JetCollectionLabel  = "ak4PFJetsPuppi",
+    JetCorrections = "dqmAk4PuppiL2L3ResidualCorrector",
+)
 pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
     fillMetHighLevel = True,#fills only lumisec plots
     fillCandidateMaps = False,


### PR DESCRIPTION
#### PR description:

Adding the PUPPI collection for both jets and METs to the offline DQM JetMET sequence, as presented [here](https://indico.cern.ch/event/1386418/#3-updates-on-puppi-for-dc).

#### PR validation:

```
echo '{
"369978" : [[1, 800]]
}' > step1_lumiRanges.log  2>&1

(dasgoclient --limit 0 --query 'lumi,file dataset=/JetMET0/Run2023D-v1/RAW run=369978' --format json | das-selected-lumis.py 1,800 ) | sort -u > step1_dasquery.log  2>&1

cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2023 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2023 -n 1000 --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root  --nThreads 8

cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@jetmet --datatier RECO,MINIAOD,NANOAOD,DQMIO --eventcontent RECO,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3_2023 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT -n 1000 --filein  file:step2.root  --fileout file:step3.root  --nThreads 8

cmsDriver.py step4  -s HARVESTING:@jetmet --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3_2023 -n 1000 --filein file:step3_inDQM.root --fileout file:step4.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport
