### PR TITLE
Refactor scatterer addition in aGblPoint to explicitly specify type for scatPrecision.inverse()

### DIFF
--- a/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
+++ b/Alignment/ReferenceTrajectories/src/ReferenceTrajectory.cc
@@ -1024,7 +1024,7 @@ bool ReferenceTrajectory::addMaterialEffectsLocalGbl(const std::vector<Algebraic
       }
     } else {
       // GBL add scatterer to point
-      aGblPoint.addScatterer(scatterer, scatPrecision.inverse());
+      aGblPoint.addScatterer(scatterer, Eigen::Matrix2d(scatPrecision.inverse()));
     }
     // add point to list
     GblPointList.push_back(aGblPoint);
@@ -1129,7 +1129,7 @@ bool ReferenceTrajectory::addMaterialEffectsCurvlinGbl(const std::vector<Algebra
     }
 
     // GBL add scatterer to point
-    aGblPoint.addScatterer(scatterer, scatPrecDiag);
+    aGblPoint.addScatterer(scatterer, Eigen::Vector2d(scatPrecDiag));
 
     // add point to list
     GblPointList.push_back(aGblPoint);


### PR DESCRIPTION
#### PR description:

To test with https://github.com/cms-sw/cmsdist/pull/9053

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
