### PR TITLE
Phase2 L1T, Correlator Layer-2 : support emulation of with TMUX18 input + GT interface tweaks

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/egamma.h
+++ b/DataFormats/L1TParticleFlow/interface/egamma.h
@@ -168,7 +168,7 @@ namespace l1ct {
       ele.v3.eta = CTtoGT_eta(hwVtxEta());
       ele.qualityFlags = hwQual;
       // NOTE: GT:  0 = positive, 1 = negative, CT: 0 = negative, 1 = positive
-      ele.charge = !hwCharge & ele.valid;
+      ele.charge = (!hwCharge) & ele.valid;
       ele.z0(l1ct::z0_t::width - 1, 0) = hwZ0(l1ct::z0_t::width - 1, 0);
       ele.isolationPT = hwIso;
       return ele;

--- a/DataFormats/L1TParticleFlow/interface/egamma.h
+++ b/DataFormats/L1TParticleFlow/interface/egamma.h
@@ -73,8 +73,8 @@ namespace l1ct {
       pho.v3.pt = CTtoGT_pt(hwPt);
       pho.v3.phi = CTtoGT_phi(hwPhi);
       pho.v3.eta = CTtoGT_eta(hwEta);
-      pho.quality = hwQual;
-      pho.isolation = hwIso;
+      pho.qualityFlags = hwQual;
+      pho.isolationPT = hwIso;
       return pho;
     }
   };
@@ -166,11 +166,11 @@ namespace l1ct {
       ele.v3.pt = CTtoGT_pt(hwPt);
       ele.v3.phi = CTtoGT_phi(hwVtxPhi());
       ele.v3.eta = CTtoGT_eta(hwVtxEta());
-      ele.quality = hwQual;
+      ele.qualityFlags = hwQual;
       // NOTE: GT:  0 = positive, 1 = negative, CT: 0 = negative, 1 = positive
-      ele.charge = !hwCharge;
+      ele.charge = !hwCharge & ele.valid;
       ele.z0(l1ct::z0_t::width - 1, 0) = hwZ0(l1ct::z0_t::width - 1, 0);
-      ele.isolation = hwIso;
+      ele.isolationPT = hwIso;
       return ele;
     }
   };

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -257,10 +257,10 @@ namespace l1gt {
   struct Electron {
     valid_t valid;
     ThreeVector v3;
-    egquality_t quality;
+    egquality_t qualityFlags;
     ap_uint<1> charge;
     z0_t z0;
-    iso_t isolation;
+    iso_t isolationPT;
 
     static const int BITWIDTH = 96;
     inline ap_uint<BITWIDTH> pack() const {
@@ -268,8 +268,8 @@ namespace l1gt {
       unsigned int start = 0;
       pack_into_bits(ret, start, valid);
       pack_into_bits(ret, start, v3.pack());
-      pack_into_bits(ret, start, quality);
-      pack_into_bits(ret, start, isolation);
+      pack_into_bits(ret, start, qualityFlags);
+      pack_into_bits(ret, start, isolationPT);
       pack_into_bits(ret, start, charge);
       pack_into_bits(ret, start, z0);
       return ret;
@@ -281,8 +281,8 @@ namespace l1gt {
       unpack_from_bits(src, start, v3.pt);
       unpack_from_bits(src, start, v3.phi);
       unpack_from_bits(src, start, v3.eta);
-      unpack_from_bits(src, start, quality);
-      unpack_from_bits(src, start, isolation);
+      unpack_from_bits(src, start, qualityFlags);
+      unpack_from_bits(src, start, isolationPT);
       unpack_from_bits(src, start, charge);
       unpack_from_bits(src, start, z0);
     }
@@ -309,8 +309,8 @@ namespace l1gt {
   struct Photon {
     valid_t valid;
     ThreeVector v3;
-    egquality_t quality;
-    iso_t isolation;
+    egquality_t qualityFlags;
+    iso_t isolationPT;
 
     static const int BITWIDTH = 96;
     inline ap_uint<BITWIDTH> pack() const {
@@ -318,8 +318,8 @@ namespace l1gt {
       unsigned int start = 0;
       pack_into_bits(ret, start, valid);
       pack_into_bits(ret, start, v3.pack());
-      pack_into_bits(ret, start, quality);
-      pack_into_bits(ret, start, isolation);
+      pack_into_bits(ret, start, qualityFlags);
+      pack_into_bits(ret, start, isolationPT);
       return ret;
     }
 
@@ -329,8 +329,8 @@ namespace l1gt {
       unpack_from_bits(src, start, v3.pt);
       unpack_from_bits(src, start, v3.phi);
       unpack_from_bits(src, start, v3.eta);
-      unpack_from_bits(src, start, quality);
-      unpack_from_bits(src, start, isolation);
+      unpack_from_bits(src, start, qualityFlags);
+      unpack_from_bits(src, start, isolationPT);
     }
 
     inline static Photon unpack_ap(const ap_uint<BITWIDTH> &src) {

--- a/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTProducer.cc
@@ -310,7 +310,7 @@ namespace l1t {
     std::unique_ptr<P2GTCandidateCollection> outputCollection = std::make_unique<P2GTCandidateCollection>();
     const TkEmCollection &collection = event.get(cl2PhotonToken_);
     for (size_t i = 0; i < collection.size() && i < 12; i++) {
-      l1gt::Photon gtPhoton = l1gt::Photon::unpack_ap(const_cast<TkEm &>(collection[i]).egBinaryWord<96>());
+      l1gt::Photon gtPhoton = collection[i].hwObj();
       P2GTCandidate gtObj(0,
                           reco::ParticleState::PolarLorentzVector(scales_.to_pT(gtPhoton.v3.pt.V.to_int()),
                                                                   scales_.to_eta(gtPhoton.v3.eta.V.to_int()),
@@ -319,8 +319,8 @@ namespace l1t {
       gtObj.hwPT_ = gtPhoton.v3.pt.V.to_int();
       gtObj.hwPhi_ = gtPhoton.v3.phi.V.to_int();
       gtObj.hwEta_ = gtPhoton.v3.eta.V.to_int();
-      gtObj.hwIso_ = gtPhoton.isolation.V.to_int();
-      gtObj.hwQual_ = gtPhoton.quality.V.to_int();
+      gtObj.hwIso_ = gtPhoton.isolationPT.V.to_int();
+      gtObj.hwQual_ = gtPhoton.qualityFlags.V.to_int();
       gtObj.objectType_ = P2GTCandidate::CL2Photons;
 
       outputCollection->push_back(gtObj);
@@ -332,7 +332,7 @@ namespace l1t {
     std::unique_ptr<P2GTCandidateCollection> outputCollection = std::make_unique<P2GTCandidateCollection>();
     const TkElectronCollection &collection = event.get(cl2ElectronToken_);
     for (size_t i = 0; i < collection.size() && i < 12; i++) {
-      l1gt::Electron gtElectron = l1gt::Electron::unpack_ap(const_cast<TkElectron &>(collection[i]).egBinaryWord<96>());
+      l1gt::Electron gtElectron = collection[i].hwObj();
       int hwZ0 = gtElectron.z0.V.to_int() << 7;
       P2GTCandidate gtObj(scales_.to_chg(gtElectron.charge.V.to_int()),
                           reco::ParticleState::PolarLorentzVector(scales_.to_pT(gtElectron.v3.pt.V.to_int()),
@@ -344,8 +344,8 @@ namespace l1t {
       gtObj.hwPhi_ = gtElectron.v3.phi.V.to_int();
       gtObj.hwEta_ = gtElectron.v3.eta.V.to_int();
       gtObj.hwZ0_ = hwZ0;
-      gtObj.hwIso_ = gtElectron.isolation.V.to_int();
-      gtObj.hwQual_ = gtElectron.quality.V.to_int();
+      gtObj.hwIso_ = gtElectron.isolationPT.V.to_int();
+      gtObj.hwQual_ = gtElectron.qualityFlags.V.to_int();
       gtObj.hwCharge_ = gtElectron.charge.V.to_int();
       gtObj.objectType_ = P2GTCandidate::CL2Electrons;
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/egamma/l2egsorter_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/egamma/l2egsorter_ref.h
@@ -17,28 +17,28 @@ namespace l1ct {
 
   class L2EgSorterEmulator {
   public:
-    L2EgSorterEmulator(unsigned int nBoards, unsigned int nEGPerBoard, unsigned int nEGOut, bool debug)
-        : nBOARDS(nBoards), nEGPerBoard(nEGPerBoard), nEGOut(nEGOut), debug_(debug) {}
+    L2EgSorterEmulator(unsigned int nRegions, unsigned int nEGPerRegion, unsigned int nEGOut, bool debug)
+        : nREGIONS(nRegions), nEGPerRegion(nEGPerRegion), nEGOut(nEGOut), debug_(debug) {}
 
     L2EgSorterEmulator(const edm::ParameterSet &iConfig);
 
     virtual ~L2EgSorterEmulator() {}
 
-    template <int NBoards, int NObjs>
+    template <int NRegions, int NObjs>
     void toFirmware(const std::vector<l1ct::OutputBoard> &in,
-                    EGIsoObj (&photons_in)[NBoards][NObjs],
-                    EGIsoEleObj (&eles_in)[NBoards][NObjs]) const {
-      for (unsigned int ib = 0; ib < NBoards; ib++) {
-        const auto &board = in[ib];
+                    EGIsoObj (&photons_in)[NRegions][NObjs],
+                    EGIsoEleObj (&eles_in)[NRegions][NObjs]) const {
+      for (unsigned int ib = 0; ib < NRegions; ib++) {
+        const auto &region = in[ib];
         for (unsigned int io = 0; io < NObjs; io++) {
           EGIsoObj pho;
           EGIsoEleObj ele;
-          if (io < board.egphoton.size())
-            pho = board.egphoton[io];
+          if (io < region.egphoton.size())
+            pho = region.egphoton[io];
           else
             pho.clear();
-          if (io < board.egelectron.size())
-            ele = board.egelectron[io];
+          if (io < region.egelectron.size())
+            ele = region.egelectron[io];
           else
             ele.clear();
 
@@ -59,17 +59,17 @@ namespace l1ct {
 
     void setDebug(int verbose) { debug_ = verbose; }
 
-    unsigned int nInputBoards() const { return nBOARDS; }
-    unsigned int nInputObjPerBoard() const { return nEGPerBoard; }
+    unsigned int nInputRegions() const { return nREGIONS; }
+    unsigned int nInputObjPerRegion() const { return nEGPerRegion; }
     unsigned int nOutputObj() const { return nEGOut; }
 
   private:
     template <typename T>
     void resize_input(std::vector<T> &in) const {
-      if (in.size() > nEGPerBoard) {
-        in.resize(nEGPerBoard);
-      } else if (in.size() < nEGPerBoard) {
-        for (unsigned int i = 0, diff = (nEGPerBoard - in.size()); i < diff; ++i) {
+      if (in.size() > nEGPerRegion) {
+        in.resize(nEGPerRegion);
+      } else if (in.size() < nEGPerRegion) {
+        for (unsigned int i = 0, diff = (nEGPerRegion - in.size()); i < diff; ++i) {
           in.push_back(T());
           in.back().clear();
         }
@@ -90,17 +90,16 @@ namespace l1ct {
     }
 
     template <typename T>
-    void merge_boards(const std::vector<T> &in_board1,
-                      const std::vector<T> &in_board2,
-                      std::vector<T> &out,
-                      unsigned int nOut) const {
+    void merge_regions(const std::vector<T> &in_region1,
+                       const std::vector<T> &in_region2,
+                       std::vector<T> &out,
+                       unsigned int nOut) const {
       // we crate a bitonic list
-      out = in_board1;
+      out = in_region1;
       std::reverse(out.begin(), out.end());
-      std::copy(in_board2.begin(), in_board2.end(), std::back_inserter(out));
+      std::copy(in_region2.begin(), in_region2.end(), std::back_inserter(out));
       hybridBitonicMergeRef(&out[0], out.size(), 0, false);
 
-      // std::merge(in_board1.begin(), in_board1.end(), in_board2_copy.begin(), in_board2_copy.end(), std::back_inserter(out), comparePt<T>);
       if (out.size() > nOut)
         out.resize(nOut);
     }
@@ -112,7 +111,7 @@ namespace l1ct {
         if (out.size() > nEGOut)
           out.resize(nEGOut);
       } else if (in_objs.size() == 2) {
-        merge_boards(in_objs[0], in_objs[1], out, nEGOut);
+        merge_regions(in_objs[0], in_objs[1], out, nEGOut);
       } else {
         std::vector<std::vector<T>> to_merge;
         for (unsigned int id = 0, idn = 1; id < in_objs.size(); id += 2, idn = id + 1) {
@@ -120,7 +119,7 @@ namespace l1ct {
             to_merge.push_back(in_objs[id]);
           } else {
             std::vector<T> pair_merge;
-            merge_boards(in_objs[id], in_objs[idn], pair_merge, nEGPerBoard);
+            merge_regions(in_objs[id], in_objs[idn], pair_merge, nEGPerRegion);
             to_merge.push_back(pair_merge);
           }
         }
@@ -128,8 +127,8 @@ namespace l1ct {
       }
     }
 
-    const unsigned int nBOARDS;
-    const unsigned int nEGPerBoard;
+    const unsigned int nREGIONS;
+    const unsigned int nEGPerRegion;
     const unsigned int nEGOut;
     int debug_;
   };

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCorrelatorLayer1Producer.cc
@@ -1182,6 +1182,7 @@ void L1TCorrelatorLayer1Producer::putEgObjects(edm::Event &iEvent,
       tkele.setEgBinaryWord(egele.pack(), l1t::TkElectron::HWEncoding::CT);
       tkele.setIdScore(egele.floatIDScore());
       tkele.setCharge(egele.intCharge());
+      tkele.setTrkzVtx(egele.floatZ0());
       tkeles->push_back(tkele);
       nele_obj.push_back(tkeles->size() - 1);
     }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
@@ -322,7 +322,7 @@ void L1TCtL2EgProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::Ev
   merge(tkEGInputs_, iEvent, constituents, outEgs);
   iEvent.put(std::move(outEgs), tkEGInstanceLabel_);
 
-  auto regions = std::make_unique<std::vector<l1ct::OutputBoard>>(l2egsorter.nInputBoards());
+  auto regions = std::make_unique<std::vector<l1ct::OutputBoard>>(l2egsorter.nInputRegions());
 
   merge(tkEleInputs_, iEvent, constituents, regions);
   merge(tkEmInputs_, iEvent, constituents, regions);
@@ -337,7 +337,7 @@ void L1TCtL2EgProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::Ev
 
       if (inData.has(linkData.linkId))
         data = inData.at(linkData.linkId);
-      encodeLayer1EgObjs(l2egsorter.nInputObjPerBoard(), data, (*regions)[ireg].egphoton, (*regions)[ireg].egelectron);
+      encodeLayer1EgObjs(l2egsorter.nInputObjPerRegion(), data, (*regions)[ireg].egphoton, (*regions)[ireg].egelectron);
       data.resize(data.size() + linkData.nTrailingWords, {0});
       inData.add(linkData.linkId, data);
     }

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
@@ -370,7 +370,7 @@ l1t::TkEm L1TCtL2EgProducer::convertFromEmu(const l1ct::EGIsoObjEmu &egiso,
                  constituentsPtrs[egiso.src_idx].first,
                  egiso.floatRelIso(l1ct::EGIsoObjEmu::IsoType::TkIso),
                  egiso.floatRelIso(l1ct::EGIsoObjEmu::IsoType::TkIsoPV));
-  tkem.setHwQual(gteg.quality);
+  tkem.setHwQual(gteg.qualityFlags);
   tkem.setPFIsol(egiso.floatRelIso(l1ct::EGIsoObjEmu::IsoType::PfIso));
   tkem.setPFIsolPV(egiso.floatRelIso(l1ct::EGIsoObjEmu::IsoType::PfIsoPV));
   tkem.setPuppiIsol(egiso.floatRelIso(l1ct::EGIsoObjEmu::IsoType::PuppiIso));
@@ -390,12 +390,13 @@ l1t::TkElectron L1TCtL2EgProducer::convertFromEmu(const l1ct::EGIsoEleObjEmu &eg
                         constituentsPtrs[egele.src_idx].first,
                         constituentsPtrs[egele.src_idx].second,
                         egele.floatRelIso(l1ct::EGIsoEleObjEmu::IsoType::TkIso));
-  tkele.setHwQual(gteg.quality);
+  tkele.setHwQual(gteg.qualityFlags);
   tkele.setPFIsol(egele.floatRelIso(l1ct::EGIsoEleObjEmu::IsoType::PfIso));
   tkele.setPuppiIsol(egele.floatRelIso(l1ct::EGIsoEleObjEmu::IsoType::PuppiIso));
   tkele.setEgBinaryWord(gteg.pack(), l1t::TkElectron::HWEncoding::GT);
   tkele.setIdScore(egele.floatIDScore());
   tkele.setCharge(egele.intCharge());
+  tkele.setTrkzVtx(l1gt::Scales::floatZ0(gteg.z0));
   return tkele;
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1TCtL2EgProducer.cc
@@ -36,9 +36,10 @@ private:
   std::vector<ap_uint<64>> encodeLayer1(const std::vector<EGIsoObjEmu> &photons) const;
   std::vector<ap_uint<64>> encodeLayer1(const std::vector<EGIsoEleObjEmu> &electrons) const;
 
-  std::vector<ap_uint<64>> encodeLayer1EgObjs(unsigned int nObj,
-                                              const std::vector<EGIsoObjEmu> &photons,
-                                              const std::vector<EGIsoEleObjEmu> &electrons) const;
+  void encodeLayer1EgObjs(unsigned int nObj,
+                          std::vector<ap_uint<64>> &data,
+                          const std::vector<EGIsoObjEmu> &photons,
+                          const std::vector<EGIsoEleObjEmu> &electrons) const;
 
   void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
@@ -56,25 +57,29 @@ private:
   template <class T>
   class PFInstanceInputs {
   public:
-    typedef std::vector<std::pair<edm::EDGetTokenT<T>, std::vector<int>>> InputTokenAndChannels;
+    typedef std::vector<std::pair<edm::EDGetTokenT<T>, std::vector<int>>> InputTokenAndRegions;
     PFInstanceInputs(L1TCtL2EgProducer *prod, const std::vector<edm::ParameterSet> &confs) {
       for (const auto &conf : confs) {
         const auto &producer_tag = conf.getParameter<edm::InputTag>("pfProducer");
-        tokensAndChannels_.push_back(std::make_pair(
+        tokensAndRegions_.push_back(std::make_pair(
             prod->consumes<T>(edm::InputTag(producer_tag.label(), producer_tag.instance(), producer_tag.process())),
-            conf.getParameter<std::vector<int>>("channels")));
+            conf.getParameter<std::vector<int>>("regions")));
       }
     }
 
-    const InputTokenAndChannels &tokensAndChannels() const { return tokensAndChannels_; }
+    const InputTokenAndRegions &tokensAndRegions() const { return tokensAndRegions_; }
 
   private:
-    InputTokenAndChannels tokensAndChannels_;
+    InputTokenAndRegions tokensAndRegions_;
   };
 
   class PatternWriter {
   public:
-    PatternWriter(const edm::ParameterSet &conf) : dataWriter_(nullptr) {
+    PatternWriter(const edm::ParameterSet &conf)
+        : region2link_(5),
+          dataWriter_(nullptr),
+          nEvPerFile_(conf.getParameter<uint32_t>("eventsPerFile")),
+          enventIndex_(0) {
       unsigned int nFramesPerBX = conf.getParameter<uint32_t>("nFramesPerBX");
 
       std::map<l1t::demo::LinkId, std::pair<l1t::demo::ChannelSpec, std::vector<size_t>>> channelSpecs;
@@ -84,11 +89,42 @@ private:
         unsigned int eventGap =
             inTMUX * nFramesPerBX - channelConf.getParameter<uint32_t>("nWords");  // assuming 96bit (= 3/2 word)
                                                                                    // words  = TMUX*9-2*3/2*words
+
         std::vector<uint32_t> chns = channelConf.getParameter<std::vector<uint32_t>>("channels");
-        channelSpecs[l1t::demo::LinkId{channelConf.getParameter<std::string>("interface"),
-                                       channelConf.getParameter<uint32_t>("id")}] =
-            std::make_pair(l1t::demo::ChannelSpec{inTMUX, eventGap},
-                           std::vector<size_t>(std::begin(chns), std::end(chns)));
+
+        std::string interface = channelConf.getParameter<std::string>("interface");
+        unsigned int chId = channelConf.getParameter<uint32_t>("id");
+        l1t::demo::LinkId linkId{interface, size_t(chId)};
+        channelSpecs[linkId] = std::make_pair(l1t::demo::ChannelSpec{inTMUX, eventGap},
+                                              std::vector<size_t>(std::begin(chns), std::end(chns)));
+
+        // NOTE: this could be parametrized from CFG
+        if (inTMUX == 6) {
+          if (interface == "eglayer1Barrel" || interface == "eglayer1Endcap") {
+            // Layer1 TMUX=6 => each one of the regions is mapped to a link
+            // with the same ID
+            // # of words = 16 (pho) + 2*16 (ele) = 48
+            // no filling words needed
+            region2link_[chId] = RegionLinkMetadata{linkId, 0};
+          }
+        } else if (inTMUX == 18) {
+          if (interface == "eglayer1Barrel") {
+            // Layer1 TMUX=18 => 3 regions are mapped to the same link
+            // one every 6 BX x 9 words = 54 words
+            // # of data words = 16 (pho) + 2*16 (ele) = 48
+            // # we fill with 54-48 = 6 empty words
+            region2link_[0] = RegionLinkMetadata{linkId, 6};
+            region2link_[1] = RegionLinkMetadata{linkId, 6};
+            region2link_[2] = RegionLinkMetadata{linkId, 0};
+          } else if (interface == "eglayer1Endcap") {
+            // Layer1 TMUX=18 => 2 endcap regions are mapped to the same link
+            // one every 9 BX x 9 words = 81 words
+            // # of data words = 16 (pho) + 2*16 (ele) = 48
+            // # we fill with 81-48 = 33 empty words
+            region2link_[3] = RegionLinkMetadata{linkId, 33};
+            region2link_[4] = RegionLinkMetadata{linkId, 0};
+          }
+        }
       }
 
       dataWriter_ = std::make_unique<l1t::demo::BoardDataWriter>(
@@ -101,12 +137,31 @@ private:
           channelSpecs);
     }
 
-    void addEvent(const l1t::demo::EventData &eventData) { dataWriter_->addEvent(eventData); }
+    struct RegionLinkMetadata {
+      l1t::demo::LinkId linkId;
+      unsigned int nTrailingWords;
+    };
+
+    void addEvent(const l1t::demo::EventData &eventData) {
+      dataWriter_->addEvent(eventData);
+      enventIndex_++;
+      if (enventIndex_ % nEvPerFile_ == 0)
+        dataWriter_->flush();
+    }
 
     void flush() { dataWriter_->flush(); }
 
+    const RegionLinkMetadata &region2Link(unsigned int region) const {
+      assert(region < region2link_.size());
+      return region2link_.at(region);
+    }
+
   private:
+    std::vector<RegionLinkMetadata> region2link_;
+
     std::unique_ptr<l1t::demo::BoardDataWriter> dataWriter_;
+    uint32_t nEvPerFile_;
+    uint32_t enventIndex_;
   };
 
   template <class TT, class T>
@@ -115,33 +170,33 @@ private:
              ConstituentPtrVector &constituentsPtrs,
              std::unique_ptr<TT> &out) const {
     edm::Handle<T> handle;
-    for (const auto &tokenAndChannel : instance.tokensAndChannels()) {
-      iEvent.getByToken(tokenAndChannel.first, handle);
-      populate(out, handle, tokenAndChannel.second, constituentsPtrs);
+    for (const auto &tokenAndRegions : instance.tokensAndRegions()) {
+      iEvent.getByToken(tokenAndRegions.first, handle);
+      populate(out, handle, tokenAndRegions.second, constituentsPtrs);
     }
   }
 
   template <class TT, class T>
   void populate(std::unique_ptr<T> &out,
                 const edm::Handle<TT> &in,
-                const std::vector<int> &links,
+                const std::vector<int> &regions,
                 ConstituentPtrVector &constituentsPtrs) const {
-    assert(links.size() == in->nRegions());
+    assert(regions.size() == in->nRegions());
     for (unsigned int iBoard = 0, nBoard = in->nRegions(); iBoard < nBoard; ++iBoard) {
       auto region = in->region(iBoard);
-      int linkID = links[iBoard];
-      if (linkID < 0)
+      int regionID = regions[iBoard];
+      if (regionID < 0)
         continue;
-      // std::cout << "Board eta: " << in->eta(iBoard) << " phi: " << in->phi(iBoard) << " link: " << linkID << std::endl;
+      // std::cout << "Board eta: " << in->eta(iBoard) << " phi: " << in->phi(iBoard) << " link: " << regionID << std::endl;
       for (const auto &obj : region) {
-        convertToEmu(obj, constituentsPtrs, out->at(linkID));
+        convertToEmu(obj, constituentsPtrs, out->at(regionID));
       }
     }
   }
 
   void populate(std::unique_ptr<BXVector<l1t::EGamma>> &out,
                 const edm::Handle<BXVector<l1t::EGamma>> &in,
-                const std::vector<int> &links,
+                const std::vector<int> &regions,
                 ConstituentPtrVector &constituentsPtrs) const {
     for (int bx = in->getFirstBX(); bx <= in->getLastBX(); bx++) {
       for (auto egee_itr = in->begin(bx); egee_itr != in->end(bx); egee_itr++) {
@@ -247,19 +302,17 @@ std::vector<ap_uint<64>> L1TCtL2EgProducer::encodeLayer1(const std::vector<EGIso
   return ret;
 }
 
-std::vector<ap_uint<64>> L1TCtL2EgProducer::encodeLayer1EgObjs(unsigned int nObj,
-                                                               const std::vector<EGIsoObjEmu> &photons,
-                                                               const std::vector<EGIsoEleObjEmu> &electrons) const {
-  std::vector<ap_uint<64>> ret;
+void L1TCtL2EgProducer::encodeLayer1EgObjs(unsigned int nObj,
+                                           std::vector<ap_uint<64>> &data,
+                                           const std::vector<EGIsoObjEmu> &photons,
+                                           const std::vector<EGIsoEleObjEmu> &electrons) const {
   auto encoded_photons = encodeLayer1(photons);
   encoded_photons.resize(nObj, {0});
   auto encoded_eles = encodeLayer1(electrons);
   encoded_eles.resize(2 * nObj, {0});
 
-  std::copy(encoded_photons.begin(), encoded_photons.end(), std::back_inserter(ret));
-  std::copy(encoded_eles.begin(), encoded_eles.end(), std::back_inserter(ret));
-
-  return ret;
+  std::copy(encoded_photons.begin(), encoded_photons.end(), std::back_inserter(data));
+  std::copy(encoded_eles.begin(), encoded_eles.end(), std::back_inserter(data));
 }
 
 void L1TCtL2EgProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &) const {
@@ -269,24 +322,31 @@ void L1TCtL2EgProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::Ev
   merge(tkEGInputs_, iEvent, constituents, outEgs);
   iEvent.put(std::move(outEgs), tkEGInstanceLabel_);
 
-  auto boards = std::make_unique<std::vector<l1ct::OutputBoard>>(l2egsorter.nInputBoards());
+  auto regions = std::make_unique<std::vector<l1ct::OutputBoard>>(l2egsorter.nInputBoards());
 
-  merge(tkEleInputs_, iEvent, constituents, boards);
-  merge(tkEmInputs_, iEvent, constituents, boards);
+  merge(tkEleInputs_, iEvent, constituents, regions);
+  merge(tkEmInputs_, iEvent, constituents, regions);
 
   if (doInPtrn_) {
+    std::map<unsigned int, l1t::demo::LinkId> regio2link;
+
     l1t::demo::EventData inData;
-    for (unsigned int ibrd = 0; ibrd < boards->size(); ibrd++) {
-      inData.add(
-          {"eglayer1", ibrd},
-          encodeLayer1EgObjs(l2egsorter.nInputObjPerBoard(), (*boards)[ibrd].egphoton, (*boards)[ibrd].egelectron));
+    for (unsigned int ireg = 0; ireg < regions->size(); ireg++) {
+      const auto &linkData = inPtrnWrt_->region2Link(ireg);
+      std::vector<ap_uint<64>> data;
+
+      if (inData.has(linkData.linkId))
+        data = inData.at(linkData.linkId);
+      encodeLayer1EgObjs(l2egsorter.nInputObjPerBoard(), data, (*regions)[ireg].egphoton, (*regions)[ireg].egelectron);
+      data.resize(data.size() + linkData.nTrailingWords, {0});
+      inData.add(linkData.linkId, data);
     }
     inPtrnWrt_->addEvent(inData);
   }
 
   std::vector<EGIsoObjEmu> out_photons_emu;
   std::vector<EGIsoEleObjEmu> out_eles_emu;
-  l2egsorter.run(*boards, out_photons_emu, out_eles_emu);
+  l2egsorter.run(*regions, out_photons_emu, out_eles_emu);
 
   // PUPPI isolation
   auto &pfObjs = iEvent.get(pfObjsToken_);

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
@@ -7,35 +7,35 @@ l1tLayer2EG = cms.EDProducer(
     tkElectrons=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCal", 'L1TkElePerBoard'),
-            channels=cms.vint32(3, 4)
+            regions=cms.vint32(3, 4)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1Barrel", 'L1TkElePerBoard'),
-            channels=cms.vint32(0, 1, 2)
+            regions=cms.vint32(0, 1, 2)
         ),
     ),
     tkEms=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCal", 'L1TkEmPerBoard'),
-            channels=cms.vint32(3, 4)
+            regions=cms.vint32(3, 4)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalNoTK", 'L1TkEmPerBoard'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1Barrel", 'L1TkEmPerBoard'),
-            channels=cms.vint32(0, 1, 2)
+            regions=cms.vint32(0, 1, 2)
         ),
     ),
     tkEgs=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCal", 'L1Eg'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalNoTK", 'L1Eg'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
     ),
     l1PFObjects = cms.InputTag("l1tLayer2Deregionizer", "Puppi"),
@@ -77,39 +77,40 @@ l1tLayer2EG = cms.EDProducer(
         outputFileExtension=cms.string("txt.gz"),
         TMUX=cms.uint32(6),
         maxLinesPerFile=cms.uint32(1024),
+        eventsPerFile=cms.uint32(12),
         channels=cms.VPSet(
             cms.PSet(
                 TMUX=cms.uint32(6),
                 nWords=cms.uint32(48),  # = 16*2words ele + 16words photons
-                interface=cms.string("eglayer1"),
+                interface=cms.string("eglayer1Barrel"),
                 id=cms.uint32(0),
                 channels=cms.vuint32(0)
                 ),
             cms.PSet(
                 TMUX=cms.uint32(6),
                 nWords=cms.uint32(48),
-                interface=cms.string("eglayer1"),
+                interface=cms.string("eglayer1Barrel"),
                 id=cms.uint32(1),
                 channels=cms.vuint32(1)
                 ),
             cms.PSet(
                 TMUX=cms.uint32(6),
                 nWords=cms.uint32(48),
-                interface=cms.string("eglayer1"),
+                interface=cms.string("eglayer1Barrel"),
                 id=cms.uint32(2),
                 channels=cms.vuint32(2)
                 ),
             cms.PSet(
                 TMUX=cms.uint32(6),
                 nWords=cms.uint32(48),
-                interface=cms.string("eglayer1"),
+                interface=cms.string("eglayer1Endcap"),
                 id=cms.uint32(3),
                 channels=cms.vuint32(3)
                 ),
             cms.PSet(
                 TMUX=cms.uint32(6),
                 nWords=cms.uint32(48),
-                interface=cms.string("eglayer1"),
+                interface=cms.string("eglayer1Endcap"),
                 id=cms.uint32(4),
                 channels=cms.vuint32(4)
                 ),
@@ -123,6 +124,7 @@ l1tLayer2EG = cms.EDProducer(
         outputFileExtension=cms.string("txt.gz"),
         TMUX=cms.uint32(6),
         maxLinesPerFile=cms.uint32(1024),
+        eventsPerFile=cms.uint32(12),
         channels=cms.VPSet(
             cms.PSet(
                 TMUX=cms.uint32(6),
@@ -189,6 +191,65 @@ l1tLayer2EGElliptic = l1tLayer2EG.clone(
         ),
     ),
 )
+
+# EG Layer2 with Layer1 @ TMUX18
+l1tLayer2EGTM18 = l1tLayer2EG.clone(
+    tkElectrons=cms.VPSet(
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1HGCalTM18", 'L1TkElePerBoard'),
+            regions=cms.vint32(3, 4)
+        ),
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1BarrelSerenityTM18", 'L1TkElePerBoard'),
+            regions=cms.vint32(0, 1, 2)
+        ),
+    ),
+    tkEms=cms.VPSet(
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1HGCalTM18", 'L1TkEmPerBoard'),
+            regions=cms.vint32(3, 4)
+        ),
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1HGCalNoTKTM18", 'L1TkEmPerBoard'),
+            regions=cms.vint32(-1)
+        ),
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1BarrelSerenityTM18", 'L1TkEmPerBoard'),
+            regions=cms.vint32(0, 1, 2)
+        ),
+    ),
+    tkEgs=cms.VPSet(
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1HGCalTM18", 'L1Eg'),
+            regions=cms.vint32(-1)
+        ),
+        cms.PSet(
+            pfProducer=cms.InputTag("l1tLayer1HGCalNoTKTM18", 'L1Eg'),
+            regions=cms.vint32(-1)
+        ),
+    ),
+)
+
+l1tLayer2EGTM18.inPatternFile.outputFilename = "L1TCTL2EG_TMUX18_InPattern"
+l1tLayer2EGTM18.inPatternFile.channels = cms.VPSet(
+    cms.PSet(
+        TMUX=cms.uint32(18),
+        nWords=cms.uint32(156),  # = (16*2words ele + 16words photons) * 3 (regions) every 6 BX (54 words) = 48+6(empty)+48+6(empty)+48 = 156
+        interface=cms.string("eglayer1Barrel"),
+        id=cms.uint32(0),
+        channels=cms.vuint32(0,2,4)
+        ),
+    cms.PSet(
+        TMUX=cms.uint32(18),
+        nWords=cms.uint32(129), # (16*2words ele + 16words photons) * 2 (regions) every 9 BX (81 words) = 48+33(empty)+48
+        interface=cms.string("eglayer1Endcap"),
+        id=cms.uint32(1),
+        channels=cms.vuint32(1,3,5)
+        ),
+)
+l1tLayer2EGTM18.outPatternFile.outputFilename = 'L1TCTL2EG_TMUX18_OutPattern'
+# FIXME: we need to schedule a new deregionizer for TM18
+# l1tLayer2EGTM18.l1PFObjects = cms.InputTag("l1tLayer2Deregionizer", "Puppi"),
 
 
 L1TLayer2EGTask = cms.Task(

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
@@ -43,8 +43,8 @@ l1tLayer2EG = cms.EDProducer(
     tkEmInstanceLabel=cms.string("L1CtTkEm"),
     tkEleInstanceLabel=cms.string("L1CtTkElectron"),
     sorter=cms.PSet(
-        nBOARDS=cms.uint32(5),
-        nEGPerBoard=cms.uint32(16),
+        nREGIONS=cms.uint32(5),
+        nEGPerRegion=cms.uint32(16),
         nEGOut=cms.uint32(12),
         debug=cms.untracked.uint32(0),
     ),

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer2EG_cff.py
@@ -159,35 +159,35 @@ l1tLayer2EGElliptic = l1tLayer2EG.clone(
      tkElectrons=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalElliptic", 'L1TkElePerBoard'),
-            channels=cms.vint32(3, 4)
+            regions=cms.vint32(3, 4)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1Barrel", 'L1TkElePerBoard'),
-            channels=cms.vint32(0, 1, 2)
+            regions=cms.vint32(0, 1, 2)
         ),
     ),
     tkEms=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalElliptic", 'L1TkEmPerBoard'),
-            channels=cms.vint32(3, 4)
+            regions=cms.vint32(3, 4)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalNoTK", 'L1TkEmPerBoard'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1Barrel", 'L1TkEmPerBoard'),
-            channels=cms.vint32(0, 1, 2)
+            regions=cms.vint32(0, 1, 2)
         ),
     ),
     tkEgs=cms.VPSet(
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalElliptic", 'L1Eg'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
         cms.PSet(
             pfProducer=cms.InputTag("l1tLayer1HGCalNoTK", 'L1Eg'),
-            channels=cms.vint32(-1)
+            regions=cms.vint32(-1)
         ),
     ),
 )

--- a/L1Trigger/Phase2L1ParticleFlow/src/egamma/l2egsorter_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/egamma/l2egsorter_ref.cpp
@@ -12,8 +12,8 @@ using namespace l1ct;
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 l1ct::L2EgSorterEmulator::L2EgSorterEmulator(const edm::ParameterSet &pset)
-    : L2EgSorterEmulator(pset.getParameter<uint32_t>("nBOARDS"),
-                         pset.getParameter<uint32_t>("nEGPerBoard"),
+    : L2EgSorterEmulator(pset.getParameter<uint32_t>("nREGIONS"),
+                         pset.getParameter<uint32_t>("nEGPerRegion"),
                          pset.getParameter<uint32_t>("nEGOut"),
                          pset.getUntrackedParameter<uint32_t>("debug", 0)) {}
 #endif
@@ -43,11 +43,11 @@ void L2EgSorterEmulator::run(const std::vector<l1ct::OutputBoard> &in,
                              std::vector<EGIsoObjEmu> &out_photons,
                              std::vector<EGIsoEleObjEmu> &out_eles) const {
   if (debug_) {
-    unsigned int board_n = 0;
-    for (const auto &board : in) {
-      dbgCout() << "BOARD " << board_n++ << std::endl;
-      print_objects(board.egphoton, "photon_in");
-      print_objects(board.egelectron, "electron_in");
+    unsigned int region_n = 0;
+    for (const auto &region : in) {
+      dbgCout() << "REGION " << region_n++ << std::endl;
+      print_objects(region.egphoton, "photon_in");
+      print_objects(region.egelectron, "electron_in");
     }
   }
 
@@ -56,9 +56,9 @@ void L2EgSorterEmulator::run(const std::vector<l1ct::OutputBoard> &in,
   std::vector<std::vector<EGIsoEleObjEmu>> eles_in;
   photons_in.reserve(in.size());
   eles_in.reserve(in.size());
-  for (const auto &board : in) {
-    std::vector<EGIsoObjEmu> photons = board.egphoton;
-    std::vector<EGIsoEleObjEmu> eles = board.egelectron;
+  for (const auto &region : in) {
+    std::vector<EGIsoObjEmu> photons = region.egphoton;
+    std::vector<EGIsoEleObjEmu> eles = region.egelectron;
     resize_input(photons);
     resize_input(eles);
 

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -187,10 +187,15 @@ if args.tm18:
     process.runPF.insert(process.runPF.index(process.l1tLayer1HGCal)+1, process.l1tLayer1HGCalTM18)
     process.runPF.insert(process.runPF.index(process.l1tLayer1HGCalNoTK)+1, process.l1tLayer1HGCalNoTKTM18)
     process.runPF.insert(process.runPF.index(process.l1tLayer1BarrelSerenity)+1, process.l1tLayer1BarrelSerenityTM18)
+    # FIXME: we need to schedule a new deregionizer for TM18
+    process.runPF.insert(process.runPF.index(process.l1tLayer2EG)+1, process.l1tLayer2EGTM18)
     if not args.patternFilesOFF:
         process.l1tLayer1HGCalTM18.patternWriters = cms.untracked.VPSet(*hgcalTM18WriterConfigs)
         process.l1tLayer1HGCalNoTKTM18.patternWriters = cms.untracked.VPSet(hgcalNoTKOutputTM18WriterConfig)
         process.l1tLayer1BarrelSerenityTM18.patternWriters = cms.untracked.VPSet()
+        process.l1tLayer2EGTM18.writeInPattern = True
+        process.l1tLayer2EGTM18.writeOutPattern = True
+
     if not args.dumpFilesOFF:
         for det in "HGCalTM18", "HGCalNoTKTM18", "BarrelSerenityTM18":
                 getattr(process, 'l1tLayer1'+det).dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -57,8 +57,19 @@ process.load('L1Trigger.L1TTrackMatch.l1tGTTInputProducer_cfi')
 process.load('L1Trigger.L1TTrackMatch.l1tTrackSelectionProducer_cfi')
 process.l1tTrackSelectionProducer.processSimulatedTracks = False # these would need stubs, and are not used anyway
 process.load('L1Trigger.VertexFinder.l1tVertexProducer_cfi')
-from L1Trigger.Phase2L1GMT.gmt_cfi import l1tStandaloneMuons
-process.l1tSAMuonsGmt = l1tStandaloneMuons.clone()
+from L1Trigger.Configuration.SimL1Emulator_cff import l1tSAMuonsGmt
+process.l1tSAMuonsGmt = l1tSAMuonsGmt.clone()
+from L1Trigger.L1CaloTrigger.l1tPhase2L1CaloEGammaEmulator_cfi import l1tPhase2L1CaloEGammaEmulator
+process.l1tPhase2L1CaloEGammaEmulator = l1tPhase2L1CaloEGammaEmulator.clone()
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloPFClusterEmulator_cfi import l1tPhase2CaloPFClusterEmulator
+process.l1tPhase2CaloPFClusterEmulator = l1tPhase2CaloPFClusterEmulator.clone()
+
+process.L1TInputTask = cms.Task(
+    process.l1tSAMuonsGmt,
+    process.l1tPhase2L1CaloEGammaEmulator,
+    process.l1tPhase2CaloPFClusterEmulator
+)
+
 
 from L1Trigger.Phase2L1ParticleFlow.l1tJetFileWriter_cfi import l1tSeededConeJetFileWriter
 l1ctLayer2SCJetsProducts = cms.VPSet([cms.PSet(jets = cms.InputTag("l1tSC4PFL1PuppiCorrectedEmulator"),
@@ -119,7 +130,9 @@ if not args.patternFilesOFF:
     process.l1tLayer1HF.patternWriters = cms.untracked.VPSet(*hfWriterConfigs)
 
 process.runPF = cms.Path( 
-        process.l1tSAMuonsGmt +
+        # process.l1tSAMuonsGmt + 
+        # process.l1tPhase2L1CaloEGammaEmulator + 
+        # process.l1tPhase2CaloPFClusterEmulator +
         process.l1tGTTInputProducer +
         process.l1tTrackSelectionProducer +
         process.l1tVertexFinderEmulator +
@@ -138,8 +151,8 @@ process.runPF = cms.Path(
         # process.l1tLayer2SeedConeJetWriter +
         process.l1tLayer2EG
     )
+process.runPF.associate(process.L1TInputTask)
 process.runPF.associate(process.L1TLayer1TaskInputsTask)
-
 
 #####################################################################################################################
 ## Layer 2 e/gamma 
@@ -200,4 +213,4 @@ if args.tm18:
         for det in "HGCalTM18", "HGCalNoTKTM18", "BarrelSerenityTM18":
                 getattr(process, 'l1tLayer1'+det).dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
 
-process.source.fileNames  = [ '/store/cmst3/group/l1tr/gpetrucc/12_5_X/NewInputs125X/150223/TTbar_PU200/inputs125X_1.root' ]
+process.source.fileNames  = [ '/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root' ]


### PR DESCRIPTION
#### PR description:

The PR introduces the following changes:
- support pattern file creation for Correlator Layer-2 e/gamma boards with TMUX18 Layer-1 inputs.
- tweak the GT interface, renaming the `isolation` and `quality` methods of HW GT object according to the new convention.
- set the charge of non-valid HW GT electron objects to 0.
- address precision of the `z0` parameter in TkElectron to have the same precision as in HW

#### PR validation:

No expected change in performance: changes are only related to interfaces with emulator code.

This is equivalent to: 
https://github.com/cms-l1t-offline/cmssw/pull/1215
