### PR TITLE
Tau spring24 update

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/PFTau.h
@@ -13,8 +13,8 @@ namespace l1t {
   static constexpr float PFTAU_NN_SLOPE = 0.2;
   static constexpr float PFTAU_NN_OVERALL_SCALE = 1. / 20.1;
 
-  static constexpr float PFTAU_NN_LOOSE_CUT = 0.28;
-  static constexpr float PFTAU_NN_TIGHT_CUT = 0.25;
+  static constexpr float PFTAU_NN_LOOSE_CUT = 0.22;
+  static constexpr float PFTAU_NN_TIGHT_CUT = 0.4;
 
   static constexpr float PFTAU_PF_LOOSE_CUT = 10.0;
   static constexpr float PFTAU_PF_TIGHT_CUT = 5.0;
@@ -63,10 +63,7 @@ namespace l1t {
       return passLooseNN();
     }
     bool passLoosePF() const { return fullIso_ < PFTAU_PF_LOOSE_CUT; }
-    bool passTightNN() const {
-      return iso_ * (PFTAU_NN_OFFSET + PFTAU_NN_SLOPE * (min(pt(), PFTAU_NN_PT_CUTOFF))) * PFTAU_NN_OVERALL_SCALE >
-             PFTAU_NN_TIGHT_CUT;
-    }
+    bool passTightNN() const { return iso_ > PFTAU_NN_TIGHT_CUT; }
     bool passTightNNMass() const {
       if (!passMass())
         return false;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/TauNNIdHW.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/TauNNIdHW.h
@@ -25,11 +25,11 @@ namespace L1TauEmu {
   //This way, the least significant bit of etaphi_t is exactly 0.01
   //Even though 0.01 is not a power of 2
   static constexpr float etaphi_base = 100. / 64;
-  typedef ap_ufixed<16, 14> pt_t;        // 1 unit = 0.25 GeV;
-  typedef ap_fixed<10, 4> etaphi_t;      // 1 unit = 0.01;
-  typedef ap_fixed<12, 6> detaphi_t;     // type for the difference between etas or phis
-  typedef ap_fixed<18, 9> detaphi2_t;    // type for detaphi_t squared
-  typedef ap_fixed<22, 16> pt_etaphi_t;  // type for product of pt with deta or phi
+  typedef ap_ufixed<14, 12, AP_TRN, AP_SAT> pt_t;  // 1 unit = 0.25 GeV;
+  typedef ap_fixed<10, 4> etaphi_t;                // 1 unit = 0.01;
+  typedef ap_fixed<12, 6> detaphi_t;               // type for the difference between etas or phis
+  typedef ap_fixed<18, 9> detaphi2_t;              // type for detaphi_t squared
+  typedef ap_fixed<22, 16> pt_etaphi_t;            // type for product of pt with deta or phi
   typedef ap_int<8> dxy_t;
   typedef ap_int<10> z0_t;
   typedef ap_uint<5> count_t;  // type for multiplicity

--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/defines.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/defines.h
@@ -24,7 +24,7 @@
 #define N_LAYER_20 1
 
 // hls-fpga-machine-learning insert layer-precision
-typedef ap_fixed<16, 6> input_t;
+typedef ap_fixed<16, 10> input_t;
 typedef ap_fixed<24, 12> input2_t;
 typedef ap_fixed<16, 6> model_default_t;
 typedef ap_fixed<16, 6> layer2_t;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -97,10 +97,6 @@ void L1NNTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     process_SW(*l1PFCandidates, lTaus);
   }
 
-  if (lTaus->empty()) {
-    PFTau dummy;
-    lTaus->push_back(dummy);
-  }
   std::sort(lTaus->begin(), lTaus->end(), [](l1t::PFTau i, l1t::PFTau j) { return (i.pt() > j.pt()); });
   iEvent.put(std::move(lTaus), "L1PFTausNN");
 }


### PR DESCRIPTION
#### PR description:

This PR is to update some fixes in the Tau NN that was merged in  #43639. In particular, the input types were changed to `ap_fixed<16,6>` which introduced in-consistency in performance in CMSSW as compared to python simulation.

#### PR validation:

- Codes compiled, and formatted. 
- Performance was checked by making various performance plots:

 
![image](https://github.com/cms-l1t-offline/cmssw/assets/35171417/11e2bf8d-3224-4bb5-b5a4-2d9bff2bc0f5)
