### PR TITLE
Fix tag for the SiPixelLorentzAngleSimRcd in the Phase2 MC GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '140X_mcRun4_realistic_v2'
+    'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Fix the phase2_realistic GT: in a previous update of that GT (ported to autoCond with [#43763](https://github.com/cms-sw/cmssw/pull/43763)) a mistake slipped in because a wrong tag was taken for SiPixelLorentzAngleSimRcd. This is corrected in the `GT140X_mcRun4_realistic_v3`

Relevant github issue describing the need to move the default phase2 geometry to D98 is still https://github.com/cms-sw/cmssw/issues/42945

Modified tag:
- **SiPixelLorentzAngleSimRcd** from  `SiPixelLorentzAngle_phase2_T25_v0_mc` to `SiPixelSimLorentzAngle_phase2_T25_v0_mc`

Difference with respect to the previous run4 MC GT:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun4_realistic_v2/140X_mcRun4_realistic_v3

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

It will be backported to CMSSW_14_0_X