### PR TITLE
Hack `EgammaHLTR9IDProducer` to be able to run it in Phase2 HLT

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTR9IDProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTR9IDProducer.cc
@@ -83,8 +83,8 @@ void EgammaHLTR9IDProducer::produce(edm::StreamID sid, edm::Event& iEvent, const
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);  //-recoecalcandHandle->begin());
     if (recoecalcandref->superCluster()->seed()->seed().det() != DetId::Ecal) {     //HGCAL, skip for now
-      r9Map.insert(recoecalcandref, 0);
-      r95x5Map.insert(recoecalcandref, 0);
+      r9Map.insert(recoecalcandref, 1.0);
+      r95x5Map.insert(recoecalcandref, 1.0);
       continue;
     }
     float r9 = -1;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTR9IDProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTR9IDProducer.cc
@@ -82,7 +82,11 @@ void EgammaHLTR9IDProducer::produce(edm::StreamID sid, edm::Event& iEvent, const
   reco::RecoEcalCandidateIsolationMap r95x5Map(recoecalcandHandle);
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);  //-recoecalcandHandle->begin());
-
+    if (recoecalcandref->superCluster()->seed()->seed().det() != DetId::Ecal) {     //HGCAL, skip for now
+      r9Map.insert(recoecalcandref, 0);
+      r95x5Map.insert(recoecalcandref, 0);
+      continue;
+    }
     float r9 = -1;
     float r95x5 = -1;
 


### PR DESCRIPTION
#### PR description:

Currently, in Phase2 HLT, we do not use R9 variable. But it will be good to explore the potential of this variable at Phase2 HLT, as this variable was useful in Run3/Run2 HLT. With this PR, it is now possible to run `EgammaHLTR9IDProducer` on Phase2 samples. The R9 distribution, that was obtained by running on one root file of this sample[1], is meaningful, and is pasted below.

[1] `/RelValH125GGgluonfusion_14/CMSSW_14_0_0_pre3-140X_mcRun4_realistic_v1_STD_2026D98_noPU-v1/GEN-SIM-DIGI-RAW`

![r9](https://github.com/cms-sw/cmssw/assets/5052706/f5869d6a-14ae-4956-b1ff-5f6ebb1660d9)


#### PR validation:

CMSSW compiles. Phase2 HLT menu runs fine.