### PR TITLE
Remove invalid tool from L1Trigger/L1TZDC

### DIFF
--- a/L1Trigger/L1TZDC/plugins/BuildFile.xml
+++ b/L1Trigger/L1TZDC/plugins/BuildFile.xml
@@ -1,7 +1,3 @@
-<!-- Copied from L1Trigger/L1TCalorimeter/plugins BuildFile.xml 2023.08.02 -->
-<!-- Modified for ZDC by Chris McGinn -->
-<!-- Email christopher.mc.ginn@cern.ch or cfmcginn on github for issues -->
-
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
@@ -13,7 +9,6 @@
 <use name="CondFormats/L1TObjects"/>
 <use name="CondFormats/DataRecord"/>
 <use name="L1Trigger/L1TCalorimeter"/>
-<use name="L1Trigger/L1TZDC"/>
 <library file="*.cc" name="L1TriggerL1TZDCPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Building the package `L1Trigger/L1TZDC` prints the warning
```
****WARNING: Invalid tool L1Trigger/L1TZDC. Please fix src/L1Trigger/L1TZDC/plugins/BuildFile.xml file.
```

`L1Trigger/L1TZDC` is not a valid dependency, because it does not have `interface/` and `src/` directories, and does not provide a `BuildFile.xml`.

This change removed the dependency on it.

#### PR validation:

None.