### PR TITLE
add input / output LA `TkDetMaps` in `SiStripLorentzAnglePCLHarvester`

### DIFF
--- a/CalibTracker/SiStripCommon/interface/TkDetMap.h
+++ b/CalibTracker/SiStripCommon/interface/TkDetMap.h
@@ -1,5 +1,5 @@
-#ifndef CalibTracker_SiStripCommon_TKHistoMap_h
-#define CalibTracker_SiStripCommon_TKHistoMap_h
+#ifndef CalibTracker_SiStripCommon_TkDetMap_h
+#define CalibTracker_SiStripCommon_TkDetMap_h
 
 #include <vector>
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/43962. Title says it all, add `TkDetMaps` for module-level inspection of input and output LA values.
Additionally do not write a payload if the output value is identically 0.

#### PR validation:

Run on 3.8T run with data from the Strip Tracker via:

```bash
cmsDriver.py stepHarvest -s ALCAHARVEST:SiStripLA \
	     --conditions 140X_dataRun3_Express_v2 \
	     --scenario cosmics \
	     --data \
	     --era Run3_2023 \
	     -n -1 \
	     --dasquery='file dataset=/StreamExpressCosmics/Run2023F-PromptCalibProdSiStripLA-Express-v1/ALCAPROMPT run=373245'
```
and checked the output maps are filled correctly.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to CMSSW_14_0_X for data-taking purposes