### PR TITLE
Add Veto Threshold to HCAL TP Emulator

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
+++ b/CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h
@@ -36,6 +36,7 @@ public:
     std::string targetfirmware;
     int generalizedindex;
     int weight;
+    int codedvetothreshold;
     std::vector<unsigned int> lut;
     std::vector<uint64_t> mask;
   } Config;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -979,8 +979,10 @@ std::map<int, std::shared_ptr<LutXml>> HcalLutManager::getCompressionLutXmlFromC
 
     _cfg.lut = _coder.getCompressionLUT(_detid);
     auto pWeight = conditions->getHcalTPChannelParameter(_detid, false);
-    if (pWeight)
+    if (pWeight) {
       _cfg.weight = pWeight->getauxi1();
+      _cfg.codedvetothreshold = pWeight->getauxi2();
+    }
 
     int crot = 100 * row->crate + row->slot;
     unsigned int size = _cfg.lut.size();

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -83,6 +83,8 @@ public:
   void setPeakFinderAlgorithm(int algo);
   void setWeightsQIE11(const edm::ParameterSet& weightsQIE11);
   void setWeightQIE11(int aieta, int weight);
+  void setCodedVetoThresholds(const edm::ParameterSet& codedVetoThresholds);
+  void setCodedVetoThreshold(int aieta, int codedVetoThreshold);
   void setNCTScaleShift(int);
   void setRCTScaleShift(int);
 
@@ -142,6 +144,7 @@ private:
   bool peakfind_;
   std::vector<double> weights_;
   std::array<std::array<int, 2>, 29> weightsQIE11_;
+  std::array<int, 29> codedVetoThresholds_;
   int latency_;
   uint32_t FG_threshold_;
   std::vector<uint32_t> FG_HF_thresholds_;

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -48,6 +48,43 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     FG_threshold = cms.uint32(12), ## threshold for setting fine grain bit
     FG_HF_thresholds = cms.vuint32(17, 255), ## thresholds for setting fine grain bit
     ZS_threshold = cms.uint32(1),  ## threshold for setting TP zero suppression
+
+    # To be used when overriding the CondDB, default is with vetoing off ("coded" threshold = 0)
+    # To run PFA1' + vetoing with no threshold, use 2048
+    # All other values (1, 2047) are interpreted literally as the PFA1' veto threshold 
+    codedVetoThresholds = cms.PSet(
+        ieta1  = cms.int32(0),
+        ieta2  = cms.int32(0),
+        ieta3  = cms.int32(0),
+        ieta4  = cms.int32(0),
+        ieta5  = cms.int32(0),
+        ieta6  = cms.int32(0),
+        ieta7  = cms.int32(0),
+        ieta8  = cms.int32(0),
+        ieta9  = cms.int32(0),
+        ieta10 = cms.int32(0),
+        ieta11 = cms.int32(0),
+        ieta12 = cms.int32(0),
+        ieta13 = cms.int32(0),
+        ieta14 = cms.int32(0),
+        ieta15 = cms.int32(0),
+        ieta16 = cms.int32(0),
+        ieta17 = cms.int32(0),
+        ieta18 = cms.int32(0),
+        ieta19 = cms.int32(0),
+        ieta20 = cms.int32(0),
+        ieta21 = cms.int32(0),
+        ieta22 = cms.int32(0),
+        ieta23 = cms.int32(0),
+        ieta24 = cms.int32(0),
+        ieta25 = cms.int32(0),
+        ieta26 = cms.int32(0),
+        ieta27 = cms.int32(0),
+        ieta28 = cms.int32(0)
+    ),
+
+    overrideDBvetoThresholdsHB = cms.bool(False),
+    overrideDBvetoThresholdsHE = cms.bool(False),
     numberOfSamples = cms.int32(4),
     numberOfPresamples = cms.int32(2),
     numberOfSamplesHF = cms.int32(4),


### PR DESCRIPTION
#### PR description:

This PR incorporates a threshold for vetoing when applying the FIR filter during emulation of HCAL TP energy reconstruction in HB and HE. The veto threshold is taken from the `auxi2` field of the `HcalTPChannelParameters` object for robust control of the veto threshold online and offline. 

Small change in logic is incurred at L519 of HcalTrigPrimAlgo, where `check_sat` is now only defined by saturation in BX0 or BX1.

ATTN: @Michael-Krohn, @abdoulline, @jhakala

#### PR validation:


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is targeting 14_1_X; however, a backport shall be prepared for 14_0_X.