### PR TITLE
[backport] Improve handling of TF CUDA tests for 14_0_X

### DIFF
--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -5,7 +5,7 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+<iftool name="tf_cuda_support">
   <bin name="testTFHelloWorldCUDA" file="testRunner.cpp,testHelloWorldCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -29,7 +29,7 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+<iftool name="tf_cuda_support">
   <bin name="testTFMetaGraphLoadingCUDA" file="testRunner.cpp,testMetaGraphLoadingCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -52,7 +52,7 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+<iftool name="tf_cuda_support">
   <bin name="testTFGraphLoadingCUDA" file="testRunner.cpp,testGraphLoadingCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -75,7 +75,8 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+
+<iftool name="tf_cuda_support">
   <bin name="testTFConstSessionCUDA" file="testRunner.cpp,testConstSessionCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -98,7 +99,7 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+<iftool name="tf_cuda_support">
   <bin name="testTFSessionCacheCUDA" file="testRunner.cpp,testSessionCacheCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -121,7 +122,8 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
-<iftool name="cuda">
+
+<iftool name="tf_cuda_support">
   <bin name="testTFThreadPoolsCUDA" file="testRunner.cpp,testThreadPoolsCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>
@@ -145,7 +147,7 @@
 </bin>
 
 
-<iftool name="cuda">
+<iftool name="tf_cuda_support">
   <bin name="testTFVisibleDevicesCUDA" file="testRunner.cpp,testVisibleDevicesCUDA.cc">
     <use name="boost_filesystem"/>
     <use name="catch2"/>


### PR DESCRIPTION
#### PR description:

This PR improves the handling of CUDA unit tests for the TensorFlow package, using a new `tf_cuda_support` tool from scram , which checks if the GPU support is enabled in TensorFlow compilation. 

The PR also makes the TF cuda tests more strict by checking explicitely if a CUDA device is visible to TF and not only to cmssw.  

The test `testTFVisibleDevicesCUDA` is in fact run by the framework as a CUDA device is registered, but then TF does not recognize the device and the test fails.   The other `testTF*CUDA` tests were passing silently using the CPU to run the test.  After this PR all the TF sessions using  `tf::backend::cuda` , but  not finding a GPU will fail explicitly. 

- This PR is needed to continue the integration of CUDA 12.4 in https://github.com/cms-sw/cmsdist/pull/9046. 
- This PR needs https://github.com/cms-sw/cmsdist/pull/9066 (thanks to @smuzaffar https://github.com/cms-sw/cmssw/pull/44376#issuecomment-1992693414)
- This PR is a backport of https://github.com/cms-sw/cmssw/pull/44376