### PR TITLE
[14.0.X] EL9-migration related patches to All-in-one

### DIFF
--- a/Alignment/OfflineValidation/bin/DMRtrends.cc
+++ b/Alignment/OfflineValidation/bin/DMRtrends.cc
@@ -136,17 +136,17 @@ int trends(int argc, char *argv[]) {
 
   for (auto const &Variable : validation.get_child("Variables")) {
     vector<tuple<TString, TString, float, float>> DMRs{{"mu", "#mu [#mum]", -6, 6},
-                                                       {"sigma", "#sigma_{#mu} [#mum]", -15, 15},
+                                                       {"sigma", "#sigma_{#mu} [#mum]", -5, 5},
                                                        {"muplus", "#mu outward [#mum]", -6, 6},
-                                                       {"sigmaplus", "#sigma_{#mu outward} [#mum]", -15, 15},
+                                                       {"sigmaplus", "#sigma_{#mu outward} [#mum]", -5, 5},
                                                        {"muminus", "#mu inward [#mum]", -6, 6},
-                                                       {"sigmaminus", "#sigma_{#mu inward} [#mum]", -15, 15},
-                                                       {"deltamu", "#Delta#mu [#mum]", -15, 15},
-                                                       {"sigmadeltamu", "#sigma_{#Delta#mu} [#mum]", -15, 15},
-                                                       {"musigma", "#mu [#mum]", -6, 6},
-                                                       {"muplussigmaplus", "#mu outward [#mum]", -15, 15},
-                                                       {"muminussigmaminus", "#mu inward [#mum]", -15, 15},
-                                                       {"deltamusigmadeltamu", "#Delta#mu [#mum]", -15, 15}};
+                                                       {"sigmaminus", "#sigma_{#mu inward} [#mum]", -5, 5},
+                                                       {"deltamu", "#Delta#mu [#mum]", -5, 5},
+                                                       {"sigmadeltamu", "#sigma_{#Delta#mu} [#mum]", -5, 5},
+                                                       {"musigma", "#mu [#mum]", -2, 4},
+                                                       {"muplussigmaplus", "#mu outward [#mum]", -5, 5},
+                                                       {"muminussigmaminus", "#mu inward [#mum]", -5, 5},
+                                                       {"deltamusigmadeltamu", "#Delta#mu [#mum]", -5, 10}};
 
     if (Variable.second.get_value<string>() == "DrmsNR") {
       DMRs = {{"mu", "RMS(x'_{pred}-x'_{hit} /#sigma)", -1.2, 1.2},

--- a/Alignment/OfflineValidation/bin/PVtrends.cc
+++ b/Alignment/OfflineValidation/bin/PVtrends.cc
@@ -140,8 +140,8 @@ int trends(int argc, char *argv[]) {
                outputdir.data(),
                Form("mean %s", titles[i].data()),
                Form("mean %s", ytitles[i].data()),
-               -7.,
-               10.,
+               -4.,
+               8.,
                style,
                GetLumi,
                lumiAxisType.data());
@@ -150,7 +150,7 @@ int trends(int argc, char *argv[]) {
               Form("RMS %s", titles[i].data()),
               Form("RMS %s", ytitles[i].data()),
               0.,
-              35.,
+              25.,
               style,
               GetLumi,
               lumiAxisType.data());
@@ -181,12 +181,15 @@ int trends(int argc, char *argv[]) {
       int color = alignment.second.get<int>("color");
       int style = floor(alignment.second.get<double>("style") / 100.);
       gMean->SetMarkerColor(color);
+      gMean->SetLineColor(color);  // no need to be set but looks better IMHO
       gMean->SetMarkerStyle(style);
+      gMean->SetMarkerSize(1.6);
 
       hRMS->SetTitle(gtitle);  // for the legend
       //hRMS ->SetTitle(""); // for the legend
       hRMS->SetMarkerSize(0.6);
       hRMS->SetMarkerColor(color);
+      hRMS->SetLineColor(color);  // needs to be set, otherwise color is NOT picked up
       hRMS->SetMarkerStyle(style);
 
       mean(gMean, "PZ", "p", fullRange);

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
@@ -118,6 +118,7 @@ private:
   bool weightById_;
   std::string weightByIdFile_;
   std::vector<unsigned int> weightByIdVector_;
+  SiPixelPI::phase phase_;
 
   std::vector<uint32_t> detIdFlagVector_;
   align::StructureType commonTrackerLevel_;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS.py
@@ -38,6 +38,7 @@ def MTS(config, validationDir):
                 local = {}
                 local["output"] = "{}/{}/MTS/{}/{}/{}/{}".format(config["LFS"], config["name"], mtsType, alignment, singleName, IOV)
                 local["alignment"] = copy.deepcopy(config["alignments"][alignment])
+                local["alignment"]["name"] = alignment
                 local["validation"] = copy.deepcopy(config["validations"]["MTS"][mtsType][singleName])
                 local["validation"].pop("alignments")
                 local["validation"]["IOV"] = IOV

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS_cfg.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/MTS_cfg.py
@@ -145,9 +145,7 @@ if "conditions" in config["alignment"]:
       process,
       "conditionsIn{}".format(condition),
       poolDBESSource.clone(
-        # FIXME%START
-        connect = cms.string("sqlite_file:" + str(config["alignment"]["conditions"][condition]["connect"]) if "alignments_MP.db" in str(config["alignment"]["conditions"][condition]["connect"]) else str(config["alignment"]["conditions"][condition]["connect"])),
-        #FIXME%END
+        connect = cms.string(str(config["alignment"]["conditions"][condition]["connect"])),
         toGet = cms.VPSet(
           cms.PSet(
             record = cms.string(str(condition)),

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/findAndChange.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/findAndChange.py
@@ -89,7 +89,7 @@ def get_all_keys(var):
        Generate all keys for nested dictionary
        - reserved keywords are not picked up
     """
-    reserved_keys = ["customrighttitle","title"]
+    reserved_keys = ["customrighttitle","title","Rlabel"]
     if hasattr(var,'items'):
         for k, v in var.items():
             if k in reserved_keys: continue

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/templates/condorTemplate.submit
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/templates/condorTemplate.submit
@@ -4,7 +4,7 @@ executable = run.sh
 output = condor/condor.out
 error  = condor/condor.err
 log    = condor/condor.log
-requirements = (OpSysAndVer =?= "CentOS7")
+requirements = (OpSysAndVer =?= "AlmaLinux9")
 +JobFlavour = "espresso"
 +AccountingGroup = "group_u_CMS.CAF.ALCA"
 queue

--- a/Alignment/OfflineValidation/python/TkAlMap.py
+++ b/Alignment/OfflineValidation/python/TkAlMap.py
@@ -45,7 +45,7 @@ KNOWN_VARIABLES = {
         'name' : 'r #Delta#phi',
         'units': '#mum rad',
         'scale': 10000.,
-        'range': [-200., 200.],
+        'range': [-100., 100.],
         },
     'dphi': {
         'name' : '#Delta#phi',
@@ -222,7 +222,7 @@ class TkAlMap:
         self.colors = []
         #self.palette = array('i', [])
         col_idx = self.start_color_idx + self.n_color_color_bar + 10
-        self.col_dic = {}
+        self.col_dic = {} #Never used explicitly but needs to keep TColor values in the global memory
         self.rgb_map = {}
         #pal_idx = 0
         #self.pal_map = {}
@@ -236,16 +236,17 @@ class TkAlMap:
             self.colors.append(idx)
             col_idx +=1
             self.rgb_map[idx] = col_idx
-            #print( idx, (r+0.)/255., (g+0.)/255., (b+0.)/255.)
-            #color = ROOT.TColor(col_idx, (r+0.)/255., (g+0.)/255., (b+0.)/255.)
 
-            #self.col_dic[idx] = ROOT.TColor(col_idx, (r+0.)/255., (g+0.)/255., (b+0.)/255.)
             try:
-                col = ROOT.gROOT.GetColor(col_idx)
-                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.)
-                self.col_dic[idx] = col
+                col = ROOT.gROOT.GetColor(col_idx) #Here still OK
+                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.) #Here segmentation if color index does not exist
+                self.col_dic[idx] = col #Here the new color is saved in in the global variable
             except:
-                self.col_dic[idx] = ROOT.TColor(col_idx, (r+0.)/255., (g+0.)/255., (b+0.)/255.)
+                #Here the 6 argument TColor init with dummy rgb must be used, 4 argument one does not work (ROOT bug?)
+                #New color index is defined and SetRGB must also be called to overwrite dummy rgb
+                col = ROOT.TColor(col_idx, 0., 0., 0., "", 1)
+                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.)
+                self.col_dic[idx] = col #Here the new color is saved in in the global variable
             #self.palette.append(col_idx)
         print('TkAlMap: map contains '+str(len(self.colors))+' colors')
      
@@ -273,7 +274,6 @@ class TkAlMap:
                 value_range = self.max_val - self.min_val
                 if value_range == 0.: value_frac = 0.5
                 else: value_frac = (val - self.min_val + 0.)/(value_range + 0.)
-
         if self.palette == 1:
             r = 255
             g = 255
@@ -323,7 +323,6 @@ class TkAlMap:
                 col = self.rgb_map[rgb]
                 #col = self.pal_map[rgb]
                 #col = self.col_dic[rgb]
-                #print(val, rgb, col)
                 self.TkAlMap_TPL_dict[module].SetFillColor(col)
                 #self.TkAlMap_TPL_dict[module].SetFillColor(TEST_COLOR_IDX)
             ####else: print('Warning: Unknown module '+str(module))
@@ -373,11 +372,15 @@ class TkAlMap:
             col_idx += 1
             r, g, b = self.get_color_rgb(val)
             try:
-                col = ROOT.gROOT.GetColor(col_idx)
-                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.)
-                self.color_bar_colors[col_idx] = col
+                col = ROOT.gROOT.GetColor(col_idx) #Here still OK
+                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.) #Here segmentation if color index does not exist
+                self.color_bar_colors[col_idx] = col #Here the new color is saved in in the global variable
             except:
-                self.color_bar_colors[col_idx] = ROOT.TColor(col_idx, (r+0.)/255., (g+0.)/255., (b+0.)/255.)
+                #Here the 6 argument TColor init with dummy rgb must be used, 4 argument one does not work (ROOT bug?)
+                #New color index is defined and SetRGB must also be called to overwrite dummy rgb
+                col = ROOT.TColor(col_idx, 0., 0., 0., "", 1)
+                col.SetRGB((r+0.)/255., (g+0.)/255., (b+0.)/255.)
+                self.color_bar_colors[col_idx] = col #Here the new color is saved in in the global variable 
             x2 = x1 + b_dx 
             y2 = y1 + b_dy + b_width 
             x = array('d', [x1, x1, x2, x2])

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -336,6 +336,9 @@ def main():
             ## Customize the condor submit file for this specific job
             condorSubmitCustomization = {"overwrite": [], "addBefore": []}
 
+            ## Hack to solve condor dagman issue with passing environmental variables
+            condorSubmitCustomization["addBefore"].append('+JobFlavour|+environment = "CMSSW_BASE={}"'.format(fnc.digest_path("$CMSSW_BASE")))
+
             # Take given flavour for the job, except if overwritten in job config
             condorSubmitCustomization["overwrite"].append('+JobFlavour = "{}"'.format(args.job_flavour if not 'flavour' in job else job['flavour']))
             

--- a/Alignment/OfflineValidation/src/Trend.cc
+++ b/Alignment/OfflineValidation/src/Trend.cc
@@ -54,6 +54,7 @@ float Run2Lumi::operator()() const { return operator()(firstRun, lastRun); }
 template <typename T>
 void CopyStyle(T* objIn, T* objOut) {
   objOut->SetLineColor(objIn->GetLineColor());
+  objOut->SetLineColor(objIn->GetMarkerColor());
   objOut->SetMarkerColor(objIn->GetMarkerColor());
   objOut->SetFillColorAlpha(objIn->GetFillColor(), 0.2);  // TODO??
 
@@ -292,4 +293,5 @@ Trend::~Trend() {
 
   c.RedrawAxis();
   c.SaveAs(Form("%s/%s.pdf", outputDir, c.GetName()), Form("Title:%s", c.GetTitle()));
+  c.SaveAs(Form("%s/%s.png", outputDir, c.GetName()), Form("Title:%s", c.GetTitle()));
 }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44364

#### PR description:

This PR mostly concerns patches for TkAl all-in-one validation tool needed after the lxplus migration to EL9. Among those the most relevant are:
   * changes to the HTCondor submission file
   * fixes on ROOT-related issues (that escaped our unit tests) for the GCP tool
   * The rest of the changes is plot style-related.

#### PR validation:

All unit tests passed for el8_amd64_gcc12 (CMSSW_14_1_X_2024-03-09-1100). Code checks ok. Code format done.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/44364 for the data-taking release.