### PR TITLE
Make repack process be able to generate new data tiers: L1SCOUT, HLTSCOUT

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -72,8 +72,6 @@ def repackProcess(**args):
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 
-        if dataTier != defaultDataTier:
-            outputModule.outputCommands = copy.copy(eventContent.outputCommands)
 
         outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string(dataTier))
 

--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -72,6 +72,9 @@ def repackProcess(**args):
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 
+        if dataTier != defaultDataTier:
+            outputModule.outputCommands = copy.copy(eventContent.outputCommands)
+
         outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string(dataTier))
 
         if maxSize != None:
@@ -87,4 +90,5 @@ def repackProcess(**args):
         process.outputPath += outputModule
 
     return process
+
 

--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -21,6 +21,8 @@ def repackProcess(**args):
 
     """
     from Configuration.EventContent.EventContent_cff import RAWEventContent
+    from Configuration.EventContent.EventContent_cff import HLTSCOUTEventContent
+    from Configuration.EventContent.EventContent_cff import L1SCOUTEventContent
     process = cms.Process("REPACK")
     process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
@@ -42,6 +44,16 @@ def repackProcess(**args):
         fileNames = cms.untracked.vstring()
         )
 
+    defaultDataTier = "RAW"
+
+    # Should we default to something if dataTier arg isn't provided?
+    dataTier = args.get('dataTier', defaultDataTier)
+    eventContent = RAWEventContent
+    if dataTier == "HLTSCOUT":
+        eventContent = HLTSCOUTEventContent
+    elif dataTier == "L1SCOUT":
+        eventContent = L1SCOUTEventContent
+
     outputs = args.get('outputs', [])
 
     if len(outputs) > 0:
@@ -55,12 +67,12 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
-            compressionAlgorithm=copy.copy(RAWEventContent.compressionAlgorithm),
-            compressionLevel=copy.copy(RAWEventContent.compressionLevel),
+            compressionAlgorithm=copy.copy(eventContent.compressionAlgorithm),
+            compressionLevel=copy.copy(eventContent.compressionLevel),
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 
-        outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string("RAW"))
+        outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string(dataTier))
 
         if maxSize != None:
             outputModule.maxSize = cms.untracked.int32(maxSize)
@@ -75,3 +87,4 @@ def repackProcess(**args):
         process.outputPath += outputModule
 
     return process
+

--- a/Configuration/DataProcessing/test/RunRepack.py
+++ b/Configuration/DataProcessing/test/RunRepack.py
@@ -18,21 +18,28 @@ class RunRepack:
     def __init__(self):
         self.selectEvents = None
         self.inputLFN = None
+        self.dataTier = None
 
     def __call__(self):
         if self.inputLFN == None:
             msg = "No --lfn specified"
             raise RuntimeError(msg)
+        allowedDataTiers = ["RAW", "HLTSCOUT", "L1SCOUT"]
+        if self.dataTier == None: 
+            self.dataTier = "RAW"
+        elif self.dataTier not in allowedDataTiers:
+            msg = f"{self.dataTier} isn't an allowed datatier for repacking. Allowed data tiers: {allowedDataTiers}"
+            raise RuntimeError(msg)
 
         outputs = []
-        outputs.append( { 'moduleLabel' : "write_PrimDS1_RAW" } )
-        outputs.append( { 'moduleLabel' : "write_PrimDS2_RAW" } )
+        outputs.append( { 'moduleLabel' : f"write_PrimDS1_{self.dataTier}" } )
+        outputs.append( { 'moduleLabel' : f"write_PrimDS2_{self.dataTier}" } )
         if self.selectEvents != None:
             outputs[0]['selectEvents'] = self.selectEvents.split(',')
             outputs[1]['selectEvents'] = self.selectEvents.split(',')
 
         try:
-            process = repackProcess(outputs = outputs)
+            process = repackProcess(outputs = outputs, dataTier = self.dataTier)
         except Exception as ex:
             msg = "Error creating process for Repack:\n"
             msg += str(ex)
@@ -54,7 +61,7 @@ class RunRepack:
 
 
 if __name__ == '__main__':
-    valid = ["select-events=", "lfn="]
+    valid = ["select-events=", "lfn=", "data-tier="]
              
     usage = \
 """
@@ -63,9 +70,10 @@ RunRepack.py <options>
 Where options are:
  --select-events (option, event selection based on trigger paths)
  --lfn=/store/input/lfn
+ --data-tier=RAW|HLTSCOUT|L1SCOUT
 
 Example:
-python RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever
+python RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever --data-tier RAW|HLTSCOUT|L1SCOUT
 
 """
     try:
@@ -83,5 +91,8 @@ python RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever
             repackinator.selectEvents = arg
         if opt == "--lfn" :
             repackinator.inputLFN = arg
+        if opt == "--data-tier" :
+            repackinator.dataTier = arg
 
     repackinator()
+

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -120,13 +120,13 @@ fastSim.toModify(RecoLocalTrackerFEVT, outputCommands = fastSimEC.RecoLocalTrack
 fastSim.toReplaceWith(SimG4CoreRAW, fastSimEC.SimRAW)
 fastSim.toReplaceWith(SimG4CoreRECO, fastSimEC.SimRECO)
 
-def SwapKeepAndDrop(l):	
-    r=[]	
-    for item in l:	
-        if 'keep ' in item:	
-            r.append(item.replace('keep ','drop '))	
-        elif 'drop ' in item:	
-            r.append(item.replace('drop ','keep '))	
+def SwapKeepAndDrop(l): 
+    r=[]    
+    for item in l:  
+        if 'keep ' in item: 
+            r.append(item.replace('keep ','drop ')) 
+        elif 'drop ' in item:   
+            r.append(item.replace('drop ','keep ')) 
     return r
 
 #
@@ -187,48 +187,28 @@ approxSiStripClusters.toModify(RAWEventContent,
 
 #
 # HLTSCOUT Data Tier definition
-# TODO: Currently identical to RAW. Needs to be updated once it's known how it differs from RAW
+#
 #
 HLTSCOUTEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep  FEDRawDataCollection_rawDataCollector_*_*',
-        'keep  FEDRawDataCollection_source_*_*'),
+    outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
-HLTSCOUTEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
 HLTSCOUTEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
-
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-approxSiStripClusters.toModify(HLTSCOUTEventContent,
-                              outputCommands = HLTSCOUTEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIds_hltSiStripRawToDigi_*_*'
-                              ])
 
 #
 # L1SCOUT Data Tier definition
-# TODO: Currently identical to RAW. Needs to be updated once it's known how it differs from RAW
 #
 #
 L1SCOUTEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *',
-        'keep  FEDRawDataCollection_rawDataCollector_*_*',
-        'keep  FEDRawDataCollection_source_*_*'),
+    outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
     compressionAlgorithm=cms.untracked.string("LZMA"),
     compressionLevel=cms.untracked.int32(4)
 )
 L1SCOUTEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
-L1SCOUTEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 
-from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
-approxSiStripClusters.toModify(L1SCOUTEventContent,
-                              outputCommands = L1SCOUTEventContent.outputCommands+[
-                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
-                                  'keep DetIds_hltSiStripRawToDigi_*_*'
-                              ])
 
 #
 #
@@ -303,8 +283,8 @@ RAWRECOEventContent = cms.PSet(
 )
 RAWRECOEventContent.outputCommands.extend(RECOEventContent.outputCommands)
 RAWRECOEventContent.outputCommands.extend(cms.untracked.vstring(
-	'keep FEDRawDataCollection_rawDataCollector_*_*',
-	'keep FEDRawDataCollection_source_*_*')
+    'keep FEDRawDataCollection_rawDataCollector_*_*',
+    'keep FEDRawDataCollection_source_*_*')
 )
 #
 #
@@ -358,8 +338,8 @@ RAWAODEventContent = cms.PSet(
 )
 RAWAODEventContent.outputCommands.extend(AODEventContent.outputCommands)
 RAWAODEventContent.outputCommands.extend(cms.untracked.vstring(
-	'keep FEDRawDataCollection_rawDataCollector_*_*',
-	'keep FEDRawDataCollection_source_*_*')
+    'keep FEDRawDataCollection_rawDataCollector_*_*',
+    'keep FEDRawDataCollection_source_*_*')
 )
 #
 #
@@ -868,10 +848,10 @@ REPACKRAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputComman
 REPACKRAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend([
-	'drop FEDRawDataCollection_source_*_*',
+    'drop FEDRawDataCollection_source_*_*',
         'drop FEDRawDataCollection_rawDataCollector_*_*'])
 REPACKRAWEventContent.outputCommands.extend([
-	'drop FEDRawDataCollection_source_*_*',
+    'drop FEDRawDataCollection_source_*_*',
         'drop FEDRawDataCollection_rawDataCollector_*_*'])
 
 #from modules in Configuration.StandardSequence.Generator_cff fixGenInfo
@@ -956,8 +936,8 @@ RAWMINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(cms.untracked.vstring(
-	'keep FEDRawDataCollection_rawDataCollector_*_*',
-	'keep FEDRawDataCollection_source_*_*'))
+    'keep FEDRawDataCollection_rawDataCollector_*_*',
+    'keep FEDRawDataCollection_source_*_*'))
 
 RAWMINIAODSIMEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
@@ -991,4 +971,5 @@ for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventConten
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropSimDigis)
 for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropPatTrigger)
+
 

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -120,13 +120,13 @@ fastSim.toModify(RecoLocalTrackerFEVT, outputCommands = fastSimEC.RecoLocalTrack
 fastSim.toReplaceWith(SimG4CoreRAW, fastSimEC.SimRAW)
 fastSim.toReplaceWith(SimG4CoreRECO, fastSimEC.SimRECO)
 
-def SwapKeepAndDrop(l): 
-    r=[]    
-    for item in l:  
-        if 'keep ' in item: 
-            r.append(item.replace('keep ','drop ')) 
-        elif 'drop ' in item:   
-            r.append(item.replace('drop ','keep ')) 
+def SwapKeepAndDrop(l):	
+    r=[]	
+    for item in l:	
+        if 'keep ' in item:	
+            r.append(item.replace('keep ','drop '))	
+        elif 'drop ' in item:	
+            r.append(item.replace('drop ','keep '))	
     return r
 
 #
@@ -184,7 +184,6 @@ approxSiStripClusters.toModify(RAWEventContent,
                                   'keep DetIds_hltSiStripRawToDigi_*_*'
                               ])
 
-
 #
 # HLTSCOUT Data Tier definition
 #
@@ -208,7 +207,6 @@ L1SCOUTEventContent = cms.PSet(
     compressionLevel=cms.untracked.int32(4)
 )
 L1SCOUTEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
-
 
 #
 #
@@ -283,8 +281,8 @@ RAWRECOEventContent = cms.PSet(
 )
 RAWRECOEventContent.outputCommands.extend(RECOEventContent.outputCommands)
 RAWRECOEventContent.outputCommands.extend(cms.untracked.vstring(
-    'keep FEDRawDataCollection_rawDataCollector_*_*',
-    'keep FEDRawDataCollection_source_*_*')
+	'keep FEDRawDataCollection_rawDataCollector_*_*',
+	'keep FEDRawDataCollection_source_*_*')
 )
 #
 #
@@ -338,8 +336,8 @@ RAWAODEventContent = cms.PSet(
 )
 RAWAODEventContent.outputCommands.extend(AODEventContent.outputCommands)
 RAWAODEventContent.outputCommands.extend(cms.untracked.vstring(
-    'keep FEDRawDataCollection_rawDataCollector_*_*',
-    'keep FEDRawDataCollection_source_*_*')
+	'keep FEDRawDataCollection_rawDataCollector_*_*',
+	'keep FEDRawDataCollection_source_*_*')
 )
 #
 #
@@ -848,10 +846,10 @@ REPACKRAWSIMEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputComman
 REPACKRAWSIMEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend([
-    'drop FEDRawDataCollection_source_*_*',
+	'drop FEDRawDataCollection_source_*_*',
         'drop FEDRawDataCollection_rawDataCollector_*_*'])
 REPACKRAWEventContent.outputCommands.extend([
-    'drop FEDRawDataCollection_source_*_*',
+	'drop FEDRawDataCollection_source_*_*',
         'drop FEDRawDataCollection_rawDataCollector_*_*'])
 
 #from modules in Configuration.StandardSequence.Generator_cff fixGenInfo
@@ -936,8 +934,8 @@ RAWMINIAODEventContent.outputCommands.extend(MicroEventContent.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 RAWMINIAODEventContent.outputCommands.extend(cms.untracked.vstring(
-    'keep FEDRawDataCollection_rawDataCollector_*_*',
-    'keep FEDRawDataCollection_source_*_*'))
+	'keep FEDRawDataCollection_rawDataCollector_*_*',
+	'keep FEDRawDataCollection_source_*_*'))
 
 RAWMINIAODSIMEventContent= cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
@@ -971,5 +969,3 @@ for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventConten
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropSimDigis)
 for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropPatTrigger)
-
-

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -184,6 +184,52 @@ approxSiStripClusters.toModify(RAWEventContent,
                                   'keep DetIds_hltSiStripRawToDigi_*_*'
                               ])
 
+
+#
+# HLTSCOUT Data Tier definition
+# TODO: Currently identical to RAW. Needs to be updated once it's known how it differs from RAW
+#
+HLTSCOUTEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep  FEDRawDataCollection_rawDataCollector_*_*',
+        'keep  FEDRawDataCollection_source_*_*'),
+    splitLevel = cms.untracked.int32(0),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
+)
+HLTSCOUTEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+HLTSCOUTEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
+
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(HLTSCOUTEventContent,
+                              outputCommands = HLTSCOUTEventContent.outputCommands+[
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIds_hltSiStripRawToDigi_*_*'
+                              ])
+
+#
+# L1SCOUT Data Tier definition
+# TODO: Currently identical to RAW. Needs to be updated once it's known how it differs from RAW
+#
+#
+L1SCOUTEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *',
+        'keep  FEDRawDataCollection_rawDataCollector_*_*',
+        'keep  FEDRawDataCollection_source_*_*'),
+    splitLevel = cms.untracked.int32(0),
+    compressionAlgorithm=cms.untracked.string("LZMA"),
+    compressionLevel=cms.untracked.int32(4)
+)
+L1SCOUTEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+L1SCOUTEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
+
+from Configuration.ProcessModifiers.approxSiStripClusters_cff import approxSiStripClusters
+approxSiStripClusters.toModify(L1SCOUTEventContent,
+                              outputCommands = L1SCOUTEventContent.outputCommands+[
+                                  'keep *_hltSiStripClusters2ApproxClusters_*_*',
+                                  'keep DetIds_hltSiStripRawToDigi_*_*'
+                              ])
+
 #
 #
 # HLTONLY Data Tier definition
@@ -945,3 +991,4 @@ for _entry in [FEVTDEBUGHLTEventContent,FEVTDEBUGEventContent,RECOSIMEventConten
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropSimDigis)
 for _entry in [MINIAODEventContent, MINIAODSIMEventContent]:
     fastSim.toModify(_entry, outputCommands = _entry.outputCommands + fastSimEC.dropPatTrigger)
+


### PR DESCRIPTION
#### PR description:

This PR updates the REPACK process such that it is able to generate two new data tiers: `HLTSCOUT` and `L1SCOUT` in addition to `RAW`. I've updated the event content of `HLTSCOUT` and `L1SCOUT` such that they inherit their output commands from `HLTriggerRAW` and `L1TriggerRAW` respectively. Additionally, I've included the output commands of L1SCOUT and HLTSCOUT in the output module of the Repack process.

I've coordinated with @drkovalskyi @germanfgv @dynamic-entropy on this work.

Related tickets: 

- https://its.cern.ch/jira/browse/CMSTZ-1069
- https://its.cern.ch/jira/browse/CMSTRANSF-829

#### PR validation:

I used `Configuration/DataProcessing/test/RunRepack.py` for testing. I added a new option to this script

```

$ python3 DataProcessing/test/RunRepack.py --lfn /store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat --data-tier RAW
Now do:
cmsRun -e RunRepackCfg.py
[haozturk@lxplus802 Configuration]$ cmsRun -e RunRepackCfg.py
08-Mar-2024 15:55:15 CET  Initiating request to open file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
08-Mar-2024 15:55:17 CET  Successfully opened file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
Begin processing the 1st record. Run 377350, Event 172727, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:20.650 CET
Begin processing the 2nd record. Run 377350, Event 255073, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:20.739 CET
Begin processing the 3rd record. Run 377350, Event 495959, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:20.825 CET
Begin processing the 4th record. Run 377350, Event 5487, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:20.907 CET
Begin processing the 5th record. Run 377350, Event 5498, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:20.990 CET
Begin processing the 6th record. Run 377350, Event 4244, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:21.075 CET
Begin processing the 7th record. Run 377350, Event 5482, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:21.164 CET
Begin processing the 8th record. Run 377350, Event 4232, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:21.250 CET
Begin processing the 9th record. Run 377350, Event 4252, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:21.329 CET
Begin processing the 10th record. Run 377350, Event 5499, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:21.419 CET
08-Mar-2024 15:55:21 CET  Closed file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
[haozturk@lxplus802 Configuration]$ python3 DataProcessing/test/RunRepack.py --lfn /store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat --data-tier L1SCOUT
Now do:
cmsRun -e RunRepackCfg.py
[haozturk@lxplus802 Configuration]$ cmsRun -e RunRepackCfg.py
08-Mar-2024 15:55:38 CET  Initiating request to open file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
08-Mar-2024 15:55:40 CET  Successfully opened file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
Begin processing the 1st record. Run 377350, Event 172727, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:41.687 CET
Begin processing the 2nd record. Run 377350, Event 255073, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:41.760 CET
Begin processing the 3rd record. Run 377350, Event 495959, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:41.837 CET
Begin processing the 4th record. Run 377350, Event 5487, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:41.905 CET
Begin processing the 5th record. Run 377350, Event 5498, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:41.973 CET
Begin processing the 6th record. Run 377350, Event 4244, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:42.041 CET
Begin processing the 7th record. Run 377350, Event 5482, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:42.108 CET
Begin processing the 8th record. Run 377350, Event 4232, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:42.174 CET
Begin processing the 9th record. Run 377350, Event 4252, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:42.238 CET
Begin processing the 10th record. Run 377350, Event 5499, LumiSection 1 on stream 0 at 08-Mar-2024 15:55:42.305 CET
08-Mar-2024 15:55:42 CET  Closed file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
[haozturk@lxplus802 Configuration]$ 
[haozturk@lxplus802 Configuration]$ 
[haozturk@lxplus802 Configuration]$ python3 DataProcessing/test/RunRepack.py --lfn /store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat --data-tier HLTSCOUT
Now do:
cmsRun -e RunRepackCfg.py
[haozturk@lxplus802 Configuration]$ cmsRun -e RunRepackCfg.py
08-Mar-2024 15:56:00 CET  Initiating request to open file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
08-Mar-2024 15:56:02 CET  Successfully opened file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
Begin processing the 1st record. Run 377350, Event 172727, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.414 CET
Begin processing the 2nd record. Run 377350, Event 255073, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.495 CET
Begin processing the 3rd record. Run 377350, Event 495959, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.577 CET
Begin processing the 4th record. Run 377350, Event 5487, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.656 CET
Begin processing the 5th record. Run 377350, Event 5498, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.737 CET
Begin processing the 6th record. Run 377350, Event 4244, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.818 CET
Begin processing the 7th record. Run 377350, Event 5482, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.903 CET
Begin processing the 8th record. Run 377350, Event 4232, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:03.984 CET
Begin processing the 9th record. Run 377350, Event 4252, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:04.071 CET
Begin processing the 10th record. Run 377350, Event 5499, LumiSection 1 on stream 0 at 08-Mar-2024 15:56:04.160 CET
08-Mar-2024 15:56:04 CET  Closed file root://eoscms.cern.ch//eos/cms/store/t0streamer/Data/PhysicsCommissioning/000/377/350/run377350_ls0001_streamPhysicsCommissioning_StorageManager.dat
[haozturk@lxplus802 Configuration]$ 
[haozturk@lxplus802 Configuration]$ ls -l
total 3195
drwxr-xr-x. 2 haozturk zp   4096 Mar  8 15:51 DataProcessing
drwxr-xr-x. 2 haozturk zp   4096 Mar  8 15:51 EventContent
-rw-r--r--. 1 haozturk zp  14137 Mar  8 15:56 FrameworkJobReport.xml
-rw-r--r--. 1 haozturk zp   8411 Mar  8 15:55 RunRepackCfg.py
-rw-r--r--. 1 haozturk zp 561807 Mar  8 15:56 write_PrimDS1_HLTSCOUT.root
-rw-r--r--. 1 haozturk zp 495347 Mar  8 15:55 write_PrimDS1_L1SCOUT.root
-rw-r--r--. 1 haozturk zp 562065 Mar  8 15:55 write_PrimDS1_RAW.root
-rw-r--r--. 1 haozturk zp 561807 Mar  8 15:56 write_PrimDS2_HLTSCOUT.root
-rw-r--r--. 1 haozturk zp 495347 Mar  8 15:55 write_PrimDS2_L1SCOUT.root
-rw-r--r--. 1 haozturk zp 562065 Mar  8 15:55 write_PrimDS2_RAW.root
[haozturk@lxplus802 Configuration]$ edmDumpEventContent write_PrimDS1_RAW.root 
Type                      Module                   Label     Process   
-----------------------------------------------------------------------
GlobalObjectMapRecord     "hltGtStage2ObjectMap"   ""        "HLT"     
edm::TriggerResults       "TriggerResults"         ""        "HLT"     
trigger::TriggerEvent     "hltTriggerSummaryAOD"   ""        "HLT"     
FEDRawDataCollection      "rawDataCollector"       ""        "LHC"     
[haozturk@lxplus802 Configuration]$ edmDumpEventContent write_PrimDS1_L1SCOUT.root 
Type                     Module               Label     Process   
------------------------------------------------------------------
FEDRawDataCollection     "rawDataCollector"   ""        "LHC"     
[haozturk@lxplus802 Configuration]$ edmDumpEventContent write_PrimDS1_HLTSCOUT.root 
Type                      Module                   Label     Process   
-----------------------------------------------------------------------
GlobalObjectMapRecord     "hltGtStage2ObjectMap"   ""        "HLT"     
edm::TriggerResults       "TriggerResults"         ""        "HLT"     
trigger::TriggerEvent     "hltTriggerSummaryAOD"   ""        "HLT"     
FEDRawDataCollection      "rawDataCollector"       ""        "LHC"  
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Original PR: https://github.com/cms-sw/cmssw/pull/44381 

