### PR TITLE
`L1TUtmTriggerMenu_PayloadInspector`: support comparison of conditions

### DIFF
--- a/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
+++ b/CondCore/L1TPlugins/interface/L1TUtmTriggerMenuPayloadInspectorHelper.h
@@ -18,16 +18,20 @@ namespace L1TUtmTriggerMenuInspectorHelper {
   class L1UtmTriggerMenuInfo {
   public:
     // constructor
-    L1UtmTriggerMenuInfo(const L1TUtmTriggerMenu* l1utmMenu) { m_map = l1utmMenu->getAlgorithmMap(); }
+    L1UtmTriggerMenuInfo(const L1TUtmTriggerMenu* l1utmMenu) {
+      m_algoMap = l1utmMenu->getAlgorithmMap();
+      m_condMap = l1utmMenu->getConditionMap();
+    }
 
     // destructor
     ~L1UtmTriggerMenuInfo() = default;
 
   public:
+    //___________________________________________________________________
     const std::vector<std::string> listOfAlgos() const {
       std::vector<std::string> output;
-      std::transform(m_map.begin(),
-                     m_map.end(),
+      std::transform(m_algoMap.begin(),
+                     m_algoMap.end(),
                      std::back_inserter(output),
                      [](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
                        return pair.first;  // Extracting the string key using lambda
@@ -36,69 +40,106 @@ namespace L1TUtmTriggerMenuInspectorHelper {
     }
 
     //___________________________________________________________________
-    const std::vector<std::string> listOfCommonAlgos(const L1TUtmTriggerMenu* other) const {
-      const auto& otherMap = other->getAlgorithmMap();
+    const std::vector<std::string> listOfConditions() const {
+      std::vector<std::string> output;
+      std::transform(m_condMap.begin(),
+                     m_condMap.end(),
+                     std::back_inserter(output),
+                     [](const std::pair<std::string, L1TUtmCondition>& pair) {
+                       return pair.first;  // Extracting the string key using lambda
+                     });
+      return output;
+    }
+
+    //___________________________________________________________________
+    template <typename T>
+    const std::vector<std::string> listOfCommonKeys(const L1TUtmTriggerMenu* other) const {
+      const auto& otherMap = getOtherMap<T>(other);
+      const auto& thisMap = getThisMap<T>();
 
       std::vector<std::string> commonKeys;
 
       // Lambda function to find common keys and store them in commonKeys vector
-      std::for_each(
-          m_map.begin(), m_map.end(), [&commonKeys, &otherMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
-            const std::string& key = pair.first;
+      std::for_each(thisMap.begin(), thisMap.end(), [&commonKeys, &otherMap](const std::pair<std::string, T>& pair) {
+        const std::string& key = pair.first;
 
-            // Check if the key exists in map2
-            if (otherMap.find(key) != otherMap.end()) {
-              commonKeys.push_back(key);
-            }
-          });
+        // Check if the key exists in map2
+        if (otherMap.find(key) != otherMap.end()) {
+          commonKeys.push_back(key);
+        }
+      });
       return commonKeys;
     }
 
     //___________________________________________________________________
+    template <typename T>
     const std::vector<std::string> onlyInThis(const L1TUtmTriggerMenu* other) const {
-      const auto& otherMap = other->getAlgorithmMap();
+      const auto& otherMap = getOtherMap<T>(other);
+      const auto& thisMap = getThisMap<T>();
 
       std::vector<std::string> stringsOnlyInFirstMap;
 
-      // Lambda function to extract only the strings present in m_map but not in otherMap
-      std::for_each(m_map.begin(),
-                    m_map.end(),
-                    [&stringsOnlyInFirstMap, &otherMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
-                      const std::string& key = pair.first;
-                      // Check if the key exists in otherMap
-                      if (otherMap.find(key) == otherMap.end()) {
-                        stringsOnlyInFirstMap.push_back(key);  // Add key to the vector
-                      }
-                    });
+      // Lambda function to extract only the strings present in thisMap but not in otherMap
+      std::for_each(
+          thisMap.begin(), thisMap.end(), [&stringsOnlyInFirstMap, &otherMap](const std::pair<std::string, T>& pair) {
+            const std::string& key = pair.first;
+            // Check if the key exists in otherMap
+            if (otherMap.find(key) == otherMap.end()) {
+              stringsOnlyInFirstMap.push_back(key);  // Add key to the vector
+            }
+          });
 
       return stringsOnlyInFirstMap;
     }
 
     //___________________________________________________________________
+    template <typename T>
     const std::vector<std::string> onlyInOther(const L1TUtmTriggerMenu* other) const {
-      const auto& otherMap = other->getAlgorithmMap();
+      const auto& otherMap = getOtherMap<T>(other);
+      const auto& thisMap = getThisMap<T>();
 
       std::vector<std::string> stringsOnlyInSecondMap;
 
-      // Lambda function capturing 'this' to access the member variable 'm_map'
-      std::for_each(otherMap.begin(),
-                    otherMap.end(),
-                    [this, &stringsOnlyInSecondMap](const std::pair<std::string, L1TUtmAlgorithm>& pair) {
-                      const std::string& key = pair.first;
+      // Lambda function capturing 'this' to access the member variable 'thisMap'
+      std::for_each(
+          otherMap.begin(), otherMap.end(), [thisMap, &stringsOnlyInSecondMap](const std::pair<std::string, T>& pair) {
+            const std::string& key = pair.first;
 
-                      // Check if the key exists in m_map
-                      if (this->m_map.find(key) == this->m_map.end()) {
-                        stringsOnlyInSecondMap.push_back(key);  // Add key to the vector
-                      }
-                    });
+            // Check if the key exists in thisMap
+            if (thisMap.find(key) == thisMap.end()) {
+              stringsOnlyInSecondMap.push_back(key);  // Add key to the vector
+            }
+          });
 
       return stringsOnlyInSecondMap;
     }
 
   private:
-    l1tUtmAlgoMap m_map;
+    l1tUtmAlgoMap m_algoMap;
+    l1tUtmConditionMap m_condMap;
+
+    // Helper function to get otherMap based on T
+    template <typename T>
+    decltype(auto) getOtherMap(const L1TUtmTriggerMenu* other) const {
+      if constexpr (std::is_same<T, L1TUtmCondition>::value) {
+        return other->getConditionMap();
+      } else {
+        return other->getAlgorithmMap();
+      }
+    }
+
+    // Helper function to get this Map based on T
+    template <typename T>
+    decltype(auto) getThisMap() const {
+      if constexpr (std::is_same<T, L1TUtmCondition>::value) {
+        return m_condMap;
+      } else {
+        return m_algoMap;
+      }
+    }
   };
 
+  template <typename T>
   class L1TUtmTriggerMenuDisplay {
   public:
     L1TUtmTriggerMenuDisplay(const L1TUtmTriggerMenu* thisMenu, std::string theTag, std::string theIOV)
@@ -110,10 +151,13 @@ namespace L1TUtmTriggerMenuInspectorHelper {
       return;
     }
 
+    // Function to set label based on the type T
+    std::string getLabel() const;
+
     //___________________________________________________________________
     void plotDiffWithOtherMenu(const L1TUtmTriggerMenu* other, std::string theRefTag, std::string theRefIOV) {
-      const auto& vec_only_in_this = m_info.onlyInThis(other);
-      const auto& vec_only_in_other = m_info.onlyInOther(other);
+      const auto& vec_only_in_this = m_info.template onlyInThis<T>(other);
+      const auto& vec_only_in_other = m_info.template onlyInOther<T>(other);
 
       // preparations for plotting
       // starting table at y=1.0 (top of the canvas)
@@ -130,7 +174,7 @@ namespace L1TUtmTriggerMenuInspectorHelper {
 
       // title for plot
       y_x1.push_back(y);
-      s_x1.push_back("#scale[1.1]{Algo Name}");
+      s_x1.push_back(getLabel());
       y_x2.push_back(y);
       s_x2.push_back("#scale[1.1]{Target tag / IOV: #color[2]{" + m_tagName + "} / " + m_IOVsinceDisplay + "}");
 
@@ -208,6 +252,17 @@ namespace L1TUtmTriggerMenuInspectorHelper {
     std::string m_IOVsinceDisplay;  //!< iov since
     std::string m_imageFileName;    //!< image file name
   };
+
+  // Explicit specialization outside the class
+  template <>
+  std::string L1TUtmTriggerMenuDisplay<L1TUtmCondition>::getLabel() const {
+    return "#scale[1.1]{Condition Name}";
+  }
+
+  template <>
+  std::string L1TUtmTriggerMenuDisplay<L1TUtmAlgorithm>::getLabel() const {
+    return "#scale[1.1]{Algo Name}";
+  }
 }  // namespace L1TUtmTriggerMenuInspectorHelper
 
 #endif

--- a/CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc
+++ b/CondCore/L1TPlugins/plugins/L1TUtmTriggerMenu_PayloadInspector.cc
@@ -116,7 +116,7 @@ namespace {
     }  // fill
   };
 
-  template <IOVMultiplicity nIOVs, int ntags>
+  template <typename T, IOVMultiplicity nIOVs, int ntags>
   class L1TUtmTriggerMenu_CompareAlgosBase : public PlotImage<L1TUtmTriggerMenu, nIOVs, ntags> {
   public:
     L1TUtmTriggerMenu_CompareAlgosBase()
@@ -152,7 +152,8 @@ namespace {
       if (tmpTagName.empty())
         tmpTagName = f_tagname;
 
-      L1TUtmTriggerMenuInspectorHelper::L1TUtmTriggerMenuDisplay thePlot(last_payload.get(), tmpTagName, lastIOVsince);
+      L1TUtmTriggerMenuInspectorHelper::L1TUtmTriggerMenuDisplay<T> thePlot(
+          last_payload.get(), tmpTagName, lastIOVsince);
       thePlot.setImageFileName(this->m_imageFileName);
       thePlot.plotDiffWithOtherMenu(first_payload.get(), f_tagname, firstIOVsince);
 
@@ -160,8 +161,11 @@ namespace {
     }
   };
 
-  using L1TUtmTriggerMenu_CompareAlgos = L1TUtmTriggerMenu_CompareAlgosBase<MULTI_IOV, 1>;
-  using L1TUtmTriggerMenu_CompareAlgosTwoTags = L1TUtmTriggerMenu_CompareAlgosBase<SINGLE_IOV, 2>;
+  using L1TUtmTriggerMenu_CompareAlgos = L1TUtmTriggerMenu_CompareAlgosBase<L1TUtmAlgorithm, MULTI_IOV, 1>;
+  using L1TUtmTriggerMenu_CompareAlgosTwoTags = L1TUtmTriggerMenu_CompareAlgosBase<L1TUtmAlgorithm, SINGLE_IOV, 2>;
+
+  using L1TUtmTriggerMenu_CompareConditions = L1TUtmTriggerMenu_CompareAlgosBase<L1TUtmCondition, MULTI_IOV, 1>;
+  using L1TUtmTriggerMenu_CompareConditionsTwoTags = L1TUtmTriggerMenu_CompareAlgosBase<L1TUtmCondition, SINGLE_IOV, 2>;
 
 }  // namespace
 
@@ -169,4 +173,6 @@ PAYLOAD_INSPECTOR_MODULE(L1TUtmTriggerMenu) {
   PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenuDisplayAlgos);
   PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareAlgos);
   PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareAlgosTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareConditions);
+  PAYLOAD_INSPECTOR_CLASS(L1TUtmTriggerMenu_CompareConditionsTwoTags);
 }

--- a/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
+++ b/CondCore/L1TPlugins/test/testL1TObjectsPayloadInspector.cpp
@@ -42,16 +42,23 @@ int main(int argc, char** argv) {
   test2.process(connectionString, PI::mk_input(tag, start, end));
   edm::LogPrint("testL1TObjectsPayloadInspector") << test2.data() << std::endl;
 
+  L1TUtmTriggerMenu_CompareConditions test3;
+  test3.process(connectionString, PI::mk_input(tag, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test3.data() << std::endl;
+
   tag = "L1Menu_CollisionsHeavyIons2023_v1_1_4_xml";
   std::string tag2 = "L1Menu_CollisionsHeavyIons2023_v1_1_5_xml";
   start = static_cast<unsigned long long>(1);
   end = static_cast<unsigned long long>(1);
 
-  L1TUtmTriggerMenu_CompareAlgosTwoTags test3;
-  test3.process(connectionString, PI::mk_input(tag, start, end, tag2, start, end));
-  edm::LogPrint("testL1TObjectsPayloadInspector") << test3.data() << std::endl;
+  L1TUtmTriggerMenu_CompareAlgosTwoTags test4;
+  test4.process(connectionString, PI::mk_input(tag, start, end, tag2, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test4.data() << std::endl;
 
-  tag = "L1TGlobalPrescalesVetos_passThrough_mc";
+  L1TUtmTriggerMenu_CompareConditionsTwoTags test5;
+  test5.process(connectionString, PI::mk_input(tag, start, end, tag2, start, end));
+  edm::LogPrint("testL1TObjectsPayloadInspector") << test5.data() << std::endl;
+
   edm::LogPrint("testL1TObjectsPayloadInspector") << "## Exercising  L1TGlobalPrescalesVetos tests" << std::endl;
 
   Py_Finalize();

--- a/CondCore/L1TPlugins/test/testL1TPI.sh
+++ b/CondCore/L1TPlugins/test/testL1TPI.sh
@@ -27,7 +27,7 @@ getPayloadData.py \
 mv *.png $W_DIR/results/L1TUtmTriggerMenuPlot.png
 
 ####################
-# Test L1UtmTriggerMenu comparison (two IOVs, same tag)
+# Test L1UtmTriggerMenu algo comparison (two IOVs, same tag)
 ####################
 getPayloadData.py \
     --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
@@ -38,10 +38,10 @@ getPayloadData.py \
     --db Prod \
     --test;
 
-mv *.png $W_DIR/results/L1TUtmTriggerMenu_Compare.png
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareAlgos.png
 
 ####################
-# Test L1UtmTriggerMenu comparison (two tags)
+# Test L1UtmTriggerMenu algo comparison (two tags)
 ####################
 getPayloadData.py \
     --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
@@ -54,4 +54,35 @@ getPayloadData.py \
     --db Prod \
     --test;
 
-mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareTwoTags.png
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareAlgosTwoTags.png
+
+####################
+# Test L1UtmTriggerMenu conditions comparison (two IOVs, same tag)
+####################
+getPayloadData.py \
+    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
+    --plot plot_L1TUtmTriggerMenu_CompareConditions \
+    --tag L1TUtmTriggerMenu_Stage2v0_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "375649", "end_iov": "375650"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareConditions.png
+
+####################
+# Test L1UtmTriggerMenu conditions comparison (two tags)
+####################
+getPayloadData.py \
+    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
+    --plot plot_L1TUtmTriggerMenu_CompareConditionsTwoTags \
+    --tag L1Menu_CollisionsHeavyIons2023_v1_1_4_xml \
+    --tagtwo L1Menu_CollisionsHeavyIons2023_v1_1_5_xml \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/results/L1TUtmTriggerMenu_CompareConditionsTwoTags.png
+


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/43359. 
Support in `L1TUtmTriggerMenu_PayloadInspector` comparison of `conditions` in addition to the `algorithms`. 
This is achieved by templating the existing `L1TUtmTriggerMenuDisplay` and `L1UtmTriggerMenuInfo` classes.
Unit tests and example scripts are updated as well.

#### PR validation:

Relies on the existing unit tests.
Also running:

```bash
getPayloadData.py \
    --plugin pluginL1TUtmTriggerMenu_PayloadInspector \
    --plot plot_L1TUtmTriggerMenu_CompareConditionsTwoTags \
    --tag L1Menu_Collisions2024_v1_0_0_xml \
    --tagtwo L1Menu_Collisions2024_v1_0_1_xml \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;
```

I obtain the following plot:

![image](https://github.com/cms-sw/cmssw/assets/5082376/77ee9709-0e10-4283-8089-9d65f18cdda3)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, no backport needed