### PR TITLE
[14.0.X] Miscellaneous fixes for dqm online clients 

### DIFF
--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -13,11 +13,10 @@ unitTest=False
 if 'unitTest=True' in sys.argv:
     unitTest=True
 
-process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siPixelDigis', 
-					 'sipixelEDAClient'),
-    cout = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')),
-    destinations = cms.untracked.vstring('cout')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.debugModules = cms.untracked.vstring('siPixelDigis','sipixelEDAClient')
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('ERROR')
 )
 
 #----------------------------

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePixel3DPrimaryVertices_cfi.py
@@ -12,12 +12,28 @@ pixelVertices = offlinePrimaryVertices.clone(
         maxEta = 100.,
     ),
 
-    TkClusParameters = dict(
-        TkDAClusParameters = dict(
-            dzCutOff = 4.0,
-            Tmin = 2.4,
-            vertexSize = 0.01,
-            uniquetrkweight = 0.9
+    TkClusParameters = cms.PSet(
+        algorithm   = cms.string("DA_vect"),
+        TkDAClusParameters = cms.PSet(
+            # the first 4 parameters are adjusted for pixel vertices
+            dzCutOff = cms.double(4.),        # outlier rejection after freeze-out (T<Tmin)
+            Tmin = cms.double(2.4),           # end of vertex splitting
+            vertexSize = cms.double(0.01),    # added in quadrature to track-z resolution
+            uniquetrkweight = cms.double(0.9),# require at least two tracks with this weight at T=Tpurge
+            # the rest is the same as the default defined in OfflinePrimaryVertices
+            coolingFactor = cms.double(0.6),  # moderate annealing speed
+            zrange = cms.double(4.),          # consider only clusters within 4 sigma*sqrt(T) of a track
+            delta_highT = cms.double(1.e-2),  # convergence requirement at high T
+            delta_lowT = cms.double(1.e-3),   # convergence requirement at low T
+            convergence_mode = cms.int32(0),  # 0 = two steps, 1 = dynamic with sqrt(T)
+            Tpurge = cms.double(2.0),         # cleaning
+            Tstop = cms.double(0.5),          # end of annealing
+            d0CutOff = cms.double(3.),        # downweight high IP tracks
+            zmerge = cms.double(1e-2),        # merge intermediat clusters separated by less than zmerge
+            uniquetrkminp = cms.double(0.0),  # minimal a priori track weight for counting unique tracks
+            runInBlocks = cms.bool(False),    # activate the DA running in blocks of z sorted tracks
+            block_size = cms.uint32(10000),   # block size in tracks
+            overlap_frac = cms.double(0.0)    # overlap between consecutive blocks (blocks_size*overlap_frac)
         )
     ),
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44384

#### PR description:

The night of 13th March 2024, [run 377827](https://cmsoms.cern.ch/cms/runs/report?cms_run=377827) was mistakenly acquired using the DQM DAQ key `hi_run` (despite having other collision keys).
This uncovered a couple of leftovers from PRs https://github.com/cms-sw/cmssw/pull/43846 and https://github.com/cms-sw/cmssw/pull/43257 that made few DQM online clients crash (see logs at [DQM square](https://cmsweb.cern.ch/dqm/dqm-square/?run=377827&db=production)).
These are fixed here. 
 
#### PR validation:

```
python3 beam_dqm_sourceclient-live_cfg.py runkey=hi_run
python3 beampixel_dqm_sourceclient-live_cfg.py runkey=hi_run
python3 pixellumi_dqm_sourceclient-live_cfg.py runkey=hi_run
```

all compile fine now.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/44384 to CMSSW_14_0_X for 2024 data-taking purposes.