### PR TITLE
Implement AlpakaBackendProducer and AlpakaBackendFilter [14.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaCore/plugins/AlpakaBackendFilter.cc
+++ b/HeterogeneousCore/AlpakaCore/plugins/AlpakaBackendFilter.cc
@@ -1,0 +1,48 @@
+#include <array>
+#include <string>
+#include <vector>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/Backend.h"
+
+class AlpakaBackendFilter : public edm::global::EDFilter<> {
+public:
+  explicit AlpakaBackendFilter(edm::ParameterSet const& config)
+      : producer_(consumes<unsigned short>(config.getParameter<edm::InputTag>("producer"))), backends_{} {
+    for (auto const& backend : config.getParameter<std::vector<std::string>>("backends")) {
+      backends_[static_cast<unsigned short>(cms::alpakatools::toBackend(backend))] = true;
+    }
+  }
+
+  bool filter(edm::StreamID sid, edm::Event& event, edm::EventSetup const& setup) const final {
+    return backends_[event.get(producer_)];
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::EDGetTokenT<unsigned short> producer_;
+  std::array<bool, static_cast<short>(cms::alpakatools::Backend::size)> backends_;
+};
+
+void AlpakaBackendFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("producer", edm::InputTag("alpakaBackendProducer", "backend"))
+      ->setComment(
+          "Use the 'backend' instance label to read the backend indicator that is implicitly produced by every alpaka "
+          "EDProducer.");
+  desc.add<std::vector<std::string>>("backends", {"SerialSync"})
+      ->setComment("Valid backends are 'SerialSync', 'CudaAsync', 'ROCmAsync', and 'TbbAsync'.");
+  descriptions.addWithDefaultLabel(desc);
+  descriptions.setComment(
+      "This EDFilter accepts events if the alpaka EDProducer 'producer' was run on a backend among those listed by the "
+      "'backends' parameter.");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(AlpakaBackendFilter);

--- a/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
@@ -7,7 +7,7 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<library file="alpaka/*.cc" name="HeterogeneousCoreAlpakaTestPluginsPortable">
+<library file="alpaka/*.cc" name="HeterogeneousCoreAlpakaCorePluginsPortable">
   <use name="alpaka"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/plugins/BuildFile.xml
@@ -3,5 +3,17 @@
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="alpaka/*.cc" name="HeterogeneousCoreAlpakaTestPluginsPortable">
+  <use name="alpaka"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HeterogeneousCore/AlpakaCore/plugins/alpaka/AlpakaBackendProducer.cc
+++ b/HeterogeneousCore/AlpakaCore/plugins/alpaka/AlpakaBackendProducer.cc
@@ -1,0 +1,31 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EventSetup.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaBackendProducer : public global::EDProducer<> {
+  public:
+    AlpakaBackendProducer(edm::ParameterSet const& config){};
+
+    void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addWithDefaultLabel(desc);
+      descriptions.setComment(
+          "The alpaka EDProducer does not have any explicit products. "
+          "Its only purpose is to produce a 'backend' value.");
+    }
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(AlpakaBackendProducer);

--- a/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/test/BuildFile.xml
@@ -1,0 +1,3 @@
+<test name="testAlpakaBackendFilter" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaCore/test/testAlpakaBackendFilter.py">
+  <flags ALPAKA_BACKENDS="1"/>
+</test>

--- a/HeterogeneousCore/AlpakaCore/test/testAlpakaBackendFilter.py
+++ b/HeterogeneousCore/AlpakaCore/test/testAlpakaBackendFilter.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+# choose a different alpaka backend depending on the SCRAM test being run
+try:
+    backend = os.environ['SCRAM_ALPAKA_BACKEND']
+except:
+    backend = 'SerialSync'
+
+# map the alpaka backends to the process accelerators
+accelerators = {
+    'SerialSync': 'cpu',
+    'CudaAsync':  'gpu-nvidia',
+    'ROCmAsync':  'gpu-amd'
+}
+
+print(f"Testing the alpaka backend {backend} using the process accelerator {accelerators[backend]}")
+
+import FWCore.ParameterSet.Config as cms
+from HeterogeneousCore.AlpakaCore.functions import *
+
+process = cms.Process('Test')
+
+process.options.accelerators = [ accelerators[backend] ]
+
+process.maxEvents.input = 10
+
+process.source = cms.Source('EmptySource')
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.alpakaBackendProducer = cms.EDProducer('AlpakaBackendProducer@alpaka')
+
+process.alpakaBackendFilter = cms.EDFilter('AlpakaBackendFilter',
+  producer = cms.InputTag('alpakaBackendProducer', 'backend'),
+  backends = cms.vstring(backend)
+)
+
+process.mustRun = cms.EDProducer("edmtest::MustRunIntProducer", ivalue=cms.int32(1))
+process.mustNotRun = cms.EDProducer("FailingProducer")
+
+process.SelectedBackend = cms.Path(process.alpakaBackendProducer + process.alpakaBackendFilter + process.mustRun)
+process.AnyOtherBackend = cms.Path(process.alpakaBackendProducer + ~process.alpakaBackendFilter + process.mustNotRun)
+
+process.options.wantSummary = True


### PR DESCRIPTION
#### PR description:

Implement `AlpakaBackendProducer`, an empty alpaka-based `EDProducer` whose only purpose is to save in the event what alpaka backend has been used.

Implement `AlpakaBackendFilter`, an `EDFilter` that selects events based on the alpaka backend used to run a previous producer.

Implement a unit test for both modules.

The aim is to replace this `SwitchProducer` in the HLT menu
```python

process.statusOnGPU = SwitchProducerCUDA(
   cpu = cms.EDProducer( "BooleanProducer",
       value = cms.bool( False )
   ),
  cuda = cms.EDProducer( "BooleanProducer",
       value = cms.bool( True )
   ),
 )

process.statusOnGPUFilter = cms.EDFilter( "BooleanFilter",
    src = cms.InputTag( "statusOnGPU" )
)

process.Status_OnCPU = cms.Path( process.statusOnGPU + ~process.statusOnGPUFilter )
process.Status_OnGPU = cms.Path( process.statusOnGPU + process.statusOnGPUFilter )
```
with this alpaka-based solution
```python
process.hltBackend = cms.EDProducer('AlpakaBackendProducer@alpaka')

process.hltStatusOnGPUFilter = cms.EDFilter('AlpakaBackendFilter',
  producer = cms.InputTag('hltBackend', 'backend'),
  backends = cms.vstring('CudaAsync', 'ROCmAsync')
)

process.Status_OnCPU = cms.Path( process.hltBackend + ~process.hltStatusOnGPUFilter )
process.Status_OnGPU = cms.Path( process.hltBackend + process.hltStatusOnGPUFilter )
```

#### PR validation:

The new unit test passes.

#### Backport status

Backport of #44387 to 14.0.x for data taking.