### PR TITLE
Update unpacker for L1T Calo scouting

### DIFF
--- a/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
@@ -62,9 +62,9 @@ namespace l1ScoutingRun3 {
 
   namespace bmtf {
     struct block {
-        uint64_t stub[8];
+      uint64_t stub[8];
     };
-  } // namespace bmtf
+  }  // namespace bmtf
 
 }  // namespace l1ScoutingRun3
 #endif  // L1ScoutingRawToDigi_blocks_h

--- a/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
@@ -22,8 +22,8 @@ namespace l1ScoutingRun3 {
 
   namespace demux {
 
-    // unrolled frame block
-    struct block {
+    // unrolled DMA block
+    struct dmaBlock {
       uint32_t header;
       uint32_t bx;
       uint32_t orbit;
@@ -44,7 +44,27 @@ namespace l1ScoutingRun3 {
       uint32_t link7;
       uint32_t tau1[6];
     };
+
+    struct caloObjTcpBlock {
+      uint32_t header;
+      uint32_t bx;
+      uint32_t orbit;
+      uint32_t obj[12];
+    };
+
+    struct caloSumTcpBlock {
+      uint32_t bx;
+      uint32_t orbit;
+      uint32_t sum[6];
+    };
+
   }  // namespace demux
+
+  namespace bmtf {
+    struct block {
+        uint64_t stub[8];
+    };
+  } // namespace bmtf
 
 }  // namespace l1ScoutingRun3
 #endif  // L1ScoutingRawToDigi_blocks_h

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
@@ -3,9 +3,11 @@
 ScCaloRawToDigi::ScCaloRawToDigi(const edm::ParameterSet& iConfig) {
   using namespace edm;
   using namespace l1ScoutingRun3;
-  srcInputTag = iConfig.getParameter<InputTag>("srcInputTag");
-  enableAllSums_ = iConfig.getUntrackedParameter<bool>("enableAllSums", false);
+  srcInputTag_ = iConfig.getParameter<InputTag>("srcInputTag");
+  enableAllSums_ = iConfig.getParameter<bool>("enableAllSums");
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+  dataSourceConfig_ = iConfig.getParameter<edm::ParameterSet>("dataSource");
+  rawToken_ = consumes<SDSRawDataCollection>(srcInputTag_);
 
   orbitBufferJets_ = std::vector<std::vector<Jet>>(3565);
   orbitBufferEGammas_ = std::vector<std::vector<EGamma>>(3565);
@@ -21,8 +23,6 @@ ScCaloRawToDigi::ScCaloRawToDigi(const edm::ParameterSet& iConfig) {
   produces<TauOrbitCollection>().setBranchAlias("TauOrbitCollection");
   produces<EGammaOrbitCollection>().setBranchAlias("EGammaOrbitCollection");
   produces<BxSumsOrbitCollection>().setBranchAlias("BxSumsOrbitCollection");
-
-  rawToken = consumes<SDSRawDataCollection>(srcInputTag);
 }
 
 ScCaloRawToDigi::~ScCaloRawToDigi(){};
@@ -32,22 +32,53 @@ void ScCaloRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace l1ScoutingRun3;
 
   Handle<SDSRawDataCollection> ScoutingRawDataCollection;
-  iEvent.getByToken(rawToken, ScoutingRawDataCollection);
-
-  const FEDRawData& sourceRawData = ScoutingRawDataCollection->FEDData(SDSNumbering::CaloSDSID);
-  size_t orbitSize = sourceRawData.size();
+  iEvent.getByToken(rawToken_, ScoutingRawDataCollection);
 
   std::unique_ptr<JetOrbitCollection> unpackedJets(new JetOrbitCollection);
   std::unique_ptr<TauOrbitCollection> unpackedTaus(new TauOrbitCollection);
   std::unique_ptr<EGammaOrbitCollection> unpackedEGammas(new EGammaOrbitCollection);
   std::unique_ptr<BxSumsOrbitCollection> unpackedEtSums(new BxSumsOrbitCollection);
 
-  if ((sourceRawData.size() == 0) && debug_) {
-    std::cout << "No raw data for CALO source\n";
-  }
+  // reset counters
+  nJetsOrbit_ = 0;
+  nEGammasOrbit_ = 0;
+  nTausOrbit_ = 0;
+  nEtSumsOrbit_ = 0;
 
-  // unpack current orbit and store data into the orbitBufferr
-  unpackOrbit(sourceRawData.data(), orbitSize);
+  std::string dataSourceMode = dataSourceConfig_.getParameter<std::string>("dataSourceMode");
+  if (dataSourceMode == "DMA") {
+    // Packet from DMA contains all the objects
+    int sourceId = dataSourceConfig_.getParameter<int>("sourceId"); 
+    if (sourceId!=SDSNumbering::CaloSDSID) edm::LogWarning("ScCaloRawToDIgi::produce")
+                                            << "Provided an unexpected source ID: "
+                                            << sourceId << "/" << SDSNumbering::CaloSDSID
+                                            << " [provided/expected]";
+    unpackOrbitFromDMA(ScoutingRawDataCollection, sourceId);
+  }
+  else if (dataSourceMode == "TCP") {
+    // unpack jets
+    jetSourceIdList_ = dataSourceConfig_.getParameter<std::vector<int>>("jetSourceIdList");
+    unpackTcpData(ScoutingRawDataCollection,
+                  jetSourceIdList_, CaloObjectType::Jet);
+
+    // unpack e/gamma
+    eGammaSourceIdList_ = dataSourceConfig_.getParameter<std::vector<int>>("eGammaSourceIdList");
+    unpackTcpData(ScoutingRawDataCollection,
+                  eGammaSourceIdList_, CaloObjectType::EGamma);
+
+    // unpack taus
+    tauSourceIdList_ = dataSourceConfig_.getParameter<std::vector<int>>("tauSourceIdList");
+    unpackTcpData(ScoutingRawDataCollection,
+                  tauSourceIdList_, CaloObjectType::Tau);
+
+    // unpack et sums
+    etSumSourceIdList_ = dataSourceConfig_.getParameter<std::vector<int>>("etSumSourceIdList");
+    unpackTcpData(ScoutingRawDataCollection,
+                  etSumSourceIdList_, CaloObjectType::EtSum);
+  } else {
+    throw cms::Exception("ScCaloRawToDIgi::produce") 
+            << "Unknown data source mode. Use DMA or TCP(default).";
+  }
 
   // fill orbit collection and clear the Bx buffer vector
   unpackedJets->fillAndClear(orbitBufferJets_, nJetsOrbit_);
@@ -62,22 +93,26 @@ void ScCaloRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put(std::move(unpackedEtSums));
 }
 
-void ScCaloRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
+void ScCaloRawToDigi::unpackOrbitFromDMA(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
+                                         int sourceId) {
   using namespace l1ScoutingRun3;
 
-  // reset counters
-  nJetsOrbit_ = 0;
-  nEGammasOrbit_ = 0;
-  nTausOrbit_ = 0;
-  nEtSumsOrbit_ = 0;
+  const FEDRawData& sourceRawData = ScoutingRawDataCollection->FEDData(sourceId);
+  if ((sourceRawData.size() == 0) && debug_) {
+    std::cout << "No raw data for CALO DMA source ID=" << sourceId << std::endl;
+  }
+
+  // get orbit size and raw data
+  size_t len = sourceRawData.size();
+  const unsigned char* buf = sourceRawData.data();
 
   size_t pos = 0;
 
   while (pos < len) {
-    assert(pos + sizeof(demux::block) <= len);
+    assert(pos + sizeof(demux::dmaBlock) <= len);
 
-    demux::block* bl = (demux::block*)(buf + pos);
-    pos += sizeof(demux::block);
+    demux::dmaBlock* bl = (demux::dmaBlock*)(buf + pos);
+    pos += sizeof(demux::dmaBlock);
 
     assert(pos <= len);
     uint32_t orbit = bl->orbit & 0x7FFFFFFF;
@@ -90,32 +125,32 @@ void ScCaloRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
     // unpack jets from first link
     if (debug_)
       std::cout << "--- Jets link 1 ---\n";
-    unpackLinkJets(bl->jet1, bx);
+    unpackJets(bl->jet1, bx, 6);
 
     // unpack jets from second link
     if (debug_)
       std::cout << "--- Jets link 2 ---\n";
-    unpackLinkJets(bl->jet2, bx);
+    unpackJets(bl->jet2, bx, 6);
 
     // unpack eg from first link
     if (debug_)
       std::cout << "--- E/g link 1 ---\n";
-    unpackLinkEGammas(bl->egamma1, bx);
+    unpackEGammas(bl->egamma1, bx, 6);
 
     // unpack eg from second link link
     if (debug_)
       std::cout << "--- E/g link 2 ---\n";
-    unpackLinkEGammas(bl->egamma2, bx);
+    unpackEGammas(bl->egamma2, bx, 6);
 
     // unpack taus from first link
     if (debug_)
       std::cout << "--- Taus link 1 ---\n";
-    unpackLinkTaus(bl->tau1, bx);
+    unpackTaus(bl->tau1, bx, 6);
 
     // unpack taus from second link
     if (debug_)
       std::cout << "--- Taus link 2 ---\n";
-    unpackLinkTaus(bl->tau2, bx);
+    unpackTaus(bl->tau2, bx, 6);
 
     // unpack et sums
     if (debug_)
@@ -125,11 +160,86 @@ void ScCaloRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
   }  // end of bx objects
 }
 
-void ScCaloRawToDigi::unpackLinkJets(uint32_t* dataBlock, int bx) {
+void ScCaloRawToDigi::unpackTcpData(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
+                                    std::vector<int> sourceList,
+                                    CaloObjectType dataType){
+  using namespace l1ScoutingRun3;
+  for (const int &sourceId: sourceList){
+    if ((sourceId<SDSNumbering::CaloTCPMinSDSID)||(sourceId>SDSNumbering::CaloTCPMaxSDSID)) {
+      edm::LogWarning("ScCaloRawToDIgi::unpackTCPData")
+                      << "Source ID outside the expected range " << sourceId 
+                      << "/[" << SDSNumbering::CaloTCPMinSDSID << "-" << SDSNumbering::CaloTCPMaxSDSID << "]"
+                      << " [provided/expected range]";
+    }
+    const FEDRawData& sourceRawData = ScoutingRawDataCollection->FEDData(sourceId);
+    size_t orbitSize = sourceRawData.size();
+
+    if ((sourceRawData.size() == 0) && debug_) {
+      //std::cout << "No raw data for calo " << CaloObjTypeTxt[dataType] << ", TCP source ID=" << sourceId << std::endl;
+      std::cout << "No raw data for calo TCP source ID=" << sourceId << std::endl;
+    }
+
+    unpackOrbitFromTCP(sourceRawData.data(), orbitSize, dataType);
+  }
+}
+
+void ScCaloRawToDigi::unpackOrbitFromTCP(const unsigned char* buf, size_t len, CaloObjectType dataType) {
+  using namespace l1ScoutingRun3;
+  size_t pos = 0;
+
+  while (pos < len) {
+    // frame header is present
+    assert(pos + 4 <= len);
+    
+    // unpack calo sums block
+    if (dataType==CaloObjectType::EtSum){
+      demux::caloSumTcpBlock* bl = (demux::caloSumTcpBlock*)(buf + pos);
+      pos += sizeof(demux::caloSumTcpBlock);
+      assert(pos <= len);
+      if (debug_)
+        std::cout << "Sums BX -> " << bl->bx << std::endl;
+      unpackEtSums(bl->sum, bl->bx);
+    } else {
+      // unpack jet/eg/tau
+      demux::caloObjTcpBlock* bl = (demux::caloObjTcpBlock*)(buf + pos);
+      int nObj = (bl->header) & 0xff;
+      pos += 12 + nObj*4;
+
+      switch (dataType) {
+        case CaloObjectType::Jet:
+          if (debug_)
+            std::cout << "Jets BX -> " << bl->bx << std::endl;
+          unpackJets(bl->obj, bl->bx, nObj);
+          break;
+
+        case CaloObjectType::EGamma:
+          if (debug_)
+            std::cout << "E/Gammas BX -> " << bl->bx << std::endl;
+          unpackEGammas(bl->obj, bl->bx, nObj);
+          break;
+
+        case CaloObjectType::Tau:
+          if (debug_)
+            std::cout << "Taus BX -> " << bl->bx << std::endl;
+          unpackTaus(bl->obj, bl->bx, nObj);
+          break;
+
+        default:
+          throw cms::Exception("ScCaloRawToDigi::unpackOrbitFromTCP") 
+                << "Unknown data type.";
+          break;
+      }
+
+    } // unpack sums and calo objects
+    
+  }  // end of bx objects
+}
+
+void ScCaloRawToDigi::unpackJets(uint32_t* dataBlock, int bx, int nObjets) {
   using namespace l1ScoutingRun3;
 
   int32_t ET(0), Eta(0), Phi(0), Qual(0);
-  for (uint32_t i = 0; i < 6; i++) {
+  for (int i = 0; i < nObjets; i++) {
     ET = ((dataBlock[i] >> demux::shiftsJet::ET) & demux::masksJet::ET);
 
     if (ET != 0) {
@@ -153,11 +263,11 @@ void ScCaloRawToDigi::unpackLinkJets(uint32_t* dataBlock, int bx) {
   }  // end link jets unpacking loop
 }
 
-void ScCaloRawToDigi::unpackLinkEGammas(uint32_t* dataBlock, int bx) {
+void ScCaloRawToDigi::unpackEGammas(uint32_t* dataBlock, int bx, int nObjets) {
   using namespace l1ScoutingRun3;
 
   int32_t ET(0), Eta(0), Phi(0), Iso(0);
-  for (uint32_t i = 0; i < 6; i++) {
+  for (int i = 0; i < nObjets; i++) {
     ET = ((dataBlock[i] >> demux::shiftsEGamma::ET) & demux::masksEGamma::ET);
     if (ET != 0) {
       Eta = ((dataBlock[i] >> demux::shiftsEGamma::eta) & demux::masksEGamma::eta);
@@ -180,11 +290,11 @@ void ScCaloRawToDigi::unpackLinkEGammas(uint32_t* dataBlock, int bx) {
   }  // end link e/gammas unpacking loop
 }
 
-void ScCaloRawToDigi::unpackLinkTaus(uint32_t* dataBlock, int bx) {
+void ScCaloRawToDigi::unpackTaus(uint32_t* dataBlock, int bx, int nObjets) {
   using namespace l1ScoutingRun3;
 
   int32_t ET(0), Eta(0), Phi(0), Iso(0);
-  for (uint32_t i = 0; i < 6; i++) {
+  for (int i = 0; i < nObjets; i++) {
     ET = ((dataBlock[i] >> demux::shiftsTau::ET) & demux::masksTau::ET);
     if (ET != 0) {
       Eta = ((dataBlock[i] >> demux::shiftsTau::eta) & demux::masksTau::eta);
@@ -212,12 +322,12 @@ void ScCaloRawToDigi::unpackEtSums(uint32_t* dataBlock, int bx) {
 
   BxSums bxSums;
 
-  int32_t ETEt(0), ETEttem(0), ETMinBiasHFP0(0);                                // ET
-  int32_t HTEt(0), HTtowerCount(0), HTMinBiasHFM0(0);                           // HT
-  int32_t ETmissEt(0), ETmissPhi(0), ETmissASYMET(0), ETmissMinBiasHFP1(0);     //ETMiss
-  int32_t HTmissEt(0), HTmissPhi(0), HTmissASYMHT(0), HTmissMinBiasHFM1(0);     // HTMiss
-  int32_t ETHFmissEt(0), ETHFmissPhi(0), ETHFmissASYMETHF(0), ETHFmissCENT(0);  // ETHFMiss
-  int32_t HTHFmissEt(0), HTHFmissPhi(0), HTHFmissASYMHTHF(0), HTHFmissCENT(0);  // HTHFMiss
+  int32_t ETEt(0), ETEttem(0), ETMinBiasHFP0(0);                                // ET block
+  int32_t HTEt(0), HTtowerCount(0), HTMinBiasHFM0(0);                           // HT block
+  int32_t ETmissEt(0), ETmissPhi(0), ETmissASYMET(0), ETmissMinBiasHFP1(0);     // ETMiss block
+  int32_t HTmissEt(0), HTmissPhi(0), HTmissASYMHT(0), HTmissMinBiasHFM1(0);     // HTMiss block
+  int32_t ETHFmissEt(0), ETHFmissPhi(0), ETHFmissASYMETHF(0), ETHFmissCENT(0);  // ETHFMiss block
+  int32_t HTHFmissEt(0), HTHFmissPhi(0), HTHFmissASYMHTHF(0), HTHFmissCENT(0);  // HTHFMiss block
 
   // ET block
   ETEt = ((dataBlock[0] >> demux::shiftsESums::ETEt) & demux::masksESums::ETEt);
@@ -312,7 +422,7 @@ void ScCaloRawToDigi::unpackEtSums(uint32_t* dataBlock, int bx) {
 
   if (debug_) {
     std::cout << "Raw frames:\n";
-    for (int frame = 0; frame < 6; frame++) {
+    for (int frame = 0; frame < 6; frame++) { 
       std::cout << "  frame " << frame << ": 0x" << std::hex << dataBlock[frame] << std::dec << std::endl;
     }
     printBxSums(bxSums);
@@ -321,8 +431,19 @@ void ScCaloRawToDigi::unpackEtSums(uint32_t* dataBlock, int bx) {
 
 void ScCaloRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("srcInputTag", edm::InputTag("rawDataCollector"));
+  {
+    edm::ParameterSetDescription dataSource;
+    dataSource.add<std::string>("dataSourceMode", std::string("TCP"));
+    dataSource.add<std::vector<int>>("jetSourceIdList", std::vector<int>({22}));
+    dataSource.add<std::vector<int>>("eGammaSourceIdList", std::vector<int>({23}));
+    dataSource.add<std::vector<int>>("tauSourceIdList", std::vector<int>({25}));
+    dataSource.add<std::vector<int>>("etSumSourceIdList", std::vector<int>({24}));
+    desc.add("dataSource", dataSource);
+  }
+  desc.add<bool>("enableAllSums", true);
+  desc.addUntracked<bool>("debug", false);
+  descriptions.add("ScCaloRawToDigi", desc);
 }
 
 DEFINE_FWK_MODULE(ScCaloRawToDigi);

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.cc
@@ -48,7 +48,7 @@ void ScCaloRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   std::string dataSourceMode = dataSourceConfig_.getParameter<std::string>("dataSourceMode");
   if (dataSourceMode == "DMA") {
     // Packet from DMA contains all the objects
-    int sourceId = dataSourceConfig_.getParameter<int>("sourceId");
+    int sourceId = dataSourceConfig_.getParameter<int>("dmaSourceId");
     if (sourceId != SDSNumbering::CaloSDSID)
       edm::LogWarning("ScCaloRawToDIgi::produce") << "Provided an unexpected source ID: " << sourceId << "/"
                                                   << SDSNumbering::CaloSDSID << " [provided/expected]";
@@ -430,6 +430,7 @@ void ScCaloRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descripti
     dataSource.add<std::vector<int>>("eGammaSourceIdList", std::vector<int>({23}));
     dataSource.add<std::vector<int>>("tauSourceIdList", std::vector<int>({25}));
     dataSource.add<std::vector<int>>("etSumSourceIdList", std::vector<int>({24}));
+    dataSource.add<int>("dmaSourceId", 2);
     desc.add("dataSource", dataSource);
   }
   desc.add<bool>("enableAllSums", true);

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -64,3 +64,4 @@ private:
   std::vector<int> tauSourceIdList_;
   std::vector<int> etSumSourceIdList_;
 };
+

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -64,4 +64,3 @@ private:
   std::vector<int> tauSourceIdList_;
   std::vector<int> etSumSourceIdList_;
 };
-

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -32,11 +32,10 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  enum class CaloObjectType {Jet, EGamma, Tau, EtSum};
+  enum class CaloObjectType { Jet, EGamma, Tau, EtSum };
 
-  void unpackOrbitFromDMA(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
-                          int sourceId);
-  void unpackTcpData(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
+  void unpackOrbitFromDMA(edm::Handle<SDSRawDataCollection>& ScoutingRawDataCollection, int sourceId);
+  void unpackTcpData(edm::Handle<SDSRawDataCollection>& ScoutingRawDataCollection,
                      std::vector<int> sourceList,
                      CaloObjectType dataType);
   void unpackOrbitFromTCP(const unsigned char* buf, size_t len, CaloObjectType dataType);
@@ -55,13 +54,13 @@ private:
   std::vector<std::vector<l1ScoutingRun3::BxSums>> orbitBufferEtSums_;
 
   bool debug_ = false;
-  bool enableAllSums_ = false; // write the full sert of ET sums
+  bool enableAllSums_ = false;  // write the full sert of ET sums
   edm::InputTag srcInputTag_;
   edm::EDGetToken rawToken_;
-  std::string dataSourceMode_; // data from TCP / DMA
+  std::string dataSourceMode_;  // data from TCP / DMA
   edm::ParameterSet dataSourceConfig_;
   std::vector<int> jetSourceIdList_;
   std::vector<int> eGammaSourceIdList_;
   std::vector<int> tauSourceIdList_;
-  std::vector<int> etSumSourceIdList_; 
+  std::vector<int> etSumSourceIdList_;
 };

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScCALORawToDigi.h
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 class ScCaloRawToDigi : public edm::stream::EDProducer<> {
 public:
@@ -31,11 +32,18 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void unpackOrbit(const unsigned char* buf, size_t len);
+  enum class CaloObjectType {Jet, EGamma, Tau, EtSum};
 
-  void unpackLinkJets(uint32_t* dataBlock, int bx);
-  void unpackLinkEGammas(uint32_t* dataBlock, int bx);
-  void unpackLinkTaus(uint32_t* dataBlock, int bx);
+  void unpackOrbitFromDMA(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
+                          int sourceId);
+  void unpackTcpData(edm::Handle<SDSRawDataCollection> &ScoutingRawDataCollection,
+                     std::vector<int> sourceList,
+                     CaloObjectType dataType);
+  void unpackOrbitFromTCP(const unsigned char* buf, size_t len, CaloObjectType dataType);
+
+  void unpackJets(uint32_t* dataBlock, int bx, int nObjets);
+  void unpackEGammas(uint32_t* dataBlock, int bx, int nObjets);
+  void unpackTaus(uint32_t* dataBlock, int bx, int nObjets);
   void unpackEtSums(uint32_t* dataBlock, int bx);
 
   int nJetsOrbit_, nEGammasOrbit_, nTausOrbit_, nEtSumsOrbit_;
@@ -47,7 +55,13 @@ private:
   std::vector<std::vector<l1ScoutingRun3::BxSums>> orbitBufferEtSums_;
 
   bool debug_ = false;
-  bool enableAllSums_ = false;
-  edm::InputTag srcInputTag;
-  edm::EDGetToken rawToken;
+  bool enableAllSums_ = false; // write the full sert of ET sums
+  edm::InputTag srcInputTag_;
+  edm::EDGetToken rawToken_;
+  std::string dataSourceMode_; // data from TCP / DMA
+  edm::ParameterSet dataSourceConfig_;
+  std::vector<int> jetSourceIdList_;
+  std::vector<int> eGammaSourceIdList_;
+  std::vector<int> tauSourceIdList_;
+  std::vector<int> etSumSourceIdList_; 
 };

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -13,7 +13,7 @@ ScGMTRawToDigi::ScGMTRawToDigi(const edm::ParameterSet& iConfig) {
   }
   nMuonsOrbit_ = 0;
 
-  produces<l1ScoutingRun3::MuonOrbitCollection>().setBranchAlias("MuonOrbitCollection");
+  produces<l1ScoutingRun3::MuonOrbitCollection>("Muon").setBranchAlias("MuonOrbitCollection");
   rawToken = consumes<SDSRawDataCollection>(srcInputTag);
 }
 
@@ -41,7 +41,7 @@ void ScGMTRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   unpackedMuons->fillAndClear(orbitBuffer_, nMuonsOrbit_);
 
   // store collection in the event
-  iEvent.put(std::move(unpackedMuons));
+  iEvent.put(std::move(unpackedMuons), "Muon");
 }
 
 void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.cc
@@ -3,6 +3,7 @@
 ScGMTRawToDigi::ScGMTRawToDigi(const edm::ParameterSet& iConfig) {
   using namespace edm;
   srcInputTag = iConfig.getParameter<InputTag>("srcInputTag");
+  skipInterm_ = iConfig.getParameter<bool>("skipInterm");
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
 
   // initialize orbit buffer for BX 1->3564;
@@ -78,7 +79,7 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
 
     for (unsigned int i = 0; i < mAcount + mBcount; i++) {
       uint32_t interm = (bl->mu[i].extra >> ugmt::shiftsMuon::interm) & ugmt::masksMuon::interm;
-      if (interm == 1) {
+      if ((interm == 1) && (skipInterm_)) {
         if (debug_) {
           std::cout << " -> Excluding intermediate muon\n";
         }
@@ -157,8 +158,10 @@ void ScGMTRawToDigi::unpackOrbit(const unsigned char* buf, size_t len) {
 
 void ScGMTRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("srcInputTag", edm::InputTag("rawDataCollector"));
+  desc.add<bool>("skipInterm", true);
+  desc.addUntracked<bool>("debug", false);
+  descriptions.add("ScGMTRawToDigi", desc);
 }
 
 DEFINE_FWK_MODULE(ScGMTRawToDigi);

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScGMTRawToDigi.h
@@ -39,6 +39,7 @@ private:
   int nMuonsOrbit_;
 
   bool debug_ = false;
+  bool skipInterm_ = true;
   edm::InputTag srcInputTag;
   edm::EDGetToken rawToken;
 };

--- a/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
@@ -1,7 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
+# default parameters for the DMA input source
+dmaDataModeParameters = cms.PSet(
+  dataSourceMode=cms.string("DMA"),
+  sourceId=cms.int32(2)
+)
+
+# default parameters for the TCP source
+tcpDataModeParameters = cms.PSet(
+  dataSourceMode=cms.string("TCP"),
+  jetSourceIdList = cms.vint32(22),
+  eGammaSourceIdList = cms.vint32(23),
+  tauSourceIdList = cms.vint32(25),
+  etSumSourceIdList = cms.vint32(24),
+)
+
 ScCaloUnpacker = cms.EDProducer("ScCaloRawToDigi",
   srcInputTag = cms.InputTag("rawDataCollector"),
+  # DMA / TCP mode configs
+  dataSource = tcpDataModeParameters,
+  # unpack the full set of energy sums
+  enableAllSums = cms.bool(True),
   # print all objects
   debug = cms.untracked.bool(False)
 )

--- a/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScCaloRawToDigi_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # default parameters for the DMA input source
 dmaDataModeParameters = cms.PSet(
   dataSourceMode=cms.string("DMA"),
-  sourceId=cms.int32(2)
+  dmaSourceId=cms.int32(2)
 )
 
 # default parameters for the TCP source
@@ -24,3 +24,4 @@ ScCaloUnpacker = cms.EDProducer("ScCaloRawToDigi",
   # print all objects
   debug = cms.untracked.bool(False)
 )
+

--- a/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 ScGmtUnpacker = cms.EDProducer('ScGMTRawToDigi',
   srcInputTag = cms.InputTag('rawDataCollector'),
+  # skip intermediate muons
+  skipInterm = cms.bool(True),
   # print all objects
   debug = cms.untracked.bool(False)
 )

--- a/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScGMTRawToDigi_cfi.py
@@ -7,3 +7,4 @@ ScGmtUnpacker = cms.EDProducer('ScGMTRawToDigi',
   # print all objects
   debug = cms.untracked.bool(False)
 )
+


### PR DESCRIPTION
#### PR description:

This PR updates the unpacker for L1T Calo scouting, following the upgrade of HW/SW upgrade of the scouting DAQ system.  

#### PR validation:

The PR has been validated using data collected with the scouting system in the past week(s) and comparing results with L1T objects collected during CRAFT with the cdaq. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport to CMSSW_14_0_X: https://github.com/cms-sw/cmssw/pull/44394
