### PR TITLE
Update for simulation of pixel bad components

### DIFF
--- a/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
+++ b/SimGeneral/MixingModule/python/SiPixelSimParameters_cfi.py
@@ -136,6 +136,7 @@ premix_stage1.toModify(SiPixelSimBlock,
     AddNoisyPixels = False,
     AddPixelInefficiency = False, #done in second step
     KillBadFEDChannels = False, #done in second step
+    killModules = False #done in second step
 )
 
 # Threshold in electrons are the Official CRAFT09 numbers:

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -21,7 +21,8 @@ from CalibTracker.SiPixelESProducers.siPixelQualityForDigitizerESProducer_cfi im
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(pixelDigitizer,
     AddPixelInefficiency = False, # will be added in DataMixer
-    KillBadFEDChannels = False # will be added in DataMixer
+    KillBadFEDChannels = False, # will be added in DataMixer
+    killModules = False # will be added in DataMixer
 )
 
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer, _premixStage1ModifyDict

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -20,7 +20,8 @@ from CalibTracker.SiPixelESProducers.siPixelQualityForDigitizerESProducer_cfi im
 # customization applies only to phase0/1 pixel.
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(pixelDigitizer,
-    AddPixelInefficiency = False # will be added in DataMixer
+    AddPixelInefficiency = False, # will be added in DataMixer
+    KillBadFEDChannels = False # will be added in DataMixer
 )
 
 from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import phase2TrackerDigitizer as _phase2TrackerDigitizer, _premixStage1ModifyDict

--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -51,7 +51,6 @@ mixData = cms.EDProducer("PreMixingModule",
                 # To preserve the behaviour of copy-pasted version of premix worker
                 # All these are done in stage1 (for both signal and pileup)
                 AddNoise = False,
-                killModules = False,
                 MissCalibrate = False,
             ),
             workerType = cms.string("PreMixingSiPixelWorker"),


### PR DESCRIPTION
#### PR description:

This is a backport of https://github.com/cms-sw/cmssw/pull/44276 and https://github.com/cms-sw/cmssw/pull/44320. The primary goal was to backport https://github.com/cms-sw/cmssw/pull/44320 but to be able to cherry-pick its commit from the CMSSW_14_1_X branch, https://github.com/cms-sw/cmssw/pull/44276 had to be cherry-picked first (they both modify `SimGeneral/MixingModule/python/pixelDigitizer_cfi.py`).

This PR is relevant for the Run 3 MC production.

@sroychow