### PR TITLE
[CMSSW_14_0_X] Update 2024 MC GTs with the L1 menu L1Menu_Collisions2024_v1_0_1_xml

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -90,13 +90,13 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
-    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v3',
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v4',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v2',
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

Update the 2024  MC GTs with the new L1 menu as in cmsTalk https://cms-talk.web.cern.ch/t/update-of-the-2024-l1-menu-tag-l1menu-collisions2024-v1-0-1/36759

The updated tag for L1TUtmTriggerMenuRcd is
From:   **L1Menu_Collisions2024_v1_0_0_xml**
To:   	**L1Menu_Collisions2024_v1_0_1_xml**

**GT differences**

- phase1_2024_design: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v4/140X_mcRun3_2024_design_v3

- phase1_2024_realistic: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v5/140X_mcRun3_2024_realistic_v4

- phase1_2024_cosmics:https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v5/140X_mcRun3_2024cosmics_realistic_deco_v4

- phase1_2024_cosmics_design: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v3/140X_mcRun3_2024cosmics_design_deco_v2

#### PR validation:

Tested in master

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #44389