### PR TITLE
Fix Looper type name used in python

### DIFF
--- a/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
@@ -22,7 +22,7 @@ const std::string edm::ParameterSetDescriptionFillerBase::kEmpty("");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForService("Service");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForESSource("ESSource");
 const std::string edm::ParameterSetDescriptionFillerBase::kBaseForESProducer("ESProducer");
-const std::string edm::ParameterSetDescriptionFillerBase::kBaseForEDLooper("EDLooper");
+const std::string edm::ParameterSetDescriptionFillerBase::kBaseForEDLooper("Looper");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDAnalyzer("EDAnalyzer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDProducer("EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDFilter("EDFilter");


### PR DESCRIPTION
#### PR description:

- auto generated cfi.py files had wrong python type name

#### PR validation:

Code compiles. A hand import of a newly generated file into python does work.