### PR TITLE
add a python compilation unit test for DQM online clients

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -196,8 +196,7 @@ elif runTypeName == 'hi_run':
     process.ecalDigisCPU.InputLabel = 'rawDataRepacker'
 elif runTypeName == 'hpu_run':
     if not unitTest:
-        process.source.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('*'))
-
+        process.source.SelectEvents = cms.untracked.vstring("*")
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
@@ -91,25 +91,17 @@ process.PrescaleService = cms.Service( "PrescaleService",
         prescales = cms.vuint32(6)
       ),
      )
-    )
+)
 
-
-process.load("DQM.HLTEvF.TrigResRateMon_cfi")
-
-# run on 1 out of 8 SM, LSSize 23 -> 23/8 = 2.875
-# stream is prescaled by 10, to correct change LSSize 23 -> 23/10 = 2.3
-process.trRateMon.LuminositySegmentSize = 2.3
-
+process.load("DQM.HLTEvF.triggerRatesMonitor_cfi")
 
 # Add RawToDigi
-process.rateMon = cms.EndPath(process.hltPreTrigResRateMon *process.trRateMon)
-
+process.rateMon = cms.EndPath(process.hltPreTrigResRateMon *process.triggerRatesMonitor)
 
 process.pp = cms.Path(process.dqmEnv+process.dqmSaver+process.dqmSaverPB)
 
 process.dqmEnv.subSystemFolder = 'HLT/TrigResults'
 #process.hltResults.plotAll = True
-
 
 ### process customizations included here
 from DQM.Integration.config.online_customizations_cfi import *

--- a/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
@@ -146,7 +146,6 @@ process.l1tMonitorOnline.remove(process.l1tRpctf)
 process.l1tMonitorOnline.remove(process.l1tGmt)
 
 #process.l1tMonitorOnline.remove(process.l1tGt) 
-process.l1tGt.HistFolder = "L1T/L1TGTTestCrate"
 
 #process.l1tMonitorOnline.remove(process.l1ExtraDqmSeq)
 

--- a/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
@@ -87,8 +87,6 @@ process.l1HwValEmulatorMonitorPath = cms.Path(process.l1Stage1HwValEmulatorMonit
 #process.valRctDigis.getFedsFromOmds = cms.bool(True)
 
 process.stage1UnpackerPath = cms.Path(process.caloStage1Digis+process.caloStage1LegacyFormatDigis)
-process.caloStage1LegacyFormatDigis.bxMin = -2
-process.caloStage1LegacyFormatDigis.bxMax = 2
 
 #
 process.l1EmulatorMonitorClientPath = cms.Path(process.l1EmulatorMonitorClient)

--- a/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import sys
 # $Id: physics_dqm_sourceclient-live_cfg.py,v 1.11 2012/02/13 15:09:30 lilopera Exp $
 
 import FWCore.ParameterSet.Config as cms

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -474,10 +474,7 @@ if (process.runType.getRunType() == process.runType.hpu_run):
     process.load('RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff')
     import RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi
     process.load('RecoTracker.FinalTrackSelectors.earlyGeneralTracks_cfi')
-    process.earlyGeneralTracks.TrackProducers = (
-        cms.InputTag('initialStepTracks'),
-        )
-
+    process.earlyGeneralTracks.TrackProducers = cms.VInputTag(cms.InputTag('initialStepTracks'))
     process.earlyGeneralTracks.hasSelector=cms.vint32(1)
     process.earlyGeneralTracks.selectedTrackQuals = cms.VInputTag(
 #        cms.InputTag("initialStepSelector","initialStep"),

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -34,3 +34,11 @@
 <!-- <test name="TestDQMOnlineClient-hcalcalib_dqm_sourceclient" command="runtest.sh hcalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <test name="TestDQMOnlineClient-visualization" command="runtest.sh visualization-live_cfg.py" />
 <test name="TestDQMOnlineClient-visualization_secondInstance" command="runtest.sh visualization-live-secondInstance_cfg.py" />
+<!--tests that the configuration is compilable for the full matrix of combinations -->
+<test name="TestDQMOnlineClients-compilation_pp_run" command="runCompilationTest.sh pp_run"/>
+<test name="TestDQMOnlineClients-compilation_pp_run_stage1" command="runCompilationTest.sh pp_run_stage1"/>
+<test name="TestDQMOnlineClients-compilation_cosmic_run" command="runCompilationTest.sh cosmic_run"/>
+<test name="TestDQMOnlineClients-compilation_cosmic_run_stage1" command="runCompilationTest.sh cosmic_run_stage1"/>
+<test name="TestDQMOnlineClients-compilation_hi_run" command="runCompilationTest.sh hi_run"/>
+<test name="TestDQMOnlineClients-compilation_hpu_run" command="runCompilationTest.sh hpu_run"/>
+<test name="TestDQMOnlineClients-compilation_commissioning_run" command="runCompilationTest.sh commissioning_run"/>

--- a/DQM/Integration/test/runCompilationTest.sh
+++ b/DQM/Integration/test/runCompilationTest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if the key argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <key>"
+    exit 1
+fi
+
+# Extract the key from the command line argument
+key="$1"
+
+# Define a function to run the python command
+run_python_command() {
+    function die { echo $1: status $2 ; exit $2; }
+
+    entry="$1"
+    key="$2"
+
+    # Check conditions to skip certain combinations
+    if [[ "$entry" == *visualization-live_cfg.py* && ( "$key" == "pp_run_stage1" || "$key" == "cosmic_run_stage1" || "$key" == "hpu_run" ) ]]; then
+        echo "===== Skipping Test \"python3 $entry runkey=$key\" ===="
+        return
+    fi
+
+    # Otherwise, proceed with the test
+    echo "===== Test \"python3 $entry runkey=$key\" ===="
+    (python3 "$entry" runkey="$key" > /dev/null) 2>&1 || die "Failure using python3 $entry" $?
+}
+
+# Run the tests for the specified key
+echo "Running tests for key: $key"
+for entry in "${CMSSW_BASE}/src/DQM/Integration/python/clients/"*"-live_cfg.py"; do
+    run_python_command "$entry" "$key"
+done
+
+# All tests passed
+echo "All tests passed!"

--- a/DQM/Physics/python/qcdLowPtDQM_cfi.py
+++ b/DQM/Physics/python/qcdLowPtDQM_cfi.py
@@ -7,7 +7,7 @@ from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi         import *
 from RecoLocalTracker.SiPixelRecHits.PixelCPEESProducers_cff    import *
 
-siPixelDigis.InputLabel = cms.InputTag("source")
+siPixelDigis.cpu.InputLabel = cms.InputTag("source")
 
 myRecoSeq1 = cms.Sequence(
     siPixelDigis    *


### PR DESCRIPTION
#### PR description:

In preparing https://github.com/cms-sw/cmssw/pull/44384 I noticed that the test coverage of DQM online clients is somewhat poor since the existing unit tests do not contemplate all the possible run keys that can be exercised at P5. 
It would be costly in terms of execution time and in terms of storage space (to store the input RAW data / streamer files) to cover all the possible uses cases in a battery of unit tests that actually execute `cmsRun`  of these configurations, but at least they could be compiled to spot obvious configuration problems (as the ones resolved in https://github.com/cms-sw/cmssw/pull/44384).
This is proposed in this PR.
In order to make the new unit test run, some leftover configuration issues have been fixed. I assume they are somehow irrelevant as they pertain to combinations that are probably never run online, but nevertheless to avoid too much ad hoc handling in the test they are fixed here.

#### PR validation:

The newly added unit tests: `scram b runtests_TestDQMOnlineClients-compilation_[*]` run fine.

[*] = `'pp_run'`,`'pp_run_stage1'`,`'cosmic_run'`,`'cosmic_run_stage1'`,`'hi_run'`,`'hpu_run'`,`'commissioning_run'`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but if desired it can be backported to CMSSW_14_0_X for data-taking purposes