### PR TITLE
[L1T] Fix for is not a valid DT id error

### DIFF
--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -99,7 +99,7 @@ void MuonPathSLFitter::analyze(MuonPathPtr &inMPath,
   auto sl = inMPath->primitive(0)->superLayerId();  // 0, 1, 2
 
   int selected_lay = 1;
-  if (inMPath->primitive(0)->tdcTimeStamp() != -1)
+  if (inMPath->primitive(0)->cameraId() > 0)
     selected_lay = 0;
 
   int dumLayId = inMPath->primitive(selected_lay)->cameraId();


### PR DESCRIPTION
#### PR description:

This PR fixes a small bug in the DT L1T Phase2 emulator which prevents processing Slice Test data giving the following error when non valid subdetetcor IDs are unpacked (e.g.):

"det: 15 subdet: 7 is not a valid DT id"

#### PR validation:

Tested with Slice test 2024 real data,