### PR TITLE
Add use of unsubtracted jets in RecoBTag info producers

### DIFF
--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -24,6 +24,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
 
 using namespace btagbtvdeep;
 
@@ -39,12 +40,13 @@ private:
   typedef reco::VertexCompositePtrCandidateCollection SVCollection;
   typedef reco::VertexCollection VertexCollection;
   typedef edm::View<reco::Candidate> CandidateView;
+  typedef edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView>> JetMatchMap;
 
   void beginStream(edm::StreamID) override {}
   void produce(edm::Event &, const edm::EventSetup &) override;
   void endStream() override {}
 
-  void fillParticleFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &jet);
+  void fillParticleFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &unsubJet, const reco::Jet &jet);
   void fillSVFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &jet);
   void fillParticleFeaturesHLT(DeepBoostedJetFeatures &fts, const reco::Jet &jet, const reco::VertexRefProd &PVRefProd);
   void fillSVFeaturesHLT(DeepBoostedJetFeatures &fts, const reco::Jet &jet);
@@ -66,6 +68,7 @@ private:
   const bool use_hlt_features_;
 
   edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
+  edm::EDGetTokenT<JetMatchMap> unsubjet_map_token_;
   edm::EDGetTokenT<VertexCollection> vtx_token_;
   edm::EDGetTokenT<SVCollection> sv_token_;
   edm::EDGetTokenT<CandidateView> pfcand_token_;
@@ -73,6 +76,7 @@ private:
   bool use_puppi_value_map_;
   bool use_pvasq_value_map_;
   bool is_packed_pf_candidate_collection_;
+  bool use_unsubjet_map_;
 
   edm::EDGetTokenT<edm::ValueMap<float>> puppi_value_map_token_;
   edm::EDGetTokenT<edm::ValueMap<int>> pvasq_value_map_token_;
@@ -229,6 +233,7 @@ DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(const edm::Paramete
       pfcand_token_(consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("pf_candidates"))),
       use_puppi_value_map_(false),
       use_pvasq_value_map_(false),
+      use_unsubjet_map_(false),
       track_builder_token_(
           esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))),
       covarianceVersion_(iConfig.getParameter<int>("covarianceVersion")),
@@ -300,6 +305,12 @@ DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(const edm::Paramete
     trkPhi_value_map_token_ = consumes<edm::ValueMap<float>>(trkPhi_value_map_tag);
   }
 
+  const auto &unsubjet_map_tag = iConfig.getUntrackedParameter<edm::InputTag>("unsubjet_map", {});
+  if (!unsubjet_map_tag.label().empty()) {
+    unsubjet_map_token_ = consumes<JetMatchMap>(unsubjet_map_tag);
+    use_unsubjet_map_ = true;
+  }
+
   produces<DeepBoostedJetTagInfoCollection>();
 }
 
@@ -324,6 +335,7 @@ void DeepBoostedJetTagInfoProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
   desc.add<edm::InputTag>("pf_candidates", edm::InputTag("particleFlow"));
   desc.add<edm::InputTag>("jets", edm::InputTag("ak8PFJetsPuppi"));
+  desc.addUntracked<edm::InputTag>("unsubjet_map", {});
   desc.add<edm::InputTag>("puppi_value_map", edm::InputTag("puppi"));
   desc.add<edm::InputTag>("vertex_associator", edm::InputTag("primaryVertexAssociation", "original"));
   desc.add<bool>("use_scouting_features", false);
@@ -347,6 +359,7 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent, const edm::Event
   auto output_tag_infos = std::make_unique<DeepBoostedJetTagInfoCollection>();
   // Input jets
   auto jets = iEvent.getHandle(jet_token_);
+  auto unsubjet_map = use_unsubjet_map_ ? iEvent.getHandle(unsubjet_map_token_) : edm::Handle<JetMatchMap>();
   // Primary vertexes
   if (!use_scouting_features_) {
     iEvent.getByToken(vtx_token_, vtxs_);
@@ -392,6 +405,8 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent, const edm::Event
   for (std::size_t jet_n = 0; jet_n < jets->size(); jet_n++) {
     const auto &jet = (*jets)[jet_n];
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
+    const auto &unsubJet =
+        (use_unsubjet_map_ && (*unsubjet_map)[jet_ref].isNonnull()) ? *(*unsubjet_map)[jet_ref] : jet;
 
     // create jet features
     DeepBoostedJetFeatures features;
@@ -421,13 +436,13 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent, const edm::Event
     if (jet.pt() < min_jet_pt_ or std::abs(jet.eta()) > max_jet_eta_) {
       fill_vars = false;
     }
-    if (jet.numberOfDaughters() == 0 and !use_scouting_features_) {
+    if (unsubJet.numberOfDaughters() == 0 and !use_scouting_features_) {
       fill_vars = false;
     }
 
     // fill features
     if (fill_vars) {
-      fillParticleFeatures(features, jet);
+      fillParticleFeatures(features, unsubJet, jet);
       if (!use_scouting_features_) {
         fillSVFeatures(features, jet);
       }
@@ -475,7 +490,9 @@ bool DeepBoostedJetTagInfoProducer::useTrackProperties(const reco::PFCandidate *
   return track != nullptr and track->pt() > min_pt_for_track_properties_;
 };
 
-void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures &fts, const reco::Jet &jet) {
+void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures &fts,
+                                                         const reco::Jet &unsubJet,
+                                                         const reco::Jet &jet) {
   // some jet properties
   math::XYZVector jet_dir = jet.momentum().Unit();
   TVector3 jet_direction(jet.momentum().Unit().x(), jet.momentum().Unit().y(), jet.momentum().Unit().z());
@@ -492,7 +509,7 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
 
   // make list of pf-candidates to be considered
   std::vector<reco::CandidatePtr> daughters;
-  for (const auto &dau : jet.daughterPtrVector()) {
+  for (const auto &dau : unsubJet.daughterPtrVector()) {
     // remove particles w/ extremely low puppi weights
     // [Note] use jet daughters here to get the puppiWgt correctly
     if ((puppiWgt(dau)) < min_puppi_wgt_)

--- a/RecoBTag/FeatureTools/test/BuildFile.xml
+++ b/RecoBTag/FeatureTools/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="testRecoBTagInfoWithUnsubJets" command="cmsRun ${LOCALTOP}/src/RecoBTag/FeatureTools/test/u0_cfg.py"/>

--- a/RecoBTag/FeatureTools/test/u0_cfg.py
+++ b/RecoBTag/FeatureTools/test/u0_cfg.py
@@ -1,0 +1,74 @@
+# Unit test configuration file for RecoBTagInfo producers:
+# Verify the use of unsubtracted jet map
+#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load('Configuration.Geometry.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(2)
+)
+
+process.source = cms.Source("PoolSource",
+        fileNames = cms.untracked.vstring("root://xrootd-cms.infn.it//store/hidata/HIRun2023A/HIPhysicsRawPrime0/MINIAOD/PromptReco-v2/000/375/823/00000/8158260e-df3c-45a5-a121-55345a682a23.root")
+)
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '132X_dataRun3_Prompt_v4', '')
+
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+process.ak4PFJets = ak4PFJets.clone(rParam = 0.4, src = 'packedPFCandidates')
+
+process.unsubJets = cms.EDProducer("JetMatcherDR",
+    source = cms.InputTag("ak4PFJets"),
+    matched = cms.InputTag("ak4PFJets")
+)
+
+from RecoBTag.FeatureTools.pfDeepFlavourTagInfos_cfi import pfDeepFlavourTagInfos
+process.pfDeepFlavourTagInfos = pfDeepFlavourTagInfos.clone(
+    jets = "ak4PFJets",
+    unsubjet_map = "unsubJets",
+    fallback_puppi_weight = True,
+    fallback_vertex_association = True,
+    puppi_value_map = "",
+    secondary_vertices = "inclusiveCandidateSecondaryVertices",
+    shallow_tag_infos = "pfDeepCSVTagInfos",
+    vertex_associator = "",
+    vertices = "offlineSlimmedPrimaryVertices"
+)
+
+from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
+process.pfDeepBoostedJetTagInfos = pfDeepBoostedJetTagInfos.clone(
+    jets = "ak4PFJets",
+    unsubjet_map = "unsubJets",
+    use_puppiP4 = False,
+    puppi_value_map = "",
+    secondary_vertices = "inclusiveCandidateSecondaryVertices",
+    vertex_associator = "",
+    vertices = "offlineSlimmedPrimaryVertices",
+    pf_candidates = "packedPFCandidates"
+)
+
+from RecoBTag.FeatureTools.pfParticleTransformerAK4TagInfos_cfi import pfParticleTransformerAK4TagInfos
+process.pfParticleTransformerAK4TagInfos = pfParticleTransformerAK4TagInfos.clone(
+    jets = "ak4PFJets",
+    unsubjet_map = "unsubJets",
+    fallback_puppi_weight = True,
+    fallback_vertex_association = True,
+    puppi_value_map = "",
+    secondary_vertices = "inclusiveCandidateSecondaryVertices",
+    vertex_associator = "",
+    vertices = "offlineSlimmedPrimaryVertices"
+)
+
+process.p = cms.Path(process.ak4PFJets *
+                     process.unsubJets *
+                     process.pfDeepFlavourTagInfos *
+                     process.pfDeepBoostedJetTagInfos *
+                     process.pfParticleTransformerAK4TagInfos)

--- a/RecoJets/JetProducers/plugins/JetMatcherDR.cc
+++ b/RecoJets/JetProducers/plugins/JetMatcherDR.cc
@@ -1,0 +1,50 @@
+/* \class JetMatcherDR
+ *
+ * Producer for association map:
+ * class to match two collections of jet with one-to-one matching
+ * All elements of class "matched" are matched to each element of class "source" minimizing DeltaR
+ *
+ */
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+class JetMatcherDR : public edm::global::EDProducer<> {
+public:
+  typedef edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > JetMatchMap;
+  explicit JetMatcherDR(const edm::ParameterSet& iConfig)
+      : sourceToken_(consumes<reco::JetView>(iConfig.getParameter<edm::InputTag>("source"))),
+        matchedToken_(consumes<reco::JetView>(iConfig.getParameter<edm::InputTag>("matched"))) {
+    produces<JetMatchMap>();
+  };
+  ~JetMatcherDR() override{};
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  const edm::EDGetTokenT<reco::JetView> sourceToken_;
+  const edm::EDGetTokenT<reco::JetView> matchedToken_;
+};
+
+void JetMatcherDR::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  const auto& source = iEvent.getHandle(sourceToken_);
+  const auto& matched = iEvent.getHandle(matchedToken_);
+  auto matching = std::make_unique<JetMatchMap>(source, matched);
+  for (size_t i = 0; i < source->size(); i++) {
+    std::pair<int, float> m(-1, 999.f);
+    for (size_t j = 0; j < matched->size(); j++) {
+      const auto dR = deltaR((*source)[i].p4(), (*matched)[j].p4());
+      if (dR < m.second)
+        m = {j, dR};
+    }
+    matching->insert(source->refAt(i), m.first >= 0 ? matched->refAt(m.first) : reco::JetBaseRef());
+  }
+  iEvent.put(std::move(matching));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(JetMatcherDR);


### PR DESCRIPTION
#### PR description:

While using constituent subtracted (CS) jets in PbPb collisions, which runs the underlying event subtraction particle-by-particle defined in [ref](https://arxiv.org/abs/1905.03470), it was observed that the b-tagging performance decreased due to some of the displaced tracks being zero'd out by the subtraction algorithm. The solution to recover the b-tagging performance when using CS jets was to use instead the unsubtracted particles in the b-tag info producers.

So this PR implements a jet matcher by deltaR that allows to match CS jet collections to unsubtracted jet collections and creates an association map between these two collections. This map is then later added to the Deep Boosted, Deep Flavour and the Particle Transformer tag info producers to access the unsubtracted jet associated to the CS jet and use the unsubtrated particles instead. The logic is defined such that if the map is not provided (default behavior), the particles of the input jet collection is always used as currently done.

#### PR validation:

This PR was validated in CMSSW_13_2_10 using a TTbar sample.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

@mandrenguyen 
