### PR TITLE
Be able to generate dummy _cfi.py files for ConfDB parsing

### DIFF
--- a/FWCore/ParameterSet/python/DummyCfis.py
+++ b/FWCore/ParameterSet/python/DummyCfis.py
@@ -1,0 +1,99 @@
+import importlib
+from FWCore.ParameterSet.ModulesProxy import _ModuleProxy
+from FWCore.ParameterSet.Types import _ProxyParameter, _RequiredParameter, _OptionalParameter
+import FWCore.ParameterSet.Config as cms
+
+#setup defaults for each type
+cms.int32.dummyDefault = 999
+cms.uint32.dummyDefault = 999
+cms.int64.dummyDefault = 999
+cms.uint64.dummyDefault = 999
+cms.string.dummyDefault="__default__"
+cms.double.dummyDefault = 9999
+cms.vdouble.dummyDefault = []
+cms.vint32.dummyDefault = []
+cms.vuint32.dummyDefault = []
+cms.vint64.dummyDefault = []
+cms.vuint64.dummyDefault=[]
+cms.vstring.dummyDefault=[]
+cms.bool.dummyDefault = False
+cms.PSet.dummyDefault = cms.PSet()
+cms.VPSet.dummyDefault = cms.VPSet()
+cms.InputTag.dummyDefault = "__dummy__"
+cms.VInputTag.dummyDefault = []
+cms.ESInputTag.dummyDefault=":__dummy__"
+cms.VESInputTag.dummyValue = []
+cms.EventID.dummyDefault="0:0:0"
+cms.VEventID.dummyDefault =[]
+cms.LuminosityBlockID.dummyDefault = "0:0"
+cms.VLuminosityBlockID.dummyDefault=[]
+cms.EventRange.dummyDefault="0:0"
+cms.VEventRange.dummyDefault=[]
+cms.LuminosityBlockRange.dummyDefault="0:0"
+cms.VLuminosityBlockID.dummyDefault=[]
+cms.FileInPath.dummyDefault="__dummy__"
+
+
+
+def create_cfis(modName: str, writeRequired, writeOptional):
+    modules = importlib.import_module(modName+".modules")
+    for (n,m) in (x for x in modules.__dict__.items() if isinstance(x[1], _ModuleProxy)):
+        print(modName +'.'+n)
+        write_cfi(modName+'.'+n, writeRequired, writeOptional)
+
+def write_cfi(pythonModuleName, writeRequired, writeOptional):
+    parts = pythonModuleName.split('.')
+    filename = parts[-1][0].lower()+parts[-1][1:]
+    f = open(filename+"_cfi.py",'x')
+    f.writelines(["import FWCore.ParameterSet.DummyCfis as dc\n",
+                  "import sys\n",
+                  "dc.create_module('{}', sys.modules[__name__], {}, {})\n".format(pythonModuleName, writeRequired, writeOptional)])
+    f.close()
+    
+def setDefaultInPSet(pset: cms.PSet, writeRequired, writeOptional):
+    for n in pset.parameterNames_():
+        setADefault(pset, n, writeRequired, writeOptional)
+
+def setADefault(obj, paramName, writeRequired, writeOptional):
+    p = getattr(obj, paramName)
+    #print(p)
+    if (isinstance(p, _RequiredParameter) and writeRequired) or (isinstance(p, _OptionalParameter) and writeOptional):
+        p.setValue(p._ProxyParameter__type.dummyDefault)
+    if isinstance(p, cms.PSet):
+        setDefaultInPSet(p, writeRequired, writeOptional)
+    if isinstance(p, cms.VPSet):
+        for pset in p:
+            setDefaultInPSet(pset, writeRequired, writeOptional)
+
+def setDefaultsInModule(mod, writeRequired, writeOptional):
+    for n in mod.parameterNames_():
+        setADefault(mod, n, writeRequired, writeOptional)
+    return mod
+    
+def create_module(pythonModuleName: str, localPythonModule, writeRequired, writeOptional ):
+    parts = pythonModuleName.split('.')
+    pmod = importlib.import_module(pythonModuleName)
+    setattr(localPythonModule, parts[-1][0].lower()+parts[-1][1:], setDefaultsInModule(getattr(pmod, parts[-1])(), writeRequired, writeOptional ) )
+    
+    
+#create_cfis("FWCore.Integration")
+
+if __name__ == '__main__':
+    import FWCore.ParameterSet.Config as cms
+    test = cms.EDAnalyzer("Foo",
+                          a = cms.optional.int32,
+                          b = cms.optional.string,
+                          c = cms.optional.PSet,
+                          d = cms.untracked.PSet(a=cms.int32(1), b= cms.optional.untracked.PSet),
+                          e = cms.required.EventID,
+                          f = cms.optional.LuminosityBlockID,
+                          g = cms.optional.EventRange,
+                          h = cms.optional.LuminosityBlockRange,
+                          j = cms.optional.InputTag,
+                          k = cms.optional.ESInputTag,
+                          l = cms.optional.FileInPath
+    )
+    print(test.dumpPython())
+    setDefaultsInModule(test, True, False)
+    print(test.dumpPython())
+    

--- a/FWCore/ParameterSet/scripts/edmMakeDummyCfis.py
+++ b/FWCore/ParameterSet/scripts/edmMakeDummyCfis.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import os
+import  sys
+from FWCore.ParameterSet.DummyCfis import create_cfis
+
+
+##########################
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Expand python configuration")
+    parser.add_argument("cfipythondir",
+                    help="cfipython dir for the configurations files to read")
+    parser.add_argument("--required", action="store_true",
+                        help="Add dummy values for cms.required parameters")
+    parser.add_argument("--optional", action="store_true",
+                        help="Add dummy values for cms.optional parameters")
+
+    options = parser.parse_args()
+
+
+    base = Path(options.cfipythondir)
+
+    work = Path.cwd() / 'cfis'
+    work.mkdir()
+    os.chdir(work)
+    for subsys in (x for x in base.iterdir() if x.is_dir()):
+        newSub = work /subsys.name
+        newSub.mkdir()
+        os.chdir(newSub)
+        for pkg in (y for y in subsys.iterdir() if y.is_dir()):
+            newPkg = newSub / pkg.name
+            newPkg.mkdir()
+            os.chdir(newPkg)
+            if (pkg / "modules.py").exists():
+                create_cfis(subsys.name + '.'+pkg.name, writeRequired=options.required, writeOptional=options.optional)


### PR DESCRIPTION
#### PR description:

This is a demonstrator made up of a script and a python helper module which uses the new module python _construction_ ability in the framework to generate dummy _cfi.py files which ConfDB can parse.

These dummy _cfis inject dummy values in the cases where the parameters of the module are of type `cms.optional` or `cms.required` as those are not types ConfDB can handle.

#### PR validation:

Ran the script on a CMSSW_14_1_0_pre1 area and generated all cfi files. Tested if each one of the files would load properly in python. A few failed because of a file in <SubSystem>/<Package>/python which had the same name as the generated 'module construction' file. I made PRs changing those file names.