### PR TITLE
Remove unused strstream to fix the deprecated header warning

### DIFF
--- a/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc
@@ -18,7 +18,6 @@
 
 // system include files
 #include <memory>
-#include <strstream>
 
 // user include files
 #include "FWCore/Framework/interface/ModuleFactory.h"

--- a/L1Trigger/L1TMuon/src/L1TMuonGlobalParamsHelper.cc
+++ b/L1Trigger/L1TMuon/src/L1TMuonGlobalParamsHelper.cc
@@ -1,5 +1,4 @@
 #include <iomanip>
-#include <strstream>
 
 #include "L1Trigger/L1TMuon/interface/L1TMuonGlobalParamsHelper.h"
 #include "L1Trigger/L1TCommon/interface/ConvertToLUT.h"

--- a/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlap/plugins/L1TMuonOverlapTrackProducer.cc
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <strstream>
 #include <vector>
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"

--- a/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFProcessor.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <algorithm>
-#include <strstream>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFSorter.cc
@@ -1,6 +1,5 @@
 #include <cassert>
 #include <iostream>
-#include <strstream>
 #include <algorithm>
 #include <bitset>
 

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <strstream>
 
 #include "CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonGlobalParams.h"


### PR DESCRIPTION
This Pr removes the unused `strstream` header which should fix the warnings like [a] from the IB. These warnings are ignored by bot as these are generated from gcc header 

[a]
```
In file included from /pool/condor/dir_2001197/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/backward/strstream:50,
                 from src/L1Trigger/L1TMuon/plugins/L1TMuonGlobalParamsESProducer.cc:21:
  /pool/condor/dir_2001197/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
```