### PR TITLE
KalmanFilter fix for Phase 2 L1 tracking

### DIFF
--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -551,7 +551,7 @@ namespace tmtt {
       matRinv = TMatrixD(TMatrixD::kInverted, matR);
     } else {
       // Protection against rare maths instability.
-      const TMatrixD unitMatrix(TMatrixD::kUnit, TMatrixD(nHelixPar_, nHelixPar_));
+      const TMatrixD unitMatrix(TMatrixD::kUnit, TMatrixD(2, 2));
       const double big = 9.9e9;
       matRinv = big * unitMatrix;
     }


### PR DESCRIPTION
@tomalin

#### PR description:

This PR resolves the failure reported in #44306. The problem was that `matRinv` is defined as a 2×2 matrix:
https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_0/L1Trigger/TrackFindingTMTT/src/KFbase.cc#L549
while `unitMatrix` is defined as a 5×5 matrix (`nHelixPar_` is five when running the extended tracking):
https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_0/L1Trigger/TrackFindingTMTT/src/KFbase.cc#L554

So then there is an exception caused by assigning one to the other on this line:
https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_0/L1Trigger/TrackFindingTMTT/src/KFbase.cc#L556
Hence the error message:
```
…
[a] Fatal Root Error: @SUB=operator=(const TMatrixT &)
matrices not compatible
```

#### PR validation:

A recipe for reproducing the exception can be found in #44306. The changes in this PR allow the recipe to run without any exception.