### PR TITLE
Allow storing 2024 geometry in GEMGeometryParsFromDD

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -76,7 +76,9 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
       // back to chambers
       fvGE2.parent();
       fvGE2.parent();
-      doSuper = (nGE21 < 2 && fvGE2.nextSibling());
+      // in 2021 we have 1 demonstrator chamber in 2024 we have 3 chambers.
+      // Need to account for both
+      doSuper = (nGE21 < 4 && fvGE2.nextSibling());
     } else {
       edm::LogError("GEMGeometryParsFromDD") << "Failed to find next child volume. Cannot determine presence of GE 2/1";
     }


### PR DESCRIPTION
#### PR description:

The GEMGeometryParsFromDDD has a check for the demonstrator which doesn't work for the 2024 geometry. This PR allows the geometry to be dumped properly in order to make a tag.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Dumped the 2024 geometry (with modified version of [1] to load 2024) and checked that it ran over some 2024 data to read out the new GEM chambers (using also the 2024 alignments and channel map). Since it only affects writing the geometry, there should be no visible changes with this PR.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
