### PR TITLE
Add NanoAOD flavours parameter to PromptReco

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,nanoFlavours,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -71,6 +71,8 @@ class Reco(Scenario):
                     miniAODStep = ',PAT'
                 if a['dataTier'] in ['NANOAOD', 'NANOEDMAOD']:
                     nanoAODStep = ',NANO'
+                    if "nanoFlavours" in args:
+                        nanoAODStep += nanoFlavours(args['nanoFlavours'])
                     args['customs'].append('PhysicsTools/NanoAOD/nano_cff.nanoL1TrigObjCustomize')
 
         self._checkRepackedFlag(options, **args)

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -132,6 +132,20 @@ def dqmSeq(args,default):
     else:
         return default
 
+def nanoFlavours(flavours):
+    """
+    _nanoFlavours_
+
+    Creates and returns the configuration string for the NANO flavours
+    from the list of flavors to be run.
+
+    """
+
+    step = ''
+    if len(flavours) >0 :
+        step = ':'+('+'.join(flavours))
+    return step
+
 def gtNameAndConnect(globalTag, args):
     if 'globalTagConnect' in args and args['globalTagConnect'] != '':
         return globalTag + ','+args['globalTagConnect']        

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -27,6 +27,7 @@ class RunPromptReco:
         self.noOutput = False
         self.globalTag = None
         self.inputLFN = None
+        self.nanoFlavours = None
         self.alcaRecos = None
         self.PhysicsSkims = None
         self.dqmSeq = None
@@ -92,6 +93,9 @@ class RunPromptReco:
                                      'moduleLabel' : "write_%s" % dataTier })
                 kwds['outputs'] = outputs
 
+                if self.nanoFlavours:
+                    kwds['nanoFlavours'] = self.nanoFlavours
+
                 if self.alcaRecos:
                     kwds['skims'] = self.alcaRecos
 
@@ -103,7 +107,7 @@ class RunPromptReco:
 
                 if self.setRepacked:
                     kwds['repacked'] = self.isRepacked
-                
+
                 if self.nThreads:
                     kwds['nThreads'] = self.nThreads
 
@@ -148,7 +152,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "miniaod", "nanoaod", "dqm", "dqmio", "no-output", "nThreads=", 
-             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=", "isRepacked", "isNotRepacked" ]
+             "global-tag=", "lfn=", "nanoFlavours=", "alcarecos=", "PhysicsSkims=", "dqmSeq=", "isRepacked", "isNotRepacked" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -158,20 +162,21 @@ Where options are:
  --aod (to enable AOD output)
  --miniaod (to enable MiniAOD output)
  --nanoaod (to enable NanoAOD output)
+ --nanoFlavours=flavour_plus_separated_list
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
  --isRepacked --isNotRepacked (to override default repacked flags)
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
- --alcarecos=alcareco_plus_seprated_list
- --PhysicsSkims=skim_plus_seprated_list
+ --alcarecos=alcareco_plus_separated_list
+ --PhysicsSkims=skim_plus_separated_list
  --dqmSeq=dqmSeq_plus_separated_list
  --nThreads=Number_of_cores_or_Threads_used
 Example:
 python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
 python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
-python RunPromptReco.py --scenario=ppEra_Run2_2016 --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias --PhysicsSkims=@SingleMuon
+python RunPromptReco.py --scenario=ppEra_Run2_2016 --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --nanoFlavours=@MUPOG --alcarecos=TkAlMinBias+SiStripCalMinBias --PhysicsSkims=@SingleMuon
 """
     try:
         opts, args = getopt.getopt(sys.argv[1:], "", valid)
@@ -206,6 +211,8 @@ python RunPromptReco.py --scenario=ppEra_Run2_2016 --reco --aod --dqmio --global
             recoinator.globalTag = arg
         if opt == "--lfn" :
             recoinator.inputLFN = arg
+        if opt == "--nanoFlavours":
+            recoinator.nanoFlavours = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--alcarecos":
             recoinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
         if opt == "--PhysicsSkims":

--- a/Configuration/DataProcessing/test/run_CfgTest_8.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_8.sh
@@ -14,6 +14,7 @@ declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --nanoFlavours=@PHYS"
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@Muon0"
 done
 


### PR DESCRIPTION
#### PR description:

Adds the capacity to specify flavours for NanoAOD in PromptReco 


#### PR validation:
Using the updated `RunPromptReco.py` with `--nanoFlavours=@PHYS+@MUPOG`, ConfigBuilder shows the proper flavours:
```
$ python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario=ppEra_Run3_2023 --reco --aod --miniaod --nanoaod --dqmio --global-tag 140X_dataRun3_Prompt_v2 --lfn=file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2024/Muon0/RAW/v13033023/000/369/998/00000/0181983c-310f-4b2e-8d66-57d58a3bf1c1.root --PhysicsSkims=ZMu+EXODisappTrk+LogError+LogErrorMonitor+EXOCSCCluster+EXODisappMuon --nanoFlavours=@PHYS+@MUPOG
Retrieved Scenario: ppEra_Run3_2023
...
Step: RAW2DIGI Spec: 
Step: L1Reco Spec: 
Step: RECO Spec: 
Step: ALCAPRODUCER Spec: ['@allForPrompt']
Step: SKIM Spec: ['ZMu', 'EXODisappTrk', 'LogError', 'LogErrorMonitor', 'EXOCSCCluster', 'EXODisappMuon']
Step: PAT Spec: 
Step: NANO Spec: ['@PHYS', '@MUPOG']
in prepare_nano @PHYS+@MUPOG
Step: DQM Spec: 
...
```
Here without `--nanoFlavours`:
```
$ python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario=ppEra_Run3_2023 --reco --aod --miniaod --nanoaod --dqmio --global-tag 140X_dataRun3_Prompt_v2 --lfn=file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2024/Muon0/RAW/v13033023/000/369/998/00000/0181983c-310f-4b2e-8d66-57d58a3bf1c1.root --PhysicsSkims=ZMu+EXODisappTrk+LogError+LogErrorMonitor+EXOCSCCluster+EXODisappMuon                            
Retrieved Scenario: ppEra_Run3_2023
...
Step: RAW2DIGI Spec: 
Step: L1Reco Spec: 
Step: RECO Spec: 
Step: ALCAPRODUCER Spec: ['@allForPrompt']
Step: SKIM Spec: ['ZMu', 'EXODisappTrk', 'LogError', 'LogErrorMonitor', 'EXOCSCCluster', 'EXODisappMuon']
Step: PAT Spec: 
Step: NANO Spec: 
in prepare_nano nanoSequence
Step: DQM Spec: 
...
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_14_0_X
Backport: #44454 
