### PR TITLE
Fix track sort order in PixelTrackProducerFromSoAAlpaka [14.0.x]

### DIFF
--- a/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
+++ b/RecoTracker/PixelTrackFitting/plugins/PixelTrackProducerFromSoAAlpaka.cc
@@ -178,8 +178,12 @@ void PixelTrackProducerFromSoAAlpaka<TrackerTraits>::produce(edm::StreamID strea
   //sort index by pt
   std::vector<int32_t> sortIdxs(nTracks);
   std::iota(sortIdxs.begin(), sortIdxs.end(), 0);
+  // sort good-quality tracks by pt, keep bad-quality tracks at the bottom
   std::sort(sortIdxs.begin(), sortIdxs.end(), [&](int32_t const i1, int32_t const i2) {
-    return tsoa.view()[i1].pt() > tsoa.view()[i2].pt();
+    if (quality[i1] >= minQuality_ && quality[i2] >= minQuality_)
+      return tsoa.view()[i1].pt() > tsoa.view()[i2].pt();
+    else
+      return quality[i1] > quality[i2];
   });
 
   //store the index of the SoA: indToEdm[index_SoAtrack] -> index_edmTrack (if it exists)


### PR DESCRIPTION
#### PR description:

Port the fix to `PixelTrackProducerFromSoA` from #42428 by @silviodonato to `PixelTrackProducerFromSoAAlpaka`.

Clean up `PixelTrackProducerFromSoA` and `PixelTrackProducerFromSoAAlpaka`.

#### PR validation:

The online HLT menu v1 was run with these changes.

#### Backport status

Backported of #44441 for data taking.