### PR TITLE
Initialize statsGuard_ on LogErrorEventFilter

### DIFF
--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -116,7 +116,7 @@ private:
   size_t maxSavedEventsPerLumi_;
   bool verbose_, veryVerbose_;
   bool taggedMode_, forcedValue_;
-  mutable std::atomic<bool> statsGuard_;
+  mutable std::atomic<bool> statsGuard_{false};
 
   template <typename Collection>
   static void increment(ErrorSet &scoreboard, Collection &list);


### PR DESCRIPTION
#### PR description:

I found `statsGuard_` being uninitialized while running valgrind a workflow mentioned in https://github.com/cms-sw/cmssw/issues/44413. This fix might address those failures.

#### PR validation:

Valgrind warning is gone.