### PR TITLE
[AArch64, PowerPC] Fix deprecated-copy warnings in extBasic{2,3}DVector

### DIFF
--- a/DataFormats/GeometryVector/interface/private/extBasic2DVector.h
+++ b/DataFormats/GeometryVector/interface/private/extBasic2DVector.h
@@ -26,6 +26,9 @@ public:
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
   Basic2DVector(const Basic2DVector& p) : v(p.v) {}
 
+  /// Assignment operator
+  Basic2DVector& operator=(const Basic2DVector&) = default;
+
   template <typename U>
   Basic2DVector(const Basic2DVector<U>& p) : v{T(p.v[0]), T(p.v[1])} {}
 

--- a/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
@@ -45,6 +45,9 @@ public:
   /// Copy constructor from same type. Should not be needed but for gcc bug 12685
   Basic3DVector(const Basic3DVector& p) : v(p.v) {}
 
+  /// Assignment operator
+  Basic3DVector& operator=(const Basic3DVector&) = default;
+
   /// Copy constructor and implicit conversion from Basic3DVector of different precision
   template <class U>
   Basic3DVector(const Basic3DVector<U>& p) : v{T(p.v[0]), T(p.v[1]), T(p.v[2]), T(p.v[3])} {}


### PR DESCRIPTION
#### PR description:

Fix deprecated-copy warnings in PowerPC and AArch64 builds:

```
  .../src/DataFormats/L1THGCal/interface/HGCalClusterT.h:292:23: warning: implicitly-declared 'constexpr Basic3DVector<float>& Basic3DVector<float>::operator=(const Basic3DVector<float>&)' is deprecated [-Wdeprecated-copy]
   292 |         clusterCentre = clusterCentre * mipPt_ + constituentCentre * cMipt;
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from .../src/DataFormats/GeometryVector/interface/Basic3DVector.h:7,
                 from .../src/DataFormats/GeometryVector/interface/PV3DBase.h:4,
                 from .../src/DataFormats/GeometryVector/interface/Point3DBase.h:5,
                 from .../src/DataFormats/GeometryVector/interface/GlobalPoint.h:5,
                 from .../src/DataFormats/L1THGCal/interface/HGCalTriggerCell.h:4,
                 from .../src/DataFormats/L1THGCal/interface/HGCalCluster.h:6:
.../src/DataFormats/GeometryVector/interface/private/extBasic3DVector.h:46:3: note: because 'Basic3DVector<float>' has user-provided 'Basic3DVector<T>::Basic3DVector(const Basic3DVector<T>&) [with T = float]'
   46 |   Basic3DVector(const Basic3DVector& p) : v(p.v) {}
      |   ^~~~~~~~~~~~~
In file included from .../src/DataFormats/L1THGCal/interface/HGCalMulticluster.h:6,
                 from src/DataFormats/L1THGCal/src/HGCalMulticluster.cc:1:
.../src/DataFormats/L1THGCal/interface/HGCalClusterT.h: In instantiation of 'void l1t::HGCalClusterT<C>::updateP4AndPosition(const edm::Ptr<T>&, bool, float) [with C = l1t::HGCalCluster]':
.../src/DataFormats/L1THGCal/interface/HGCalClusterT.h:66:7:   required from 'void l1t::HGCalClusterT<C>::addConstituent(const edm::Ptr<T>&, bool, float) [with C = l1t::HGCalCluster]'
.../src/DataFormats/L1THGCal/interface/HGCalClusterT.h:44:7:   required from 'l1t::HGCalClusterT<C>::HGCalClusterT(const edm::Ptr<T>&, float) [with C = l1t::HGCalCluster]'
src/DataFormats/L1THGCal/src/HGCalMulticluster.cc:9:96:   required from here
  .../src/DataFormats/L1THGCal/interface/HGCalClusterT.h:292:23: warning: implicitly-declared 'constexpr Basic3DVector<float>& Basic3DVector<float>::operator=(const Basic3DVector<float>&)' is deprecated [-Wdeprecated-copy]
   292 |         clusterCentre = clusterCentre * mipPt_ + constituentCentre * cMipt;
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from .../src/DataFormats/GeometryVector/interface/Basic3DVector.h:7,
                 from .../src/DataFormats/GeometryVector/interface/PV3DBase.h:4,
                 from .../src/DataFormats/GeometryVector/interface/Point3DBase.h:5,
                 from .../src/DataFormats/GeometryVector/interface/GlobalPoint.h:5,
                 from .../src/DataFormats/L1THGCal/interface/HGCalClusterT.h:6:
.../src/DataFormats/GeometryVector/interface/private/extBasic3DVector.h:46:3: note: because 'Basic3DVector<float>' has user-provided 'Basic3DVector<T>::Basic3DVector(const Basic3DVector<T>&) [with T = float]'
   46 |   Basic3DVector(const Basic3DVector& p) : v(p.v) {}
      |   ^~~~~~~~~~~~~
```

Same fix as in https://github.com/cms-sw/cmssw/pull/43460, but for `extBasic{2,3}DVector` instead of `sseBasic{2,3}DVector`.

#### PR validation:

Local tests