### PR TITLE
Add l1tPhase2L1CaloEGammaEmulator to the phase 2 L1 event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -237,6 +237,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tTkMuonsGmt_*_*',
         'keep *_l1tSAMuonsGmt_*_*',
         'keep *_l1tTkMuonsGmtLowPtFix_*_*', # in the long run this should be removed, but these fix objects will be used for now.
+	'keep *_l1tPhase2L1CaloEGammaEmulator_*_*',
         ]
     obj.outputCommands += l1Phase2Digis
 


### PR DESCRIPTION
This PR adds a new collection to the phase-2 L1 event content.

This PR superseeds https://github.com/cms-sw/cmssw/pull/43872.