### PR TITLE
[CPP20] Remove deprecated implicit capture of this

### DIFF
--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -167,7 +167,7 @@ namespace edm {
                              std::shared_ptr<ESHandleExceptionFactory>& whyFailedFactory) const {
         DataKey const* dataKey = nullptr;
         if (iResolverIndex.value() == std::numeric_limits<int>::max()) {
-          whyFailedFactory = makeESHandleExceptionFactory([=] {
+          whyFailedFactory = makeESHandleExceptionFactory([this] {
             NoProductResolverException<DataT> ex(this->key(), {});
             return std::make_exception_ptr(ex);
           });
@@ -178,7 +178,7 @@ namespace edm {
                iResolverIndex.value() < static_cast<ESResolverIndex::Value_t>(keysForProxies_.size()));
         void const* pValue = this->getFromResolverAfterPrefetch(iResolverIndex, iTransientAccessOnly, oDesc, dataKey);
         if (nullptr == pValue) {
-          whyFailedFactory = makeESHandleExceptionFactory([=] {
+          whyFailedFactory = makeESHandleExceptionFactory([this, dataKey] {
             NoProductResolverException<DataT> ex(this->key(), *dataKey);
             return std::make_exception_ptr(ex);
           });

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -1,5 +1,8 @@
 /**----------------------------------------------------------------------
   ----------------------------------------------------------------------*/
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wc++20-extensions"
+#endif
 
 #include "FWCore/Framework/interface/Principal.h"
 
@@ -581,7 +584,7 @@ namespace edm {
 
     ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, sra, mcc);
     if (result == nullptr) {
-      return BasicHandle(makeHandleExceptionFactory([=]() -> std::shared_ptr<cms::Exception> {
+      return BasicHandle(makeHandleExceptionFactory([=, this]() -> std::shared_ptr<cms::Exception> {
         return makeNotFoundException(
             "getByLabel",
             kindOfType,

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -5,6 +5,10 @@ Toy EDProducers of Ints for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wc++20-extensions"
+#endif
+
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -610,7 +614,7 @@ namespace edmtest {
   public:
     explicit ManyIntWhenRegisteredProducer(edm::ParameterSet const& p)
         : sourceLabel_(p.getParameter<std::string>("src")) {
-      callWhenNewProductsRegistered([=](edm::BranchDescription const& iBranch) {
+      callWhenNewProductsRegistered([=, this](edm::BranchDescription const& iBranch) {
         if (iBranch.moduleLabel() == sourceLabel_) {
           if (iBranch.branchType() != edm::InEvent) {
             throw edm::Exception(edm::errors::UnimplementedFeature)

--- a/FWCore/Modules/src/SwitchProducer.cc
+++ b/FWCore/Modules/src/SwitchProducer.cc
@@ -1,3 +1,7 @@
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Wc++20-extensions"
+#endif
+
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -24,7 +28,7 @@ namespace edm {
     auto const& moduleLabel = iConfig.getParameter<std::string>("@module_label");
     auto const& chosenLabel = iConfig.getUntrackedParameter<std::string>("@chosen_case");
     auto const& processName = iConfig.getUntrackedParameter<std::string>("@process_name");
-    callWhenNewProductsRegistered([=](edm::BranchDescription const& iBranch) {
+    callWhenNewProductsRegistered([=, this](edm::BranchDescription const& iBranch) {
       if (iBranch.moduleLabel() == chosenLabel and iBranch.processName() == processName) {
         if (iBranch.branchType() != InEvent) {
           throw Exception(errors::UnimplementedFeature)

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/Transition.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/DeviceProductType.h"

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
@@ -53,7 +53,7 @@ void PatternRecognitionbyFastJet<TILES>::buildJetAndTracksters(std::vector<Pseud
   }
 
   auto trackster_idx = result.size();
-  auto jetsSize = std::count_if(jets.begin(), jets.end(), [=](fastjet::PseudoJet jet) {
+  auto jetsSize = std::count_if(jets.begin(), jets.end(), [this](fastjet::PseudoJet jet) {
     return jet.constituents().size() > static_cast<unsigned int>(minNumLayerCluster_);
   });
   result.resize(trackster_idx + jetsSize);


### PR DESCRIPTION
#### PR description:

Fix deprecated implicit capture of `this` in lambda-functions: [ISO/IEC JTC 1/SC 22/WG 21 P0806R2](https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2018/p0806r2.html):

```
>> Compiling  src/FWCore/Framework/src/ProductResolvers.cc
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/bin/c++ -c -DGNU_GCC -D_GNU_SOURCE -DTBB_USE_GLIBCXX_VERSION=120301 -DTBB_SUPPRESS_DEPRECATED_MESSAGES -DTBB_PREVIEW_RESUMABLE_TASKS=1 -DTBB_PREVIEW_TASK_GROUP_EXTENSIONS=1 -DBOOST_SPIRIT_THREADSAFE -DPHOENIX_THREADSAFE -DBOOST_MATH_DISABLE_STD_FPCLASSIFY -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX -DCMSSW_GIT_HASH='CMSSW_14_1_CPP20_X_2024-03-15-1100' -DPROJECT_NAME='CMSSW' -DPROJECT_VERSION='CMSSW_14_1_CPP20_X_2024-03-15-1100' -I/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/0a59af9379b9d52eacf3467d0009648c/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_CPP20_X_2024-03-15-1100/src -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/pcre/8.43-37eb2e8b73bab83d6645ecfd5d73dcaa/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/boost/1.80.0-fe384ba674f25ab3d69ff12635560905/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/bz2lib/1.0.6-d065ccd79984efc6d4660f410e4c81de/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/libuuid/2.34-27ce4c3579b5b1de2808ea9c4cd8ed29/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/lcg/root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include -isystem/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tbb/v2021.9.0-80bf70515b37b5bee8132dd589b2bef9/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/xz/5.2.5-6f3f49b07db84e10c9be594a1176c114/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/zlib/1.2.11-51072030b7f93c3ac6c4235f21e413cb/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/fmt/8.0.1-786658da8424a36fd9daec568588b7aa/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/md5/1.0.0-5b594b264e04ae51e893b1d69a797ec6/include -I/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/tinyxml2/6.2.0-b248972f299359d73b1605c96291455f/include -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++20 -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -Wno-error=array-bounds -Warray-bounds -fuse-ld=bfd -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-unused-parameter -Wunused -Wparentheses -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto=auto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -fPIC -MMD -MF tmp/el8_amd64_gcc12/src/FWCore/Framework/src/FWCoreFramework/ProductResolvers.cc.d src/FWCore/Framework/src/ProductResolvers.cc -o tmp/el8_amd64_gcc12/src/FWCore/Framework/src/FWCoreFramework/ProductResolvers.cc.o
src/FWCore/Framework/src/Principal.cc: In lambda function:
  src/FWCore/Framework/src/Principal.cc:584:53: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
   584 |       return BasicHandle(makeHandleExceptionFactory([=]() -> std::shared_ptr<cms::Exception> {
      |                                                     ^
src/FWCore/Framework/src/Principal.cc:584:53: note: add explicit 'this' or '*this' capture
```

#### PR validation:

Bot tests