### PR TITLE
[14_0_X] Produce r9 and trackIso(hollow cone) in EGamma development path

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaHollowTrackIsoL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaHollowTrackIsoL1Seeded_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltEgammaHollowTrackIsoL1Seeded = cms.EDProducer("EgammaHLTPhotonTrackIsolationProducersRegional",
+    countTracks = cms.bool(False),
+    egTrkIsoConeSize = cms.double(0.29),
+    egTrkIsoPtMin = cms.double(1.0),
+    egTrkIsoRSpan = cms.double(999999.0),
+    egTrkIsoStripBarrel = cms.double(0.03),
+    egTrkIsoStripEndcap = cms.double(0.03),
+    egTrkIsoVetoConeSize = cms.double(0.06),
+    egTrkIsoZSpan = cms.double(999999.0),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesL1Seeded"),
+    trackProducer = cms.InputTag("generalTracks")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaHollowTrackIsoUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaHollowTrackIsoUnseeded_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltEgammaHollowTrackIsoUnseeded = cms.EDProducer("EgammaHLTPhotonTrackIsolationProducersRegional",
+    countTracks = cms.bool(False),
+    egTrkIsoConeSize = cms.double(0.29),
+    egTrkIsoPtMin = cms.double(1.0),
+    egTrkIsoRSpan = cms.double(999999.0),
+    egTrkIsoStripBarrel = cms.double(0.03),
+    egTrkIsoStripEndcap = cms.double(0.03),
+    egTrkIsoVetoConeSize = cms.double(0.06),
+    egTrkIsoZSpan = cms.double(999999.0),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    trackProducer = cms.InputTag("generalTracks")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaR9L1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaR9L1Seeded_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+hltEgammaR9L1Seeded  = cms.EDProducer( "EgammaHLTR9IDProducer",
+                                       ecalRechitEB = cms.InputTag("hltRechitInRegionsECAL","EcalRecHitsEB"),
+                                       ecalRechitEE = cms.InputTag("hltRechitInRegionsECAL","EcalRecHitsEE"),
+                                       recoEcalCandidateProducer = cms.InputTag( "hltEgammaCandidatesL1Seeded" )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaR9Unseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltEgammaR9Unseeded_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+hltEgammaR9Unseeded  = cms.EDProducer( "EgammaHLTR9IDProducer",
+                                       ecalRechitEB = cms.InputTag( "hltEcalRecHit:EcalRecHitsEB" ),
+                                       ecalRechitEE = cms.InputTag( "hltEcalRecHit:EcalRecHitsEE" ),
+                                       recoEcalCandidateProducer = cms.InputTag( "hltEgammaCandidatesUnseeded" )
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/tasks/HLTEle5OpenL1SeededTask_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/tasks/HLTEle5OpenL1SeededTask_cfi.py
@@ -10,6 +10,8 @@ from ..modules.hltEgammaHcalPFClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsL1Seeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHoverEL1Seeded_cfi import *
+from ..modules.hltEgammaR9L1Seeded_cfi import *
+from ..modules.hltEgammaHollowTrackIsoL1Seeded_cfi import *
 
 HLTEle5OpenL1SeededTask = cms.Task(
     hltEgammaCandidatesL1Seeded,
@@ -21,5 +23,7 @@ HLTEle5OpenL1SeededTask = cms.Task(
     hltEgammaHGCALIDVarsL1Seeded,
     hltEgammaHGCalLayerClusterIsoL1Seeded,
     hltEgammaHcalPFClusterIsoL1Seeded,
-    hltEgammaHoverEL1Seeded
+    hltEgammaHoverEL1Seeded,
+    hltEgammaR9L1Seeded,
+    hltEgammaHollowTrackIsoL1Seeded
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/tasks/HLTEle5OpenUnseededTask_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/tasks/HLTEle5OpenUnseededTask_cfi.py
@@ -10,6 +10,8 @@ from ..modules.hltEgammaHcalPFClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsUnseeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHoverEUnseeded_cfi import *
+from ..modules.hltEgammaR9Unseeded_cfi import *
+from ..modules.hltEgammaHollowTrackIsoUnseeded_cfi import *
 
 HLTEle5OpenUnseededTask = cms.Task(
     hltEgammaCandidatesUnseeded,
@@ -21,5 +23,7 @@ HLTEle5OpenUnseededTask = cms.Task(
     hltEgammaHGCALIDVarsUnseeded,
     hltEgammaHGCalLayerClusterIsoUnseeded,
     hltEgammaHcalPFClusterIsoUnseeded,
-    hltEgammaHoverEUnseeded
+    hltEgammaHoverEUnseeded,
+    hltEgammaR9Unseeded,
+    hltEgammaHollowTrackIsoUnseeded
 )


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/44423. It's not a verbatim backport, which is not possible in this case as there were some technical changes in 14_1_X (https://github.com/cms-sw/cmssw/pull/44025) which was not backported to 14_0_X.

#### PR validation:

Phase2 HLT menu runs fine.