### PR TITLE
DeepTau - Do not call TF inference with empty grid

### DIFF
--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -732,7 +732,10 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
 
 std::vector<float> L2TauNNProducer::getTauScore(const tensorflow::Tensor& cellGridMatrix) {
   std::vector<tensorflow::Tensor> pred_tensor;
-  tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
+  // Check for empty input
+  if (cellGridMatrix.NumElements() != 0) {
+    tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
+  }
   const int nTau = cellGridMatrix.shape().dim_size(0);
   std::vector<float> pred_vector(nTau);
   for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -731,17 +731,16 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
 }
 
 std::vector<float> L2TauNNProducer::getTauScore(const tensorflow::Tensor& cellGridMatrix) {
-  std::vector<tensorflow::Tensor> pred_tensor;
-  // Check for empty input
-  if (cellGridMatrix.NumElements() != 0) {
-    tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
-  }
   const int nTau = cellGridMatrix.shape().dim_size(0);
   std::vector<float> pred_vector(nTau);
-  for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {
-    pred_vector[tau_idx] = pred_tensor[0].matrix<float>()(tau_idx, 0);
+  if (nTau > 0) {
+    // Only run the inference if there are taus to process
+    std::vector<tensorflow::Tensor> pred_tensor;
+    tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
+    for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {
+      pred_vector[tau_idx] = pred_tensor[0].matrix<float>()(tau_idx, 0);
+    }
   }
-
   return pred_vector;
 }
 

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -550,76 +550,75 @@ private:
       std::cout << "<DeepTauId::createConvFeatures (is_inner = " << is_inner << ")>:" << std::endl;
       std::cout << "number of valid cells = " << grid.num_valid_cells() << std::endl;
     }
+
+    const size_t n_valid_cells = grid.num_valid_cells();
+    tensorflow::Tensor predTensor;
     tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
 
-    eGammaTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
-        tensorflow::DT_FLOAT,
-        tensorflow::TensorShape{
-            (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::EgammaBlockInputs::NumberOfInputs});
-    muonTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
-        tensorflow::DT_FLOAT,
-        tensorflow::TensorShape{
-            (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::MuonBlockInputs::NumberOfInputs});
-    hadronsTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
-        tensorflow::DT_FLOAT,
-        tensorflow::TensorShape{
-            (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::HadronBlockInputs::NumberOfInputs});
-
-    eGammaTensor_[is_inner]->flat<float>().setZero();
-    muonTensor_[is_inner]->flat<float>().setZero();
-    hadronsTensor_[is_inner]->flat<float>().setZero();
-
-    unsigned idx = 0;
-    for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
-      for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
-        if (debug_level >= 2) {
-          std::cout << "processing ( eta = " << eta << ", phi = " << phi << " )" << std::endl;
-        }
-        const CellIndex cell_index{eta, phi};
-        const auto cell_iter = grid.find(cell_index);
-        if (cell_iter != grid.end()) {
-          if (debug_level >= 2) {
-            std::cout << " creating inputs for ( eta = " << eta << ", phi = " << phi << " ): idx = " << idx
-                      << std::endl;
-          }
-          const Cell& cell = cell_iter->second;
-          createEgammaBlockInputs<CandidateCastType>(idx,
-                                                     tau,
-                                                     tau_index,
-                                                     tau_ref,
-                                                     pv,
-                                                     rho,
-                                                     electrons,
-                                                     pfCands,
-                                                     cell,
-                                                     tau_funcs,
-                                                     is_inner,
-                                                     *eGammaTensor_[is_inner]);
-          createMuonBlockInputs<CandidateCastType>(
-              idx, tau, tau_index, tau_ref, pv, rho, muons, pfCands, cell, tau_funcs, is_inner, *muonTensor_[is_inner]);
-          createHadronsBlockInputs<CandidateCastType>(
-              idx, tau, tau_index, tau_ref, pv, rho, pfCands, cell, tau_funcs, is_inner, *hadronsTensor_[is_inner]);
-          idx += 1;
-        } else {
-          if (debug_level >= 2) {
-            std::cout << " skipping creation of inputs, because ( eta = " << eta << ", phi = " << phi
-                      << " ) is not in the grid !!" << std::endl;
-          }
-        }
-      }
-    }
-    tensorflow::Tensor predTensor;
     //check if at least one input is there to
     //avoid calling TF with empty grid #TODO understand why the grid is empty
-    if (idx != 0) {
-      predTensor = getPartialPredictions(is_inner);
-    } else {
-      if (debug_level >= 2) {
-        std::cout << " no valid cells found, skipped TF evaluation" << std::endl;
+    if (n_valid_cells > 0) {
+      eGammaTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
+          tensorflow::DT_FLOAT,
+          tensorflow::TensorShape{
+              (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::EgammaBlockInputs::NumberOfInputs});
+      muonTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
+          tensorflow::DT_FLOAT,
+          tensorflow::TensorShape{
+              (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::MuonBlockInputs::NumberOfInputs});
+      hadronsTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
+          tensorflow::DT_FLOAT,
+          tensorflow::TensorShape{
+              (long long int)grid.num_valid_cells(), 1, 1, dnn_inputs_v2::HadronBlockInputs::NumberOfInputs});
+
+      eGammaTensor_[is_inner]->flat<float>().setZero();
+      muonTensor_[is_inner]->flat<float>().setZero();
+      hadronsTensor_[is_inner]->flat<float>().setZero();
+
+      unsigned idx = 0;
+      for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
+        for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
+          if (debug_level >= 2) {
+            std::cout << "processing ( eta = " << eta << ", phi = " << phi << " )" << std::endl;
+          }
+          const CellIndex cell_index{eta, phi};
+          const auto cell_iter = grid.find(cell_index);
+          if (cell_iter != grid.end()) {
+            if (debug_level >= 2) {
+              std::cout << " creating inputs for ( eta = " << eta << ", phi = " << phi << " ): idx = " << idx
+                        << std::endl;
+            }
+            const Cell& cell = cell_iter->second;
+            createEgammaBlockInputs<CandidateCastType>(idx,
+                                                       tau,
+                                                       tau_index,
+                                                       tau_ref,
+                                                       pv,
+                                                       rho,
+                                                       electrons,
+                                                       pfCands,
+                                                       cell,
+                                                       tau_funcs,
+                                                       is_inner,
+                                                       *eGammaTensor_[is_inner]);
+            createMuonBlockInputs<CandidateCastType>(
+                idx, tau, tau_index, tau_ref, pv, rho, muons, pfCands, cell, tau_funcs, is_inner, *muonTensor_[is_inner]);
+            createHadronsBlockInputs<CandidateCastType>(
+                idx, tau, tau_index, tau_ref, pv, rho, pfCands, cell, tau_funcs, is_inner, *hadronsTensor_[is_inner]);
+            idx += 1;
+          } else {
+            if (debug_level >= 2) {
+              std::cout << " skipping creation of inputs, because ( eta = " << eta << ", phi = " << phi
+                        << " ) is not in the grid !!" << std::endl;
+            }
+          }
+        }
       }
+      // Calling TF prediction only if n_valid_cells > 0
+      predTensor = getPartialPredictions(is_inner);
     }
 
-    idx = 0;
+    unsigned idx = 0;
     for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
       for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {
         const CellIndex cell_index{eta, phi};

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -530,6 +530,7 @@ private:
                       {"outer_all_dropout_4/Identity"},
                       &pred_vector);
     }
+
     return pred_vector.at(0);
   }
 
@@ -547,8 +548,10 @@ private:
                           bool is_inner) {
     if (debug_level >= 2) {
       std::cout << "<DeepTauId::createConvFeatures (is_inner = " << is_inner << ")>:" << std::endl;
+      std::cout << "number of valid cells = " << grid.num_valid_cells() << std::endl;
     }
     tensorflow::Tensor& convTensor = *convTensor_.at(is_inner);
+
     eGammaTensor_[is_inner] = std::make_unique<tensorflow::Tensor>(
         tensorflow::DT_FLOAT,
         tensorflow::TensorShape{
@@ -605,8 +608,17 @@ private:
         }
       }
     }
+    tensorflow::Tensor predTensor;
+    //check if at least one input is there to
+    //avoid calling TF with empty grid #TODO understand why the grid is empty
+    if (idx != 0) {
+      predTensor = getPartialPredictions(is_inner);
+    } else {
+      if (debug_level >= 2) {
+        std::cout << " no valid cells found, skipped TF evaluation" << std::endl;
+      }
+    }
 
-    const auto predTensor = getPartialPredictions(is_inner);
     idx = 0;
     for (int eta = -grid.maxEtaIndex(); eta <= grid.maxEtaIndex(); ++eta) {
       for (int phi = -grid.maxPhiIndex(); phi <= grid.maxPhiIndex(); ++phi) {


### PR DESCRIPTION
#### PR description:

Fix DeepTau issue https://github.com/cms-sw/cmssw/issues/44333

```
[2] Calling method for module DeepTauId/'hltHpsPFTauDeepTauProducerForVBFIsoTau'
Exception Message:
error while running session: INVALID_ARGUMENT: Incompatible shapes: [0,1,1,64] vs. [154]
```

The number of `valid_grid_cells` [here](https://github.com/cms-sw/cmssw/blob/619b1aa756a2181a5d946f22b4bba8c96c57b84d/RecoTauTag/RecoTau/plugins/DeepTauId.cc#L1123) is 0 for some events and this is creating a `TF::Tensor` with shape [0, 1, 1, N].  

When this input is passed to a TF model executed on a CPU without `AVX512F AVX512_VNNI`,  the model is executed and returns an empty output without complaining.  When `AVX512F AVX512_VNNI` instructions are present, the TF executor complains. 

This PR avoids calling the TF inference if empty inputs are detected. 

The grid should never be empty. The issue will be followed up with Tau experts (enter here issue number..)

#### PR validation:
Works on the issue reproducer from https://github.com/cms-sw/cmssw/issues/44333#issuecomment-1989632992
- lxplus901 for AVX512
- Pick event:
```
edmCopyPickMerge outputFile=pickevents.root eventsToProcess=367131:196942831 inputFiles=/store/data/Run2023C/DisplacedJet/RAW/v1/000/367/131/00000/9f3f571f-6dc9-4bda-a68b-5d1b9a5fc3ac.root
```
- Run:
```
cmsDriver.py step2 --conditions auto:run3_hlt_relval --data --datatier FEVTDEBUGHLT --era Run3_2023 --eventcontent FEVTDEBUGHLT --filein file:pickevents.root --fileout file:step2.root --nStreams 4 --nThreads 8 --number -1 --process reHLT --python_filename step_2_cfg.py --step L1REPACK:Full,HLT:@relval2024 --accelerators cpu
```