### PR TITLE
Use default operator= in CondFormats/CSCObjects

### DIFF
--- a/CondFormats/CSCObjects/interface/CSCDQM_DCSBase.h
+++ b/CondFormats/CSCObjects/interface/CSCDQM_DCSBase.h
@@ -88,15 +88,6 @@ namespace cscdqm {
     /** Get CSC Detector Id object from the address */
     CSCDetId getDetId() const { return CSCDetId(iendcap, istation, iring, ichamber); }
 
-    /** Assignment operator */
-    DCSAddressType& operator=(const DCSAddressType& a) {
-      iendcap = a.iendcap;
-      istation = a.istation;
-      iring = a.iring;
-      ichamber = a.ichamber;
-      return *this;
-    }
-
     /** Output stream operator */
     friend std::ostream& operator<<(std::ostream& out, const DCSAddressType& a) {
       std::ostringstream os;

--- a/CondFormats/CSCObjects/interface/CSCDQM_DCSData.h
+++ b/CondFormats/CSCObjects/interface/CSCDQM_DCSData.h
@@ -47,14 +47,6 @@ namespace cscdqm {
       return out << os.str();
     }
 
-    TempMeasType& operator=(const TempMeasType& m) {
-      adr = m.adr;
-      board = m.board;
-      boardId = m.boardId;
-      value = m.value;
-      return *this;
-    }
-
     COND_SERIALIZABLE;
   };
 
@@ -72,13 +64,6 @@ namespace cscdqm {
       os << "position:" << m.position;
       os << " V = " << m.value << "V";
       return out << os.str();
-    }
-
-    HVVMeasType& operator=(const HVVMeasType& m) {
-      adr = m.adr;
-      position = m.position;
-      value = m.value;
-      return *this;
     }
 
     COND_SERIALIZABLE;
@@ -104,14 +89,6 @@ namespace cscdqm {
       return out << os.str();
     }
 
-    LVVMeasType& operator=(const LVVMeasType& m) {
-      adr = m.adr;
-      board = m.board;
-      boardId = m.boardId;
-      nominal_v = m.nominal_v;
-      return *this;
-    }
-
     COND_SERIALIZABLE;
   };
 
@@ -135,15 +112,6 @@ namespace cscdqm {
       os << " " << m.nominal_v << "V";
       os << " " << m.value << "A";
       return out << os.str();
-    }
-
-    LVIMeasType& operator=(const LVIMeasType& m) {
-      adr = m.adr;
-      board = m.board;
-      boardId = m.boardId;
-      nominal_v = m.nominal_v;
-      value = m.value;
-      return *this;
     }
 
     COND_SERIALIZABLE;


### PR DESCRIPTION
#### PR description:

This avoids a clang warning about deprecated auto generated copy constructors.

#### PR validation:

Building code under CMSSW_14_1_CLANG_X_2024-03-18-2300 no longer issues the warnings.