### PR TITLE
Use default op= in LASModuleProfile

### DIFF
--- a/Alignment/LaserAlignment/interface/LASModuleProfile.h
+++ b/Alignment/LaserAlignment/interface/LASModuleProfile.h
@@ -20,7 +20,6 @@ public:
   void SetValue(unsigned int theStripNumber, const double& theValue) { data.at(theStripNumber) = theValue; }
   void SetAllValuesTo(const double&);
   void DumpToArray(double[512]);
-  LASModuleProfile& operator=(const LASModuleProfile&);
   LASModuleProfile operator+(const LASModuleProfile&);
   LASModuleProfile operator-(const LASModuleProfile&);
   LASModuleProfile operator+(const double[512]);

--- a/Alignment/LaserAlignment/src/LASModuleProfile.cc
+++ b/Alignment/LaserAlignment/src/LASModuleProfile.cc
@@ -100,21 +100,6 @@ void LASModuleProfile::Init(void) {
   data.resize(512);
 }
 
-LASModuleProfile& LASModuleProfile::operator=(const LASModuleProfile& anotherProfile) {
-  ///
-  ///
-  ///
-
-  // check for self-assignment
-  if (this != &anotherProfile) {
-    for (unsigned int i = 0; i < 512; ++i) {
-      data.at(i) = anotherProfile.GetValue(i);
-    }
-  }
-
-  return *this;
-}
-
 LASModuleProfile LASModuleProfile::operator+(const LASModuleProfile& anotherProfile) {
   ///
   ///


### PR DESCRIPTION
#### PR description:

This avoids a clang warning about deprecated copy constructor.

#### PR validation:

Compiling under CMSSW_14_1_CLANG_X_2024-03-18-2300 shows the warnings went away.