### PR TITLE
TkAl: fix PV validation and PV resolution submission scripts

### DIFF
--- a/Alignment/OfflineValidation/test/PVResolutionExample.ini
+++ b/Alignment/OfflineValidation/test/PVResolutionExample.ini
@@ -1,10 +1,9 @@
-# submitPVResolutionJobs.py -j UNIT_TEST -i PVResolutionExample.ini -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -v
+# submitPVResolutionJobs.py -j UNIT_TEST -i PVResolutionExample.ini -D /JetHT/Run2022B-TkAlJetHT-PromptReco-v1/ALCARECO -v
 [Input]
-# also on afs:
-#lumimask=/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/DCSOnly/json_DCSONLY.txt
-lumimask=/eos/cms/store/group/comm_dqm/certification/Collisions18/13TeV/DCSOnly/json_DCSONLY.txt
+lumimask=/eos/user/c/cmsdqm/www/CAF/certification/Collisions22/DCSOnly_JSONS/Cert_Collisions2022_355100_362760_eraBCDEFG_13p6TeV_DCSOnly_TkPx_New.json
+trackcollection=ALCARECOTkAlJetHT
 [Validation:Prompt]
-globaltag=111X_dataRun2_v3
+globaltag=140X_dataRun3_Prompt_v2
 records=TrackerAlignmentRcd:TrackerAlignment_PCL_byRun_v2_express,TrackerAlignmentErrorExtendedRcd:TrackerAlignmentExtendedErr_2009_v2_express_IOVs,TrackerSurfaceDeformationRcd:TrackerSurafceDeformations_v1_express
-[Validation:Ultra-Legacy]
-globaltag=111X_dataRun2_v3
+[Validation:ReReco]
+globaltag=140X_dataRun3_ForTkAlReReco_v1

--- a/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
+++ b/Alignment/OfflineValidation/test/PrimaryVertexResolution_templ_cfg.py
@@ -55,6 +55,12 @@ options.register ('external',
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "record:fle.db picks the following record from this external file")
 
+options.register ('TrackCollection',
+                  'ALCARECOTkAlMinBias',
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "track collection to use")
+
 options.register ('GlobalTag',
                   '110X_dataRun3_Prompt_v3',
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
@@ -63,13 +69,14 @@ options.register ('GlobalTag',
 
 options.parseArguments()
 
+print("TrackCollection   : ", options.TrackCollection)
 print("conditionGT       : ", options.GlobalTag)
 print("conditionOverwrite: ", options.records)
 print("external conditions:", options.external)
 print("outputFile        : ", options.outputRootFile)
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr = cms.untracked.PSet(enable = cms.untracked.bool(False))
+process.MessageLogger.cerr = cms.untracked.PSet(enable = cms.untracked.bool(True)) #False to silence errors
 process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
         reportEvery = cms.untracked.int32(1000) # every 100th only
         #    limit = cms.untracked.int32(10)       # or limit to 10 printouts...
@@ -126,7 +133,7 @@ process.GlobalTag.toGet = cms.VPSet(*records)
 
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 # remove the following lines if you run on RECO files
-process.TrackRefitter.src = 'ALCARECOTkAlMinBias'
+process.TrackRefitter.src =  options.TrackCollection
 process.TrackRefitter.NavigationSchool = ''
 
 ####################################################################

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVrbr.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVrbr.sh
@@ -11,3 +11,18 @@ echo " TESTING Primary Vertex Validation run-by-run submission ..."
 submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2023D-TkAlMinBias-PromptReco-v2/ALCARECO \
   -i ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
 
+echo -e "\n\n TESTING Primary Vertex Validation script execution ..."
+# Define script name
+scriptName="PVValidation_testingOfflineGT_HLTPhysics_Run2023D_0.sh"
+
+# Create directory if it doesn't exist
+mkdir -p "./testExecution"
+
+# Copy script to the test execution directory
+cp -pr "./BASH/${scriptName}" "./testExecution/"
+
+# Change directory to the test execution directory
+cd "./testExecution" || exit 1
+
+# Execute the script and handle errors
+./"${scriptName}" || die "Failure running PVValidation script" $?

--- a/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
+++ b/Alignment/OfflineValidation/test/testingScripts/test_unitSubmitPVsplit.sh
@@ -3,5 +3,24 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo " TESTING Split Vertex Validation submission ..."
-submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO \
+submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2022B-TkAlJetHT-PromptReco-v1/ALCARECO \
   -i ${CMSSW_BASE}/src/Alignment/OfflineValidation/test/PVResolutionExample.ini --unitTest || die "Failure running Split Vertex Validation submission" $?
+
+echo -e "\n\n TESTING Primary Vertex Split script execution ..."
+# Define script name
+scriptName="batchHarvester_Prompt_0.sh"
+
+# Create directory if it doesn't exist
+mkdir -p "./testExecution"
+
+# Copy script to the test execution directory
+cp -pr "./BASH/${scriptName}" "./testExecution/"
+
+# Change directory to the test execution directory
+cd "./testExecution" || exit 1
+
+# Execute the script and handle errors
+./"${scriptName}" || die "Failure running PVSplit script" $?
+
+# Dump to screen the content of the log file
+cat log*.out


### PR DESCRIPTION
#### PR description:

The goal of this PR is to fix the scripts `submitPVResolutionJobs.py` and `submitPVValidationJobs.py` such that they can run in recent releases and with recent (Run 3) data.
The related unit tests are improved such that, in addition to technically creating the configuration to be run with HTCondor, said configuration is also tested for at least one job (running locally).

#### PR validation:

Run successfully:
   * `scram b runtests_SubmitPVsplit`
   * `scram b runtests_SubmitPVrbr`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported to CMSSW_14_0_X for 2024 data-taking purposes.