### PR TITLE
[WIP] [CPP20] Fix deprecated enum arithmetics

### DIFF
--- a/Alignment/Geners/interface/GenericIO.hh
+++ b/Alignment/Geners/interface/GenericIO.hh
@@ -351,14 +351,19 @@ namespace gs {
       // Note that the pointee itself can not be a pointer.
       typedef typename IOPointeeType<Ptr>::type Pointee;
       typedef IOTraits<Pointee> M;
-      static_assert((M::Signature & (M::ISPOINTER | M::ISSHAREDPTR)) == 0, "can not read pointers to pointers");
+      static_assert(
+          (static_cast<int>(M::Signature) & (static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR))) == 0,
+          "can not read pointers to pointers");
 
       return GenericReader<
           Stream,
           State,
           Pointee,
-          Int2Type<M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISHEAPREADABLE | M::ISPLACEREADABLE | M::ISPAIR |
-                                  M::ISTUPLE | M::ISEXTERNAL | M::ISSTRING)>>::readIntoPtr(ptr, str, s, processClassId);
+          Int2Type<static_cast<int>(M::Signature) &
+                   (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) |
+                    static_cast<int>(M::ISHEAPREADABLE) | static_cast<int>(M::ISPLACEREADABLE) |
+                    static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISTUPLE) | static_cast<int>(M::ISEXTERNAL) |
+                    static_cast<int>(M::ISSTRING))>>::readIntoPtr(ptr, str, s, processClassId);
     }
   };
 
@@ -370,14 +375,19 @@ namespace gs {
       // Note that the pointee itself can not be a pointer.
       typedef typename IOPointeeType<Ptr>::type Pointee;
       typedef IOTraits<Pointee> M;
-      static_assert((M::Signature & (M::ISNULLPOINTER | M::ISSHAREDPTR)) == 0, "can not read pointers to pointers");
+      static_assert((static_cast<int>(M::Signature) &
+                     (static_cast<int>(M::ISNULLPOINTER) | static_cast<int>(M::ISSHAREDPTR))) == 0,
+                    "can not read pointers to pointers");
 
       return GenericReader<
           Stream,
           State,
           Pointee,
-          Int2Type<M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISPUREHEAPREADABLE | M::ISPLACEREADABLE | M::ISPAIR |
-                                  M::ISTUPLE | M::ISEXTERNAL | M::ISSTRING)>>::readIntoPtr(ptr, str, s, processClassId);
+          Int2Type<static_cast<int>(M::Signature) &
+                   (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) |
+                    static_cast<int>(M::ISPUREHEAPREADABLE) | static_cast<int>(M::ISPLACEREADABLE) |
+                    static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISTUPLE) | static_cast<int>(M::ISEXTERNAL) |
+                    static_cast<int>(M::ISSTRING))>>::readIntoPtr(ptr, str, s, processClassId);
     }
   };
 

--- a/Alignment/Geners/interface/ProcessItem.hh
+++ b/Alignment/Geners/interface/ProcessItem.hh
@@ -118,8 +118,11 @@ namespace gs {
         T,
         Arg1,
         Arg2,
-        M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISWRITABLE | M::ISPOINTER | M::ISSHAREDPTR | M::ISIOPTR |
-                       M::ISPAIR | M::ISSTRING | M::ISTUPLE | M::ISEXTERNAL)>::process(obj, a1, p2, processClassId);
+        static_cast<int>(M::Signature) &
+            (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) | static_cast<int>(M::ISWRITABLE) |
+             static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR) | static_cast<int>(M::ISIOPTR) |
+             static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISSTRING) | static_cast<int>(M::ISTUPLE) |
+             static_cast<int>(M::ISEXTERNAL))>::process(obj, a1, p2, processClassId);
   }
 }  // namespace gs
 

--- a/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
@@ -146,7 +146,8 @@ inline const uint32_t SiStripRegionCabling::region(const PositionIndex index) co
 inline const uint32_t SiStripRegionCabling::elementIndex(const uint32_t region,
                                                          const SubDet subdet,
                                                          const uint32_t layer) {
-  return region * ALLSUBDETS * ALLLAYERS + subdet * ALLLAYERS + layer;
+  return region * static_cast<int>(ALLSUBDETS) * static_cast<int>(ALLLAYERS) + subdet * static_cast<int>(ALLLAYERS) +
+         layer;
 }
 
 inline const uint32_t SiStripRegionCabling::elementIndex(const PositionIndex index,
@@ -167,6 +168,8 @@ inline const SiStripRegionCabling::SubDet SiStripRegionCabling::subdet(const uin
   return static_cast<SiStripRegionCabling::SubDet>((index / ALLLAYERS) % ALLSUBDETS);
 }
 
-inline const uint32_t SiStripRegionCabling::region(const uint32_t index) { return index / (ALLSUBDETS * ALLLAYERS); }
+inline const uint32_t SiStripRegionCabling::region(const uint32_t index) {
+  return index / (static_cast<int>(ALLSUBDETS) * static_cast<int>(ALLLAYERS));
+}
 
 #endif

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -206,8 +206,8 @@ bool ECALpedestalPCLHarvester::checkVariation(const EcalPedestalsMap& oldPedesta
       nAnomaliesEE++;
   }
 
-  if (nAnomaliesEB > thresholdAnomalies_ * EBDetId::kSizeForDenseIndexing ||
-      nAnomaliesEE > thresholdAnomalies_ * EEDetId::kSizeForDenseIndexing)
+  if (nAnomaliesEB > thresholdAnomalies_ * static_cast<int>(EBDetId::kSizeForDenseIndexing) ||
+      nAnomaliesEE > thresholdAnomalies_ * static_cast<int>(EEDetId::kSizeForDenseIndexing))
     return true;
 
   return false;

--- a/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
@@ -117,7 +117,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EB Channel Status Masks, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)ebcount / kEBChannels * 100.;
+      Double_t prop = (Double_t)ebcount / static_cast<int>(kEBChannels) * 100.;
       sprintf(txt, "%d/61200 (%4.3f%%)", ebcount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);
@@ -252,7 +252,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EE Channel Status Masks, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)eecount / kEEChannels * 100.;
+      Double_t prop = (Double_t)eecount / static_cast<int>(kEEChannels) * 100.;
       sprintf(txt, "%d/14648 (%4.3f%%)", eecount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);

--- a/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
@@ -122,7 +122,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EB DQM Channel Status, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)ebcount / kEBChannels * 100.;
+      Double_t prop = (Double_t)ebcount / static_cast<int>(kEBChannels) * 100.;
       sprintf(txt, "%d/61200 (%4.3f%%)", ebcount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);
@@ -263,7 +263,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EE DQM Channel Status, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)eecount / kEEChannels * 100.;
+      Double_t prop = (Double_t)eecount / static_cast<int>(kEEChannels) * 100.;
       sprintf(txt, "%d/14648 (%4.3f%%)", eecount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);

--- a/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
@@ -85,8 +85,8 @@ namespace {
       EBrms = sqrt(EBrms);
       if (EBrms == 0.)
         EBrms = 0.001;
-      double pEBmin = EBmean - kRMS * EBrms;
-      double pEBmax = EBmean + kRMS * EBrms;
+      double pEBmin = EBmean - static_cast<int>(kRMS) * EBrms;
+      double pEBmax = EBmean + static_cast<int>(kRMS) * EBrms;
       //      std::cout << " mean " << EBmean << " rms " << EBrms << " entries " << EBtot << " min " << pEBmin << " max " << pEBmax << std::endl;
       vt = (double)EEtot;
       EEmean = EEmean / vt;
@@ -94,8 +94,8 @@ namespace {
       EErms = sqrt(EErms);
       if (EErms == 0.)
         EErms = 0.001;
-      double pEEmin = EEmean - kRMS * EErms;
-      double pEEmax = EEmean + kRMS * EErms;
+      double pEEmin = EEmean - static_cast<int>(kRMS) * EErms;
+      double pEEmax = EEmean + static_cast<int>(kRMS) * EErms;
       //      std::cout << " mean " << EEmean << " rms " << EErms << " entries " << EEtot << " min " << pEEmin << " max " << pEEmax << std::endl;
 
       gStyle->SetPalette(1);
@@ -232,8 +232,8 @@ namespace {
       EBrms = sqrt(EBrms);
       if (EBrms == 0.)
         EBrms = 0.001;
-      double pEBmin = EBmean - kRMS * EBrms;
-      double pEBmax = EBmean + kRMS * EBrms;
+      double pEBmin = EBmean - static_cast<int>(kRMS) * EBrms;
+      double pEBmax = EBmean + static_cast<int>(kRMS) * EBrms;
       //      std::cout << " mean " << EBmean << " rms " << EBrms << " entries " << EBtot << " min " << pEBmin << " max " << pEBmax << std::endl;
       vt = (double)EEtot;
       EEmean = EEmean / vt;
@@ -241,8 +241,8 @@ namespace {
       EErms = sqrt(EErms);
       if (EErms == 0.)
         EErms = 0.001;
-      double pEEmin = EEmean - kRMS * EErms;
-      double pEEmax = EEmean + kRMS * EErms;
+      double pEEmin = EEmean - static_cast<int>(kRMS) * EErms;
+      double pEEmax = EEmean + static_cast<int>(kRMS) * EErms;
       //      std::cout << " mean " << EEmean << " rms " << EErms << " entries " << EEtot << " min " << pEEmin << " max " << pEEmax << std::endl;
 
       gStyle->SetPalette(1);

--- a/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
@@ -170,8 +170,8 @@ namespace {
         EBrms[valId] = sqrt(EBrms[valId]);
         if (EBrms[valId] == 0.)
           EBrms[valId] = 0.001;
-        pEBmin[valId] = EBmean[valId] - kRMS * EBrms[valId];
-        pEBmax[valId] = EBmean[valId] + kRMS * EBrms[valId];
+        pEBmin[valId] = EBmean[valId] - static_cast<int>(kRMS) * EBrms[valId];
+        pEBmax[valId] = EBmean[valId] + static_cast<int>(kRMS) * EBrms[valId];
         //	std::cout << " mean " << EBmean[valId] << " rms " << EBrms[valId] << " entries " << EBtot[valId] << " min " << pEBmin[valId]
         //		  << " max " << pEBmax[valId] << std::endl;
         vt = (double)EEtot[valId];
@@ -180,8 +180,8 @@ namespace {
         EErms[valId] = sqrt(EErms[valId]);
         if (EErms[valId] == 0.)
           EErms[valId] = 0.001;
-        pEEmin[valId] = EEmean[valId] - kRMS * EErms[valId];
-        pEEmax[valId] = EEmean[valId] + kRMS * EErms[valId];
+        pEEmin[valId] = EEmean[valId] - static_cast<int>(kRMS) * EErms[valId];
+        pEEmax[valId] = EEmean[valId] + static_cast<int>(kRMS) * EErms[valId];
         //	std::cout << " mean " << EEmean[valId] << " rms " << EErms[valId] << " entries " << EEtot[valId] << " min " << pEEmin[valId]
         //		  << " max " << pEEmax[valId] << std::endl;
       }
@@ -424,8 +424,8 @@ namespace {
         EBrms[valId] = sqrt(EBrms[valId]);
         if (EBrms[valId] == 0.)
           EBrms[valId] = 0.001;
-        pEBmin[valId] = EBmean[valId] - kRMS * EBrms[valId];
-        pEBmax[valId] = EBmean[valId] + kRMS * EBrms[valId];
+        pEBmin[valId] = EBmean[valId] - static_cast<int>(kRMS) * EBrms[valId];
+        pEBmax[valId] = EBmean[valId] + static_cast<int>(kRMS) * EBrms[valId];
         //	std::cout << " mean " << EBmean[valId] << " rms " << EBrms[valId] << " entries " << EBtot[valId] << " min " << pEBmin[valId]
         //		  << " max " << pEBmax[valId] << std::endl;
         vt = (double)EEtot[valId];
@@ -434,8 +434,8 @@ namespace {
         EErms[valId] = sqrt(EErms[valId]);
         if (EErms[valId] == 0.)
           EErms[valId] = 0.001;
-        pEEmin[valId] = EEmean[valId] - kRMS * EErms[valId];
-        pEEmax[valId] = EEmean[valId] + kRMS * EErms[valId];
+        pEEmin[valId] = EEmean[valId] - static_cast<int>(kRMS) * EErms[valId];
+        pEEmax[valId] = EEmean[valId] + static_cast<int>(kRMS) * EErms[valId];
         //	std::cout << " mean " << EEmean[valId] << " rms " << EErms[valId] << " entries " << EEtot[valId] << " min " << pEEmin[valId]
         //		  << " max " << pEEmax[valId] << std::endl;
       }

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -345,8 +345,8 @@ namespace {
         EBrms[gId] = sqrt(EBrms[gId]);
         if (EBrms[gId] == 0.)
           EBrms[gId] = 0.001;
-        pEBmin[gId] = EBmean[gId] - kRMS * EBrms[gId];
-        pEBmax[gId] = EBmean[gId] + kRMS * EBrms[gId];
+        pEBmin[gId] = EBmean[gId] - static_cast<int>(kRMS) * EBrms[gId];
+        pEBmax[gId] = EBmean[gId] + static_cast<int>(kRMS) * EBrms[gId];
         //	std::cout << " mean " << EBmean[gId] << " rms " << EBrms[gId] << " entries " << EBtot[gId] << " min " << pEBmin[gId]
         //		  << " max " << pEBmax[gId] << std::endl;
         if (pEBmin[gId] < 0.)
@@ -357,8 +357,8 @@ namespace {
         EErms[gId] = sqrt(EErms[gId]);
         if (EErms[gId] == 0.)
           EErms[gId] = 0.001;
-        pEEmin[gId] = EEmean[gId] - kRMS * EErms[gId];
-        pEEmax[gId] = EEmean[gId] + kRMS * EErms[gId];
+        pEEmin[gId] = EEmean[gId] - static_cast<int>(kRMS) * EErms[gId];
+        pEEmax[gId] = EEmean[gId] + static_cast<int>(kRMS) * EErms[gId];
         //	std::cout << " mean " << EEmean[gId] << " rms " << EErms[gId] << " entries " << EEtot[gId] << " min " << pEEmin[gId]
         //		  << " max " << pEEmax[gId] << std::endl;
         if (pEEmin[gId] < 0.)
@@ -789,8 +789,8 @@ namespace {
         EBrms[gId] = sqrt(EBrms[gId]);
         if (EBrms[gId] == 0.)
           EBrms[gId] = 0.001;
-        pEBmin[gId] = EBmean[gId] - kRMS * EBrms[gId];
-        pEBmax[gId] = EBmean[gId] + kRMS * EBrms[gId];
+        pEBmin[gId] = EBmean[gId] - static_cast<int>(kRMS) * EBrms[gId];
+        pEBmax[gId] = EBmean[gId] + static_cast<int>(kRMS) * EBrms[gId];
         //	std::cout << " mean " << EBmean[gId] << " rms " << EBrms[gId] << " entries " << EBtot[gId] << " min " << pEBmin[gId]
         //		  << " max " << pEBmax[gId] << std::endl;
         vt = (double)EEtot[gId];
@@ -799,8 +799,8 @@ namespace {
         EErms[gId] = sqrt(EErms[gId]);
         if (EErms[gId] == 0.)
           EErms[gId] = 0.001;
-        pEEmin[gId] = EEmean[gId] - kRMS * EErms[gId];
-        pEEmax[gId] = EEmean[gId] + kRMS * EErms[gId];
+        pEEmin[gId] = EEmean[gId] - static_cast<int>(kRMS) * EErms[gId];
+        pEEmax[gId] = EEmean[gId] + static_cast<int>(kRMS) * EErms[gId];
         //	std::cout << " mean " << EEmean[gId] << " rms " << EErms[gId] << " entries " << EEtot[gId] << " min " << pEEmin[gId]
         //		  << " max " << pEEmax[gId] << std::endl;
       }
@@ -1041,9 +1041,9 @@ namespace {
     EcalPedestalsEEMean6Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap pedestal gain6 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1092,9 +1092,9 @@ namespace {
     EcalPedestalsEEMean1Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap pedestal gain1 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1289,9 +1289,9 @@ namespace {
     EcalPedestalsEERMS12Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain12 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1341,9 +1341,9 @@ namespace {
     EcalPedestalsEERMS6Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain6 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1391,9 +1391,9 @@ namespace {
     EcalPedestalsEERMS1Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain1 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,

--- a/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
@@ -118,8 +118,8 @@ namespace {
           EBrms[s] = sqrt(EBrms[s]);
         else
           EBrms[s] = 1.e-06;
-        pEBmin[s] = EBmean[s] - kRMS * EBrms[s];
-        pEBmax[s] = EBmean[s] + kRMS * EBrms[s];
+        pEBmin[s] = EBmean[s] - static_cast<int>(kRMS) * EBrms[s];
+        pEBmax[s] = EBmean[s] + static_cast<int>(kRMS) * EBrms[s];
         std::cout << "EB sample " << s << " mean " << EBmean[s] << " rms " << EBrms[s] << " entries " << EBtot[s]
                   << " min " << pEBmin[s] << " max " << pEBmax[s] << std::endl;
         //	if(pEBmin[s] <= 0.) pEBmin[s] = 1.e-06;
@@ -130,8 +130,8 @@ namespace {
           EErms[s] = sqrt(EErms[s]);
         else
           EErms[s] = 1.e-06;
-        pEEmin[s] = EEmean[s] - kRMS * EErms[s];
-        pEEmax[s] = EEmean[s] + kRMS * EErms[s];
+        pEEmin[s] = EEmean[s] - static_cast<int>(kRMS) * EErms[s];
+        pEEmax[s] = EEmean[s] + static_cast<int>(kRMS) * EErms[s];
         std::cout << "EE sample " << s << " mean " << EEmean[s] << " rms " << EErms[s] << " entries " << EEtot[s]
                   << " min " << pEEmin[s] << " max " << pEEmax[s] << std::endl;
         //	if(pEEmin[s] <= 0.) pEEmin[s] = 1.e-06;

--- a/CondCore/PCLConfigPlugins/plugins/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
+++ b/CondCore/PCLConfigPlugins/plugins/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
@@ -119,7 +119,7 @@ namespace AlignPCLThresholdPlotHelper {
 
       // needed for the internal loop
       const auto& local_end_of_types = isHighGranularity_ ? END_OF_TYPES : FRACTION_CUT;
-      const int N_Y_BINS = AlignPCLThresholds::extra_DOF * local_end_of_types;
+      const int N_Y_BINS = static_cast<int>(AlignPCLThresholds::extra_DOF) * local_end_of_types;
 
       auto Thresholds =
           std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), N_Y_BINS, 0, N_Y_BINS);
@@ -310,7 +310,7 @@ namespace AlignPCLThresholdPlotHelper {
 
       // needed for the internal loop
       const auto& local_end_of_types = isHighGranularity_ ? END_OF_TYPES : FRACTION_CUT;
-      const int N_Y_BINS = AlignPCLThresholds::extra_DOF * local_end_of_types;
+      const int N_Y_BINS = static_cast<int>(AlignPCLThresholds::extra_DOF) * local_end_of_types;
 
       auto Thresholds = std::make_unique<TH2F>(
           "Thresholds", "", v_intersection.size(), 0, v_intersection.size(), N_Y_BINS, 0, N_Y_BINS);

--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -106,12 +106,13 @@ const bool AlignPCLThresholdsHG::hasFloatMap(const std::string &AlignableId) con
 
 //****************************************************************************//
 const int AlignPCLThresholdsHG::payloadVersion() const {
-  switch (FSIZE + ISIZE + SSIZE) {
+  switch (static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE)) {
     case 6:
       return 1;
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
-          << "Payload version with parameter size equal to " << FSIZE + ISIZE + SSIZE << " is not defined.\n";
+          << "Payload version with parameter size equal to "
+          << static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE) << " is not defined.\n";
   }
 }
 

--- a/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
@@ -262,8 +262,8 @@ TrackCount::TrackCount(const edm::ParameterSet& iConfig)
   m_hnlayerphieta->GetXaxis()->SetTitle("#eta");
   m_hnlayerphieta->GetYaxis()->SetTitle("#phi");
 
-  m_halgo =
-      tfserv->make<TH1D>("algo", "Algorithm number", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  m_halgo = tfserv->make<TH1D>(
+      "algo", "Algorithm number", reco::TrackBase::algoSize, -0.5, static_cast<int>(reco::TrackBase::algoSize) - 0.5);
   m_halgo->GetXaxis()->SetTitle("algorithm");
   m_halgo->GetYaxis()->SetTitle("Tracks");
   m_hphieta = tfserv->make<TH2D>("phivseta", "#phi vs #eta", netabin2d, etamin, etamax, 40, -M_PI, M_PI);

--- a/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
@@ -281,7 +281,7 @@ void DiamondSampicCalibrationDQMSource::analyze(const edm::Event &event, const e
                                                        hitHistoTmpYAxis->GetBinCenter(startBin + i));
 
         //All plots with Time
-        if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE)) {
           int db = (detIdToHw[detId] & 0xE0) >> 5;
           int sampic = (detIdToHw[detId] & 0x10) >> 4;
           int channel = (detIdToHw[detId] & 0x0F);

--- a/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
@@ -603,7 +603,7 @@ void DiamondSampicDQMSource::analyze(const edm::Event &event, const edm::EventSe
         }
 
         //All plots with Time
-        if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE)) {
           for (int i = 0; i < numOfBins; ++i)
             potPlots_[detId_pot].hitDistribution2dWithTime->Fill(detId.plane() + UFSDShift,
                                                                  hitHistoTmpYAxis->GetBinCenter(startBin + i));

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -378,27 +378,27 @@ void TotemT2DQMSource::fillFlags(const TotemT2Digi& digi, const TotemT2DetId& de
   const TotemT2DetId secId(detid.armId());
   const TotemT2DetId planeId(detid.planeId());
   if (digi.hasTE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2TE + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2TE + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2TE + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2TE));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2TE));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2TE));
   }
 
   if (digi.hasLE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2LE + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2LE + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2LE + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2LE));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2LE));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2LE));
   }
 
   if (digi.hasManyTE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2MT + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2MT + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2MT + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2MT));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2MT));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2MT));
   }
 
   if (digi.hasManyLE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2ML + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2ML + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2ML + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2ML));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2ML));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2ML));
   }
 }
 

--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -110,8 +110,9 @@ namespace ecaldqm {
     kEBTCCLow = 36,
     kEBTCCHigh = 71,
 
-    nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
-    nTowers = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
+    nChannels = static_cast<int>(EBDetId::kSizeForDenseIndexing) + static_cast<int>(EEDetId::kSizeForDenseIndexing),
+    nTowers =
+        static_cast<int>(EcalTrigTowerDetId::kEBTotalTowers) + static_cast<int>(EcalScDetId::kSizeForDenseIndexing)
   };
 
   extern std::vector<unsigned> const memDCC;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -169,7 +169,7 @@ namespace ecaldqm {
             break;
           case kProjEta:
             if (_zside == 0) {
-              specs.nbins = nEEEtaBins / (3. - etaBound) * 6.;
+              specs.nbins = static_cast<int>(nEEEtaBins) / (3. - etaBound) * 6.;
               specs.low = -3.;
               specs.high = 3.;
             } else {
@@ -351,11 +351,12 @@ namespace ecaldqm {
             specs.nbins = nEBEtaBins + 2 * nEEEtaBins;
             specs.edges = std::vector(specs.nbins + 1, 0.f);
             for (int i(0); i <= nEEEtaBins; i++)
-              specs.edges[i] = -3. + (3. - etaBound) / nEEEtaBins * i;
+              specs.edges[i] = -3. + (3. - etaBound) / static_cast<double>(nEEEtaBins) * i;
             for (int i(1); i <= nEBEtaBins; i++)
-              specs.edges[i + nEEEtaBins] = -etaBound + 2. * etaBound / nEBEtaBins * i;
+              specs.edges[i + nEEEtaBins] = -etaBound + 2. * etaBound / static_cast<double>(nEBEtaBins) * i;
             for (int i(1); i <= nEEEtaBins; i++)
-              specs.edges[i + nEEEtaBins + nEBEtaBins] = etaBound + (3. - etaBound) / nEEEtaBins * i;
+              specs.edges[i + nEEEtaBins + nEBEtaBins] =
+                  etaBound + (3. - etaBound) / static_cast<double>(nEEEtaBins) * i;
             specs.title = "eta";
             break;
           case kProjPhi:

--- a/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
@@ -154,7 +154,7 @@ namespace ecaldqm {
       if (status == kGood && sLaser) {
         for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
           sLaser->use(wlItr->second);
-          if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -166,7 +166,7 @@ namespace ecaldqm {
         if (id.subdetId() == EcalEndcap) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLed->use(wlItr->second);
-            if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -177,7 +177,7 @@ namespace ecaldqm {
       if (status == kGood && sTestPulse) {
         for (map<int, unsigned>::iterator gainItr(tpGainToME_.begin()); gainItr != tpGainToME_.end(); ++gainItr) {
           sTestPulse->use(gainItr->second);
-          if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -187,7 +187,7 @@ namespace ecaldqm {
       if (status == kGood && sPedestal) {
         for (map<int, unsigned>::iterator gainItr(pedGainToME_.begin()); gainItr != pedGainToME_.end(); ++gainItr) {
           sPedestal->use(gainItr->second);
-          if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -211,13 +211,13 @@ namespace ecaldqm {
 
         int status(kGood);
 
-        if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == kBad)
+        if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad))
           status = kBad;
 
         if (status == kGood && sLaserPN) {
           for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
             sLaserPN->use(wlItr->second);
-            if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -227,7 +227,7 @@ namespace ecaldqm {
         if (status == kGood && sLedPN) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLedPN->use(wlItr->second);
-            if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -237,7 +237,7 @@ namespace ecaldqm {
         if (status == kGood && sTestPulsePN) {
           for (map<int, unsigned>::iterator gainItr(tpPNGainToME_.begin()); gainItr != tpPNGainToME_.end(); ++gainItr) {
             sTestPulsePN->use(gainItr->second);
-            if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -248,7 +248,7 @@ namespace ecaldqm {
           for (map<int, unsigned>::iterator gainItr(pedPNGainToME_.begin()); gainItr != pedPNGainToME_.end();
                ++gainItr) {
             sPedestalPN->use(gainItr->second);
-            if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }

--- a/DQM/EcalMonitorClient/src/CertificationClient.cc
+++ b/DQM/EcalMonitorClient/src/CertificationClient.cc
@@ -31,7 +31,7 @@ namespace ecaldqm {
       meanValue += certValue * nCrystals(iDCC + 1);
     }
 
-    meCertification.fill(getEcalDQMSetupObjects(), meanValue / nChannels);
+    meCertification.fill(getEcalDQMSetupObjects(), meanValue / static_cast<double>(nChannels));
   }
 
   DEFINE_ECALDQM_WORKER(CertificationClient);

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -111,7 +111,7 @@ namespace ecaldqm {
       float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
       if (entriesLS < minChannelEntries_)
         continue;
-      if (chStatus != EcalChannelStatusCode::kOk)
+      if (chStatus != static_cast<float>(EcalChannelStatusCode::kOk))
         continue;  // exclude problematic channels
 
       // Get max/min

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -146,7 +146,7 @@ namespace ecaldqm {
 
       if (entriesLS < minChannelEntries)
         continue;
-      if (chStatus != EcalChannelStatusCode::kOk)
+      if (chStatus != static_cast<float>(EcalChannelStatusCode::kOk))
         continue;  // exclude problematic channels
 
       // Keep running count of timing mean, rms, and N_hits

--- a/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
+++ b/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
@@ -40,7 +40,7 @@ namespace ecaldqm {
     enum Constants {
       nFIRTaps = 6,
       bytesPerCrystal = 24,
-      nRU = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
+      nRU = static_cast<int>(EcalTrigTowerDetId::kEBTotalTowers) + static_cast<int>(EcalScDetId::kSizeForDenseIndexing)
     };
 
   private:

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -236,8 +236,10 @@ namespace ecaldqm {
     }
 
     if (isEB) {
-      meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / nEBDCC);
-      meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / nEBDCC);
+      meHighIntPayload.fill(
+          getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / static_cast<double>(nEBDCC));
+      meLowIntPayload.fill(
+          getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / static_cast<double>(nEBDCC));
     } else {
       meHighIntPayload.fill(
           getEcalDQMSetupObjects(), -EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -264,8 +264,8 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                    -0.5,
                    nErrors - 0.5,
                    nFEDs,
-                   FEDNumbering::MINSiPixeluTCAFEDID - 0.5,
-                   FEDNumbering::MAXSiPixeluTCAFEDID - 0.5);
+                   static_cast<double>(FEDNumbering::MINSiPixeluTCAFEDID) - 0.5,
+                   static_cast<double>(FEDNumbering::MAXSiPixeluTCAFEDID) - 0.5);
   for (int j = 0; j < nErrors; j++) {
     const auto& errorCode = static_cast<SiPixelFEDErrorCodes>(j + k_FED25);
     h_FEDerrorVsFEDIdUnbalance_->setBinLabel(j + 1, errorCodeToTypeMap.at(errorCode));

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -72,8 +72,11 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run cons
   TrackPtNegative_->setAxisTitle("p_{T} of tracks charge < 0");
 
   histname = "TrackQuality_";
-  TrackQuality_ = iBooker.book1D(
-      histname + AlgoName, histname + AlgoName, reco::TrackBase::qualitySize, -0.5, reco::TrackBase::qualitySize - 0.5);
+  TrackQuality_ = iBooker.book1D(histname + AlgoName,
+                                 histname + AlgoName,
+                                 reco::TrackBase::qualitySize,
+                                 -0.5,
+                                 static_cast<double>(reco::TrackBase::qualitySize) - 0.5);
   TrackQuality_->setAxisTitle("quality");
   for (int i = 0; i < reco::TrackBase::qualitySize; ++i) {
     TrackQuality_->getTH1()->GetXaxis()->SetBinLabel(

--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -138,7 +138,7 @@ public:
 
     const unsigned int nTrParm(tvec.size() / T::k_NumberOfCellsForCorners);
 
-    assert(dvec.size() == T::k_NumberOfShapes * T::k_NumberOfParametersPerShape);
+    assert(dvec.size() == static_cast<int>(T::k_NumberOfShapes) * static_cast<int>(T::k_NumberOfParametersPerShape));
 
     PtrType ptr = std::make_unique<T>();
 

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -64,7 +64,8 @@ void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
   fillNamedParams(fv0, geom);
 
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   DDFilteredView fv(*cpv, filter);
 
@@ -123,7 +124,8 @@ void CaloGeometryLoader<T>::makeGeometry(const cms::DDCompactView* cpv,
   fillNamedParams(fv, geom);
 
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   std::string attribute = "ReadOutName";
   cms::DDSpecParRefs ref;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -1269,7 +1269,7 @@ unsigned int HcalTopology::detId2denseIdHT(const DetId& id) const {
   } else {
     index = kHTSizePreLS1;
     if (zside == -1)
-      index += ((kHTSizePhase1 - kHTSizePreLS1) / 2);
+      index += ((static_cast<double>(kHTSizePhase1) - static_cast<double>(kHTSizePreLS1)) / 2);
     index += (36 * (ietaAbs - 30) + ((iphi - 1) / 2));
   }
 

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
@@ -44,7 +44,8 @@ void CaloGeometryLoaderTest<T>::makeGeometry(const DDCompactView* cpv,
                                              const Alignments* alignments,
                                              const Alignments* globals) {
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   DDFilteredView fv(*cpv, m_filter);
 

--- a/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
@@ -48,7 +48,8 @@ void CastorHardcodeGeometryLoader::fill(HcalCastorDetId::Section section, CaloSu
   if (geom->cornersMgr() == nullptr)
     geom->allocateCorners(HcalCastorDetId::kSizeForDenseIndexing);
   if (geom->parMgr() == nullptr)
-    geom->allocatePar(CastorGeometry::k_NumberOfShapes * CastorGeometry::k_NumberOfParametersPerShape,
+    geom->allocatePar(static_cast<int>(CastorGeometry::k_NumberOfShapes) *
+                          static_cast<int>(CastorGeometry::k_NumberOfParametersPerShape),
                       CastorGeometry::k_NumberOfParametersPerShape);
 
   // start by making the new HcalDetIds
@@ -118,7 +119,7 @@ void CastorHardcodeGeometryLoader::makeCell(const HcalCastorDetId& detId, CaloSu
   const double leg(dR + dy);
   const double len(sqrt(leg * leg + dx * dx));
 
-  static const double dphi(2. * M_PI / (1.0 * HcalCastorDetId::kNumberSectorsPerEnd));
+  static const double dphi(2. * M_PI / (1.0 * static_cast<double>(HcalCastorDetId::kNumberSectorsPerEnd)));
 
   const double fphi(atan(dx / (dR + dy)));
 

--- a/Geometry/ForwardGeometry/src/ZdcHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/ZdcHardcodeGeometryLoader.cc
@@ -58,8 +58,9 @@ void ZdcHardcodeGeometryLoader::fill(HcalZDCDetId::Section section, ReturnType g
   if (geom->cornersMgr() == nullptr)
     geom->allocateCorners(HcalZDCDetId::kSizeForDenseIndexing);
   if (geom->parMgr() == nullptr)
-    geom->allocatePar(ZdcGeometry::k_NumberOfParametersPerShape * ZdcGeometry::k_NumberOfShapes,
-                      ZdcGeometry::k_NumberOfParametersPerShape);
+    geom->allocatePar(
+        static_cast<int>(ZdcGeometry::k_NumberOfParametersPerShape) * static_cast<int>(ZdcGeometry::k_NumberOfShapes),
+        ZdcGeometry::k_NumberOfParametersPerShape);
 
   edm::LogVerbatim("ZdcGeometry") << "Number of ZDC DetIds made: " << section << " " << zdcIds.size();
 

--- a/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
@@ -138,7 +138,7 @@ lclphidat CSCSectorReceiverLUT::calcLocalPhi(const lclphiadd& theadd) const {
   lclphidat data;
 
   constexpr int maxPhiL = 1 << CSCBitWidths::kLocalPhiDataBitWidth;
-  double binPhiL = static_cast<double>(maxPhiL) / (2. * CSCConstants::MAX_NUM_STRIPS_RUN1);
+  double binPhiL = static_cast<double>(maxPhiL) / (2. * static_cast<double>(CSCConstants::MAX_NUM_STRIPS_RUN1));
 
   double patternOffset;
 
@@ -257,7 +257,7 @@ gblphidat CSCSectorReceiverLUT::calcGlobalPhiME(const gblphiadd& address) const 
 
   // We will use these to convert the local phi into radians.
   constexpr unsigned int maxPhiL = 1 << CSCBitWidths::kLocalPhiDataBitWidth;
-  const double binPhiL = static_cast<double>(maxPhiL) / (2. * CSCConstants::MAX_NUM_STRIPS_RUN1);
+  const double binPhiL = static_cast<double>(maxPhiL) / (2. * static_cast<double>(CSCConstants::MAX_NUM_STRIPS_RUN1));
 
   if (cscid < CSCTriggerNumbering::minTriggerCscId()) {
     edm::LogWarning("CSCSectorReceiverLUT|getGlobalPhiValue")
@@ -656,7 +656,8 @@ gbletadat CSCSectorReceiverLUT::calcGlobalEtaME(const gbletaadd& address) const 
   double float_eta = getGlobalEtaValue(address.cscid, address.wire_group, address.phi_local);
   unsigned int_eta = 0;
   unsigned bend_global = 0;  // not filled yet... will change when it is.
-  const double etaPerBin = (CSCTFConstants::maxEta - CSCTFConstants::minEta) / CSCTFConstants::etaBins;
+  const double etaPerBin =
+      (CSCTFConstants::maxEta - CSCTFConstants::minEta) / static_cast<double>(CSCTFConstants::etaBins);
   const unsigned me12EtaCut = 56;
 
   if ((float_eta < CSCTFConstants::minEta) || (float_eta >= CSCTFConstants::maxEta)) {

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctMet.cc
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctMet.cc
@@ -162,7 +162,8 @@ L1GctMet::etmiss_internal L1GctMet::useHtMissLutAlgo(const int ex, const int ey,
   static const int componentMask = maxComponent - 1;
   static const int maxPosComponent = componentMask >> 1;
 
-  static const int maxInput = 1 << (L1GctHtMissLut::kHxOrHyMissComponentNBits + kExOrEyMissComponentShift - 1);
+  static const int maxInput = 1 << (static_cast<int>(L1GctHtMissLut::kHxOrHyMissComponentNBits) +
+                                    static_cast<int>(kExOrEyMissComponentShift) - 1);
 
   static const unsigned resultMagMask = (1 << L1GctHtMissLut::kHtMissMagnitudeNBits) - 1;
   static const unsigned resultPhiMask = (1 << L1GctHtMissLut::kHtMissAngleNBits) - 1;
@@ -315,8 +316,9 @@ const bool L1GctMet::inputOverFlow() const {
   bool result = m_exComponent.overFlow() || m_eyComponent.overFlow();
 
   if (m_algoType == useHtMissLut) {
-    static const int maxComponentInput =
-        (1 << (L1GctHtMissLut::kHxOrHyMissComponentNBits + kExOrEyMissComponentShift - 1)) - 1;
+    static const int maxComponentInput = (1 << (static_cast<int>(L1GctHtMissLut::kHxOrHyMissComponentNBits) +
+                                                static_cast<int>(kExOrEyMissComponentShift) - 1)) -
+                                         1;
 
     // Emulate the (symmetric) overflow condition used in the firmware
     result |= (m_exComponent.value() > maxComponentInput) || (m_exComponent.value() < -maxComponentInput) ||

--- a/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
+++ b/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
@@ -507,11 +507,11 @@ inline void L1DummyProducer::SimpleDigi(int,
   enum eMinNum { MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1 };
   enum eMaxNum { MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6 };
   float rnd = engine->flat();
-  int ec = (int)(MIN_ENDCAP + (MAX_ENDCAP - MIN_ENDCAP) * rnd + 1);
-  int st = (int)(MIN_STATION + (MAX_STATION - MIN_STATION) * rnd + 1);
-  int rg = (int)(MIN_RING + (MAX_RING - MIN_RING) * rnd + 1);
-  int ch = (int)(MIN_CHAMBER + (MAX_CHAMBER - MIN_CHAMBER) * rnd + 1);
-  int lr = (int)(MIN_LAYER + (MAX_LAYER - MIN_LAYER) * rnd + 1);
+  int ec = (int)(MIN_ENDCAP + (static_cast<int>(MAX_ENDCAP) - MIN_ENDCAP) * rnd + 1);
+  int st = (int)(MIN_STATION + (static_cast<int>(MAX_STATION) - MIN_STATION) * rnd + 1);
+  int rg = (int)(MIN_RING + (static_cast<int>(MAX_RING) - MIN_RING) * rnd + 1);
+  int ch = (int)(MIN_CHAMBER + (static_cast<int>(MAX_CHAMBER) - MIN_CHAMBER) * rnd + 1);
+  int lr = (int)(MIN_LAYER + (static_cast<int>(MAX_LAYER) - MIN_LAYER) * rnd + 1);
   CSCDetId did = CSCDetId(ec, st, rg, ch, lr);
   //CSCDetId did = CSCDetId();   //DetId(DetId::Muon, MuonSubdetId::CSC)
   //MuonDigiCollection::insertDigi(const IndexType& index, const DigiType& digi)

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
@@ -105,7 +105,7 @@ L1ExtraTestAnalyzer::L1ExtraTestAnalyzer(const edm::ParameterSet &iConfig)
             "Triggers",
             2 * l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 1,
             -0.75,
-            l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 0.5 - 0.75) {
+            static_cast<double>(l1extra::L1ParticleMap::kNumOfL1TriggerTypes) + 0.5 - 0.75) {
   // now do what ever initialization is needed
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -48,19 +48,25 @@ void JetId::setNNVectorVar() {
         NNvectorVar_.push_back(0);
       continue;
     }
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron && fCharge_.get()[i0] < 0);       // Electron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron && fCharge_.get()[i0] > 0);       // Positron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon && fCharge_.get()[i0] < 0);           // Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon && fCharge_.get()[i0] > 0);           // Anti-Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Photon);                                   // Photon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::NeutralHadron);                            // Neutral Had
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] < 0);  // Pion
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] > 0);  // Anti-Pion
-    NNvectorVar_.push_back(fDZ_.get()[i0]);                                                               //dZ
-    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));                                   //d0
-    NNvectorVar_.push_back(fPt_.get()[i0]);   //pT as a fraction of jet pT
-    NNvectorVar_.push_back(fEta_.get()[i0]);  //dEta from jet axis
-    NNvectorVar_.push_back(fPhi_.get()[i0]);  //dPhi from jet axis
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Electron) &&
+                           fCharge_.get()[i0] < 0);  // Electron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Electron) &&
+                           fCharge_.get()[i0] > 0);  // Positron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Muon) &&
+                           fCharge_.get()[i0] < 0);  // Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Muon) &&
+                           fCharge_.get()[i0] > 0);                                                  // Anti-Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Photon));         // Photon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::NeutralHadron));  // Neutral Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::ChargedHadron) &&
+                           fCharge_.get()[i0] < 0);  // Pion
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::ChargedHadron) &&
+                           fCharge_.get()[i0] > 0);                      // Anti-Pion
+    NNvectorVar_.push_back(fDZ_.get()[i0]);                              //dZ
+    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));  //d0
+    NNvectorVar_.push_back(fPt_.get()[i0]);                              //pT as a fraction of jet pT
+    NNvectorVar_.push_back(fEta_.get()[i0]);                             //dEta from jet axis
+    NNvectorVar_.push_back(fPhi_.get()[i0]);                             //dPhi from jet axis
   }
 }
 float JetId::EvaluateNN() {

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -32,11 +32,11 @@ void TauNNId::setNNVectorVar() {
         NNvectorVar_.push_back(0);
       continue;
     }
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Photon);         // Photon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron);       // Electron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon);           // Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::NeutralHadron);  // Neutral Had
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron);  // Charged Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Photon));         // Photon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Electron));       // Electron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Muon));           // Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::NeutralHadron));  // Neutral Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::ChargedHadron));  // Charged Had
   }
 }
 float TauNNId::EvaluateNN() {

--- a/L1Trigger/RPCTrigger/src/RPCConst.cc
+++ b/L1Trigger/RPCTrigger/src/RPCConst.cc
@@ -71,24 +71,24 @@ int RPCConst::towerNumFromEta(const double eta) {
 }
 
 double RPCConst::phiFromSegmentNum(const int iseg) {
-  double phi = OFFSET + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
+  double phi = static_cast<double>(OFFSET) + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
   return (phi < 2. * m_pi) ? phi : phi - 2. * m_pi;
 }
 
 double RPCConst::phiFromLogSegSec(const int logSegment, const int logSector) {
   int iseg = logSegment * 12 + logSector;
-  double phi = OFFSET + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
+  double phi = static_cast<double>(OFFSET) + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
   return (phi < 2. * m_pi) ? phi : phi - 2. * m_pi;
 }
 
 int RPCConst::segmentNumFromPhi(const double phi) {
   double iphi;
-  if (phi - OFFSET < 0) {
+  if (phi - static_cast<double>(OFFSET) < 0) {
     iphi = 2 * m_pi + phi;
   } else {
-    iphi = phi - OFFSET;
+    iphi = phi - static_cast<double>(OFFSET);
   }
-  int iseg = (int)(iphi * RPCConst::NSEG / (2. * m_pi));
+  int iseg = (int)(iphi * static_cast<double>(RPCConst::NSEG) / (2. * m_pi));
   return iseg;
 }
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -327,7 +327,8 @@ namespace trklet {
       for (int iRegion = 0; iRegion < setup_->numRegions(); iRegion++) {
         int buffered_tracks[] = {0, 0};
         for (int iTrack = 0;
-             iTrack < setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize);
+             iTrack < setup_->numFramesIO() *
+                          ((double)TTBV::S_ / static_cast<double>(TTTrack_TrackWord::TrackBitWidths::kTrackWordSize));
              iTrack++) {
           for (int iWorker = 0; iWorker < setup_->kfNumWorker(); iWorker++) {
             for (int iLink = 0; iLink < setup_->tfpNumChannel(); iLink++) {
@@ -377,7 +378,8 @@ namespace trklet {
               trackRef = it.first;
           }
           if ((int)iTrack / 3 <=
-              setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize))
+              setup_->numFramesIO() *
+                  ((double)TTBV::S_ / static_cast<double>(TTTrack_TrackWord::TrackBitWidths::kTrackWordSize)))
             accepted[iLink].emplace_back(
                 std::make_pair(trackRef,
                                (sortedPartialTracks[iLink][iTrack - 1].slice(partialTrackWordBits_) +

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -276,8 +276,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
           // We put it in the rejected container, flagged with offset to indicate reason.
 
           if (FEreject) {
-            tempTTStub.setRawBend(CBCFailOffset + 2. * tempTTStub.rawBend());
-            tempTTStub.setBendOffset(CBCFailOffset + 2. * tempTTStub.bendOffset());
+            tempTTStub.setRawBend(static_cast<double>(CBCFailOffset) + 2. * tempTTStub.rawBend());
+            tempTTStub.setBendOffset(static_cast<double>(CBCFailOffset) + 2. * tempTTStub.bendOffset());
             tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
             tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
             tempStubRej.push_back(tempTTStub);
@@ -324,8 +324,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
 
             if (CIC_reject)  // The stub added does not pass the cut
             {
-              tempTTStub.setRawBend(CICFailOffset + 2. * tempTTStub.rawBend());
-              tempTTStub.setBendOffset(CICFailOffset + 2. * tempTTStub.bendOffset());
+              tempTTStub.setRawBend(static_cast<double>(CICFailOffset) + 2. * tempTTStub.rawBend());
+              tempTTStub.setBendOffset(static_cast<double>(CICFailOffset) + 2. * tempTTStub.bendOffset());
               tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
               tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
               tempStubRej.push_back(tempTTStub);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -841,7 +841,7 @@ namespace l1tVertexFinder {
       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13 = z0_13 + (1 << (TrackBitWidths::kZ0Size - 1));
       // Shift the bits down to truncate the dynamic range to the most significant HistogramBitWidths::kBinFixedSize bits
       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13_reduced =
-          absz0_13 >> (TrackBitWidths::kZ0Size - HistogramBitWidths::kBinFixedSize);
+          absz0_13 >> (static_cast<int>(TrackBitWidths::kZ0Size) - static_cast<int>(HistogramBitWidths::kBinFixedSize));
       // Put the relevant bits into the histbin_t container
       histbin_t bin = absz0_13_reduced.range(HistogramBitWidths::kBinFixedSize - 1, 0);
 

--- a/RecoPPS/Local/src/TotemTimingTrackRecognition.cc
+++ b/RecoPPS/Local/src/TotemTimingTrackRecognition.cc
@@ -18,7 +18,7 @@ TotemTimingTrackRecognition::TotemTimingTrackRecognition(const edm::ParameterSet
 //----------------------------------------------------------------------------------------------------
 
 void TotemTimingTrackRecognition::addHit(const TotemTimingRecHit& recHit) {
-  if (recHit.time() != TotemTimingRecHit::NO_T_AVAILABLE)
+  if (recHit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE))
     hitVectorMap_[0].emplace_back(recHit);
 }
 

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -156,8 +156,8 @@ public:
     ical = &eventSetup->getData(m_interCalibConstantsMCToken);
     // adc to GeV
     agc = &eventSetup->getData(m_adcToGeVConstantToken);
-    m_maxEneEB = (agc->getEBValue()) * theDefaultGains[1] * MAXADC * m_EBs25notCont;
-    m_maxEneEE = (agc->getEEValue()) * theDefaultGains[1] * MAXADC * m_EEs25notCont;
+    m_maxEneEB = (agc->getEBValue()) * theDefaultGains[1] * static_cast<double>(MAXADC) * m_EBs25notCont;
+    m_maxEneEE = (agc->getEEValue()) * theDefaultGains[1] * static_cast<double>(MAXADC) * m_EEs25notCont;
 
     if (m_timeDependent) {
       //----

--- a/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
@@ -106,7 +106,7 @@ void EcalCoder::encode(const EcalSamples& ecalSamples, EcalDataFrame& df, CLHEP:
 
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gains[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gains[igain]);
     maxADC[igain] = ADCGAINSWITCH;  // saturation at 4080 for middle and high gains x6 & x12
     if (igain == NGAINS)
       maxADC[igain] = MAXADC;  // saturation at 4095 for low gain x1

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -34,7 +34,7 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
   for (unsigned int igain(0); igain <= NGAINS; ++igain) {
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gainRatios[igain]);
   }
 
   //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;
@@ -141,7 +141,7 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
   for (unsigned int igain(0); igain <= NGAINS; ++igain) {
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gainRatios[igain]);
   }
 
   //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -554,13 +554,13 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::Eve
 
   delete defaultRatios;
 
-  const double EBscale((agc->getEBValue()) * theGains[1] * (m_Coder->MAXADC) * m_EBs25notCont);
+  const double EBscale((agc->getEBValue()) * theGains[1] * static_cast<double>(m_Coder->MAXADC) * m_EBs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEBValue() << "\n"
                        << " notCont = " << m_EBs25notCont << "\n"
                        << " saturation for EB = " << EBscale << ", " << m_EBs25notCont;
 
-  const double EEscale((agc->getEEValue()) * theGains[1] * (m_Coder->MAXADC) * m_EEs25notCont);
+  const double EEscale((agc->getEEValue()) * theGains[1] * static_cast<double>(m_Coder->MAXADC) * m_EEs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEEValue() << "\n"
                        << " notCont = " << m_EEs25notCont << "\n"

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -24,7 +24,8 @@ HcalSiPMHitResponse::HcalSiPMHitResponse(const CaloVSimParameterMap* parameterMa
       theSiPM(),
       PreMixDigis(PreMix1),
       HighFidelityPreMix(HighFidelity),
-      nbins((PreMixDigis and HighFidelityPreMix) ? 1 : BUNCHSPACE * HcalPulseShapes::invDeltaTSiPM_),
+      nbins((PreMixDigis and HighFidelityPreMix) ? 1
+                                                 : static_cast<float>(BUNCHSPACE) * HcalPulseShapes::invDeltaTSiPM_),
       dt(HcalPulseShapes::deltaTSiPM_),
       invdt(HcalPulseShapes::invDeltaTSiPM_) {
   //fill shape map
@@ -43,7 +44,7 @@ int HcalSiPMHitResponse::getReadoutFrameSize(const DetId& id) const {
   int readoutFrameSize = parameters.readoutFrameSize();
   if (PreMixDigis and HighFidelityPreMix) {
     //preserve fidelity of time info
-    readoutFrameSize *= BUNCHSPACE * HcalPulseShapes::invDeltaTSiPM_;
+    readoutFrameSize *= static_cast<float>(BUNCHSPACE) * HcalPulseShapes::invDeltaTSiPM_;
   }
   return readoutFrameSize;
 }
@@ -127,7 +128,8 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
     LogDebug("HcalSiPMHitResponse") << " energy: " << hit.energy() << " photons: " << photons << " time: " << time;
     LogDebug("HcalSiPMHitResponse") << " timePhase: " << pars.timePhase() << " tof: " << tof
                                     << " binOfMaximum: " << pars.binOfMaximum() << " phaseShift: " << thePhaseShift_;
-    double tzero(0.0 + pars.timePhase() - (time - tof) - BUNCHSPACE * (pars.binOfMaximum() - thePhaseShift_));
+    double tzero(0.0 + pars.timePhase() - (time - tof) -
+                 static_cast<double>(BUNCHSPACE) * (pars.binOfMaximum() - thePhaseShift_));
     LogDebug("HcalSiPMHitResponse") << " tzero: " << tzero;
     double tzero_bin(-tzero * invdt);
     LogDebug("HcalSiPMHitResponse") << " corrected tzero: " << tzero_bin << '\n';

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -647,7 +647,7 @@ GlobalPoint CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorre
     int ring = 1;  // Default to ME1/b
     if (lct.getStrip() > CSCConstants::MAX_HALF_STRIP_ME1B) {
       ring = 4;  // Change to ME1/a if the HalfStrip Number exceeds the range of ME1/b
-      fractional_strip -= CSCConstants::NUM_STRIPS_ME1B;
+      fractional_strip -= static_cast<float>(CSCConstants::NUM_STRIPS_ME1B);
     }
     CSCDetId cscId_(cscId.endcap(), cscId.station(), ring, cscId.chamber(), cscId.layer());
     cscId = cscId_;

--- a/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
@@ -131,10 +131,16 @@ void ElectronConversionRejectionValidator::bookHistograms(DQMStore::IBooker& ibo
 
   h_convLog10TrailTrackpt_ = ibooker.book1D("convLog10TrailTrackpt", "# of Electrons", ptBin, -2.0, 3.0);
 
-  h_convLeadTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
-  h_convTrailTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_convLeadTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                        "# of Electrons",
+                                        reco::TrackBase::algoSize,
+                                        -0.5,
+                                        static_cast<double>(reco::TrackBase::algoSize) - 0.5);
+  h_convTrailTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                         "# of Electrons",
+                                         reco::TrackBase::algoSize,
+                                         -0.5,
+                                         static_cast<double>(reco::TrackBase::algoSize) - 0.5);
 }
 
 void ElectronConversionRejectionValidator::analyze(const edm::Event& e, const edm::EventSetup&) {

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3126,8 +3126,11 @@ void PhotonValidator::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&
   h_trkProv_[0] = iBooker.book1D("allTrkProv", " Track pair provenance ", 4, 0., 4.);
   h_trkProv_[1] = iBooker.book1D("assTrkProv", " Track pair provenance ", 4, 0., 4.);
   //
-  h_trkAlgo_ =
-      iBooker.book1D("allTrackAlgo", " Track Algo ", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_trkAlgo_ = iBooker.book1D("allTrackAlgo",
+                              " Track Algo ",
+                              reco::TrackBase::algoSize,
+                              -0.5,
+                              static_cast<double>(reco::TrackBase::algoSize) - 0.5);
   h_convAlgo_ = iBooker.book1D("allConvAlgo", " Conv Algo ", 5, -0.5, 4.5);
   h_convQuality_ = iBooker.book1D("allConvQuality", "Conv quality ", 11, -0.5, 11.);
 


### PR DESCRIPTION
#### PR description:

In C++20, arithmetic and comparision operations between different `enum`s, and between floating-point types and `enum` are deprecated:

```
src/DQM/CTPPS/plugins/TotemT2DQMSource.cc: In member function 'void TotemT2DQMSource::fillFlags(const TotemT2Digi&, const TotemT2DetId&)':
  src/DQM/CTPPS/plugins/TotemT2DQMSource.cc:381:47: warning: arithmetic between enumeration type 'TotemT2DQMSource::evFlag' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
   381 |     sectorPlots_[secId].eventFlags->Fill(t2TE + 0.0);
      |                                          ~~~~~^~~~~
<...>
src/DQM/CTPPS/plugins/TotemTimingDQMSource.cc: In member function 'virtual void TotemTimingDQMSource::analyze(const edm::Event&, const edm::EventSetup&)':
  src/DQM/CTPPS/plugins/TotemTimingDQMSource.cc:622:27: warning: comparison of floating-point type 'float' with enumeration type 'TotemTimingRecHit::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   622 |         if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
      |             ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DQM/CTPPS/plugins/TotemTimingDQMSource.cc:679:25: warning: comparison of floating-point type 'float' with enumeration type 'TotemTimingRecHit::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   679 |       if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE && potPlots_.find(detId_pot) != potPlots_.end() &&
      |           ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

#### PR validation:

Bot tests