### PR TITLE
Numerical stability fix for Phase 2 L1 tracking

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -675,7 +675,8 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     // The expanded version of this expression is more stable for extremely
     // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
     // the domain of asin.
-    double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+    double sin_val =
+        0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
@@ -684,7 +685,8 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     // The expanded version of this expression is more stable for extremely
     // high-pT (high-rho) tracks. But we also explicitly restrict cos_val to
     // the domain of acos.
-    double cos_val = 0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
+    double cos_val =
+        0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
     cos_val = std::max(std::min(cos_val, 1.0), -1.0);
     double beta = std::acos(cos_val);
     stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
@@ -698,7 +700,8 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     // The expanded version of this expression is more stable for extremely
     // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
     // the domain of asin.
-    double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+    double sin_val =
+        0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -672,12 +672,13 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
   if (st->isBarrel()) {
     stub_r = settings_.rmean(stubLayer - 1);
 
-    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+    double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);
 
-    double beta = std::acos((rho * rho + rho_minus_d0 * rho_minus_d0 - stub_r * stub_r) / (2 * rho * rho_minus_d0));
+    double cos_val = 0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
+    double beta = std::acos(cos_val);
     stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
   } else {
     stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
@@ -686,7 +687,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
     stub_r = sqrt(r_square);
 
-    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+    double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -673,11 +673,13 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     stub_r = settings_.rmean(stubLayer - 1);
 
     double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+    sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);
 
     double cos_val = 0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
+    cos_val = std::max(std::min(cos_val, 1.0), -1.0);
     double beta = std::acos(cos_val);
     stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
   } else {
@@ -688,6 +690,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     stub_r = sqrt(r_square);
 
     double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+    sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -672,9 +672,9 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
   if (st->isBarrel()) {
     stub_r = settings_.rmean(stubLayer - 1);
 
-    // The expanded version of this expression is more stable for extremely
-    // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
-    // the domain of asin.
+    // The expanded version of this expression is more stable for very low-pT
+    // (high-rho) tracks. But we also explicitly restrict sin_val to the domain
+    // of asin.
     double sin_val =
         0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);
@@ -682,9 +682,9 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);
 
-    // The expanded version of this expression is more stable for extremely
-    // high-pT (high-rho) tracks. But we also explicitly restrict cos_val to
-    // the domain of acos.
+    // The expanded version of this expression is more stable for very low-pT
+    // (high-rho) tracks. But we also explicitly restrict cos_val to the domain
+    // of acos.
     double cos_val =
         0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
     cos_val = std::max(std::min(cos_val, 1.0), -1.0);
@@ -697,9 +697,9 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
     stub_r = sqrt(r_square);
 
-    // The expanded version of this expression is more stable for extremely
-    // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
-    // the domain of asin.
+    // The expanded version of this expression is more stable for very low-pT
+    // (high-rho) tracks. But we also explicitly restrict sin_val to the domain
+    // of asin.
     double sin_val =
         0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -672,12 +672,18 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
   if (st->isBarrel()) {
     stub_r = settings_.rmean(stubLayer - 1);
 
+    // The expanded version of this expression is more stable for extremely
+    // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
+    // the domain of asin.
     double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);
     stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
     stub_phi = reco::reduceRange(stub_phi);
 
+    // The expanded version of this expression is more stable for extremely
+    // high-pT (high-rho) tracks. But we also explicitly restrict cos_val to
+    // the domain of acos.
     double cos_val = 0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
     cos_val = std::max(std::min(cos_val, 1.0), -1.0);
     double beta = std::acos(cos_val);
@@ -689,6 +695,9 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
     stub_r = sqrt(r_square);
 
+    // The expanded version of this expression is more stable for extremely
+    // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
+    // the domain of asin.
     double sin_val = 0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
     sin_val = std::max(std::min(sin_val, 1.0), -1.0);
     stub_phi = tracklet->phi0() - std::asin(sin_val);


### PR DESCRIPTION
@tomalin 

#### PR description:

This PR fixes a numerical stability issue with the L1 extended tracking emulation, in particular, when seed stubs are invented, and their z-coordinates are calculated here:
https://github.com/cms-sw/cmssw/blob/CMSSW_14_0_0/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc#L680-L681
When the tracklet pT is ~high~ low enough, the argument to `std::acos` can sometimes be outside [-1, 1]. So you get track candidates like the following (note the stub with `z=nan`):
```
Input track cand: [phiSec,etaReg]=[1,12] HT(m,c)=(6858246,1) q/pt=-0.0711 tanL=1.5208 z0=-3.1506 phi0=0.7636 nStubs=8 d0=2.2936
stub layers = [ 2, 2, 2, 3, 4, 11, 11, 12 ]   KF stub layers = [ 1, 1, 1, 2, 3, 4, 4, 5 ]

stub index=1003 layerId=2 r=37.1777 phi=0.7170 z=53.2697 sigmaX=0.0029 sigmaZ=0.0423 TPids=
stub index=5031 layerId=2 r=37.1777 phi=0.7197 z=53.1452 sigmaX=0.0029 sigmaZ=0.0423 TPids=
stub index=6004 layerId=2 r=37.1777 phi=0.7097 z=nan sigmaX=0.0029 sigmaZ=0.0423 TPids=
stub index=2023 layerId=3 r=54.3401 phi=0.7435 z=79.4590 sigmaX=0.0029 sigmaZ=0.0423 TPids=
stub index=4019 layerId=4 r=70.4373 phi=0.7602 z=101.1695 sigmaX=0.0026 sigmaZ=1.4506 TPids=
stub index=58 layerId=11 r=88.2589 phi=0.7735 z=131.1914 sigmaX=0.0026 sigmaZ=1.4506 TPids=
stub index=7051 layerId=11 r=93.8537 phi=0.7748 z=133.4150 sigmaX=0.0026 sigmaZ=1.4506 TPids=
stub index=3033 layerId=12 r=104.8286 phi=0.7868 z=152.7650 sigmaX=0.0026 sigmaZ=1.4506 TPids=
```

Ultimately, this causes a failure when calculating the determinant of a matrix during the Kalman filter fit, leading to the error reported in #44306:
```
…
[a] Fatal Root Error: @SUB=TDecompLU::DecomposeLUCrout
matrix is singular
```
The matrix is not singular though, it just has not-a-number entries coming from applying `std::acos` to a number outside [-1, 1].

Expanding the argument to `std::acos` seems to solve the issue. Just to be safe, I made similar expansions for the arguments to `std::asin` used elsewhere in the same method, and I explicitly replace the arguments with -1 or 1 if they still happen to be outside [-1, 1].

#### PR validation:

The error reported in #44306, which I was able to reproduce by rerunning one of the PU relval jobs listed there, goes away after applying these changes.