### PR TITLE
HLT XGBoost Photon MVA and Diphoton combination filter

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
@@ -1,0 +1,157 @@
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
+#include <vector>
+#include <memory>
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
+class HLTEgammaDoubleXGBoostCombFilter : public HLTFilter {
+public:
+  explicit HLTEgammaDoubleXGBoostCombFilter(edm::ParameterSet const&);
+  ~HLTEgammaDoubleXGBoostCombFilter() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  bool hltFilter(edm::Event& event,
+                 const edm::EventSetup& setup,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+  const double highMassCut_;
+  const std::vector<double> leadCutHighMass1_;
+  const std::vector<double> subCutHighMass1_;
+  const std::vector<double> leadCutHighMass2_;
+  const std::vector<double> subCutHighMass2_;
+  const std::vector<double> leadCutHighMass3_;
+  const std::vector<double> subCutHighMass3_;
+
+  const double lowMassCut_;
+  const std::vector<double> leadCutLowMass1_;
+  const std::vector<double> subCutLowMass1_;
+  const std::vector<double> leadCutLowMass2_;
+  const std::vector<double> subCutLowMass2_;
+  const std::vector<double> leadCutLowMass3_;
+  const std::vector<double> subCutLowMass3_;
+
+  const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candToken_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> mvaToken_;
+};
+
+HLTEgammaDoubleXGBoostCombFilter::HLTEgammaDoubleXGBoostCombFilter(edm::ParameterSet const& config)
+    : HLTFilter(config),
+      highMassCut_(config.getParameter<double>("highMassCut")),
+      leadCutHighMass1_(config.getParameter<std::vector<double>>("leadCutHighMass1")),
+      subCutHighMass1_(config.getParameter<std::vector<double>>("subCutHighMass1")),
+      leadCutHighMass2_(config.getParameter<std::vector<double>>("leadCutHighMass2")),
+      subCutHighMass2_(config.getParameter<std::vector<double>>("subCutHighMass2")),
+      leadCutHighMass3_(config.getParameter<std::vector<double>>("leadCutHighMass3")),
+      subCutHighMass3_(config.getParameter<std::vector<double>>("subCutHighMass3")),
+
+      lowMassCut_(config.getParameter<double>("lowMassCut")),
+      leadCutLowMass1_(config.getParameter<std::vector<double>>("leadCutLowMass1")),
+      subCutLowMass1_(config.getParameter<std::vector<double>>("subCutLowMass1")),
+      leadCutLowMass2_(config.getParameter<std::vector<double>>("leadCutLowMass2")),
+      subCutLowMass2_(config.getParameter<std::vector<double>>("subCutLowMass2")),
+      leadCutLowMass3_(config.getParameter<std::vector<double>>("leadCutLowMass3")),
+      subCutLowMass3_(config.getParameter<std::vector<double>>("subCutLowMass3")),
+
+      candToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("candTag"))),
+      mvaToken_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("mvaPhotonTag"))) {}
+
+void HLTEgammaDoubleXGBoostCombFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+
+  desc.add<double>("highMassCut", 95.0);
+  desc.add<std::vector<double>>("leadCutHighMass1", {0.98, 0.95});
+  desc.add<std::vector<double>>("subCutHighMass1", {0.0, 0.04});
+  desc.add<std::vector<double>>("leadCutHighMass2", {0.85, 0.85});
+  desc.add<std::vector<double>>("subCutHighMass2", {0.04, 0.08});
+  desc.add<std::vector<double>>("leadCutHighMass3", {0.30, 0.50});
+  desc.add<std::vector<double>>("subCutHighMass3", {0.15, 0.20});
+
+  desc.add<double>("lowMassCut", 60.0);
+  desc.add<std::vector<double>>("leadCutLowMass1", {0.98, 0.90});
+  desc.add<std::vector<double>>("subCutLowMass1", {0.04, 0.05});
+  desc.add<std::vector<double>>("leadCutLowMass2", {0.90, 0.80});
+  desc.add<std::vector<double>>("subCutLowMass2", {0.10, 0.10});
+  desc.add<std::vector<double>>("leadCutLowMass3", {0.60, 0.60});
+  desc.add<std::vector<double>>("subCutLowMass3", {0.30, 0.30});
+
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltEgammaCandidatesUnseeded"));
+  desc.add<edm::InputTag>("mvaPhotonTag", edm::InputTag("PhotonXGBoostProducer"));
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+bool HLTEgammaDoubleXGBoostCombFilter::hltFilter(edm::Event& event,
+                                                 const edm::EventSetup& setup,
+                                                 trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  //producer collection (hltEgammaCandidates(Unseeded))
+  const auto& recCollection = event.getHandle(candToken_);
+
+  //get hold of photon MVA association map
+  const auto& mvaMap = event.getHandle(mvaToken_);
+
+  std::vector<math::XYZTLorentzVector> p4s(recCollection->size());
+  std::vector<bool> isTight(recCollection->size());
+
+  bool accept = false;
+
+  for (size_t i = 0; i < recCollection->size(); i++) {
+    edm::Ref<reco::RecoEcalCandidateCollection> refi(recCollection, i);
+    float EtaSCi = refi->eta();
+    int eta1 = (std::abs(EtaSCi) < 1.5) ? 0 : 1;
+    float mvaScorei = (*mvaMap).find(refi)->val;
+    math::XYZTLorentzVector p4i = refi->p4();
+    for (size_t j = i + 1; j < recCollection->size(); j++) {
+      edm::Ref<reco::RecoEcalCandidateCollection> refj(recCollection, j);
+      float EtaSCj = refj->eta();
+      int eta2 = (std::abs(EtaSCj) < 1.5) ? 0 : 1;
+      float mvaScorej = (*mvaMap).find(refj)->val;
+      math::XYZTLorentzVector p4j = refj->p4();
+      math::XYZTLorentzVector pairP4 = p4i + p4j;
+      double mass = pairP4.M();
+      if (mass >= highMassCut_) {
+        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutHighMass1_[eta1] && mvaScorej > subCutHighMass1_[eta2]) ||
+                                       (mvaScorei > leadCutHighMass2_[eta1] && mvaScorej > subCutHighMass2_[eta2]) ||
+                                       (mvaScorei > leadCutHighMass3_[eta1] && mvaScorej > subCutHighMass3_[eta2]))) {
+          accept = true;
+        }  //if scoreI > scoreJ
+        else if (mvaScorej > mvaScorei &&
+                 ((mvaScorej > leadCutHighMass1_[eta1] && mvaScorei > subCutHighMass1_[eta2]) ||
+                  (mvaScorej > leadCutHighMass2_[eta1] && mvaScorei > subCutHighMass2_[eta2]) ||
+                  (mvaScorej > leadCutHighMass3_[eta1] && mvaScorei > subCutHighMass3_[eta2]))) {
+          accept = true;
+        }  // if scoreJ > scoreI
+      }    //If high mass
+      else if (mass > lowMassCut_ && mass < highMassCut_) {
+        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutLowMass1_[eta1] && mvaScorej > subCutLowMass1_[eta2]) ||
+                                       (mvaScorei > leadCutLowMass2_[eta1] && mvaScorej > subCutLowMass2_[eta2]) ||
+                                       (mvaScorei > leadCutLowMass3_[eta1] && mvaScorej > subCutLowMass3_[eta2]))) {
+          accept = true;
+        }  //if scoreI > scoreJ
+        else if (mvaScorej > mvaScorei && ((mvaScorej > leadCutLowMass1_[eta1] && mvaScorei > subCutLowMass1_[eta2]) ||
+                                           (mvaScorej > leadCutLowMass2_[eta1] && mvaScorei > subCutLowMass2_[eta2]) ||
+                                           (mvaScorej > leadCutLowMass3_[eta1] && mvaScorei > subCutLowMass3_[eta2]))) {
+          accept = true;
+        }  //if scoreJ > scoreI
+      }    //If low mass
+    }      //j loop
+  }        //i loop
+  return accept;
+}  //Definition
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTEgammaDoubleXGBoostCombFilter);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -63,6 +63,7 @@ EgammaHLTClusterShapeProducer::EgammaHLTClusterShapeProducer(const edm::Paramete
   produces<reco::RecoEcalCandidateIsolationMap>("sigmaIPhiIPhi5x5NoiseCleaned");
   produces<reco::RecoEcalCandidateIsolationMap>("sMajor");
   produces<reco::RecoEcalCandidateIsolationMap>("sMinor");
+  produces<reco::RecoEcalCandidateIsolationMap>("e2x2");
 }
 
 EgammaHLTClusterShapeProducer::~EgammaHLTClusterShapeProducer() {}
@@ -108,6 +109,8 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
   reco::RecoEcalCandidateIsolationMap clshSMajorMap(recoecalcandHandle);
   reco::RecoEcalCandidateIsolationMap clshSMinorMap(recoecalcandHandle);
 
+  reco::RecoEcalCandidateIsolationMap e2x2Map(recoecalcandHandle);
+
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);
     if (recoecalcandref->superCluster()->seed()->seed().det() != DetId::Ecal) {  //HGCAL, skip for now
@@ -121,6 +124,8 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
       clshSMajorMap.insert(recoecalcandref, 0);
       clshSMinorMap.insert(recoecalcandref, 0);
+
+      e2x2Map.insert(recoecalcandref, 0);
 
       continue;
     }
@@ -161,6 +166,9 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
     float sMin = moments.sMin;
     clshSMajorMap.insert(recoecalcandref, sMaj);
     clshSMinorMap.insert(recoecalcandref, sMin);
+
+    auto const e2x2 = lazyTools.e2x2(*(recoecalcandref->superCluster()->seed()));
+    e2x2Map.insert(recoecalcandref, e2x2);
   }
 
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clshMap));
@@ -175,6 +183,8 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clshSMajorMap), "sMajor");
   iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(clshSMinorMap), "sMinor");
+
+  iEvent.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(e2x2Map), "e2x2");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoEgamma/PhotonIdentification/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/BuildFile.xml
@@ -22,6 +22,7 @@
 <use name="RecoLocalCalo/HcalRecAlgos"/>
 <use name="PhysicsTools/TensorFlow" />
 <use name="CommonTools/MVAUtils" />
+<use name="xgboost"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
@@ -1,0 +1,28 @@
+#ifndef ReciEgamma_PhotonIdentification_PhotonXGBoostEstimator_h
+#define ReciEgamma_PhotonIdentification_PhotonXGBoostEstimator_h
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "xgboost/c_api.h"
+
+class PhotonXGBoostEstimator {
+public:
+  PhotonXGBoostEstimator(const edm::FileInPath& weightsFile, int best_ntree_limit);
+  ~PhotonXGBoostEstimator();
+
+  float computeMva(float rawEnergyIn,
+                   float r9In,
+                   float sigmaIEtaIEtaIn,
+                   float etaWidthIn,
+                   float phiWidthIn,
+                   float e2x2In,
+                   float etaIn,
+                   float hOvrEIn,
+                   float ecalPFIsoIn) const;
+
+private:
+  BoosterHandle booster_;
+  int best_ntree_limit_ = -1;
+  std::string config_;
+};
+
+#endif

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
@@ -1,0 +1,137 @@
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h"
+
+#include <memory>
+#include <vector>
+
+class PhotonXGBoostProducer : public edm::global::EDProducer<> {
+public:
+  explicit PhotonXGBoostProducer(edm::ParameterSet const&);
+  ~PhotonXGBoostProducer() = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+  const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candToken_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> tokenR9_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> tokenHoE_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> tokenSigmaiEtaiEta_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> tokenE2x2_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> tokenIso_;
+  const edm::FileInPath mvaFileXgbB_;
+  const edm::FileInPath mvaFileXgbE_;
+  const unsigned mvaNTreeLimitB_;
+  const unsigned mvaNTreeLimitE_;
+  const double mvaThresholdEt_;
+  std::unique_ptr<PhotonXGBoostEstimator> mvaEstimatorB_;
+  std::unique_ptr<PhotonXGBoostEstimator> mvaEstimatorE_;
+};
+
+PhotonXGBoostProducer::PhotonXGBoostProducer(edm::ParameterSet const& config)
+    : candToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("candTag"))),
+      tokenR9_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("inputTagR9"))),
+      tokenHoE_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("inputTagHoE"))),
+      tokenSigmaiEtaiEta_(
+          consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("inputTagSigmaiEtaiEta"))),
+      tokenE2x2_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("inputTagE2x2"))),
+      tokenIso_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("inputTagIso"))),
+      mvaFileXgbB_(config.getParameter<edm::FileInPath>("mvaFileXgbB")),
+      mvaFileXgbE_(config.getParameter<edm::FileInPath>("mvaFileXgbE")),
+      mvaNTreeLimitB_(config.getParameter<unsigned int>("mvaNTreeLimitB")),
+      mvaNTreeLimitE_(config.getParameter<unsigned int>("mvaNTreeLimitE")),
+      mvaThresholdEt_(config.getParameter<double>("mvaThresholdEt")) {
+  mvaEstimatorB_ = std::make_unique<PhotonXGBoostEstimator>(mvaFileXgbB_, mvaNTreeLimitB_);
+  mvaEstimatorE_ = std::make_unique<PhotonXGBoostEstimator>(mvaFileXgbE_, mvaNTreeLimitE_);
+  produces<reco::RecoEcalCandidateIsolationMap>();
+}
+
+void PhotonXGBoostProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("candTag", edm::InputTag("hltEgammaCandidatesUnseeded"));
+  desc.add<edm::InputTag>("inputTagR9", edm::InputTag("hltEgammaR9IDUnseeded", "r95x5"));
+  desc.add<edm::InputTag>("inputTagHoE", edm::InputTag("hltEgammaHoverEUnseeded"));
+  desc.add<edm::InputTag>("inputTagSigmaiEtaiEta",
+                          edm::InputTag("hltEgammaClusterShapeUnseeded", "sigmaIEtaIEta5x5NoiseCleaned"));
+  desc.add<edm::InputTag>("inputTagE2x2", edm::InputTag("hltEgammaClusterShapeUnseeded", "e2x2"));
+  desc.add<edm::InputTag>("inputTagIso", edm::InputTag("hltEgammaEcalPFClusterIsoUnseeded"));
+  desc.add<edm::FileInPath>("mvaFileXgbB",
+                            edm::FileInPath("RecoEgamma/PhotonIdentification/data/xgb_photonmva_barrel_v1.bin"));
+  desc.add<edm::FileInPath>("mvaFileXgbE",
+                            edm::FileInPath("RecoEgamma/PhotonIdentification/data/xgb_photonmva_endcap_v1.bin"));
+  desc.add<unsigned int>("mvaNTreeLimitB", 55);
+  desc.add<unsigned int>("mvaNTreeLimitE", 48);
+  desc.add<double>("mvaThresholdEt", 0);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void PhotonXGBoostProducer::produce(edm::StreamID, edm::Event& event, edm::EventSetup const& setup) const {
+  const auto& recCollection = event.getHandle(candToken_);
+
+  //get hold of r9 association map
+  const auto& r9Map = event.getHandle(tokenR9_);
+
+  //get hold of HoE association map
+  const auto& hoEMap = event.getHandle(tokenHoE_);
+
+  //get hold of isolated association map
+  const auto& sigmaiEtaiEtaMap = event.getHandle(tokenSigmaiEtaiEta_);
+
+  //get hold of e2x2 (s4) association map
+  const auto& e2x2Map = event.getHandle(tokenE2x2_);
+
+  //get hold of Ecal isolation association map
+  const auto& isoMap = event.getHandle(tokenIso_);
+
+  //output
+  reco::RecoEcalCandidateIsolationMap mvaScoreMap(recCollection);
+
+  for (size_t i = 0; i < recCollection->size(); i++) {
+    edm::Ref<reco::RecoEcalCandidateCollection> ref(recCollection, i);
+
+    float etaSC = ref->eta();
+
+    float scEnergy = ref->superCluster()->energy();
+    float r9 = (*r9Map).find(ref)->val;
+    float hoe = (*hoEMap).find(ref)->val / scEnergy;
+    float siEtaiEta = (*sigmaiEtaiEtaMap).find(ref)->val;
+    float e2x2 = (*e2x2Map).find(ref)->val;
+    float iso = (*isoMap).find(ref)->val;
+
+    float rawEnergy = ref->superCluster()->rawEnergy();
+    float etaW = ref->superCluster()->etaWidth();
+    float phiW = ref->superCluster()->phiWidth();
+
+    float scEt = scEnergy / cosh(etaSC);
+    if (scEt < 0.)
+      scEt = 0.; /* first and second order terms assume non-negative energies */
+
+    float xgbScore = -100.;
+    //compute only above threshold used for training and cand filter, else store negative value into the association map.
+    if (scEt >= mvaThresholdEt_) {
+      if (std::abs(etaSC) < 1.5)
+        xgbScore = mvaEstimatorB_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, e2x2, etaSC, hoe, iso);
+      else
+        xgbScore = mvaEstimatorE_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, e2x2, etaSC, hoe, iso);
+    }
+    mvaScoreMap.insert(ref, xgbScore);
+  }
+  event.put(std::make_unique<reco::RecoEcalCandidateIsolationMap>(mvaScoreMap));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PhotonXGBoostProducer);

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
@@ -69,12 +69,12 @@ void PhotonXGBoostProducer::fillDescriptions(edm::ConfigurationDescriptions& des
                           edm::InputTag("hltEgammaClusterShapeUnseeded", "sigmaIEtaIEta5x5NoiseCleaned"));
   desc.add<edm::InputTag>("inputTagE2x2", edm::InputTag("hltEgammaClusterShapeUnseeded", "e2x2"));
   desc.add<edm::InputTag>("inputTagIso", edm::InputTag("hltEgammaEcalPFClusterIsoUnseeded"));
-  desc.add<edm::FileInPath>("mvaFileXgbB",
-                            edm::FileInPath("RecoEgamma/PhotonIdentification/data/xgb_photonmva_barrel_v1.bin"));
-  desc.add<edm::FileInPath>("mvaFileXgbE",
-                            edm::FileInPath("RecoEgamma/PhotonIdentification/data/xgb_photonmva_endcap_v1.bin"));
-  desc.add<unsigned int>("mvaNTreeLimitB", 55);
-  desc.add<unsigned int>("mvaNTreeLimitE", 48);
+  desc.add<edm::FileInPath>(
+      "mvaFileXgbB", edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_168_Barrel_v1.bin"));
+  desc.add<edm::FileInPath>(
+      "mvaFileXgbE", edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_158_Endcap_v1.bin"));
+  desc.add<unsigned int>("mvaNTreeLimitB", 168);
+  desc.add<unsigned int>("mvaNTreeLimitE", 158);
   desc.add<double>("mvaThresholdEt", 0);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
@@ -1,0 +1,60 @@
+#include "RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h"
+#include <sstream>
+
+PhotonXGBoostEstimator::PhotonXGBoostEstimator(const edm::FileInPath& weightsFile, int best_ntree_limit) {
+  XGBoosterCreate(NULL, 0, &booster_);
+  XGBoosterLoadModel(booster_, weightsFile.fullPath().c_str());
+  best_ntree_limit_ = best_ntree_limit;
+
+  std::stringstream config;
+  config << "{\"training\": false, \"type\": 0, \"iteration_begin\": 0, \"iteration_end\": " << best_ntree_limit_
+         << ", \"strict_shape\": false}";
+  config_ = config.str();
+}
+
+PhotonXGBoostEstimator::~PhotonXGBoostEstimator() { XGBoosterFree(booster_); }
+
+namespace {
+  enum inputIndexes {
+    rawEnergy = 0,      // 0
+    r9 = 1,             // 1
+    sigmaIEtaIEta = 2,  // 2
+    etaWidth = 3,       // 3
+    phiWidth = 4,       // 4
+    e2x2 = 5,           // 5
+    eta = 6,            // 6
+    hOvrE = 7,          // 7
+    ecalPFIso = 8,      // 8
+  };
+}  // namespace
+
+float PhotonXGBoostEstimator::computeMva(float rawEnergyIn,
+                                         float r9In,
+                                         float sigmaIEtaIEtaIn,
+                                         float etaWidthIn,
+                                         float phiWidthIn,
+                                         float e2x2In,
+                                         float etaIn,
+                                         float hOvrEIn,
+                                         float ecalPFIsoIn) const {
+  float var[9];
+  var[rawEnergy] = rawEnergyIn;
+  var[r9] = r9In;
+  var[sigmaIEtaIEta] = sigmaIEtaIEtaIn;
+  var[etaWidth] = etaWidthIn;
+  var[phiWidth] = phiWidthIn;
+  var[e2x2] = e2x2In;
+  var[eta] = etaIn;
+  var[hOvrE] = hOvrEIn;
+  var[ecalPFIso] = ecalPFIsoIn;
+
+  DMatrixHandle dmat;
+  XGDMatrixCreateFromMat(var, 1, 9, -999.9f, &dmat);
+  uint64_t const* out_shape;
+  uint64_t out_dim;
+  const float* out_result = NULL;
+  XGBoosterPredictFromDMatrix(booster_, dmat, config_.c_str(), &out_shape, &out_dim, &out_result);
+  float ret = out_result[0];
+  XGDMatrixFree(dmat);
+  return ret;
+}

--- a/RecoEgamma/PhotonIdentification/test/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/test/BuildFile.xml
@@ -1,1 +1,8 @@
+<use name="catch2"/>
+<bin file="test_PhotonMvaXgb.cc" name="RecoEgammaPhotonIdentificationTest">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="RecoEgamma/PhotonIdentification"/>
+</bin>
+
 <test name="runtestRecoEgammaPhotonIdentification" command="runtests.sh"/>

--- a/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
+++ b/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
@@ -1,0 +1,47 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h"
+
+#include <memory>
+
+#define INPUT_LEN 10
+#define NTREE_LIMIT_B_V1 168
+#define NTREE_LIMIT_E_V1 158
+
+float const vars_in[INPUT_LEN][9] = {
+    {134.303, 0.945981, 0.0264346, 0.012448, 0.0208734, 113.405, 1.7446, 0.00437808, 0.303464},
+    {95.8896, 0.988677, 0.0217735, 0.0137696, 0.0441448, 90.7534, 1.85852, 0.0176929, 0},
+    {10.2401, 1.1569, 0.00201483, 3.62996e-08, 4.7182e-08, 10.2401, 1.78352, 0.030019, 0.544686},
+    {29.9392, 0.697065, 0.0081139, 0.00515725, 0.0200072, 18.7519, -0.330034, 0.069339, 0},
+    {108.427, 0.911677, 0.0246062, 0.0105294, 0.0453685, 85.5906, -1.74928, 0.0195397, 1.00826},
+    {19.6606, 1, 0.00818396, 0.00822772, 0.0219786, 19.6606, -2.39845, 0.0758766, 0},
+    {66.2052, 0.784169, 0.00864794, 0.0141328, 0.0932173, 40.2147, -1.37391, 0.00421972, 0.662302},
+    {8.74049, 0.519034, 0.00893926, 0.00879872, 0.0741009, 4.24432, -0.913888, 0.0324049, 2.66463},
+    {231.613, 1.13042, 0.0213042, 0.0278477, 0.017684, 231.613, -2.61615, 0.0236956, 0},
+    {70.3165, 0.987047, 0.00893917, 0.00897895, 0.00935749, 65.8019, -0.495195, 0.042801, 0.331989}};
+
+const float mva_score_v1[INPUT_LEN] = {
+    0.98634, 0.97501, 0.00179, 0.70818, 0.98374, 0.00153, 0.97103, 0.00009, 0.00626, 0.95222};
+
+TEST_CASE("RecoEgamma/PhotonIdentification testXGBPhoton", "[TestPhotonMvaXgb]") {
+  auto mvaEstimatorB = std::make_unique<PhotonXGBoostEstimator>(
+      edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_168_Barrel_v1.bin"), NTREE_LIMIT_B_V1);
+  auto mvaEstimatorE = std::make_unique<PhotonXGBoostEstimator>(
+      edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_158_Endcap_v1.bin"), NTREE_LIMIT_E_V1);
+
+  SECTION("Test mva_compute") {
+    for (unsigned int i = 0; i < INPUT_LEN; i++) {
+      float xgbScore;
+      const float *v = vars_in[i];
+      float etaSC = v[6];
+      if (abs(etaSC) < 1.5)
+        xgbScore = mvaEstimatorB->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+      else
+        xgbScore = mvaEstimatorE->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+      CHECK_THAT(xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001));
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR uses XGBoost C API to implement calculation of the score of Photons for HLT.
Combination filter is provided with the aim of implementing diphoton paths.
Total of 9 HLT variables are used as input.

For binary model files, NTree Limit parameter must be provided (it is not saved in the model file).

Note: at this time model training files are not provided, until they are finalized.
At that point we will request: cms-data repository for model files, define default parameters (cuts) and add unit test which ensures XGBoost (v1.7.5 currently used in CMSSW) calculates scores correctly with given model files and parameters.

Initially this is opened as Draft PR. Backport to 14_0_X is planned.

#### PR validation:

Initially passes HLT integration tests (caveat: all events rejected at the combination filter due to low statistics, but no errors)

Sample HLT snippet used for this:
```
process.hltPreDiphotonMVA = cms.EDFilter( "HLTPrescaler",
     offset = cms.uint32( 0 ),
     L1GtReadoutRecordTag = cms.InputTag( "hltGtStage2Digis" )
)

process.hltDiEG14p25EtEta2p55UnseededFilter = cms.EDFilter( "HLT1Photon",
     saveTags = cms.bool( True ),
     inputTag = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     triggerType = cms.int32( 92 ),
     MinE = cms.double( -1.0 ),
     MinPt = cms.double( 14.25 ),
     MinMass = cms.double( -1.0 ),
     MaxMass = cms.double( -1.0 ),
     MinEta = cms.double( -1.0 ),
     MaxEta = cms.double( 2.55 ),
     MinN = cms.int32( 2 )
)

process.PhotonXGBoostProducer = cms.EDProducer("PhotonXGBoostProducer",
     candTag = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     inputTagR9 = cms.InputTag("hltEgammaR9IDUnseeded", "r95x5"),
     inputTagHoE = cms.InputTag("hltEgammaHoverEUnseeded"),
     inputTagSigmaiEtaiEta = cms.InputTag("hltEgammaClusterShapeUnseeded", "sigmaIEtaIEta5x5NoiseCleaned"),
     inputTagE2x2 = cms.InputTag("hltEgammaClusterShapeUnseeded", "e2x2"),
     inputTagIso = cms.InputTag("hltEgammaEcalPFClusterIsoUnseeded"),
     mvaFileXgbB = cms.FileInPath("RecoEgamma/PhotonIdentification/data/barrel.bin"), #copy by hand
     mvaFileXgbE = cms.FileInPath("RecoEgamma/PhotonIdentification/data/barrel.bin"), #copy by hand
     mvaNTreeLimitB = cms.uint32(168),
     mvaNTreeLimitE = cms.uint32(158),
     mvaThresholdEt = cms.double(14.25)
)

process.HLTEgammaDoubleXGBoostCombFilter = cms.EDFilter("HLTEgammaDoubleXGBoostCombFilter",
     saveTags = cms.bool( True ),
     candTag = cms.InputTag( "hltEgammaCandidatesUnseeded" ),
     mvaPhotonTag = cms.InputTag( "PhotonXGBoostProducer" ),
     highMassCut = cms.double(95),
     leadCutHighMass1 = cms.vdouble(0.98,0.95),
     subCutHighMass1 = cms.vdouble(0.00,0.04),
     leadCutHighMass2 = cms.vdouble(0.85,0.85),
     subCutHighMass2 = cms.vdouble(0.04,0.08),
     leadCutHighMass3 = cms.vdouble(0.30,0.50),
     subCutHighMass3 = cms.vdouble(0.15,0.20),
     lowMassCut = cms.double(60),
     leadCutLowMass1 = cms.vdouble(0.98,0.90),
     subCutLowMass1 = cms.vdouble(0.04,0.05),
     leadCutLowMass2 = cms.vdouble(0.90,0.80),
     subCutLowMass2 = cms.vdouble(0.10,0.10),
     leadCutLowMass3 = cms.vdouble(0.60,0.60),
     subCutLowMass3 = cms.vdouble(0.30,0.30),

process.HLTDiphotonMvaTestSequence = cms.Sequence( process.HLTDoFullUnpackingEgammaEcalSequence + process.HLTPFClusteringForEgamma + process.hltEgammaCandidates + process.hltEGL1SingleAndDoubleEGOrFilter + process.hltEG30L1SingleAndDoubleEGOrEtFilter + process.HLTPFClusteringForEgammaUnseeded + process.hltEgammaCandidatesUnseeded + process.hltDiEG14p25EtEta2p55UnseededFilter + process.hltEgammaR9IDUnseeded + process.HLTDoLocalHcalSequence + process.HLTFastJetForEgamma + process.hltEgammaHoverEUnseeded + process.hltEgammaClusterShapeUnseeded + process.hltEgammaEcalPFClusterIsoUnseeded )

process.HLT_Diphoton_MVA = cms.Path( process.HLTBeginSequence + process.hltL1sSingleAndDoubleEGor + process.HLTDiphotonMvaTestSequence  + process.PhotonXGBoostProducer + process.HLTEgammaDoubleXGBoostCombFilter + process.HLTEndSequence )

process.schedule.insert( process.schedule.index( process.HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v20 ) + 1, process.HLT_Diphoton_MVA )

getattr(process.datasets, 'EGamma0').append('HLT_Diphoton_MVA')
getattr(process.datasets, 'EGamma1').append('HLT_Diphoton_MVA')
getattr(process.datasets, 'OnlineMonitor').append('HLT_Diphoton_MVA')

process.hltDatasetEGamma.triggerConditions.append('HLT_Diphoton_MVA')
process.hltDatasetOnlineMonitor.triggerConditions.append('HLT_Diphoton_MVA')
```