### PR TITLE
Removed explicit copy ctr in TrackStub

### DIFF
--- a/DataFormats/L1CSCTrackFinder/interface/TrackStub.h
+++ b/DataFormats/L1CSCTrackFinder/interface/TrackStub.h
@@ -24,7 +24,6 @@ namespace csctf {
     TrackStub() {}
     TrackStub(const CSCCorrelatedLCTDigi &, const DetId &);
     TrackStub(const CSCCorrelatedLCTDigi &, const DetId &, const unsigned &phi, const unsigned &eta);
-    TrackStub(const TrackStub &);
 
     /// set Eta and Phi from integer values.
     void setEtaPacked(const unsigned &eta_) { theEta_ = eta_; }

--- a/DataFormats/L1CSCTrackFinder/src/TrackStub.cc
+++ b/DataFormats/L1CSCTrackFinder/src/TrackStub.cc
@@ -16,13 +16,6 @@ namespace csctf {
   TrackStub::TrackStub(const CSCCorrelatedLCTDigi& aDigi, const DetId& aDetId, const unsigned& phi, const unsigned& eta)
       : CSCCorrelatedLCTDigi(aDigi), theDetId_(aDetId.rawId()), thePhi_(phi), theEta_(eta), link_(0) {}
 
-  TrackStub::TrackStub(const TrackStub& aTrackStub)
-      : CSCCorrelatedLCTDigi(aTrackStub),
-        theDetId_(aTrackStub.theDetId_),
-        thePhi_(aTrackStub.thePhi_),
-        theEta_(aTrackStub.theEta_),
-        link_(aTrackStub.link_) {}
-
   unsigned TrackStub::endcap() const {
     int e = 0;
 


### PR DESCRIPTION
#### PR description:

This avoids a clang compiler warning about deprecated default op=.

#### PR validation:

Compiling code under CMSSW_14_1_CLANG_X_2024-03-19-2300 no longer issues warnings.