### PR TITLE
Apply rule-of-5 to ESPreFunctorDecorator

### DIFF
--- a/FWCore/Framework/interface/ESPreFunctorDecorator.h
+++ b/FWCore/Framework/interface/ESPreFunctorDecorator.h
@@ -33,7 +33,11 @@ namespace edm {
     class ESPreFunctorDecorator {
     public:
       ESPreFunctorDecorator(const TFunctor& iCaller) : caller_(iCaller) {}
-      const ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete;  // stop default
+      ESPreFunctorDecorator() = delete;
+      ESPreFunctorDecorator(ESPreFunctorDecorator&&) = default;
+      ESPreFunctorDecorator(ESPreFunctorDecorator const&) = default;
+      ESPreFunctorDecorator& operator=(const ESPreFunctorDecorator&) = delete;  // stop default
+      ESPreFunctorDecorator& operator=(ESPreFunctorDecorator&&) = delete;
 
       //virtual ~ESPreFunctorDecorator();
 


### PR DESCRIPTION
#### PR description:

This avoids a compiler warning under clang.

#### PR validation:

Compiling code under CMSSW_14_1_CLANG_X_2024-03-19-2300 no longer issues a warning.