### PR TITLE
Use default ctr in HGCal data formats

### DIFF
--- a/DataFormats/HGCDigi/interface/HGCDataFrame.h
+++ b/DataFormats/HGCDigi/interface/HGCDataFrame.h
@@ -23,7 +23,6 @@ public:
   */
   HGCDataFrame() : id_(0), maxSampleSize_(15) { data_.resize(maxSampleSize_); }
   HGCDataFrame(const D& id) : id_(id), maxSampleSize_(15) { data_.resize(maxSampleSize_); }
-  HGCDataFrame(const HGCDataFrame& o) : data_(o.data_), id_(o.id_), maxSampleSize_(o.maxSampleSize_) {}
 
   /**
     @short det id

--- a/DataFormats/HGCalDigi/interface/HGCalElectronicsId.h
+++ b/DataFormats/HGCalDigi/interface/HGCalElectronicsId.h
@@ -41,7 +41,6 @@ public:
   explicit HGCalElectronicsId(
       uint16_t fedid, uint8_t captureblock, uint8_t econdidx, uint8_t econderx, uint8_t halfrocch);
   explicit HGCalElectronicsId(uint32_t value) : value_(value) {}
-  HGCalElectronicsId(const HGCalElectronicsId& o) : value_(o.value_) {}
 
   /**
      @short getters


### PR DESCRIPTION
#### PR description:

This avoids a clang compiler warning.

#### PR validation:

Compiling under CMSSW_14_1_CLANG_X_2024-03-19-2300 no longer issues a warning.