### PR TITLE
[CPP20][ALCA, DB] Remove deprecated enum arithmetic

### DIFF
--- a/Alignment/Geners/interface/GenericIO.hh
+++ b/Alignment/Geners/interface/GenericIO.hh
@@ -312,7 +312,11 @@ namespace gs {
     inline static bool process(T &s, Stream &is, State *st, const bool processClassId) {
       typedef IOTraits<T> M;
       T *ps = &s;
-      return GenericReader<Stream, State, T, Int2Type<M::Signature &(M::ISPLACEREADABLE | M::ISHEAPREADABLE)>>::
+      return GenericReader<Stream,
+                           State,
+                           T,
+                           Int2Type<static_cast<int>(M::Signature) &
+                                    (static_cast<int>(M::ISPLACEREADABLE) | static_cast<int>(M::ISHEAPREADABLE))>>::
           readIntoPtr(ps, is, st, processClassId);
     }
   };
@@ -334,7 +338,9 @@ namespace gs {
       // decision which simplifies things considerably.
       typedef typename IOPointeeType<Ptr>::type Pointee;
       typedef IOTraits<Pointee> M;
-      static_assert((M::Signature & (M::ISPOINTER | M::ISSHAREDPTR)) == 0, "can not write pointers to pointers");
+      static_assert(
+          (static_cast<int>(M::Signature) & (static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR))) == 0,
+          "can not write pointers to pointers");
 
       // Can't have NULL pointers either. But this
       // can be checked at run time only.

--- a/Alignment/Geners/interface/GenericIO.hh
+++ b/Alignment/Geners/interface/GenericIO.hh
@@ -351,14 +351,19 @@ namespace gs {
       // Note that the pointee itself can not be a pointer.
       typedef typename IOPointeeType<Ptr>::type Pointee;
       typedef IOTraits<Pointee> M;
-      static_assert((M::Signature & (M::ISPOINTER | M::ISSHAREDPTR)) == 0, "can not read pointers to pointers");
+      static_assert(
+          (static_cast<int>(M::Signature) & (static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR))) == 0,
+          "can not read pointers to pointers");
 
       return GenericReader<
           Stream,
           State,
           Pointee,
-          Int2Type<M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISHEAPREADABLE | M::ISPLACEREADABLE | M::ISPAIR |
-                                  M::ISTUPLE | M::ISEXTERNAL | M::ISSTRING)>>::readIntoPtr(ptr, str, s, processClassId);
+          Int2Type<static_cast<int>(M::Signature) &
+                   (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) |
+                    static_cast<int>(M::ISHEAPREADABLE) | static_cast<int>(M::ISPLACEREADABLE) |
+                    static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISTUPLE) | static_cast<int>(M::ISEXTERNAL) |
+                    static_cast<int>(M::ISSTRING))>>::readIntoPtr(ptr, str, s, processClassId);
     }
   };
 
@@ -370,14 +375,19 @@ namespace gs {
       // Note that the pointee itself can not be a pointer.
       typedef typename IOPointeeType<Ptr>::type Pointee;
       typedef IOTraits<Pointee> M;
-      static_assert((M::Signature & (M::ISNULLPOINTER | M::ISSHAREDPTR)) == 0, "can not read pointers to pointers");
+      static_assert((static_cast<int>(M::Signature) &
+                     (static_cast<int>(M::ISNULLPOINTER) | static_cast<int>(M::ISSHAREDPTR))) == 0,
+                    "can not read pointers to pointers");
 
       return GenericReader<
           Stream,
           State,
           Pointee,
-          Int2Type<M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISPUREHEAPREADABLE | M::ISPLACEREADABLE | M::ISPAIR |
-                                  M::ISTUPLE | M::ISEXTERNAL | M::ISSTRING)>>::readIntoPtr(ptr, str, s, processClassId);
+          Int2Type<static_cast<int>(M::Signature) &
+                   (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) |
+                    static_cast<int>(M::ISPUREHEAPREADABLE) | static_cast<int>(M::ISPLACEREADABLE) |
+                    static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISTUPLE) | static_cast<int>(M::ISEXTERNAL) |
+                    static_cast<int>(M::ISSTRING))>>::readIntoPtr(ptr, str, s, processClassId);
     }
   };
 

--- a/Alignment/Geners/interface/ProcessItem.hh
+++ b/Alignment/Geners/interface/ProcessItem.hh
@@ -118,8 +118,11 @@ namespace gs {
         T,
         Arg1,
         Arg2,
-        M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISWRITABLE | M::ISPOINTER | M::ISSHAREDPTR | M::ISIOPTR |
-                       M::ISPAIR | M::ISSTRING | M::ISTUPLE | M::ISEXTERNAL)>::process(obj, a1, p2, processClassId);
+        static_cast<int>(M::Signature) &
+            (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) | static_cast<int>(M::ISWRITABLE) |
+             static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR) | static_cast<int>(M::ISIOPTR) |
+             static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISSTRING) | static_cast<int>(M::ISTUPLE) |
+             static_cast<int>(M::ISEXTERNAL))>::process(obj, a1, p2, processClassId);
   }
 }  // namespace gs
 

--- a/Alignment/Geners/interface/ProcessItem.hh
+++ b/Alignment/Geners/interface/ProcessItem.hh
@@ -335,8 +335,11 @@ namespace gs {
         T,
         Arg1,
         Arg2,
-        M::Signature &(M::ISPOD | M::ISSTDCONTAINER | M::ISWRITABLE | M::ISPOINTER | M::ISSHAREDPTR | M::ISIOPTR |
-                       M::ISPAIR | M::ISSTRING | M::ISTUPLE | M::ISEXTERNAL)>::process(obj, a1, p2, processClassId);
+        static_cast<int>(M::Signature) &
+            (static_cast<int>(M::ISPOD) | static_cast<int>(M::ISSTDCONTAINER) | static_cast<int>(M::ISWRITABLE) |
+             static_cast<int>(M::ISPOINTER) | static_cast<int>(M::ISSHAREDPTR) | static_cast<int>(M::ISIOPTR) |
+             static_cast<int>(M::ISPAIR) | static_cast<int>(M::ISSTRING) | static_cast<int>(M::ISTUPLE) |
+             static_cast<int>(M::ISEXTERNAL))>::process(obj, a1, p2, processClassId);
   }
 }  // namespace gs
 

--- a/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
@@ -162,10 +162,11 @@ inline const uint32_t SiStripRegionCabling::elementIndex(const Position position
   return elementIndex(region(position), subdet, layer);
 }
 
-inline const uint32_t SiStripRegionCabling::layer(const uint32_t index) { return index % ALLLAYERS; }
+inline const uint32_t SiStripRegionCabling::layer(const uint32_t index) { return index % static_cast<int>(ALLLAYERS); }
 
 inline const SiStripRegionCabling::SubDet SiStripRegionCabling::subdet(const uint32_t index) {
-  return static_cast<SiStripRegionCabling::SubDet>((index / ALLLAYERS) % ALLSUBDETS);
+  return static_cast<SiStripRegionCabling::SubDet>((index / static_cast<int>(ALLLAYERS)) %
+                                                   static_cast<int>(ALLSUBDETS));
 }
 
 inline const uint32_t SiStripRegionCabling::region(const uint32_t index) {

--- a/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRegionCabling.h
@@ -146,7 +146,8 @@ inline const uint32_t SiStripRegionCabling::region(const PositionIndex index) co
 inline const uint32_t SiStripRegionCabling::elementIndex(const uint32_t region,
                                                          const SubDet subdet,
                                                          const uint32_t layer) {
-  return region * ALLSUBDETS * ALLLAYERS + subdet * ALLLAYERS + layer;
+  return region * static_cast<int>(ALLSUBDETS) * static_cast<int>(ALLLAYERS) + subdet * static_cast<int>(ALLLAYERS) +
+         layer;
 }
 
 inline const uint32_t SiStripRegionCabling::elementIndex(const PositionIndex index,
@@ -167,6 +168,8 @@ inline const SiStripRegionCabling::SubDet SiStripRegionCabling::subdet(const uin
   return static_cast<SiStripRegionCabling::SubDet>((index / ALLLAYERS) % ALLSUBDETS);
 }
 
-inline const uint32_t SiStripRegionCabling::region(const uint32_t index) { return index / (ALLSUBDETS * ALLLAYERS); }
+inline const uint32_t SiStripRegionCabling::region(const uint32_t index) {
+  return index / (static_cast<int>(ALLSUBDETS) * static_cast<int>(ALLLAYERS));
+}
 
 #endif

--- a/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
+++ b/Calibration/EcalCalibAlgos/src/ECALpedestalPCLHarvester.cc
@@ -206,8 +206,8 @@ bool ECALpedestalPCLHarvester::checkVariation(const EcalPedestalsMap& oldPedesta
       nAnomaliesEE++;
   }
 
-  if (nAnomaliesEB > thresholdAnomalies_ * EBDetId::kSizeForDenseIndexing ||
-      nAnomaliesEE > thresholdAnomalies_ * EEDetId::kSizeForDenseIndexing)
+  if (nAnomaliesEB > thresholdAnomalies_ * static_cast<int>(EBDetId::kSizeForDenseIndexing) ||
+      nAnomaliesEE > thresholdAnomalies_ * static_cast<int>(EEDetId::kSizeForDenseIndexing))
     return true;
 
   return false;

--- a/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
@@ -117,7 +117,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EB Channel Status Masks, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)ebcount / kEBChannels * 100.;
+      Double_t prop = (Double_t)ebcount / static_cast<int>(kEBChannels) * 100.;
       sprintf(txt, "%d/61200 (%4.3f%%)", ebcount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);
@@ -252,7 +252,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EE Channel Status Masks, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)eecount / kEEChannels * 100.;
+      Double_t prop = (Double_t)eecount / static_cast<int>(kEEChannels) * 100.;
       sprintf(txt, "%d/14648 (%4.3f%%)", eecount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);

--- a/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
@@ -122,7 +122,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EB DQM Channel Status, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)ebcount / kEBChannels * 100.;
+      Double_t prop = (Double_t)ebcount / static_cast<int>(kEBChannels) * 100.;
       sprintf(txt, "%d/61200 (%4.3f%%)", ebcount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);
@@ -263,7 +263,7 @@ namespace {
       t1.DrawLatex(0.5, 0.96, Form("EE DQM Channel Status, IOV %i", run));
 
       char txt[80];
-      Double_t prop = (Double_t)eecount / kEEChannels * 100.;
+      Double_t prop = (Double_t)eecount / static_cast<int>(kEEChannels) * 100.;
       sprintf(txt, "%d/14648 (%4.3f%%)", eecount, prop);
       t1.SetTextColor(2);
       t1.SetTextSize(0.045);

--- a/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
@@ -85,8 +85,8 @@ namespace {
       EBrms = sqrt(EBrms);
       if (EBrms == 0.)
         EBrms = 0.001;
-      double pEBmin = EBmean - kRMS * EBrms;
-      double pEBmax = EBmean + kRMS * EBrms;
+      double pEBmin = EBmean - static_cast<int>(kRMS) * EBrms;
+      double pEBmax = EBmean + static_cast<int>(kRMS) * EBrms;
       //      std::cout << " mean " << EBmean << " rms " << EBrms << " entries " << EBtot << " min " << pEBmin << " max " << pEBmax << std::endl;
       vt = (double)EEtot;
       EEmean = EEmean / vt;
@@ -94,8 +94,8 @@ namespace {
       EErms = sqrt(EErms);
       if (EErms == 0.)
         EErms = 0.001;
-      double pEEmin = EEmean - kRMS * EErms;
-      double pEEmax = EEmean + kRMS * EErms;
+      double pEEmin = EEmean - static_cast<int>(kRMS) * EErms;
+      double pEEmax = EEmean + static_cast<int>(kRMS) * EErms;
       //      std::cout << " mean " << EEmean << " rms " << EErms << " entries " << EEtot << " min " << pEEmin << " max " << pEEmax << std::endl;
 
       gStyle->SetPalette(1);
@@ -232,8 +232,8 @@ namespace {
       EBrms = sqrt(EBrms);
       if (EBrms == 0.)
         EBrms = 0.001;
-      double pEBmin = EBmean - kRMS * EBrms;
-      double pEBmax = EBmean + kRMS * EBrms;
+      double pEBmin = EBmean - static_cast<int>(kRMS) * EBrms;
+      double pEBmax = EBmean + static_cast<int>(kRMS) * EBrms;
       //      std::cout << " mean " << EBmean << " rms " << EBrms << " entries " << EBtot << " min " << pEBmin << " max " << pEBmax << std::endl;
       vt = (double)EEtot;
       EEmean = EEmean / vt;
@@ -241,8 +241,8 @@ namespace {
       EErms = sqrt(EErms);
       if (EErms == 0.)
         EErms = 0.001;
-      double pEEmin = EEmean - kRMS * EErms;
-      double pEEmax = EEmean + kRMS * EErms;
+      double pEEmin = EEmean - static_cast<int>(kRMS) * EErms;
+      double pEEmax = EEmean + static_cast<int>(kRMS) * EErms;
       //      std::cout << " mean " << EEmean << " rms " << EErms << " entries " << EEtot << " min " << pEEmin << " max " << pEEmax << std::endl;
 
       gStyle->SetPalette(1);

--- a/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
@@ -170,8 +170,8 @@ namespace {
         EBrms[valId] = sqrt(EBrms[valId]);
         if (EBrms[valId] == 0.)
           EBrms[valId] = 0.001;
-        pEBmin[valId] = EBmean[valId] - kRMS * EBrms[valId];
-        pEBmax[valId] = EBmean[valId] + kRMS * EBrms[valId];
+        pEBmin[valId] = EBmean[valId] - static_cast<int>(kRMS) * EBrms[valId];
+        pEBmax[valId] = EBmean[valId] + static_cast<int>(kRMS) * EBrms[valId];
         //	std::cout << " mean " << EBmean[valId] << " rms " << EBrms[valId] << " entries " << EBtot[valId] << " min " << pEBmin[valId]
         //		  << " max " << pEBmax[valId] << std::endl;
         vt = (double)EEtot[valId];
@@ -180,8 +180,8 @@ namespace {
         EErms[valId] = sqrt(EErms[valId]);
         if (EErms[valId] == 0.)
           EErms[valId] = 0.001;
-        pEEmin[valId] = EEmean[valId] - kRMS * EErms[valId];
-        pEEmax[valId] = EEmean[valId] + kRMS * EErms[valId];
+        pEEmin[valId] = EEmean[valId] - static_cast<int>(kRMS) * EErms[valId];
+        pEEmax[valId] = EEmean[valId] + static_cast<int>(kRMS) * EErms[valId];
         //	std::cout << " mean " << EEmean[valId] << " rms " << EErms[valId] << " entries " << EEtot[valId] << " min " << pEEmin[valId]
         //		  << " max " << pEEmax[valId] << std::endl;
       }
@@ -424,8 +424,8 @@ namespace {
         EBrms[valId] = sqrt(EBrms[valId]);
         if (EBrms[valId] == 0.)
           EBrms[valId] = 0.001;
-        pEBmin[valId] = EBmean[valId] - kRMS * EBrms[valId];
-        pEBmax[valId] = EBmean[valId] + kRMS * EBrms[valId];
+        pEBmin[valId] = EBmean[valId] - static_cast<int>(kRMS) * EBrms[valId];
+        pEBmax[valId] = EBmean[valId] + static_cast<int>(kRMS) * EBrms[valId];
         //	std::cout << " mean " << EBmean[valId] << " rms " << EBrms[valId] << " entries " << EBtot[valId] << " min " << pEBmin[valId]
         //		  << " max " << pEBmax[valId] << std::endl;
         vt = (double)EEtot[valId];
@@ -434,8 +434,8 @@ namespace {
         EErms[valId] = sqrt(EErms[valId]);
         if (EErms[valId] == 0.)
           EErms[valId] = 0.001;
-        pEEmin[valId] = EEmean[valId] - kRMS * EErms[valId];
-        pEEmax[valId] = EEmean[valId] + kRMS * EErms[valId];
+        pEEmin[valId] = EEmean[valId] - static_cast<int>(kRMS) * EErms[valId];
+        pEEmax[valId] = EEmean[valId] + static_cast<int>(kRMS) * EErms[valId];
         //	std::cout << " mean " << EEmean[valId] << " rms " << EErms[valId] << " entries " << EEtot[valId] << " min " << pEEmin[valId]
         //		  << " max " << pEEmax[valId] << std::endl;
       }

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -988,9 +988,9 @@ namespace {
     EcalPedestalsEEMean12Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap pedestal gain12 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<double>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<double>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -345,8 +345,8 @@ namespace {
         EBrms[gId] = sqrt(EBrms[gId]);
         if (EBrms[gId] == 0.)
           EBrms[gId] = 0.001;
-        pEBmin[gId] = EBmean[gId] - kRMS * EBrms[gId];
-        pEBmax[gId] = EBmean[gId] + kRMS * EBrms[gId];
+        pEBmin[gId] = EBmean[gId] - static_cast<int>(kRMS) * EBrms[gId];
+        pEBmax[gId] = EBmean[gId] + static_cast<int>(kRMS) * EBrms[gId];
         //	std::cout << " mean " << EBmean[gId] << " rms " << EBrms[gId] << " entries " << EBtot[gId] << " min " << pEBmin[gId]
         //		  << " max " << pEBmax[gId] << std::endl;
         if (pEBmin[gId] < 0.)
@@ -357,8 +357,8 @@ namespace {
         EErms[gId] = sqrt(EErms[gId]);
         if (EErms[gId] == 0.)
           EErms[gId] = 0.001;
-        pEEmin[gId] = EEmean[gId] - kRMS * EErms[gId];
-        pEEmax[gId] = EEmean[gId] + kRMS * EErms[gId];
+        pEEmin[gId] = EEmean[gId] - static_cast<int>(kRMS) * EErms[gId];
+        pEEmax[gId] = EEmean[gId] + static_cast<int>(kRMS) * EErms[gId];
         //	std::cout << " mean " << EEmean[gId] << " rms " << EErms[gId] << " entries " << EEtot[gId] << " min " << pEEmin[gId]
         //		  << " max " << pEEmax[gId] << std::endl;
         if (pEEmin[gId] < 0.)
@@ -789,8 +789,8 @@ namespace {
         EBrms[gId] = sqrt(EBrms[gId]);
         if (EBrms[gId] == 0.)
           EBrms[gId] = 0.001;
-        pEBmin[gId] = EBmean[gId] - kRMS * EBrms[gId];
-        pEBmax[gId] = EBmean[gId] + kRMS * EBrms[gId];
+        pEBmin[gId] = EBmean[gId] - static_cast<int>(kRMS) * EBrms[gId];
+        pEBmax[gId] = EBmean[gId] + static_cast<int>(kRMS) * EBrms[gId];
         //	std::cout << " mean " << EBmean[gId] << " rms " << EBrms[gId] << " entries " << EBtot[gId] << " min " << pEBmin[gId]
         //		  << " max " << pEBmax[gId] << std::endl;
         vt = (double)EEtot[gId];
@@ -799,8 +799,8 @@ namespace {
         EErms[gId] = sqrt(EErms[gId]);
         if (EErms[gId] == 0.)
           EErms[gId] = 0.001;
-        pEEmin[gId] = EEmean[gId] - kRMS * EErms[gId];
-        pEEmax[gId] = EEmean[gId] + kRMS * EErms[gId];
+        pEEmin[gId] = EEmean[gId] - static_cast<int>(kRMS) * EErms[gId];
+        pEEmax[gId] = EEmean[gId] + static_cast<int>(kRMS) * EErms[gId];
         //	std::cout << " mean " << EEmean[gId] << " rms " << EErms[gId] << " entries " << EEtot[gId] << " min " << pEEmin[gId]
         //		  << " max " << pEEmax[gId] << std::endl;
       }
@@ -1041,9 +1041,9 @@ namespace {
     EcalPedestalsEEMean6Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap pedestal gain6 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1092,9 +1092,9 @@ namespace {
     EcalPedestalsEEMean1Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap pedestal gain1 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1289,9 +1289,9 @@ namespace {
     EcalPedestalsEERMS12Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain12 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1341,9 +1341,9 @@ namespace {
     EcalPedestalsEERMS6Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain6 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,
@@ -1391,9 +1391,9 @@ namespace {
     EcalPedestalsEERMS1Map()
         : cond::payloadInspector::Histogram2D<EcalPedestals>("ECAL Endcap noise gain1 - map",
                                                              "ix",
-                                                             2.2 * IX_MAX,
+                                                             2.2 * static_cast<int>(IX_MAX),
                                                              IX_MIN,
-                                                             2.2 * IX_MAX + 1,
+                                                             2.2 * static_cast<int>(IX_MAX) + 1,
                                                              "iy",
                                                              IY_MAX,
                                                              IY_MIN,

--- a/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
@@ -118,8 +118,8 @@ namespace {
           EBrms[s] = sqrt(EBrms[s]);
         else
           EBrms[s] = 1.e-06;
-        pEBmin[s] = EBmean[s] - kRMS * EBrms[s];
-        pEBmax[s] = EBmean[s] + kRMS * EBrms[s];
+        pEBmin[s] = EBmean[s] - static_cast<int>(kRMS) * EBrms[s];
+        pEBmax[s] = EBmean[s] + static_cast<int>(kRMS) * EBrms[s];
         std::cout << "EB sample " << s << " mean " << EBmean[s] << " rms " << EBrms[s] << " entries " << EBtot[s]
                   << " min " << pEBmin[s] << " max " << pEBmax[s] << std::endl;
         //	if(pEBmin[s] <= 0.) pEBmin[s] = 1.e-06;
@@ -130,8 +130,8 @@ namespace {
           EErms[s] = sqrt(EErms[s]);
         else
           EErms[s] = 1.e-06;
-        pEEmin[s] = EEmean[s] - kRMS * EErms[s];
-        pEEmax[s] = EEmean[s] + kRMS * EErms[s];
+        pEEmin[s] = EEmean[s] - static_cast<int>(kRMS) * EErms[s];
+        pEEmax[s] = EEmean[s] + static_cast<int>(kRMS) * EErms[s];
         std::cout << "EE sample " << s << " mean " << EEmean[s] << " rms " << EErms[s] << " entries " << EEtot[s]
                   << " min " << pEEmin[s] << " max " << pEEmax[s] << std::endl;
         //	if(pEEmin[s] <= 0.) pEEmin[s] = 1.e-06;

--- a/CondCore/PCLConfigPlugins/plugins/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
+++ b/CondCore/PCLConfigPlugins/plugins/SiPixelAliPCLThresholdsPayloadInspectorHelper.h
@@ -119,7 +119,7 @@ namespace AlignPCLThresholdPlotHelper {
 
       // needed for the internal loop
       const auto& local_end_of_types = isHighGranularity_ ? END_OF_TYPES : FRACTION_CUT;
-      const int N_Y_BINS = AlignPCLThresholds::extra_DOF * local_end_of_types;
+      const int N_Y_BINS = static_cast<int>(AlignPCLThresholds::extra_DOF) * local_end_of_types;
 
       auto Thresholds =
           std::make_unique<TH2F>("Thresholds", "", alignables.size(), 0, alignables.size(), N_Y_BINS, 0, N_Y_BINS);
@@ -310,7 +310,7 @@ namespace AlignPCLThresholdPlotHelper {
 
       // needed for the internal loop
       const auto& local_end_of_types = isHighGranularity_ ? END_OF_TYPES : FRACTION_CUT;
-      const int N_Y_BINS = AlignPCLThresholds::extra_DOF * local_end_of_types;
+      const int N_Y_BINS = static_cast<int>(AlignPCLThresholds::extra_DOF) * local_end_of_types;
 
       auto Thresholds = std::make_unique<TH2F>(
           "Thresholds", "", v_intersection.size(), 0, v_intersection.size(), N_Y_BINS, 0, N_Y_BINS);

--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -106,12 +106,13 @@ const bool AlignPCLThresholdsHG::hasFloatMap(const std::string &AlignableId) con
 
 //****************************************************************************//
 const int AlignPCLThresholdsHG::payloadVersion() const {
-  switch (FSIZE + ISIZE + SSIZE) {
+  switch (static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE)) {
     case 6:
       return 1;
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
-          << "Payload version with parameter size equal to " << FSIZE + ISIZE + SSIZE << " is not defined.\n";
+          << "Payload version with parameter size equal to "
+          << static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE) << " is not defined.\n";
   }
 }
 


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on `enum`s are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests
