### PR TITLE
[CPP20][DQM] Remove deprecated enum arithmetic

### DIFF
--- a/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
@@ -281,7 +281,7 @@ void DiamondSampicCalibrationDQMSource::analyze(const edm::Event &event, const e
                                                        hitHistoTmpYAxis->GetBinCenter(startBin + i));
 
         //All plots with Time
-        if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE)) {
           int db = (detIdToHw[detId] & 0xE0) >> 5;
           int sampic = (detIdToHw[detId] & 0x10) >> 4;
           int channel = (detIdToHw[detId] & 0x0F);

--- a/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
@@ -603,7 +603,7 @@ void DiamondSampicDQMSource::analyze(const edm::Event &event, const edm::EventSe
         }
 
         //All plots with Time
-        if (rechit.time() != TotemTimingRecHit::NO_T_AVAILABLE) {
+        if (rechit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE)) {
           for (int i = 0; i < numOfBins; ++i)
             potPlots_[detId_pot].hitDistribution2dWithTime->Fill(detId.plane() + UFSDShift,
                                                                  hitHistoTmpYAxis->GetBinCenter(startBin + i));

--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -378,27 +378,27 @@ void TotemT2DQMSource::fillFlags(const TotemT2Digi& digi, const TotemT2DetId& de
   const TotemT2DetId secId(detid.armId());
   const TotemT2DetId planeId(detid.planeId());
   if (digi.hasTE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2TE + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2TE + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2TE + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2TE));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2TE));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2TE));
   }
 
   if (digi.hasLE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2LE + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2LE + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2LE + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2LE));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2LE));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2LE));
   }
 
   if (digi.hasManyTE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2MT + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2MT + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2MT + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2MT));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2MT));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2MT));
   }
 
   if (digi.hasManyLE()) {
-    sectorPlots_[secId].eventFlags->Fill(t2ML + 0.0);
-    planePlots_[planeId].eventFlagsPl->Fill(t2ML + 0.0);
-    channelPlots_[detid].eventFlagsCh->Fill(t2ML + 0.0);
+    sectorPlots_[secId].eventFlags->Fill(static_cast<double>(t2ML));
+    planePlots_[planeId].eventFlagsPl->Fill(static_cast<double>(t2ML));
+    channelPlots_[detid].eventFlagsCh->Fill(static_cast<double>(t2ML));
   }
 }
 

--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -110,8 +110,9 @@ namespace ecaldqm {
     kEBTCCLow = 36,
     kEBTCCHigh = 71,
 
-    nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
-    nTowers = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
+    nChannels = static_cast<int>(EBDetId::kSizeForDenseIndexing) + static_cast<int>(EEDetId::kSizeForDenseIndexing),
+    nTowers =
+        static_cast<int>(EcalTrigTowerDetId::kEBTotalTowers) + static_cast<int>(EcalScDetId::kSizeForDenseIndexing)
   };
 
   extern std::vector<unsigned> const memDCC;

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -169,7 +169,7 @@ namespace ecaldqm {
             break;
           case kProjEta:
             if (_zside == 0) {
-              specs.nbins = nEEEtaBins / (3. - etaBound) * 6.;
+              specs.nbins = static_cast<int>(nEEEtaBins) / (3. - etaBound) * 6.;
               specs.low = -3.;
               specs.high = 3.;
             } else {
@@ -351,11 +351,12 @@ namespace ecaldqm {
             specs.nbins = nEBEtaBins + 2 * nEEEtaBins;
             specs.edges = std::vector(specs.nbins + 1, 0.f);
             for (int i(0); i <= nEEEtaBins; i++)
-              specs.edges[i] = -3. + (3. - etaBound) / nEEEtaBins * i;
+              specs.edges[i] = -3. + (3. - etaBound) / static_cast<double>(nEEEtaBins) * i;
             for (int i(1); i <= nEBEtaBins; i++)
-              specs.edges[i + nEEEtaBins] = -etaBound + 2. * etaBound / nEBEtaBins * i;
+              specs.edges[i + nEEEtaBins] = -etaBound + 2. * etaBound / static_cast<double>(nEBEtaBins) * i;
             for (int i(1); i <= nEEEtaBins; i++)
-              specs.edges[i + nEEEtaBins + nEBEtaBins] = etaBound + (3. - etaBound) / nEEEtaBins * i;
+              specs.edges[i + nEEEtaBins + nEBEtaBins] =
+                  etaBound + (3. - etaBound) / static_cast<double>(nEEEtaBins) * i;
             specs.title = "eta";
             break;
           case kProjPhi:

--- a/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc
@@ -154,7 +154,7 @@ namespace ecaldqm {
       if (status == kGood && sLaser) {
         for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
           sLaser->use(wlItr->second);
-          if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -166,7 +166,7 @@ namespace ecaldqm {
         if (id.subdetId() == EcalEndcap) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLed->use(wlItr->second);
-            if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -177,7 +177,7 @@ namespace ecaldqm {
       if (status == kGood && sTestPulse) {
         for (map<int, unsigned>::iterator gainItr(tpGainToME_.begin()); gainItr != tpGainToME_.end(); ++gainItr) {
           sTestPulse->use(gainItr->second);
-          if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -187,7 +187,7 @@ namespace ecaldqm {
       if (status == kGood && sPedestal) {
         for (map<int, unsigned>::iterator gainItr(pedGainToME_.begin()); gainItr != pedGainToME_.end(); ++gainItr) {
           sPedestal->use(gainItr->second);
-          if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+          if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
             status = kBad;
             break;
           }
@@ -211,13 +211,13 @@ namespace ecaldqm {
 
         int status(kGood);
 
-        if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == kBad)
+        if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad))
           status = kBad;
 
         if (status == kGood && sLaserPN) {
           for (map<int, unsigned>::iterator wlItr(laserWlToME_.begin()); wlItr != laserWlToME_.end(); ++wlItr) {
             sLaserPN->use(wlItr->second);
-            if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -227,7 +227,7 @@ namespace ecaldqm {
         if (status == kGood && sLedPN) {
           for (map<int, unsigned>::iterator wlItr(ledWlToME_.begin()); wlItr != ledWlToME_.end(); ++wlItr) {
             sLedPN->use(wlItr->second);
-            if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -237,7 +237,7 @@ namespace ecaldqm {
         if (status == kGood && sTestPulsePN) {
           for (map<int, unsigned>::iterator gainItr(tpPNGainToME_.begin()); gainItr != tpPNGainToME_.end(); ++gainItr) {
             sTestPulsePN->use(gainItr->second);
-            if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }
@@ -248,7 +248,7 @@ namespace ecaldqm {
           for (map<int, unsigned>::iterator gainItr(pedPNGainToME_.begin()); gainItr != pedPNGainToME_.end();
                ++gainItr) {
             sPedestalPN->use(gainItr->second);
-            if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
+            if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == static_cast<double>(kBad)) {
               status = kBad;
               break;
             }

--- a/DQM/EcalMonitorClient/src/CertificationClient.cc
+++ b/DQM/EcalMonitorClient/src/CertificationClient.cc
@@ -31,7 +31,7 @@ namespace ecaldqm {
       meanValue += certValue * nCrystals(iDCC + 1);
     }
 
-    meCertification.fill(getEcalDQMSetupObjects(), meanValue / nChannels);
+    meCertification.fill(getEcalDQMSetupObjects(), meanValue / static_cast<double>(nChannels));
   }
 
   DEFINE_ECALDQM_WORKER(CertificationClient);

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -111,7 +111,7 @@ namespace ecaldqm {
       float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
       if (entriesLS < minChannelEntries_)
         continue;
-      if (chStatus != EcalChannelStatusCode::kOk)
+      if (chStatus != static_cast<float>(EcalChannelStatusCode::kOk))
         continue;  // exclude problematic channels
 
       // Get max/min

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -146,7 +146,7 @@ namespace ecaldqm {
 
       if (entriesLS < minChannelEntries)
         continue;
-      if (chStatus != EcalChannelStatusCode::kOk)
+      if (chStatus != static_cast<float>(EcalChannelStatusCode::kOk))
         continue;  // exclude problematic channels
 
       // Keep running count of timing mean, rms, and N_hits

--- a/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
+++ b/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
@@ -40,7 +40,7 @@ namespace ecaldqm {
     enum Constants {
       nFIRTaps = 6,
       bytesPerCrystal = 24,
-      nRU = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
+      nRU = static_cast<int>(EcalTrigTowerDetId::kEBTotalTowers) + static_cast<int>(EcalScDetId::kSizeForDenseIndexing)
     };
 
   private:

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -236,8 +236,10 @@ namespace ecaldqm {
     }
 
     if (isEB) {
-      meHighIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / nEBDCC);
-      meLowIntPayload.fill(getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / nEBDCC);
+      meHighIntPayload.fill(
+          getEcalDQMSetupObjects(), EcalBarrel, nHighInt[0] * bytesPerCrystal / 1024. / static_cast<double>(nEBDCC));
+      meLowIntPayload.fill(
+          getEcalDQMSetupObjects(), EcalBarrel, nLowInt[0] * bytesPerCrystal / 1024. / static_cast<double>(nEBDCC));
     } else {
       meHighIntPayload.fill(
           getEcalDQMSetupObjects(), -EcalEndcap, nHighInt[0] * bytesPerCrystal / 1024. / (nEEDCC / 2));

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -264,8 +264,8 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                    -0.5,
                    nErrors - 0.5,
                    nFEDs,
-                   FEDNumbering::MINSiPixeluTCAFEDID - 0.5,
-                   FEDNumbering::MAXSiPixeluTCAFEDID - 0.5);
+                   static_cast<double>(FEDNumbering::MINSiPixeluTCAFEDID) - 0.5,
+                   static_cast<double>(FEDNumbering::MAXSiPixeluTCAFEDID) - 0.5);
   for (int j = 0; j < nErrors; j++) {
     const auto& errorCode = static_cast<SiPixelFEDErrorCodes>(j + k_FED25);
     h_FEDerrorVsFEDIdUnbalance_->setBinLabel(j + 1, errorCodeToTypeMap.at(errorCode));

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -72,8 +72,11 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run cons
   TrackPtNegative_->setAxisTitle("p_{T} of tracks charge < 0");
 
   histname = "TrackQuality_";
-  TrackQuality_ = iBooker.book1D(
-      histname + AlgoName, histname + AlgoName, reco::TrackBase::qualitySize, -0.5, reco::TrackBase::qualitySize - 0.5);
+  TrackQuality_ = iBooker.book1D(histname + AlgoName,
+                                 histname + AlgoName,
+                                 reco::TrackBase::qualitySize,
+                                 -0.5,
+                                 static_cast<double>(reco::TrackBase::qualitySize) - 0.5);
   TrackQuality_->setAxisTitle("quality");
   for (int i = 0; i < reco::TrackBase::qualitySize; ++i) {
     TrackQuality_->getTH1()->GetXaxis()->SetBinLabel(

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -647,7 +647,7 @@ GlobalPoint CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorre
     int ring = 1;  // Default to ME1/b
     if (lct.getStrip() > CSCConstants::MAX_HALF_STRIP_ME1B) {
       ring = 4;  // Change to ME1/a if the HalfStrip Number exceeds the range of ME1/b
-      fractional_strip -= CSCConstants::NUM_STRIPS_ME1B;
+      fractional_strip -= static_cast<float>(CSCConstants::NUM_STRIPS_ME1B);
     }
     CSCDetId cscId_(cscId.endcap(), cscId.station(), ring, cscId.chamber(), cscId.layer());
     cscId = cscId_;

--- a/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
@@ -131,10 +131,16 @@ void ElectronConversionRejectionValidator::bookHistograms(DQMStore::IBooker& ibo
 
   h_convLog10TrailTrackpt_ = ibooker.book1D("convLog10TrailTrackpt", "# of Electrons", ptBin, -2.0, 3.0);
 
-  h_convLeadTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
-  h_convTrailTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_convLeadTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                        "# of Electrons",
+                                        reco::TrackBase::algoSize,
+                                        -0.5,
+                                        static_cast<double>(reco::TrackBase::algoSize) - 0.5);
+  h_convTrailTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                         "# of Electrons",
+                                         reco::TrackBase::algoSize,
+                                         -0.5,
+                                         static_cast<double>(reco::TrackBase::algoSize) - 0.5);
 }
 
 void ElectronConversionRejectionValidator::analyze(const edm::Event& e, const edm::EventSetup&) {

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3126,8 +3126,11 @@ void PhotonValidator::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&
   h_trkProv_[0] = iBooker.book1D("allTrkProv", " Track pair provenance ", 4, 0., 4.);
   h_trkProv_[1] = iBooker.book1D("assTrkProv", " Track pair provenance ", 4, 0., 4.);
   //
-  h_trkAlgo_ =
-      iBooker.book1D("allTrackAlgo", " Track Algo ", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_trkAlgo_ = iBooker.book1D("allTrackAlgo",
+                              " Track Algo ",
+                              reco::TrackBase::algoSize,
+                              -0.5,
+                              static_cast<double>(reco::TrackBase::algoSize) - 0.5);
   h_convAlgo_ = iBooker.book1D("allConvAlgo", " Conv Algo ", 5, -0.5, 4.5);
   h_convQuality_ = iBooker.book1D("allConvQuality", "Conv quality ", 11, -0.5, 11.);
 


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on enums are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests.