### PR TITLE
[CPP20][GEOMETRY] Remove deprecated enum arithmetic

### DIFF
--- a/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryDBEP.h
@@ -138,7 +138,7 @@ public:
 
     const unsigned int nTrParm(tvec.size() / T::k_NumberOfCellsForCorners);
 
-    assert(dvec.size() == T::k_NumberOfShapes * T::k_NumberOfParametersPerShape);
+    assert(dvec.size() == static_cast<int>(T::k_NumberOfShapes) * static_cast<int>(T::k_NumberOfParametersPerShape));
 
     PtrType ptr = std::make_unique<T>();
 

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -64,7 +64,8 @@ void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
   fillNamedParams(fv0, geom);
 
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   DDFilteredView fv(*cpv, filter);
 
@@ -123,7 +124,8 @@ void CaloGeometryLoader<T>::makeGeometry(const cms::DDCompactView* cpv,
   fillNamedParams(fv, geom);
 
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   std::string attribute = "ReadOutName";
   cms::DDSpecParRefs ref;

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -1269,7 +1269,7 @@ unsigned int HcalTopology::detId2denseIdHT(const DetId& id) const {
   } else {
     index = kHTSizePreLS1;
     if (zside == -1)
-      index += ((kHTSizePhase1 - kHTSizePreLS1) / 2);
+      index += ((static_cast<double>(kHTSizePhase1) - static_cast<double>(kHTSizePreLS1)) / 2);
     index += (36 * (ietaAbs - 30) + ((iphi - 1) / 2));
   }
 

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
@@ -44,7 +44,8 @@ void CaloGeometryLoaderTest<T>::makeGeometry(const DDCompactView* cpv,
                                              const Alignments* alignments,
                                              const Alignments* globals) {
   geom->allocateCorners(T::k_NumberOfCellsForCorners);
-  geom->allocatePar(T::k_NumberOfParametersPerShape * T::k_NumberOfShapes, T::k_NumberOfParametersPerShape);
+  geom->allocatePar(static_cast<int>(T::k_NumberOfParametersPerShape) * static_cast<int>(T::k_NumberOfShapes),
+                    T::k_NumberOfParametersPerShape);
 
   DDFilteredView fv(*cpv, m_filter);
 

--- a/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/CastorHardcodeGeometryLoader.cc
@@ -48,7 +48,8 @@ void CastorHardcodeGeometryLoader::fill(HcalCastorDetId::Section section, CaloSu
   if (geom->cornersMgr() == nullptr)
     geom->allocateCorners(HcalCastorDetId::kSizeForDenseIndexing);
   if (geom->parMgr() == nullptr)
-    geom->allocatePar(CastorGeometry::k_NumberOfShapes * CastorGeometry::k_NumberOfParametersPerShape,
+    geom->allocatePar(static_cast<int>(CastorGeometry::k_NumberOfShapes) *
+                          static_cast<int>(CastorGeometry::k_NumberOfParametersPerShape),
                       CastorGeometry::k_NumberOfParametersPerShape);
 
   // start by making the new HcalDetIds
@@ -118,7 +119,7 @@ void CastorHardcodeGeometryLoader::makeCell(const HcalCastorDetId& detId, CaloSu
   const double leg(dR + dy);
   const double len(sqrt(leg * leg + dx * dx));
 
-  static const double dphi(2. * M_PI / (1.0 * HcalCastorDetId::kNumberSectorsPerEnd));
+  static const double dphi(2. * M_PI / (1.0 * static_cast<double>(HcalCastorDetId::kNumberSectorsPerEnd)));
 
   const double fphi(atan(dx / (dR + dy)));
 

--- a/Geometry/ForwardGeometry/src/ZdcHardcodeGeometryLoader.cc
+++ b/Geometry/ForwardGeometry/src/ZdcHardcodeGeometryLoader.cc
@@ -58,8 +58,9 @@ void ZdcHardcodeGeometryLoader::fill(HcalZDCDetId::Section section, ReturnType g
   if (geom->cornersMgr() == nullptr)
     geom->allocateCorners(HcalZDCDetId::kSizeForDenseIndexing);
   if (geom->parMgr() == nullptr)
-    geom->allocatePar(ZdcGeometry::k_NumberOfParametersPerShape * ZdcGeometry::k_NumberOfShapes,
-                      ZdcGeometry::k_NumberOfParametersPerShape);
+    geom->allocatePar(
+        static_cast<int>(ZdcGeometry::k_NumberOfParametersPerShape) * static_cast<int>(ZdcGeometry::k_NumberOfShapes),
+        ZdcGeometry::k_NumberOfParametersPerShape);
 
   edm::LogVerbatim("ZdcGeometry") << "Number of ZDC DetIds made: " << section << " " << zdcIds.size();
 


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on enums are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests.