### PR TITLE
[CPP20][L1,UPGRADE] Remove deprecated enum arithmetic

### DIFF
--- a/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
@@ -138,7 +138,7 @@ lclphidat CSCSectorReceiverLUT::calcLocalPhi(const lclphiadd& theadd) const {
   lclphidat data;
 
   constexpr int maxPhiL = 1 << CSCBitWidths::kLocalPhiDataBitWidth;
-  double binPhiL = static_cast<double>(maxPhiL) / (2. * CSCConstants::MAX_NUM_STRIPS_RUN1);
+  double binPhiL = static_cast<double>(maxPhiL) / (2. * static_cast<double>(CSCConstants::MAX_NUM_STRIPS_RUN1));
 
   double patternOffset;
 
@@ -257,7 +257,7 @@ gblphidat CSCSectorReceiverLUT::calcGlobalPhiME(const gblphiadd& address) const 
 
   // We will use these to convert the local phi into radians.
   constexpr unsigned int maxPhiL = 1 << CSCBitWidths::kLocalPhiDataBitWidth;
-  const double binPhiL = static_cast<double>(maxPhiL) / (2. * CSCConstants::MAX_NUM_STRIPS_RUN1);
+  const double binPhiL = static_cast<double>(maxPhiL) / (2. * static_cast<double>(CSCConstants::MAX_NUM_STRIPS_RUN1));
 
   if (cscid < CSCTriggerNumbering::minTriggerCscId()) {
     edm::LogWarning("CSCSectorReceiverLUT|getGlobalPhiValue")
@@ -656,7 +656,8 @@ gbletadat CSCSectorReceiverLUT::calcGlobalEtaME(const gbletaadd& address) const 
   double float_eta = getGlobalEtaValue(address.cscid, address.wire_group, address.phi_local);
   unsigned int_eta = 0;
   unsigned bend_global = 0;  // not filled yet... will change when it is.
-  const double etaPerBin = (CSCTFConstants::maxEta - CSCTFConstants::minEta) / CSCTFConstants::etaBins;
+  const double etaPerBin =
+      (CSCTFConstants::maxEta - CSCTFConstants::minEta) / static_cast<double>(CSCTFConstants::etaBins);
   const unsigned me12EtaCut = 56;
 
   if ((float_eta < CSCTFConstants::minEta) || (float_eta >= CSCTFConstants::maxEta)) {

--- a/L1Trigger/GlobalCaloTrigger/src/L1GctMet.cc
+++ b/L1Trigger/GlobalCaloTrigger/src/L1GctMet.cc
@@ -162,7 +162,8 @@ L1GctMet::etmiss_internal L1GctMet::useHtMissLutAlgo(const int ex, const int ey,
   static const int componentMask = maxComponent - 1;
   static const int maxPosComponent = componentMask >> 1;
 
-  static const int maxInput = 1 << (L1GctHtMissLut::kHxOrHyMissComponentNBits + kExOrEyMissComponentShift - 1);
+  static const int maxInput = 1 << (static_cast<int>(L1GctHtMissLut::kHxOrHyMissComponentNBits) +
+                                    static_cast<int>(kExOrEyMissComponentShift) - 1);
 
   static const unsigned resultMagMask = (1 << L1GctHtMissLut::kHtMissMagnitudeNBits) - 1;
   static const unsigned resultPhiMask = (1 << L1GctHtMissLut::kHtMissAngleNBits) - 1;
@@ -315,8 +316,9 @@ const bool L1GctMet::inputOverFlow() const {
   bool result = m_exComponent.overFlow() || m_eyComponent.overFlow();
 
   if (m_algoType == useHtMissLut) {
-    static const int maxComponentInput =
-        (1 << (L1GctHtMissLut::kHxOrHyMissComponentNBits + kExOrEyMissComponentShift - 1)) - 1;
+    static const int maxComponentInput = (1 << (static_cast<int>(L1GctHtMissLut::kHxOrHyMissComponentNBits) +
+                                                static_cast<int>(kExOrEyMissComponentShift) - 1)) -
+                                         1;
 
     // Emulate the (symmetric) overflow condition used in the firmware
     result |= (m_exComponent.value() > maxComponentInput) || (m_exComponent.value() < -maxComponentInput) ||

--- a/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
+++ b/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
@@ -507,11 +507,11 @@ inline void L1DummyProducer::SimpleDigi(int,
   enum eMinNum { MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1 };
   enum eMaxNum { MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6 };
   float rnd = engine->flat();
-  int ec = (int)(MIN_ENDCAP + (static_cast<int>(MAX_ENDCAP) - MIN_ENDCAP) * rnd + 1);
-  int st = (int)(MIN_STATION + (static_cast<int>(MAX_STATION) - MIN_STATION) * rnd + 1);
-  int rg = (int)(MIN_RING + (static_cast<int>(MAX_RING) - MIN_RING) * rnd + 1);
-  int ch = (int)(MIN_CHAMBER + (static_cast<int>(MAX_CHAMBER) - MIN_CHAMBER) * rnd + 1);
-  int lr = (int)(MIN_LAYER + (static_cast<int>(MAX_LAYER) - MIN_LAYER) * rnd + 1);
+  int ec = (int)(static_cast<int>(MIN_ENDCAP) + (static_cast<int>(MAX_ENDCAP) - MIN_ENDCAP) * rnd + 1);
+  int st = (int)(static_cast<int>(MIN_STATION) + (static_cast<int>(MAX_STATION) - MIN_STATION) * rnd + 1);
+  int rg = (int)(static_cast<int>(MIN_RING) + (static_cast<int>(MAX_RING) - MIN_RING) * rnd + 1);
+  int ch = (int)(static_cast<int>(MIN_CHAMBER) + (static_cast<int>(MAX_CHAMBER) - MIN_CHAMBER) * rnd + 1);
+  int lr = (int)(static_cast<int>(MIN_LAYER) + (static_cast<int>(MAX_LAYER) - MIN_LAYER) * rnd + 1);
   CSCDetId did = CSCDetId(ec, st, rg, ch, lr);
   //CSCDetId did = CSCDetId();   //DetId(DetId::Muon, MuonSubdetId::CSC)
   //MuonDigiCollection::insertDigi(const IndexType& index, const DigiType& digi)

--- a/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
+++ b/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
@@ -507,11 +507,11 @@ inline void L1DummyProducer::SimpleDigi(int,
   enum eMinNum { MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1 };
   enum eMaxNum { MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6 };
   float rnd = engine->flat();
-  int ec = (int)(MIN_ENDCAP + (MAX_ENDCAP - MIN_ENDCAP) * rnd + 1);
-  int st = (int)(MIN_STATION + (MAX_STATION - MIN_STATION) * rnd + 1);
-  int rg = (int)(MIN_RING + (MAX_RING - MIN_RING) * rnd + 1);
-  int ch = (int)(MIN_CHAMBER + (MAX_CHAMBER - MIN_CHAMBER) * rnd + 1);
-  int lr = (int)(MIN_LAYER + (MAX_LAYER - MIN_LAYER) * rnd + 1);
+  int ec = (int)(MIN_ENDCAP + (static_cast<int>(MAX_ENDCAP) - MIN_ENDCAP) * rnd + 1);
+  int st = (int)(MIN_STATION + (static_cast<int>(MAX_STATION) - MIN_STATION) * rnd + 1);
+  int rg = (int)(MIN_RING + (static_cast<int>(MAX_RING) - MIN_RING) * rnd + 1);
+  int ch = (int)(MIN_CHAMBER + (static_cast<int>(MAX_CHAMBER) - MIN_CHAMBER) * rnd + 1);
+  int lr = (int)(MIN_LAYER + (static_cast<int>(MAX_LAYER) - MIN_LAYER) * rnd + 1);
   CSCDetId did = CSCDetId(ec, st, rg, ch, lr);
   //CSCDetId did = CSCDetId();   //DetId(DetId::Muon, MuonSubdetId::CSC)
   //MuonDigiCollection::insertDigi(const IndexType& index, const DigiType& digi)

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
@@ -105,7 +105,7 @@ L1ExtraTestAnalyzer::L1ExtraTestAnalyzer(const edm::ParameterSet &iConfig)
             "Triggers",
             2 * l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 1,
             -0.75,
-            l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 0.5 - 0.75) {
+            static_cast<double>(l1extra::L1ParticleMap::kNumOfL1TriggerTypes) + 0.5 - 0.75) {
   // now do what ever initialization is needed
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -48,19 +48,25 @@ void JetId::setNNVectorVar() {
         NNvectorVar_.push_back(0);
       continue;
     }
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron && fCharge_.get()[i0] < 0);       // Electron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron && fCharge_.get()[i0] > 0);       // Positron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon && fCharge_.get()[i0] < 0);           // Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon && fCharge_.get()[i0] > 0);           // Anti-Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Photon);                                   // Photon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::NeutralHadron);                            // Neutral Had
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] < 0);  // Pion
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron && fCharge_.get()[i0] > 0);  // Anti-Pion
-    NNvectorVar_.push_back(fDZ_.get()[i0]);                                                               //dZ
-    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));                                   //d0
-    NNvectorVar_.push_back(fPt_.get()[i0]);   //pT as a fraction of jet pT
-    NNvectorVar_.push_back(fEta_.get()[i0]);  //dEta from jet axis
-    NNvectorVar_.push_back(fPhi_.get()[i0]);  //dPhi from jet axis
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Electron) &&
+                           fCharge_.get()[i0] < 0);  // Electron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Electron) &&
+                           fCharge_.get()[i0] > 0);  // Positron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Muon) &&
+                           fCharge_.get()[i0] < 0);  // Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Muon) &&
+                           fCharge_.get()[i0] > 0);                                                  // Anti-Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::Photon));         // Photon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::NeutralHadron));  // Neutral Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::ChargedHadron) &&
+                           fCharge_.get()[i0] < 0);  // Pion
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<double>(l1t::PFCandidate::ChargedHadron) &&
+                           fCharge_.get()[i0] > 0);                      // Anti-Pion
+    NNvectorVar_.push_back(fDZ_.get()[i0]);                              //dZ
+    NNvectorVar_.push_back(std::hypot(fDX_.get()[i0], fDY_.get()[i0]));  //d0
+    NNvectorVar_.push_back(fPt_.get()[i0]);                              //pT as a fraction of jet pT
+    NNvectorVar_.push_back(fEta_.get()[i0]);                             //dEta from jet axis
+    NNvectorVar_.push_back(fPhi_.get()[i0]);                             //dPhi from jet axis
   }
 }
 float JetId::EvaluateNN() {

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -32,11 +32,11 @@ void TauNNId::setNNVectorVar() {
         NNvectorVar_.push_back(0);
       continue;
     }
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Photon);         // Photon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron);       // Electron
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon);           // Muon
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::NeutralHadron);  // Neutral Had
-    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron);  // Charged Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Photon));         // Photon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Electron));       // Electron
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::Muon));           // Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::NeutralHadron));  // Neutral Had
+    NNvectorVar_.push_back(fId_.get()[i0] == static_cast<float>(l1t::PFCandidate::ChargedHadron));  // Charged Had
   }
 }
 float TauNNId::EvaluateNN() {

--- a/L1Trigger/RPCTrigger/src/RPCConst.cc
+++ b/L1Trigger/RPCTrigger/src/RPCConst.cc
@@ -71,24 +71,24 @@ int RPCConst::towerNumFromEta(const double eta) {
 }
 
 double RPCConst::phiFromSegmentNum(const int iseg) {
-  double phi = OFFSET + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
+  double phi = static_cast<double>(OFFSET) + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
   return (phi < 2. * m_pi) ? phi : phi - 2. * m_pi;
 }
 
 double RPCConst::phiFromLogSegSec(const int logSegment, const int logSector) {
   int iseg = logSegment * 12 + logSector;
-  double phi = OFFSET + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
+  double phi = static_cast<double>(OFFSET) + 2. * m_pi * (iseg) / (double)RPCConst::NSEG;
   return (phi < 2. * m_pi) ? phi : phi - 2. * m_pi;
 }
 
 int RPCConst::segmentNumFromPhi(const double phi) {
   double iphi;
-  if (phi - OFFSET < 0) {
+  if (phi - static_cast<double>(OFFSET) < 0) {
     iphi = 2 * m_pi + phi;
   } else {
-    iphi = phi - OFFSET;
+    iphi = phi - static_cast<double>(OFFSET);
   }
-  int iseg = (int)(iphi * RPCConst::NSEG / (2. * m_pi));
+  int iseg = (int)(iphi * static_cast<double>(RPCConst::NSEG) / (2. * m_pi));
   return iseg;
 }
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -327,7 +327,8 @@ namespace trklet {
       for (int iRegion = 0; iRegion < setup_->numRegions(); iRegion++) {
         int buffered_tracks[] = {0, 0};
         for (int iTrack = 0;
-             iTrack < setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize);
+             iTrack < setup_->numFramesIO() *
+                          ((double)TTBV::S_ / static_cast<double>(TTTrack_TrackWord::TrackBitWidths::kTrackWordSize));
              iTrack++) {
           for (int iWorker = 0; iWorker < setup_->kfNumWorker(); iWorker++) {
             for (int iLink = 0; iLink < setup_->tfpNumChannel(); iLink++) {
@@ -377,7 +378,8 @@ namespace trklet {
               trackRef = it.first;
           }
           if ((int)iTrack / 3 <=
-              setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize))
+              setup_->numFramesIO() *
+                  ((double)TTBV::S_ / static_cast<double>(TTTrack_TrackWord::TrackBitWidths::kTrackWordSize)))
             accepted[iLink].emplace_back(
                 std::make_pair(trackRef,
                                (sortedPartialTracks[iLink][iTrack - 1].slice(partialTrackWordBits_) +

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -276,8 +276,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
           // We put it in the rejected container, flagged with offset to indicate reason.
 
           if (FEreject) {
-            tempTTStub.setRawBend(CBCFailOffset + 2. * tempTTStub.rawBend());
-            tempTTStub.setBendOffset(CBCFailOffset + 2. * tempTTStub.bendOffset());
+            tempTTStub.setRawBend(static_cast<double>(CBCFailOffset) + 2. * tempTTStub.rawBend());
+            tempTTStub.setBendOffset(static_cast<double>(CBCFailOffset) + 2. * tempTTStub.bendOffset());
             tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
             tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
             tempStubRej.push_back(tempTTStub);
@@ -324,8 +324,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
 
             if (CIC_reject)  // The stub added does not pass the cut
             {
-              tempTTStub.setRawBend(CICFailOffset + 2. * tempTTStub.rawBend());
-              tempTTStub.setBendOffset(CICFailOffset + 2. * tempTTStub.bendOffset());
+              tempTTStub.setRawBend(static_cast<double>(CICFailOffset) + 2. * tempTTStub.rawBend());
+              tempTTStub.setBendOffset(static_cast<double>(CICFailOffset) + 2. * tempTTStub.bendOffset());
               tempClusLowerRej.push_back(*(tempTTStub.clusterRef(0)));
               tempClusUpperRej.push_back(*(tempTTStub.clusterRef(1)));
               tempStubRej.push_back(tempTTStub);

--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -841,7 +841,7 @@ namespace l1tVertexFinder {
       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13 = z0_13 + (1 << (TrackBitWidths::kZ0Size - 1));
       // Shift the bits down to truncate the dynamic range to the most significant HistogramBitWidths::kBinFixedSize bits
       ap_int<TrackBitWidths::kZ0Size + 1> absz0_13_reduced =
-          absz0_13 >> (TrackBitWidths::kZ0Size - HistogramBitWidths::kBinFixedSize);
+          absz0_13 >> (static_cast<int>(TrackBitWidths::kZ0Size) - static_cast<int>(HistogramBitWidths::kBinFixedSize));
       // Put the relevant bits into the histbin_t container
       histbin_t bin = absz0_13_reduced.range(HistogramBitWidths::kBinFixedSize - 1, 0);
 


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on enums are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests.
