### PR TITLE
[CPP20][RECONSTRUCTION] Remove deprecated enum arithmetic

### DIFF
--- a/RecoPPS/Local/src/TotemTimingTrackRecognition.cc
+++ b/RecoPPS/Local/src/TotemTimingTrackRecognition.cc
@@ -18,7 +18,7 @@ TotemTimingTrackRecognition::TotemTimingTrackRecognition(const edm::ParameterSet
 //----------------------------------------------------------------------------------------------------
 
 void TotemTimingTrackRecognition::addHit(const TotemTimingRecHit& recHit) {
-  if (recHit.time() != TotemTimingRecHit::NO_T_AVAILABLE)
+  if (recHit.time() != static_cast<float>(TotemTimingRecHit::NO_T_AVAILABLE))
     hitVectorMap_[0].emplace_back(recHit);
 }
 


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on enums are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests.
