### PR TITLE
[CPP20][SIMULATION] Remove deprecated enum arithmetic

### DIFF
--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -156,8 +156,8 @@ public:
     ical = &eventSetup->getData(m_interCalibConstantsMCToken);
     // adc to GeV
     agc = &eventSetup->getData(m_adcToGeVConstantToken);
-    m_maxEneEB = (agc->getEBValue()) * theDefaultGains[1] * MAXADC * m_EBs25notCont;
-    m_maxEneEE = (agc->getEEValue()) * theDefaultGains[1] * MAXADC * m_EEs25notCont;
+    m_maxEneEB = (agc->getEBValue()) * theDefaultGains[1] * static_cast<double>(MAXADC) * m_EBs25notCont;
+    m_maxEneEE = (agc->getEEValue()) * theDefaultGains[1] * static_cast<double>(MAXADC) * m_EEs25notCont;
 
     if (m_timeDependent) {
       //----

--- a/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
@@ -106,7 +106,7 @@ void EcalCoder::encode(const EcalSamples& ecalSamples, EcalDataFrame& df, CLHEP:
 
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gains[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gains[igain]);
     maxADC[igain] = ADCGAINSWITCH;  // saturation at 4080 for middle and high gains x6 & x12
     if (igain == NGAINS)
       maxADC[igain] = MAXADC;  // saturation at 4095 for low gain x1

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -34,7 +34,7 @@ CaloSamples EcalSignalGenerator<EBDigitizerTraits>::samplesInPE(const DIGI &digi
   for (unsigned int igain(0); igain <= NGAINS; ++igain) {
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gainRatios[igain]);
   }
 
   //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;
@@ -141,7 +141,7 @@ CaloSamples EcalSignalGenerator<EEDigitizerTraits>::samplesInPE(const DIGI &digi
   for (unsigned int igain(0); igain <= NGAINS; ++igain) {
     LSB[igain] = 0.;
     if (igain > 0)
-      LSB[igain] = Emax / (MAXADC * gainRatios[igain]);
+      LSB[igain] = Emax / (static_cast<double>(MAXADC) * gainRatios[igain]);
   }
 
   //    std::cout << " intercal, LSBs, egains " << icalconst << " " << LSB[0] << " " << LSB[1] << " " << gainRatios[0] << " " << gainRatios[1] << " " << Emax << std::endl;

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -554,13 +554,13 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::Eve
 
   delete defaultRatios;
 
-  const double EBscale((agc->getEBValue()) * theGains[1] * (m_Coder->MAXADC) * m_EBs25notCont);
+  const double EBscale((agc->getEBValue()) * theGains[1] * static_cast<double>(m_Coder->MAXADC) * m_EBs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEBValue() << "\n"
                        << " notCont = " << m_EBs25notCont << "\n"
                        << " saturation for EB = " << EBscale << ", " << m_EBs25notCont;
 
-  const double EEscale((agc->getEEValue()) * theGains[1] * (m_Coder->MAXADC) * m_EEs25notCont);
+  const double EEscale((agc->getEEValue()) * theGains[1] * static_cast<double>(m_Coder->MAXADC) * m_EEs25notCont);
 
   LogDebug("EcalDigi") << " GeV/ADC = " << agc->getEEValue() << "\n"
                        << " notCont = " << m_EEs25notCont << "\n"

--- a/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalSiPMHitResponse.cc
@@ -24,7 +24,8 @@ HcalSiPMHitResponse::HcalSiPMHitResponse(const CaloVSimParameterMap* parameterMa
       theSiPM(),
       PreMixDigis(PreMix1),
       HighFidelityPreMix(HighFidelity),
-      nbins((PreMixDigis and HighFidelityPreMix) ? 1 : BUNCHSPACE * HcalPulseShapes::invDeltaTSiPM_),
+      nbins((PreMixDigis and HighFidelityPreMix) ? 1
+                                                 : static_cast<float>(BUNCHSPACE) * HcalPulseShapes::invDeltaTSiPM_),
       dt(HcalPulseShapes::deltaTSiPM_),
       invdt(HcalPulseShapes::invDeltaTSiPM_) {
   //fill shape map
@@ -43,7 +44,7 @@ int HcalSiPMHitResponse::getReadoutFrameSize(const DetId& id) const {
   int readoutFrameSize = parameters.readoutFrameSize();
   if (PreMixDigis and HighFidelityPreMix) {
     //preserve fidelity of time info
-    readoutFrameSize *= BUNCHSPACE * HcalPulseShapes::invDeltaTSiPM_;
+    readoutFrameSize *= static_cast<float>(BUNCHSPACE) * HcalPulseShapes::invDeltaTSiPM_;
   }
   return readoutFrameSize;
 }
@@ -127,7 +128,8 @@ void HcalSiPMHitResponse::add(const PCaloHit& hit, CLHEP::HepRandomEngine* engin
     LogDebug("HcalSiPMHitResponse") << " energy: " << hit.energy() << " photons: " << photons << " time: " << time;
     LogDebug("HcalSiPMHitResponse") << " timePhase: " << pars.timePhase() << " tof: " << tof
                                     << " binOfMaximum: " << pars.binOfMaximum() << " phaseShift: " << thePhaseShift_;
-    double tzero(0.0 + pars.timePhase() - (time - tof) - BUNCHSPACE * (pars.binOfMaximum() - thePhaseShift_));
+    double tzero(0.0 + pars.timePhase() - (time - tof) -
+                 static_cast<double>(BUNCHSPACE) * (pars.binOfMaximum() - thePhaseShift_));
     LogDebug("HcalSiPMHitResponse") << " tzero: " << tzero;
     double tzero_bin(-tzero * invdt);
     LogDebug("HcalSiPMHitResponse") << " corrected tzero: " << tzero_bin << '\n';


### PR DESCRIPTION
#### PR description:

Some arithmetic and logic operations on enums are deprecated in C++20. This PR aims to fix these.

#### PR validation:

Bot tests.