### PR TITLE
[14_0_X] PFMet and PuppiMET Branches in NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -3,27 +3,30 @@ from  PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleSingletonCandidateFlatTableProducer_cfi import simpleSingletonCandidateFlatTableProducer
 
 ##################### Tables for final output and docs ##########################
-metTable = simpleSingletonCandidateFlatTableProducer.clone(
+pfmetTable = simpleSingletonCandidateFlatTableProducer.clone(
     src = cms.InputTag("slimmedMETs"),
-    name = cms.string("MET"),
+    name = cms.string("PFMET"),
     doc = cms.string("slimmedMET, type-1 corrected PF MET"),
     variables = cms.PSet(PTVars,
-       sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
+      
        covXX = Var("getSignificanceMatrix().At(0,0)",float,doc="xx element of met covariance matrix", precision=8),
        covXY = Var("getSignificanceMatrix().At(0,1)",float,doc="xy element of met covariance matrix", precision=8),
        covYY = Var("getSignificanceMatrix().At(1,1)",float,doc="yy element of met covariance matrix", precision=8),
        significance = Var("metSignificance()", float, doc="MET significance",precision=10),
+       sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10), 
        sumPtUnclustered = Var("metSumPtUnclustered()", float, doc="sumPt used for MET significance",precision=10),
-       MetUnclustEnUpDeltaX = Var("shiftedPx('UnclusteredEnUp')-px()", float, doc="Delta (METx_mod-METx) Unclustered Energy Up",precision=10),
-       MetUnclustEnUpDeltaY = Var("shiftedPy('UnclusteredEnUp')-py()", float, doc="Delta (METy_mod-METy) Unclustered Energy Up",precision=10),
+       ptUnclusteredUp = Var("shiftedPt('UnclusteredEnUp')", float, doc="Unclustered up pt",precision=10),
+       ptUnclusteredDown = Var("shiftedPt('UnclusteredEnDown')", float, doc="Unclustered down pt",precision=10),
+       phiUnclusteredUp = Var("shiftedPhi('UnclusteredEnUp')", float, doc="Unclustered up phi",precision=10),
+       phiUnclusteredDown = Var("shiftedPhi('UnclusteredEnDown')", float, doc="Unclustered down phi",precision=10),
 
     ),
 )
 
 
 rawMetTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
-    name = cms.string("RawMET"),
+    src = pfmetTable.src,
+    name = cms.string("RawPFMET"),
     doc = cms.string("raw PF MET"),
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
        pt  = Var("uncorPt",  float, doc="pt", precision=10),
@@ -34,7 +37,7 @@ rawMetTable = simpleSingletonCandidateFlatTableProducer.clone(
 
 
 caloMetTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
+    src = pfmetTable.src,
     name = cms.string("CaloMET"),
     doc = cms.string("Offline CaloMET (muon corrected)"),
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
@@ -49,19 +52,17 @@ puppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     name = cms.string("PuppiMET"),
     doc = cms.string("PUPPI  MET"),
     variables = cms.PSet(PTVars,
+       covXX = Var("getSignificanceMatrix().At(0,0)",float,doc="xx element of met covariance matrix", precision=8),
+       covXY = Var("getSignificanceMatrix().At(0,1)",float,doc="xy element of met covariance matrix", precision=8),
+       covYY = Var("getSignificanceMatrix().At(1,1)",float,doc="yy element of met covariance matrix", precision=8),
+       significance = Var("metSignificance()", float, doc="MET significance",precision=10),
        sumEt = Var("sumEt()", float, doc="scalar sum of Et",precision=10),
-       ptJERUp = Var("shiftedPt('JetResUp')", float, doc="JER up pt",precision=10),
-       ptJERDown = Var("shiftedPt('JetResDown')", float, doc="JER down pt",precision=10),
-       phiJERUp = Var("shiftedPhi('JetResUp')", float, doc="JER up phi",precision=10),
-       phiJERDown = Var("shiftedPhi('JetResDown')", float, doc="JER down phi",precision=10),
-       ptJESUp = Var("shiftedPt('JetEnUp')", float, doc="JES up pt",precision=10),
-       ptJESDown = Var("shiftedPt('JetEnDown')", float, doc="JES down pt",precision=10),
-       phiJESUp = Var("shiftedPhi('JetEnUp')", float, doc="JES up phi",precision=10),
-       phiJESDown = Var("shiftedPhi('JetEnDown')", float, doc="JES down phi",precision=10),
+       sumPtUnclustered = Var("metSumPtUnclustered()", float, doc="sumPt used for MET significance",precision=10),
        ptUnclusteredUp = Var("shiftedPt('UnclusteredEnUp')", float, doc="Unclustered up pt",precision=10),
        ptUnclusteredDown = Var("shiftedPt('UnclusteredEnDown')", float, doc="Unclustered down pt",precision=10),
        phiUnclusteredUp = Var("shiftedPhi('UnclusteredEnUp')", float, doc="Unclustered up phi",precision=10),
        phiUnclusteredDown = Var("shiftedPhi('UnclusteredEnDown')", float, doc="Unclustered down phi",precision=10),
+
     ),
 )
 
@@ -76,9 +77,9 @@ rawPuppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),)
 
 
-tkMetTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
-    name = cms.string("TkMET"),
+trkMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+    src = pfmetTable.src,
+    name = cms.string("TrkMET"),
     doc = cms.string("Track MET computed with tracks from PV0 ( pvAssociationQuality()>=4 ) "),
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
        pt = Var("corPt('RawTrk')", float, doc="raw track MET pt",precision=10),
@@ -87,21 +88,11 @@ tkMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),
 )
 
-chsMetTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
-    name = cms.string("ChsMET"),
-    doc = cms.string("PF MET computed with CHS PF candidates"),
-    variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
-       pt = Var("corPt('RawChs')", float, doc="raw chs PF MET pt",precision=10),
-       phi = Var("corPhi('RawChs')", float, doc="raw chs PF MET phi",precision=10),
-       sumEt = Var("corSumEt('RawChs')", float, doc="raw chs PF scalar sum of Et",precision=10),
-    ),
-)
 
 deepMetResolutionTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
     # current deepMets are saved in slimmedMETs in MiniAOD,
-    # in the same way as chsMet/TkMET
-    src = metTable.src,
+    # in the same way as chsMet/TrkMET
+    src = pfmetTable.src,
     name = cms.string("DeepMETResolutionTune"),
     doc = cms.string("Deep MET trained with resolution tune"),
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
@@ -111,7 +102,7 @@ deepMetResolutionTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
 )
 
 deepMetResponseTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
+    src = pfmetTable.src,
     name = cms.string("DeepMETResponseTune"),
     doc = cms.string("Deep MET trained with extra response tune"),
     variables = cms.PSet(#NOTA BENE: we don't copy PTVars here!
@@ -121,7 +112,7 @@ deepMetResponseTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
 )
 
 metMCTable = simpleSingletonCandidateFlatTableProducer.clone(
-    src = metTable.src,
+    src = pfmetTable.src,
     name = cms.string("GenMET"),
     doc = cms.string("Gen MET"),
     variables = cms.PSet(
@@ -131,5 +122,6 @@ metMCTable = simpleSingletonCandidateFlatTableProducer.clone(
 )
 
 
-metTablesTask = cms.Task( metTable, rawMetTable, caloMetTable, puppiMetTable, rawPuppiMetTable, tkMetTable, chsMetTable, deepMetResolutionTuneTable, deepMetResponseTuneTable )
+metTablesTask = cms.Task(pfmetTable, rawMetTable, caloMetTable, puppiMetTable, rawPuppiMetTable, trkMetTable, 
+        deepMetResolutionTuneTable, deepMetResponseTuneTable )
 metMCTask = cms.Task( metMCTable )

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -13,14 +13,6 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('sumEt', 'sumEt', 20, 200, 3000, 'scalar sum of Et'),
             )
         ),
-        ChsMET = cms.PSet(
-            sels = cms.PSet(),
-            plots = cms.VPSet(
-                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'raw chs PF MET phi'),
-                Plot1D('pt', 'pt', 20, 0, 400, 'raw chs PF MET pt'),
-                Plot1D('sumEt', 'sumEt', 20, 600, 5000, 'raw chs PF scalar sum of Et'),
-            )
-        ),
         CorrT1METJet = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
@@ -493,24 +485,34 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('', '', 100, 0, 2, 'all weights'),
             )
         ),
-
-        MET = cms.PSet(
+        PFMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
-                Plot1D('MetUnclustEnUpDeltaX', 'MetUnclustEnUpDeltaX', 20, -20, 20, 'Delta (METx_mod-METx) Unclustered Energy Up'),
-                Plot1D('MetUnclustEnUpDeltaY', 'MetUnclustEnUpDeltaY', 20, -10, 10, 'Delta (METy_mod-METy) Unclustered Energy Up'),
                 Plot1D('covXX', 'covXX', 20, 0, 40000, 'xx element of met covariance matrix'),
                 Plot1D('covXY', 'covXY', 20, -8000, 8000, 'xy element of met covariance matrix'),
                 Plot1D('covYY', 'covYY', 20, 0, 50000, 'yy element of met covariance matrix'),
-                Plot1D('fiducialGenPhi', 'fiducialGenPhi', 20, -3.14159, 3.14159, 'phi'),
-                Plot1D('fiducialGenPt', 'fiducialGenPt', 20, 0, 400, 'pt'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
                 Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
                 Plot1D('significance', 'significance', 20, 0, 200, 'MET significance'),
                 Plot1D('sumEt', 'sumEt', 20, 600, 5000, 'scalar sum of Et'),
                 Plot1D('sumPtUnclustered', 'sumPtUnclustered', 20, 0, 3000, 'sumPt used for MET significance'),
+
+                Plot1D('ptUnclusteredUp', 'ptUnclusteredUp', 20, 0, 400, 'pt Unclustered Up'),
+                Plot1D('ptUnclusteredDown', 'ptUnclusteredDown', 20, 0, 400, 'pt Unclustered Down'),
+                Plot1D('phiUnclusteredUp', 'phiUnclusteredUp', 20, -3.14159, 3.14159, 'phi Unclustered Up'),
+                Plot1D('phiUnclusteredDown', 'phiUnclusteredDown', 20, -3.14159, 3.14159, 'phi Unclustered Down'),
+
             )
         ),
+       
+        FiducialMET = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
+                Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
+                )
+        ),
+
         Muon = cms.PSet(
             sels = cms.PSet(
                 Good = cms.string('pt > 15 && abs(dxy) < 0.2 && abs(dz) < 0.5 && mediumId && miniPFRelIso_all < 0.4')
@@ -722,24 +724,23 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
         PuppiMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
+
+                Plot1D('covXX', 'covXX', 20, 0, 40000, 'xx element of met covariance matrix'),
+                Plot1D('covXY', 'covXY', 20, -8000, 8000, 'xy element of met covariance matrix'),
+                Plot1D('covYY', 'covYY', 20, 0, 50000, 'yy element of met covariance matrix'),
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
-                Plot1D('phiJERUp', 'phiJERUp', 20, -3.14159, 3.14159, 'JER up phi'),
-                Plot1D('phiJERDown', 'phiJERDown', 20, -3.14159, 3.14159, 'JER down phi'),
-                Plot1D('phiJESUp', 'phiJESUp', 20, -3.14159, 3.14159, 'JES up phi'),
-                Plot1D('phiJESDown', 'phiJESDown', 20, -3.14159, 3.14159, 'JES down phi'),
-                Plot1D('phiUnclusteredUp', 'phiUnclusteredUp', 20, -3.14159, 3.14159, 'Unclustered up phi'),
-                Plot1D('phiUnclusteredDown', 'phiUnclusteredDown', 20, -3.14159, 3.14159, 'Unclustered down phi'),
                 Plot1D('pt', 'pt', 20, 0, 400, 'pt'),
-                Plot1D('ptJERUp', 'ptJERUp', 20, 0, 400, 'JER up pt'),
-                Plot1D('ptJERDown', 'ptJERDown', 20, 0, 400, 'JER down pt'),
-                Plot1D('ptJESUp', 'ptJESUp', 20, 0, 400, 'JES up pt'),
-                Plot1D('ptJESDown', 'ptJESDown', 20, 0, 400, 'JES down pt'),
-                Plot1D('ptUnclusteredUp', 'ptUnclusteredUp', 20, 0, 400, 'Unclustered up pt'),
-                Plot1D('ptUnclusteredDown', 'ptUnclusteredDown', 20, 0, 400, 'Unclustered down pt'),
-                Plot1D('sumEt', 'sumEt', 20, 200, 3000, 'scalar sum of Et'),
+                Plot1D('significance', 'significance', 20, 0, 200, 'PuppiMET significance'),
+                Plot1D('sumEt', 'sumEt', 20, 600, 5000, 'scalar sum of Et'),
+                Plot1D('sumPtUnclustered', 'sumPtUnclustered', 20, 0, 3000, 'sumPt used for PuppiMET significance'),
+                
+                Plot1D('ptUnclusteredUp', 'ptUnclusteredUp', 20, 0, 400, 'pt Unclustered Up'),
+                Plot1D('ptUnclusteredDown', 'ptUnclusteredDown', 20, 0, 400, 'pt Unclustered Down'),
+                Plot1D('phiUnclusteredUp', 'phiUnclusteredUp', 20, -3.14159, 3.14159, 'phi Unclustered Up'),
+                Plot1D('phiUnclusteredDown', 'phiUnclusteredDown', 20, -3.14159, 3.14159, 'phi Unclustered Down'),
             )
         ),
-        RawMET = cms.PSet(
+        RawPFMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
@@ -873,7 +874,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 NoPlot('status'),
             )
         ),        
-        TkMET = cms.PSet(
+        TrkMET = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(
                 Plot1D('phi', 'phi', 20, -3.14159, 3.14159, 'phi'),
@@ -966,3 +967,4 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
         ),
     )
 )
+

--- a/PhysicsTools/NanoAOD/python/particlelevel_cff.py
+++ b/PhysicsTools/NanoAOD/python/particlelevel_cff.py
@@ -91,13 +91,9 @@ tautagger = cms.EDProducer("GenJetTauTaggerProducer",
 
 rivetMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     src = cms.InputTag("particleLevel:mets"),
-    name = cms.string("MET"),
+    name = cms.string("FiducialMET"),
     doc = cms.string("MET from Rivet-based ParticleLevelProducer in fiducial volume abs(eta)<5"),
-    extension = cms.bool(True),
-    variables = cms.PSet(
-       fiducialGenPt  = Var("pt",  float, precision=10),
-       fiducialGenPhi = Var("phi", float, precision=10),
-    ),
+    variables = cms.PSet(PTVars),
 )
 
 HTXSCategoryTable = simpleHTXSFlatTableProducer.clone(


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/44038.

This should supersede https://github.com/cms-sw/cmssw/pull/44383.

> PR description:
> 
> PFMet and PuppiMET do not have the same variables stored in NanoAOD
> Idea is to have a consistent variables stored in both the PFMET and PuppiMET at the NanoAOD for next data taking
> Remove / Rename some of the other relevant branches
> 
