### PR TITLE
Add missing import of TauolaPolar PSet in one Generator config

### DIFF
--- a/Configuration/Generator/python/DYToTauTau_M-50_14TeV_pythia8_tauola_cff.py
+++ b/Configuration/Generator/python/DYToTauTau_M-50_14TeV_pythia8_tauola_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
-
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
 
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",


### PR DESCRIPTION
#### PR description:

Errors with workflow 13045 in [one PR test](https://github.com/cms-sw/cmssw/pull/44497#issuecomment-2011775460) revealed a missing import in the DYToTauTau_M-50_14TeV_pythia8_tauola_cff.py config
Apparently that workflow was not tested that often, otherwise it would have been noticed earlier on. Anyhow, the config is wrong and it should be fixed

#### PR validation:

Generator step of wf 13045 succeeds

