### PR TITLE
ticlv5: Optimize CLUE2D

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -200,8 +200,9 @@ std::vector<reco::BasicCluster> HGCalCLUEAlgoT<T, STRATEGY>::getClusters(bool) {
         }
       } else {
         for (auto cellIdx : cl) {
-          x += cellsOnLayer.dim1[cellIdx] * cellsOnLayer.weight[cellIdx];
-          y += cellsOnLayer.dim2[cellIdx] * cellsOnLayer.weight[cellIdx];
+          auto position = rhtools_.getPosition(cellsOnLayer.detid[cellIdx]);
+          x += position.x() * cellsOnLayer.weight[cellIdx];
+          y += position.y() * cellsOnLayer.weight[cellIdx];
         }
       }
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -21,9 +21,9 @@
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 // C/C++ headers
-#include <set>
 #include <string>
 #include <vector>
+#include <limits>
 
 template <typename TILE, typename STRATEGY>
 class HGCalCLUEAlgoT : public HGCalClusteringAlgoBase {
@@ -45,6 +45,8 @@ public:
         fcPerEle_(ps.getParameter<double>("fcPerEle")),
         nonAgedNoises_(ps.getParameter<std::vector<double>>("noises")),
         noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
+        thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
+        positionDeltaRho2_(ps.getParameter<double>("positionDeltaRho2")),
         use2x2_(ps.getParameter<bool>("use2x2")),
         initialized_(false) {}
 
@@ -137,6 +139,8 @@ private:
   double noiseMip_;
   std::vector<std::vector<double>> thresholds_;
   std::vector<std::vector<double>> v_sigmaNoise_;
+  std::vector<double> thresholdW0_;
+  double positionDeltaRho2_;
 
   bool use2x2_;
 
@@ -159,6 +163,7 @@ private:
     std::vector<float> sigmaNoise;
     std::vector<std::vector<int>> followers;
     std::vector<bool> isSeed;
+    float layerDim3 = std::numeric_limits<float>::infinity();
 
     void clear() {
       detid.clear();


### PR DESCRIPTION
This PR aims at optimizing the HGCAL Layer Clustering by moving the calculation of the position of the layer clusters from the producer to the algorithm where the SoA of the rechits is already available, hence avoiding slow and frequent calls to the geometry.

The validation was done using `ttbar PU200` samples in `CMSSW_14_1_0_pre1`.
It shows a speed-up of about **25%** of the CLUE Algorithm, or about 190ms per event both at HLT and in the offline reconstruction.

In this first commit, the results should be identical. 
After the tests have run, I will push also some commits where I reduce some parameters precision from 64bits to 32bits floating point, which should also improve further the performance.

