### PR TITLE
[CPP20][GEOMETRY] Replace some enums with constexpr ints

### DIFF
--- a/DataFormats/EcalDetId/interface/EBDetId.h
+++ b/DataFormats/EcalDetId/interface/EBDetId.h
@@ -152,7 +152,7 @@ public:
   // eta coverage of one crystal (approximate)
   static const float crystalUnitToEta;
 
-  enum { kSizeForDenseIndexing = MAX_HASH + 1 };
+  static constexpr int kSizeForDenseIndexing = MAX_HASH + 1;
 
   // function modes for (int, int) constructor
   static const int ETAPHIMODE = 0;

--- a/DataFormats/EcalDetId/interface/EEDetId.h
+++ b/DataFormats/EcalDetId/interface/EEDetId.h
@@ -319,15 +319,13 @@ public:
    */
   static const int ICR_MAX = 25;
 
-  enum {
-    /** Number of crystals per Dee
-     */
-    kEEhalf = 7324,
+  /** Number of crystals per Dee
+   */
+  static constexpr int kEEhalf = 7324;
     /** Number of dense crystal indices, that is number of
      * crystals per endcap.
      */
-    kSizeForDenseIndexing = 2 * kEEhalf
-  };
+  static constexpr int kSizeForDenseIndexing = 2 * kEEhalf ;
 
   /*@{*/
   /** function modes for EEDetId(int, int, int, int) constructor

--- a/DataFormats/EcalDetId/interface/EEDetId.h
+++ b/DataFormats/EcalDetId/interface/EEDetId.h
@@ -322,10 +322,10 @@ public:
   /** Number of crystals per Dee
    */
   static constexpr int kEEhalf = 7324;
-    /** Number of dense crystal indices, that is number of
+  /** Number of dense crystal indices, that is number of
      * crystals per endcap.
      */
-  static constexpr int kSizeForDenseIndexing = 2 * kEEhalf ;
+  static constexpr int kSizeForDenseIndexing = 2 * kEEhalf;
 
   /*@{*/
   /** function modes for EEDetId(int, int, int, int) constructor

--- a/DataFormats/EcalDetId/interface/ESDetId.h
+++ b/DataFormats/EcalDetId/interface/ESDetId.h
@@ -99,7 +99,7 @@ private:
   static const unsigned short hy2[kXYMAX];
 
 public:
-  enum { kSizeForDenseIndexing = kLa };
+  static constexpr int kSizeForDenseIndexing = kLa;
 };
 
 std::ostream& operator<<(std::ostream&, const ESDetId& id);

--- a/DataFormats/HcalDetId/interface/HcalCastorDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCastorDetId.h
@@ -64,12 +64,12 @@ public:
   // get the individual cell id
   //  int channel() const;
 
-  enum {
+  static constexpr int
     kNumberModulesPerEnd = 14,
     kNumberSectorsPerEnd = 16,
     kNumberCellsPerEnd = kNumberModulesPerEnd * kNumberSectorsPerEnd,
     kSizeForDenseIndexing = kNumberCellsPerEnd
-  };
+  ;
 
   uint32_t denseIndex() const;
 

--- a/DataFormats/HcalDetId/interface/HcalCastorDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalCastorDetId.h
@@ -64,12 +64,9 @@ public:
   // get the individual cell id
   //  int channel() const;
 
-  static constexpr int
-    kNumberModulesPerEnd = 14,
-    kNumberSectorsPerEnd = 16,
-    kNumberCellsPerEnd = kNumberModulesPerEnd * kNumberSectorsPerEnd,
-    kSizeForDenseIndexing = kNumberCellsPerEnd
-  ;
+  static constexpr int kNumberModulesPerEnd = 14, kNumberSectorsPerEnd = 16,
+                       kNumberCellsPerEnd = kNumberModulesPerEnd * kNumberSectorsPerEnd,
+                       kSizeForDenseIndexing = kNumberCellsPerEnd;
 
   uint32_t denseIndex() const;
 

--- a/DataFormats/HcalDetId/interface/HcalZDCDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalZDCDetId.h
@@ -200,7 +200,7 @@ private:
 public:
   constexpr static int32_t kSizeForDenseIndexingRun1 = 2 * kDepRun1;
   constexpr static int32_t kSizeForDenseIndexingRun3 = 2 * kDepRun3;
-  enum { kSizeForDenseIndexing = kSizeForDenseIndexingRun1 };
+  constexpr static int32_t kSizeForDenseIndexing = kSizeForDenseIndexingRun1;
 };
 
 std::ostream& operator<<(std::ostream&, const HcalZDCDetId& id);

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -224,18 +224,9 @@ private:
   SegmentationMap depthSegmentation_;
   SegmentationMap depthSegmentationOne_;
 
-  static constexpr int
-    kHBhalf = 1296,
-    kHEhalf = 1296,
-    kHOhalf = 1080,
-    kHFhalf = 864,
-    kHThalf = 2088,
-    kZDChalf = 11,
-    kCASTORhalf = 224,
-    kCALIBhalf = 693,
-    kHThalfPhase1 = 2520,
-    kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf
-  ;
+  static constexpr int kHBhalf = 1296, kHEhalf = 1296, kHOhalf = 1080, kHFhalf = 864, kHThalf = 2088, kZDChalf = 11,
+                       kCASTORhalf = 224, kCALIBhalf = 693, kHThalfPhase1 = 2520,
+                       kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf;
   static constexpr int kSizeForDenseIndexingPreLS1 = 2 * kHcalhalf;
   static constexpr int kHBSizePreLS1 = 2 * kHBhalf;
   static constexpr int kHESizePreLS1 = 2 * kHEhalf;

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -224,7 +224,7 @@ private:
   SegmentationMap depthSegmentation_;
   SegmentationMap depthSegmentationOne_;
 
-  enum {
+  static constexpr int
     kHBhalf = 1296,
     kHEhalf = 1296,
     kHOhalf = 1080,
@@ -235,15 +235,15 @@ private:
     kCALIBhalf = 693,
     kHThalfPhase1 = 2520,
     kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf
-  };
-  enum { kSizeForDenseIndexingPreLS1 = 2 * kHcalhalf };
-  enum { kHBSizePreLS1 = 2 * kHBhalf };
-  enum { kHESizePreLS1 = 2 * kHEhalf };
-  enum { kHOSizePreLS1 = 2 * kHOhalf };
-  enum { kHFSizePreLS1 = 2 * kHFhalf };
-  enum { kHTSizePreLS1 = 2 * kHThalf };
-  enum { kHTSizePhase1 = 2 * kHThalfPhase1 };
-  enum { kCALIBSizePreLS1 = 2 * kCALIBhalf };
+  ;
+  static constexpr int kSizeForDenseIndexingPreLS1 = 2 * kHcalhalf;
+  static constexpr int kHBSizePreLS1 = 2 * kHBhalf;
+  static constexpr int kHESizePreLS1 = 2 * kHEhalf;
+  static constexpr int kHOSizePreLS1 = 2 * kHOhalf;
+  static constexpr int kHFSizePreLS1 = 2 * kHFhalf;
+  static constexpr int kHTSizePreLS1 = 2 * kHThalf;
+  static constexpr int kHTSizePhase1 = 2 * kHThalfPhase1;
+  static constexpr int kCALIBSizePreLS1 = 2 * kCALIBhalf;
   static constexpr int minMaxDepth_ = 4;
   static constexpr unsigned int minPhi_ = 1, maxPhi_ = 72;
   static constexpr unsigned int kOffCalibHB_ = 0;

--- a/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalBarrelGeometry.h
@@ -37,11 +37,11 @@ public:
 
   typedef EBDetId DetIdType;
 
-  enum { k_NumberOfCellsForCorners = EBDetId::kSizeForDenseIndexing };
+  static constexpr int k_NumberOfCellsForCorners = EBDetId::kSizeForDenseIndexing;
 
-  enum { k_NumberOfShapes = 17 };
+  static constexpr int k_NumberOfShapes = 17;
 
-  enum { k_NumberOfParametersPerShape = 11 };
+  static constexpr int k_NumberOfParametersPerShape = 11;
 
   static std::string dbString() { return "PEcalBarrelRcd"; }
 

--- a/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalEndcapGeometry.h
@@ -38,11 +38,11 @@ public:
 
   typedef EEDetId DetIdType;
 
-  enum { k_NumberOfCellsForCorners = EEDetId::kSizeForDenseIndexing };
+  static constexpr int k_NumberOfCellsForCorners = EEDetId::kSizeForDenseIndexing;
 
-  enum { k_NumberOfShapes = 1 };
+  static constexpr int k_NumberOfShapes = 1;
 
-  enum { k_NumberOfParametersPerShape = 11 };
+  static constexpr int k_NumberOfParametersPerShape = 11;
 
   static std::string dbString() { return "PEcalEndcapRcd"; }
 

--- a/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
+++ b/Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h
@@ -30,11 +30,11 @@ public:
   typedef CaloSubdetectorGeometry::ParVecVec ParVecVec;
   typedef ESDetId DetIdType;
 
-  enum { k_NumberOfCellsForCorners = ESDetId::kSizeForDenseIndexing };
+  static constexpr int k_NumberOfCellsForCorners = ESDetId::kSizeForDenseIndexing;
 
-  enum { k_NumberOfShapes = 4 };
+  static constexpr int k_NumberOfShapes = 4;
 
-  enum { k_NumberOfParametersPerShape = 4 };
+  static constexpr int k_NumberOfParametersPerShape = 4;
 
   static std::string dbString() { return "PEcalPreshowerRcd"; }
 

--- a/Geometry/ForwardGeometry/interface/CastorGeometry.h
+++ b/Geometry/ForwardGeometry/interface/CastorGeometry.h
@@ -25,11 +25,11 @@ public:
   typedef PCastorRcd PGeometryRecord;
   typedef HcalCastorDetId DetIdType;
 
-  enum { k_NumberOfCellsForCorners = HcalCastorDetId::kSizeForDenseIndexing };
+  static constexpr int k_NumberOfCellsForCorners = HcalCastorDetId::kSizeForDenseIndexing;
 
-  enum { k_NumberOfShapes = 4 };
+  static constexpr int k_NumberOfShapes = 4;
 
-  enum { k_NumberOfParametersPerShape = 6 };
+  static constexpr int k_NumberOfParametersPerShape = 6;
 
   static std::string dbString() { return "PCastorRcd"; }
 

--- a/Geometry/ForwardGeometry/interface/ZdcGeometry.h
+++ b/Geometry/ForwardGeometry/interface/ZdcGeometry.h
@@ -23,11 +23,11 @@ public:
   typedef PZdcRcd PGeometryRecord;
   typedef HcalZDCDetId DetIdType;
 
-  enum { k_NumberOfCellsForCorners = HcalZDCDetId::kSizeForDenseIndexing };
+  static constexpr int k_NumberOfCellsForCorners = HcalZDCDetId::kSizeForDenseIndexing;
 
-  enum { k_NumberOfShapes = 3 };
+  static constexpr int k_NumberOfShapes = 3;
 
-  enum { k_NumberOfParametersPerShape = 4 };
+  static constexpr int k_NumberOfParametersPerShape = 4;
 
   static std::string dbString() { return "PZdcRcd"; }
 


### PR DESCRIPTION
#### PR description:

Replace some enums with constexpr ints to avoid deprecated enum arithmetics. Replaces https://github.com/cms-sw/cmssw/pull/44488 following @makortel's suggestion.

#### PR validation:

Bot tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
