### PR TITLE
[CPP20][DQM] Replace some enums with constexpr ints

### DIFF
--- a/DQM/CTPPS/plugins/TotemT2DQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemT2DQMSource.cc
@@ -58,7 +58,7 @@ private:
   static constexpr double T2_BIN_WIDTH_NS_ = 25. / 4;
   MonitorElement* totemT2ErrorFlags_2D_ = nullptr;
 
-  enum evFlag { t2TE = 0, t2LE, t2MT, t2ML };
+  static constexpr int t2TE = 0, t2LE = 1, t2MT = 2, t2ML = 3;
 
   const unsigned int nbinsx_, nbinsy_;
   const unsigned int windowsNum_;

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -54,21 +54,13 @@ namespace ecaldqm {
       nBinType
     };
 
-    enum Constants {
-      nPresetBinnings = kRCT + 1,
-
-      nEBSMEta = 85,
-      nEBSMPhi = 20,
-      nEESMX = 40,
-      nEESMXRed = 30,  // for EE+-01&05&09
-      nEESMXExt = 45,  // for EE+-02&08
-      nEESMY = 40,
-      nEESMYRed = 35,  // for EE+-03&07
-
-      nEBEtaBins = 34,
-      nEEEtaBins = 20,
-      nPhiBins = 36
-    };
+    typedef int Constants;
+    static constexpr int nPresetBinnings = kRCT + 1, nEBSMEta = 85, nEBSMPhi = 20, nEESMX = 40,
+                         nEESMXRed = 30,  // for EE+-01&05&09
+        nEESMXExt = 45,                   //for EE+-02&08
+        nEESMY = 40,
+                         nEESMYRed = 35,  // for EE+-03&07
+        nEBEtaBins = 34, nEEEtaBins = 20, nPhiBins = 36;
 
     struct AxisSpecs {
       int nbins;

--- a/DQM/EcalCommon/interface/MESetBinningUtils.h
+++ b/DQM/EcalCommon/interface/MESetBinningUtils.h
@@ -55,12 +55,12 @@ namespace ecaldqm {
     };
 
     typedef int Constants;
-    static constexpr int nPresetBinnings = kRCT + 1, nEBSMEta = 85, nEBSMPhi = 20, nEESMX = 40,
-                         nEESMXRed = 30,  // for EE+-01&05&09
-        nEESMXExt = 45,                   //for EE+-02&08
-        nEESMY = 40,
-                         nEESMYRed = 35,  // for EE+-03&07
-        nEBEtaBins = 34, nEEEtaBins = 20, nPhiBins = 36;
+    static constexpr int nPresetBinnings = kRCT + 1, nEBSMEta = 85, nEBSMPhi = 20, nEESMX = 40;
+    static constexpr int nEESMXRed = 30;  // for EE+-01&05&09
+    static constexpr int nEESMXExt = 45;  //for EE+-02&08
+    static constexpr int nEESMY = 40;
+    static constexpr int nEESMYRed = 35;  // for EE+-03&07
+    static constexpr int nEBEtaBins = 34, nEEEtaBins = 20, nPhiBins = 36;
 
     struct AxisSpecs {
       int nbins;

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -108,7 +108,7 @@ namespace ecaldqm {
 
       // Fill Presample Trend plots:
       // Use PedestalByLS which only contains digis from "current" LS
-      float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
+      int chStatus = static_cast<int>(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
       if (entriesLS < minChannelEntries_)
         continue;
       if (chStatus != EcalChannelStatusCode::kOk)

--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -142,7 +142,7 @@ namespace ecaldqm {
       float entriesLS(tLSItr->getBinEntries());
       float meanLS(tLSItr->getBinContent());
       float rmsLS(tLSItr->getBinError() * sqrt(entriesLS));
-      float chStatus(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
+      int chStatus = static_cast<int>(sChStatus.getBinContent(getEcalDQMSetupObjects(), id));
 
       if (entriesLS < minChannelEntries)
         continue;

--- a/DataFormats/CTPPSReco/interface/TotemTimingRecHit.h
+++ b/DataFormats/CTPPSReco/interface/TotemTimingRecHit.h
@@ -17,7 +17,7 @@
 class TotemTimingRecHit : public CTPPSTimingRecHit {
 public:
   enum TimingAlgorithm { NOT_SET, CFD, SMART, SIMPLE };
-  enum { NO_T_AVAILABLE = -100 };
+  static constexpr int NO_T_AVAILABLE = -100;
 
   TotemTimingRecHit()
       : CTPPSTimingRecHit(), sampicThresholdTime_(0), tPrecision_(0), amplitude_(0), baselineRMS_(0), mode_(NOT_SET) {}

--- a/DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h
+++ b/DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h
@@ -107,17 +107,11 @@ public:
   static const int SUBDETIJMODE = 0;
   static const int SUBDETDCCTTMODE = 1;
 
-  enum {
-    kEETowersInPhiPerEndcap = 4 * kEETowersInPhiPerQuadrant,
-    kEEOuterEta = 18,
-    kEEInnerEta = 28,
-    kEETowersInEta = (kEEInnerEta - kEEOuterEta + 1),
-    kEBHalfTowers = kEBTowersPerSM * 18,
-    kEBTotalTowers = kEBHalfTowers * 2,
-    kEETowersPerEndcap = kEETowersInEta * kEETowersInPhiPerEndcap - 72,
-    kEETotalTowers = kEETowersPerEndcap * 2,
-    kSizeForDenseIndexing = kEBTotalTowers + kEETotalTowers
-  };
+  static constexpr int kEETowersInPhiPerEndcap = 4 * kEETowersInPhiPerQuadrant, kEEOuterEta = 18, kEEInnerEta = 28,
+                       kEETowersInEta = (kEEInnerEta - kEEOuterEta + 1), kEBHalfTowers = kEBTowersPerSM * 18,
+                       kEBTotalTowers = kEBHalfTowers * 2,
+                       kEETowersPerEndcap = kEETowersInEta * kEETowersInPhiPerEndcap - 72,
+                       kEETotalTowers = kEETowersPerEndcap * 2, kSizeForDenseIndexing = kEBTotalTowers + kEETotalTowers;
 };
 
 std::ostream& operator<<(std::ostream&, const EcalTrigTowerDetId& id);


### PR DESCRIPTION
#### PR description:

Replace some enums with constexpr ints to avoid deprecated enum arithmetics. Replaces https://github.com/cms-sw/cmssw/pull/44487 following @makortel's suggestion.

#### PR validation:

Bot tests
