### PR TITLE
Fix two spinlocks

### DIFF
--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -71,9 +71,9 @@ namespace {
   };
   std::unique_ptr<std::atomic<bool>, release> make_guard(std::atomic<bool> &b) noexcept {
     bool expected = false;
-    while (not b.compare_exchange_strong(expected, true))
-      ;
-
+    while (not b.compare_exchange_strong(expected, true)) {
+      expected = false;
+    }
     return std::unique_ptr<std::atomic<bool>, release>(&b, release());
   }
 

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -133,7 +133,7 @@ namespace edm {
 
   void Path::threadsafe_setFailedModuleInfo(int nwrwue, bool iExcept) {
     bool expected = false;
-    while (stateLock_.compare_exchange_strong(expected, true)) {
+    while (not stateLock_.compare_exchange_strong(expected, true)) {
       expected = false;
     }
     if (iExcept) {


### PR DESCRIPTION
#### PR description:

Fix two spin locks that had bugs. One in LogErrorEventFilter and one in Path. Both could cause rare data races and crashes.

The one in LogErrorEventFilter was causing rare crashes in the IBs recently and that caused us to notice the problem. This is a minimal fix. We are going to discuss this more and possibly make further changes related to this in the future. See Issue #44413 for discussion.

The problem in Path has been there 4 years and no one has noticed or connected any problems to it. The problem in LogErrorEventFilter has been there 5 years and the problems were only recently noticed. I'm not sure if this is worth back porting or not. The problem should be occurring only very rarely...

In part the fix is a test. The problems are not reproducible so we are not 100% sure this fixes the problem. We plan to observe the IBs after this is merged and see if the recently noticed problems stop occurring.

#### PR validation:

Relies on existing tests.
