### PR TITLE
Fix sequences in HLT Upgrade simplified menu

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu37_Mu27_FromL1TkMuon_cfi.py
@@ -9,9 +9,19 @@ from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..sequences.HLTBeginSequence_cfi import *
 from ..sequences.HLTEndSequence_cfi import *
 from ..sequences.HLTMuonsSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 from ..sequences.itLocalRecoSequence_cfi import *
 from ..sequences.muonlocalrecoSequence_cfi import *
 from ..sequences.otLocalRecoSequence_cfi import *
 
-HLT_Mu37_Mu27_FromL1TkMuon = cms.Path(HLTBeginSequence+hltDoubleMuon7DZ1p0+muonlocalrecoSequence+itLocalRecoSequence+otLocalRecoSequence+hltPhase2PixelFitterByHelixProjections+hltPhase2PixelTrackFilterByKinematics+HLTTrackingV61Sequence+HLTMuonsSequence+hltPhase2L3MuonCandidates+hltL3fL1DoubleMu155fPreFiltered27+hltL3fL1DoubleMu155fFiltered37+HLTEndSequence)
+HLT_Mu37_Mu27_FromL1TkMuon = cms.Path(HLTBeginSequence
++hltDoubleMuon7DZ1p0
++muonlocalrecoSequence
++itLocalRecoSequence
++otLocalRecoSequence
++hltPhase2PixelFitterByHelixProjections
++hltPhase2PixelTrackFilterByKinematics
++HLTMuonsSequence
++hltPhase2L3MuonCandidates
++hltL3fL1DoubleMu155fPreFiltered27
++hltL3fL1DoubleMu155fFiltered37
++HLTEndSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
@@ -12,4 +12,13 @@ from ..sequences.itLocalRecoSequence_cfi import *
 from ..sequences.muonlocalrecoSequence_cfi import *
 from ..sequences.otLocalRecoSequence_cfi import *
 
-HLT_Mu50_FromL1TkMuon = cms.Path(HLTBeginSequence+muonlocalrecoSequence+itLocalRecoSequence+otLocalRecoSequence+hltPhase2PixelFitterByHelixProjections+hltPhase2PixelTrackFilterByKinematics+HLTTrackingV61Sequence+HLTMuonsSequence+hltPhase2L3MuonCandidates+hltL3fL1TkSingleMu22L3Filtered50Q+HLTEndSequence)
+HLT_Mu50_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +muonlocalrecoSequence
+    +itLocalRecoSequence
+    +otLocalRecoSequence
+    +hltPhase2PixelFitterByHelixProjections
+    +hltPhase2PixelTrackFilterByKinematics
+    +HLTMuonsSequence
+    +hltPhase2L3MuonCandidates
+    +hltL3fL1TkSingleMu22L3Filtered50Q
+    +HLTEndSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoFullUnpackingEgammaEcalSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoFullUnpackingEgammaEcalSequence_cfi.py
@@ -6,6 +6,5 @@ from ..modules.ecalMultiFitUncalibRecHit_cfi import *
 from ..modules.hltEcalDetIdToBeRecovered_cfi import *
 from ..modules.hltEcalDigis_cfi import *
 from ..modules.hltEcalRecHit_cfi import *
-from ..modules.hltEcalUncalibRecHit_cfi import *
 
-HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(hltEcalDigis+bunchSpacingProducer+hltEcalDetIdToBeRecovered+hltEcalUncalibRecHit+ecalMultiFitUncalibRecHit+hltEcalRecHit+ecalDetailedTimeRecHit)
+HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(hltEcalDigis+bunchSpacingProducer+hltEcalDetIdToBeRecovered+ecalMultiFitUncalibRecHit+hltEcalRecHit+ecalDetailedTimeRecHit)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededInnerSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededInnerSequence_cfi.py
@@ -1,5 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
+from ..modules.hltDiEG12EtL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoClusterShapeL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoEcalIsoL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoHcalIsoL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoHEL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoHgcalHEL1SeededFilter_cfi import *
+from ..modules.hltDiEG2312IsoHgcalIsoL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoBestGsfChi2L1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoBestGsfNLayerITL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoGsfDetaL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoGsfDphiL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoGsfTrackIsoL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoPixelMatchL1SeededFilter_cfi import *
+from ..modules.hltDiEle2312IsoPMS2L1SeededFilter_cfi import *
+from ..modules.hltEG23EtL1SeededFilter_cfi import *
+from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
+from ..modules.hltEGL1SeedsForDoubleEleIsolatedFilter_cfi import *
 from ..modules.hltEgammaCandidatesL1Seeded_cfi import *
 from ..modules.hltEgammaClusterShapeL1Seeded_cfi import *
 from ..modules.hltEgammaEcalPFClusterIsoL1Seeded_cfi import *
@@ -9,5 +30,36 @@ from ..modules.hltEgammaHcalPFClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsL1Seeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHoverEL1Seeded_cfi import *
+from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTDoubleEle2312IsoL1SeededInnerSequence = cms.Sequence(hltEgammaCandidatesL1Seeded+hltEgammaClusterShapeL1Seeded+hltEgammaHGCALIDVarsL1Seeded+hltEgammaHoverEL1Seeded+hltEgammaEcalPFClusterIsoL1Seeded+hltEgammaHGCalLayerClusterIsoL1Seeded+hltEgammaHcalPFClusterIsoL1Seeded+hltEgammaEleL1TrkIsoL1Seeded+hltEgammaEleGsfTrackIsoV6L1Seeded)
+HLTDoubleEle2312IsoL1SeededInnerSequence = cms.Sequence(hltEgammaCandidatesL1Seeded
+    +hltEgammaClusterShapeL1Seeded
+    +hltEgammaHGCALIDVarsL1Seeded
+    +hltEgammaHoverEL1Seeded
+    +hltEgammaEcalPFClusterIsoL1Seeded
+    +hltEgammaHGCalLayerClusterIsoL1Seeded
+    +hltEgammaHcalPFClusterIsoL1Seeded
+    +hltEgammaEleL1TrkIsoL1Seeded
+    +hltEgammaCandidatesWrapperL1Seeded
+    +hltEG23EtL1SeededFilter
+    +hltDiEG12EtL1SeededFilter
+    +hltDiEG2312IsoClusterShapeL1SeededFilter
+    +hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter
+    +hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter
+    +hltDiEG2312IsoHgcalHEL1SeededFilter
+    +hltDiEG2312IsoHEL1SeededFilter
+    +hltDiEG2312IsoEcalIsoL1SeededFilter
+    +hltDiEG2312IsoHgcalIsoL1SeededFilter
+    +hltDiEG2312IsoHcalIsoL1SeededFilter
+    +hltDiEle2312IsoPixelMatchL1SeededFilter
+    +hltDiEle2312IsoPMS2L1SeededFilter
+    +hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter
+    +hltDiEle2312IsoGsfDetaL1SeededFilter
+    +hltDiEle2312IsoGsfDphiL1SeededFilter
+    +hltDiEle2312IsoBestGsfNLayerITL1SeededFilter
+    +hltDiEle2312IsoBestGsfChi2L1SeededFilter
+    +hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter
+    +HLTTrackingV61Sequence
+    +hltEgammaEleGsfTrackIsoV6L1Seeded
+    +hltDiEle2312IsoGsfTrackIsoL1SeededFilter)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoubleEle2312IsoL1SeededSequence_cfi.py
@@ -1,26 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltDiEG12EtL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoClusterShapeL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoEcalIsoL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoHcalIsoL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoHEL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoHgcalHEL1SeededFilter_cfi import *
-from ..modules.hltDiEG2312IsoHgcalIsoL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoBestGsfChi2L1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoBestGsfNLayerITL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoGsfDetaL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoGsfDphiL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoGsfTrackIsoL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoPixelMatchL1SeededFilter_cfi import *
-from ..modules.hltDiEle2312IsoPMS2L1SeededFilter_cfi import *
-from ..modules.hltEG23EtL1SeededFilter_cfi import *
-from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
-from ..modules.hltEGL1SeedsForDoubleEleIsolatedFilter_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTDoubleEle2312IsoL1SeededInnerSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
@@ -31,6 +10,16 @@ from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTDoubleEle2312IsoL1SeededSequence = cms.Sequence(HLTL1Sequence+hltEGL1SeedsForDoubleEleIsolatedFilter+HLTDoFullUnpackingEgammaEcalL1SeededSequence+HLTEGammaDoLocalHcalSequence+HLTPFClusteringForEgammaL1SeededSequence+HLTHgcalTiclPFClusteringForEgammaL1SeededSequence+HLTFastJetForEgammaSequence+HLTPFHcalClusteringForEgammaSequence+HLTElePixelMatchL1SeededSequence+HLTTrackingV61Sequence+HLTGsfElectronL1SeededSequence+HLTDoubleEle2312IsoL1SeededInnerSequence+hltEgammaCandidatesWrapperL1Seeded+hltEG23EtL1SeededFilter+hltDiEG12EtL1SeededFilter+hltDiEG2312IsoClusterShapeL1SeededFilter+hltDiEG2312IsoClusterShapeSigmavvL1SeededFilter+hltDiEG2312IsoClusterShapeSigmawwL1SeededFilter+hltDiEG2312IsoHgcalHEL1SeededFilter+hltDiEG2312IsoHEL1SeededFilter+hltDiEG2312IsoEcalIsoL1SeededFilter+hltDiEG2312IsoHgcalIsoL1SeededFilter+hltDiEG2312IsoHcalIsoL1SeededFilter+hltDiEle2312IsoPixelMatchL1SeededFilter+hltDiEle2312IsoPMS2L1SeededFilter+hltDiEle2312IsoGsfOneOEMinusOneOPL1SeededFilter+hltDiEle2312IsoGsfDetaL1SeededFilter+hltDiEle2312IsoGsfDphiL1SeededFilter+hltDiEle2312IsoBestGsfNLayerITL1SeededFilter+hltDiEle2312IsoBestGsfChi2L1SeededFilter+hltDiEle2312IsoGsfTrackIsoFromL1TracksL1SeededFilter+hltDiEle2312IsoGsfTrackIsoL1SeededFilter)
+HLTDoubleEle2312IsoL1SeededSequence = cms.Sequence(HLTL1Sequence
+    +hltEGL1SeedsForDoubleEleIsolatedFilter
+    +HLTDoFullUnpackingEgammaEcalL1SeededSequence
+    +HLTEGammaDoLocalHcalSequence
+    +HLTPFClusteringForEgammaL1SeededSequence
+    +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
+    +HLTFastJetForEgammaSequence
+    +HLTPFHcalClusteringForEgammaSequence
+    +HLTElePixelMatchL1SeededSequence
+    +HLTGsfElectronL1SeededSequence
+    +HLTDoubleEle2312IsoL1SeededInnerSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededInnerSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededInnerSequence_cfi.py
@@ -9,5 +9,55 @@ from ..modules.hltEgammaHcalPFClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsL1Seeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHoverEL1Seeded_cfi import *
+from ..modules.hltEG26EtL1SeededFilter_cfi import *
+from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
+from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
+from ..modules.hltEle26WP70BestGsfChi2L1SeededFilter_cfi import *
+from ..modules.hltEle26WP70BestGsfNLayerITL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeSigmavvL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeSigmawwL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70EcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70GsfDetaL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70GsfDphiL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70GsfOneOEMinusOneOPL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70GsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70GsfTrackIsoL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70HcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70HEL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70HgcalHEL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70HgcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70PixelMatchL1SeededFilter_cfi import *
+from ..modules.hltEle26WP70PMS2L1SeededFilter_cfi import *
+from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle26WP70L1SeededInnerSequence = cms.Sequence(hltEgammaCandidatesL1Seeded+hltEgammaClusterShapeL1Seeded+hltEgammaHGCALIDVarsL1Seeded+hltEgammaHoverEL1Seeded+hltEgammaEcalPFClusterIsoL1Seeded+hltEgammaHGCalLayerClusterIsoL1Seeded+hltEgammaHcalPFClusterIsoL1Seeded+hltEgammaEleL1TrkIsoL1Seeded+hltEgammaEleGsfTrackIsoV6L1Seeded)
+HLTEle26WP70L1SeededInnerSequence = cms.Sequence(hltEgammaCandidatesL1Seeded
+    +hltEgammaClusterShapeL1Seeded
+    +hltEgammaHGCALIDVarsL1Seeded
+    +hltEgammaHoverEL1Seeded
+    +hltEgammaEcalPFClusterIsoL1Seeded
+    +hltEgammaHGCalLayerClusterIsoL1Seeded
+    +hltEgammaHcalPFClusterIsoL1Seeded
+    +hltEgammaEleL1TrkIsoL1Seeded
+    +hltEgammaCandidatesWrapperL1Seeded
+    +hltEG26EtL1SeededFilter
+    +hltEle26WP70ClusterShapeL1SeededFilter
+    +hltEle26WP70ClusterShapeSigmavvL1SeededFilter
+    +hltEle26WP70ClusterShapeSigmawwL1SeededFilter
+    +hltEle26WP70HgcalHEL1SeededFilter
+    +hltEle26WP70HEL1SeededFilter
+    +hltEle26WP70EcalIsoL1SeededFilter
+    +hltEle26WP70HgcalIsoL1SeededFilter
+    +hltEle26WP70HcalIsoL1SeededFilter
+    +hltEle26WP70PixelMatchL1SeededFilter
+    +hltEle26WP70PMS2L1SeededFilter
+    +hltEle26WP70GsfOneOEMinusOneOPL1SeededFilter
+    +hltEle26WP70GsfDetaL1SeededFilter
+    +hltEle26WP70GsfDphiL1SeededFilter
+    +hltEle26WP70BestGsfNLayerITL1SeededFilter
+    +hltEle26WP70BestGsfChi2L1SeededFilter
+    +hltEle26WP70GsfTrackIsoFromL1TracksL1SeededFilter
+    +HLTTrackingV61Sequence
+    +hltEgammaEleGsfTrackIsoV6L1Seeded
+    +hltEle26WP70GsfTrackIsoL1SeededFilter
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70L1SeededSequence_cfi.py
@@ -1,25 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltEG26EtL1SeededFilter_cfi import *
-from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
-from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
-from ..modules.hltEle26WP70BestGsfChi2L1SeededFilter_cfi import *
-from ..modules.hltEle26WP70BestGsfNLayerITL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeSigmavvL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeSigmawwL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70EcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70GsfDetaL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70GsfDphiL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70GsfOneOEMinusOneOPL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70GsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70GsfTrackIsoL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70HcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70HEL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70HgcalHEL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70HgcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70PixelMatchL1SeededFilter_cfi import *
-from ..modules.hltEle26WP70PMS2L1SeededFilter_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTEle26WP70L1SeededInnerSequence_cfi import *
@@ -30,6 +10,16 @@ from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle26WP70L1SeededSequence = cms.Sequence(HLTL1Sequence+hltEGL1SeedsForSingleEleIsolatedFilter+HLTDoFullUnpackingEgammaEcalL1SeededSequence+HLTEGammaDoLocalHcalSequence+HLTPFClusteringForEgammaL1SeededSequence+HLTHgcalTiclPFClusteringForEgammaL1SeededSequence+HLTFastJetForEgammaSequence+HLTPFHcalClusteringForEgammaSequence+HLTElePixelMatchL1SeededSequence+HLTTrackingV61Sequence+HLTGsfElectronL1SeededSequence+HLTEle26WP70L1SeededInnerSequence+hltEgammaCandidatesWrapperL1Seeded+hltEG26EtL1SeededFilter+hltEle26WP70ClusterShapeL1SeededFilter+hltEle26WP70ClusterShapeSigmavvL1SeededFilter+hltEle26WP70ClusterShapeSigmawwL1SeededFilter+hltEle26WP70HgcalHEL1SeededFilter+hltEle26WP70HEL1SeededFilter+hltEle26WP70EcalIsoL1SeededFilter+hltEle26WP70HgcalIsoL1SeededFilter+hltEle26WP70HcalIsoL1SeededFilter+hltEle26WP70PixelMatchL1SeededFilter+hltEle26WP70PMS2L1SeededFilter+hltEle26WP70GsfOneOEMinusOneOPL1SeededFilter+hltEle26WP70GsfDetaL1SeededFilter+hltEle26WP70GsfDphiL1SeededFilter+hltEle26WP70BestGsfNLayerITL1SeededFilter+hltEle26WP70BestGsfChi2L1SeededFilter+hltEle26WP70GsfTrackIsoFromL1TracksL1SeededFilter+hltEle26WP70GsfTrackIsoL1SeededFilter)
+HLTEle26WP70L1SeededSequence = cms.Sequence(HLTL1Sequence
+    +hltEGL1SeedsForSingleEleIsolatedFilter
+    +HLTDoFullUnpackingEgammaEcalL1SeededSequence
+    +HLTEGammaDoLocalHcalSequence
+    +HLTPFClusteringForEgammaL1SeededSequence
+    +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
+    +HLTFastJetForEgammaSequence
+    +HLTPFHcalClusteringForEgammaSequence
+    +HLTElePixelMatchL1SeededSequence
+    +HLTGsfElectronL1SeededSequence
+    +HLTEle26WP70L1SeededInnerSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededInnerSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededInnerSequence_cfi.py
@@ -9,5 +9,55 @@ from ..modules.hltEgammaHcalPFClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsUnseeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHoverEUnseeded_cfi import *
+from ..modules.hltEG26EtUnseededFilter_cfi import *
+from ..modules.hltEgammaCandidatesWrapperUnseeded_cfi import *
+from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
+from ..modules.hltEle26WP70BestGsfChi2UnseededFilter_cfi import *
+from ..modules.hltEle26WP70BestGsfNLayerITUnseededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeSigmavvUnseededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeSigmawwUnseededFilter_cfi import *
+from ..modules.hltEle26WP70ClusterShapeUnseededFilter_cfi import *
+from ..modules.hltEle26WP70EcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle26WP70GsfDetaUnseededFilter_cfi import *
+from ..modules.hltEle26WP70GsfDphiUnseededFilter_cfi import *
+from ..modules.hltEle26WP70GsfOneOEMinusOneOPUnseededFilter_cfi import *
+from ..modules.hltEle26WP70GsfTrackIsoFromL1TracksUnseededFilter_cfi import *
+from ..modules.hltEle26WP70GsfTrackIsoUnseededFilter_cfi import *
+from ..modules.hltEle26WP70HcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle26WP70HEUnseededFilter_cfi import *
+from ..modules.hltEle26WP70HgcalHEUnseededFilter_cfi import *
+from ..modules.hltEle26WP70HgcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle26WP70PixelMatchUnseededFilter_cfi import *
+from ..modules.hltEle26WP70PMS2UnseededFilter_cfi import *
+from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle26WP70UnseededInnerSequence = cms.Sequence(hltEgammaCandidatesUnseeded+hltEgammaClusterShapeUnseeded+hltEgammaHGCALIDVarsUnseeded+hltEgammaHoverEUnseeded+hltEgammaEcalPFClusterIsoUnseeded+hltEgammaHGCalLayerClusterIsoUnseeded+hltEgammaHcalPFClusterIsoUnseeded+hltEgammaEleL1TrkIsoUnseeded+hltEgammaEleGsfTrackIsoV6Unseeded)
+HLTEle26WP70UnseededInnerSequence = cms.Sequence(hltEgammaCandidatesUnseeded
+    +hltEgammaClusterShapeUnseeded
+    +hltEgammaHGCALIDVarsUnseeded
+    +hltEgammaHoverEUnseeded
+    +hltEgammaEcalPFClusterIsoUnseeded
+    +hltEgammaHGCalLayerClusterIsoUnseeded
+    +hltEgammaHcalPFClusterIsoUnseeded
+    +hltEgammaEleL1TrkIsoUnseeded
+    +hltEgammaCandidatesWrapperUnseeded
+    +hltEG26EtUnseededFilter
+    +hltEle26WP70ClusterShapeUnseededFilter
+    +hltEle26WP70ClusterShapeSigmavvUnseededFilter
+    +hltEle26WP70ClusterShapeSigmawwUnseededFilter
+    +hltEle26WP70HgcalHEUnseededFilter
+    +hltEle26WP70HEUnseededFilter
+    +hltEle26WP70EcalIsoUnseededFilter
+    +hltEle26WP70HgcalIsoUnseededFilter
+    +hltEle26WP70HcalIsoUnseededFilter
+    +hltEle26WP70PixelMatchUnseededFilter
+    +hltEle26WP70PMS2UnseededFilter
+    +hltEle26WP70GsfOneOEMinusOneOPUnseededFilter
+    +hltEle26WP70GsfDetaUnseededFilter
+    +hltEle26WP70GsfDphiUnseededFilter
+    +hltEle26WP70BestGsfNLayerITUnseededFilter
+    +hltEle26WP70BestGsfChi2UnseededFilter
+    +hltEle26WP70GsfTrackIsoFromL1TracksUnseededFilter
+    +HLTTrackingV61Sequence
+    +hltEgammaEleGsfTrackIsoV6Unseeded
+    +hltEle26WP70GsfTrackIsoUnseededFilter
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle26WP70UnseededSequence_cfi.py
@@ -1,25 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltEG26EtUnseededFilter_cfi import *
-from ..modules.hltEgammaCandidatesWrapperUnseeded_cfi import *
-from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
-from ..modules.hltEle26WP70BestGsfChi2UnseededFilter_cfi import *
-from ..modules.hltEle26WP70BestGsfNLayerITUnseededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeSigmavvUnseededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeSigmawwUnseededFilter_cfi import *
-from ..modules.hltEle26WP70ClusterShapeUnseededFilter_cfi import *
-from ..modules.hltEle26WP70EcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle26WP70GsfDetaUnseededFilter_cfi import *
-from ..modules.hltEle26WP70GsfDphiUnseededFilter_cfi import *
-from ..modules.hltEle26WP70GsfOneOEMinusOneOPUnseededFilter_cfi import *
-from ..modules.hltEle26WP70GsfTrackIsoFromL1TracksUnseededFilter_cfi import *
-from ..modules.hltEle26WP70GsfTrackIsoUnseededFilter_cfi import *
-from ..modules.hltEle26WP70HcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle26WP70HEUnseededFilter_cfi import *
-from ..modules.hltEle26WP70HgcalHEUnseededFilter_cfi import *
-from ..modules.hltEle26WP70HgcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle26WP70PixelMatchUnseededFilter_cfi import *
-from ..modules.hltEle26WP70PMS2UnseededFilter_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTEle26WP70UnseededInnerSequence_cfi import *
@@ -30,6 +10,16 @@ from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle26WP70UnseededSequence = cms.Sequence(HLTL1Sequence+hltEGL1SeedsForSingleEleIsolatedFilter+HLTDoFullUnpackingEgammaEcalSequence+HLTEGammaDoLocalHcalSequence+HLTPFClusteringForEgammaUnseededSequence+HLTHgcalTiclPFClusteringForEgammaUnseededSequence+HLTFastJetForEgammaSequence+HLTPFHcalClusteringForEgammaSequence+HLTElePixelMatchUnseededSequence+HLTTrackingV61Sequence+HLTGsfElectronUnseededSequence+HLTEle26WP70UnseededInnerSequence+hltEgammaCandidatesWrapperUnseeded+hltEG26EtUnseededFilter+hltEle26WP70ClusterShapeUnseededFilter+hltEle26WP70ClusterShapeSigmavvUnseededFilter+hltEle26WP70ClusterShapeSigmawwUnseededFilter+hltEle26WP70HgcalHEUnseededFilter+hltEle26WP70HEUnseededFilter+hltEle26WP70EcalIsoUnseededFilter+hltEle26WP70HgcalIsoUnseededFilter+hltEle26WP70HcalIsoUnseededFilter+hltEle26WP70PixelMatchUnseededFilter+hltEle26WP70PMS2UnseededFilter+hltEle26WP70GsfOneOEMinusOneOPUnseededFilter+hltEle26WP70GsfDetaUnseededFilter+hltEle26WP70GsfDphiUnseededFilter+hltEle26WP70BestGsfNLayerITUnseededFilter+hltEle26WP70BestGsfChi2UnseededFilter+hltEle26WP70GsfTrackIsoFromL1TracksUnseededFilter+hltEle26WP70GsfTrackIsoUnseededFilter)
+HLTEle26WP70UnseededSequence = cms.Sequence(HLTL1Sequence
+    +hltEGL1SeedsForSingleEleIsolatedFilter
+    +HLTDoFullUnpackingEgammaEcalSequence
+    +HLTEGammaDoLocalHcalSequence
+    +HLTPFClusteringForEgammaUnseededSequence
+    +HLTHgcalTiclPFClusteringForEgammaUnseededSequence
+    +HLTFastJetForEgammaSequence
+    +HLTPFHcalClusteringForEgammaSequence
+    +HLTElePixelMatchUnseededSequence
+    +HLTGsfElectronUnseededSequence
+    +HLTEle26WP70UnseededInnerSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededInnerSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededInnerSequence_cfi.py
@@ -6,5 +6,51 @@ from ..modules.hltEgammaEleL1TrkIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHcalPFClusterIsoL1Seeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsL1Seeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoL1Seeded_cfi import *
+from ..modules.hltEG32EtL1SeededFilter_cfi import *
+from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
+from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
+from ..modules.hltEle32WPTightBestGsfChi2L1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightBestGsfNLayerITL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeSigmavvL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeSigmawwL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightEcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfDetaL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfDphiL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfOneOEMinusOneOPL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfTrackIsoL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightHcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightHEL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightHgcalHEL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightHgcalIsoL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightPixelMatchL1SeededFilter_cfi import *
+from ..modules.hltEle32WPTightPMS2L1SeededFilter_cfi import *
+from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle32WPTightL1SeededInnerSequence = cms.Sequence(hltEgammaHGCALIDVarsL1Seeded+hltEgammaEcalPFClusterIsoL1Seeded+hltEgammaHGCalLayerClusterIsoL1Seeded+hltEgammaHcalPFClusterIsoL1Seeded+hltEgammaEleL1TrkIsoL1Seeded+hltEgammaEleGsfTrackIsoV6L1Seeded)
+HLTEle32WPTightL1SeededInnerSequence = cms.Sequence(hltEgammaHGCALIDVarsL1Seeded
+    +hltEgammaEcalPFClusterIsoL1Seeded
+    +hltEgammaHGCalLayerClusterIsoL1Seeded
+    +hltEgammaHcalPFClusterIsoL1Seeded
+    +hltEgammaEleL1TrkIsoL1Seeded
+    +hltEgammaCandidatesWrapperL1Seeded
+    +hltEG32EtL1SeededFilter
+    +hltEle32WPTightClusterShapeL1SeededFilter
+    +hltEle32WPTightClusterShapeSigmavvL1SeededFilter
+    +hltEle32WPTightClusterShapeSigmawwL1SeededFilter
+    +hltEle32WPTightHgcalHEL1SeededFilter
+    +hltEle32WPTightHEL1SeededFilter
+    +hltEle32WPTightEcalIsoL1SeededFilter
+    +hltEle32WPTightHgcalIsoL1SeededFilter
+    +hltEle32WPTightHcalIsoL1SeededFilter
+    +hltEle32WPTightPixelMatchL1SeededFilter
+    +hltEle32WPTightPMS2L1SeededFilter
+    +hltEle32WPTightGsfOneOEMinusOneOPL1SeededFilter
+    +hltEle32WPTightGsfDetaL1SeededFilter
+    +hltEle32WPTightGsfDphiL1SeededFilter
+    +hltEle32WPTightBestGsfNLayerITL1SeededFilter
+    +hltEle32WPTightBestGsfChi2L1SeededFilter
+    +hltEle32WPTightGsfTrackIsoFromL1TracksL1SeededFilter
+    +HLTTrackingV61Sequence
+    +hltEgammaEleGsfTrackIsoV6L1Seeded
+    +hltEle32WPTightGsfTrackIsoL1SeededFilter)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightL1SeededSequence_cfi.py
@@ -1,25 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltEG32EtL1SeededFilter_cfi import *
-from ..modules.hltEgammaCandidatesWrapperL1Seeded_cfi import *
-from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
-from ..modules.hltEle32WPTightBestGsfChi2L1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightBestGsfNLayerITL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeSigmavvL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeSigmawwL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightEcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfDetaL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfDphiL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfOneOEMinusOneOPL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfTrackIsoFromL1TracksL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfTrackIsoL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightHcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightHEL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightHgcalHEL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightHgcalIsoL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightPixelMatchL1SeededFilter_cfi import *
-from ..modules.hltEle32WPTightPMS2L1SeededFilter_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalL1SeededSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTEle32WPTightL1SeededInnerSequence_cfi import *
@@ -30,6 +10,16 @@ from ..sequences.HLTHgcalTiclPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaL1SeededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle32WPTightL1SeededSequence = cms.Sequence(HLTL1Sequence+hltEGL1SeedsForSingleEleIsolatedFilter+HLTDoFullUnpackingEgammaEcalL1SeededSequence+HLTEGammaDoLocalHcalSequence+HLTPFClusteringForEgammaL1SeededSequence+HLTHgcalTiclPFClusteringForEgammaL1SeededSequence+HLTFastJetForEgammaSequence+HLTPFHcalClusteringForEgammaSequence+HLTElePixelMatchL1SeededSequence+HLTTrackingV61Sequence+HLTGsfElectronL1SeededSequence+HLTEle32WPTightL1SeededInnerSequence+hltEgammaCandidatesWrapperL1Seeded+hltEG32EtL1SeededFilter+hltEle32WPTightClusterShapeL1SeededFilter+hltEle32WPTightClusterShapeSigmavvL1SeededFilter+hltEle32WPTightClusterShapeSigmawwL1SeededFilter+hltEle32WPTightHgcalHEL1SeededFilter+hltEle32WPTightHEL1SeededFilter+hltEle32WPTightEcalIsoL1SeededFilter+hltEle32WPTightHgcalIsoL1SeededFilter+hltEle32WPTightHcalIsoL1SeededFilter+hltEle32WPTightPixelMatchL1SeededFilter+hltEle32WPTightPMS2L1SeededFilter+hltEle32WPTightGsfOneOEMinusOneOPL1SeededFilter+hltEle32WPTightGsfDetaL1SeededFilter+hltEle32WPTightGsfDphiL1SeededFilter+hltEle32WPTightBestGsfNLayerITL1SeededFilter+hltEle32WPTightBestGsfChi2L1SeededFilter+hltEle32WPTightGsfTrackIsoFromL1TracksL1SeededFilter+hltEle32WPTightGsfTrackIsoL1SeededFilter)
+HLTEle32WPTightL1SeededSequence = cms.Sequence(HLTL1Sequence
+    +hltEGL1SeedsForSingleEleIsolatedFilter
+    +HLTDoFullUnpackingEgammaEcalL1SeededSequence
+    +HLTEGammaDoLocalHcalSequence
+    +HLTPFClusteringForEgammaL1SeededSequence
+    +HLTHgcalTiclPFClusteringForEgammaL1SeededSequence
+    +HLTFastJetForEgammaSequence
+    +HLTPFHcalClusteringForEgammaSequence
+    +HLTElePixelMatchL1SeededSequence
+    +HLTGsfElectronL1SeededSequence
+    +HLTEle32WPTightL1SeededInnerSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededInnerSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededInnerSequence_cfi.py
@@ -9,5 +9,55 @@ from ..modules.hltEgammaHcalPFClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHGCALIDVarsUnseeded_cfi import *
 from ..modules.hltEgammaHGCalLayerClusterIsoUnseeded_cfi import *
 from ..modules.hltEgammaHoverEUnseeded_cfi import *
+from ..modules.hltEG32EtUnseededFilter_cfi import *
+from ..modules.hltEgammaCandidatesWrapperUnseeded_cfi import *
+from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
+from ..modules.hltEle32WPTightBestGsfChi2UnseededFilter_cfi import *
+from ..modules.hltEle32WPTightBestGsfNLayerITUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeSigmavvUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeSigmawwUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightClusterShapeUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightEcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfDetaUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfDphiUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfOneOEMinusOneOPUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfTrackIsoFromL1TracksUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightGsfTrackIsoUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightHcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightHEUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightHgcalHEUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightHgcalIsoUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightPixelMatchUnseededFilter_cfi import *
+from ..modules.hltEle32WPTightPMS2UnseededFilter_cfi import *
+from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle32WPTightUnseededInnerSequence = cms.Sequence(hltEgammaHGCALIDVarsUnseeded+hltEgammaEcalPFClusterIsoUnseeded+hltEgammaHGCalLayerClusterIsoUnseeded+hltEgammaHcalPFClusterIsoUnseeded+hltEgammaCandidatesUnseeded+hltEgammaClusterShapeUnseeded+hltEgammaEleGsfTrackIsoV6Unseeded+hltEgammaEleL1TrkIsoUnseeded+hltEgammaHoverEUnseeded)
+HLTEle32WPTightUnseededInnerSequence = cms.Sequence(hltEgammaHGCALIDVarsUnseeded
+    +hltEgammaEcalPFClusterIsoUnseeded
+    +hltEgammaHGCalLayerClusterIsoUnseeded
+    +hltEgammaHcalPFClusterIsoUnseeded
+    +hltEgammaEleL1TrkIsoUnseeded
+    +hltEgammaHoverEUnseeded
+    +hltEgammaCandidatesUnseeded
+    +hltEgammaClusterShapeUnseeded
+    +hltEgammaCandidatesWrapperUnseeded
+    +hltEG32EtUnseededFilter
+    +hltEle32WPTightClusterShapeUnseededFilter
+    +hltEle32WPTightClusterShapeSigmavvUnseededFilter
+    +hltEle32WPTightClusterShapeSigmawwUnseededFilter
+    +hltEle32WPTightHgcalHEUnseededFilter
+    +hltEle32WPTightHEUnseededFilter
+    +hltEle32WPTightEcalIsoUnseededFilter
+    +hltEle32WPTightHgcalIsoUnseededFilter
+    +hltEle32WPTightHcalIsoUnseededFilter
+    +hltEle32WPTightPixelMatchUnseededFilter
+    +hltEle32WPTightPMS2UnseededFilter
+    +hltEle32WPTightGsfOneOEMinusOneOPUnseededFilter
+    +hltEle32WPTightGsfDetaUnseededFilter
+    +hltEle32WPTightGsfDphiUnseededFilter
+    +hltEle32WPTightBestGsfNLayerITUnseededFilter
+    +hltEle32WPTightBestGsfChi2UnseededFilter
+    +hltEle32WPTightGsfTrackIsoFromL1TracksUnseededFilter
+    +HLTTrackingV61Sequence
+    +hltEgammaEleGsfTrackIsoV6Unseeded
+    +hltEle32WPTightGsfTrackIsoUnseededFilter
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTEle32WPTightUnseededSequence_cfi.py
@@ -1,25 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from ..modules.hltEG32EtUnseededFilter_cfi import *
-from ..modules.hltEgammaCandidatesWrapperUnseeded_cfi import *
-from ..modules.hltEGL1SeedsForSingleEleIsolatedFilter_cfi import *
-from ..modules.hltEle32WPTightBestGsfChi2UnseededFilter_cfi import *
-from ..modules.hltEle32WPTightBestGsfNLayerITUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeSigmavvUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeSigmawwUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightClusterShapeUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightEcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfDetaUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfDphiUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfOneOEMinusOneOPUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfTrackIsoFromL1TracksUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightGsfTrackIsoUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightHcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightHEUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightHgcalHEUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightHgcalIsoUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightPixelMatchUnseededFilter_cfi import *
-from ..modules.hltEle32WPTightPMS2UnseededFilter_cfi import *
 from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
 from ..sequences.HLTEGammaDoLocalHcalSequence_cfi import *
 from ..sequences.HLTEle32WPTightUnseededInnerSequence_cfi import *
@@ -30,6 +10,16 @@ from ..sequences.HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTL1Sequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPFHcalClusteringForEgammaSequence_cfi import *
-from ..sequences.HLTTrackingV61Sequence_cfi import *
 
-HLTEle32WPTightUnseededSequence = cms.Sequence(HLTL1Sequence+hltEGL1SeedsForSingleEleIsolatedFilter+HLTDoFullUnpackingEgammaEcalSequence+HLTEGammaDoLocalHcalSequence+HLTPFClusteringForEgammaUnseededSequence+HLTHgcalTiclPFClusteringForEgammaUnseededSequence+HLTFastJetForEgammaSequence+HLTPFHcalClusteringForEgammaSequence+HLTElePixelMatchUnseededSequence+HLTTrackingV61Sequence+HLTGsfElectronUnseededSequence+HLTEle32WPTightUnseededInnerSequence+hltEgammaCandidatesWrapperUnseeded+hltEG32EtUnseededFilter+hltEle32WPTightClusterShapeUnseededFilter+hltEle32WPTightClusterShapeSigmavvUnseededFilter+hltEle32WPTightClusterShapeSigmawwUnseededFilter+hltEle32WPTightHgcalHEUnseededFilter+hltEle32WPTightHEUnseededFilter+hltEle32WPTightEcalIsoUnseededFilter+hltEle32WPTightHgcalIsoUnseededFilter+hltEle32WPTightHcalIsoUnseededFilter+hltEle32WPTightPixelMatchUnseededFilter+hltEle32WPTightPMS2UnseededFilter+hltEle32WPTightGsfOneOEMinusOneOPUnseededFilter+hltEle32WPTightGsfDetaUnseededFilter+hltEle32WPTightGsfDphiUnseededFilter+hltEle32WPTightBestGsfNLayerITUnseededFilter+hltEle32WPTightBestGsfChi2UnseededFilter+hltEle32WPTightGsfTrackIsoFromL1TracksUnseededFilter+hltEle32WPTightGsfTrackIsoUnseededFilter)
+HLTEle32WPTightUnseededSequence = cms.Sequence(HLTL1Sequence
+    +hltEGL1SeedsForSingleEleIsolatedFilter
+    +HLTDoFullUnpackingEgammaEcalSequence
+    +HLTEGammaDoLocalHcalSequence
+    +HLTPFClusteringForEgammaUnseededSequence
+    +HLTHgcalTiclPFClusteringForEgammaUnseededSequence
+    +HLTFastJetForEgammaSequence
+    +HLTPFHcalClusteringForEgammaSequence
+    +HLTElePixelMatchUnseededSequence
+    +HLTGsfElectronUnseededSequence
+    +HLTEle32WPTightUnseededInnerSequence
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTFastJetForEgammaSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTFastJetForEgammaSequence_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from ..modules.ecalMultiFitUncalibRecHit_cfi import *
 from ..modules.hltEcalRecHit_cfi import *
-from ..modules.hltEcalUncalibRecHit_cfi import *
 from ..modules.hltFixedGridRhoFastjetAllCaloForEGamma_cfi import *
 
-HLTFastJetForEgammaSequence = cms.Sequence(hltEcalUncalibRecHit+ecalMultiFitUncalibRecHit+hltEcalRecHit+hltFixedGridRhoFastjetAllCaloForEGamma)
+HLTFastJetForEgammaSequence = cms.Sequence(ecalMultiFitUncalibRecHit+hltEcalRecHit+hltFixedGridRhoFastjetAllCaloForEGamma)


### PR DESCRIPTION
#### PR description:

This PR optimises the sequence-based HLT Upgrade Phase2 menu. Main ingredients:

* Remove full Tracking sequence from Muon paths that do not use it
* Remove `hltEcalUncalibRecHit` module as a duplicate of `ecalMultiFitUncalibRecHit`
* Optimally reorder filters in Egamma Paths by running full tracking at the very end, before the last filter that needs tracks.

#### PR validation:

Tested using HLT Upgrade Simplified menu.

With these changes, the timing as measured on my development machine went down quite a bit:

![before](https://github.com/cms-sw/cmssw/assets/1169991/ecbec2ad-0b4d-454d-8453-f59b6903267d)
![after](https://github.com/cms-sw/cmssw/assets/1169991/e90e3914-ffb6-4b2b-a607-b278828895f2)

**Nota Bene:** For the timing measurements above, the Tau paths have been disabled temporarily because they were causing the triggering of full tracking on all events. This will likely be fixed once L1 seeding for Tau paths is introduced.