### PR TITLE
Make combined modules the default

### DIFF
--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -17,10 +17,10 @@ name: PR validation with GitLab CI
 on: # Controls when the action will run.
   workflow_dispatch:
   push: # Please specify your branch down here if you want CI to run for each push to it.
-    branches: [L1TK-dev-13_3_0_pre2]
+    branches: [L1TK-dev-14_0_0_pre2]
     # branches: [myBranchUnderTest]
   pull_request: # Run CI if someone makes a PR to any branch
-    # branches: [L1TK-dev-13_3_0_pre2] # Optionally only run CI if PR is to this branch.
+    # branches: [L1TK-dev-14_0_0_pre2] # Optionally only run CI if PR is to this branch.
     
 env:
   mirror_repo: "https://gitlab.cern.ch/cms-l1tk/cmssw_CI" # gitlab mirror

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -1,0 +1,80 @@
+#####################################################################
+# This triggers git Continuous Integration tests when a PR to       #
+# any branch is made. Or if a code-commit is made to any            #
+# test branch (temporarily) specified below.                        #
+#                                                                   #
+# The tests themselves are delegated to a gitlab CI runner          #
+# controlled by the .gitlab-ci.yml file at                          #
+# https://gitlab.cern.ch/cms-l1tk/cmssw_CI .                        #
+# N.B. .gitlab-ci.yml must be update if the CMSSW version changes.  #
+#                                                                   # 
+# Communication between the github & gitlab CIs is done via scripts #
+# at https://github.com/cms-L1TK/gitlab-mirror-and-ci-action        #
+#####################################################################
+
+name: PR validation with GitLab CI
+ 
+on: # Controls when the action will run.
+  workflow_dispatch:
+  push: # Please specify your branch down here if you want CI to run for each push to it.
+    branches: [L1TK-dev-13_3_0_pre2]
+    # branches: [myBranchUnderTest]
+  pull_request: # Run CI if someone makes a PR to any branch
+    # branches: [L1TK-dev-13_3_0_pre2] # Optionally only run CI if PR is to this branch.
+    
+env:
+  mirror_repo: "https://gitlab.cern.ch/cms-l1tk/cmssw_CI" # gitlab mirror
+  current_branch: "unitialized"
+
+jobs:
+  trigger_gitlab_CI: # https://github.com/marketplace/actions/mirror-to-gitlab-and-run-gitlab-ci
+    name: trigger_gitlab_CI
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: DebugPrint
+      run: |
+        echo "github.ref = ${{ github.ref }}"
+        env
+
+    - name: Redefine branch on pull_request
+      if: github.event_name == 'pull_request'
+      run: |
+        # Sets env. variable $current_branch
+        echo "current_branch=$(echo ${{ github.head_ref }})" >> $GITHUB_ENV
+
+    - name: Redefine branch on push
+      if: github.event_name == 'push'
+      run: |
+        # Sets env. variable $current_branch
+        echo "current_branch=$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
+
+    - name: Print generic gitlab CI location
+      run: |
+        echo "In general, gitlab CI jobs run in https://gitlab.cern.ch/cms-l1tk/cmssw_CI/-/pipelines"      
+
+    - name: Trigger gitlab CI run
+      # Communicate between gitlab & github, and trigger gitlab CI run.
+      # (Forked from https://github.com/SvanBoxel/gitlab-mirror-and-ci-action).
+      uses: cms-L1TK/gitlab-mirror-and-ci-action@master
+      env:
+        GITLAB_HOSTNAME: "gitlab.cern.ch"
+        GITLAB_USERNAME: "cms-l1tk"   
+        GITLAB_PASSWORD: ${{ secrets.GITLAB_L1TK_CMSSW_CI_TOKEN_2FA }} # Generate token here: https://gitlab.cern.ch/cms-l1tk/cmssw_CI/-/settings/access_tokens and add it to GitHub secrets https://github.com/cms-L1TK/cmssw/settings/secrets/actions   
+        GITLAB_PROJECT_ID: "124851" # ID visible at https://gitlab.cern.ch/cms-l1tk/cmssw_CI
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
+        MIRROR_REPO: ${{ env.mirror_repo }} # gitlab mirror.
+        IS_CMSSW: "true" # Is repo CMSSW or something else (e.g. HLS)?
+        CHECKOUT_BRANCH: ${{ env.current_branch }} # Needed so push to gitlab can work
+        REMOVE_BRANCH: "true" # Refreshes branch on mirror, which triggers CI run there.
+        REBASE_MASTER: "false" # If true would rebase to "master", which isn't used in cms-L1TK.
+        RETURN_FILE: "pipeline_url.txt" # Output file with gitlab pipeline url
+
+    - name: print summary
+      if: always()
+      run: |
+        echo ""
+        echo "==========================================================="
+        echo "DETAILED OUTPUT FROM CMSSW COMPILATION & RUN AVAILABLE "
+        echo "AT FOLLOWING GITLAB CI URL:"
+        cat pipeline_url.txt

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -551,7 +551,7 @@ namespace tmtt {
       matRinv = TMatrixD(TMatrixD::kInverted, matR);
     } else {
       // Protection against rare maths instability.
-      const TMatrixD unitMatrix(TMatrixD::kUnit, TMatrixD(nHelixPar_, nHelixPar_));
+      const TMatrixD unitMatrix(TMatrixD::kUnit, TMatrixD(2, 2));
       const double big = 9.9e9;
       matRinv = big * unitMatrix;
     }

--- a/L1Trigger/TrackFindingTracklet/README.md
+++ b/L1Trigger/TrackFindingTracklet/README.md
@@ -9,7 +9,7 @@ For the baseline HYBRID algo, which runs Tracklet pattern reco followed
 by KF track fit, TrackFindingTracklet/interface/Settings.h configures the pattern reco stage, (although some parameters there are overridden by l1tTTTracksFromTrackletEmulation_cfi.py).
 The KF fit is configured by the constructor of TrackFindingTMTT/src/Settings.cc.
 
-The ROOT macros L1TrackNtuplePlot.C & L1TrackQualityPlot.C make tracking 
+The ROOT macros L1TrackNtuplePlot.C & L1TrackQualityPlot.C make track 
 performance & BDT track quality performance plots from the TTree. 
 Both can be run via makeHists.csh .
 

--- a/L1Trigger/TrackFindingTracklet/README.md
+++ b/L1Trigger/TrackFindingTracklet/README.md
@@ -15,3 +15,8 @@ Both can be run via makeHists.csh .
 
 The optional "NewKF" track fit can be run by changing L1TRKALGO=HYBRID_NEWKF. It corresponds to the curent FW, but is is not yet the default, as only a basic duplicate track removal is available for it. It is configured via 
 TrackTrigger/python/ProducerSetup_cfi.py, (which also configures the DTC).
+
+For experts
+============
+
+1) To make plots to monitor data rates assicuated to truncation after each step in the tracklet pattern reco algo, set writeMonitorData_ = true in Settings.h . This creates txt files, which the ROOT macros in https://github.com/cms-L1TK/TrackPerf/tree/master/PatternReco can then use to study truncation of individual algo steps within tracklet chain.

--- a/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
@@ -38,6 +38,7 @@ namespace trklet {
   private:
     unsigned int layerdisk_;
     bool barrel_;
+    bool first_;
 
     unsigned int phiregion_;
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -893,7 +893,9 @@ namespace trklet {
         {"TRE", 108},
         {"DR", 108}};  //Specifies how many tracks allowed per bin in DR
 
-    // If set to true this will generate debub printout in text files
+    // If set to true this creates txt files, which the ROOT macros in 
+    // https://github.com/cms-L1TK/TrackPerf/tree/master/PatternReco
+    // can then use to study truncation of individual algo steps within tracklet chain.
     std::unordered_map<std::string, bool> writeMonitorData_{{"IL", false},
                                                             {"TE", false},
                                                             {"CT", false},

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -440,15 +440,15 @@ namespace trklet {
     //have the factor if 2
     double krprojshiftdisk() const { return 2 * kr(); }
 
-    double benddecode(int ibend, int layerdisk, bool isPSmodule) const {
+    double benddecode(unsigned int ibend, unsigned int layerdisk, bool isPSmodule) const {
       if (layerdisk >= N_LAYER && (!isPSmodule))
-        layerdisk += (N_LAYER - 1);
+        layerdisk += N_DISK;
       double bend = benddecode_[layerdisk][ibend];
       assert(bend < 99.0);
       return bend;
     }
 
-    double bendcut(int ibend, int layerdisk, bool isPSmodule) const {
+    double bendcut(unsigned int ibend, unsigned int layerdisk, bool isPSmodule) const {
       if (layerdisk >= N_LAYER && (!isPSmodule))
         layerdisk += N_DISK;
       double bendcut = bendcut_[layerdisk][ibend];

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -893,7 +893,7 @@ namespace trklet {
         {"TRE", 108},
         {"DR", 108}};  //Specifies how many tracks allowed per bin in DR
 
-    // If set to true this creates txt files, which the ROOT macros in 
+    // If set to true this creates txt files, which the ROOT macros in
     // https://github.com/cms-L1TK/TrackPerf/tree/master/PatternReco
     // can then use to study truncation of individual algo steps within tracklet chain.
     std::unordered_map<std::string, bool> writeMonitorData_{{"IL", false},

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1028,11 +1028,12 @@ namespace trklet {
     bool reduced_{false};        // use reduced (Summer Chain) config
     bool inventStubs_{true};     // invent seeding stub coordinates based on tracklet traj
 
-    // Use combined TP (TE+TC) and MP (PR+ME+MC) configuration (with prompt tracking)
-    bool combined_{false};
-    // N.B. To use combined modules with extended tracking, edit
-    // Tracklet_cfi.py to refer to *_hourglassExtendedCombined.dat,
-    // but leave combined_=false.
+    // Use combined TP (TE+TC) & MP (PR+ME+MC) config (with prompt tracking)
+    bool combined_{true};
+    // N.B. For extended tracking, this combined_ is overridden by python cfg
+    // to false, but combined modules are nonetheless used by default.
+    // If you don't want them, edit l1tTTTracksFromTrackletEmulation_cfi.py
+    // to refer to *_hourglassExtended.dat .
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/interface/Track.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Track.h
@@ -59,7 +59,7 @@ namespace trklet {
     double phi0(Settings const& settings) const;
 
     //The following return the floating point track parameters by undigitizing the digitized parameters
-    double eta(Settings const& settings) const { return (asinh(ipars_.t() + 0.5) * settings.ktpars()); }
+    double eta(Settings const& settings) const { return (asinh((ipars_.t() + 0.5) * settings.ktpars())); }
     double tanL(Settings const& settings) const { return (ipars_.t() + 0.5) * settings.ktpars(); }
     double z0(Settings const& settings) const { return (ipars_.z0() + 0.5) * settings.kz0pars(); }
     double rinv(Settings const& settings) const { return (ipars_.rinv() + 0.5) * settings.krinvpars(); }

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -282,6 +282,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   settings_.setExtended(extended_);
   settings_.setReduced(reduced_);
   settings_.setNHelixPar(nHelixPar_);
+  // combined_ must be false for extended tracking, regardless of whether
+  // combined modules are used or not.
+  if (extended_)
+    settings_.setCombined(false);
 
   settings_.setFitPatternFile(fitPatternFile.fullPath());
   settings_.setProcessingModulesFile(processingModulesFile.fullPath());

--- a/L1Trigger/TrackFindingTracklet/python/L1TrackNtupleMaker_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/L1TrackNtupleMaker_cfi.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+# Configuration for Ntuple maker for analyzing L1 track performance.
+# The parameters specified here are suitable for  Hybrid prompt track collections
+
+L1TrackNtupleMaker = cms.EDAnalyzer('L1TrackNtupleMaker',
+      # MyProcess is the (unsigned) PDGID corresponding to the process which is run
+      # e.g. single electron/positron = 11
+      #      single pion+/pion- = 211
+      #      single muon+/muon- = 13
+      #      pions in jets = 6
+      #      taus = 15
+      #      all TPs = 1 (pp collisions)
+       MyProcess = cms.int32(1),
+       DebugMode = cms.bool(False),      # printout lots of debug statements
+       SaveAllTracks = cms.bool(True),   # save *all* L1 tracks, not just truth matched to primary particle
+       SaveStubs = cms.bool(False),      # save some info for *all* stubs
+       L1Tk_nPar = cms.int32(4), # use 4 or 5-parameter L1 tracking?
+       L1Tk_minNStub = cms.int32(4),     # L1 tracks with >= 4 stubs
+       TP_minNStub = cms.int32(4),       # require TP to have >= X number of stubs associated with it
+       TP_minNStubLayer = cms.int32(4),  # require TP to have stubs in >= X layers/disks
+       TP_minPt = cms.double(1.9),       # only save TPs with pt > X GeV
+       TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
+       TP_maxZ0 = cms.double(30.0),      # only save TPs with |z0| < X cm
+       L1TrackInputTag = cms.InputTag("l1tTTTracksFromTrackletEmulation",  "Level1TTTracks"),         # TTTrack input
+       MCTruthTrackInputTag = cms.InputTag( "TTTrackAssociatorFromPixelDigis",  "Level1TTTracks"),  # MCTruth input
+       # other input collections
+       L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
+       MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
+       MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
+       TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
+       TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),
+       # tracking in jets (--> requires AK4 genjet collection present!)
+       TrackingInJets = cms.bool(False),
+       GenJetInputTag = cms.InputTag("ak4GenJets", "")
+)
+

--- a/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
@@ -15,11 +15,13 @@ l1tTTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                Extended = cms.bool(False),
                                                Reduced = cms.bool(False),
                                                Hnpar = cms.uint32(4),
+                                               # This file not used with Hybrid algo.
                                                # (if running on CRAB use "../../fitpattern.txt" etc instead)
                                                fitPatternFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/fitpattern.txt'),
-                                               memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtended.dat'),
-                                               processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtended.dat'),
-                                               wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtended.dat'),
+                                              # These 3 files only used for extended or reduced mode.
+                                               memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtendedCombined.dat'),
+                                               processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtendedCombined.dat'),
+                                               wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtendedCombined.dat'),
                                                # Quality Flag and Quality params
                                                TrackQuality = cms.bool(True),
                                                TrackQualityPSet = cms.PSet(TrackQualityParams),

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -141,7 +141,7 @@ void MatchEngineUnit::processPipeline() {
     int diskps = (!barrel_) && isPSmodule;
 
     //here we always use the larger number of bits for the bend
-    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
+    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv____ << nbits) + vmstub____.bend().value();
 
     //Check if stub z position consistent
     int idrz = stubfinerz - projfinerz____;

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -141,7 +141,7 @@ void MatchEngineUnit::processPipeline() {
     int diskps = (!barrel_) && isPSmodule;
 
     //here we always use the larger number of bits for the bend
-    unsigned int index = (diskps << (nbits + NRINVBITS)) + (projrinv____ << nbits) + vmstub____.bend().value();
+    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
 
     //Check if stub z position consistent
     int idrz = stubfinerz - projfinerz____;

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -582,11 +582,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel && (ideltaz << dzshift_ < best_ideltaz_barrel) &&
                    (ideltaz << dzshift_ >= -best_ideltaz_barrel));
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_barrel = std::abs(ideltaphi);
-      best_ideltaz_barrel = std::abs(ideltaz << dzshift_);
-    }
 
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
@@ -609,6 +604,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
         imatch = keep;
       }
+    }
+    // Update the "best" values
+    if (imatch) {
+      best_ideltaphi_barrel = std::abs(ideltaphi);
+      best_ideltaz_barrel = std::abs(ideltaz << dzshift_);
     }
 
     if (imatch) {
@@ -767,11 +767,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     bool match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
     bool imatch = (std::abs(ideltaphi * irstub) < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
-      best_ideltar_disk = std::abs(ideltar);
-    }
 
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
@@ -788,6 +783,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
         imatch = keep;
       }
+    }
+    // Update the "best" values
+    if (imatch) {
+      best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
+      best_ideltar_disk = std::abs(ideltar);
     }
 
     if (imatch) {

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -118,6 +118,7 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
   best_ideltar_disk = 0xFFFF;
   curr_tracklet = nullptr;
   next_tracklet = nullptr;
+  first_ = false;
 }
 
 void MatchProcessor::addOutput(MemoryBase* memory, string output) {
@@ -541,7 +542,8 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     next_tracklet = tracklet;
 
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+    bool newtracklet = (!first_ || next_tracklet != curr_tracklet);
+    first_ = newtracklet ? true : first_;
     if (istep == 0)
       best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
     // If so, replace the "best" values with the cut tables
@@ -742,7 +744,8 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     curr_tracklet = next_tracklet;
     next_tracklet = tracklet;
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+    bool newtracklet = (!first_ || next_tracklet != curr_tracklet);
+    first_ = newtracklet ? true : first_;
     // If so, replace the "best" values with the cut tables
     if (newtracklet) {
       best_ideltaphi_disk = idrphicut;

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -36,7 +36,7 @@ unsigned int MemoryBase::initLayerDisk(unsigned int pos) {
   initLayerDisk(pos, layer, disk);
 
   if (disk > 0)
-    return N_DISK + disk;
+    return N_LAYER + disk - 1;
   return layer - 1;
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/StubKiller.cc
+++ b/L1Trigger/TrackFindingTracklet/src/StubKiller.cc
@@ -220,7 +220,7 @@ bool StubKiller::killStub(const TTStub<Ref_Phase2TrackerDigi_>* stub,
                           const double fractionOfStubsToKillInLayers,
                           const double fractionOfStubsToKillEverywhere) {
   // Only kill stubs in specified layers
-  if (layersToKill.empty()) {
+  if (!layersToKill.empty()) {
     // Get the layer the stub is in, and check if it's in the layer you want to kill
     DetId stackDetid = stub->getDetId();
     DetId geoDetId(stackDetid.rawId() + 1);
@@ -277,7 +277,7 @@ bool StubKiller::killStub(const TTStub<Ref_Phase2TrackerDigi_>* stub,
 }
 
 bool StubKiller::killStubInDeadModule(const TTStub<Ref_Phase2TrackerDigi_>* stub) {
-  if (deadModules_.empty()) {
+  if (!deadModules_.empty()) {
     DetId stackDetid = stub->getDetId();
     DetId geoDetId(stackDetid.rawId() + 1);
     if (deadModules_.find(geoDetId) != deadModules_.end())

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -728,6 +728,15 @@ std::string Tracklet::trackfitstr() const {
 
     oss += "1|";  // valid bit
     oss += tmp.str() + "|";
+    if (settings_.combined()) {
+      if (seedIndex() == Seed::L1D1 || seedIndex() == Seed::L2D1) {
+        oss += outerFPGAStub()->phiregionstr() + "|";
+        oss += innerFPGAStub()->phiregionstr() + "|";
+      } else {
+        oss += innerFPGAStub()->phiregionstr() + "|";
+        oss += outerFPGAStub()->phiregionstr() + "|";
+      }
+    }
     oss += innerFPGAStub()->stubindex().str() + "|";
     oss += outerFPGAStub()->stubindex().str() + "|";
     oss += fpgapars_.rinv().str() + "|";

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -230,6 +230,8 @@ void TrackletProcessorDisplaced::addInput(MemoryBase* memory, string input) {
 }
 
 void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
+  unsigned int countall = 0;
+  unsigned int countsel = 0;
   // unsigned int nThirdStubs = 0;
   // unsigned int nOuterStubs = 0;
   count_ = 0;
@@ -385,6 +387,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
 
                       const Stub* innerFPGAStub = firstallstub;
@@ -408,8 +412,15 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
 
-                      if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-                          outerFPGAStub->layerdisk() >= N_LAYER) {
+                      if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+                          outerFPGAStub->layerdisk() < N_LAYER) {
+                        bool accept =
+                            LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                        if (accept)
+                          countsel++;
+                      } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+                                 outerFPGAStub->layerdisk() >= N_LAYER) {
                         throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
                       }
 
@@ -495,6 +506,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
 
                       const Stub* innerFPGAStub = firstallstub;
@@ -517,6 +530,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet")
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
+
+                      bool accept =
+                          LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                      if (accept)
+                        countsel++;
 
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
@@ -601,6 +620,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
 
                       const Stub* innerFPGAStub = firstallstub;
@@ -624,6 +645,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
 
+                      bool accept =
+                          DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                      if (accept)
+                        countsel++;
+
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
@@ -636,5 +663,9 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         }
       }
     }
+  }
+
+  if (settings_.writeMonitorData("TPD")) {
+    globals_->ofstream("trackletprocessordisplaced.txt") << getName() << " " << countall << " " << countsel << endl;
   }
 }

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -247,6 +247,7 @@ private:
   std::vector<int>* m_allstub_isBarrel;  // stub is in barrel (1) or in disk (0)
   std::vector<int>* m_allstub_layer;
   std::vector<int>* m_allstub_isPSmodule;
+  std::vector<int>* m_allstub_isTiltedBarrel;
 
   std::vector<float>* m_allstub_trigDisplace;
   std::vector<float>* m_allstub_trigOffset;
@@ -541,6 +542,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_allstub_isBarrel = new std::vector<int>;
   m_allstub_layer = new std::vector<int>;
   m_allstub_isPSmodule = new std::vector<int>;
+  m_allstub_isTiltedBarrel = new std::vector<int>;
   m_allstub_trigDisplace = new std::vector<float>;
   m_allstub_trigOffset = new std::vector<float>;
   m_allstub_trigPos = new std::vector<float>;
@@ -662,6 +664,7 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("allstub_isBarrel", &m_allstub_isBarrel);
     eventTree->Branch("allstub_layer", &m_allstub_layer);
     eventTree->Branch("allstub_isPSmodule", &m_allstub_isPSmodule);
+    eventTree->Branch("allstub_isTiltedBarrel", &m_allstub_isTiltedBarrel);
 
     eventTree->Branch("allstub_trigDisplace", &m_allstub_trigDisplace);
     eventTree->Branch("allstub_trigOffset", &m_allstub_trigOffset);
@@ -798,6 +801,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_allstub_isBarrel->clear();
     m_allstub_layer->clear();
     m_allstub_isPSmodule->clear();
+    m_allstub_isTiltedBarrel->clear();
 
     m_allstub_trigDisplace->clear();
     m_allstub_trigOffset->clear();
@@ -904,6 +908,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         if (topol->nrows() == 960)
           isPSmodule = 1;
 
+        const unsigned int tobSide = tTopo->tobSide(detid); // nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3
+        int isTiltedBarrel = 0;
+	if (isBarrel == 1 && (tobSide == 1 || tobSide == 2))
+          isTiltedBarrel = 1;
+
         MeasurementPoint coords = tempStubPtr->clusterRef(0)->findAverageLocalCoordinatesCentered();
         LocalPoint clustlp = topol->localPosition(coords);
         GlobalPoint posStub = theGeomDet->surface().toGlobal(clustlp);
@@ -924,6 +933,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         m_allstub_isBarrel->push_back(isBarrel);
         m_allstub_layer->push_back(layer);
         m_allstub_isPSmodule->push_back(isPSmodule);
+        m_allstub_isTiltedBarrel->push_back(isTiltedBarrel);
 
         m_allstub_trigDisplace->push_back(trigDisplace);
         m_allstub_trigOffset->push_back(trigOffset);

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -908,9 +908,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         if (topol->nrows() == 960)
           isPSmodule = 1;
 
-        const unsigned int tobSide = tTopo->tobSide(detid); // nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3
+        const unsigned int tobSide = tTopo->tobSide(detid);  // nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3
         int isTiltedBarrel = 0;
-	if (isBarrel == 1 && (tobSide == 1 || tobSide == 2))
+        if (isBarrel == 1 && (tobSide == 1 || tobSide == 2))
           isTiltedBarrel = 1;
 
         MeasurementPoint coords = tempStubPtr->clusterRef(0)->findAverageLocalCoordinatesCentered();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -15,8 +15,8 @@ process = cms.Process("L1TrackNtuple")
 ############################################################
 
 # D88 used for CMSSW_12_6 datasets, and D98 recommended for more recent ones.
-#GEOMETRY = "D88"
-GEOMETRY = "D98"
+GEOMETRY = "D88"
+#GEOMETRY = "D98"
 
 # Set L1 tracking algorithm:
 # 'HYBRID' (baseline, 4par fit) or 'HYBRID_DISPLACED' (extended, 5par fit).

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -14,9 +14,9 @@ process = cms.Process("L1TrackNtuple")
 # edit options here
 ############################################################
 
-# D88 used for CMSSW_12_6 datasets, and D98 recommended for more recent ones.
-GEOMETRY = "D88"
-#GEOMETRY = "D98"
+# D88 was used for CMSSW_12_6 datasets, and D98 recommended for more recent ones.
+#GEOMETRY = "D88"
+GEOMETRY = "D98"
 
 # Set L1 tracking algorithm:
 # 'HYBRID' (baseline, 4par fit) or 'HYBRID_DISPLACED' (extended, 5par fit).
@@ -66,28 +66,26 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 #from MCsamples.Scripts.getCMSdata_cfi import *
 #from MCsamples.Scripts.getCMSlocaldata_cfi import *
 
-if GEOMETRY == "D88":
+if GEOMETRY == "D98":
 
   # Read data from card files (defines getCMSdataFromCards()):
-  #from MCsamples.RelVal_1260_D88.PU200_TTbar_14TeV_cfi import *
+  #from MCsamples.RelVal_1400_D98.PU200_TTbar_14TeV_cfi import *
   #inputMC = getCMSdataFromCards()
 
   # Or read .root files from directory on local computer:
-  #dirName = "$scratchmc/MCsamples1260_D88/RelVal/TTbar/PU0/"
+  #dirName = "$scratchmc/MCsamples1400_D98/RelVal/TTbar/PU0/"
   #inputMC=getCMSlocaldata(dirName)
 
   # Or read specified dataset (accesses CMS DB, so use this method only occasionally):
-  #dataName="/RelValTTbar_14TeV/CMSSW_12_6_0-PU_125X_mcRun4_realistic_v5_2026D88PU200RV183v2-v1/GEN-SIM-DIGI-RAW"
+  #dataName="/RelValTTbar_14TeV/CMSSW_14_0_0_pre2-PU_133X_mcRun4_realistic_v1_STD_2026D98_PU200_RV229-v1/GEN-SIM-DIGI-RAW"
   #inputMC=getCMSdata(dataName)
+
+  inputMC = ["/store/relval/CMSSW_14_0_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_133X_mcRun4_realistic_v1_STD_2026D98_PU200_RV229-v1/2580000/0b2b0b0b-f312-48a8-9d46-ccbadc69bbfd.root"]
+
+elif GEOMETRY == "D88":
 
   # Read specified .root file:
   inputMC = ["/store/mc/CMSSW_12_6_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_125X_mcRun4_realistic_v5_2026D88PU200RV183v2-v1/30000/0959f326-3f52-48d8-9fcf-65fc41de4e27.root"]
-  #inputMC = ["/store/relval/CMSSW_12_6_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun4_realistic_v5_2026D88noPURV183-v1/2590000/176e8b2a-035c-4df1-9a23-f1bfdec9de37.root"]
-
-elif GEOMETRY == "D98":
-
-  inputMC = ["/store/relval/CMSSW_14_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_133X_mcRun4_realistic_v1_2026D98PU200-v1/2590000/0743fe7e-cda0-45d9-a226-b2c618826730.root"]
-  #inputMC = ["/store/relval/CMSSW_14_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/133X_mcRun4_realistic_v1_2026D98noPU-v1/2590000/1870d216-b207-40be-9ee4-a453ce17ec94.root"]
 
 else:
 
@@ -121,14 +119,14 @@ process.load('L1Trigger.TrackerTFP.ProducerES_cff')
 process.load('L1Trigger.TrackerTFP.ProducerLayerEncoding_cff')
 
 # remake stubs?
-from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
-process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
+#from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
+#process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
 
-from SimTracker.TrackTriggerAssociation.TTClusterAssociation_cfi import *
-TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
+#from SimTracker.TrackTriggerAssociation.TTClusterAssociation_cfi import *
+#TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
 
-process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
-process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
+#process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
+#process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
 
 
 # DTC emulation
@@ -142,7 +140,8 @@ process.load('L1Trigger.TrackerDTC.ProducerED_cff')
 #process.TrackTriggerSetup.Hybrid.MinPt = 1.0
 
 process.dtc = cms.Path(process.TrackerDTCProducer)#*process.TrackerDTCAnalyzer)
-
+# Throw error if reading MC produced with different stub window sizes.
+process.TrackerDTCProducer.CheckHistory = True
 
 ############################################################
 # L1 tracking
@@ -266,13 +265,13 @@ process.ana = cms.Path(process.L1TrackNtuple)
 ############################################################
 
 # use this if you want to re-run the stub making
-process.schedule = cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
+#process.schedule = cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 # use this if cluster/stub associators not available
 # process.schedule = cms.Schedule(process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 # use this to only run tracking + track associator
-#process.schedule = cms.Schedule(process.dtc,process.TTTracksEmulationWithTruth,process.ana)
+process.schedule = cms.Schedule(process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 
 ############################################################

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -95,15 +95,15 @@ else:
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))
 
-if GEOMETRY == "D76":
-  # If reading old MC dataset, drop incompatible EDProducts.
-  process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
-  process.source.inputCommands = cms.untracked.vstring()
-  process.source.inputCommands.append('keep  *_*_*Level1TTTracks*_*')
-  process.source.inputCommands.append('keep  *_*_*StubAccepted*_*')
-  process.source.inputCommands.append('keep  *_*_*ClusterAccepted*_*')
-  process.source.inputCommands.append('keep  *_*_*MergedTrackTruth*_*')
-  process.source.inputCommands.append('keep  *_genParticles_*_*')
+#if GEOMETRY == "D76":
+#  # If reading old MC dataset, drop incompatible EDProducts.
+#  process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
+#  process.source.inputCommands = cms.untracked.vstring()
+#  process.source.inputCommands.append('keep  *_*_*Level1TTTracks*_*')
+#  process.source.inputCommands.append('keep  *_*_*StubAccepted*_*')
+#  process.source.inputCommands.append('keep  *_*_*ClusterAccepted*_*')
+#  process.source.inputCommands.append('keep  *_*_*MergedTrackTruth*_*')
+#  process.source.inputCommands.append('keep  *_genParticles_*_*')
 
 # Use skipEvents to select particular single events for test vectors
 #process.source.skipEvents = cms.untracked.uint32(11)

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -1,3 +1,6 @@
+# N,B, DUE TO THE CHANGE IN STUB WINDOW SIZES WITH CMSSW 14_2_0_PRE2, THIS JOB HAS BEEN NODIFIED TO
+# RECREATE THE STUBS, WHICH IS NECESSARY WHEN RUNNING ON MONTE CARLO GENERATED WITH OLDER VERSIONS.
+
 ############################################################
 # define basic process
 ############################################################
@@ -11,9 +14,9 @@ process = cms.Process("L1TrackNtuple")
 # edit options here
 ############################################################
 
-# D76 used for old CMSSW_11_3 MC datasets. D88 used for CMSSW_12_6 datasets.
-#GEOMETRY = "D76"  
-GEOMETRY = "D88"
+# D88 used for CMSSW_12_6 datasets, and D98 recommended for more recent ones.
+#GEOMETRY = "D88"
+GEOMETRY = "D98"
 
 # Set L1 tracking algorithm:
 # 'HYBRID' (baseline, 4par fit) or 'HYBRID_DISPLACED' (extended, 5par fit).
@@ -37,12 +40,10 @@ process.MessageLogger.L1track = dict(limit = -1)
 process.MessageLogger.Tracklet = dict(limit = -1)
 process.MessageLogger.TrackTriggerHPH = dict(limit = -1)
 
-if GEOMETRY == "D76" or GEOMETRY == "D88":
-    # Use D88 for both, as both correspond to identical CMS Tracker design, and D76 
-    # unavailable in CMSSW_12_6_0. 
+if GEOMETRY == "D88" or GEOMETRY == 'D98':
     print("using geometry " + GEOMETRY + " (tilted)")
-    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
-    process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
+    process.load('Configuration.Geometry.GeometryExtended2026' + GEOMETRY + 'Reco_cff')
+    process.load('Configuration.Geometry.GeometryExtended2026' + GEOMETRY +'_cff')
 else:
     print("this is not a valid geometry!!!")
 
@@ -57,7 +58,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 # input and output
 ############################################################
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 #--- To use MCsamples scripts, defining functions get*data*() for easy MC access,
 #--- follow instructions in https://github.com/cms-L1TK/MCsamples
@@ -65,19 +66,14 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 #from MCsamples.Scripts.getCMSdata_cfi import *
 #from MCsamples.Scripts.getCMSlocaldata_cfi import *
 
-if GEOMETRY == "D76":
-
-  # Read specified .root file:
-  inputMC = ["/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/00026541-6200-4eed-b6f8-d3a1fd720e9c.root"]
-
-elif GEOMETRY == "D88":
+if GEOMETRY == "D88":
 
   # Read data from card files (defines getCMSdataFromCards()):
   #from MCsamples.RelVal_1260_D88.PU200_TTbar_14TeV_cfi import *
   #inputMC = getCMSdataFromCards()
 
   # Or read .root files from directory on local computer:
-  #dirName = "$scratchmc/MCsamples1260_D88/RelVal/TTbar/PU200/"
+  #dirName = "$scratchmc/MCsamples1260_D88/RelVal/TTbar/PU0/"
   #inputMC=getCMSlocaldata(dirName)
 
   # Or read specified dataset (accesses CMS DB, so use this method only occasionally):
@@ -86,6 +82,12 @@ elif GEOMETRY == "D88":
 
   # Read specified .root file:
   inputMC = ["/store/mc/CMSSW_12_6_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_125X_mcRun4_realistic_v5_2026D88PU200RV183v2-v1/30000/0959f326-3f52-48d8-9fcf-65fc41de4e27.root"]
+  #inputMC = ["/store/relval/CMSSW_12_6_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/125X_mcRun4_realistic_v5_2026D88noPURV183-v1/2590000/176e8b2a-035c-4df1-9a23-f1bfdec9de37.root"]
+
+elif GEOMETRY == "D98":
+
+  inputMC = ["/store/relval/CMSSW_14_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_133X_mcRun4_realistic_v1_2026D98PU200-v1/2590000/0743fe7e-cda0-45d9-a226-b2c618826730.root"]
+  #inputMC = ["/store/relval/CMSSW_14_0_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/133X_mcRun4_realistic_v1_2026D98noPU-v1/2590000/1870d216-b207-40be-9ee4-a453ce17ec94.root"]
 
 else:
 
@@ -106,7 +108,7 @@ if GEOMETRY == "D76":
 # Use skipEvents to select particular single events for test vectors
 #process.source.skipEvents = cms.untracked.uint32(11)
 
-process.TFileService = cms.Service("TFileService", fileName = cms.string('TTbar_PU200_'+GEOMETRY+'.root'), closeFileFast = cms.untracked.bool(True))
+process.TFileService = cms.Service("TFileService", fileName = cms.string('L1TrkNtuple.root'), closeFileFast = cms.untracked.bool(True))
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
 
@@ -119,14 +121,14 @@ process.load('L1Trigger.TrackerTFP.ProducerES_cff')
 process.load('L1Trigger.TrackerTFP.ProducerLayerEncoding_cff')
 
 # remake stubs?
-#from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
-#process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
+from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
+process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
 
-#from SimTracker.TrackTriggerAssociation.TTClusterAssociation_cfi import *
-#TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
+from SimTracker.TrackTriggerAssociation.TTClusterAssociation_cfi import *
+TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
 
-#process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
-#process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
+process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
+process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
 
 
 # DTC emulation
@@ -264,13 +266,13 @@ process.ana = cms.Path(process.L1TrackNtuple)
 ############################################################
 
 # use this if you want to re-run the stub making
-# process.schedule = cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
+process.schedule = cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 # use this if cluster/stub associators not available
 # process.schedule = cms.Schedule(process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 # use this to only run tracking + track associator
-process.schedule = cms.Schedule(process.dtc,process.TTTracksEmulationWithTruth,process.ana)
+#process.schedule = cms.Schedule(process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 
 ############################################################

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -222,40 +222,14 @@ else:
     print("ERROR: Unknown L1TRKALGO option")
     exit(1)
 
-############################################################
-# Define the track ntuple process, MyProcess is the (unsigned) PDGID corresponding to the process which is run
-# e.g. single electron/positron = 11
-#      single pion+/pion- = 211
-#      single muon+/muon- = 13
-#      pions in jets = 6
-#      taus = 15
-#      all TPs = 1
-############################################################
 
-process.L1TrackNtuple = cms.EDAnalyzer('L1TrackNtupleMaker',
-                                       MyProcess = cms.int32(1),
-                                       DebugMode = cms.bool(False),      # printout lots of debug statements
-                                       SaveAllTracks = cms.bool(True),   # save *all* L1 tracks, not just truth matched to primary particle
-                                       SaveStubs = cms.bool(False),      # save some info for *all* stubs
-                                       L1Tk_nPar = cms.int32(NHELIXPAR), # use 4 or 5-parameter L1 tracking?
-                                       L1Tk_minNStub = cms.int32(4),     # L1 tracks with >= 4 stubs
-                                       TP_minNStub = cms.int32(4),       # require TP to have >= X number of stubs associated with it
-                                       TP_minNStubLayer = cms.int32(4),  # require TP to have stubs in >= X layers/disks
-                                       TP_minPt = cms.double(1.9),       # only save TPs with pt > X GeV
-                                       TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
-                                       TP_maxZ0 = cms.double(30.0),      # only save TPs with |z0| < X cm
-                                       L1TrackInputTag = cms.InputTag(L1TRK_NAME, L1TRK_LABEL),         # TTTrack input
-                                       MCTruthTrackInputTag = cms.InputTag(L1TRUTH_NAME, L1TRK_LABEL),  # MCTruth input
-                                       # other input collections
-                                       L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
-                                       MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
-                                       MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
-                                       TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
-                                       TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),
-                                       # tracking in jets (--> requires AK4 genjet collection present!)
-                                       TrackingInJets = cms.bool(False),
-                                       GenJetInputTag = cms.InputTag("ak4GenJets", "")
-                                       )
+# Define L1 track ntuple maker
+from L1Trigger.TrackFindingTracklet.L1TrackNtupleMaker_cfi import *
+process.L1TrackNtuple = L1TrackNtupleMaker.clone(
+   L1Tk_nPar = NHELIXPAR, # use 4 or 5-parameter L1 tracking?
+   L1TrackInputTag = (L1TRK_NAME, L1TRK_LABEL),         # TTTrack input
+   MCTruthTrackInputTag = (L1TRUTH_NAME, L1TRK_LABEL),  # MCTruth input
+)
 
 process.ana = cms.Path(process.L1TrackNtuple)
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -1,7 +1,7 @@
 // ----------------------------------------------------------------------------------------------------------------
 // Basic example ROOT script for making tracking performance plots using the ntuples produced by L1TrackNtupleMaker.cc
 //
-// e.g. in ROOT do: .L L1TrackNtuplePlot.C++, L1TrackNtuplePlot("TTbar_PU200_hybrid")
+// e.g. in ROOT do: .L L1TrackNtuplePlot.C++, L1TrackNtuplePlot("L1TrkNtuple")
 //
 // By Louise Skinnari, June 2013
 // ----------------------------------------------------------------------------------------------------------------

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -76,6 +76,9 @@ void L1TrackNtuplePlot(TString type,
 
   SetPlotStyle();
 
+  cout.setf(ios::fixed);
+  cout.precision(2);
+
   // ----------------------------------------------------------------------------------------------------------------
   // define input options
 
@@ -1021,7 +1024,6 @@ void L1TrackNtuplePlot(TString type,
   // ----------------------------------------------------------------------------------------------------------------
 
   int nevt = tree->GetEntries();
-  cout << "number of events = " << nevt << endl;
 
   // ----------------------------------------------------------------------------------------------------------------
   // event loop
@@ -3633,10 +3635,18 @@ void L1TrackNtuplePlot(TString type,
     c.SaveAs(DIR + type + "_trk_pt.pdf");
   }
 
+  // Sample z0 resolution at a couple of rapidity points.
+  float etaSample1 = h2_resVsEta_z0_68->GetXaxis()->GetBinCenter(1);
+  float etaSample2 = h2_resVsEta_z0_68->GetXaxis()->GetBinCenter(0.8 * nETARANGE);
+  float z0ResSample1 = h2_resVsEta_z0_68->GetBinContent(1);
+  float z0ResSample2 = h2_resVsEta_z0_68->GetBinContent(0.8 * nETARANGE);
+
   fout->Close();
 
   // ---------------------------------------------------------------------------------------------------------
   //some printouts
+
+  cout << "number of events = " << nevt << endl;
 
   float k = (float)n_match_eta1p0;
   float N = (float)n_all_eta1p0;
@@ -3691,7 +3701,11 @@ void L1TrackNtuplePlot(TString type,
   cout << "# tracks/event (no pt cut)= " << (float)ntrk / nevt << endl;
   cout << "# tracks/event (pt > " << std::max(TP_minPt, 2.0f) << ") = " << (float)ntrk_pt2 / nevt << endl;
   cout << "# tracks/event (pt > 3.0) = " << (float)ntrk_pt3 / nevt << endl;
-  cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl;
+  cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl << endl;
+
+  // z0 resolution
+  cout << "z0 resolution = " << z0ResSample1 << "cm at |eta| = " << etaSample1 << endl;
+  cout << "z0 resolution = " << z0ResSample2 << "cm at |eta| = " << etaSample2 << endl;
 }
 
 void SetPlotStyle() {

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -43,7 +43,7 @@ echo "MVA track quality Histograms written to MVA_plots/"
 # Run track performance plotting macro
 set plotMacro = $CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
 if (-e TrkPlots) rm -r TrkPlots
-\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 19 >! results.out 
+\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 24 >! results.out 
 cat results.out
 echo "Tracking performance summary written to results.out"
 echo "Track performance histograms written to TrkPlots/"  

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -13,7 +13,7 @@
 ########################################################################
 
 if ($#argv == 0) then
-  set inputFullFileName = "TTbar_PU200_D88.root"
+  set inputFullFileName = "L1TrkNtuple.root"
 else
   set inputFullFileName = $1
 endif

--- a/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
@@ -11,7 +11,10 @@
 # It should be copied somewhere like /eos/user/t/tomalin/
 # using cp on lxplus. And a link created to it from 
 # somewhere like 
-# https://cernbox.cern.ch/index.php/apps/files/?dir=/&
+# https://cernbox.cern.ch/index.php/apps/files/?dir=/& .
+# N.B. The "quicklink" this gives is buggy. Take the encoded 
+# string from it and insert it into something like:
+#https://cernbox.cern.ch/remote.php/dav/public-files/4wMLEX986bdIs8U/skimmedForCI_14_0_0.root
 # The link to the skimmed dataset should be referred to in
 # https://gitlab.cern.ch/cms-l1tk/cmssw_CI .
 #-----------------------------------------------------------
@@ -36,8 +39,8 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
 # D88 geometry (T24 tracker)
-process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D98Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D98_cff')
 
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
@@ -50,12 +53,8 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
 from MCsamples.Scripts.getCMSdata_cfi import *
 
 # Read data from card files (defines getCMSdataFromCards()):
-#from MCsamples.RelVal_1130_D76.PU0_TTbar_14TeV_cfi import *
-#inputMC = getCMSdataFromCards()
-
-#dataName="/RelValTTbar_14TeV/CMSSW_12_6_0_pre4-125X_mcRun4_realistic_v2_2026D88noPU-v1/GEN-SIM-DIGI-RAW"
-dataName="/RelValTTbar_14TeV/CMSSW_12_6_0-125X_mcRun4_realistic_v5_2026D88noPURV183-v1/GEN-SIM-DIGI-RAW"
-inputMC=getCMSdata(dataName)
+from MCsamples.RelVal_1400_D98.PU0_TTbar_14TeV_cfi import *
+inputMC = getCMSdataFromCards()
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))
 
@@ -77,8 +76,8 @@ process.output.outputCommands.append('keep  *_*_*MergedTrackTruth*_*')
 process.output.outputCommands.append('keep  *_genParticles_*_*')
 
 # Add this if you need to rereconstruct the stubs.
-process.output.outputCommands.append('keep  Phase2TrackerDigi*_mix_Tracker_*')
-process.output.outputCommands.append('keep  PixelDigiSimLinked*_simSiPixelDigis_Tracker_*')
+#process.output.outputCommands.append('keep  Phase2TrackerDigi*_mix_Tracker_*')
+#process.output.outputCommands.append('keep  PixelDigiSimLinked*_simSiPixelDigis_Tracker_*')
 
 process.pd = cms.EndPath(process.output)
 

--- a/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
@@ -7,8 +7,12 @@
 # the git CI runs on to check new code.
 #
 # Whenever the L1 tracking group switches to a new default
-# MC dataset, this skim should be run on ttbar+0PU MC, 
-# and the skimmed dataset placed in
+# MC dataset, this skim should be run on ttbar+0PU MC.
+# It should be copied somewhere like /eos/user/t/tomalin/
+# using cp on lxplus. And a link created to it from 
+# somewhere like 
+# https://cernbox.cern.ch/index.php/apps/files/?dir=/&
+# The link to the skimmed dataset should be referred to in
 # https://gitlab.cern.ch/cms-l1tk/cmssw_CI .
 #-----------------------------------------------------------
 
@@ -49,7 +53,8 @@ from MCsamples.Scripts.getCMSdata_cfi import *
 #from MCsamples.RelVal_1130_D76.PU0_TTbar_14TeV_cfi import *
 #inputMC = getCMSdataFromCards()
 
-dataName="/RelValTTbar_14TeV/CMSSW_12_6_0_pre4-125X_mcRun4_realistic_v2_2026D88noPU-v1/GEN-SIM-DIGI-RAW"
+#dataName="/RelValTTbar_14TeV/CMSSW_12_6_0_pre4-125X_mcRun4_realistic_v2_2026D88noPU-v1/GEN-SIM-DIGI-RAW"
+dataName="/RelValTTbar_14TeV/CMSSW_12_6_0-125X_mcRun4_realistic_v5_2026D88noPURV183-v1/GEN-SIM-DIGI-RAW"
 inputMC=getCMSdata(dataName)
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))
@@ -70,6 +75,10 @@ process.output.outputCommands.append('keep  *_*_*StubAccepted*_*')
 process.output.outputCommands.append('keep  *_*_*ClusterAccepted*_*')
 process.output.outputCommands.append('keep  *_*_*MergedTrackTruth*_*')
 process.output.outputCommands.append('keep  *_genParticles_*_*')
+
+# Add this if you need to rereconstruct the stubs.
+process.output.outputCommands.append('keep  Phase2TrackerDigi*_mix_Tracker_*')
+process.output.outputCommands.append('keep  PixelDigiSimLinked*_simSiPixelDigis_Tracker_*')
 
 process.pd = cms.EndPath(process.output)
 


### PR DESCRIPTION
#### PR description:

Made combined modules the default for both prompt and extended tracking.

When running on ttbar+200PU, the performance of the extended tracking gets significantly worse. Although its efficiency and resolution remain almost unchanged, it outputs 20% more tracks.  The performance of the prompt tracking is little changed, aside from a slight efficiency drop due to increased truncation.