### PR TITLE
[CLANG_X] Use generated copy ctor in SimpleSAXParser

### DIFF
--- a/Fireworks/Core/interface/SimpleSAXParser.h
+++ b/Fireworks/Core/interface/SimpleSAXParser.h
@@ -74,8 +74,6 @@ public:
 
     Attribute(const std::string &iKey, const std::string &iValue) : key(iKey), value(iValue) {}
 
-    Attribute(const Attribute &attr) : key(attr.key), value(attr.value) {}
-
     bool operator<(const Attribute &attribute) const { return this->key < attribute.key; }
   };
 


### PR DESCRIPTION
#### PR description:

This avoid clang compiler warning:
```
>> Compiling  src/Fireworks/Core/src/fwPaths.cc
.../bin/clang++ -c <snip> src/Fireworks/Core/src/fwPaths.cc -o tmp/el8_amd64_gcc12/src/Fireworks/Core/src/FireworksCore/fwPaths.cc.o
In file included from src/Fireworks/Core/src/SimpleSAXParser.cc:1:
  .../src/Fireworks/Core/interface/SimpleSAXParser.h:77:5: warning: definition of implicit copy assignment operator for 'Attribute' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]
    77 |     Attribute(const Attribute &attr) : key(attr.key), value(attr.value) {}
      |     ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/bits/vector.tcc:430:19: note: in implicit copy assignment operator for 'SimpleSAXParser::Attribute' first required here
  430 |       *__position = std::forward<_Arg>(__arg);
      |                   ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/bits/vector.tcc:157:6: note: in instantiation of function template specialization 'std::vector<SimpleSAXParser::Attribute>::_M_insert_aux<SimpleSAXParser::Attribute>' requested here
  157 |             _M_insert_aux(__pos, std::move(__x_copy._M_val()));
      |             ^
src/Fireworks/Core/src/SimpleSAXParser.cc:128:24: note: in instantiation of member function 'std::vector<SimpleSAXParser::Attribute>::insert' requested here
  128 |           m_attributes.insert(i, attr);
      |                        ^
1 warning generated.
```

#### PR validation:

Bot tests
