### PR TITLE
[CLANG_X] Use generated copy ctor in FTLDataFrameT

### DIFF
--- a/DataFormats/FTLDigi/interface/FTLDataFrameT.h
+++ b/DataFormats/FTLDigi/interface/FTLDataFrameT.h
@@ -23,7 +23,6 @@ public:
   */
   FTLDataFrameT() : id_(0), maxSampleSize_(15) { data_.resize(maxSampleSize_); }
   FTLDataFrameT(const D& id) : id_(id), maxSampleSize_(15) { data_.resize(maxSampleSize_); }
-  FTLDataFrameT(const FTLDataFrameT& o) : data_(o.data_), id_(o.id_), maxSampleSize_(o.maxSampleSize_) {}
 
   /**
     @short det id


### PR DESCRIPTION
#### PR description:

This avoids Clang warning:
```
 <...>/CMSSW_14_1_CLANG_X_2024-03-24-2300/src/DataFormats/FTLDigi/interface/FTLDataFrameT.h:26:3: warning: definition of implicit copy assignment operator for 'FTLDataFrameT<BTLDetId, BTLSample, mtdhelpers::BTLRowColDecode>' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]
    26 |   FTLDataFrameT(const FTLDataFrameT& o) : data_(o.data_), id_(o.id_), maxSampleSize_(o.maxSampleSize_) {}
      |   ^
```

#### PR validation:

Bot tests