### PR TITLE
[CLANG_X] Use generated copy ctor in WeightsInfo

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
@@ -9,7 +9,6 @@
 namespace gen {
   struct WeightsInfo {
     WeightsInfo() : id(""), wgt(0.) {}
-    WeightsInfo(const WeightsInfo& o) : id(o.id), wgt(o.wgt) {}
     WeightsInfo(const std::string& s, const double w) : id(s), wgt(w) {}
     std::string id;
     double wgt;


### PR DESCRIPTION
#### PR description:

This avoids Clang warning:
```
  <...>/CMSSW_14_1_CLANG_X_2024-03-24-2300/src/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h:12:5: warning: definition of implicit copy assignment operator for 'WeightsInfo' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]
    12 |     WeightsInfo(const WeightsInfo& o) : id(o.id), wgt(o.wgt) {}
      |     ^
```

#### PR validation:

Bot tests