### PR TITLE
[CLANG_X] Use generated ctor in VertexProperty

### DIFF
--- a/SimGeneral/MixingModule/interface/DecayGraph.h
+++ b/SimGeneral/MixingModule/interface/DecayGraph.h
@@ -66,8 +66,6 @@ struct EdgeProperty {
 struct VertexProperty {
   VertexProperty() : simTrack(nullptr), cumulative_simHits(0) {}
   VertexProperty(const SimTrack *t, int c) : simTrack(t), cumulative_simHits(c) {}
-  VertexProperty(const VertexProperty &other)
-      : simTrack(other.simTrack), cumulative_simHits(other.cumulative_simHits) {}
   const SimTrack *simTrack;
   int cumulative_simHits;
 };


### PR DESCRIPTION
#### PR description:

This avoids Clang warning:
```
  <...>/CMSSW_14_1_CLANG_X_2024-03-24-2300/src/SimGeneral/MixingModule/interface/DecayGraph.h:69:3: warning: definition of implicit copy assignment operator for 'VertexProperty' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]
    69 |   VertexProperty(const VertexProperty &other)
      |   ^
```

#### PR validation:

Bot tests