### PR TITLE
XGBoost producer bugfix and unit test fix for non-x86_64 (14_0_X)

### DIFF
--- a/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
@@ -14,7 +14,7 @@ public:
                    float sigmaIEtaIEtaIn,
                    float etaWidthIn,
                    float phiWidthIn,
-                   float e2x2In,
+                   float s4In,
                    float etaIn,
                    float hOvrEIn,
                    float ecalPFIsoIn) const;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
@@ -110,6 +110,7 @@ void PhotonXGBoostProducer::produce(edm::StreamID, edm::Event& event, edm::Event
     float hoe = (*hoEMap).find(ref)->val / scEnergy;
     float siEtaiEta = (*sigmaiEtaiEtaMap).find(ref)->val;
     float e2x2 = (*e2x2Map).find(ref)->val;
+    float s4 = e2x2 / scEnergy;
     float iso = (*isoMap).find(ref)->val;
 
     float rawEnergy = ref->superCluster()->rawEnergy();
@@ -124,9 +125,9 @@ void PhotonXGBoostProducer::produce(edm::StreamID, edm::Event& event, edm::Event
     //compute only above threshold used for training and cand filter, else store negative value into the association map.
     if (scEt >= mvaThresholdEt_) {
       if (std::abs(etaSC) < 1.5)
-        xgbScore = mvaEstimatorB_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, e2x2, etaSC, hoe, iso);
+        xgbScore = mvaEstimatorB_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, s4, etaSC, hoe, iso);
       else
-        xgbScore = mvaEstimatorE_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, e2x2, etaSC, hoe, iso);
+        xgbScore = mvaEstimatorE_->computeMva(rawEnergy, r9, siEtaiEta, etaW, phiW, s4, etaSC, hoe, iso);
     }
     mvaScoreMap.insert(ref, xgbScore);
   }

--- a/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
@@ -21,7 +21,7 @@ namespace {
     sigmaIEtaIEta = 2,  // 2
     etaWidth = 3,       // 3
     phiWidth = 4,       // 4
-    e2x2 = 5,           // 5
+    s4 = 5,             // 5
     eta = 6,            // 6
     hOvrE = 7,          // 7
     ecalPFIso = 8,      // 8
@@ -33,7 +33,7 @@ float PhotonXGBoostEstimator::computeMva(float rawEnergyIn,
                                          float sigmaIEtaIEtaIn,
                                          float etaWidthIn,
                                          float phiWidthIn,
-                                         float e2x2In,
+                                         float s4In,
                                          float etaIn,
                                          float hOvrEIn,
                                          float ecalPFIsoIn) const {
@@ -43,7 +43,7 @@ float PhotonXGBoostEstimator::computeMva(float rawEnergyIn,
   var[sigmaIEtaIEta] = sigmaIEtaIEtaIn;
   var[etaWidth] = etaWidthIn;
   var[phiWidth] = phiWidthIn;
-  var[e2x2] = e2x2In;
+  var[s4] = s4In;
   var[eta] = etaIn;
   var[hOvrE] = hOvrEIn;
   var[ecalPFIso] = ecalPFIsoIn;

--- a/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
+++ b/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
@@ -37,7 +37,7 @@ TEST_CASE("RecoEgamma/PhotonIdentification testXGBPhoton", "[TestPhotonMvaXgb]")
       float xgbScore;
       const float *v = vars_in[i];
       float etaSC = v[6];
-      if (abs(etaSC) < 1.5)
+      if (std::abs(etaSC) < 1.5)
         xgbScore = mvaEstimatorB->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
       else
         xgbScore = mvaEstimatorE->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);


### PR DESCRIPTION
It has been reported that inference in the unit test does not pass on ARM and PPC architectures, so, in agreement with HLT, we leavel the unit test check only for x86_64 (which is sufficient for HLT workloads).

Below is the log of tests which were failing on ARM64 and ppc 64 LE. This always with same numerical values on these two architecture. Cause of that will be investigated.

```
src/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc:44: FAILED:
  CHECK_THAT( xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001) )
with expansion:
  0.91074f is within 0.0001 of 0.9863399863

src/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc:44: FAILED:
  CHECK_THAT( xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001) )
with expansion:
  0.82656f is within 0.0001 of 0.9750099778

src/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc:44: FAILED:
  CHECK_THAT( xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001) )
with expansion:
  0.0f is within 0.0001 of 0.00179

src/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc:44: FAILED:
  CHECK_THAT( xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001) )
with expansion:
  0.93808f is within 0.0001 of 0.9837399721
```

*UPDATE*: another commit was pushed. This fixes another problem with the XGBoost photon producer. It was not scaling e2x2 variable by SC energy (s4). It should not impact the unit test.

#### PR validation:
Unit test unchanged for x86_64 and should pass on all architectures now.

… ARM and PPC architectures, so leaving the check only for X86_64

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #44531

Update: caused by behavior of `abs`. As in the master PR, a fix switching to `std::abs` is pushed.