### PR TITLE
[CPP20][L1,UPGRADE] Replace some enums with constexpr ints

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCConstants.h
+++ b/DataFormats/CSCDigi/interface/CSCConstants.h
@@ -53,51 +53,50 @@ public:
   };
 
   // distrips, strips, half-strips
-  enum Strip_Info {
-    // Each CFEB reads out 8 distrips...
-    NUM_DISTRIPS_PER_CFEB = 8,
-    //...16 strips...
-    NUM_STRIPS_PER_CFEB = 2 * NUM_DISTRIPS_PER_CFEB,
-    //...32 half-strips.
-    NUM_HALF_STRIPS_PER_CFEB = 2 * NUM_STRIPS_PER_CFEB,
-    // There are exactly 80 or 112 strips...
-    MAX_NUM_STRIPS_RUN1 = MAX_CFEBS_RUN1 * NUM_STRIPS_PER_CFEB,  // 80
-    MAX_NUM_STRIPS_RUN2 = MAX_CFEBS_RUN2 * NUM_STRIPS_PER_CFEB,  // 112
-    //...and 160 or 224 half-strips for 5 or 7 CFEBs...
-    MAX_NUM_HALF_STRIPS_RUN1 = MAX_CFEBS_RUN1 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    MAX_NUM_HALF_STRIPS_RUN2 = MAX_CFEBS_RUN2 * NUM_HALF_STRIPS_PER_CFEB,  // 224
-    // ...but depending on the chamber, there may or may not be strip staggering.
-    /* CMS-MUO-16-001: "[..] alternate layers in a CSC are staggered by half a strip width, except
+  static constexpr int
+      // Each CFEB reads out 8 distrips...
+      NUM_DISTRIPS_PER_CFEB = 8,
+      //...16 strips...
+      NUM_STRIPS_PER_CFEB = 2 * NUM_DISTRIPS_PER_CFEB,
+      //...32 half-strips.
+      NUM_HALF_STRIPS_PER_CFEB = 2 * NUM_STRIPS_PER_CFEB,
+      // There are exactly 80 or 112 strips...
+      MAX_NUM_STRIPS_RUN1 = MAX_CFEBS_RUN1 * NUM_STRIPS_PER_CFEB,  // 80
+      MAX_NUM_STRIPS_RUN2 = MAX_CFEBS_RUN2 * NUM_STRIPS_PER_CFEB,  // 112
+      //...and 160 or 224 half-strips for 5 or 7 CFEBs...
+      MAX_NUM_HALF_STRIPS_RUN1 = MAX_CFEBS_RUN1 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      MAX_NUM_HALF_STRIPS_RUN2 = MAX_CFEBS_RUN2 * NUM_HALF_STRIPS_PER_CFEB,  // 224
+      // ...but depending on the chamber, there may or may not be strip staggering.
+      /* CMS-MUO-16-001: "[..] alternate layers in a CSC are staggered by half a strip width, except
        in the ME1/1 chambers where the strips are narrower and the effect is small" */
-    // _TRIGGER is added at the end, because these constants are only used in the trigger
-    MAX_NUM_HALF_STRIPS_RUN1_TRIGGER = 1 + MAX_NUM_HALF_STRIPS_RUN1,  // 161
-    MAX_NUM_HALF_STRIPS_RUN2_TRIGGER = 1 + MAX_NUM_HALF_STRIPS_RUN2,  // 225
-    // Number of strips in ME11 (special case)
-    NUM_STRIPS_ME1A_GANGED = NUM_CFEBS_ME1A_GANGED * NUM_STRIPS_PER_CFEB,      // 16
-    NUM_STRIPS_ME1A_UNGANGED = NUM_CFEBS_ME1A_UNGANGED * NUM_STRIPS_PER_CFEB,  // 48
-    NUM_STRIPS_ME1B = NUM_CFEBS_ME1B * NUM_STRIPS_PER_CFEB,                    // 64
-    // Number of half-strips in ME11 (special case)
-    NUM_HALF_STRIPS_ME1A_GANGED = NUM_CFEBS_ME1A_GANGED * NUM_HALF_STRIPS_PER_CFEB,      // 32
-    NUM_HALF_STRIPS_ME1A_UNGANGED = NUM_CFEBS_ME1A_UNGANGED * NUM_HALF_STRIPS_PER_CFEB,  // 96
-    NUM_HALF_STRIPS_ME1B = NUM_CFEBS_ME1B * NUM_HALF_STRIPS_PER_CFEB,                    // 128
-    NUM_HALF_STRIPS_ME11_GANGED = NUM_CFEBS_ME11_GANGED * NUM_HALF_STRIPS_PER_CFEB,      // 160
-    NUM_HALF_STRIPS_ME11_UNGANGED = NUM_CFEBS_ME11_UNGANGED * NUM_HALF_STRIPS_PER_CFEB,  // 224
-    // max halfstrip number in ME1/1 chambers
-    MAX_HALF_STRIP_ME1A_GANGED = NUM_HALF_STRIPS_ME1A_GANGED - 1,      // 31
-    MAX_HALF_STRIP_ME1A_UNGANGED = NUM_HALF_STRIPS_ME1A_UNGANGED - 1,  // 95
-    MAX_HALF_STRIP_ME1B = NUM_HALF_STRIPS_ME1B - 1,                    // 127
-    // half-strips for the rest of the system
-    NUM_HALF_STRIPS_ME12 = NUM_CFEBS_ME12 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME13 = NUM_CFEBS_ME13 * NUM_HALF_STRIPS_PER_CFEB,  // 128
-    NUM_HALF_STRIPS_ME21 = NUM_CFEBS_ME21 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME22 = NUM_CFEBS_ME22 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME31 = NUM_CFEBS_ME31 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME32 = NUM_CFEBS_ME32 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME41 = NUM_CFEBS_ME41 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    NUM_HALF_STRIPS_ME42 = NUM_CFEBS_ME42 * NUM_HALF_STRIPS_PER_CFEB,  // 160
-    // useful for the comparator code algorithm
-    INVALID_HALF_STRIP = 65535
-  };
+      // _TRIGGER is added at the end, because these constants are only used in the trigger
+      MAX_NUM_HALF_STRIPS_RUN1_TRIGGER = 1 + MAX_NUM_HALF_STRIPS_RUN1,  // 161
+      MAX_NUM_HALF_STRIPS_RUN2_TRIGGER = 1 + MAX_NUM_HALF_STRIPS_RUN2,  // 225
+      // Number of strips in ME11 (special case)
+      NUM_STRIPS_ME1A_GANGED = NUM_CFEBS_ME1A_GANGED * NUM_STRIPS_PER_CFEB,      // 16
+      NUM_STRIPS_ME1A_UNGANGED = NUM_CFEBS_ME1A_UNGANGED * NUM_STRIPS_PER_CFEB,  // 48
+      NUM_STRIPS_ME1B = NUM_CFEBS_ME1B * NUM_STRIPS_PER_CFEB,                    // 64
+      // Number of half-strips in ME11 (special case)
+      NUM_HALF_STRIPS_ME1A_GANGED = NUM_CFEBS_ME1A_GANGED * NUM_HALF_STRIPS_PER_CFEB,      // 32
+      NUM_HALF_STRIPS_ME1A_UNGANGED = NUM_CFEBS_ME1A_UNGANGED * NUM_HALF_STRIPS_PER_CFEB,  // 96
+      NUM_HALF_STRIPS_ME1B = NUM_CFEBS_ME1B * NUM_HALF_STRIPS_PER_CFEB,                    // 128
+      NUM_HALF_STRIPS_ME11_GANGED = NUM_CFEBS_ME11_GANGED * NUM_HALF_STRIPS_PER_CFEB,      // 160
+      NUM_HALF_STRIPS_ME11_UNGANGED = NUM_CFEBS_ME11_UNGANGED * NUM_HALF_STRIPS_PER_CFEB,  // 224
+      // max halfstrip number in ME1/1 chambers
+      MAX_HALF_STRIP_ME1A_GANGED = NUM_HALF_STRIPS_ME1A_GANGED - 1,      // 31
+      MAX_HALF_STRIP_ME1A_UNGANGED = NUM_HALF_STRIPS_ME1A_UNGANGED - 1,  // 95
+      MAX_HALF_STRIP_ME1B = NUM_HALF_STRIPS_ME1B - 1,                    // 127
+      // half-strips for the rest of the system
+      NUM_HALF_STRIPS_ME12 = NUM_CFEBS_ME12 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME13 = NUM_CFEBS_ME13 * NUM_HALF_STRIPS_PER_CFEB,  // 128
+      NUM_HALF_STRIPS_ME21 = NUM_CFEBS_ME21 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME22 = NUM_CFEBS_ME22 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME31 = NUM_CFEBS_ME31 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME32 = NUM_CFEBS_ME32 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME41 = NUM_CFEBS_ME41 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      NUM_HALF_STRIPS_ME42 = NUM_CFEBS_ME42 * NUM_HALF_STRIPS_PER_CFEB,  // 160
+      // useful for the comparator code algorithm
+      INVALID_HALF_STRIP = 65535;
 
   // CSCs have 6 layers. The key (reference) layer is the third layer
   enum Layer_Info { NUM_LAYERS = 6, KEY_CLCT_LAYER = 3, KEY_ALCT_LAYER = 3 };

--- a/DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h
+++ b/DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h
@@ -31,7 +31,7 @@ public:
 
   enum Digis_Info { MAX_DIGIS_PER_ALCT = 10, MAX_DIGIS_PER_CLCT = 8 };
 
-  enum eta_info { etaBins = 1 << CSCBitWidths::kGlobalEtaBitWidth };
+  static constexpr int etaBins = 1 << CSCBitWidths::kGlobalEtaBitWidth;
 
   enum MPC_stubs { maxStubs = 3 };
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -49,11 +49,11 @@ public:
     kPhiSize = 12,        // Width of phi
     kRinvSize = 15,       // Width of Rinv
     kValidSize = 1,       // Valid bit
-
-    kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size + kChi2RZSize + kD0Size +
-                     kBendChi2Size + kHitPatternSize + kMVAQualitySize +
-                     kMVAOtherSize,  // Width of the track word in bits
   };
+  static constexpr int kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size +
+                                        kChi2RZSize + kD0Size + kBendChi2Size + kHitPatternSize + kMVAQualitySize +
+                                        kMVAOtherSize  // Width of the track word in bits
+      ;
 
   enum TrackBitLocations {
     // The location of the least significant bit (LSB) and most significant bit (MSB) in the track word for different fields
@@ -129,8 +129,8 @@ public:
   typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
 
   // Track word types
-  typedef std::bitset<TrackBitWidths::kTrackWordSize> tkword_bs_t;  // Entire track word;
-  typedef ap_uint<TrackBitWidths::kTrackWordSize> tkword_t;         // Entire track word;
+  typedef std::bitset<kTrackWordSize> tkword_bs_t;  // Entire track word;
+  typedef ap_uint<kTrackWordSize> tkword_t;         // Entire track word;
 
 public:
   // ----------Constructors --------------------------

--- a/L1Trigger/GlobalCaloTrigger/interface/L1GctHtMissLut.h
+++ b/L1Trigger/GlobalCaloTrigger/interface/L1GctHtMissLut.h
@@ -21,7 +21,7 @@ class L1GctHtMissLut : public L1GctLut<16, 12>
 
 {
 public:
-  enum numberOfBits { kHxOrHyMissComponentNBits = 8, kHtMissMagnitudeNBits = 7, kHtMissAngleNBits = 5 };
+  static constexpr int kHxOrHyMissComponentNBits = 8, kHtMissMagnitudeNBits = 7, kHtMissAngleNBits = 5;
 
   // Definitions.
   static const int NAddress, NData;

--- a/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
+++ b/L1Trigger/HardwareValidation/plugins/L1DummyProducer.h
@@ -504,8 +504,9 @@ inline void L1DummyProducer::SimpleDigi(int,
   //tbd: set non-trivial random values
   dg.clear();  // set contents to zero
   //CSCDetId( int iendcap, int istation, int iring, int ichamber, int ilayer = 0 );
-  enum eMinNum { MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1 };
-  enum eMaxNum { MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6 };
+  static constexpr int MIN_ENDCAP = 1, MIN_STATION = 1, MIN_RING = 1, MIN_CHAMBER = 1, MIN_LAYER = 1;
+  static constexpr int MAX_ENDCAP = 2, MAX_STATION = 4, MAX_RING = 4, MAX_CHAMBER = 36, MAX_LAYER = 6;
+
   float rnd = engine->flat();
   int ec = (int)(MIN_ENDCAP + (MAX_ENDCAP - MIN_ENDCAP) * rnd + 1);
   int st = (int)(MIN_STATION + (MAX_STATION - MIN_STATION) * rnd + 1);

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraTestAnalyzer.cc
@@ -105,7 +105,7 @@ L1ExtraTestAnalyzer::L1ExtraTestAnalyzer(const edm::ParameterSet &iConfig)
             "Triggers",
             2 * l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 1,
             -0.75,
-            l1extra::L1ParticleMap::kNumOfL1TriggerTypes + 0.5 - 0.75) {
+            static_cast<double>(l1extra::L1ParticleMap::kNumOfL1TriggerTypes) + 0.5 - 0.75) {
   // now do what ever initialization is needed
 }
 

--- a/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/JetId.h
@@ -43,7 +43,7 @@ private:
   unique_ptr<float[]> fPt_;
   unique_ptr<float[]> fEta_;
   unique_ptr<float[]> fPhi_;
-  unique_ptr<float[]> fId_;
+  unique_ptr<int[]> fId_;
   unique_ptr<int[]> fCharge_;
   unique_ptr<float[]> fDZ_;
   unique_ptr<float[]> fDX_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -26,6 +26,6 @@ private:
   unique_ptr<float[]> fPt_;
   unique_ptr<float[]> fEta_;
   unique_ptr<float[]> fPhi_;
-  unique_ptr<float[]> fId_;
+  unique_ptr<int[]> fId_;
 };
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/JetId.cc
@@ -13,7 +13,7 @@ JetId::JetId(const std::string &iInput,
   fPt_ = std::make_unique<float[]>(fNParticles_);
   fEta_ = std::make_unique<float[]>(fNParticles_);
   fPhi_ = std::make_unique<float[]>(fNParticles_);
-  fId_ = std::make_unique<float[]>(fNParticles_);
+  fId_ = std::make_unique<int[]>(fNParticles_);
   fCharge_ = std::make_unique<int[]>(fNParticles_);
   fDZ_ = std::make_unique<float[]>(fNParticles_);
   fDX_ = std::make_unique<float[]>(fNParticles_);
@@ -31,7 +31,7 @@ JetId::JetId(const std::string &iInput, const std::string &iOutput, const BJetTF
   fPt_ = std::make_unique<float[]>(fNParticles_);
   fEta_ = std::make_unique<float[]>(fNParticles_);
   fPhi_ = std::make_unique<float[]>(fNParticles_);
-  fId_ = std::make_unique<float[]>(fNParticles_);
+  fId_ = std::make_unique<int[]>(fNParticles_);
   fCharge_ = std::make_unique<int[]>(fNParticles_);
   fDZ_ = std::make_unique<float[]>(fNParticles_);
   fDX_ = std::make_unique<float[]>(fNParticles_);

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -17,7 +17,7 @@ TauNNId::TauNNId(const std::string &iInput,
   fPt_ = std::make_unique<float[]>(fNParticles_);
   fEta_ = std::make_unique<float[]>(fNParticles_);
   fPhi_ = std::make_unique<float[]>(fNParticles_);
-  fId_ = std::make_unique<float[]>(fNParticles_);
+  fId_ = std::make_unique<int[]>(fNParticles_);
   fInput_ = iInput;
 }
 

--- a/L1Trigger/RPCTrigger/interface/RPCConst.h
+++ b/L1Trigger/RPCTrigger/interface/RPCConst.h
@@ -22,16 +22,15 @@
 
 class RPCConst {
 public:
-  enum {
-    ITOW_MIN = 0,   //!< Minimal number of abs(m_tower_number)
-    ITOW_MAX = 16,  //!< Maximal number of abs(m_tower_number)
-    //ITOW_MAX_LOWPT  = 7,      //!< Max m_tower number to which low_pt algorithm is used
-    IPT_MAX = 31,        //!< Max pt bin code
-    NSTRIPS = 1152,      //!< m_Number of Rpc strips in phi direction.
-    NSEG = NSTRIPS / 8,  //!< m_Number of trigger segments. One segment covers 8 RPC strips
-                         //!<in referencial plane (hardware 2 or 6(2')
-    OFFSET = 5           //!< Offset of the first trigger phi sector [deg]
-  };
+  static constexpr int ITOW_MIN = 0,  //!< Minimal number of abs(m_tower_number)
+      ITOW_MAX = 16,                  //!< Maximal number of abs(m_tower_number)
+      //ITOW_MAX_LOWPT  = 7,      //!< Max m_tower number to which low_pt algorithm is used
+      IPT_MAX = 31,        //!< Max pt bin code
+      NSTRIPS = 1152,      //!< m_Number of Rpc strips in phi direction.
+      NSEG = NSTRIPS / 8,  //!< m_Number of trigger segments. One segment covers 8 RPC strips
+                           //!<in referencial plane (hardware 2 or 6(2')
+      OFFSET = 5           //!< Offset of the first trigger phi sector [deg]
+      ;
 
   //static const int m_TOWER_COUNT = 16 + 1; //!< Only half of the detector.
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -326,8 +326,7 @@ namespace trklet {
            // Route Tracks in eta based on their sort key
       for (int iRegion = 0; iRegion < setup_->numRegions(); iRegion++) {
         int buffered_tracks[] = {0, 0};
-        for (int iTrack = 0;
-             iTrack < setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize);
+        for (int iTrack = 0; iTrack < setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::kTrackWordSize);
              iTrack++) {
           for (int iWorker = 0; iWorker < setup_->kfNumWorker(); iWorker++) {
             for (int iLink = 0; iLink < setup_->tfpNumChannel(); iLink++) {
@@ -376,8 +375,7 @@ namespace trklet {
             if (it.second == outputStreamsTracks[iLink][(int)(iTrack - 1) / 3].first)
               trackRef = it.first;
           }
-          if ((int)iTrack / 3 <=
-              setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::TrackBitWidths::kTrackWordSize))
+          if ((int)iTrack / 3 <= setup_->numFramesIO() * ((double)TTBV::S_ / TTTrack_TrackWord::kTrackWordSize))
             accepted[iLink].emplace_back(
                 std::make_pair(trackRef,
                                (sortedPartialTracks[iLink][iTrack - 1].slice(partialTrackWordBits_) +

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.h
@@ -51,7 +51,7 @@ public:
   ~TTStubBuilder() override;
 
   // TTStub bendOffset has this added to it, if stub truncated by FE, to indicate reason.
-  enum FEreject { CBCFailOffset = 500, CICFailOffset = 1000 };
+  static constexpr int CBCFailOffset = 500, CICFailOffset = 1000;
 
 private:
   /// Data members


### PR DESCRIPTION
#### PR description:

Replace some enums with constexpr ints to avoid deprecated enum arithmetics. Replaces https://github.com/cms-sw/cmssw/pull/44489 following @makortel's suggestion.

#### PR validation:

Bot tests
