### PR TITLE
[CPP20][SIMULATION] Replace some enums with constexpr int

### DIFF
--- a/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h
@@ -34,7 +34,7 @@ class CaloHitResponse {
 public:
   typedef std::map<DetId, CaloSamples> AnalogSignalMap;
   // get this from somewhere external
-  enum { BUNCHSPACE = 25 };
+  static constexpr int BUNCHSPACE = 25;
   static constexpr double dt = 0.5;
   static constexpr int invdt = 2;
 

--- a/SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h
+++ b/SimCalorimetry/CaloSimAlgos/interface/CaloShapeIntegrator.h
@@ -10,7 +10,7 @@
 
 class CaloShapeIntegrator : public CaloVShape {
 public:
-  enum { BUNCHSPACE = 25 };
+  static constexpr int BUNCHSPACE = 25;
 
   CaloShapeIntegrator(const CaloVShape *aShape);
 

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalCoder.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalCoder.h
@@ -30,12 +30,11 @@ public:
 
   typedef CorrelatedNoisifier<EcalCorrMatrix> Noisifier;
 
-  enum {
-    NBITS = 12,            // number of available bits
-    MAXADC = 4095,         // 2^12 -1,  adc max range
-    ADCGAINSWITCH = 4079,  // adc gain switch
-    NGAINS = 3             // number of electronic gains
-  };
+  static constexpr int NBITS = 12,  // number of available bits
+      MAXADC = 4095,                // 2^12 -1,  adc max range
+      ADCGAINSWITCH = 4079,         // adc gain switch
+      NGAINS = 3                    // number of electronic gains
+      ;
 
   /// ctor
   EcalCoder(bool addNoise,

--- a/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
+++ b/SimCalorimetry/EcalSimAlgos/interface/EcalSignalGenerator.h
@@ -246,12 +246,10 @@ private:
 
   // much of this stolen from EcalSimAlgos/EcalCoder
 
-  enum {
-    NBITS = 12,            // number of available bits
-    MAXADC = 4095,         // 2^12 -1,  adc max range
-    ADCGAINSWITCH = 4079,  // adc gain switch
-    NGAINS = 3
-  };  // number of electronic gains
+  static constexpr int NBITS = 12,  // number of available bits
+      MAXADC = 4095,                // 2^12 -1,  adc max range
+      ADCGAINSWITCH = 4079,         // adc gain switch
+      NGAINS = 3;                   // number of electronic gains
 
   CaloSamples samplesInPE(const DIGI& digi);  // have to define this separately for ES
 


### PR DESCRIPTION
#### PR description:

Replace some enums with constexpr ints to avoid deprecated enum arithmetics. Replaces https://github.com/cms-sw/cmssw/pull/44491 following @makortel's suggestion.

#### PR validation:

Bot tests