### PR TITLE
[CPP20] Cleanup BuildFile.xml for Alignment/OfflineValidation

### DIFF
--- a/Alignment/OfflineValidation/bin/BuildFile.xml
+++ b/Alignment/OfflineValidation/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags CXXFLAGS="-g -Wall  -O3 -Wall -std=c++17 -lASImage -lMultiProc" />
+<flags CXXFLAGS="-Wall -O3 -Wall -lASImage -lMultiProc" />
 <use name="Alignment/OfflineValidation"/>
 <use name="boost" />
 <use name="boost_filesystem"/>

--- a/Alignment/OfflineValidation/bin/BuildFile.xml
+++ b/Alignment/OfflineValidation/bin/BuildFile.xml
@@ -1,4 +1,4 @@
-<flags CXXFLAGS="-Wall -O3 -Wall -lASImage -lMultiProc" />
+<flags CXXFLAGS="-g -O3 -Wall -lASImage -lMultiProc" />
 <use name="Alignment/OfflineValidation"/>
 <use name="boost" />
 <use name="boost_filesystem"/>

--- a/Alignment/OfflineValidation/macros/trackSplitPlot.C
+++ b/Alignment/OfflineValidation/macros/trackSplitPlot.C
@@ -387,7 +387,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,
     setAxisLabels(p[i], type, xvar, yvar, relative, pull);
   }
 
-  if (type == Histogram && !pull && any_of(begin(used), end(used), identity<bool>)) {
+  if (type == Histogram && !pull && any_of(begin(used), end(used), ::identity<bool>)) {
     if (legendOptions.Contains("mean")) {
       summaryfile << "   mu_Delta" << yvar;
       if (relative)


### PR DESCRIPTION
#### PR description:

In CPP20 IBs, the following warning is [emitted](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CPP20_X_2024-03-22-1100/Alignment/OfflineValidation):

```
>> Compiling  src/Alignment/OfflineValidation/bin/Options.cc
c++ <...> src/Alignment/OfflineValidation/bin/Options.cc -o tmp/el8_amd64_gcc12/src/Alignment/OfflineValidation/bin/DMRmerge/Options.cc.o
In file included from /.../root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include/ROOT/RConfig.hxx:23,
                 from /.../root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include/RtypesCore.h:23,
                 from /.../root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include/Rtypes.h:23,
                 from /.../root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include/TString.h:26,
                 from src/Alignment/OfflineValidation/bin/DMRmerge.cc:16:
  /.../root/6.30.05-f5dcc69f8d11cd2c28768dbd60c84339/include/RConfigure.h:30:4: warning: #warning "The C++ standard in this build does not match ROOT configuration (202002L); this might cause unexpected issues" [-Wcpp]
    30 | #  warning "The C++ standard in this build does not match ROOT configuration (202002L); this might cause unexpected issues"
      |    ^~~~~~~
```

This PR removes explicit setting of C++ standard (as well as disabled debug symbols and duplicate `-Wall` flag)

#### PR validation:

Bot tests
