### PR TITLE
Unpack displaced pT from OMTF at the uGMT inputs

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
@@ -20,7 +20,7 @@ namespace l1t {
       for (auto imu = muons->begin(); imu != muons->end(); imu++) {
         if (imu->processor() + 1 == board_id) {
           uint32_t firstWord(0), lastWord(0);
-          RegionalMuonRawDigiTranslator::generatePackedDataWords(*imu, firstWord, lastWord, isKalman_, false);
+          RegionalMuonRawDigiTranslator::generatePackedDataWords(*imu, firstWord, lastWord, isKalman_, false, false);
           payloadMap_[bmtfBlockID].push_back(firstWord);  //imu->link()*2+1
           payloadMap_[bmtfBlockID].push_back(lastWord);   //imu->link()*2+1
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -67,7 +67,7 @@ namespace l1t {
 
           RegionalMuonCand muCand;
           RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
-              muCand, raw_first, raw_secnd, processor, tftype::bmtf, isKalman, false);
+              muCand, raw_first, raw_secnd, processor, tftype::bmtf, isKalman, false, false);
 
           if (muCand.hwPt() == 0) {
             continue;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -45,6 +45,9 @@ namespace l1t {
       if (fed == 1402) {
         auto gmt_in_packer = static_pointer_cast<l1t::stage2::RegionalMuonGMTPacker>(
             PackerFactory::get()->make("stage2::RegionalMuonGMTPacker"));
+        if (fw >= 0x8010000) {
+          gmt_in_packer->setUseOmtfDisplacementInfo();
+        }
         if (fw >= 0x8000000) {
           gmt_in_packer->setUseEmtfLooseShowers();
         }
@@ -103,6 +106,9 @@ namespace l1t {
       // input muons on links 36-71
       auto gmt_in_unp = static_pointer_cast<l1t::stage2::RegionalMuonGMTUnpacker>(
           UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker"));
+      if (fw >= 0x8010000) {
+        gmt_in_unp->setUseOmtfDisplacementInfo();
+      }
       if (fw >= 0x8000000) {
         gmt_in_unp->setUseEmtfLooseShowers();
       }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
@@ -108,7 +108,8 @@ namespace l1t {
               uint32_t msw{0};
               uint32_t lsw{0};
 
-              RegionalMuonRawDigiTranslator::generatePackedDataWords(mu, lsw, msw, isKbmtf_, useEmtfDisplacementInfo_);
+              RegionalMuonRawDigiTranslator::generatePackedDataWords(
+                  mu, lsw, msw, isKbmtf_, useOmtfDisplacementInfo_, useEmtfDisplacementInfo_);
 
               buf.at(frameIdx++) = lsw;
               buf.at(frameIdx++) = msw;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -15,6 +15,7 @@ namespace l1t {
     public:
       Blocks pack(const edm::Event&, const PackerTokens*) override;
       void setIsKbmtf() { isKbmtf_ = true; };
+      void setUseOmtfDisplacementInfo() { useOmtfDisplacementInfo_ = true; };
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; };
       void setUseEmtfNominalTightShowers() { useEmtfNominalTightShowers_ = true; };
       void setUseEmtfLooseShowers() { useEmtfLooseShowers_ = true; };
@@ -42,6 +43,7 @@ namespace l1t {
       static constexpr size_t wordsPerBx_ = 6;  // number of 32 bit words per BX
 
       bool isKbmtf_{false};
+      bool useOmtfDisplacementInfo_{false};
       bool useEmtfDisplacementInfo_{false};
       bool useEmtfNominalTightShowers_{false};
       bool useEmtfLooseShowers_{false};

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -109,8 +109,14 @@ namespace l1t {
             RegionalMuonCand mu;
             mu.setMuIdx(nWord / 2);
 
-            RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
-                mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isKbmtf_, useEmtfDisplacementInfo_);
+            RegionalMuonRawDigiTranslator::fillRegionalMuonCand(mu,
+                                                                raw_data_00_31,
+                                                                raw_data_32_63,
+                                                                processor,
+                                                                trackFinder,
+                                                                isKbmtf_,
+                                                                useOmtfDisplacementInfo_,
+                                                                useEmtfDisplacementInfo_);
 
             LogDebug("L1T") << "Mu" << nWord / 2 << ": eta " << mu.hwEta() << " phi " << mu.hwPhi() << " pT "
                             << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid "

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -11,6 +11,7 @@ namespace l1t {
     public:
       bool unpack(const Block& block, UnpackerCollections* coll) override;
       void setIsKbmtf() { isKbmtf_ = true; }
+      void setUseOmtfDisplacementInfo() { useOmtfDisplacementInfo_ = true; }
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; }
       void setUseEmtfNominalTightShowers() { useEmtfNominalTightShowers_ = true; }
       void setUseEmtfLooseShowers() { useEmtfLooseShowers_ = true; }
@@ -20,6 +21,7 @@ namespace l1t {
       static constexpr unsigned bxzs_enable_shift_ = 1;
 
       bool isKbmtf_{false};
+      bool useOmtfDisplacementInfo_{false};
       bool useEmtfDisplacementInfo_{false};
       bool useEmtfNominalTightShowers_{false};
       bool useEmtfLooseShowers_{false};

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -13,9 +13,15 @@ namespace l1t {
                                      int proc,
                                      tftype tf,
                                      bool isKbmtf,
+                                     bool useOmtfDisplacementInfo,
                                      bool useEmtfDisplacementInfo);
-    static void fillRegionalMuonCand(
-        RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isKbmtf, bool useEmtfDisplacementInfo);
+    static void fillRegionalMuonCand(RegionalMuonCand& mu,
+                                     uint64_t dataword,
+                                     int proc,
+                                     tftype tf,
+                                     bool isKbmtf,
+                                     bool useOmtfDisplacementInfo,
+                                     bool useEmtfDisplacementInfo);
     static bool fillRegionalMuonShower(RegionalMuonShower& muShower,
                                        std::vector<uint32_t> bxPayload,
                                        int proc,
@@ -26,13 +32,17 @@ namespace l1t {
                                         uint32_t& raw_data_00_31,
                                         uint32_t& raw_data_32_63,
                                         bool isKbmtf,
+                                        bool useOmtfDisplacementInfo,
                                         bool useEmtfDisplacementInfo);
     static void generatePackedShowerPayload(const RegionalMuonShower& shower,
                                             std::array<uint32_t, 6>& payload,
                                             bool useEmtfNominalTightShowers,
                                             bool useEmtfLooseShowers);
-    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isKbmtf, bool useEmtfDisplacementInfo);
-    static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
+    static uint64_t generate64bitDataWord(const RegionalMuonCand& mu,
+                                          bool isKbmtf,
+                                          bool useOmtfDisplacementInfo,
+                                          bool useEmtfDisplacementInfo);
+    static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman, bool useOmtfDisplacementInfo);
 
     static constexpr unsigned ptMask_ = 0x1FF;
     static constexpr unsigned ptShift_ = 0;
@@ -53,6 +63,7 @@ namespace l1t {
     static constexpr unsigned emtfDxyShift_ = 29;
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
     static constexpr unsigned bmtfPtUnconstrainedShift_ = 23;
+    static constexpr unsigned kOmtfPtUnconstrainedShift_ = 18;
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -65,7 +65,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
         }
         l1upgradetfmuon_.tfMuonDecodedTrAdd.push_back(decoded_track_address);
         l1upgradetfmuon_.tfMuonHwTrAdd.push_back(
-            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isRun3_));
+            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isRun3_, isRun3_));
         l1upgradetfmuon_.nTfMuons++;
       }
     }


### PR DESCRIPTION
#### PR description:

uGMT now uses the unconstrained pT from OMTF, so we need to unpack it. I've added the functionality to pack and unpack it in this PR.
