### PR TITLE
Protection of hcalcalib DQM client when hltHcalCalibrationRaw is not found

### DIFF
--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -239,12 +239,12 @@ process.p = cms.Path(
 #-------------------------------------
 print("Final Source settings:", process.source)
 process.options = cms.untracked.PSet(
-		Rethrow = cms.untracked.vstring(
-			"ProductNotFound",
-			"TooManyProducts",
-			"TooFewProducts"
-		)
-#		SkipEvent = cms.untracked.vstring(
-#			'ProductNotFound'
-#		)
+	Rethrow = cms.untracked.vstring(
+                #			"ProductNotFound",
+                "TooManyProducts",
+		"TooFewProducts"
+	),
+        TryToContinue = cms.untracked.vstring(
+                'ProductNotFound'                        
+        )
 )


### PR DESCRIPTION
#### PR description:

In the ECAL laser test runs, run 378496 and 378498, hcalcalib DQM clients crashed with the following error:
`
----- Begin Fatal Exception 26-Mar-2024 15:41:37 CET-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 378496 lumi: 1 event: 5835 stream: 0
   [1] Running path 'p'
   [2] Calling method for module HcalRawToDigi/'hcalDigis'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: FEDRawDataCollection
Looking for module label: hltHcalCalibrationRaw
Looking for productInstanceName: 
`


Previously in 13_0_X releases, SkipEvent was used to prevent this error. The protection was removed after moving to 14_X. This PR re-introduced the protection using TryToContinue.


#### PR validation:
A test has been done at the playback using the DQM streamers 378496. We were able to reproduce the crash using the current hcalcalib and removed the crash (skipping events) when using the code of this PR. 