### PR TITLE
Add QuadJet with 3 b-tag PNet trigger to the DQM offline

### DIFF
--- a/DQMOffline/Trigger/python/DisplacedVertices_Monitor_cff.py
+++ b/DQMOffline/Trigger/python/DisplacedVertices_Monitor_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
+
+PFHT330_TripleBTag_bjet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/EXO/DisplacedVertices/FullyHadronic/TripleBTag/',
+    enable2DPlots = False,
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>45 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 4,
+    bjetSelection    = 'pt>45 & abs(eta)<2.4',
+    btagAlgos        = ["pfParticleNetAK4DiscriminatorsJetTagsForRECO:BvsAll"],
+    workingpoint     = 0.0359, # Loose (According to: https://btv-wiki.docs.cern.ch/ScaleFactors/Run3Summer23BPix/)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+                 HTBinning    = [0,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers 
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_PNet3BTag_4p3_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*']),
+    #requireValidHLTPaths = False, #For debugging
+)
+
+PFHT330_TripleBTag_bjet_backup = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/EXO/DisplacedVertices/FullyHadronic/TripleBTagBackup/',
+    enable2DPlots = False,
+    # Selections                                                                                                                                                                                                   
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>45 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 4,
+    bjetSelection    = 'pt>45 & abs(eta)<2.4',
+    btagAlgos        = ["pfParticleNetAK4DiscriminatorsJetTagsForRECO:BvsAll"],
+    workingpoint     = 0.0359, #Loose
+    # Binning                                                                                                                                                  
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+                 HTBinning    = [0,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers                                                                                                                                                                                                     
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_PNet3BTag_2p0_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*']),
+    #requireValidHLTPaths = False, #For debugging
+)
+
+exoHLTDisplacedVerticesmonitoring = cms.Sequence(
+    PFHT330_TripleBTag_bjet
+    + PFHT330_TripleBTag_bjet_backup
+)

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -219,6 +219,90 @@ DisplacedJet_jetRatioHemHep17 = DQMEDHarvester("DQMGenericClient",
 
  )
 
+DisplacedVertices_PFHT330_TripleBTag = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/EXO/DisplacedVertices/FullyHadronic/*"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_jetPt_1       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_numerator       jetPt_1_denominator",
+        "effic_jetPt_2       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_numerator       jetPt_2_denominator",
+        "effic_jetPt_3       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_numerator       jetPt_3_denominator",
+        "effic_jetPt_4       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_numerator       jetPt_4_denominator",
+
+        "effic_jetEta_1      'efficiency vs 1st jet #eta;jet #eta;efficiency' jetEta_1_numerator     jetEta_1_denominator",
+        "effic_jetEta_2      'efficiency vs 2nd jet #eta;jet #eta;efficiency' jetEta_2_numerator     jetEta_2_denominator",
+        "effic_jetEta_3      'efficiency vs 3rd jet #eta;jet #eta;efficiency' jetEta_3_numerator     jetEta_3_denominator",
+        "effic_jetEta_4      'efficiency vs 4th jet #eta;jet #eta;efficiency' jetEta_4_numerator     jetEta_4_denominator",
+
+        "effic_jetPhi_1      'efficiency vs 1st jet #phi;jet #phi;efficiency'    jetPhi_1_numerator      jetPhi_1_denominator",
+        "effic_jetPhi_2      'efficiency vs 2nd jet #phi;jet #phi;efficiency'    jetPhi_2_numerator      jetPhi_2_denominator",
+        "effic_jetPhi_3      'efficiency vs 3rd jet #phi;jet #phi;efficiency'    jetPhi_3_numerator      jetPhi_3_denominator",
+        "effic_jetPhi_4      'efficiency vs 4th jet #phi;jet #phi;efficiency'    jetPhi_4_numerator      jetPhi_4_denominator",
+
+        "effic_bjetPt_1      'efficiency vs 1st b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
+        "effic_bjetPt_2      'efficiency vs 2nd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_2_numerator  bjetPt_2_denominator",
+        "effic_bjetPt_3      'efficiency vs 3rd b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_3_numerator  bjetPt_3_denominator",
+        "effic_bjetPt_4      'efficiency vs 4th b-jet p_{T};bjet p_{T} [GeV];efficiency' bjetPt_4_numerator  bjetPt_4_denominator",
+
+        "effic_bjetEta_1     'efficiency vs 1st b-jet #eta;bjet #eta;efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
+        "effic_bjetEta_2     'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency'  bjetEta_2_numerator   bjetEta_2_denominator",
+        "effic_bjetEta_3     'efficiency vs 3rd b-jet #eta;bjet #eta;efficiency'  bjetEta_3_numerator   bjetEta_3_denominator",
+        "effic_bjetEta_4     'efficiency vs 4th b-jet #eta;bjet #eta;efficiency'  bjetEta_4_numerator   bjetEta_4_denominator",
+
+        "effic_bjetPhi_1     'efficiency vs 1st b-jet #phi;bjet #phi;efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
+        "effic_bjetPhi_2     'efficiency vs 2nd b-jet #phi;bjet #phi;efficiency'  bjetPhi_2_numerator   bjetPhi_2_denominator",
+        "effic_bjetPhi_3     'efficiency vs 3rd b-jet #phi;bjet #phi;efficiency'  bjetPhi_3_numerator   bjetPhi_3_denominator",
+        "effic_bjetPhi_4     'efficiency vs 4th b-jet #phi;bjet #phi;efficiency'  bjetPhi_4_numerator   bjetPhi_4_denominator",
+
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet Discrim;bjet Discrim;efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_2     'efficiency vs 2nd b-jet Discrim;bjet Discrim;efficiency' bjetCSV_2_numerator  bjetCSV_2_denominator",
+        "effic_bjetCSV_3     'efficiency vs 3nd b-jet Discrim;bjet Discrim;efficiency' bjetCSV_3_numerator  bjetCSV_3_denominator",
+        "effic_bjetCSV_4     'efficiency vs 4nd b-jet Discrim;bjet Discrim;efficiency' bjetCSV_4_numerator  bjetCSV_4_denominator",
+
+        "effic_eventHT       'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_numerator       eventHT_denominator",
+        "effic_jetEtaPhi_HEP17       'efficiency vs jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_HEP17_numerator       jetEtaPhi_HEP17_denominator",
+
+        "effic_jetPt_1_variableBinning       'efficiency vs 1st jet p_{T};jet p_{T} [GeV];efficiency' jetPt_1_variableBinning_numerator       jetPt_1_variableBinning_denominator",
+        "effic_jetPt_2_variableBinning       'efficiency vs 2nd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_2_variableBinning_numerator       jetPt_2_variableBinning_denominator",
+        "effic_jetPt_3_variableBinning       'efficiency vs 3rd jet p_{T};jet p_{T} [GeV];efficiency' jetPt_3_variableBinning_numerator       jetPt_3_variableBinning_denominator",
+        "effic_jetPt_4_variableBinning       'efficiency vs 4th jet p_{T};jet p_{T} [GeV];efficiency' jetPt_4_variableBinning_numerator       jetPt_4_variableBinning_denominator",
+
+        "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet #eta;bjet #eta;efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
+        "effic_bjetEta_2_variableBinning  'efficiency vs 2nd b-jet #eta;bjet #eta;efficiency' bjetEta_2_variableBinning_numerator     bjetEta_2_variableBinning_denominator",
+        "effic_bjetEta_3_variableBinning  'efficiency vs 3rd b-jet #eta;bjet #eta;efficiency' bjetEta_3_variableBinning_numerator     bjetEta_3_variableBinning_denominator",
+        "effic_bjetEta_4_variableBinning  'efficiency vs 4th b-jet #eta;bjet #eta;efficiency' bjetEta_4_variableBinning_numerator     bjetEta_4_variableBinning_denominator",
+
+        "effic_eventHT_variableBinning    'efficiency vs event H_{T};event H_{T} [GeV];efficiency' eventHT_variableBinning_numerator       eventHT_variableBinning_denominator",
+
+        "effic_jetMulti       'efficiency vs jet multiplicity;jet multiplicity;efficiency' jetMulti_numerator       jetMulti_denominator",
+        "effic_bjetMulti      'efficiency vs b-jet multiplicity;bjet multiplicity;efficiency' bjetMulti_numerator   bjetMulti_denominator",
+
+        "effic_jetPtEta_1     'efficiency vs 1st jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_1_numerator       jetPtEta_1_denominator",
+        "effic_jetPtEta_2     'efficiency vs 2nd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_2_numerator       jetPtEta_2_denominator",
+        "effic_jetPtEta_3     'efficiency vs 3rd jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_3_numerator       jetPtEta_3_denominator",
+        "effic_jetPtEta_4     'efficiency vs 4th jet p_{T}-#eta;jet p_{T} [GeV];jet #eta' jetPtEta_4_numerator       jetPtEta_4_denominator",
+
+        "effic_jetEtaPhi_1    'efficiency vs 1st jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_1_numerator       jetEtaPhi_1_denominator",
+        "effic_jetEtaPhi_2    'efficiency vs 2nd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_2_numerator       jetEtaPhi_2_denominator",
+        "effic_jetEtaPhi_3    'efficiency vs 3rd jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_3_numerator       jetEtaPhi_3_denominator",
+        "effic_jetEtaPhi_4    'efficiency vs 4th jet #eta-#phi;jet #eta;jet #phi' jetEtaPhi_4_numerator       jetEtaPhi_4_denominator",
+
+        "effic_bjetPtEta_1    'efficiency vs 1st b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_1_numerator   bjetPtEta_1_denominator",
+        "effic_bjetPtEta_2    'efficiency vs 2nd b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_2_numerator   bjetPtEta_2_denominator",
+        "effic_bjetPtEta_3    'efficiency vs 3rd b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_3_numerator   bjetPtEta_3_denominator",
+        "effic_bjetPtEta_4    'efficiency vs 4th b-jet p_{T}-#eta;jet p_{T} [GeV];bjet #eta' bjetPtEta_4_numerator   bjetPtEta_4_denominator",
+
+        "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
+        "effic_bjetEtaPhi_2    'efficiency vs 2nd b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_2_numerator  bjetEtaPhi_2_denominator",
+        "effic_bjetEtaPhi_3    'efficiency vs 3rd b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_3_numerator  bjetEtaPhi_3_denominator",
+        "effic_bjetEtaPhi_4    'efficiency vs 4th b-jet #eta-#phi;bjet #eta;bjet #phi' bjetEtaPhi_4_numerator  bjetEtaPhi_4_denominator",
+
+        "effic_bjetCSVHT_1 'efficiency vs 1st b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_1_numerator bjetCSVHT_1_denominator"
+        "effic_bjetCSVHT_2 'efficiency vs 2nd b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_2_numerator bjetCSVHT_2_denominator"
+        "effic_bjetCSVHT_3 'efficiency vs 3rd b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_3_numerator bjetCSVHT_3_denominator"
+        "effic_bjetCSVHT_4 'efficiency vs 4th b-jet Discrim - event H_{T};bjet Discrim;event H_{T} [GeV]' bjetCSVHT_4_numerator bjetCSVHT_4_denominator"
+    ),
+)
 
 exoticaClient = cms.Sequence(
     NoBPTXEfficiency

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -8,6 +8,7 @@ from DQMOffline.Trigger.METplusTrackMonitor_cff import *
 from DQMOffline.Trigger.MuonMonitor_cff import *
 from DQMOffline.Trigger.DisplacedJet_Monitor_cff import *
 from DQMOffline.Trigger.DiDispStaMuonMonitor_cff import *
+from DQMOffline.Trigger.DisplacedVertices_Monitor_cff import *
 
 exoticaMonitorHLT = cms.Sequence(
     exoHLTMETmonitoring
@@ -18,6 +19,7 @@ exoticaMonitorHLT = cms.Sequence(
   + exoHLTMETplusTrackMonitoring
   + exoHLTMuonmonitoring
   + exoHLTDisplacedJetmonitoring
+  + exoHLTDisplacedVerticesmonitoring
 )
 
 


### PR DESCRIPTION
#### PR description:

Added the Particle Net migrated version of the QuadJet with 3 b-tag trigger to the offline DQM. This trigger path was approved by TSG on March 13th (https://indico.cern.ch/event/1389073/).

As pointed out in the JIRA CMSHLT-3119, the validation strategy should be the same as the previous version of the path (using DeepJet), so it was copied over from the top DQM code with the necessary parameter changes. It's now important only to the Exotica PAG, so it was included in the Exotica DQM.

#### PR validation:

The DQM code was validated using a runTheMatrix workflow (modified to use the new trigger path). The resulting DQM file was uploaded to the DQM GUI at http://dqm-dev-test.cern.ch:8060/dqm/dev/ and it's a RelVal file. In particular, check that the new DQM plots are being created at the new HLT/EXO/DisplacedVertices/* folder and are populated with the passing events. 
