### PR TITLE
[MTD] Addition of mtd association maps to the event content

### DIFF
--- a/SimFastTiming/Configuration/python/SimFastTiming_EventContent_cff.py
+++ b/SimFastTiming/Configuration/python/SimFastTiming_EventContent_cff.py
@@ -21,7 +21,7 @@ SimFastTimingPREMIX = cms.PSet(
 )
 
 _phase2_timing_extraCommands = cms.PSet( # using PSet in order to customize with Modifier
-    value = cms.vstring( 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*' )
+    value = cms.vstring( 'keep *_mix_FTLBarrel_*','keep *_mix_FTLEndcap_*','keep *_mix_InitialVertices_*', 'keep *_mtdRecoClusterToSimLayerClusterAssociation_*_*', 'keep *_mtdSimLayerClusterToTPAssociation_*_*')
 )
 # For premixing switch the sim digi collections to the ones including pileup
 # Unsure what to do with InitialVertices, they don't seem to be consumed downstream?


### PR DESCRIPTION
#### PR description:

With this PR, Mtd association maps ( Mtd reco clusters <-> MtdSimLayerClusters, MtdSimLayerClusters <-> tracking particles) are added to the SimFastTiming event content.
The collections added to the event are the following ones:

MtdRecoClusterToSimLayerClusterAssociationMap   "mtdRecoClusterToSimLayerClusterAssociation"   ""                "RECO"    
MtdSimLayerClusterToRecoClusterAssociationMap   "mtdRecoClusterToSimLayerClusterAssociation"   ""                "RECO"    
edm::AssociationMap<edm::OneToMany<vector<MtdSimLayerCluster>,vector<TrackingParticle>,unsigned int> >    "mtdSimLayerClusterToTPAssociation"   ""                "RECO"    
edm::AssociationMap<edm::OneToMany<vector<TrackingParticle>,vector<MtdSimLayerCluster>,unsigned int> >    "mtdSimLayerClusterToTPAssociation"   ""                "RECO" 

This allows running the Mtd validation code (see https://github.com/cms-sw/cmssw/blob/master/Validation/MtdValidation/test/mtdValidation_cfg.py) also standalone, without need to re-run the corresponding association maps producer.


#### PR validation:

- tested on workflow 24807.0 (SingleMuPt10+2026D98) and verified that the event content is updated as expected
- running the mtd Validation sequence standalone now works fine 

