### PR TITLE
Make PYTHIA 8 photon flux more configurable.

### DIFF
--- a/Configuration/Generator/python/Pythia8PhotonFluxSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8PhotonFluxSettings_cfi.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration for photon flux in PbPb
+PhotonFlux_PbPb = cms.PSet(
+    beamTypeA = cms.int32(1000822080),
+    beamTypeB = cms.int32(1000822080),
+    radiusA = cms.untracked.double(6.636),
+    radiusB = cms.untracked.double(6.636),
+    zA = cms.untracked.int32(82),
+    zB = cms.untracked.int32(82)  
+)
+
+# configuration for photon flux in OO
+PhotonFlux_OO = cms.PSet(
+    beamTypeA = cms.int32(80160),
+    beamTypeB = cms.int32(80160),
+    radiusA = cms.untracked.double(3.02),
+    radiusB = cms.untracked.double(3.02),
+    zA = cms.untracked.int32(8),
+    zB = cms.untracked.int32(8)
+)
+
+# configuration for photon flux in XeXe
+# radius from charged particle raa: https://arxiv.org/pdf/1809.00201.pdf
+PhotonFlux_XeXe = cms.PSet(
+    beamTypeA = cms.int32(5418),
+    beamTypeB = cms.int32(5418),
+    radiusA = cms.untracked.double(5.4),
+    radiusB = cms.untracked.double(5.4),
+    zA = cms.untracked.int32(54),
+    zB = cms.untracked.int32(54)
+)

--- a/Configuration/Generator/python/Pythia8_GammaNucleus_5p36TeV_cfi.py
+++ b/Configuration/Generator/python/Pythia8_GammaNucleus_5p36TeV_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8PhotonFluxSettings_cfi import PhotonFlux_PbPb
 
 generator = cms.EDFilter("Pythia8GeneratorFilter",
     maxEventsToPrint = cms.untracked.int32(1),
@@ -6,7 +7,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(5360.),
-    doProtonPhotonFlux = cms.untracked.bool(True),
+    PhotonFlux = PhotonFlux_PbPb,
     PythiaParameters = cms.PSet(
         parameterSets = cms.vstring('pythia8_example02'),
         pythia8_example02 = cms.vstring(

--- a/GeneratorInterface/Pythia8Interface/test/pythia8ex2_ConvertToMain70_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8ex2_ConvertToMain70_cfg.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8PhotonFluxSettings_cfi import PhotonFlux_PbPb
 
 process = cms.Process("PROD")
 
@@ -12,36 +13,13 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(5360.),
-    doProtonPhotonFlux = cms.untracked.bool(True),
-    #PPbarInitialState = cms.PSet(),
-    #SLHAFileForPythia8 = cms.string('Configuration/Generator/data/CSA07SUSYBSM_LM9p_sftsdkpyt_slha.out'),
-    #reweightGen = cms.PSet( # flat in pT
-    #   pTRef = cms.double(15.0),
-    #   power = cms.double(4.5)
-    #),
-    #reweightGenRap = cms.PSet( # flat in eta
-    #   yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
-    #   yLabPower = cms.double(2.),
-    #   yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
-    #   yCMPower = cms.double(2.),
-    #   pTHatMin = cms.double(15.),
-    #   pTHatMax = cms.double(3000.)
-    #),
-    #reweightGenPtHatRap = cms.PSet( # flat in Pt and eta
-    #   yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
-    #   yLabPower = cms.double(2.),
-    #   yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
-    #   yCMPower = cms.double(2.),
-    #   pTHatMin = cms.double(15.),
-    #   pTHatMax = cms.double(3000.)
-    #),
+    PhotonFlux = PhotonFlux_PbPb,
     PythiaParameters = cms.PSet(
         pythia8_example02 = cms.vstring('HardQCD:all = on',
-                                        'PhaseSpace:pTHatMin = 10.',#CM Edit 20->10
+                                        'PhaseSpace:pTHatMin = 10.',
                                         'PhotonParton:all = on',#Added from main70
                                         'MultipartonInteractions:pT0Ref = 3.0',#Added from main70
                                         'PDF:beamA2gamma = on',#Added from main70
-                                        #This option below crashes - debug
                                         'PDF:proton2gammaSet = 0',#Added from main70
                                         'PDF:useHardNPDFB = on',
                                         'PDF:gammaFluxApprox2bMin = 13.272',
@@ -51,9 +29,6 @@ process.generator = cms.EDFilter("Pythia8GeneratorFilter",
         parameterSets = cms.vstring('pythia8_example02')
     )
 )
-
-# in order to use lhapdf PDF add a line like this to pythia8_example02:
-# 'PDF:pSet = LHAPDF6:CT10'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",

--- a/GeneratorInterface/Pythia8Interface/test/pythia8ex2_ConvertToMain70_cfg_Fragment.py
+++ b/GeneratorInterface/Pythia8Interface/test/pythia8ex2_ConvertToMain70_cfg_Fragment.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8PhotonFluxSettings_cfi import PhotonFlux_PbPb
 
 _generator = cms.EDFilter("Pythia8GeneratorFilter",
     maxEventsToPrint = cms.untracked.int32(1),
@@ -6,36 +7,13 @@ _generator = cms.EDFilter("Pythia8GeneratorFilter",
     filterEfficiency = cms.untracked.double(1.0),
     pythiaHepMCVerbosity = cms.untracked.bool(False),
     comEnergy = cms.double(5360.),
-    doProtonPhotonFlux = cms.untracked.bool(True),
-    #PPbarInitialState = cms.PSet(),
-    #SLHAFileForPythia8 = cms.string('Configuration/Generator/data/CSA07SUSYBSM_LM9p_sftsdkpyt_slha.out'),
-    #reweightGen = cms.PSet( # flat in pT
-    #   pTRef = cms.double(15.0),
-    #   power = cms.double(4.5)
-    #),
-    #reweightGenRap = cms.PSet( # flat in eta
-    #   yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
-    #   yLabPower = cms.double(2.),
-    #   yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
-    #   yCMPower = cms.double(2.),
-    #   pTHatMin = cms.double(15.),
-    #   pTHatMax = cms.double(3000.)
-    #),
-    #reweightGenPtHatRap = cms.PSet( # flat in Pt and eta
-    #   yLabSigmaFunc = cms.string("15.44/pow(x,0.0253)-12.56"),
-    #   yLabPower = cms.double(2.),
-    #   yCMSigmaFunc = cms.string("5.45/pow(x+64.84,0.34)"),
-    #   yCMPower = cms.double(2.),
-    #   pTHatMin = cms.double(15.),
-    #   pTHatMax = cms.double(3000.)
-    #),
+    PhotonFlux = PhotonFlux_PbPb,
     PythiaParameters = cms.PSet(
         pythia8_example02 = cms.vstring('HardQCD:all = on',
-                                        'PhaseSpace:pTHatMin = 10.',#CM Edit 20->10
+                                        'PhaseSpace:pTHatMin = 10.',
                                         'PhotonParton:all = on',#Added from main70
                                         'MultipartonInteractions:pT0Ref = 3.0',#Added from main70
                                         'PDF:beamA2gamma = on',#Added from main70
-                                        #This option below crashes - debug
                                         'PDF:proton2gammaSet = 0',#Added from main70
                                         'PDF:useHardNPDFB = on',
                                         'PDF:gammaFluxApprox2bMin = 13.272',


### PR DESCRIPTION
This PR is designed to make the process of incorporating the photon flux with Pythia 8 more configurable and, additionally, to allow the photon to be produced from either beam, as specified from the user. The output from the fragment does not change as a result of this PR (though the manner in which the user steers things does change  - as updated in the fragment).

Verified that the new configuration runs with the photon being produced from either beam A or beam B (or both), that the default configurations for PbPb, OO, and XeXe work as expected, and that the user specifying new configurations also works. 


Will need to prepare backports for release needed for MC production (13_0_X). Note that the current release is also fine for initial MC production, this PR just allows for additional user-set options. 

@stahlleiton 
