### PR TITLE
update BMTF Emulator for backport to CMSSW_14_0_X

### DIFF
--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanAlgo.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanAlgo.cc
@@ -99,7 +99,16 @@ l1t::RegionalMuonCand L1TMuonBarrelKalmanAlgo::convertToBMTF(const L1MuKBMTrack&
   int processor = track.sector();
   int HF = track.hasFineEta();
 
-  int quality = 12 | (rank(track) >> 6);
+  int quality;
+  int r = rank(track);
+  if (r < 192)
+    quality = 12;
+  else if (r < 204)
+    quality = 13;
+  else if (r < 220)
+    quality = 14;
+  else
+    quality = 15;
 
   int dxy = abs(track.dxy()) >> 8;
   if (dxy > 3)


### PR DESCRIPTION
This is the backport to CMSSW_14_0_X of PR [#44432](https://github.com/cms-sw/cmssw/pull/44432)

This backport is required in order to deploy the new Emulator in the online DQM. 