### PR TITLE
Add HGCAL Hit calibration to Phase2 HLT.

### DIFF
--- a/HLTriggerOffline/Common/python/HLTValidation_cff.py
+++ b/HLTriggerOffline/Common/python/HLTValidation_cff.py
@@ -18,6 +18,17 @@ from HLTriggerOffline.Muon.HLTmultiTrackValidatorMuonTracks_cff import *
 from Validation.HcalDigis.HLTHcalDigisParam_cfi import *
 from Validation.HcalRecHits.HLTHcalRecHitParam_cfi import *
 
+# HGCAL Rechit Calibration
+from Validation.HGCalValidation.hgcalHitCalibrationDefault_cfi import hgcalHitCalibrationDefault as _hgcalHitCalibrationDefault
+hgcalHitCalibrationHLT = _hgcalHitCalibrationDefault.clone()
+hgcalHitCalibrationHLT.folder = "HGCalHitCalibrationHLT"
+hgcalHitCalibrationHLT.recHitsEE = cms.InputTag("HGCalRecHit", "HGCEERecHits", "HLT")
+hgcalHitCalibrationHLT.recHitsFH = cms.InputTag("HGCalRecHit", "HGCHEFRecHits", "HLT")
+hgcalHitCalibrationHLT.recHitsBH = cms.InputTag("HGCalRecHit", "HGCHEBRecHits", "HLT")
+hgcalHitCalibrationHLT.hgcalMultiClusters = cms.InputTag("None")
+hgcalHitCalibrationHLT.electrons = cms.InputTag("None")
+hgcalHitCalibrationHLT.photons = cms.InputTag("None")
+
 # offline dqm:
 # from DQMOffline.Trigger.DQMOffline_Trigger_cff.py import *
 from DQMOffline.Trigger.HLTTauDQMOffline_cff import *
@@ -70,22 +81,24 @@ hltvalidationWithMC = cms.Sequence(
 )
 
 # Temporary Phase-2 config
-# Exclude everything except Muon and JetMET for now
+# Exclude everything except Muon and JetMET for now. Add HGCAL Hit Calibration
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toReplaceWith(hltvalidationWithMC, hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
-                                                                                     HLTTauVal,
-                                                                                     egammaValidationSequence,
-                                                                                     heavyFlavorValidationSequence,
-                                                                                     #HLTJetMETValSeq,
-                                                                                     HLTSusyExoValSeq,
-                                                                                     HiggsValidationSequence,
-                                                                                     ExoticaValidationSequence,
-                                                                                     b2gHLTriggerValidation,
-                                                                                     SMPValidationSequence,
-                                                                                     hltbtagValidationSequence,
-                                                                                     hltHCALdigisAnalyzer,
-                                                                                     hltHCALRecoAnalyzer,
-                                                                                     hltHCALNoiseRates]))
+_hltvalidationWithMC_Phase2 = hltvalidationWithMC.copyAndExclude([#HLTMuonVal,
+  HLTTauVal,
+  egammaValidationSequence,
+  heavyFlavorValidationSequence,
+  #HLTJetMETValSeq,
+  HLTSusyExoValSeq,
+  HiggsValidationSequence,
+  ExoticaValidationSequence,
+  b2gHLTriggerValidation,
+  SMPValidationSequence,
+  hltbtagValidationSequence,
+  hltHCALdigisAnalyzer,
+  hltHCALRecoAnalyzer,
+  hltHCALNoiseRates])
+_hltvalidationWithMC_Phase2.insert(-1, hgcalHitCalibrationHLT)
+phase2_common.toReplaceWith(hltvalidationWithMC, _hltvalidationWithMC_Phase2)
 
 hltvalidationWithData = cms.Sequence(
 )


### PR DESCRIPTION
#### PR description:

Add the HGCAL hit calibration validation module to Phase 2 HLT validation. This will be able to catch, in future, issues similar to those reported in #44552 

#### PR validation:

Tested on a Phase2 workflow: plots are created and properly filled.

