### PR TITLE
MTD reconstruction: propagation of track time of flight uncertainty to vertex reconstruction

### DIFF
--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -215,9 +215,9 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
 
     if (sigmat0 > 0. && (!MVASel_ || (MVASel_ && trackMVAQual >= minTrackTimeQuality_))) {
       double rsigmazsq = 1. / track.dzError() / track.dzError();
-      std::array<double> rsigmat = {1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofpi * sigmatofpi),
-                                    1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofk * sigmatofk),
-                                    1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofp * sigmatofp)};
+      std::array<double, 3> rsigmat = {{1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofpi * sigmatofpi),
+                                        1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofk * sigmatofk),
+                                        1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofp * sigmatofp)}};
 
       //find associated vertex
       int vtxidx = -1;

--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -215,9 +215,9 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
 
     if (sigmat0 > 0. && (!MVASel_ || (MVASel_ && trackMVAQual >= minTrackTimeQuality_))) {
       double rsigmazsq = 1. / track.dzError() / track.dzError();
-      double rsigmat[3] = {1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofpi * sigmatofpi),
-                           1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofk * sigmatofk),
-                           1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofp * sigmatofp)};
+      std::array<double> rsigmat = {1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofpi * sigmatofpi),
+                                    1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofk * sigmatofk),
+                                    1. / std::sqrt(sigmatmtd * sigmatmtd + sigmatofp * sigmatofp)};
 
       //find associated vertex
       int vtxidx = -1;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -227,7 +227,7 @@ namespace {
   };
 
   enum class TofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
-  enum class SigmaTofCalc { kCost = 1, kSegm = 2 };
+  enum class SigmaTofCalc { kCost = 1, kSegm = 2, kMixd = 3};
 
   const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
                                                float length,
@@ -279,6 +279,11 @@ namespace {
         case SigmaTofCalc::kSegm:
           res = trs.computeSigmaTof(mass_inv2);
           break;
+        case SigmaTofCalc::kMixd:
+          float res1 = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
+                       (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
+          float res2 = trs.computeSigmaTof(mass_inv2);
+          res = sqrt(res1*res1 + res2*res2 + 2*res1*res2);
       }
 
       return res;
@@ -1112,7 +1117,8 @@ namespace {
                                                            t_vtx,
                                                            t_vtx_err,  //put vtx error by hand for the moment
                                                            false,
-                                                           TofCalc::kMixd);
+                                                           TofCalc::kMixd,
+                                                           SigmaTofCalc::kMixd);
               MTDHitMatchingInfo mi;
               mi.hit = &hit;
               mi.estChi2 = est.second;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -306,6 +306,9 @@ namespace {
       tofpid.dterror =
           sqrt(tofpid.dterror * tofpid.dterror + (tofpid.dt_p - tofpid.dt_pi) * (tofpid.dt_p - tofpid.dt_pi));
       tofpid.betaerror = tofpid.beta_p - tofpid.beta_pi;
+    } else {
+      // only add sigma(TOF) if not considering mass hp. uncertainty
+      tofpid.dterror = sqrt(tofpid.dterror * tofpid.dterror + tofpid.sigma_dt_pi * tofpid.sigma_dt_pi);
     }
 
     tofpid.dtchi2 = (tofpid.dt * tofpid.dt) / (tofpid.dterror * tofpid.dterror);
@@ -321,10 +324,12 @@ namespace {
     if (!addPIDError) {
       //*TODO* deal with heavier nucleons and/or BSM case here?
       float chi2_pi = tofpid.dtchi2;
-      float chi2_k =
-          (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) / (tofpid.dterror * tofpid.dterror);
-      float chi2_p =
-          (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) / (tofpid.dterror * tofpid.dterror);
+      float chi2_k = (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) /
+                     (tofpid.dterror * tofpid.dterror - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi +
+                      tofpid.sigma_dt_k * tofpid.sigma_dt_k);
+      float chi2_p = (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) /
+                     (tofpid.dterror * tofpid.dterror - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi +
+                      tofpid.sigma_dt_p * tofpid.sigma_dt_p);
 
       float rawprob_pi = exp(-0.5f * chi2_pi);
       float rawprob_k = exp(-0.5f * chi2_k);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -227,7 +227,7 @@ namespace {
   };
 
   enum class TofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
-  enum class SigmaTofCalc { kCost = 1, kSegm = 2, kMixd = 3};
+  enum class SigmaTofCalc { kCost = 1, kSegm = 2, kMixd = 3 };
 
   const TrackTofPidInfo computeTrackTofPidInfo(float magp2,
                                                float length,
@@ -283,7 +283,7 @@ namespace {
           float res1 = tofpid.pathlength * c_inv * trs.segmentSigmaMom_[trs.nSegment_ - 1] /
                        (magp2 * sqrt(magp2 + 1 / mass_inv2) * mass_inv2);
           float res2 = trs.computeSigmaTof(mass_inv2);
-          res = sqrt(res1*res1 + res2*res2 + 2*res1*res2);
+          res = sqrt(res1 * res1 + res2 * res2 + 2 * res1 * res2);
       }
 
       return res;

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -309,8 +309,7 @@ namespace {
     tofpid.dterror2 = tofpid.tmtderror * tofpid.tmtderror + t_vtx_err * t_vtx_err;
     tofpid.betaerror = 0.f;
     if (addPIDError) {
-      tofpid.dterror2 = tofpid.dterror2 + (tofpid.dt_p - tofpid.dt_pi) *
-                                          (tofpid.dt_p - tofpid.dt_pi);
+      tofpid.dterror2 = tofpid.dterror2 + (tofpid.dt_p - tofpid.dt_pi) * (tofpid.dt_p - tofpid.dt_pi);
       tofpid.betaerror = tofpid.beta_p - tofpid.beta_pi;
     } else {
       // only add sigma(TOF) if not considering mass hp. uncertainty
@@ -330,17 +329,12 @@ namespace {
 
     if (!addPIDError) {
       //*TODO* deal with heavier nucleons and/or BSM case here?
-      const float dterror2_wo_sigmatof =
-          tofpid.dterror2 - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
+      const float dterror2_wo_sigmatof = tofpid.dterror2 - tofpid.sigma_dt_pi * tofpid.sigma_dt_pi;
       float chi2_pi = tofpid.dtchi2;
-      float chi2_k =
-          (tofpid.tmtd - tofpid.dt_k - t_vtx) *
-          (tofpid.tmtd - tofpid.dt_k - t_vtx) /
-          (dterror2_wo_sigmatof + tofpid.sigma_dt_k * tofpid.sigma_dt_k);
-      float chi2_p =
-          (tofpid.tmtd - tofpid.dt_p - t_vtx) *
-          (tofpid.tmtd - tofpid.dt_p - t_vtx) /
-          (dterror2_wo_sigmatof + tofpid.sigma_dt_p * tofpid.sigma_dt_p);
+      float chi2_k = (tofpid.tmtd - tofpid.dt_k - t_vtx) * (tofpid.tmtd - tofpid.dt_k - t_vtx) /
+                     (dterror2_wo_sigmatof + tofpid.sigma_dt_k * tofpid.sigma_dt_k);
+      float chi2_p = (tofpid.tmtd - tofpid.dt_p - t_vtx) * (tofpid.tmtd - tofpid.dt_p - t_vtx) /
+                     (dterror2_wo_sigmatof + tofpid.sigma_dt_p * tofpid.sigma_dt_p);
 
       float rawprob_pi = exp(-0.5f * chi2_pi);
       float rawprob_k = exp(-0.5f * chi2_k);

--- a/RecoVertex/PrimaryVertexProducer/interface/VertexTimeAlgorithmFromTracksPID.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/VertexTimeAlgorithmFromTracksPID.h
@@ -21,7 +21,7 @@ public:
 protected:
   struct TrackInfo {
     double trkWeight;
-    double trkTimeError;
+    double trkTimeErrorHyp[3];
     double trkTimeHyp[3];
   };
 
@@ -31,6 +31,9 @@ protected:
   edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTofPiToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTofKToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTofPToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDSigmaTofPiToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDSigmaTofKToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDSigmaTofPToken_;
 
   double const minTrackVtxWeight_;
   double const minTrackTimeQuality_;
@@ -46,6 +49,9 @@ protected:
   edm::ValueMap<float> trackMTDTofPi_;
   edm::ValueMap<float> trackMTDTofK_;
   edm::ValueMap<float> trackMTDTofP_;
+  edm::ValueMap<float> trackMTDSigmaTofPi_;
+  edm::ValueMap<float> trackMTDSigmaTofK_;
+  edm::ValueMap<float> trackMTDSigmaTofP_;
 };
 
 #endif

--- a/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmFromTracksPID.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmFromTracksPID.cc
@@ -23,6 +23,9 @@ VertexTimeAlgorithmFromTracksPID::VertexTimeAlgorithmFromTracksPID(edm::Paramete
       trackMTDTofPiToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTofPiVMapTag"))),
       trackMTDTofKToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTofKVMapTag"))),
       trackMTDTofPToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTofPVMapTag"))),
+      trackMTDSigmaTofPiToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDSigmaTofPiVMapTag"))),
+      trackMTDSigmaTofKToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDSigmaTofKVMapTag"))),
+      trackMTDSigmaTofPToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDSigmaTofPVMapTag"))),
       minTrackVtxWeight_(iConfig.getParameter<double>("minTrackVtxWeight")),
       minTrackTimeQuality_(iConfig.getParameter<double>("minTrackTimeQuality")),
       probPion_(iConfig.getParameter<double>("probPion")),
@@ -46,6 +49,12 @@ void VertexTimeAlgorithmFromTracksPID::fillPSetDescription(edm::ParameterSetDesc
       ->setComment("Input ValueMap for track tof as kaon");
   iDesc.add<edm::InputTag>("trackMTDTofPVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackTofP"))
       ->setComment("Input ValueMap for track tof as proton");
+  iDesc.add<edm::InputTag>("trackMTDSigmaTofPiVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofPi"))
+      ->setComment("Input ValueMap for track tof uncertainty as pion");
+  iDesc.add<edm::InputTag>("trackMTDSigmaTofKVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofK"))
+      ->setComment("Input ValueMap for track tof uncertainty as kaon");
+  iDesc.add<edm::InputTag>("trackMTDSigmaTofPVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackSigmaTofP"))
+      ->setComment("Input ValueMap for track tof uncertainty as proton");
 
   iDesc.add<double>("minTrackVtxWeight", 0.5)->setComment("Minimum track weight");
   iDesc.add<double>("minTrackTimeQuality", 0.8)->setComment("Minimum MVA Quality selection on tracks");
@@ -66,6 +75,9 @@ void VertexTimeAlgorithmFromTracksPID::setEvent(edm::Event& iEvent, edm::EventSe
   trackMTDTofPi_ = iEvent.get(trackMTDTofPiToken_);
   trackMTDTofK_ = iEvent.get(trackMTDTofKToken_);
   trackMTDTofP_ = iEvent.get(trackMTDTofPToken_);
+  trackMTDSigmaTofPi_ = iEvent.get(trackMTDSigmaTofPiToken_);
+  trackMTDSigmaTofK_ = iEvent.get(trackMTDSigmaTofKToken_);
+  trackMTDSigmaTofP_ = iEvent.get(trackMTDSigmaTofPToken_);
 }
 
 bool VertexTimeAlgorithmFromTracksPID::vertexTime(float& vtxTime,
@@ -102,23 +114,36 @@ bool VertexTimeAlgorithmFromTracksPID::vertexTime(float& vtxTime,
         auto& trkInfo = v_trackInfo.back();
 
         trkInfo.trkWeight = trkWeight;
-        trkInfo.trkTimeError = trkTimeError;
+        trkInfo.trkTimeErrorHyp[0] =
+            std::sqrt(trkTimeError * trkTimeError +
+                      trackMTDSigmaTofPi_[trk.trackBaseRef()] * trackMTDSigmaTofPi_[trk.trackBaseRef()]);
+        trkInfo.trkTimeErrorHyp[1] =
+            std::sqrt(trkTimeError * trkTimeError +
+                      trackMTDSigmaTofK_[trk.trackBaseRef()] * trackMTDSigmaTofK_[trk.trackBaseRef()]);
+        trkInfo.trkTimeErrorHyp[2] =
+            std::sqrt(trkTimeError * trkTimeError +
+                      trackMTDSigmaTofP_[trk.trackBaseRef()] * trackMTDSigmaTofP_[trk.trackBaseRef()]);
 
         trkInfo.trkTimeHyp[0] = trkTime - trackMTDTofPi_[trk.trackBaseRef()];
         trkInfo.trkTimeHyp[1] = trkTime - trackMTDTofK_[trk.trackBaseRef()];
         trkInfo.trkTimeHyp[2] = trkTime - trackMTDTofP_[trk.trackBaseRef()];
 
-        auto const wgt = trkWeight / (trkTimeError * trkTimeError);
-        wsum += wgt;
+        double const wgt[3] = {trkWeight / (trkInfo.trkTimeErrorHyp[0] * trkInfo.trkTimeErrorHyp[0]),
+                               trkWeight / (trkInfo.trkTimeErrorHyp[1] * trkInfo.trkTimeErrorHyp[1]),
+                               trkWeight / (trkInfo.trkTimeErrorHyp[2] * trkInfo.trkTimeErrorHyp[2])};
 
         for (uint j = 0; j < 3; ++j) {
-          tsum += wgt * trkInfo.trkTimeHyp[j] * a[j];
+          wsum += wgt[j] * a[j];
+          tsum += wgt[j] * a[j] * trkInfo.trkTimeHyp[j];
         }
+
         LOG << "vertexTimeFromTracks:     track"
             << " pt=" << trk.track().pt() << " eta=" << trk.track().eta() << " phi=" << trk.track().phi()
             << " vtxWeight=" << trkWeight << " time=" << trkTime << " timeError=" << trkTimeError
-            << " timeQuality=" << trkTimeQuality << " timeHyp[pion]=" << trkInfo.trkTimeHyp[0]
-            << " timeHyp[kaon]=" << trkInfo.trkTimeHyp[1] << " timeHyp[proton]=" << trkInfo.trkTimeHyp[2];
+            << " timeQuality=" << trkTimeQuality << " timeHyp[pion]=" << trkInfo.trkTimeHyp[0] << " +/- "
+            << trkInfo.trkTimeErrorHyp[0] << " timeHyp[kaon]=" << trkInfo.trkTimeHyp[1] << " +/- "
+            << trkInfo.trkTimeErrorHyp[1] << " timeHyp[proton]=" << trkInfo.trkTimeHyp[2] << " +/- "
+            << trkInfo.trkTimeErrorHyp[2];
       }
     }
   }
@@ -132,27 +157,29 @@ bool VertexTimeAlgorithmFromTracksPID::vertexTime(float& vtxTime,
       w2sum = 0;
 
       for (auto const& trkInfo : v_trackInfo) {
-        double dt = trkInfo.trkTimeError;
+        double dt[3] = {trkInfo.trkTimeErrorHyp[0], trkInfo.trkTimeErrorHyp[1], trkInfo.trkTimeErrorHyp[2]};
         double e[3] = {0, 0, 0};
         const double cut_off = 4.5;
         double Z = vdt::fast_exp(
             -beta * cut_off);  // outlier rejection term Z_0 = exp(-beta * cut_off) = exp(-beta * 0.5 * 3 * 3)
+
         for (unsigned int j = 0; j < 3; j++) {
-          auto const tpull = (trkInfo.trkTimeHyp[j] - t0) / dt;
+          auto const tpull = (trkInfo.trkTimeHyp[j] - t0) / dt[j];
           e[j] = vdt::fast_exp(-0.5 * beta * tpull * tpull);
           Z += a[j] * e[j];
         }
 
-        double wsum_trk = 0;
+        double wsum_trk = 0, wsum_sigma_trk = 0;
         for (uint j = 0; j < 3; j++) {
           double wt = a[j] * e[j] / Z;
-          double w = wt * trkInfo.trkWeight / (dt * dt);
+          double w = wt * trkInfo.trkWeight / (dt[j] * dt[j]);
           wsum_trk += w;
+          wsum_sigma_trk += w * dt[j];
           tsum += w * trkInfo.trkTimeHyp[j];
         }
 
         wsum += wsum_trk;
-        w2sum += wsum_trk * wsum_trk * (dt * dt) / trkInfo.trkWeight;
+        w2sum += wsum_sigma_trk * wsum_sigma_trk;
       }
 
       if (wsum < 1e-10) {

--- a/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
@@ -28,7 +28,6 @@ bool VertexTimeAlgorithmLegacy4D::vertexTime(float& vtxTime, float& vtxTimeError
   double sumwt = 0.;
   double sumwt2 = 0.;
   double sumw = 0.;
-  double vartime = 0.;
 
   for (const auto& trk : vtx.originalTracks()) {
     const double time = trk.timeExt();
@@ -43,12 +42,8 @@ bool VertexTimeAlgorithmLegacy4D::vertexTime(float& vtxTime, float& vtxTimeError
   }
 
   if (sumw > 0) {
-    double sumsq = sumwt2 - sumwt * sumwt / sumw;
-    double chisq = num_track > 1 ? sumsq / double(num_track - 1) : sumsq / double(num_track);
-    vartime = chisq / sumw;
-
     vtxTime = sumwt / sumw;
-    vtxTimeError = sqrt(vartime);
+    vtxTimeError = 1 / sqrt(sumw);
     return true;
   }
 


### PR DESCRIPTION
#### PR description:

Following up on PR #43918, the newly introduced mass-dependent uncertainty on the time of flight of tracks has been propagated to the following reconstruction steps. This additional contribution to track time uncertainty is now:
 * included in the calculation for the MTD hit-to-track matching $\chi^2_t$ in `TrackExtenderWithMTD`;
 * has been included in the`VertexTimeAlgorithmFromTracksPID` vertex time algorithm for the 3D+t step, which now uses a different track time uncertainty for each mass hypothesis;
 * has been added to the total track time uncertainty in `TOFPIDProducer` (used in the 4D vertex reconstruction step through `DAClusterizerInZT` and `VertexTimeAlgorithmLegacy4D`).

Furthermore, an improved definition of vertex time uncertainty has been introduced in both `VertexTimeAlgorithmFromTracksPID` and `VertexTimeAlgorithmLegacy4D`.
All the mentioned modifications have been discussed and presented in MTD DPG meetings ([1](https://indico.cern.ch/event/1390639/contributions/5846173/attachments/2816111/4916250/MTDDPG_080324_palmeri.pdf), [2](https://indico.cern.ch/event/1395368/contributions/5866090/attachments/2825647/4935848/MTDDPG_220324_palmeri.pdf)).

#### PR validation:

The PR has been validated on TTbar14TeV and TTbar14TeV+PU200 samples, producing results documented in the two aforementioned presentations.