### PR TITLE
If `TClass::GetClass()` fails in `TypeWithDict::byName()`, include the argument class name in the exception message

### DIFF
--- a/FWCore/Reflection/src/TypeWithDict.cc
+++ b/FWCore/Reflection/src/TypeWithDict.cc
@@ -159,7 +159,14 @@ namespace edm {
     }
 
     // Handle classes
-    TClass* theClass = TClass::GetClass(name.c_str());
+    TClass* theClass = nullptr;
+    try {
+      theClass = TClass::GetClass(name.c_str());
+    } catch (cms::Exception& e) {
+      e.addContext("Calling edm::TypeWithDict::byName()");
+      e.addAdditionalInfo("Getting TClass for " + name);
+      throw;
+    }
     if (theClass != nullptr) {
       return TypeWithDict(theClass, property);
     }


### PR DESCRIPTION
#### PR description:

I investigated a user problem where ROOT header auto-parsing failed because of it trying to write the `cuda.pcm` to CVMFS. Printing out the `name` helped to point the actual problem (*). I thought adding the `name` to the exception message would help such investigations next time.

(*) the code used `edm::EDGetTokenT` instead of `device::EDGetToken` in an Alpaka module, that then lead to our check of "all consumed data types must have a dictionary" to make ROOT to auto-parse the headers, because the consumed (but incorrect!) type indeed did not have a dictionary

#### PR validation:

Checked the exception message in the example job. The added information would have immediately pointed towards the culprit.