### PR TITLE
[Puppi] Backport of #44050 (Hadronic tau recovery with protection for fromPV==2 charged particles) to 14_0_X

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -334,7 +334,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
               pReco.id = 1;
             else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) < fDZCut))
               pReco.id = 1;
-            else if (fUseFromPV2Recovery && lPack->fromPV() == (pat::PackedCandidate::PVTight) && (pReco.pt > fPtMinForFromPV2Recovery))
+            else if (fUseFromPV2Recovery && lPack->fromPV() == (pat::PackedCandidate::PVTight) &&
+                     (pReco.pt > fPtMinForFromPV2Recovery))
               pReco.id = 1;
             else if ((fUseDZforPileup) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) >= fDZCut))
               pReco.id = 2;

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -69,6 +69,7 @@ private:
   bool fPuppiDiagnostics;
   bool fPuppiNoLep;
   bool fUseFromPVLooseTight;
+  bool fUseFromPV2Recovery;
   bool fUseDZ;
   bool fUseDZforPileup;
   double fDZCut;
@@ -77,6 +78,7 @@ private:
   double fEtaMaxCharged;
   double fPtMaxPhotons;
   double fEtaMaxPhotons;
+  double fPtMinForFromPV2Recovery;
   uint fNumOfPUVtxsForCharged;
   double fDZCutForChargedFromPUVtxs;
   bool fUseExistingWeights;
@@ -94,6 +96,7 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fPuppiDiagnostics = iConfig.getParameter<bool>("puppiDiagnostics");
   fPuppiNoLep = iConfig.getParameter<bool>("puppiNoLep");
   fUseFromPVLooseTight = iConfig.getParameter<bool>("UseFromPVLooseTight");
+  fUseFromPV2Recovery = iConfig.getParameter<bool>("UseFromPV2Recovery");
   fUseDZ = iConfig.getParameter<bool>("UseDeltaZCut");
   fUseDZforPileup = iConfig.getParameter<bool>("UseDeltaZCutForPileup");
   fDZCut = iConfig.getParameter<double>("DeltaZCut");
@@ -102,6 +105,7 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
   fPtMaxPhotons = iConfig.getParameter<double>("PtMaxPhotons");
   fEtaMaxPhotons = iConfig.getParameter<double>("EtaMaxPhotons");
+  fPtMinForFromPV2Recovery = iConfig.getParameter<double>("PtMinForFromPV2Recovery");
   fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
   fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
@@ -285,6 +289,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
               pReco.id = 1;
             else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) < fDZCut))
               pReco.id = 1;
+            else if (fUseFromPV2Recovery && tmpFromPV == 2 && (pReco.pt > fPtMinForFromPV2Recovery))
+              pReco.id = 1;
             else if ((fUseDZforPileup) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) >= fDZCut))
               pReco.id = 2;
             else if (fUseFromPVLooseTight && tmpFromPV == 1)
@@ -327,6 +333,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             else if (std::abs(pReco.eta) > fEtaMaxCharged)
               pReco.id = 1;
             else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) < fDZCut))
+              pReco.id = 1;
+            else if (fUseFromPV2Recovery && lPack->fromPV() == (pat::PackedCandidate::PVTight) && (pReco.pt > fPtMinForFromPV2Recovery))
               pReco.id = 1;
             else if ((fUseDZforPileup) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) >= fDZCut))
               pReco.id = 2;
@@ -498,6 +506,7 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<bool>("puppiDiagnostics", false);
   desc.add<bool>("puppiNoLep", false);
   desc.add<bool>("UseFromPVLooseTight", false);
+  desc.add<bool>("UseFromPV2Recovery", false);
   desc.add<bool>("UseDeltaZCut", true);
   desc.add<bool>("UseDeltaZCutForPileup", true);
   desc.add<double>("DeltaZCut", 0.3);
@@ -508,6 +517,7 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("EtaMaxPhotons", 2.5);
   desc.add<double>("PtMaxNeutrals", 200.);
   desc.add<double>("PtMaxNeutralsStartSlope", 0.);
+  desc.add<double>("PtMinForFromPV2Recovery", 0.);
   desc.add<uint>("NumOfPUVtxsForCharged", 0);
   desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -36,6 +36,8 @@ puppi = _mod.PuppiProducer.clone(
                        DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
                        PtMaxNeutralsStartSlope = 20.,
                        PtMaxPhotons = 20.,
+                       UseFromPV2Recovery = True,
+                       PtMinForFromPV2Recovery = 4.,
                        clonePackedCands   = False, # should only be set to True for MiniAOD
                        algos          = { 
                         0: dict( 


### PR DESCRIPTION
Backport of #44050 

#### Original PR description:

(Making this PR on behalf of @abenecke)

It was spotted by the ParticleNet team that the efficiency to identify hadronic tau candidates for PUPPI jets at low pT is significantly lower than for CHS jets (https://indico.cern.ch/event/1300663/#2-particlenet-ak4-ak8-tagger-r). The main reason for this is that PUPPI treats particles with fromPV1&2 different than CHS.  It was found that PUPPI rejects one prong hadronic taus that most of the time has `fromPV==2` and `pT < 20 GeV` (`pT > 20 GeV` are protected by PUPPI already). This PR is supposed to recover the loss of hadronic tau candidates by keeping charged particles with `pT > 4 GeV` and `fromPV==2` while maintaining the jet energy resolution, eff and purity for jets. A comparison of different options was done in this presentation: https://indico.cern.ch/event/1364503/#5-puppi-tau-tune

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`