### PR TITLE
Irradiation Bias Correction (IBC) of pixel clusters at Alpaka

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
@@ -26,7 +26,8 @@ public:
                          const TrackerTopology& ttopo,
                          const SiPixelLorentzAngle* lorentzAngle,
                          const SiPixelGenErrorDBObject* genErrorDBObject,
-                         const SiPixelLorentzAngle* lorentzAngleWidth);
+                         const SiPixelLorentzAngle* lorentzAngleWidth,
+                         const bool irradiationBiasCorrection);
 
   // non-copyable
   PixelCPEFastParamsHost(PixelCPEFastParamsHost const&) = delete;
@@ -61,6 +62,7 @@ private:
   void fillParamsForDevice();
 
   Buffer buffer_;
+  bool IrradiationBiasCorrection_;
 };
 
 #endif  // RecoLocalTracker_SiPixelRecHits_interface_PixelCPEFastParamsHost_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEFastParamsHost.h
@@ -62,7 +62,7 @@ private:
   void fillParamsForDevice();
 
   Buffer buffer_;
-  bool IrradiationBiasCorrection_;
+  bool irradiationBiasCorrection_;
 };
 
 #endif  // RecoLocalTracker_SiPixelRecHits_interface_PixelCPEFastParamsHost_h

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -101,7 +101,7 @@ namespace pixelCPEforDevice {
 
     Frame frame;
     // estimated bias for generic CPE in cm
-    float deltax[CPEFastParametrisation::kGenErrorQBins], deltay[CPEFastParametrisation::kGenErrorQBins];
+    float deltax[kGenErrorQBins], deltay[kGenErrorQBins];
     // estimated bias for generic CPE in micron for dimension-1 clusters (single or double-width pixels) in cm
     // they do not depend on charge, so no splitting per qBins
     float dx1, dx2, dy1, dy2;
@@ -363,7 +363,7 @@ namespace pixelCPEforDevice {
     // whereas in CondFormats/SiPixelTransient/src/SiPixelGenError.cc it is the opposite
     // so we reverse the bin here -> kGenErrorQBins - 1 - bin
     int bin = 0;
-    bin = CPEFastParametrisation::kGenErrorQBins - 1 - cp.status[ic].qBin;
+    bin = kGenErrorQBins - 1 - cp.status[ic].qBin;
 
     if (cp.status[ic].isOneX) {  // size=1
       //for size = 1, the Lorentz shift is already accounted by the irradiation correction

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -67,7 +67,7 @@ namespace pixelCPEforDevice {
     uint16_t maxModuleStride;
     uint8_t numberOfLaddersInBarrel;
 
-    bool IrradiationBiasCorrection_;
+    bool irradiationBiasCorrection_;
   };
 
   struct DetParams {
@@ -350,7 +350,7 @@ namespace pixelCPEforDevice {
                                                   DetParams const& __restrict__ detParams,
                                                   ClusParams& cp,
                                                   uint32_t ic) {
-    if (!comParams.IrradiationBiasCorrection_) {
+    if (!comParams.irradiationBiasCorrection_) {
       return;
     }
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -346,18 +346,16 @@ namespace pixelCPEforDevice {
   }
 
   template <typename TrackerTraits>
-  constexpr inline void irradiationBiasCorrection(
-                                    CommonParams const& __restrict__ comParams,
-                                    DetParams const& __restrict__ detParams,
-                                    ClusParams& cp,
-                                    uint32_t ic)
-  {
-    if(!comParams.IrradiationBiasCorrection_){
+  constexpr inline void irradiationBiasCorrection(CommonParams const& __restrict__ comParams,
+                                                  DetParams const& __restrict__ detParams,
+                                                  ClusParams& cp,
+                                                  uint32_t ic) {
+    if (!comParams.IrradiationBiasCorrection_) {
       return;
     }
 
-    float ibc_x=0;
-    float ibc_y=0;
+    float ibc_x = 0;
+    float ibc_y = 0;
 
     // in detParams qBins are reversed bin0 -> smallest charge, bin4-> largest charge
     // whereas in CondFormats/SiPixelTransient/src/SiPixelGenError.cc it is the opposite
@@ -368,14 +366,12 @@ namespace pixelCPEforDevice {
     if (cp.status[ic].isOneX) {  // size=1
       //for size = 1, the Lorentz shift is already accounted by the irradiation correction
       ibc_x = ibc_x - detParams.shiftX;
-      if (cp.status[ic].isBigX){
+      if (cp.status[ic].isBigX) {
         ibc_x -= detParams.dx2;
-      }
-      else{
+      } else {
         ibc_x -= detParams.dx1;
       }
-    }
-    else {  // size>1
+    } else {  // size>1
       ibc_x -= detParams.deltax[bin];
     }
 
@@ -386,13 +382,12 @@ namespace pixelCPEforDevice {
         ibc_y -= detParams.dy2;
       else
         ibc_y -= detParams.dy1;
-    }
-    else {  // size>1
+    } else {  // size>1
       ibc_y -= detParams.deltay[bin];
     }
 
-  cp.xpos[ic] += ibc_x;
-  cp.ypos[ic] += ibc_y;
+    cp.xpos[ic] += ibc_x;
+    cp.ypos[ic] += ibc_y;
   }
 
   template <typename TrackerTraits>

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -360,30 +360,28 @@ namespace pixelCPEforDevice {
     // in detParams qBins are reversed bin0 -> smallest charge, bin4-> largest charge
     // whereas in CondFormats/SiPixelTransient/src/SiPixelGenError.cc it is the opposite
     // so we reverse the bin here -> kGenErrorQBins - 1 - bin
-    int bin = 0;
-    bin = kGenErrorQBins - 1 - cp.status[ic].qBin;
+    int bin = kGenErrorQBins - 1 - cp.status[ic].qBin;
 
     if (cp.status[ic].isOneX) {  // size=1
       //for size = 1, the Lorentz shift is already accounted by the irradiation correction
-      ibc_x = ibc_x - detParams.shiftX;
-      if (cp.status[ic].isBigX) {
+      ibc_x = -detParams.shiftX;
+      if (cp.status[ic].isBigX)
         ibc_x -= detParams.dx2;
-      } else {
+      else
         ibc_x -= detParams.dx1;
-      }
     } else {  // size>1
-      ibc_x -= detParams.deltax[bin];
+      ibc_x = -detParams.deltax[bin];
     }
 
     if (cp.status[ic].isOneY) {  // size=1
       //for size = 1, the Lorentz shift is already accounted by the irradiation correction
-      ibc_y = ibc_y - detParams.shiftX;
+      ibc_y = -detParams.shiftY;
       if (cp.status[ic].isBigY)
         ibc_y -= detParams.dy2;
       else
         ibc_y -= detParams.dy1;
     } else {  // size>1
-      ibc_y -= detParams.deltay[bin];
+      ibc_y = -detParams.deltay[bin];
     }
 
     cp.xpos[ic] += ibc_x;

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
@@ -42,6 +42,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     edm::ParameterSet pset_;
     bool useErrorsFromTemplates_;
+    bool irradiationBiasCorrection_;
   };
 
   using namespace edm;
@@ -52,7 +53,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     auto const& myname = p.getParameter<std::string>("ComponentName");
     auto const& magname = p.getParameter<edm::ESInputTag>("MagneticFieldRecord");
     useErrorsFromTemplates_ = p.getParameter<bool>("UseErrorsFromTemplates");
-
+    irradiationBiasCorrection_ = p.getParameter<bool>("IrradiationBiasCorrection");
     auto cc = setWhatProduced(this, myname);
     magfieldToken_ = cc.consumes(magname);
     pDDToken_ = cc.consumes();
@@ -84,8 +85,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                    iRecord.get(hTTToken_),
                                                                    &iRecord.get(lorentzAngleToken_),
                                                                    genErrorDBObjectProduct,
-                                                                   lorentzAngleWidthProduct);
-  }
+                                                                   lorentzAngleWidthProduct,
+                                                                   irradiationBiasCorrection_);
+}
 
   template <typename TrackerTraits>
   void PixelCPEFastParamsESProducerAlpaka<TrackerTraits>::fillDescriptions(
@@ -102,6 +104,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     desc.add<double>("EdgeClusterErrorX", 50.0);
     desc.add<double>("EdgeClusterErrorY", 85.0);
     desc.add<bool>("UseErrorsFromTemplates", true);
+    desc.add<bool>("IrradiationBiasCorrection", false);
     desc.add<bool>("TruncatePixelCharge", true);
 
     std::string name = "PixelCPEFastParams";

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelCPEFastParamsESProducerAlpaka.cc
@@ -87,7 +87,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                                                    genErrorDBObjectProduct,
                                                                    lorentzAngleWidthProduct,
                                                                    irradiationBiasCorrection_);
-}
+  }
 
   template <typename TrackerTraits>
   void PixelCPEFastParamsESProducerAlpaka<TrackerTraits>::fillDescriptions(

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHits.h
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHits.h
@@ -184,6 +184,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
               pixelCPEforDevice::errorFromDB<TrackerTraits>(
                   cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
+              //We need to call this after the errorFromDB as it calculates some cluster properties needed for IBC
+              pixelCPEforDevice::irradiationBiasCorrection<TrackerTraits>(
+                  cpeParams->commonParams(), cpeParams->detParams(me), clusParams, ic);
 
               // store it
               hits[h].chargeAndStatus().charge = clusParams.charge[ic];

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -369,7 +369,6 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
   theClusterParam.pixmx = std::numeric_limits<int>::max();  // max pixel charge for truncation of 2-D cluster
 
   theClusterParam.sigmay = -999.9;  // CPE Generic y-error for multi-pixel cluster
-  theClusterParam.sigmay = -999.9;  // CPE Generic y-error for multi-pixel cluster
   theClusterParam.deltay = -999.9;  // CPE Generic y-bias for multi-pixel cluster
   theClusterParam.sigmax = -999.9;  // CPE Generic x-error for multi-pixel cluster
   theClusterParam.deltax = -999.9;  // CPE Generic x-bias for multi-pixel cluster

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -32,7 +32,7 @@ PixelCPEFastParamsHost<TrackerTraits>::PixelCPEFastParamsHost(edm::ParameterSet 
           << (*genErrorDBObject_).version();
   }
 
-  IrradiationBiasCorrection_ = irradiationBiasCorrection;
+  irradiationBiasCorrection_ = irradiationBiasCorrection;
   fillParamsForDevice();
 }
 
@@ -48,7 +48,7 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
   buffer_->commonParams().thePitchY = m_DetParams[0].thePitchY;
 
   buffer_->commonParams().numberOfLaddersInBarrel = TrackerTraits::numberOfLaddersInBarrel;
-  buffer_->commonParams().IrradiationBiasCorrection_ = IrradiationBiasCorrection_;
+  buffer_->commonParams().irradiationBiasCorrection_ = irradiationBiasCorrection_;
   LogDebug("PixelCPEFastParamsHost") << "pitch & thickness " << buffer_->commonParams().thePitchX << ' '
                                      << buffer_->commonParams().thePitchY << "  "
                                      << buffer_->commonParams().theThicknessB << ' '
@@ -385,7 +385,7 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
   SiPixelGenError gtempl(this->thePixelGenError_);
   int gtemplID = theDetParam.detTemplateId;
 
-  bool IrradiationBiasCorrection_ = true;
+  bool irradiationBiasCorrection_ = true;
 
   theClusterParam.qBin_ = gtempl.qbin(gtemplID,
                                       theClusterParam.cotalpha,
@@ -393,7 +393,7 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
                                       locBz,
                                       locBx,
                                       qclus,
-                                      IrradiationBiasCorrection_,
+                                      irradiationBiasCorrection_,
                                       theClusterParam.pixmx,
                                       theClusterParam.sigmay,
                                       theClusterParam.deltay,

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -385,8 +385,6 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
   SiPixelGenError gtempl(this->thePixelGenError_);
   int gtemplID = theDetParam.detTemplateId;
 
-  bool irradiationBiasCorrection_ = true;
-
   theClusterParam.qBin_ = gtempl.qbin(gtemplID,
                                       theClusterParam.cotalpha,
                                       theClusterParam.cotbeta,

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -228,16 +228,16 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
     int qbin = pixelCPEforDevice::kGenErrorQBins;  // low charge
     int k = 0;
     int qClusIncrement = 100;
-    for (int qclus = 1000; k < CPEFastParametrisation::kGenErrorQBins; qclus += qClusIncrement) {//increase charge until we cover all qBin categories
+    for (int qclus = 1000; k < pixelCPEforDevice::kGenErrorQBins; qclus += qClusIncrement) {//increase charge until we cover all qBin categories
       errorFromTemplates(p, cp, qclus);
       if (cp.qBin_ == qbin)
         continue;
       qbin = cp.qBin_;
-      //There are two qBin categories with low charge. Their qBins are 5 and 4 (CPEFastParametrisation::kGenErrorQBins, CPEFastParametrisation::kGenErrorQBins-1)
+      //There are two qBin categories with low charge. Their qBins are 5 and 4 (pixelCPEforDevice::kGenErrorQBins, pixelCPEforDevice::kGenErrorQBins-1)
       //We increment charge until qBin gets switched from 5 and then we start writing detParams as we are not interested in cases with qBin=5
       //The problem is that with a too large qClusIncrement, we may go directly from 5 to 3, breaking the logic of the for loop
       //Therefore, we start with lower increment (100) until we get to qBin=4
-      if(qbin<CPEFastParametrisation::kGenErrorQBins){
+      if(qbin<pixelCPEforDevice::kGenErrorQBins){
         qClusIncrement=1000;
       }
       g.xfact[k] = cp.sigmax;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -175,10 +175,10 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
     g.sy1 = std::max(21, toMicron(cp.sy1));  // for some angles sy1 is very small
     g.sy2 = std::max(55, toMicron(cp.sy2));  // sometimes sy2 is smaller than others (due to angle?)
 
-    g.dx1 = cp.dx1; 
-    g.dx2 = cp.dx2; 
-    g.dy1 = cp.dy1; 
-    g.dy2 = cp.dy2; 
+    g.dx1 = cp.dx1;
+    g.dx2 = cp.dx2;
+    g.dy1 = cp.dy1;
+    g.dy2 = cp.dy2;
 
     //sample xerr as function of position
     // moduleOffsetX is the definition of TrackerTraits::xOffset,
@@ -228,7 +228,8 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
     int qbin = pixelCPEforDevice::kGenErrorQBins;  // low charge
     int k = 0;
     int qClusIncrement = 100;
-    for (int qclus = 1000; k < pixelCPEforDevice::kGenErrorQBins; qclus += qClusIncrement) {//increase charge until we cover all qBin categories
+    for (int qclus = 1000; k < pixelCPEforDevice::kGenErrorQBins;
+         qclus += qClusIncrement) {  //increase charge until we cover all qBin categories
       errorFromTemplates(p, cp, qclus);
       if (cp.qBin_ == qbin)
         continue;
@@ -237,8 +238,8 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
       //We increment charge until qBin gets switched from 5 and then we start writing detParams as we are not interested in cases with qBin=5
       //The problem is that with a too large qClusIncrement, we may go directly from 5 to 3, breaking the logic of the for loop
       //Therefore, we start with lower increment (100) until we get to qBin=4
-      if(qbin<pixelCPEforDevice::kGenErrorQBins){
-        qClusIncrement=1000;
+      if (qbin < pixelCPEforDevice::kGenErrorQBins) {
+        qClusIncrement = 1000;
       }
       g.xfact[k] = cp.sigmax;
       g.yfact[k] = cp.sigmay;
@@ -250,9 +251,10 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
       g.minCh[k++] = qclus;
 
 #ifdef EDM_ML_DEBUG
-      LogDebug("PixelCPEFastParamsHost") << i << ' ' << g.rawId << ' ' << cp.cotalpha << ' ' << qclus << ' ' << cp.qBin_ << ' '
-                               << cp.pixmx << ' ' << m * cp.sigmax << ' ' << m * cp.sx1 << ' ' << m * cp.sx2 << ' '
-                               << m * cp.sigmay << ' ' << m * cp.sy1 << ' ' << m * cp.sy2 << std::endl;
+      LogDebug("PixelCPEFastParamsHost") << i << ' ' << g.rawId << ' ' << cp.cotalpha << ' ' << qclus << ' ' << cp.qBin_
+                                         << ' ' << cp.pixmx << ' ' << m * cp.sigmax << ' ' << m * cp.sx1 << ' '
+                                         << m * cp.sx2 << ' ' << m * cp.sigmay << ' ' << m * cp.sy1 << ' ' << m * cp.sy2
+                                         << std::endl;
 #endif  // EDM_ML_DEBUG
     }
 
@@ -413,14 +415,14 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
   theClusterParam.sigmay = theClusterParam.sigmay * pixelCPEforDevice::micronsToCm;
   theClusterParam.sy1 = theClusterParam.sy1 * pixelCPEforDevice::micronsToCm;
   theClusterParam.sy2 = theClusterParam.sy2 * pixelCPEforDevice::micronsToCm;
-  
+
   theClusterParam.deltax = theClusterParam.deltax * pixelCPEforDevice::micronsToCm;
   theClusterParam.dx1 = theClusterParam.dx1 * pixelCPEforDevice::micronsToCm;
   theClusterParam.dx2 = theClusterParam.dx2 * pixelCPEforDevice::micronsToCm;
 
   theClusterParam.deltay = theClusterParam.deltay * pixelCPEforDevice::micronsToCm;
   theClusterParam.dy1 = theClusterParam.dy1 * pixelCPEforDevice::micronsToCm;
-  theClusterParam.dy2 = theClusterParam.dy2 * pixelCPEforDevice::micronsToCm; 
+  theClusterParam.dy2 = theClusterParam.dy2 * pixelCPEforDevice::micronsToCm;
 }
 
 template <>


### PR DESCRIPTION
#### PR description:

Implemented Irradiation Bias Correction (IBC) in the Alpaka version of the generic algorithm for esimating pixel cluster positions. Legacy implementation can be found [here](https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L300-L335) and [here](https://github.com/cms-sw/cmssw/blob/master/CondFormats/SiPixelTransient/src/SiPixelGenError.cc#L758-L773). The feature may be used to study how much the IBC will help with generic CPE algorithm at high irradiation doses and may be turned on if favorable.

The PR also includes a bug fix in the SiPixelRecHits/src/PixelCPEFastParamsHost.cc where template error parameters would be loaded at incorrect charge categories for certain modules. Small changes in standard workflows are expected as the errors of the RecHit positions on affected modules will differ.

#### PR validation:

Ran "11634.402" upgrade workflow in CMSSW_14_1_0_pre1 on 1000 events. Compared the results of "step3_RAW2DIGI_RECO_VALIDATION_DQM" with and without IBC using `harvestTrackValidationPlots.py` and `makeTrackValidationPlots.py`. Comparison can be found [here](https://mrogulji.web.cern.ch/mrogulji/plots_ibc_on_off/index.html). Some effects to tracking are observerd, but no major changes, which was expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.