### PR TITLE
Produce and use custom HGCal towers for baseline GCT calo jets and taus.

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -175,6 +175,8 @@ def _appendPhase2Digis(obj):
         'keep *_l1tHGCalBackEndLayer2Producer_*_*',
         'keep *_l1tHGCalTowerMapProducer_*_*',
         'keep *_l1tHGCalTowerProducer_*_*',
+        'keep *_l1tHGCalEnergySplitTowerMapProducer_*_*',
+        'keep *_l1tHGCalEnergySplitTowerProducer_*_*',
         'keep *_l1tEGammaClusterEmuProducer_*_*',
         'keep *_l1tVertexFinder_*_*',
         'keep *_l1tVertexFinderEmulator_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -121,12 +121,12 @@ from L1Trigger.L1CaloTrigger.l1tNNCaloTauEmulator_cfi import *
 _phase2_siml1emulator.add(l1tNNCaloTauEmulator)
 
 # ---- Produce the emulated CaloJets and Taus
-from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cff import *
 
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
-_phase2_siml1emulator.add(l1tPhase2CaloJetEmulator)
+_phase2_siml1emulator.add(L1TCaloJetsTausTask)
 
 
 # ########################################################################

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -126,7 +126,7 @@ from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cff import *
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
-_phase2_siml1emulator.add(L1TCaloJetsTausTask)
+_phase2_siml1emulator.add(l1tCaloJetsTausTask)
 
 
 # ########################################################################

--- a/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
@@ -1,0 +1,21 @@
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
+
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import *
+from L1Trigger.L1THGCal.l1tHGCalTowerMapProducer_cfi import L1TTriggerTowerConfig_energySplit
+from L1Trigger.L1THGCal.l1tHGCalTowerProducer_cfi import *
+
+# Add HGCal tower producers for energy split towers
+# Based on custom_towers_energySplit in L1Trigger/L1THGCal/python/customTowers.py
+parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
+l1tHGCalEnergySplitTowerMapProducer = l1tHGCalTowerMapProducer.clone()
+l1tHGCalEnergySplitTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
+l1tHGCalEnergySplitTowerProducer = l1tHGCalTowerProducer.clone( InputTowerMaps = ("l1tHGCalEnergySplitTowerMapProducer","HGCalTowerMapProcessor") )
+L1THGCalEnergySplitTowersTask = cms.Task(l1tHGCalEnergySplitTowerMapProducer, l1tHGCalEnergySplitTowerProducer)
+
+# Use energy split towers in calo jet/tau emulator
+l1tPhase2CaloJetEmulator.hgcalTowers = ("l1tHGCalEnergySplitTowerProducer","HGCalTowerProcessor")
+
+L1TCaloJetsTausTask = cms.Task(
+    L1THGCalEnergySplitTowersTask,
+    l1tPhase2CaloJetEmulator
+)

--- a/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tPhase2CaloJetEmulator_cff.py
@@ -10,12 +10,12 @@ parameters_towers_2d = L1TTriggerTowerConfig_energySplit.clone()
 l1tHGCalEnergySplitTowerMapProducer = l1tHGCalTowerMapProducer.clone()
 l1tHGCalEnergySplitTowerMapProducer.ProcessorParameters.towermap_parameters.L1TTriggerTowerConfig = parameters_towers_2d
 l1tHGCalEnergySplitTowerProducer = l1tHGCalTowerProducer.clone( InputTowerMaps = ("l1tHGCalEnergySplitTowerMapProducer","HGCalTowerMapProcessor") )
-L1THGCalEnergySplitTowersTask = cms.Task(l1tHGCalEnergySplitTowerMapProducer, l1tHGCalEnergySplitTowerProducer)
+l1tHGCalEnergySplitTowersTask = cms.Task(l1tHGCalEnergySplitTowerMapProducer, l1tHGCalEnergySplitTowerProducer)
 
 # Use energy split towers in calo jet/tau emulator
 l1tPhase2CaloJetEmulator.hgcalTowers = ("l1tHGCalEnergySplitTowerProducer","HGCalTowerProcessor")
 
-L1TCaloJetsTausTask = cms.Task(
-    L1THGCalEnergySplitTowersTask,
+l1tCaloJetsTausTask = cms.Task(
+    l1tHGCalEnergySplitTowersTask,
     l1tPhase2CaloJetEmulator
 )


### PR DESCRIPTION
#### PR description:

Modify Phase-2 GCT jet and tau objects so that they use non-default HGCal towers as input.  I made a new task that produces these new inputs towers and produces the GCT objects with these towers. The additional towers are added to the event content.

#### PR validation:

Tested in [#1226 in cms-l1t-offline](https://github.com/cms-l1t-offline/cmssw/pull/1226). New objects are produced and consumed by GCT producer, and physics performance of GCT jets and taus are as expected. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: