### PR TITLE
[14_1_X SIM] MC truth reorganisation

### DIFF
--- a/SimG4Core/Application/interface/EventAction.h
+++ b/SimG4Core/Application/interface/EventAction.h
@@ -31,7 +31,7 @@ public:
 
   inline const TrackContainer* trackContainer() const { return m_trackManager->trackContainer(); }
 
-  TrackWithHistory* getTrackByID(unsigned int id) const { return m_trackManager->getTrackByID(id); }
+  //TrackWithHistory* getTrackByID(unsigned int id) const { return m_trackManager->getTrackByID(id); }
 
   SimActivityRegistry::BeginOfEventSignal m_beginOfEventSignal;
   SimActivityRegistry::EndOfEventSignal m_endOfEventSignal;

--- a/SimG4Core/Application/interface/TrackingAction.h
+++ b/SimG4Core/Application/interface/TrackingAction.h
@@ -5,6 +5,9 @@
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
 
 #include "G4UserTrackingAction.hh"
+#include "G4Region.hh"
+
+#include <vector>
 
 class SimTrackManager;
 class TrackWithHistory;
@@ -38,7 +41,9 @@ private:
   bool checkTrack_;
   bool doFineCalo_;
   bool saveCaloBoundaryInformation_;
-  double eMinFine_;
+  double ekinMin_;
+  std::vector<double> ekinMinRegion_;
+  std::vector<G4Region*> ptrRegion_;
 };
 
 #endif

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -260,7 +260,7 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     }
     edm::LogVerbatim("SimG4CoreApplication")
         << "Produced " << p1->size()
-	<< " SimTracks: pdg, 4-momentum(GeV), vertexID, mcTruthID, flagBoundary, trackID at boundary";
+        << " SimTracks: pdg, 4-momentum(GeV), vertexID, mcTruthID, flagBoundary, trackID at boundary";
     if (1 < m_verbose) {
       int nn = p1->size();
       for (int i = 0; i < nn; ++i) {
@@ -278,8 +278,7 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::unique_ptr<edm::PSimHitContainer> product(new edm::PSimHitContainer);
       tracker->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())
-        edm::LogVerbatim("SimG4CoreApplication")
-	    << "Produced " << product->size() << " tracker hits <" << name << ">";
+        edm::LogVerbatim("SimG4CoreApplication") << "Produced " << product->size() << " tracker hits <" << name << ">";
       e.put(std::move(product), name);
     }
   }
@@ -289,8 +288,7 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::unique_ptr<edm::PCaloHitContainer> product(new edm::PCaloHitContainer);
       calo->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())
-        edm::LogVerbatim("SimG4CoreApplication")
-	    << "Produced " << product->size() << " calo hits <" << name << ">";
+        edm::LogVerbatim("SimG4CoreApplication") << "Produced " << product->size() << " calo hits <" << name << ">";
       e.put(std::move(product), name);
     }
   }

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -250,14 +250,17 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   evt->load(*p2);
 
   if (0 < m_verbose) {
-    edm::LogVerbatim("SimG4CoreApplication") << "Produced " << p2->size() << " SimVertex objects";
+    edm::LogVerbatim("SimG4CoreApplication")
+        << "Produced " << p2->size() << " SimVertecies: position(cm), time(s), parentID, vertexID, processType";
     if (1 < m_verbose) {
       int nn = p2->size();
       for (int i = 0; i < nn; ++i) {
-        edm::LogVerbatim("Vertex") << " " << (*p2)[i] << " " << (*p2)[i].processType();
+        edm::LogVerbatim("Vertex") << " " << i << ". " << (*p2)[i] << " " << (*p2)[i].processType();
       }
     }
-    edm::LogVerbatim("SimG4CoreApplication") << "Produced " << p1->size() << " SimTrack objects";
+    edm::LogVerbatim("SimG4CoreApplication")
+        << "Produced " << p1->size()
+	<< " SimTracks: pdg, 4-momentum(GeV), vertexID, mcTruthID, flagBoundary, trackID at boundary";
     if (1 < m_verbose) {
       int nn = p1->size();
       for (int i = 0; i < nn; ++i) {
@@ -275,7 +278,8 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::unique_ptr<edm::PSimHitContainer> product(new edm::PSimHitContainer);
       tracker->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())
-        edm::LogVerbatim("SimG4CoreApplication") << "Produced " << product->size() << " tracker hits <" << name << ">";
+        edm::LogVerbatim("SimG4CoreApplication")
+	    << "Produced " << product->size() << " tracker hits <" << name << ">";
       e.put(std::move(product), name);
     }
   }
@@ -285,7 +289,8 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::unique_ptr<edm::PCaloHitContainer> product(new edm::PCaloHitContainer);
       calo->fillHits(*product, name);
       if (0 < m_verbose && product != nullptr && !product->empty())
-        edm::LogVerbatim("SimG4CoreApplication") << "Produced " << product->size() << " calo hits <" << name << ">";
+        edm::LogVerbatim("SimG4CoreApplication")
+	    << "Produced " << product->size() << " calo hits <" << name << ">";
       e.put(std::move(product), name);
     }
   }

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -55,8 +55,11 @@ common_UseLuminosity = cms.PSet(
 common_MCtruth = cms.PSet(
     DoFineCalo = cms.bool(False),
     SaveCaloBoundaryInformation = cms.bool(False),
+    PersistencyEmin = cms.double(50.0), # in GeV
+    RegionEmin = cms.vdouble(), # in GeV
+    RegionEminName = cms.vstring(), # name of regions for reduced 
     # currently unused; left in place for future studies
-    EminFineTrack = cms.double(10000.0),
+    EminFineTrack = cms.double(10000.0), #in MeV
     FineCaloNames = cms.vstring('ECAL', 'HCal', 'HGCal', 'HFNoseVol', 'VCAL'),
     FineCaloLevels = cms.vint32(4, 4, 8, 3, 3),
     UseFineCalo = cms.vint32(2, 3),
@@ -73,7 +76,7 @@ fineCalo.toModify(common_MCtruth,
 ## enable CaloBoundary information for all Phase2 workflows
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(common_MCtruth,
-        SaveCaloBoundaryInformation = True
+    SaveCaloBoundaryInformation = True
 )
 
 g4SimHits = cms.EDProducer("OscarMTProducer",

--- a/SimG4Core/Application/src/EventAction.cc
+++ b/SimG4Core/Application/src/EventAction.cc
@@ -52,14 +52,14 @@ void EventAction::EndOfEventAction(const G4Event* anEvent) {
     return;
   }
 
-  m_trackManager->storeTracks();
+  //m_trackManager->storeTracks();
 
   // dispatch now end of event
   EndOfEvent e(anEvent);
   m_endOfEventSignal(&e);
 
   // delete transient objects
-  m_trackManager->reset();
+  // m_trackManager->reset();
 }
 
 void EventAction::abortEvent() { m_runInterface->abortEvent(); }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -551,15 +551,13 @@ TmpSimEvent* RunManagerMTWorker::produce(const edm::Event& inpevt,
   // We have to do the per-thread initialization, and per-thread
   // per-run initialization here by ourselves.
 
-  edm::LogVerbatim("SimG4CoreApplication")
-    << "RunManagerMTWorker::produce: start EventID=" << inpevt.id().event();
-  
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: start EventID=" << inpevt.id().event();
+
   assert(m_tls != nullptr and m_tls->threadInitialized);
   // Initialize run
   if (inpevt.id().run() != m_tls->currentRunNumber) {
     edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: RunID= " << inpevt.id().run()
-	<< "  TLS RunID= " << m_tls->currentRunNumber;
+        << "RunManagerMTWorker::produce: RunID= " << inpevt.id().run() << "  TLS RunID= " << m_tls->currentRunNumber;
     if (m_tls->currentRunNumber != 0 && !m_tls->runTerminated) {
       // If previous run in this thread was not terminated via endRun() call,
       // then terminate it now
@@ -569,15 +567,12 @@ TmpSimEvent* RunManagerMTWorker::produce(const edm::Event& inpevt,
     m_tls->currentRunNumber = inpevt.id().run();
   }
 
-    edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: Generate event ";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: Generate event ";
   m_tls->currentEvent.reset(generateEvent(inpevt));
 
-    edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: clean TmpSimEvent ";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: clean TmpSimEvent ";
   m_simEvent.clear();
-    edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: setEvent ";
+  edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: setEvent ";
   m_simEvent.setHepEvent(m_generator.genEvent());
   m_simEvent.setWeight(m_generator.eventWeight());
   if (m_generator.genVertex() != nullptr) {
@@ -594,16 +589,14 @@ TmpSimEvent* RunManagerMTWorker::produce(const edm::Event& inpevt,
 
   } else {
     edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: start EventID=" << inpevt.id().event()
-        << " StreamID=" << inpevt.streamID()
+        << "RunManagerMTWorker::produce: start EventID=" << inpevt.id().event() << " StreamID=" << inpevt.streamID()
         << " threadIndex=" << getThreadIndex() << " weight=" << m_simEvent.weight();
 
     m_tls->trackManager.get()->initialisePrimaries(m_tls->currentEvent.get());
 
     edm::LogVerbatim("SimG4CoreApplication")
-        << "RunManagerMTWorker::produce: Geant4 primary: "
-        << m_tls->currentEvent->GetNumberOfPrimaryVertex() << " vertices and "
-        << m_simEvent.nTracks() << " particles";
+        << "RunManagerMTWorker::produce: Geant4 primary: " << m_tls->currentEvent->GetNumberOfPrimaryVertex()
+        << " vertices and " << m_simEvent.nTracks() << " particles";
     // process event
     if (m_UseG4EventManager) {
       m_tls->kernel->GetEventManager()->ProcessOneEvent(m_tls->currentEvent.get());
@@ -617,7 +610,7 @@ TmpSimEvent* RunManagerMTWorker::produce(const edm::Event& inpevt,
   for (auto& sd : m_tls->sensCaloDets) {
     sd->reset();
   }
-  
+
   edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: ended Event " << inpevt.id().event();
   return &m_simEvent;
 }

--- a/SimG4Core/Application/src/TrackingAction.cc
+++ b/SimG4Core/Application/src/TrackingAction.cc
@@ -24,8 +24,7 @@ TrackingAction::TrackingAction(SimTrackManager* stm, CMSSteppingVerbose* sv, con
       doFineCalo_(p.getParameter<bool>("DoFineCalo")),
       saveCaloBoundaryInformation_(p.getParameter<bool>("SaveCaloBoundaryInformation")),
       ekinMin_(p.getParameter<double>("PersistencyEmin") * CLHEP::GeV),
-      ekinMinRegion_(p.getParameter<std::vector<double>>("RegionEmin"))
-{
+      ekinMinRegion_(p.getParameter<std::vector<double>>("RegionEmin")) {
   double eth = p.getParameter<double>("EminFineTrack") * CLHEP::MeV;
   if (doFineCalo_ && eth < ekinMin_) {
     ekinMin_ = eth;
@@ -72,22 +71,20 @@ void TrackingAction::PreUserTrackingAction(const G4Track* aTrack) {
 
 void TrackingAction::PostUserTrackingAction(const G4Track* aTrack) {
   // Tracks in history may be upgraded to stored secondary tracks,
-  // which cross the boundary between Tracker and Calo 
+  // which cross the boundary between Tracker and Calo
   int id = aTrack->GetTrackID();
   bool ok = trkInfo_->storeTrack();
   if (trkInfo_->crossedBoundary()) {
-    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(),
-					    trkInfo_->getMomentumAtBoundary());
+    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(), trkInfo_->getMomentumAtBoundary());
     ok = (ok || saveCaloBoundaryInformation_);
   }
 
   trackManager_->addTrack(ok);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("TrackingAction")
-      << "TrackingAction end track=" << id << "  "
-      << aTrack->GetDefinition()->GetParticleName() 
-      << " proposed to be saved= " << ok << " end point " << aTrack->GetPosition();
+  edm::LogVerbatim("TrackingAction") << "TrackingAction end track=" << id << "  "
+                                     << aTrack->GetDefinition()->GetParticleName() << " proposed to be saved= " << ok
+                                     << " end point " << aTrack->GetPosition();
 #endif
 
   EndOfTrack et(aTrack);

--- a/SimG4Core/Application/src/TrackingAction.cc
+++ b/SimG4Core/Application/src/TrackingAction.cc
@@ -23,30 +23,29 @@ TrackingAction::TrackingAction(SimTrackManager* stm, CMSSteppingVerbose* sv, con
       checkTrack_(p.getUntrackedParameter<bool>("CheckTrack", false)),
       doFineCalo_(p.getParameter<bool>("DoFineCalo")),
       saveCaloBoundaryInformation_(p.getParameter<bool>("SaveCaloBoundaryInformation")),
-      eMinFine_(p.getParameter<double>("EminFineTrack") * CLHEP::MeV) {
-  if (!doFineCalo_) {
-    eMinFine_ = DBL_MAX;
+      ekinMin_(p.getParameter<double>("PersistencyEmin") * CLHEP::GeV),
+      ekinMinRegion_(p.getParameter<std::vector<double>>("RegionEmin"))
+{
+  double eth = p.getParameter<double>("EminFineTrack") * CLHEP::MeV;
+  if (doFineCalo_ && eth < ekinMin_) {
+    ekinMin_ = eth;
   }
   edm::LogVerbatim("SimG4CoreApplication") << "TrackingAction: boundary: " << saveCaloBoundaryInformation_
-                                           << "; DoFineCalo: " << doFineCalo_ << "; EminFineTrack(MeV)=" << eMinFine_;
+                                           << "; DoFineCalo: " << doFineCalo_ << "; ekinMin(MeV)=" << ekinMin_;
+  if (!ekinMinRegion_.empty()) {
+    ptrRegion_.resize(ekinMinRegion_.size(), nullptr);
+  }
 }
 
 void TrackingAction::PreUserTrackingAction(const G4Track* aTrack) {
   g4Track_ = aTrack;
-  currentTrack_ = new TrackWithHistory(aTrack, aTrack->GetParentID());
+  currentTrack_ = trackManager_->getTrackWithHistory(aTrack);
 
   BeginOfTrack bt(aTrack);
   m_beginOfTrackSignal(&bt);
 
   trkInfo_ = static_cast<TrackInformation*>(aTrack->GetUserInformation());
 
-  // Always save primaries
-  // Decays from primaries are marked as primaries, but are not saved by
-  // default. The primary is the earliest ancestor, and it must be saved.
-  if (trkInfo_->isPrimary()) {
-    trackManager_->cleanTracksWithHistory();
-    currentTrack_->setToBeSaved();
-  }
   if (nullptr != steppingVerbose_) {
     steppingVerbose_->trackStarted(aTrack, false);
     if (aTrack->GetTrackID() == endPrintTrackID_) {
@@ -64,41 +63,32 @@ void TrackingAction::PreUserTrackingAction(const G4Track* aTrack) {
                                  << aTrack->GetVertexPosition().z() / CLHEP::cm << ")"
                                  << " parentid=" << aTrack->GetParentID();
 #endif
-  if (ekin > eMinFine_) {
-    // It is impossible to tell whether daughter tracks if this track may need to be saved at
-    // this point; Therefore, every track above the threshold is put in history,
-    // so that it can potentially be saved later.
-    trkInfo_->putInHistory();
+  if (ekin > ekinMin_) {
+    // Each track with energy above the threshold should be saved
+    trkInfo_->setStoreTrack();
+    currentTrack_->setToBeSaved();
   }
 }
 
 void TrackingAction::PostUserTrackingAction(const G4Track* aTrack) {
-  // Add the post-step position for every track in history to the TrackManager.
-  // Tracks in history may be upgraded to stored tracks, at which point
-  // the post-step position is needed again.
+  // Tracks in history may be upgraded to stored secondary tracks,
+  // which cross the boundary between Tracker and Calo 
   int id = aTrack->GetTrackID();
-  bool ok = (trkInfo_->storeTrack() || currentTrack_->saved());
+  bool ok = trkInfo_->storeTrack();
   if (trkInfo_->crossedBoundary()) {
-    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(), trkInfo_->getMomentumAtBoundary());
-    ok = (ok || saveCaloBoundaryInformation_ || doFineCalo_);
-  }
-  if (ok) {
-    currentTrack_->setToBeSaved();
+    currentTrack_->setCrossedBoundaryPosMom(id, trkInfo_->getPositionAtBoundary(),
+					    trkInfo_->getMomentumAtBoundary());
+    ok = (ok || saveCaloBoundaryInformation_);
   }
 
-  bool withAncestor = (trkInfo_->getIDonCaloSurface() == id || trkInfo_->isAncestor());
-  bool isInHistory = trkInfo_->isInHistory();
-
-  trackManager_->addTrack(currentTrack_, aTrack, isInHistory, withAncestor);
+  trackManager_->addTrack(ok);
 
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("TrackingAction") << "TrackingAction end track=" << id << "  "
-                                     << aTrack->GetDefinition()->GetParticleName() << " ansestor= " << withAncestor
-                                     << " saved= " << currentTrack_->saved() << " end point " << aTrack->GetPosition();
+  edm::LogVerbatim("TrackingAction")
+      << "TrackingAction end track=" << id << "  "
+      << aTrack->GetDefinition()->GetParticleName() 
+      << " proposed to be saved= " << ok << " end point " << aTrack->GetPosition();
 #endif
-  if (!isInHistory) {
-    delete currentTrack_;
-  }
 
   EndOfTrack et(aTrack);
   m_endOfTrackSignal(&et);

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -82,9 +82,6 @@ GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
 
   m_kernel->SetVerboseLevel(m_verbose);
 
-  //if (m_pUseSensitiveDetectors)
-  //  m_sdMakers = sim::sensitiveDetectorMakers(m_p, consumesCollector(), std::vector<std::string>());
-
   tokMF_ = esConsumes<MagneticField, IdealMagneticFieldRecord, edm::Transition::BeginRun>();
   if (m_pGeoFromDD4hep) {
     tokDD4hep_ = esConsumes<cms::DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>();
@@ -164,7 +161,7 @@ void GeometryProducer::makeGeom(const edm::EventSetup &es) {
     edm::LogVerbatim("GeometryProducer") << " instantiating sensitive detectors ";
     // instantiate and attach the sensitive detectors
     TmpSimEvent *ptr = nullptr;
-    m_trackManager = std::make_unique<SimTrackManager>(ptr);
+    m_trackManager = std::make_unique<SimTrackManager>(ptr, m_verbose);
     {
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
           sim::attachSD(m_sdMakers, es, catalog, m_p, m_trackManager.get(), m_registry);

--- a/SimG4Core/Notification/interface/SimTrackManager.h
+++ b/SimG4Core/Notification/interface/SimTrackManager.h
@@ -29,13 +29,10 @@ class G4Track;
 
 class SimTrackManager {
 public:
-
   explicit SimTrackManager(TmpSimEvent*, int verbose);
   ~SimTrackManager();
 
-  const std::vector<TrackWithHistory*>* trackContainer() const {
-    return m_trackContainer;
-  }
+  const std::vector<TrackWithHistory*>* trackContainer() const { return m_trackContainer; }
 
   void storeTracks();
 
@@ -43,37 +40,26 @@ public:
 
   void addTrack(bool inHistory);
   //  void addTrack(bool inHistory, bool withAncestor);
-  
-  int giveMotherNeeded(int) const {
-    return m_currTrackInfo->mcTruthID();
-  }
-  
-  bool trackExists(unsigned int) const {
-    return true;
-  }
 
-  TrackWithHistory* getTrackByID(unsigned int, bool) const {
-    return m_currHistory;
-  }
+  int giveMotherNeeded(int) const { return m_currTrackInfo->mcTruthID(); }
 
-  void setLHCTransportLink(const edm::LHCTransportLinkContainer* thisLHCTlink) {
-    theLHCTlink = thisLHCTlink;
-  }
+  bool trackExists(unsigned int) const { return true; }
+
+  TrackWithHistory* getTrackByID(unsigned int, bool) const { return m_currHistory; }
+
+  void setLHCTransportLink(const edm::LHCTransportLinkContainer* thisLHCTlink) { theLHCTlink = thisLHCTlink; }
 
   void initialisePrimaries(const G4Event*);
 
   TrackWithHistory* getTrackWithHistory(const G4Track*);
 
-  const G4Track* getCurrentTrack() const {
-    return m_currTrack;
-  } 
+  const G4Track* getCurrentTrack() const { return m_currTrack; }
 
   // stop default
   SimTrackManager(const SimTrackManager&) = delete;
   const SimTrackManager& operator=(const SimTrackManager&) = delete;
 
 private:
-
   //  void saveTrackAndItsBranch(TrackWithHistory*);
   int findOrAddVertex(math::XYZVectorD& pos, double& time, int i1, int i2);
 

--- a/SimG4Core/Notification/interface/TmpSimEvent.h
+++ b/SimG4Core/Notification/interface/TmpSimEvent.h
@@ -35,7 +35,7 @@ public:
   void addVertex(TmpSimVertex* v) { g4vertices_.push_back(v); }
   std::vector<TrackWithHistory*>* getHistories() { return &g4tracks_; }
   std::vector<TmpSimVertex*>* getVertices() { return &g4vertices_; }
-  
+
   void clear();
 
 private:

--- a/SimG4Core/Notification/interface/TmpSimEvent.h
+++ b/SimG4Core/Notification/interface/TmpSimEvent.h
@@ -1,8 +1,8 @@
 #ifndef SimG4Core_TmpSimEvent_H
 #define SimG4Core_TmpSimEvent_H
 
-#include "SimG4Core/Notification/interface/TmpSimTrack.h"
 #include "SimG4Core/Notification/interface/TmpSimVertex.h"
+#include "SimG4Core/Notification/interface/TrackWithHistory.h"
 
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
@@ -15,14 +15,14 @@ class TmpSimEvent {
 public:
   TmpSimEvent();
   ~TmpSimEvent();
-  void load(edm::SimTrackContainer& c) const;
-  void load(edm::SimVertexContainer& c) const;
+  void load(edm::SimTrackContainer&) const;
+  void load(edm::SimVertexContainer&) const;
   unsigned int nTracks() const { return g4tracks_.size(); }
   unsigned int nVertices() const { return g4vertices_.size(); }
   unsigned int nGenParts() const { return hepMCEvent_->particles_size(); }
-  void hepEvent(const HepMC::GenEvent* r) { hepMCEvent_ = r; }
+  void setHepEvent(const HepMC::GenEvent* r) { hepMCEvent_ = r; }
   const HepMC::GenEvent* hepEvent() const { return hepMCEvent_; }
-  void weight(float w) { weight_ = w; }
+  void setWeight(float w) { weight_ = w; }
   float weight() const { return weight_; }
   void collisionPoint(const math::XYZTLorentzVectorD& v) { collisionPoint_ = v; }
   const math::XYZTLorentzVectorD& collisionPoint() const { return collisionPoint_; }
@@ -30,8 +30,12 @@ public:
   const int nparam() const { return nparam_; }
   void param(const std::vector<float>& p) { param_ = p; }
   const std::vector<float>& param() const { return param_; }
-  void add(TmpSimTrack* t) { g4tracks_.push_back(t); }
-  void add(TmpSimVertex* v) { g4vertices_.push_back(v); }
+  TrackWithHistory* getHistory(unsigned int idx) { return g4tracks_[idx]; }
+  void addTrack(TrackWithHistory* t) { g4tracks_.push_back(t); }
+  void addVertex(TmpSimVertex* v) { g4vertices_.push_back(v); }
+  std::vector<TrackWithHistory*>* getHistories() { return &g4tracks_; }
+  std::vector<TmpSimVertex*>* getVertices() { return &g4vertices_; }
+  
   void clear();
 
 private:
@@ -40,7 +44,7 @@ private:
   math::XYZTLorentzVectorD collisionPoint_{math::XYZTLorentzVectorD(0., 0., 0., 0.)};
   int nparam_{0};
   std::vector<float> param_;
-  std::vector<TmpSimTrack*> g4tracks_;
+  std::vector<TrackWithHistory*> g4tracks_;
   std::vector<TmpSimVertex*> g4vertices_;
 };
 

--- a/SimG4Core/Notification/interface/TmpSimVertex.h
+++ b/SimG4Core/Notification/interface/TmpSimVertex.h
@@ -7,20 +7,22 @@
 
 class TmpSimVertex {
 public:
-  TmpSimVertex(const math::XYZVectorD& ip, double it, int iv, int typ = 0)
-      : ilv_(ip), itime_(it), itrack_(iv), ptype_(typ) {}
+ TmpSimVertex(const math::XYZVectorD& pos, double t, int id, int it, int ptyp)
+   : ilv_(pos), itime_(t), idx_{id}, itrack_(it), ptype_(ptyp) {}
   ~TmpSimVertex() = default;
-  /// index of the parent (-1 if no parent)
+  /// index of the parent (0 if no parent)
   const math::XYZVectorD& vertexPosition() const { return ilv_; }
   double vertexGlobalTime() const { return itime_; }
+  int vertexIndex() const { return idx_; }
   int parentIndex() const { return itrack_; }
   int processType() const { return ptype_; }
 
 private:
-  math::XYZVectorD ilv_;
-  double itime_;
-  int itrack_;
-  int ptype_;
+  math::XYZVectorD ilv_; // position in cm
+  double itime_; // time in ns
+  int idx_;      // vertex index
+  int itrack_;   // index of mother track
+  int ptype_;    // process type created this vertex
 };
 
 #endif

--- a/SimG4Core/Notification/interface/TmpSimVertex.h
+++ b/SimG4Core/Notification/interface/TmpSimVertex.h
@@ -7,8 +7,8 @@
 
 class TmpSimVertex {
 public:
- TmpSimVertex(const math::XYZVectorD& pos, double t, int id, int it, int ptyp)
-   : ilv_(pos), itime_(t), idx_{id}, itrack_(it), ptype_(ptyp) {}
+  TmpSimVertex(const math::XYZVectorD& pos, double t, int id, int it, int ptyp)
+      : ilv_(pos), itime_(t), idx_{id}, itrack_(it), ptype_(ptyp) {}
   ~TmpSimVertex() = default;
   /// index of the parent (0 if no parent)
   const math::XYZVectorD& vertexPosition() const { return ilv_; }
@@ -18,11 +18,11 @@ public:
   int processType() const { return ptype_; }
 
 private:
-  math::XYZVectorD ilv_; // position in cm
-  double itime_; // time in ns
-  int idx_;      // vertex index
-  int itrack_;   // index of mother track
-  int ptype_;    // process type created this vertex
+  math::XYZVectorD ilv_;  // position in cm
+  double itime_;          // time in ns
+  int idx_;               // vertex index
+  int itrack_;            // index of mother track
+  int ptype_;             // process type created this vertex
 };
 
 #endif

--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -11,15 +11,12 @@ class TrackInformation : public G4VUserTrackInformation {
 public:
   TrackInformation(){};
   ~TrackInformation() override = default;
-  inline void *operator new(size_t);
+  inline void *operator new(std::size_t);
   inline void operator delete(void *TrackInformation);
 
   bool storeTrack() const { return storeTrack_; }
   /// can only be set to true, cannot be reset to false!
-  void setStoreTrack() {
-    storeTrack_ = true;
-    isInHistory_ = true;
-  }
+  void setStoreTrack() { storeTrack_ = true; }
 
   bool isPrimary() const { return isPrimary_; }
   void setPrimary(bool v) { isPrimary_ = v; }
@@ -30,11 +27,8 @@ public:
   bool isGeneratedSecondary() const { return isGeneratedSecondary_; }
   void setGeneratedSecondary(bool v) { isGeneratedSecondary_ = v; }
 
-  bool isInHistory() const { return isInHistory_; }
-  void putInHistory() { isInHistory_ = true; }
-
   bool isAncestor() const { return flagAncestor_; }
-  void setAncestor() { flagAncestor_ = true; }
+  void putInHistory() { flagAncestor_ = true; }
 
   int mcTruthID() const { return mcTruthID_; }
   void setMCTruthID(int id) { mcTruthID_ = id; }
@@ -100,11 +94,10 @@ public:
   void Print() const override;
 
 private:
-  bool storeTrack_{false};
   bool isPrimary_{false};
   bool hasHits_{false};
   bool isGeneratedSecondary_{false};
-  bool isInHistory_{false};
+  bool storeTrack_{false};
   bool flagAncestor_{false};
   bool caloIDChecked_{false};
   bool crossedBoundary_{false};
@@ -127,7 +120,7 @@ private:
 
 extern G4ThreadLocal G4Allocator<TrackInformation> *fpTrackInformationAllocator;
 
-inline void *TrackInformation::operator new(size_t) {
+inline void *TrackInformation::operator new(std::size_t) {
   if (!fpTrackInformationAllocator)
     fpTrackInformationAllocator = new G4Allocator<TrackInformation>;
   return (void *)fpTrackInformationAllocator->MallocSingle();

--- a/SimG4Core/Notification/interface/TrackWithHistory.h
+++ b/SimG4Core/Notification/interface/TrackWithHistory.h
@@ -17,8 +17,8 @@ public:
   /** The constructor is called at time, 
      *  when some of the information may not available yet.
      */
-  TrackWithHistory(const G4Track *g4track, int pID);
-  TrackWithHistory(const G4PrimaryParticle *, int trackID, const math::XYZVectorD &pos, const double time);
+  TrackWithHistory(const G4Track*, const int mcTruthID);
+  TrackWithHistory(const G4PrimaryParticle*, const int trackID, const math::XYZVectorD &pos, const double time);
   ~TrackWithHistory() = default;
 
   inline void *operator new(std::size_t);
@@ -27,7 +27,7 @@ public:
   int trackID() const { return trackID_; }
   int particleID() const { return pdgID_; }
   int parentID() const { return parentID_; }
-  int genParticleID() const { return genParticleID_; }
+  int mcTruthID() const { return mcTruthID_; }
   int vertexID() const { return vertexID_; }
   int processType() const { return procType_; }
   int getIDAtBoundary() const { return idAtBoundary_; }
@@ -35,14 +35,13 @@ public:
   void setTrackID(int i) { trackID_ = i; }
   void setParentID(int i) { parentID_ = i; }
   void setVertexID(int i) { vertexID_ = i; }
-  void setGenParticleID(int i) { genParticleID_ = i; }
+  void setMCTruthID(int i) { mcTruthID_ = i; }
 
   double totalEnergy() const { return totalEnergy_; }
   double time() const { return time_; }
   double weight() const { return weight_; }
-  void setToBeSaved() { saved_ = true; }
+  void setToBeSaved() { storeTrack_ = true; }
   bool storeTrack() const { return storeTrack_; }
-  bool saved() const { return saved_; }
   bool crossedBoundary() const { return crossedBoundary_; }
 
   const math::XYZVectorD &momentum() const { return momentum_; }
@@ -72,7 +71,7 @@ private:
   int trackID_;
   int pdgID_;
   int parentID_;
-  int genParticleID_{-1};
+  int mcTruthID_{-1};
   int vertexID_{-1};
   int idAtBoundary_{-1};
   int procType_{0};
@@ -86,13 +85,12 @@ private:
   math::XYZVectorD tkSurfacePosition_{math::XYZVectorD(0., 0., 0.)};
   math::XYZTLorentzVectorD tkSurfaceMomentum_{math::XYZTLorentzVectorD(0., 0., 0., 0.)};
   bool storeTrack_{false};
-  bool saved_{false};
   bool crossedBoundary_{false};
 };
 
 extern G4ThreadLocal G4Allocator<TrackWithHistory> *fpTrackWithHistoryAllocator;
 
-inline void *TrackWithHistory::operator new(size_t) {
+inline void *TrackWithHistory::operator new(std::size_t) {
   if (!fpTrackWithHistoryAllocator)
     fpTrackWithHistoryAllocator = new G4Allocator<TrackWithHistory>;
   return (void *)fpTrackWithHistoryAllocator->MallocSingle();

--- a/SimG4Core/Notification/interface/TrackWithHistory.h
+++ b/SimG4Core/Notification/interface/TrackWithHistory.h
@@ -17,8 +17,8 @@ public:
   /** The constructor is called at time, 
      *  when some of the information may not available yet.
      */
-  TrackWithHistory(const G4Track*, const int mcTruthID);
-  TrackWithHistory(const G4PrimaryParticle*, const int trackID, const math::XYZVectorD &pos, const double time);
+  TrackWithHistory(const G4Track *, const int mcTruthID);
+  TrackWithHistory(const G4PrimaryParticle *, const int trackID, const math::XYZVectorD &pos, const double time);
   ~TrackWithHistory() = default;
 
   inline void *operator new(std::size_t);

--- a/SimG4Core/Notification/src/MCTruthUtil.cc
+++ b/SimG4Core/Notification/src/MCTruthUtil.cc
@@ -21,7 +21,9 @@ void MCTruthUtil::secondary(G4Track *aTrack, const G4Track &mother, int flag) {
   // Cascade decays of primary or gamma convertion inside the tracker
   // Transfer mcTruth ID from mother (to be checked in SimTrackManager)
   int mc = motherInfo->mcTruthID();
-  if (mc <= 0) { mc = aTrack->GetTrackID(); }
+  if (mc <= 0) {
+    mc = aTrack->GetTrackID();
+  }
   trkInfo->setMCTruthID(mc);
 
   if (flag >= 1) {

--- a/SimG4Core/Notification/src/MCTruthUtil.cc
+++ b/SimG4Core/Notification/src/MCTruthUtil.cc
@@ -18,30 +18,23 @@ void MCTruthUtil::secondary(G4Track *aTrack, const G4Track &mother, int flag) {
   auto motherInfo = static_cast<const TrackInformation *>(mother.GetUserInformation());
   auto trkInfo = new TrackInformation();
 
-  // Take care of cascade decays
-  if (flag == 1) {
-    trkInfo->setPrimary(true);
+  // Cascade decays of primary or gamma convertion inside the tracker
+  // Transfer mcTruth ID from mother (to be checked in SimTrackManager)
+  if (flag >= 1) {
     trkInfo->setStoreTrack();
     trkInfo->setGenParticlePID(aTrack->GetDefinition()->GetPDGEncoding());
     trkInfo->setGenParticleP(aTrack->GetMomentum().mag());
-    trkInfo->setMCTruthID(aTrack->GetTrackID());
-  } else {
-    // secondary
-    trkInfo->setGenParticlePID(motherInfo->genParticlePID());
-    trkInfo->setGenParticleP(motherInfo->genParticleP());
     trkInfo->setMCTruthID(motherInfo->mcTruthID());
-  }
-
-  // Store if decay or conversion
-  if (flag > 0) {
-    trkInfo->setStoreTrack();
     trkInfo->setIDonCaloSurface(aTrack->GetTrackID(),
                                 motherInfo->getIDCaloVolume(),
                                 motherInfo->getIDLastVolume(),
                                 aTrack->GetDefinition()->GetPDGEncoding(),
                                 aTrack->GetMomentum().mag());
   } else {
-    // transfer calo ID from mother (to be checked in TrackingAction)
+    // secondary
+    trkInfo->setGenParticlePID(motherInfo->genParticlePID());
+    trkInfo->setGenParticleP(motherInfo->genParticleP());
+    trkInfo->setMCTruthID(motherInfo->mcTruthID());
     trkInfo->setIDonCaloSurface(motherInfo->getIDonCaloSurface(),
                                 motherInfo->getIDCaloVolume(),
                                 motherInfo->getIDLastVolume(),

--- a/SimG4Core/Notification/src/MCTruthUtil.cc
+++ b/SimG4Core/Notification/src/MCTruthUtil.cc
@@ -20,11 +20,14 @@ void MCTruthUtil::secondary(G4Track *aTrack, const G4Track &mother, int flag) {
 
   // Cascade decays of primary or gamma convertion inside the tracker
   // Transfer mcTruth ID from mother (to be checked in SimTrackManager)
+  int mc = motherInfo->mcTruthID();
+  if (mc <= 0) { mc = aTrack->GetTrackID(); }
+  trkInfo->setMCTruthID(mc);
+
   if (flag >= 1) {
     trkInfo->setStoreTrack();
     trkInfo->setGenParticlePID(aTrack->GetDefinition()->GetPDGEncoding());
     trkInfo->setGenParticleP(aTrack->GetMomentum().mag());
-    trkInfo->setMCTruthID(motherInfo->mcTruthID());
     trkInfo->setIDonCaloSurface(aTrack->GetTrackID(),
                                 motherInfo->getIDCaloVolume(),
                                 motherInfo->getIDLastVolume(),
@@ -34,7 +37,6 @@ void MCTruthUtil::secondary(G4Track *aTrack, const G4Track &mother, int flag) {
     // secondary
     trkInfo->setGenParticlePID(motherInfo->genParticlePID());
     trkInfo->setGenParticleP(motherInfo->genParticleP());
-    trkInfo->setMCTruthID(motherInfo->mcTruthID());
     trkInfo->setIDonCaloSurface(motherInfo->getIDonCaloSurface(),
                                 motherInfo->getIDCaloVolume(),
                                 motherInfo->getIDLastVolume(),

--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -25,48 +25,46 @@
 
 //#define DebugLog
 
-namespace
-{
+namespace {
   const double invcm = 1.0 / CLHEP::cm;
   const double invgev = 1.0 / CLHEP::GeV;
-  const double r_limit2 = 1.e-6; // 10 micron in CMS units
-  const double t_limit = 10*CLHEP::picosecond;
-}
+  const double r_limit2 = 1.e-6;  // 10 micron in CMS units
+  const double t_limit = 10 * CLHEP::picosecond;
+}  // namespace
 
-SimTrackManager::SimTrackManager(TmpSimEvent* ptr, int ver)
-  : m_Verbose(ver),
-    m_simEvent(ptr) {
+SimTrackManager::SimTrackManager(TmpSimEvent* ptr, int ver) : m_Verbose(ver), m_simEvent(ptr) {
   m_trackContainer = m_simEvent->getHistories();
   m_g4vertices = m_simEvent->getVertices();
 }
 
 SimTrackManager::~SimTrackManager() { reset(); }
 
-void SimTrackManager::reset() {
-  m_nPrimary = m_nTracks = m_nVertices = m_nPrimVertices = 0;
-}
+void SimTrackManager::reset() { m_nPrimary = m_nTracks = m_nVertices = m_nPrimVertices = 0; }
 
 void SimTrackManager::initialisePrimaries(const G4Event* evt) {
-
   // clean previous event
   reset();
   int nv = evt->GetNumberOfPrimaryVertex();
 
   // loop over Geant4 primary vertex
-  for (int i=0; i<nv; ++i) {
+  for (int i = 0; i < nv; ++i) {
     auto v = evt->GetPrimaryVertex(i);
-    if (nullptr == v) { continue; }
-    math::XYZVectorD pos(v->GetX0()*invcm, v->GetY0()* invcm, v->GetZ0()*invcm);
+    if (nullptr == v) {
+      continue;
+    }
+    math::XYZVectorD pos(v->GetX0() * invcm, v->GetY0() * invcm, v->GetZ0() * invcm);
     double time = v->GetT0();
     int vidx = findOrAddVertex(pos, time, 0, 0);
 
     // primary particle for a vertex
     int np = v->GetNumberOfParticle();
-    for (int j=0; j<np; ++j) {
+    for (int j = 0; j < np; ++j) {
       auto prim = v->GetPrimary(j);
-      if (nullptr == prim) { continue; }
+      if (nullptr == prim) {
+        continue;
+      }
       ++m_nPrimary;
-      auto p = new TrackWithHistory(prim, m_nPrimary, pos, time); 
+      auto p = new TrackWithHistory(prim, m_nPrimary, pos, time);
       m_simEvent->addTrack(p);
       ++m_nTracks;
       p->setVertexID(vidx);
@@ -74,20 +72,18 @@ void SimTrackManager::initialisePrimaries(const G4Event* evt) {
   }
   m_nPrimVertices = m_nVertices;
   if (m_Verbose > 1) {
-    edm::LogVerbatim("SimG4CoreNotification") 
-        << "SimTrackManager::initialisePrimaries() Ntracks=" << m_nPrimary
-        << " nVertex=" << m_nVertices;
+    edm::LogVerbatim("SimG4CoreNotification")
+        << "SimTrackManager::initialisePrimaries() Ntracks=" << m_nPrimary << " nVertex=" << m_nVertices;
   }
 }
 
-int SimTrackManager::findOrAddVertex(math::XYZVectorD& pos, double& time, int i1, int i2)
-{ 
+int SimTrackManager::findOrAddVertex(math::XYZVectorD& pos, double& time, int i1, int i2) {
   // check if the vertex coincide with previous
   bool isNew = true;
   int vidx = m_nVertices;
-  for (int j=0; j<m_nVertices; ++j) {
+  for (int j = 0; j < m_nVertices; ++j) {
     if (((*m_g4vertices)[j]->vertexPosition() - pos).Mag2() < r_limit2 &&
-	std::abs((*m_g4vertices)[j]->vertexGlobalTime() - time) < t_limit) {
+        std::abs((*m_g4vertices)[j]->vertexGlobalTime() - time) < t_limit) {
       isNew = false;
       m_simVertex = (*m_g4vertices)[j];
       pos = m_simVertex->vertexPosition();
@@ -114,11 +110,9 @@ TrackWithHistory* SimTrackManager::getTrackWithHistory(const G4Track* track) {
   int id = track->GetTrackID();
 
   if (m_Verbose > 2) {
-    edm::LogVerbatim("SimG4CoreNotification") 
-        << "SimTrackManager::getTrackWithHistory id=" << id
-        << " nTracks=" << m_simEvent->nTracks()
-        << " nPrimary=" << m_nPrimary << " nVertex=" << m_nVertices
-        << " MCtruthID=" <<  m_currTrackInfo->mcTruthID();
+    edm::LogVerbatim("SimG4CoreNotification")
+        << "SimTrackManager::getTrackWithHistory id=" << id << " nTracks=" << m_simEvent->nTracks()
+        << " nPrimary=" << m_nPrimary << " nVertex=" << m_nVertices << " MCtruthID=" << m_currTrackInfo->mcTruthID();
   }
   if (id <= m_nPrimary && id > 0) {
     // use primary history
@@ -144,30 +138,29 @@ void SimTrackManager::addTrack(bool inHistory) {
   int id = m_currTrack->GetTrackID();
   int parid = m_currHistory->mcTruthID();
   if (m_Verbose > 2) {
-    edm::LogVerbatim("SimG4CoreNotification") 
-        << "SimTrackManager::addTrack id=" << id << " parentID=" << parid 
-        << " Ekin(MeV)=" << m_currTrack->GetVertexKineticEnergy()/CLHEP::GeV
-        << " vertexID=" << m_currHistory->vertexID();
+    edm::LogVerbatim("SimG4CoreNotification") << "SimTrackManager::addTrack id=" << id << " parentID=" << parid
+                                              << " Ekin(MeV)=" << m_currTrack->GetVertexKineticEnergy() / CLHEP::GeV
+                                              << " vertexID=" << m_currHistory->vertexID();
   }
   if (!inHistory && m_currHistory->crossedBoundary()) {
     if (parid < m_nTracks) {
       auto parent = (*m_trackContainer)[parid];
       if (parent->crossedBoundary()) {
-	delete m_currHistory;
-	return;
+        delete m_currHistory;
+        return;
       }
-      parent->setCrossedBoundaryPosMom(id, m_currTrackInfo->getPositionAtBoundary(),
-				       m_currTrackInfo->getMomentumAtBoundary());
+      parent->setCrossedBoundaryPosMom(
+          id, m_currTrackInfo->getPositionAtBoundary(), m_currTrackInfo->getMomentumAtBoundary());
     } else {
       delete m_currHistory;
       return;
     }
   }
-  
+
   // vertex is not yet defined
   if (m_currHistory->vertexID() < 0) {
     auto& p = m_currTrack->GetVertexPosition();
-    math::XYZVectorD pos(p.x()*invcm, p.y()* invcm, p.z()*invcm);
+    math::XYZVectorD pos(p.x() * invcm, p.y() * invcm, p.z() * invcm);
     double time = m_currHistory->time();
     int vidx = findOrAddVertex(pos, time, parid, m_currHistory->processType());
     m_currHistory->setVertexID(vidx);
@@ -182,10 +175,10 @@ void SimTrackManager::addTrack(bool inHistory) {
   const auto sp = m_currTrack->GetStep()->GetPostStepPoint();
   const auto& p = sp->GetPosition();
   const auto& v = sp->GetMomentum();
-  double e = sp->GetTotalEnergy()*invgev;
+  double e = sp->GetTotalEnergy() * invgev;
 
-  m_currHistory->setSurfacePosMom(math::XYZVectorD(p.x()*invcm, p.y()*invcm, p.z()*invcm),
-                                  math::XYZTLorentzVectorD(v.x()*invgev, v.y()*invgev, v.z()*invgev, e));
+  m_currHistory->setSurfacePosMom(math::XYZVectorD(p.x() * invcm, p.y() * invcm, p.z() * invcm),
+                                  math::XYZTLorentzVectorD(v.x() * invgev, v.y() * invgev, v.z() * invgev, e));
 }
 
 void SimTrackManager::storeTracks() {}

--- a/SimG4Core/Notification/src/TmpSimEvent.cc
+++ b/SimG4Core/Notification/src/TmpSimEvent.cc
@@ -1,12 +1,8 @@
 #include "SimG4Core/Notification/interface/TmpSimEvent.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "G4SystemOfUnits.hh"
-
-class IdSort {
-public:
-  bool operator()(const SimTrack& a, const SimTrack& b) { return a.trackId() < b.trackId(); }
-};
 
 TmpSimEvent::TmpSimEvent() {
   g4vertices_.reserve(2000);
@@ -26,44 +22,46 @@ void TmpSimEvent::clear() {
   g4vertices_.clear();
 }
 
-void TmpSimEvent::load(edm::SimTrackContainer& c) const {
+void TmpSimEvent::load(edm::SimTrackContainer& cont) const {
+  edm::LogVerbatim("SimG4CoreNotification") 
+      << "TmpSimEvent::load Ntracks=" << g4tracks_.size();
   const double invgev = 1.0 / CLHEP::GeV;
-  for (auto& trk : g4tracks_) {
-    int ip = trk->part();
+  for (auto const & trk : g4tracks_) {
+    int ip = trk->particleID();
     const math::XYZVectorD& mom = trk->momentum();
-    math::XYZTLorentzVectorD p(mom.x() * invgev, mom.y() * invgev, mom.z() * invgev, trk->energy() * invgev);
-    int iv = trk->ivert();
-    int ig = trk->igenpart();
-    int id = trk->id();
-    // ip = particle ID as PDG
-    // pp = 4-momentum in GeV
-    // iv = corresponding TmpSimVertex index
-    // ig = corresponding GenParticle index
+    math::XYZTLorentzVectorD p(mom.x() * invgev, mom.y() * invgev, mom.z() * invgev, trk->totalEnergy() * invgev);
+    int iv = trk->vertexID();
+    int ig = trk->mcTruthID();
+    int id = trk->trackID();
+    // id - track ID
+    // ip - particle ID as PDG
+    // p  - 4-momentum in GeV
+    // iv - corresponding vertex index
+    // ig - corresponding MC truth index
     SimTrack t = SimTrack(ip, p, iv, ig, trk->trackerSurfacePosition(), trk->trackerSurfaceMomentum());
     t.setTrackId(id);
     t.setEventId(EncodedEventId(0));
     t.setCrossedBoundaryVars(
         trk->crossedBoundary(), trk->getIDAtBoundary(), trk->getPositionAtBoundary(), trk->getMomentumAtBoundary());
-    c.push_back(t);
+    cont.push_back(t);
   }
-  std::stable_sort(c.begin(), c.end(), IdSort());
 }
 
-void TmpSimEvent::load(edm::SimVertexContainer& c) const {
-  const double invcm = 1.0 / CLHEP::cm;
+void TmpSimEvent::load(edm::SimVertexContainer& cont) const {
+  edm::LogVerbatim("SimG4CoreNotification") 
+      << "TmpSimEvent::load Nvertices=" << g4vertices_.size();
+
   // index of the vertex is needed to make SimVertex object
   for (unsigned int i = 0; i < g4vertices_.size(); ++i) {
     TmpSimVertex* vtx = g4vertices_[i];
-    auto pos = vtx->vertexPosition();
-    math::XYZVectorD v3(pos.x() * invcm, pos.y() * invcm, pos.z() * invcm);
-    float t = (float)(vtx->vertexGlobalTime() / CLHEP::second);
+    float t = vtx->vertexGlobalTime() / CLHEP::second;
     int iv = vtx->parentIndex();
     // v3 = position in cm
     // t  = global time in second
     // iv = index of the parent in the SimEvent SimTrack container (-1 if no parent)
-    SimVertex v = SimVertex(v3, t, iv, i);
-    v.setProcessType((unsigned int)vtx->processType());
+    SimVertex v = SimVertex(vtx->vertexPosition(), t, iv, i);
+    v.setProcessType(vtx->processType());
     v.setEventId(EncodedEventId(0));
-    c.push_back(v);
+    cont.push_back(v);
   }
 }

--- a/SimG4Core/Notification/src/TmpSimEvent.cc
+++ b/SimG4Core/Notification/src/TmpSimEvent.cc
@@ -23,10 +23,9 @@ void TmpSimEvent::clear() {
 }
 
 void TmpSimEvent::load(edm::SimTrackContainer& cont) const {
-  edm::LogVerbatim("SimG4CoreNotification") 
-      << "TmpSimEvent::load Ntracks=" << g4tracks_.size();
+  edm::LogVerbatim("SimG4CoreNotification") << "TmpSimEvent::load Ntracks=" << g4tracks_.size();
   const double invgev = 1.0 / CLHEP::GeV;
-  for (auto const & trk : g4tracks_) {
+  for (auto const& trk : g4tracks_) {
     int ip = trk->particleID();
     const math::XYZVectorD& mom = trk->momentum();
     math::XYZTLorentzVectorD p(mom.x() * invgev, mom.y() * invgev, mom.z() * invgev, trk->totalEnergy() * invgev);
@@ -48,8 +47,7 @@ void TmpSimEvent::load(edm::SimTrackContainer& cont) const {
 }
 
 void TmpSimEvent::load(edm::SimVertexContainer& cont) const {
-  edm::LogVerbatim("SimG4CoreNotification") 
-      << "TmpSimEvent::load Nvertices=" << g4vertices_.size();
+  edm::LogVerbatim("SimG4CoreNotification") << "TmpSimEvent::load Nvertices=" << g4vertices_.size();
 
   // index of the vertex is needed to make SimVertex object
   for (unsigned int i = 0; i < g4vertices_.size(); ++i) {

--- a/SimG4Core/Notification/src/TrackInformation.cc
+++ b/SimG4Core/Notification/src/TrackInformation.cc
@@ -27,7 +27,6 @@ void TrackInformation::Print() const {
                                << "                    isPrimary = " << isPrimary_ << "\n"
                                << "                    isGeneratedSecondary = " << isGeneratedSecondary_ << "\n"
                                << "                    mcTruthID = " << mcTruthID_ << "\n"
-                               << "                    isInHistory = " << isInHistory_ << "\n"
                                << "                    idOnCaloSurface = " << getIDonCaloSurface() << "\n"
                                << "                    caloIDChecked = " << caloIDChecked() << "\n"
                                << "                    idCaloVolume = " << idCaloVolume_ << "\n"

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -14,10 +14,12 @@
 
 G4ThreadLocal G4Allocator<TrackWithHistory>* fpTrackWithHistoryAllocator = nullptr;
 
-TrackWithHistory::TrackWithHistory(const G4Track* g4trk, int pID) {
+// secondary particle
+TrackWithHistory::TrackWithHistory(const G4Track* g4trk, const int pID) {
   trackID_ = g4trk->GetTrackID();
   pdgID_ = G4TrackToParticleID::particleID(g4trk);
-  parentID_ = pID;
+  parentID_ = g4trk->GetParentID();
+  mcTruthID_ = pID;
   auto mom = g4trk->GetMomentum();
   momentum_ = math::XYZVectorD(mom.x(), mom.y(), mom.z());
   totalEnergy_ = g4trk->GetTotalEnergy();
@@ -26,33 +28,35 @@ TrackWithHistory::TrackWithHistory(const G4Track* g4trk, int pID) {
   time_ = g4trk->GetGlobalTime();
   auto p = g4trk->GetCreatorProcess();
   procType_ = (nullptr != p) ? p->GetProcessSubType() : 0;
-  TrackInformation* trkinfo = static_cast<TrackInformation*>(g4trk->GetUserInformation());
-  storeTrack_ = trkinfo->storeTrack();
   auto vgprimary = g4trk->GetDynamicParticle()->GetPrimaryParticle();
+  int genID = 0;
   if (vgprimary != nullptr) {
     auto priminfo = static_cast<GenParticleInfo*>(vgprimary->GetUserInformation());
     if (nullptr != priminfo) {
-      genParticleID_ = priminfo->id();
+      genID *= priminfo->id();
     }
   }
   // V.I. weight is computed in the same way as before
   // without usage of G4Track::GetWeight()
-  weight_ = 10000 * genParticleID_;
+  weight_ = 10000 * genID;
 }
 
+// primary particle
 TrackWithHistory::TrackWithHistory(const G4PrimaryParticle* ptr, int trackID, const math::XYZVectorD& pos, double time) {
   trackID_ = trackID;
   pdgID_ = G4TrackToParticleID::particleID(ptr, trackID_);
-  parentID_ = trackID;
+  parentID_ = 0;
+  mcTruthID_ = trackID;
   auto mom = ptr->GetMomentum();
   momentum_ = math::XYZVectorD(mom.x(), mom.y(), mom.z());
   totalEnergy_ = ptr->GetTotalEnergy();
   vertexPosition_ = math::XYZVectorD(pos.x(), pos.y(), pos.z());
   time_ = time;
   storeTrack_ = true;
+  int genID = 0;
   auto priminfo = static_cast<GenParticleInfo*>(ptr->GetUserInformation());
   if (nullptr != priminfo) {
-    genParticleID_ = priminfo->id();
+    genID *= priminfo->id();
   }
-  weight_ = 10000. * genParticleID_;
+  weight_ = 10000. * genID;
 }


### PR DESCRIPTION
#### PR description:
This PR includes a general reorganisation of MC truth, which was discussed many times within SIM group. This update mainly focused on Phase-2 developments but may be useful for Run3 as well. It includes:
1) Primary particles are scored in MC truth before start of event simulation
2) Decision to store an extra particle to MC truth is made before track processing, so all hits get prepared MC truth ID
3) MC truth code significantly simplified
4) Debug printouts are improved.

#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: NO
