### PR TITLE
Initialize cut parser earlier in NanoAODDQM module

### DIFF
--- a/DataFormats/NanoAOD/interface/FlatTable.h
+++ b/DataFormats/NanoAOD/interface/FlatTable.h
@@ -100,12 +100,16 @@ namespace nanoaod {
       RowView(const FlatTable &table, unsigned int row) : table_(&table), row_(row) {}
       double getAnyValue(unsigned int column) const { return table_->getAnyValue(row_, column); }
       double getAnyValue(const std::string &column) const {
-        return table_->getAnyValue(row_, table_->columnIndex(column));
+        auto index = table_->columnIndex(column);
+        if (index == -1)
+          throwUnknownColumn(column);
+        return table_->getAnyValue(row_, index);
       }
       const FlatTable &table() const { return *table_; }
       unsigned int row() const { return row_; }
 
     private:
+      [[noreturn]] static void throwUnknownColumn(const std::string &column) noexcept(false);
       const FlatTable *table_;
       unsigned int row_;
     };

--- a/DataFormats/NanoAOD/src/FlatTable.cc
+++ b/DataFormats/NanoAOD/src/FlatTable.cc
@@ -66,3 +66,7 @@ double nanoaod::FlatTable::getAnyValue(unsigned int row, unsigned int column) co
   }
   throw cms::Exception("LogicError", "Unsupported type");
 }
+
+void nanoaod::FlatTable::RowView::throwUnknownColumn(const std::string& column) {
+  throw cms::Exception("LogicError") << "Invalid column name '" << column << "'";
+}

--- a/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODDQM.cc
@@ -22,7 +22,14 @@
 #include <type_traits>
 
 namespace {
-  std::string replaceStringsToColumGets(const std::string &expr, const nanoaod::FlatTable &table) {
+  bool notANumber(std::string const &iValue) {
+    auto find = iValue.find_first_not_of("0123456789");
+    return find != std::string::npos;
+  }
+  bool notRowMethod(std::string const &iValue) { return iValue != "row" and iValue != "table"; }
+
+  bool notAFunction(std::string const &iSuffix) { return (iSuffix.empty() or iSuffix[0] != '('); }
+  std::string replaceStringsToColumGets(const std::string &expr) {
     std::regex token("\\w+");
     std::sregex_iterator tbegin(expr.begin(), expr.end(), token), tend;
     if (tbegin == tend)
@@ -32,7 +39,7 @@ namespace {
     for (std::sregex_iterator i = tbegin; i != tend; last = i, ++i) {
       const std::smatch &match = *i;
       out << match.prefix().str();
-      if (table.columnIndex(match.str()) != -1) {
+      if (notAFunction(i->suffix().str()) and notANumber(match.str()) and notRowMethod(match.str())) {
         out << "getAnyValue(\"" << match.str() << "\")";
       } else {
         out << match.str();
@@ -203,16 +210,17 @@ private:
     std::unique_ptr<StringCutObjectSelector<FlatTable::RowView>> cutptr;
     std::vector<std::unique_ptr<Plot>> plots;
     SelGroupConfig() : name(), cutstr(), cutptr(), plots() {}
-    SelGroupConfig(const std::string &nam, const std::string &cut) : name(nam), cutstr(cut), cutptr(), plots() {}
+    SelGroupConfig(const std::string &nam, const std::string &cut) : name(nam), cutstr(cut), cutptr(), plots() {
+      if (not nullCut()) {
+        cutptr = std::make_unique<Selector>(replaceStringsToColumGets(cutstr));
+      }
+    }
     bool nullCut() const { return cutstr.empty(); }
     void fillSel(const FlatTable &table, std::vector<bool> &out) {
       out.resize(table.size());
       if (nullCut()) {
         std::fill(out.begin(), out.end(), true);
       } else {
-        if (!cutptr) {
-          cutptr = std::make_unique<Selector>(replaceStringsToColumGets(cutstr, table));
-        }
         for (unsigned int i = 0, n = table.size(); i < n; ++i) {
           out[i] = (*cutptr)(table.row(i));
         }

--- a/PhysicsTools/NanoAOD/test/BuildFile.xml
+++ b/PhysicsTools/NanoAOD/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<bin file="test_catch2_*.cc" name="testPhysicsToolsNanoAODTP">
+  <use name="FWCore/TestProcessor"/>
+  <use name="DataFormats/NanoAOD"/>
+  <use name="catch2"/>
+</bin>

--- a/PhysicsTools/NanoAOD/test/test_catch2_NanoAODDQM.cc
+++ b/PhysicsTools/NanoAOD/test/test_catch2_NanoAODDQM.cc
@@ -1,0 +1,99 @@
+#include "catch.hpp"
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/NanoAOD/interface/FlatTable.h"
+
+static constexpr auto s_tag = "[NanoAODDQM]";
+
+TEST_CASE("Standard checks of NanoAODDQM", s_tag) {
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.toTest = cms.EDProducer("NanoAODDQM",
+  vplots = cms.PSet( 
+    TEST = cms.PSet(
+       sels = cms.PSet( Good = cms.string("foo > 0 && abs(bar) > 1.3") ),
+       plots = cms.VPSet(
+          cms.PSet( name = cms.string("foo"), kind = cms.string("none"))
+       )
+    )
+  )
+ )
+process.add_(cms.Service("DQMStore"))
+process.moduleToTest(process.toTest)
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION("No event data") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.test());
+  }
+
+  SECTION("With good event data") {
+    auto token = config.produces<nanoaod::FlatTable>("test");
+    edm::test::TestProcessor tester(config);
+    auto table = std::make_unique<nanoaod::FlatTable>(1, "TEST", false);
+    table->addColumn<float>("foo", std::vector<float>(1, 3.0f), "is foo");
+    table->addColumn<float>("bar", std::vector<float>(1, 5.0f), "is bar");
+    REQUIRE_NOTHROW(tester.test(std::make_pair(token, std::move(table))));
+  }
+
+  SECTION("With wrong column name") {
+    auto token = config.produces<nanoaod::FlatTable>("test");
+    edm::test::TestProcessor tester(config);
+    auto table = std::make_unique<nanoaod::FlatTable>(1, "TEST", false);
+    table->addColumn<float>("Foo", std::vector<float>(1, 3.0f), "is foo");
+    table->addColumn<float>("bar", std::vector<float>(1, 5.0f), "is bar");
+    REQUIRE_THROWS_AS(tester.test(std::make_pair(token, std::move(table))), cms::Exception);
+  }
+
+  SECTION("beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+
+  SECTION("Use Row Method") {
+    const std::string baseConfig{
+        R"_(from FWCore.TestProcessor.TestProcess import *
+process = TestProcess()
+process.toTest = cms.EDProducer("NanoAODDQM",
+  vplots = cms.PSet( 
+    TEST = cms.PSet(
+       sels = cms.PSet( Good = cms.string("foo > 0 && row == 0") ),
+       plots = cms.VPSet(
+          cms.PSet( name = cms.string("foo"), kind = cms.string("none"))
+       )
+    )
+  )
+ )
+process.add_(cms.Service("DQMStore"))
+process.moduleToTest(process.toTest)
+)_"};
+
+    edm::test::TestProcessor::Config config{baseConfig};
+
+    auto token = config.produces<nanoaod::FlatTable>("test");
+    edm::test::TestProcessor tester(config);
+    auto table = std::make_unique<nanoaod::FlatTable>(1, "TEST", false);
+    table->addColumn<float>("foo", std::vector<float>(1, 3.0f), "is foo");
+    REQUIRE_NOTHROW(tester.test(std::make_pair(token, std::move(table))));
+  }
+}
+
+//Add additional TEST_CASEs to exercise the modules capabilities

--- a/PhysicsTools/NanoAOD/test/test_catch2_main.cc
+++ b/PhysicsTools/NanoAOD/test/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"


### PR DESCRIPTION
#### PR description:

IB RelVals have been failing because the cut parser in NanoAODDQM sometimes fails to find methods of nanoaod::FlatTable. This has been seen before and is believe to be a threading issue in ROOT related to asking for the list of methods while other ROOT calls are happening. Moving the initialization to the constructor of the module should avoid this threading problem.

The code was changed so that instead of needing the FlatTable in order to ask it what are the available columns, now the code assumes any name not related to either a function call or a known method of FlatTable::RowView is a column name. This allows the cut parser to be fully initialized in the module constructor.

Additionally, using an invalid column name in a call to FlatTable::RowView::getAnyValue now throws an exception which contains the name of the invalid column.

#### PR validation:

New unit test passes.