### PR TITLE
Fix bug in L1 track duplicate removal for displaced tracking

### DIFF
--- a/L1Trigger/TrackFindingTracklet/README.md
+++ b/L1Trigger/TrackFindingTracklet/README.md
@@ -1,4 +1,4 @@
-To run the L1 tracking & create a TTree of tracking performance:
+To run the L1 tracking & create a TTree of tracking performance: 
 
 cmsRun L1TrackNtupleMaker_cfg.py
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1026,7 +1026,7 @@ namespace trklet {
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
     bool reduced_{false};        // use reduced (Summer Chain) config
-    bool inventStubs_{true};     // invent seeding stub coordinates based on tracklet traj
+    bool inventStubs_{false};     // invent seeding stub coordinates based on tracklet traj
 
     // Use combined TP (TE+TC) and MP (PR+ME+MC) configuration (with prompt tracking)
     bool combined_{false};

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1026,7 +1026,7 @@ namespace trklet {
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
     bool reduced_{false};        // use reduced (Summer Chain) config
-    bool inventStubs_{false};     // invent seeding stub coordinates based on tracklet traj
+    bool inventStubs_{false};    // invent seeding stub coordinates based on tracklet traj
 
     // Use combined TP (TE+TC) and MP (PR+ME+MC) configuration (with prompt tracking)
     bool combined_{false};

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1051,19 +1051,14 @@ namespace trklet {
     // The DR binning below disabled, as doesn't match latest FW.
 
     //Following values are used for duplicate removal
-    //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
-    //Rinv bin edges for 6 bins.
-    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //Only one bin currently used.
     std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
-    //Phi bin edges for 2 bins.
-    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     std::vector<double> phiBins_{0, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    //int numTracksComparedPerBin_{32};
     int numTracksComparedPerBin_{9999};
 
     double sensorSpacing_2S_{0.18};

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1048,18 +1048,23 @@ namespace trklet {
     double stripLength_PS_{0.1467};
     double stripLength_2S_{5.0250};
 
+    // The DR binning below disabled, as doesn't match latest FW.
+
     //Following values are used for duplicate removal
     //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
-    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
     //Phi bin edges for 2 bins.
-    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    int numTracksComparedPerBin_{32};
+    //int numTracksComparedPerBin_{32};
+    int numTracksComparedPerBin_{9999};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -221,6 +221,8 @@ namespace trklet {
 
     unsigned int PSseed() const { return ((layer() == 1) || (layer() == 2) || (disk() != 0)) ? 1 : 0; }
 
+    // Seed type:
+    //  L1L2=0,L2L3=1,L3L4=2,L5L6=3,D1D2=4,D3D4=5,L1D1=6,L2D1=7
     unsigned int seedIndex() const { return seedIndex_; }
 
   private:

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -13,9 +13,11 @@
 #include "L1Trigger/TrackFindingTracklet/interface/HybridFit.h"
 #endif
 
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "TString.h"
 #include <unordered_set>
 #include <algorithm>
 
@@ -618,6 +620,7 @@ std::pair<int, int> PurgeDuplicate::findLayerDisk(const Stub* st) const {
 }
 
 std::string PurgeDuplicate::l1tinfo(const L1TStub* l1stub, std::string str = "") const {
+  // Uses ROOT::TString
   std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d",
                             str.c_str(),
                             l1stub->r(),
@@ -662,64 +665,65 @@ std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector,
 std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector,
                                                               const Stub* st,
                                                               const Tracklet* tracklet) const {
-  int stubLayer = (findLayerDisk(st)).first;
-  int stubDisk = (findLayerDisk(st)).second;
+  const int stubLayer = (findLayerDisk(st)).first;
+  const int stubDisk = (findLayerDisk(st)).second;
 
   double stub_phi = -99;
   double stub_z = -99;
   double stub_r = -99;
 
-  double rho = 1 / tracklet->rinv();
-  double rho_minus_d0 = rho + tracklet->d0();  // should be -, but otherwise does not work
+  const double rho = 1 / tracklet->rinv();
+  const double rho_minus_d0 = rho + tracklet->d0();  // should be -, but otherwise does not work
 
-  // exact helix
-  if (st->isBarrel()) {
-    stub_r = settings_.rmean(stubLayer - 1);
-
-    // The expanded version of this expression is more stable for very low-pT
-    // (high-rho) tracks. But we also explicitly restrict sin_val to the domain
-    // of asin.
-    double sin_val =
-        0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
-    sin_val = std::max(std::min(sin_val, 1.0), -1.0);
-    stub_phi = tracklet->phi0() - std::asin(sin_val);
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-
-    // The expanded version of this expression is more stable for very low-pT
-    // (high-rho) tracks. But we also explicitly restrict cos_val to the domain
-    // of acos.
-    double cos_val =
-        0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
-    cos_val = std::max(std::min(cos_val, 1.0), -1.0);
-    double beta = std::acos(cos_val);
-    stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
-  } else {
-    stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
-
-    double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho));  // maybe rho should be abs value
-    double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
-    stub_r = sqrt(r_square);
-
-    // The expanded version of this expression is more stable for very low-pT
-    // (high-rho) tracks. But we also explicitly restrict sin_val to the domain
-    // of asin.
-    double sin_val =
-        0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
-    sin_val = std::max(std::min(sin_val, 1.0), -1.0);
-    stub_phi = tracklet->phi0() - std::asin(sin_val);
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-  }
+  const int seed = tracklet->seedIndex();
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
-  int seed = tracklet->seedIndex();
-  if ((seed == 8 && stubLayer == 4) || (seed == 9 && stubLayer == 5) || (seed == 10 && stubLayer == 3) ||
-      (seed == 11 && abs(stubDisk) == 1)) {
+  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) ||
+      (seed == L2L3D1 && abs(stubDisk) == 1) || (seed == D1D2L2 && abs(stubDisk) == 1)) {
     stub_phi = st->l1tstub()->phi();
     stub_z = st->l1tstub()->z();
     stub_r = st->l1tstub()->r();
+  } else {
+    // exact helix
+    if (st->isBarrel()) {
+      stub_r = settings_.rmean(stubLayer - 1);
+
+      // The expanded version of this expression is more stable for extremely
+      // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
+      // the domain of asin.
+      double sin_val =
+          0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+      sin_val = std::max(std::min(sin_val, 1.0), -1.0);
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+
+      // The expanded version of this expression is more stable for extremely
+      // high-pT (high-rho) tracks. But we also explicitly restrict cos_val to
+      // the domain of acos.
+      double cos_val =
+          0.5 * (rho / rho_minus_d0) + 0.5 * (rho_minus_d0 / rho) - 0.5 * ((stub_r * stub_r) / (rho * rho_minus_d0));
+      cos_val = std::max(std::min(cos_val, 1.0), -1.0);
+      double beta = std::acos(cos_val);
+      stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
+    } else {
+      stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
+
+      double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho));  // maybe rho should be abs value
+      double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
+      stub_r = sqrt(r_square);
+
+      // The expanded version of this expression is more stable for extremely
+      // high-pT (high-rho) tracks. But we also explicitly restrict sin_val to
+      // the domain of asin.
+      double sin_val =
+          0.5 * (stub_r / rho_minus_d0) + 0.5 * (rho_minus_d0 / stub_r) - 0.5 * ((rho * rho) / (rho_minus_d0 * stub_r));
+      sin_val = std::max(std::min(sin_val, 1.0), -1.0);
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+    }
   }
 
   std::vector<double> invented_coords{stub_r, stub_z, stub_phi};

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -156,12 +156,16 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-              unsigned int curSeed = aTrack->seedIndex();
-              std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
-              if (settings_.extended())
-                seedRank.push_back(9);
-              else
+              const unsigned int curSeed = aTrack->seedIndex();
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
+              } else if (settings_.extended()) {
+                seedRank.push_back(9);
+              } else {
+                throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
+                                                 << " not found in list, and settings->extended() not set.";
+              }
 
               if (stublist.size() != stubidslist.size())
                 throw cms::Exception("LogicError")

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -76,6 +76,9 @@ void L1TrackNtuplePlot(TString type,
 
   SetPlotStyle();
 
+  cout.setf(ios::fixed);
+  cout.precision(2);
+
   // ----------------------------------------------------------------------------------------------------------------
   // define input options
 
@@ -1021,7 +1024,6 @@ void L1TrackNtuplePlot(TString type,
   // ----------------------------------------------------------------------------------------------------------------
 
   int nevt = tree->GetEntries();
-  cout << "number of events = " << nevt << endl;
 
   // ----------------------------------------------------------------------------------------------------------------
   // event loop
@@ -3633,10 +3635,18 @@ void L1TrackNtuplePlot(TString type,
     c.SaveAs(DIR + type + "_trk_pt.pdf");
   }
 
+  // Sample z0 resolution at a couple of rapidity points.
+  float etaSample1 = h2_resVsEta_z0_68->GetXaxis()->GetBinCenter(1);
+  float etaSample2 = h2_resVsEta_z0_68->GetXaxis()->GetBinCenter(0.8 * nETARANGE);
+  float z0ResSample1 = h2_resVsEta_z0_68->GetBinContent(1);
+  float z0ResSample2 = h2_resVsEta_z0_68->GetBinContent(0.8 * nETARANGE);
+
   fout->Close();
 
   // ---------------------------------------------------------------------------------------------------------
   //some printouts
+
+  cout << "number of events = " << nevt << endl;
 
   float k = (float)n_match_eta1p0;
   float N = (float)n_all_eta1p0;
@@ -3691,7 +3701,11 @@ void L1TrackNtuplePlot(TString type,
   cout << "# tracks/event (no pt cut)= " << (float)ntrk / nevt << endl;
   cout << "# tracks/event (pt > " << std::max(TP_minPt, 2.0f) << ") = " << (float)ntrk_pt2 / nevt << endl;
   cout << "# tracks/event (pt > 3.0) = " << (float)ntrk_pt3 / nevt << endl;
-  cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl;
+  cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl << endl;
+
+  // z0 resolution
+  cout << "z0 resolution = " << z0ResSample1 << "cm at |eta| = " << etaSample1 << endl;
+  cout << "z0 resolution = " << z0ResSample2 << "cm at |eta| = " << etaSample2 << endl;
 }
 
 void SetPlotStyle() {

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -43,7 +43,7 @@ echo "MVA track quality Histograms written to MVA_plots/"
 # Run track performance plotting macro
 set plotMacro = $CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
 if (-e TrkPlots) rm -r TrkPlots
-\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 19 >! results.out 
+\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 24 >! results.out 
 cat results.out
 echo "Tracking performance summary written to results.out"
 echo "Track performance histograms written to TrkPlots/"  


### PR DESCRIPTION
#### PR description:

This fixes two bugs in PurgeDuplicate.cc , which had been present since CMSSW 13_2, and which affected the extended (i.e. displaced) L1 tracking. One concerned the ranking of seed types, which had been accidentallly disabled for displced tracks. The other concerned the "inventStubs" option, Which had incorrectly assumed L2L3D1 seeds use L2D1 to determine the r-z helix params, whereas it is really L2L3. The inventStubs option has also been disabled until we've understood if it causes a memory leak.

It also includes a tidy up of the code in PurgeDuplicate::getInventedCoordsExtended() from @aehart .

On ttbar+200PU, the performance of the extended L1 tracking is:

# Before bug fix:

efficiency (for pt > 3 GeV) = 96.46 +- 0.14%
tracks/event = 350

# After bug fix:

efficiency (for Pt > 3 GeV) = 96.72 +- 0.14%
tracks/event = 262

The PR also includes minor changes to a ROOT plotting macro.