### PR TITLE
Scripts to Test MC 22-23 Production (UL-like) in IBs

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -2,3 +2,29 @@
 </test>
 <test name="test-runTheMatrix-interactive" command="test-runTheMatrix_interactive.sh">
 </test>
+
+<!-- Tests for MC production for 2022 and 2023 -->
+<!-- 
+    The conditions used here for 2022 and 2023 will be changed 
+    to use the proper GT from ALCA including the BS smearing 
+    record from GT. For the moment we use the automatic ones.
+    By default these tests won't fail if a failure happens at
+    HLT step. If you want to catch those errors please set the
+    environment variable CMSSW_MC_SETUP_TEST_CATCH_HLT.
+-->
+
+<!-- In CMSSW_13_0_18 the auto:phase1_2023_realistic (pre BPix) is 130X_mcRun3_2023_realistic_postBPix_v1 -->
+<test name="test_MC_23_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 2023v12 CMSSW_13_0_18 130X_mcRun3_2023_realistic_v13 Realistic25ns13p6TeVEarly2023Collision" />
+
+<!-- In CMSSW_12_4_20 the auto:phase1_2022_realistic (pre EE) is 124X_mcRun3_2022_realistic_v12 -->
+<test name="test_MC_22_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 2022v14 CMSSW_12_4_20 124X_mcRun3_2022_realistic_v12 Realistic25ns13p6TeVEarly2022Collision" />
+
+<!-- 
+    The setups below are "standard", with everything run 
+    in the same release (the current) with the same GT.
+    This is done to crosscheck that, in normal conditions, 
+    everything works and ther's no bug or artifact in the 
+    chain itself.  
+-->
+<test name="test_MC_23_crosscheck" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 @relval2023 ${CMSSW_VERSION} auto:phase1_2023_realistic DBrealistic" />
+<test name="test_MC_22_crosscheck" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 @relval2022 ${CMSSW_VERSION} auto:phase1_2022_realistic DBrealistic" />

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This script mimics a MC chain with HLT run 
+# a in a different release from the current one
+
+echo '#### MC Setup'
+
+workdir=$PWD
+scriptdir=$CMSSW_BASE/src/Configuration/PyReleaseValidation/test/test_mc_setup/
+
+# inputs
+conditions=$1 
+era=$2
+hlt=$3
+release_hlt=$4
+gt_hlt=$5
+beamspot=$6
+
+base_dir=$PWD
+base_cms=$CMSSW_BASE
+base_arch=$SCRAM_ARCH
+
+# to take into account changes in gcc
+base_arch_no_gcc=$(echo $SCRAM_ARCH | cut -d "_" -f -2)
+if [[ ! ("$CMSSW_VERSION" == $release_hlt) ]]; then
+    hlt_cmssw_path=$(scram list -c $release_hlt | grep -w $release_hlt | sed 's|.* ||')
+    echo $hlt_cmssw_path
+fi
+
+echo '> GT           : ' $conditions
+echo '> Era          : ' $era
+echo '> BS           : ' $beamspot
+echo '> HLT          : ' $hlt
+echo '> HLT release  : ' $release_hlt
+if [[ ! ("$CMSSW_VERSION" == $release_hlt) ]]; then
+    echo " - at ${hlt_cmssw_path}"
+fi
+echo '> HLT GT       : ' $gt_hlt
+if [[ -z "${CMSSW_MC_SETUP_TEST_CATCH_HLT}" ]]; then
+    echo ' - !! No error catch at HLT - If you want to catch them set  !!'
+    echo ' - !! the environment variable CMSSW_MC_SETUP_TEST_CATCH_HLT !!'
+fi
+echo '> Working dir  : ' $workdir
+echo ''
+############################################################################################################
+# GEN SIM
+
+${scriptdir}/test_MC_setup_gen_sim.sh $CMSSW_VERSION $conditions $era $beamspot 
+
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+############################################################################################################
+# HLT
+if [[ ! ("$CMSSW_VERSION" == $release_hlt) ]]; then
+    cd $hlt_cmssw_path
+    eval `scram runtime -sh`
+    cd $workdir
+fi
+
+${scriptdir}/test_MC_setup_hlt.sh $gt_hlt $era $hlt
+hlt_result=$?
+
+if [ $hlt_result -ne 0 ] && [[ ! -z "${CMSSW_MC_SETUP_TEST_CATCH_HLT}" ]]; then
+    exit 1;
+elif [ $hlt_result -ne 0 ]; then
+    echo "!!! HLT failed but ignoring !!!"
+    exit 0
+fi
+
+############################################################################################################
+# RECO + PAT
+if [[ ! ("$CMSSW_BASE" == $base_cms) ]]; then
+    cd $base_cms
+    eval `scram runtime -sh`
+    cd $workdir
+fi
+echo $SCRAM_ARCH
+${scriptdir}/test_MC_setup_reco.sh $release_hlt $conditions $era $hlt
+
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+############################################################################################################
+
+echo '>>>> Done! <<<<'

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_gen_sim.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_gen_sim.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+############################################################################################################
+### GEN-SIM-RAW-DIGI
+
+release=$1 
+conditions=$2
+era=$3
+beamspot=$4
+
+echo '> Running GEN,SIM + DIGI,L1,DIGI2RAW steps in ' $release
+
+cmsDriver.py TTbar_14TeV_TuneCP5_cfi --python_filename gen_sim.py \
+--eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring \
+--datatier GEN-SIM --fileout file:step1.root --conditions $conditions --beamspot $beamspot \
+--step GEN,SIM --geometry DB:Extended --era $era --mc -n 10 --no_exec
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in building the config for GEN-SIM with cmsDriver !!!!! "
+    exit 1;
+fi
+
+cmsRun gen_sim.py
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in running the config for GEN-SIM !!!!! "
+    exit 1;
+fi
+
+cmsDriver.py  --python_filename raw_digi.py --eventcontent RAWSIM \
+--customise Configuration/DataProcessing/Utils.addMonitoring \
+--datatier GEN-SIM-RAW --filein file:step1.root \
+--fileout file:step2.root --conditions $conditions --step DIGI,L1,DIGI2RAW \
+--geometry DB:Extended --era $era --mc -n -1 --no_exec
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in building the config for RAW-DIGI with cmsDriver !!!!! "
+    exit 1;
+fi
+
+cmsRun raw_digi.py
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in running the config for RAW-DIGI !!!!! "
+    exit 1;
+fi
+############################################################################################################

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_hlt.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_hlt.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+############################################################################################################
+### HLT STEP in a different release
+
+conditions=$1
+era=$2
+hlt=$3
+
+echo ">>> Running HLT:${hlt} step in " $CMSSW_BASE
+
+config_name=hlt_"$(echo "$hlt" | tr ':' _ | tr '@' _ )".py
+cmsDriver.py  --python_filename $config_name --eventcontent RAWSIM \
+--customise Configuration/DataProcessing/Utils.addMonitoring \
+--datatier GEN-SIM-RAW --fileout file:step3.root \
+--conditions $conditions \
+--customise_commands 'process.source.bypassVersionCheck = cms.untracked.bool(True)' \
+--step 'HLT:'$hlt --geometry DB:Extended --filein file:step2.root --era $era --mc -n -1 --no_exec
+
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+cmsRun $config_name
+
+if [ $? -ne 0 ]; then
+    exit 1;
+fi
+
+############################################################################################################

--- a/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_reco.sh
+++ b/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup_reco.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+############################################################################################################
+### RECO + PAT
+
+release=$1 
+conditions=$2
+era=$3
+
+#export SCRAM_ARCH=$scram_arch
+
+echo '> Running RAW2DIGI,L1Reco,RECO,RECOSIM + PAT steps in ' $release
+
+cmsDriver.py  --python_filename reco.py --eventcontent AODSIM \
+--customise Configuration/DataProcessing/Utils.addMonitoring \
+--datatier AODSIM --fileout file:step4.root \
+--conditions $conditions --step RAW2DIGI,L1Reco,RECO,RECOSIM \
+--geometry DB:Extended --filein file:step3.root --era $era \
+--mc -n -1 --no_exec
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in building the config for RECO with cmsDriver !!!!! "
+    exit 1;
+fi
+
+cmsRun reco.py
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in running the config for RECO !!!!! "
+    exit 1;
+fi
+
+
+cmsDriver.py  --python_filename pat.py --eventcontent MINIAODSIM \
+--customise Configuration/DataProcessing/Utils.addMonitoring \
+--datatier MINIAODSIM --fileout file:step5.root \
+--conditions $conditions --step PAT \
+--geometry DB:Extended --filein file:step4.root --era $era \
+--mc -n -1 --no_exec
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in building the config for PAT with cmsDriver !!!!! "
+    exit 1;
+fi
+
+cmsRun pat.py
+
+if [ $? -ne 0 ]; then
+    echo " !!!! Error in running the config for PAT !!!!! "
+    exit 1;
+fi
+
+
+############################################################################################################


### PR DESCRIPTION
This PR proposes the addition of a set of scripts to be used as IB tests to show the desired behavior of the next 2022-2023 MC campaign and to allow experts to have this run in all the IBs to follow issues and eventually find solutions. The schema for the campaign should be the following:

#### 2022 campaign
- GEN-SIM-RAW-DIGI steps run in `14_0_X`;
- HLT step for 2022 run in `12_4_X`;
- all the subsequent steps run in `14_0_X`;
- ideal pre EE issue conditions. The EE issue to be mimicked via a veto.

#### 2023 campaign
- GEN-SIM-RAW-DIGI steps run in `14_0_X`;
- HLT step for 2023 run in `13_0_X`;
- all the subsequent steps run in `14_0_X`;
- ideal pre BPix hole conditions. The BPix issue to be absorbed in the SF.

This setup poses some issues:
- forward compatibility: CMSSW does not formally support it so `12_4_X` or `13_0_X` being able to process `14_0_X` samples is not granted. 
- conditions: we need to be able to have exactly the same conditions for [`140X_*preEE*` and `124X_*preEE*`] and [`140X_*preBPix*` and `130X_*preBPix*`]. Possibly having the `SimBeamSpotObjectsRcd` in them, to be able to use the BS smearing from GT mechanism at GEN-SIM step.

To make it less cumbersome (hopefully), I've split each step in a different script and have the different setups running the same bash script with different inputs. **As they are, none of the tests technically fails**. This is intentional not to have some tests that will by definition break any IB. But any suggestion there is welcome. Each script runs the HLT step in a specific target release and all the steps in the current release. 

_Issue (?): as they are these tests take O(100s) each (so x4)._ 

We would need a back port to `14_0_X` to have it tested there.

FYI: @cms-sw/alca-l2, @cms-sw/core-l2 