### PR TITLE
[GCC13] Fix Woverloaded-virtual warning

### DIFF
--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
@@ -67,5 +67,7 @@ private:
   Bdu getBdu(std::string) const;
   Edu getEdu(std::string) const;
   Range readRange(const std::string &) const;
+
+  using PixelToFEDAssociate::operator();
 };
 #endif

--- a/CondFormats/L1TObjects/interface/L1MuPacking.h
+++ b/CondFormats/L1TObjects/interface/L1MuPacking.h
@@ -82,6 +82,11 @@ public:
           << "L1MuUnignedPacking::packedFromIdx: warning value " << idx << "exceeds " << nbits << "-bit range !!!";
     return (unsigned)idx;
   };
+
+private:
+  int signFromPacked(unsigned packed) const = 0;
+  int idxFromPacked(unsigned packed) const = 0;
+  unsigned packedFromIdx(int idx) const = 0;
 };
 
 /**
@@ -127,6 +132,11 @@ public:
           << "L1MuSignedPacking::packedFromIdx: warning value " << idx << "exceeds " << nbits << "-bit range !!!";
     return ~(std::numeric_limits<unsigned>::max() << nbits) & (idx < 0 ? (1U << nbits) + idx : idx);
   };
+
+private:
+  int signFromPacked(unsigned packed) const = 0;
+  int idxFromPacked(unsigned packed) const = 0;
+  unsigned packedFromIdx(int idx) const = 0;
 };
 
 /**

--- a/DQM/EcalCommon/interface/MESetDet0D.h
+++ b/DQM/EcalCommon/interface/MESetDet0D.h
@@ -37,6 +37,9 @@ namespace ecaldqm {
     double getBinContent(EcalDQMSetupObjects const, int, int = 0) const override;
 
     void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
+
+  private:
+    using ecaldqm::MESetEcal::operator=;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetDet1D.h
+++ b/DQM/EcalCommon/interface/MESetDet1D.h
@@ -69,6 +69,9 @@ namespace ecaldqm {
     int findBin(EcalDQMSetupObjects const, int, double, double = 0.) const override;
 
     void reset(EcalElectronicsMapping const *, double = 0., double = 0., double = 0.) override;
+
+  private:
+    using ecaldqm::MESetEcal::operator=;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetDet2D.h
+++ b/DQM/EcalCommon/interface/MESetDet2D.h
@@ -66,6 +66,9 @@ namespace ecaldqm {
     void fill_(unsigned, int, double) override;
     void fill_(unsigned, int, double, double) override;
     void fill_(unsigned, double, double, double) override;
+
+  private:
+    using ecaldqm::MESetEcal::operator=;
   };
 }  // namespace ecaldqm
 

--- a/DQM/EcalCommon/interface/MESetProjection.h
+++ b/DQM/EcalCommon/interface/MESetProjection.h
@@ -42,6 +42,9 @@ namespace ecaldqm {
 
     using MESetEcal::getBinEntries;
     double getBinEntries(EcalDQMSetupObjects const, DetId const &, int = 0) const override;
+
+  private:
+    using ecaldqm::MESetEcal::operator=;
   };
 }  // namespace ecaldqm
 

--- a/DQM/HcalCommon/interface/ContainerProf2D.h
+++ b/DQM/HcalCommon/interface/ContainerProf2D.h
@@ -76,7 +76,13 @@ namespace hcaldqm {
     void fill(HcalElectronicsId const &, double, double, double);
     void fill(HcalTrigTowerDetId const &, double, double, double);
 
-  protected:
+  private:
+    void fill(uint32_t) override{};
+    void fill(uint32_t, int) override{};
+    void fill(uint32_t, double) override{};
+    void fill(uint32_t, int, double) override{};
+    void fill(uint32_t, int, int) override{};
+    void fill(uint32_t, double, double) override{};
   };
 }  // namespace hcaldqm
 

--- a/DataFormats/L1Trigger/interface/EGamma.h
+++ b/DataFormats/L1Trigger/interface/EGamma.h
@@ -48,10 +48,12 @@ namespace l1t {
     short int shape() const;
     short int towerHoE() const;
 
-    virtual bool operator==(const l1t::EGamma& rhs) const;
-    virtual inline bool operator!=(const l1t::EGamma& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::EGamma& rhs) const;
+    inline bool operator!=(const l1t::EGamma& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // additional hardware quantities common to L1 global EG
     void clear_extended();
     short int towerIEta_;

--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -70,10 +70,12 @@ namespace l1t {
 
     EtSumType getType() const;
 
-    virtual bool operator==(const l1t::EtSum& rhs) const;
-    virtual inline bool operator!=(const l1t::EtSum& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::EtSum& rhs) const;
+    inline bool operator!=(const l1t::EtSum& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // type of EtSum
     EtSumType type_;
 

--- a/DataFormats/L1Trigger/interface/Jet.h
+++ b/DataFormats/L1Trigger/interface/Jet.h
@@ -39,10 +39,12 @@ namespace l1t {
     short int puEt() const;
     short int puDonutEt(int i) const;
 
-    virtual bool operator==(const l1t::Jet& rhs) const;
-    virtual inline bool operator!=(const l1t::Jet& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::Jet& rhs) const;
+    inline bool operator!=(const l1t::Jet& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // additional hardware quantities common to L1 global jet
     void clear_extended();
     short int towerIEta_;

--- a/DataFormats/L1Trigger/interface/Muon.h
+++ b/DataFormats/L1Trigger/interface/Muon.h
@@ -114,10 +114,12 @@ namespace l1t {
 
     inline bool debug() const { return debug_; };
 
-    virtual bool operator==(const l1t::Muon& rhs) const;
-    virtual inline bool operator!=(const l1t::Muon& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::Muon& rhs) const;
+    inline bool operator!=(const l1t::Muon& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // additional hardware quantities common to L1 global jet
     int hwCharge_;
     int hwChargeValid_;

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -79,10 +79,12 @@ namespace l1t {
     bool isTwoLooseOutOfTime() const { return false; }
     bool isOneTightOutOfTime() const { return false; }
 
-    virtual bool operator==(const l1t::MuonShower& rhs) const;
-    virtual inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::MuonShower& rhs) const;
+    inline bool operator!=(const l1t::MuonShower& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // Run-3 definitions as provided in DN-20-033
     // in time and out-of-time qualities. only 2 bits each.
     bool oneNominalInTime_;

--- a/DataFormats/L1Trigger/interface/Tau.h
+++ b/DataFormats/L1Trigger/interface/Tau.h
@@ -45,10 +45,12 @@ namespace l1t {
     bool hasEM() const;
     bool isMerged() const;
 
-    virtual bool operator==(const l1t::Tau& rhs) const;
-    virtual inline bool operator!=(const l1t::Tau& rhs) const { return !(operator==(rhs)); };
+    bool operator==(const l1t::Tau& rhs) const;
+    inline bool operator!=(const l1t::Tau& rhs) const { return !(operator==(rhs)); };
 
   private:
+    using L1Candidate::operator==;
+    using L1Candidate::operator!=;
     // additional hardware quantities common to L1 global tau
     void clear_extended();
     short int towerIEta_;

--- a/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
+++ b/DataFormats/SiStripDigi/interface/SiStripRawDigi.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_SiStripDigi_SiStripRawDigi_H
 #define DataFormats_SiStripDigi_SiStripRawDigi_H
 
+#include <cstdint>
 #include "DataFormats/Common/interface/traits.h"
 
 /** 


### PR DESCRIPTION
#### PR description:

This PR fixes `overloaded-virtual` warnings emitted by gcc13 [link](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_1_X_2024-03-29-2300/Alignment/OfflineValidation):

```
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/Jet.h:4,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h:12,
                 from src/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc:39:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/L1Candidate.h:41:18: warning: 'virtual bool l1t::L1Candidate::operator==(const l1t::L1Candidate&) const' was hidden [-Woverloaded-virtual=]
    41 |     virtual bool operator==(const l1t::L1Candidate& rhs) const;
      |                  ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/Jet.h:42:18: note:   by 'virtual bool l1t::Jet::operator==(const l1t::Jet&) const'
   42 |     virtual bool operator==(const l1t::Jet& rhs) const;
      |                  ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/L1Candidate.h:42:25: warning: 'virtual bool l1t::L1Candidate::operator!=(const l1t::L1Candidate&) const' was hidden [-Woverloaded-virtual=]
    42 |     virtual inline bool operator!=(const l1t::L1Candidate& rhs) const { return !(operator==(rhs)); };
      |                         ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/Jet.h:43:25: note:   by 'virtual bool l1t::Jet::operator!=(const l1t::Jet&) const'
   43 |     virtual inline bool operator!=(const l1t::Jet& rhs) const { return !(operator==(rhs)); };
      |                         ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/L1Candidate.h:41:18: warning: 'virtual bool l1t::L1Candidate::operator==(const l1t::L1Candidate&) const' was hidden [-Woverloaded-virtual=]
    41 |     virtual bool operator==(const l1t::L1Candidate& rhs) const;
      |                  ^~~~~~~~
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h:13:
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/Tau.h:48:18: note:   by 'virtual bool l1t::Tau::operator==(const l1t::Tau&) const'
   48 |     virtual bool operator==(const l1t::Tau& rhs) const;
      |                  ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/L1Candidate.h:42:25: warning: 'virtual bool l1t::L1Candidate::operator!=(const l1t::L1Candidate&) const' was hidden [-Woverloaded-virtual=]
    42 |     virtual inline bool operator!=(const l1t::L1Candidate& rhs) const { return !(operator==(rhs)); };
      |                         ^~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/f13f75b2cf04a5a6e5b5b92c5e0cd08a/opt/cmssw/el9_amd64_gcc13/cms/cmssw/CMSSW_14_1_X_2024-03-29-2300/src/DataFormats/L1Trigger/interface/Tau.h:49:25: note:   by 'virtual bool l1t::Tau::operator!=(const l1t::Tau&) const'
   49 |     virtual inline bool operator!=(const l1t::Tau& rhs) const { return !(operator==(rhs)); };
      |                         ^~~~~~~~
```

An alternative approach would be to make comparision operators in `l1t::Tau` etc non-virtual, since these look like final classes.

#### PR validation:

Bot tests