### PR TITLE
Backport spin lock bug fixes

### DIFF
--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -116,7 +116,7 @@ private:
   size_t maxSavedEventsPerLumi_;
   bool verbose_, veryVerbose_;
   bool taggedMode_, forcedValue_;
-  mutable std::atomic<bool> statsGuard_;
+  mutable std::atomic<bool> statsGuard_{false};
 
   template <typename Collection>
   static void increment(ErrorSet &scoreboard, Collection &list);

--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -71,9 +71,9 @@ namespace {
   };
   std::unique_ptr<std::atomic<bool>, release> make_guard(std::atomic<bool> &b) noexcept {
     bool expected = false;
-    while (not b.compare_exchange_strong(expected, true))
-      ;
-
+    while (not b.compare_exchange_strong(expected, true)) {
+      expected = false;
+    }
     return std::unique_ptr<std::atomic<bool>, release>(&b, release());
   }
 

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -133,7 +133,7 @@ namespace edm {
 
   void Path::threadsafe_setFailedModuleInfo(int nwrwue, bool iExcept) {
     bool expected = false;
-    while (stateLock_.compare_exchange_strong(expected, true)) {
+    while (not stateLock_.compare_exchange_strong(expected, true)) {
       expected = false;
     }
     if (iExcept) {


### PR DESCRIPTION
#### PR description:

Backports bug fixes to a couple of spin locks to 14_0_X. This backports PRs #44447 and #44517. See Issue #44413 for related discussion.

These bugs were causing rare seg faults in IB tests. We believe they mostly only occurred when concurrent lumis were configured and multiple lumis were actually being executed. The failure actually observed seemed more common when lumis containing no events were being processed because it requires global end lumi transitions running at the same time. Even in those circumstances the failures are rare.

#### PR validation:

Relies on existing tests.
