### PR TITLE
`TrackerAlignment_PayloadInspector`: add tag comparator in cylindrical coordinates

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -190,7 +190,7 @@ namespace {
                                                            AlignmentPI::rot_beta,
                                                            AlignmentPI::rot_gamma};
 
-      std::unordered_map<AlignmentPI::coordinate, std::unique_ptr<TH1F> > diffs;
+      std::unordered_map<AlignmentPI::coordinate, std::unique_ptr<TH1F>> diffs;
 
       // generate the map of histograms
       for (const auto &coord : coords) {
@@ -327,6 +327,264 @@ namespace {
 
   typedef TrackerAlignmentCompareAll<1, MULTI_IOV, RegionCategory::OUTER> OTAlignmentComparatorSingleTag;
   typedef TrackerAlignmentCompareAll<2, SINGLE_IOV, RegionCategory::OUTER> OTAlignmentComparatorTwoTags;
+
+  //*******************************************/
+  // Size of the movement over all partitions,
+  // one at a time (in cylindrical coordinates)
+  //******************************************//
+
+  template <int ntags, IOVMultiplicity nIOVs, RegionCategory cat>
+  class TrackerAlignmentCompareCylindricalBase : public PlotImage<Alignments, nIOVs, ntags> {
+    enum coordinate {
+      t_r = 1,
+      t_phi = 2,
+      t_z = 3,
+    };
+
+  public:
+    TrackerAlignmentCompareCylindricalBase()
+        : PlotImage<Alignments, nIOVs, ntags>("comparison of cylindrical coordinates between two geometries") {}
+
+    bool fill() override {
+      TGaxis::SetExponentOffset(-0.12, 0.01, "y");  // Y offset
+
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<Alignments> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<Alignments> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      std::vector<AlignTransform> ref_ali = first_payload->m_align;
+      std::vector<AlignTransform> target_ali = last_payload->m_align;
+
+      TCanvas canvas("Alignment Comparison", "", 2000, 600);
+      canvas.Divide(3, 1);
+
+      const bool ph2 = (ref_ali.size() > AlignmentPI::phase1size);
+
+      const std::vector<coordinate> coords = {t_r, t_phi, t_z};
+      std::unordered_map<coordinate, std::unique_ptr<TH1F>> diffs;
+
+      // Use remove_if along with a lambda expression to remove elements based on the condition (subid > 2)
+      if (cat != RegionCategory::ALL) {
+        ref_ali.erase(std::remove_if(ref_ali.begin(),
+                                     ref_ali.end(),
+                                     [](const AlignTransform &transform) {
+                                       int subid = DetId(transform.rawId()).subdetId();
+                                       return (cat == RegionCategory::INNER) ? (subid > 2) : (subid <= 2);
+                                     }),
+                      ref_ali.end());
+
+        target_ali.erase(std::remove_if(target_ali.begin(),
+                                        target_ali.end(),
+                                        [](const AlignTransform &transform) {
+                                          int subid = DetId(transform.rawId()).subdetId();
+                                          return (cat == RegionCategory::INNER) ? (subid > 2) : (subid <= 2);
+                                        }),
+                         target_ali.end());
+      }
+
+      auto h_deltaR = std::make_unique<TH1F>(
+          "deltaR", Form(";Detector Id index; #DeltaR [#mum]"), ref_ali.size(), -0.5, ref_ali.size() - 0.5);
+      auto h_deltaPhi = std::make_unique<TH1F>(
+          "deltaPhi", Form(";Detector Id index; #Delta#phi [mrad]"), ref_ali.size(), -0.5, ref_ali.size() - 0.5);
+      auto h_deltaZ = std::make_unique<TH1F>(
+          "deltaZ", Form(";Detector Id index; #DeltaZ [#mum]"), ref_ali.size(), -0.5, ref_ali.size() - 0.5);
+
+      std::map<int, AlignmentPI::partitions> boundaries;
+      if (cat < RegionCategory::OUTER) {
+        boundaries.insert({0, AlignmentPI::BPix});  // always start with BPix, not filled in the loop
+      }
+
+      int counter = 0; /* start the counter */
+      AlignmentPI::partitions currentPart = AlignmentPI::BPix;
+      for (unsigned int i = 0; i < ref_ali.size(); i++) {
+        if (ref_ali[i].rawId() == target_ali[i].rawId()) {
+          counter++;
+          int subid = DetId(ref_ali[i].rawId()).subdetId();
+          auto thePart = static_cast<AlignmentPI::partitions>(subid);
+
+          if (thePart != currentPart) {
+            currentPart = thePart;
+            boundaries.insert({counter, thePart});
+          }
+
+          const auto &deltaTrans = target_ali[i].translation() - ref_ali[i].translation();
+          double dPhi = target_ali[i].translation().phi() - ref_ali[i].translation().phi();
+          if (dPhi > M_PI) {
+            dPhi -= 2.0 * M_PI;
+          }
+          if (dPhi < -M_PI) {
+            dPhi += 2.0 * M_PI;
+          }
+
+          h_deltaR->SetBinContent(i + 1, deltaTrans.perp() * AlignmentPI::cmToUm);
+          h_deltaPhi->SetBinContent(i + 1, dPhi * AlignmentPI::tomRad);
+          h_deltaZ->SetBinContent(i + 1, deltaTrans.z() * AlignmentPI::cmToUm);
+        }
+      }
+
+      diffs[t_r] = std::move(h_deltaR);
+      diffs[t_phi] = std::move(h_deltaPhi);
+      diffs[t_z] = std::move(h_deltaZ);
+
+      unsigned int subpad{1};
+      TLegend legend = TLegend(0.17, 0.84, 0.95, 0.94);
+      legend.SetTextSize(0.023);
+      for (const auto &coord : coords) {
+        canvas.cd(subpad);
+        canvas.cd(subpad)->SetTopMargin(0.06);
+        canvas.cd(subpad)->SetLeftMargin(0.17);
+        canvas.cd(subpad)->SetRightMargin(0.05);
+        canvas.cd(subpad)->SetBottomMargin(0.15);
+        AlignmentPI::makeNicePlotStyle(diffs[coord].get(), kBlack);
+        auto max = diffs[coord]->GetMaximum();
+        auto min = diffs[coord]->GetMinimum();
+        auto range = std::abs(max) > std::abs(min) ? std::abs(max) : std::abs(min);
+        if (range == 0.f) {
+          range = 0.1;
+        }
+
+        // no negative radii differnces
+        if (coord != t_r) {
+          diffs[coord]->GetYaxis()->SetRangeUser(-range * 1.5, range * 1.5);
+        } else {
+          diffs[coord]->GetYaxis()->SetRangeUser(0., range * 1.5);
+        }
+
+        diffs[coord]->GetYaxis()->SetTitleOffset(1.5);
+        diffs[coord]->SetMarkerStyle(20);
+        diffs[coord]->SetMarkerSize(0.5);
+        diffs[coord]->Draw("P");
+
+        if (subpad == 1) { /* fill the legend only at the first pass */
+          if (this->m_plotAnnotations.ntags == 2) {
+            legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
+            legend.AddEntry(
+                diffs[coord].get(),
+                ("#splitline{" + tagname1 + " : " + firstIOVsince + "}{" + tagname2 + " : " + lastIOVsince + "}")
+                    .c_str(),
+                "PL");
+          } else {
+            legend.SetHeader(("tag: #bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+            legend.AddEntry(diffs[coord].get(),
+                            ("#splitline{IOV since: " + firstIOVsince + "}{IOV since: " + lastIOVsince + "}").c_str(),
+                            "PL");
+          }
+        }
+        subpad++;
+      }
+
+      canvas.Update();
+      canvas.cd();
+      canvas.Modified();
+
+      bool doOnlyPixel = (cat == RegionCategory::INNER);
+
+      TLine l[6][boundaries.size()];
+      TLatex tSubdet[6];
+      for (unsigned int i = 0; i < 6; i++) {
+        tSubdet[i].SetTextColor(kRed);
+        tSubdet[i].SetNDC();
+        tSubdet[i].SetTextAlign(21);
+        tSubdet[i].SetTextSize(doOnlyPixel ? 0.05 : 0.03);
+        tSubdet[i].SetTextAngle(90);
+      }
+
+      subpad = 0;
+      for (const auto &coord : coords) {
+        auto s_coord = getStringFromCoordinate(coord);
+        canvas.cd(subpad + 1);
+        for (const auto &line : boundaries | boost::adaptors::indexed(0)) {
+          const auto &index = line.index();
+          const auto value = line.value();
+          l[subpad][index] = TLine(diffs[coord]->GetBinLowEdge(value.first),
+                                   canvas.cd(subpad + 1)->GetUymin(),
+                                   diffs[coord]->GetBinLowEdge(value.first),
+                                   canvas.cd(subpad + 1)->GetUymax() * 0.84);
+          l[subpad][index].SetLineWidth(1);
+          l[subpad][index].SetLineStyle(9);
+          l[subpad][index].SetLineColor(2);
+          l[subpad][index].Draw("same");
+        }
+
+        for (const auto &elem : boundaries | boost::adaptors::indexed(0)) {
+          const auto &lm = canvas.cd(subpad + 1)->GetLeftMargin();
+          const auto &rm = 1 - canvas.cd(subpad + 1)->GetRightMargin();
+          const auto &frac = float(elem.value().first) / ref_ali.size();
+
+          LogDebug("TrackerAlignmentCompareCylindricalBase")
+              << __PRETTY_FUNCTION__ << " left margin:  " << lm << " right margin: " << rm << " fraction: " << frac;
+
+          float theX_ = lm + (rm - lm) * frac + ((elem.index() > 0 || doOnlyPixel) ? 0.025 : 0.01);
+
+          tSubdet[subpad].DrawLatex(
+              theX_, 0.23, Form("%s", AlignmentPI::getStringFromPart(elem.value().second, /*is phase2?*/ ph2).c_str()));
+        }
+
+        auto ltx = TLatex();
+        ltx.SetTextFont(62);
+        ltx.SetTextSize(0.042);
+        ltx.SetTextAlign(11);
+        ltx.DrawLatexNDC(canvas.cd(subpad + 1)->GetLeftMargin(),
+                         1 - canvas.cd(subpad + 1)->GetTopMargin() + 0.01,
+                         ("Tracker Alignment Compare : #color[4]{" + s_coord + "}").c_str());
+        legend.Draw("same");
+        subpad++;
+      }  // loop on the coordinates
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  private:
+    /*--------------------------------------------------------------------*/
+    inline std::string getStringFromCoordinate(coordinate coord)
+    /*--------------------------------------------------------------------*/
+    {
+      switch (coord) {
+        case t_r:
+          return "r-translation";
+        case t_phi:
+          return "#phi-rotation";
+        case t_z:
+          return "z-translation";
+        default:
+          return "should never be here!";
+      }
+    }
+  };
+
+  typedef TrackerAlignmentCompareCylindricalBase<1, MULTI_IOV, RegionCategory::ALL>
+      TrackerAlignmentCompareRPhiZSingleTag;
+  typedef TrackerAlignmentCompareCylindricalBase<2, SINGLE_IOV, RegionCategory::ALL> TrackerAlignmentCompareRPhiZTwoTags;
+
+  typedef TrackerAlignmentCompareCylindricalBase<1, MULTI_IOV, RegionCategory::INNER>
+      PixelAlignmentCompareRPhiZSingleTag;
+  typedef TrackerAlignmentCompareCylindricalBase<2, SINGLE_IOV, RegionCategory::INNER> PixelAlignmentCompareRPhiZTwoTags;
+
+  typedef TrackerAlignmentCompareCylindricalBase<1, MULTI_IOV, RegionCategory::OUTER> OTAlignmentCompareRPhiZSingleTag;
+  typedef TrackerAlignmentCompareCylindricalBase<2, SINGLE_IOV, RegionCategory::OUTER> OTAlignmentCompareRPhiZTwoTags;
 
   //*******************************************//
   // Size of the movement over all partitions,
@@ -609,7 +867,7 @@ namespace {
       TCanvas canvas("Alignment Comparison", "Alignment Comparison", 1800, 1200);
       canvas.Divide(3, 2);
 
-      std::unordered_map<AlignmentPI::coordinate, std::unique_ptr<TH1F> > diffs;
+      std::unordered_map<AlignmentPI::coordinate, std::unique_ptr<TH1F>> diffs;
       std::vector<AlignmentPI::coordinate> coords = {AlignmentPI::t_x,
                                                      AlignmentPI::t_y,
                                                      AlignmentPI::t_z,
@@ -1478,6 +1736,12 @@ PAYLOAD_INSPECTOR_MODULE(TrackerAlignment) {
   PAYLOAD_INSPECTOR_CLASS(OTAlignmentComparatorTwoTags);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentComparatorSingleTag);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareRPhiZSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareRPhiZTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(PixelAlignmentCompareRPhiZSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(PixelAlignmentCompareRPhiZTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(OTAlignmentCompareRPhiZSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(OTAlignmentCompareRPhiZTwoTags);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareX);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareY);
   PAYLOAD_INSPECTOR_CLASS(TrackerAlignmentCompareZ);

--- a/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
+++ b/CondCore/AlignmentPlugins/test/testTrackerAlignmentPayloadInspector.cpp
@@ -81,5 +81,11 @@ int main(int argc, char** argv) {
       PI::mk_input("TrackerAlignment_2017_ultralegacymc_v2", 1, 1, "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1));
   edm::LogPrint("testTrackerAlignmentPayloadInspector") << histo10.data();
 
+  TrackerAlignmentCompareRPhiZTwoTags histo11;
+  histo11.process(
+      connectionString,
+      PI::mk_input("TrackerAlignment_2017_ultralegacymc_v2", 1, 1, "TrackerAlignment_Upgrade2017_realistic_v2", 1, 1));
+  edm::LogPrint("testTrackerAlignmentPayloadInspector") << histo11.data();
+
   Py_Finalize();
 }


### PR DESCRIPTION
#### PR description:

The goal of this PR is to introduce a class to perform tracker alignment payload inspections using cylindrical coordinates (R, &phi;, Z). It supports both 2 IOVs within the same tag or different tags at the same time. 
Also added the new class to the battery of existing unit tests.

#### PR validation:

Run successfully the package unit tests `scram b runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A