### PR TITLE
Temporary: abort if cutParser fails to find methods

### DIFF
--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -9,6 +9,9 @@
 
 #include <string>
 
+//DEBUG THREADING PROBLEM
+#include <cstdlib>
+
 using namespace reco::parser;
 using namespace std;
 
@@ -121,6 +124,8 @@ bool MethodSetter::push(const string& name, const vector<AnyMethodArgument>& arg
     // Not a data member either, fatal error, throw.
     switch (error) {
       case reco::parser::kNameDoesNotExist: {
+        //DEBUG THREADING ISSUE
+        std::abort();
         Exception ex(begin);
         ex << "no method or data member named \"" << name << "\" found for type \"" << type.name() << "\"\n";
         // The following information is for temporary debugging only, intended to be removed later

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -178,6 +178,8 @@ void testCutParser::checkAll() {
 
   // check handling of errors
   //   first those who are the same in lazy and non lazy parsing
+  //DEBUG FOR THREADING
+  /*
   for (int lazy = 0; lazy <= 1; ++lazy) {
     sel.reset();
     CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("1abc", sel, lazy));
@@ -220,6 +222,7 @@ void testCutParser::checkAll() {
 
   sel.reset();
   CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')", sel, false), edm::Exception);
+  */ //DEBUG ENDING
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());


### PR DESCRIPTION

#### PR description:

This is to help us debug a threading issue in ROOT. The abort will cause cmsRun to pause all threads and allow us to correlate what else is running when this problem occurs.

The intent is to only use this for a very short time in the IBs to help us try to debug the underlying problem. Once we get more info, this PR should be reverted.

#### PR validation:

Code compiles.