### PR TITLE
Update L1TUtmTriggerMenu tag in 2024 MC GTs and for Run3 data RelVals

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -90,13 +90,13 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
-    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v6',
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v7',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v7',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v5',
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase2

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_0_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-02-21 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_1_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-03-20 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

The PR updates the L1TUtmTriggerMenu tag from `L1Menu_Collisions2024_v1_0_0_xml` to `L1Menu_Collisions2024_v1_1_0_xml` in the following 2024 MC GTs 

- `140X_mcRun3_2024_design_v7`
- `140X_mcRun3_2024_realistic_v8`
- `140X_mcRun3_2024cosmics_realistic_deco_v8`
- `140X_mcRun3_2024cosmics_design_deco_v6`

and the Run3 data Relval GT via modification in `autoCondModifiers.py`.

More details for the request can be found in the relevant CMS Talk post [1].

[1] https://cms-talk.web.cern.ch/t/update-of-the-2024-l1t-menu-tag-l1menu-collisions2024-v1-1-0/37795/


**GT Differences with the last ones are here**:

- **Phase1 2024 design**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v6/140X_mcRun3_2024_design_v7

- **Phase1 2024 realistic**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v7/140X_mcRun3_2024_realistic_v8

- **Phase1 2024 cosmics realistic**:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v7/140X_mcRun3_2024cosmics_realistic_deco_v8

- **Phase1 2024 cosmics design**: 
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v5/140X_mcRun3_2024cosmics_design_deco_v6

#### PR validation:

Tested with
- Data RelVal GT: ` runTheMatrix.py -l 141.044,140.065,141.008,140.022 -j 10 --ibeos` 
- 2024 MC GTs: `runTheMatrix.py -l 13050.0,13049.0,13046.0,13040.0,12933.0,12841.0,12802.0,12824.0,12834.1,13052.0 --what upgrade -j 10 --ibeos` 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport. Backport to 140X will be soon opened up