### PR TITLE
[14.0.X] HLT phase-2: fix HGCAL Layercluster and create common constants configuration for HGCAL

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalRecHitL1Seeded_cfi.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+
 
 HGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
     HGCEE_cce = cms.PSet(
@@ -48,28 +50,13 @@ HGCalRecHitL1Seeded = cms.EDProducer("HGCalRecHitProducer",
         0.0, 39.500245, 39.756638, 39.756638, 39.756638,
         39.756638, 66.020266, 92.283895, 92.283895
     ),
-    layerWeights = cms.vdouble(
-        0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-        10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-        10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-        10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-        10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-        10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-        51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-        51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-        69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-        87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-        86.92952
-    ),
+    layerWeights = HGCAL_reco_constants.dEdXweights,
     maxValSiPar = cms.double(10000.0),
     minValSiPar = cms.double(10.0),
     noiseSiPar = cms.double(5.5),
     rangeMask = cms.uint32(4294442496),
     rangeMatch = cms.uint32(1161838592),
-    sciThicknessCorrection = cms.double(0.9),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-        0.84
-    ),
+    sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+    thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
     thicknessNoseCorrection = cms.vdouble(1.132, 1.092, 1.084)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalRecHit_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 HGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
     HGCEE_cce = cms.PSet(
         refToPSet_ = cms.string('HGCAL_chargeCollectionEfficiencies')
     ),
-    HGCEE_fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+    HGCEE_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:3]),
     HGCEE_isSiFE = cms.bool(True),
     HGCEE_keV2DIGI = cms.double(0.044259),
     HGCEE_noise_fC = cms.PSet(
@@ -22,7 +23,7 @@ HGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
     HGCHEF_cce = cms.PSet(
         refToPSet_ = cms.string('HGCAL_chargeCollectionEfficiencies')
     ),
-    HGCHEF_fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+    HGCHEF_fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[3:6]),
     HGCHEF_isSiFE = cms.bool(True),
     HGCHEF_keV2DIGI = cms.double(0.044259),
     HGCHEF_noise_fC = cms.PSet(
@@ -48,28 +49,13 @@ HGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
         0.0, 39.500245, 39.756638, 39.756638, 39.756638,
         39.756638, 66.020266, 92.283895, 92.283895
     ),
-    layerWeights = cms.vdouble(
-        0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-        10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-        10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-        10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-        10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-        10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-        51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-        51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-        69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-        87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-        86.92952
-    ),
+    layerWeights = HGCAL_reco_constants.dEdXweights,
     maxValSiPar = cms.double(10000.0),
     minValSiPar = cms.double(10.0),
     noiseSiPar = cms.double(5.5),
     rangeMask = cms.uint32(4294442496),
     rangeMatch = cms.uint32(1161838592),
-    sciThicknessCorrection = cms.double(0.9),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-        0.84
-    ),
+    sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+    thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
     thicknessNoseCorrection = cms.vdouble(1.132, 1.092, 1.084)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHitL1Seeded_cfi.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 HGCalUncalibRecHitL1Seeded = cms.EDProducer("HGCalUncalibRecHitProducer",
     HGCEEConfig = cms.PSet(
         adcNbits = cms.uint32(10),
         adcSaturation = cms.double(100),
-        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:3]),
         isSiFE = cms.bool(True),
         tdcNbits = cms.uint32(12),
         tdcOnset = cms.double(60),
@@ -30,7 +31,7 @@ HGCalUncalibRecHitL1Seeded = cms.EDProducer("HGCalUncalibRecHitProducer",
     HGCHEFConfig = cms.PSet(
         adcNbits = cms.uint32(10),
         adcSaturation = cms.double(100),
-        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[3:6]),
         isSiFE = cms.bool(True),
         tdcNbits = cms.uint32(12),
         tdcOnset = cms.double(60),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHit_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
+
 
 HGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
     HGCEEConfig = cms.PSet(
         adcNbits = cms.uint32(10),
         adcSaturation = cms.double(100),
-        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[0:3]),
         isSiFE = cms.bool(True),
         tdcNbits = cms.uint32(12),
         tdcOnset = cms.double(60),
@@ -30,7 +32,7 @@ HGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
     HGCHEFConfig = cms.PSet(
         adcNbits = cms.uint32(10),
         adcSaturation = cms.double(100),
-        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        fCPerMIP = cms.vdouble(HGCAL_reco_constants.fcPerMip[3:6]),
         isSiFE = cms.bool(True),
         tdcNbits = cms.uint32(12),
         tdcOnset = cms.double(60),

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersEEL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersEEL1Seeded_cfi.py
@@ -1,61 +1,36 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
 hgcalLayerClustersEEL1Seeded = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SiCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
     ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SiCLUE')
-  
-  ),
   detector = cms.string('EE'),
   recHits = cms.InputTag('hltRechitInRegionsHGCAL', 'HGCEERecHits'),
   timeClname = cms.string('timeLayerCluster'),
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersEE_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersEE_cfi.py
@@ -1,57 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
-hgcalLayerClustersEE = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
-    ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SiCLUE')
-  
+hgcalLayerClustersEE = cms.EDProducer("HGCalLayerClusterProducer",
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SiCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
   ),
   detector = cms.string('EE'),
   recHits = cms.InputTag('HGCalRecHit', 'HGCEERecHits'),
@@ -59,4 +33,4 @@ hgcalLayerClustersEE = cms.EDProducer('HGCalLayerClusterProducer',
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
-  
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSciL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSciL1Seeded_cfi.py
@@ -1,57 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
-hgcalLayerClustersHSciL1Seeded = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
-    ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SciCLUE')
-  
+hgcalLayerClustersHSciL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SciCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
   ),
   detector = cms.string('BH'),
   recHits = cms.InputTag('hltRechitInRegionsHGCAL', 'HGCHEBRecHits'),
@@ -59,3 +33,4 @@ hgcalLayerClustersHSciL1Seeded = cms.EDProducer('HGCalLayerClusterProducer',
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSci_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSci_cfi.py
@@ -1,57 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
-hgcalLayerClustersHSci = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
-    ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SciCLUE')
-  
+hgcalLayerClustersHSci = cms.EDProducer("HGCalLayerClusterProducer",
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SciCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
   ),
   detector = cms.string('BH'),
   recHits = cms.InputTag('HGCalRecHit', 'HGCHEBRecHits'),
@@ -59,4 +33,4 @@ hgcalLayerClustersHSci = cms.EDProducer('HGCalLayerClusterProducer',
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
-  
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSiL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSiL1Seeded_cfi.py
@@ -1,57 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
-hgcalLayerClustersHSiL1Seeded = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
-    ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SiCLUE')
-  
+hgcalLayerClustersHSiL1Seeded = cms.EDProducer("HGCalLayerClusterProducer",
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SiCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
   ),
   detector = cms.string('FH'),
   recHits = cms.InputTag('hltRechitInRegionsHGCAL', 'HGCHEFRecHits'),
@@ -59,3 +33,4 @@ hgcalLayerClustersHSiL1Seeded = cms.EDProducer('HGCalLayerClusterProducer',
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSi_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hgcalLayerClustersHSi_cfi.py
@@ -1,57 +1,31 @@
 import FWCore.ParameterSet.Config as cms
+from ..psets.hgcal_reco_constants_cfi import HGCAL_reco_constants as HGCAL_reco_constants
 
-hgcalLayerClustersHSi = cms.EDProducer('HGCalLayerClusterProducer',
-  plugin = cms.PSet(
-    thresholdW0 = cms.vdouble(
-      2.9,
-      2.9,
-      2.9
-    ),
-    positionDeltaRho2 = cms.double(1.69),
-    deltac = cms.vdouble(
-      1.3,
-      1.3,
-      1.3,
-      0.0315
-    ),
-    dependSensor = cms.bool(True),
-    ecut = cms.double(3),
-    kappa = cms.double(9),
-    verbosity = cms.untracked.uint32(3),
-    dEdXweights = cms.vdouble(
-            0.0, 8.894541, 10.937907, 10.937907, 10.937907,
-            10.937907, 10.937907, 10.937907, 10.937907, 10.937907,
-            10.932882, 10.932882, 10.937907, 10.937907, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 10.938169, 10.938169,
-            10.938169, 10.938169, 10.938169, 32.332097, 51.574301,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            51.444192, 51.444192, 51.444192, 51.444192, 51.444192,
-            69.513118, 87.582044, 87.582044, 87.582044, 87.582044,
-            87.582044, 87.214571, 86.888309, 86.92952, 86.92952,
-            86.92952),
-    thicknessCorrection = cms.vdouble(
-        0.77, 0.77, 0.77, 0.84, 0.84,
-             0.84
-    ),
-    sciThicknessCorrection = cms.double(0.9),
-    deltasi_index_regemfac = cms.int32(3),
-    maxNumberOfThickIndices = cms.uint32(6),
-    fcPerMip = cms.vdouble(        2.06, 3.43, 5.15, 2.06, 3.43,            5.15),
-    fcPerEle = cms.double(0),
-    noises = cms.vdouble( 2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
-             2000.0),
-    noiseMip = cms.PSet(
-      scaleByDose = cms.bool(False),
-      scaleByDoseAlgo = cms.uint32(0),
-      scaleByDoseFactor = cms.double(1),
-      referenceIdark = cms.double(-1),
-      referenceXtalk = cms.double(-1),
-      noise_MIP = cms.double(0.01)
-    ),
-    use2x2 = cms.bool(True),
-    type = cms.string('SiCLUE')
-  
+hgcalLayerClustersHSi = cms.EDProducer("HGCalLayerClusterProducer",
+    plugin = cms.PSet(
+        dEdXweights = HGCAL_reco_constants.dEdXweights,
+        deltac = cms.vdouble(
+            1.3,
+            1.3,
+            1.3,
+            0.0315
+        ),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = HGCAL_reco_constants.fcPerEle,
+        fcPerMip = HGCAL_reco_constants.fcPerMip,
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = HGCAL_reco_constants.maxNumberOfThickIndices,
+        noiseMip = HGCAL_reco_constants.noiseMip,
+        noises = HGCAL_reco_constants.noises,
+        positionDeltaRho2 = HGCAL_reco_constants.positionDeltaRho2,
+        sciThicknessCorrection = HGCAL_reco_constants.sciThicknessCorrection,
+        thicknessCorrection = HGCAL_reco_constants.thicknessCorrection,
+        thresholdW0 = HGCAL_reco_constants.thresholdW0,
+        type = cms.string('SiCLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
   ),
   detector = cms.string('FH'),
   recHits = cms.InputTag('HGCalRecHit', 'HGCHEFRecHits'),
@@ -59,5 +33,4 @@ hgcalLayerClustersHSi = cms.EDProducer('HGCalLayerClusterProducer',
   nHitsTime = cms.uint32(3),
   mightGet = cms.optional.untracked.vstring
 )
-  
 

--- a/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/psets/hgcal_reco_constants_cfi.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+HGCAL_reco_constants = cms.PSet(
+    dEdXweights = cms.vdouble(
+        0.0, 9.205, 11.129999999999999, 11.129999999999999, 11.129999999999999,
+        11.129999999999999, 11.129999999999999, 11.129999999999999, 11.129999999999999, 11.129999999999999,
+        11.129999999999999, 11.129999999999999, 11.129999999999999, 11.129999999999999, 11.129999999999999,
+        11.129999999999999, 11.129999999999999, 11.129999999999999, 13.2, 13.2,
+        13.2, 13.2, 13.2, 13.2, 13.2,
+        13.2, 35.745000000000005, 59.665000000000006, 60.7, 60.7,
+        60.7, 60.7, 60.7, 60.7, 60.7,
+        60.7, 60.7, 71.89, 83.08, 83.255,
+        83.52000000000001, 83.61, 83.61, 83.61, 83.61,
+        83.61, 83.61, 83.61
+    ),
+    fcPerEle = cms.double(0.00016020506),
+    fcPerMip = cms.vdouble(
+            2.06, 3.43, 5.15, 2.06, 3.43,
+            5.15
+        ),
+    noises = cms.vdouble(
+            2000.0, 2400.0, 2000.0, 2000.0, 2400.0,
+            2000.0
+        ),
+    thicknessCorrection = cms.vdouble(
+            0.75, 0.76, 0.75, 0.85, 0.85,
+            0.84
+        ),
+    thresholdW0 = cms.vdouble(2.9, 2.9, 2.9),
+    sciThicknessCorrection = cms.double(0.69),
+    positionDeltaRho2 = cms.double(1.69),
+    maxNumberOfThickIndices = cms.uint32(6),
+    noiseMip = cms.PSet(
+      scaleByDose = cms.bool(False),
+      scaleByDoseAlgo = cms.uint32(0),
+      scaleByDoseFactor = cms.double(1),
+      referenceIdark = cms.double(-1),
+      referenceXtalk = cms.double(-1),
+      noise_MIP = cms.double(0.01)
+    ),
+
+)
+


### PR DESCRIPTION
This is a backport of #44552 

This PR fixes a bug where the value of fCperElectron was accidentally set to 0. This caused noise hits to seed the creation of layerclusters.
In this PR all the constants have been moved to a common file, so it's easier to maintain, and have been updated to Calorimeter Geometry v16.

Validated running workflow 24896.0 and using plots from #44558 to check the correctness of the result

FYI @felicepantaleo @rovere 