### PR TITLE
L1T P2: L1TrackVertexAssociationProducer bug fix to stop accessing data after move

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackVertexAssociationProducer.cc
@@ -563,6 +563,13 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
     }      //end if (processEmulatedTracks_)
   }        //end loop over input converted tracks
 
+  if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
+    printDebugInfo(l1SelectedTracksHandle,
+                   l1SelectedTracksEmulationHandle,
+                   vTTTrackAssociatedOutput,
+                   vTTTrackAssociatedEmulationOutput);
+  }
+
   if (processSimulatedTracks_) {
     iEvent.put(std::move(vTTTrackAssociatedOutput), outputCollectionName_);
   }
@@ -571,13 +578,6 @@ void L1TrackVertexAssociationProducer::produce(edm::StreamID, edm::Event& iEvent
     iEvent.put(std::move(vTTTrackAssociatedEmulationOutput), outputCollectionName_ + "Emulation");
     if (debug_ >= 2)
       linkLimitSelEmu.log();
-  }
-
-  if (processSimulatedTracks_ && processEmulatedTracks_ && debug_ >= 2) {
-    printDebugInfo(l1SelectedTracksHandle,
-                   l1SelectedTracksEmulationHandle,
-                   vTTTrackAssociatedOutput,
-                   vTTTrackAssociatedEmulationOutput);
   }
 }
 


### PR DESCRIPTION
#### PR description:

Currently when running `L1TrackVertexAssociationProducer` with a debug level of 2 or more the code will crash with a segfault as it is trying to access data in `vTTTrackAssociatedOutput` and `vTTTrackAssociatedEmulationOutput` which had just been moved in the preceding lines.

#### PR validation:

After moving the printDebugInfo command to before the move commands the module will run without crashing.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a port of https://github.com/cms-l1t-offline/cmssw/pull/1231