### PR TITLE
Remove explicit SimHitCollection copy-constructor

### DIFF
--- a/DataFormats/HGCalDigi/interface/PHGCSimAccumulator.h
+++ b/DataFormats/HGCalDigi/interface/PHGCSimAccumulator.h
@@ -50,7 +50,6 @@ public:
         timeArray_.emplace_back(data);
       }
     }
-    SimHitCollection(const SimHitCollection& simhitcollection) = default;
     unsigned int nhits() const { return nhits_; }
     unsigned int sampleIndex() const { return (chargeArray_[0] >> sampleOffset) & sampleMask; }
     const std::vector<unsigned short>& chargeArray() const { return chargeArray_; }


### PR DESCRIPTION
#### PR description:

Clang emits a warning:
```
  .../src/DataFormats/HGCalDigi/interface/PHGCSimAccumulator.h:53:5: warning: definition of implicit copy assignment operator for 'SimHitCollection' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
```

#### PR validation:

Bot tests.