### PR TITLE
Move Muon Paths to use sequences in HLT Phase2 Menu.

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
@@ -1,113 +1,63 @@
 import FWCore.ParameterSet.Config as cms
 
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..sequences.RawToDigiSequence_cfi import *
+from ..sequences.itLocalRecoSequence_cfi import *
+from ..sequences.otLocalRecoSequence_cfi import *
+from ..sequences.hgcalLocalRecoSequence_cfi import *
+from ..sequences.HLTDoLocalHcalSequence_cfi import *
+from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
+from ..sequences.HLTFastJetForEgammaSequence_cfi import *
+from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.pfClusteringHBHEHFSequence_cfi import *
+from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTPhase2L3OISequence_cfi import *
+from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
+from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
+from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
+from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
+from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41_cfi import *
 from ..modules.hltL3crIsoL1TkSingleMu22L3f24QL3pfhcalIsoFiltered0p40_cfi import *
 from ..modules.hltL3crIsoL1TkSingleMu22L3f24QL3pfhgcalIsoFiltered4p70_cfi import *
 from ..modules.hltL3crIsoL1TkSingleMu22L3f24QL3trkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk_cfi import *
 from ..modules.hltL3fL1TkSingleMu22L3Filtered24Q_cfi import *
-from ..sequences.HLTBeginSequence_cfi import *
-from ..sequences.HLTEndSequence_cfi import *
-from ..sequences.itLocalRecoSequence_cfi import *
-from ..modules.bunchSpacingProducer_cfi import *
-from ..modules.ecalMultiFitUncalibRecHit_cfi import *
-from ..modules.hgcalDigis_cfi import *
-from ..modules.hgcalLayerClustersEE_cfi import *
-from ..modules.hgcalLayerClustersHSci_cfi import *
-from ..modules.hgcalLayerClustersHSi_cfi import *
-from ..modules.hgcalMergeLayerClusters_cfi import *
-from ..modules.HGCalRecHit_cfi import *
-from ..modules.HGCalUncalibRecHit_cfi import *
-from ..modules.hltCsc2DRecHits_cfi import *
-from ..modules.hltCscSegments_cfi import *
-from ..modules.hltDt1DRecHits_cfi import *
-from ..modules.hltDt4DSegments_cfi import *
-from ..modules.hltEcalDetIdToBeRecovered_cfi import *
-from ..modules.hltEcalDigis_cfi import *
-from ..modules.hltEcalRecHit_cfi import *
-from ..modules.hltEcalUncalibRecHit_cfi import *
-from ..modules.hltFixedGridRhoFastjetAllCaloForEGamma_cfi import *
-from ..modules.hltGemRecHits_cfi import *
-from ..modules.hltGemSegments_cfi import *
-from ..modules.hltHbhereco_cfi import *
-from ..modules.hltHcalDigis_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonClustersRefRemoval_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMerged_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelClusterCheck_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitDoublets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeeds_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltL2MuonSeedsFromL1TkMuon_cfi import *
-from ..modules.hltL2MuonsFromL1TkMuon_cfi import *
-from ..modules.hltL2OfflineMuonSeeds_cfi import *
-from ..modules.hltParticleFlowClusterECALUncorrectedUnseeded_cfi import *
-from ..modules.hltParticleFlowClusterECALUnseeded_cfi import *
-from ..modules.hltParticleFlowClusterHBHE_cfi import *
-from ..modules.hltParticleFlowClusterHCAL_cfi import *
-from ..modules.hltParticleFlowRecHitECALUnseeded_cfi import *
-from ..modules.hltParticleFlowRecHitHBHE_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelLayerQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracks_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitDoublets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelVertices_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonTrimmedPixelVertices_cfi import *
-from ..modules.hltPhase2L3GlbMuon_cfi import *
-from ..modules.hltPhase2L3MuonCandidates_cfi import *
-from ..modules.hltPhase2L3MuonGeneralTracks_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepClusters_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepHitDoublets_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepHitTriplets_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepSeedLayers_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepSeeds_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCandidates_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackingRegions_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTracks_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepSeeds_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTrackCandidates_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTracks_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTracksSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3MuonMerged_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracks_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksHitDoublets_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksHitQuadruplets_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksSeedLayers_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksTrackingRegions_cfi import *
-from ..modules.hltPhase2L3MuonPixelVertices_cfi import *
-from ..modules.hltPhase2L3Muons_cfi import *
 from ..modules.hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000_cfi import *
 from ..modules.hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000_cfi import *
 from ..modules.hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00_cfi import *
-from ..modules.hltPhase2L3MuonsNoID_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07_cfi import *
-from ..modules.hltPhase2L3OIMuCtfWithMaterialTracks_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3OISeedsFromL2Muons_cfi import *
-from ..modules.hltPhase2L3OITrackCandidates_cfi import *
-from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
-from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
-from ..modules.hltRpcRecHits_cfi import *
-from ..modules.MeasurementTrackerEvent_cfi import *
-from ..modules.siPhase2Clusters_cfi import *
-from ..modules.siPixelClusters_cfi import *
-from ..modules.siPixelClusterShapeCache_cfi import *
-from ..modules.siPixelRecHits_cfi import *
-from ..modules.trackerClusterCheck_cfi import *
 
-HLT_IsoMu24_FromL1TkMuon = cms.Path(HLTBeginSequence+hltL3fL1TkSingleMu22L3Filtered24Q+hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41+hltL3crIsoL1TkSingleMu22L3f24QL3pfhcalIsoFiltered0p40+hltL3crIsoL1TkSingleMu22L3f24QL3pfhgcalIsoFiltered4p70+hltL3crIsoL1TkSingleMu22L3f24QL3trkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk+itLocalRecoSequence+HLTEndSequence, cms.ConditionalTask(HGCalRecHit, HGCalUncalibRecHit, MeasurementTrackerEvent, bunchSpacingProducer, ecalMultiFitUncalibRecHit, hgcalDigis, hgcalLayerClustersEE, hgcalLayerClustersHSci, hgcalLayerClustersHSi, hgcalMergeLayerClusters, hltCsc2DRecHits, hltCscSegments, hltDt1DRecHits, hltDt4DSegments, hltEcalDetIdToBeRecovered, hltEcalDigis, hltEcalRecHit, hltEcalUncalibRecHit, hltFixedGridRhoFastjetAllCaloForEGamma, hltGemRecHits, hltGemSegments, hltHbhereco, hltHcalDigis, hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks, hltIter0Phase2L3FromL1TkMuonTrackCutClassifier, hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter2Phase2L3FromL1TkMuonClustersRefRemoval, hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent, hltIter2Phase2L3FromL1TkMuonMerged, hltIter2Phase2L3FromL1TkMuonPixelClusterCheck, hltIter2Phase2L3FromL1TkMuonPixelHitDoublets, hltIter2Phase2L3FromL1TkMuonPixelHitTriplets, hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets, hltIter2Phase2L3FromL1TkMuonPixelSeeds, hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered, hltIter2Phase2L3FromL1TkMuonTrackCutClassifier, hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltL2MuonSeedsFromL1TkMuon, hltL2MuonsFromL1TkMuon, hltL2OfflineMuonSeeds, hltParticleFlowClusterECALUncorrectedUnseeded, hltParticleFlowClusterECALUnseeded, hltParticleFlowClusterHBHE, hltParticleFlowClusterHCAL, hltParticleFlowRecHitECALUnseeded, hltParticleFlowRecHitHBHE, hltPhase2L3FromL1TkMuonPixelLayerQuadruplets, hltPhase2L3FromL1TkMuonPixelTracks, hltPhase2L3FromL1TkMuonPixelTracksHitDoublets, hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets, hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions, hltPhase2L3FromL1TkMuonPixelVertices, hltPhase2L3FromL1TkMuonTrimmedPixelVertices, hltPhase2L3GlbMuon, hltPhase2L3MuonCandidates, hltPhase2L3MuonGeneralTracks, hltPhase2L3MuonHighPtTripletStepClusters, hltPhase2L3MuonHighPtTripletStepHitDoublets, hltPhase2L3MuonHighPtTripletStepHitTriplets, hltPhase2L3MuonHighPtTripletStepSeedLayers, hltPhase2L3MuonHighPtTripletStepSeeds, hltPhase2L3MuonHighPtTripletStepTrackCandidates, hltPhase2L3MuonHighPtTripletStepTrackCutClassifier, hltPhase2L3MuonHighPtTripletStepTrackingRegions, hltPhase2L3MuonHighPtTripletStepTracks, hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity, hltPhase2L3MuonInitialStepSeeds, hltPhase2L3MuonInitialStepTrackCandidates, hltPhase2L3MuonInitialStepTrackCutClassifier, hltPhase2L3MuonInitialStepTracks, hltPhase2L3MuonInitialStepTracksSelectionHighPurity, hltPhase2L3MuonMerged, hltPhase2L3MuonPixelTracks, hltPhase2L3MuonPixelTracksHitDoublets, hltPhase2L3MuonPixelTracksHitQuadruplets, hltPhase2L3MuonPixelTracksSeedLayers, hltPhase2L3MuonPixelTracksTrackingRegions, hltPhase2L3MuonPixelVertices, hltPhase2L3Muons, hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000, hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000, hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00, hltPhase2L3MuonsNoID, hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07, hltPhase2L3OIMuCtfWithMaterialTracks, hltPhase2L3OIMuonTrackCutClassifier, hltPhase2L3OIMuonTrackSelectionHighPurity, hltPhase2L3OISeedsFromL2Muons, hltPhase2L3OITrackCandidates, hltPhase2PixelFitterByHelixProjections, hltPhase2PixelTrackFilterByKinematics, hltRpcRecHits, siPhase2Clusters, siPixelClusterShapeCache, siPixelClusters, siPixelRecHits, trackerClusterCheck))
+
+
+HLT_IsoMu24_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +RawToDigiSequence
+    +itLocalRecoSequence
+    +otLocalRecoSequence
+    +HLTL2MuonsFromL1TkSequence
+    +HLTPhase2L3OISequence
+    +hltPhase2PixelFitterByHelixProjections
+    +hltPhase2PixelTrackFilterByKinematics
+    +HLTPhase2L3FromL1TkSequence
+    +HLTIter0Phase2L3FromL1TkSequence
+    +HLTIter2Phase2L3FromL1TkSequence
+    +HLTPhase2L3MuonsSequence
+    +hltL3fL1TkSingleMu22L3Filtered24Q
+    +hgcalLocalRecoSequence
+    +HLTDoLocalHcalSequence
+    +HLTDoFullUnpackingEgammaEcalSequence
+    +HLTFastJetForEgammaSequence
+    +pfClusteringHBHEHFSequence
+    +HLTPFClusteringForEgammaUnseededSequence
+    +hltPhase2L3MuonsEcalIsodR0p3dRVeto0p000
+    +hltPhase2L3MuonsHcalIsodR0p3dRVeto0p000
+    +hltPhase2L3MuonsHgcalLCIsodR0p2dRVetoEM0p00dRVetoHad0p02minEEM0p00minEHad0p00
+    +hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41
+    +hltL3crIsoL1TkSingleMu22L3f24QL3pfhcalIsoFiltered0p40
+    +hltL3crIsoL1TkSingleMu22L3f24QL3pfhgcalIsoFiltered4p70
+    +HLTPhase2L3MuonGeneralTracksSequence
+    +hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p07
+    +hltL3crIsoL1TkSingleMu22L3f24QL3trkIsoRegionalNewFiltered0p07EcalHcalHgcalTrk
+    +HLTEndSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
@@ -1,5 +1,25 @@
 import FWCore.ParameterSet.Config as cms
 
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..sequences.RawToDigiSequence_cfi import *
+from ..sequences.itLocalRecoSequence_cfi import *
+from ..sequences.otLocalRecoSequence_cfi import *
+from ..sequences.hgcalLocalRecoSequence_cfi import *
+from ..sequences.HLTDoLocalHcalSequence_cfi import *
+from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
+from ..sequences.HLTFastJetForEgammaSequence_cfi import *
+from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.pfClusteringHBHEHFSequence_cfi import *
+from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTPhase2L3OISequence_cfi import *
+from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
+from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
+from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
+from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
+from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltDiMuon178RelTrkIsoFiltered0p4_cfi import *
 from ..modules.hltDiMuon178RelTrkIsoFiltered0p4DzFiltered0p2_cfi import *
 from ..modules.hltDoubleMuon7DZ1p0_cfi import *
@@ -7,83 +27,27 @@ from ..modules.hltL1TkDoubleMuFiltered7_cfi import *
 from ..modules.hltL1TkSingleMuFiltered15_cfi import *
 from ..modules.hltL3fL1DoubleMu155fFiltered17_cfi import *
 from ..modules.hltL3fL1DoubleMu155fPreFiltered8_cfi import *
-from ..sequences.HLTBeginSequence_cfi import *
-from ..sequences.HLTEndSequence_cfi import *
-from ..modules.hltCsc2DRecHits_cfi import *
-from ..modules.hltCscSegments_cfi import *
-from ..modules.hltDt1DRecHits_cfi import *
-from ..modules.hltDt4DSegments_cfi import *
-from ..modules.hltGemRecHits_cfi import *
-from ..modules.hltGemSegments_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonClustersRefRemoval_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMerged_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelClusterCheck_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitDoublets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeeds_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltL2MuonSeedsFromL1TkMuon_cfi import *
-from ..modules.hltL2MuonsFromL1TkMuon_cfi import *
-from ..modules.hltL2OfflineMuonSeeds_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelLayerQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracks_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitDoublets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelVertices_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonTrimmedPixelVertices_cfi import *
-from ..modules.hltPhase2L3GlbMuon_cfi import *
-from ..modules.hltPhase2L3MuonCandidates_cfi import *
-from ..modules.hltPhase2L3MuonGeneralTracks_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepClusters_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepHitDoublets_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepHitTriplets_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepSeedLayers_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepSeeds_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCandidates_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTrackingRegions_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTracks_cfi import *
-from ..modules.hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepSeeds_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTrackCandidates_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTracks_cfi import *
-from ..modules.hltPhase2L3MuonInitialStepTracksSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3MuonMerged_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracks_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksHitDoublets_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksHitQuadruplets_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksSeedLayers_cfi import *
-from ..modules.hltPhase2L3MuonPixelTracksTrackingRegions_cfi import *
-from ..modules.hltPhase2L3MuonPixelVertices_cfi import *
-from ..modules.hltPhase2L3Muons_cfi import *
-from ..modules.hltPhase2L3MuonsNoID_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4_cfi import *
-from ..modules.hltPhase2L3OIMuCtfWithMaterialTracks_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3OISeedsFromL2Muons_cfi import *
-from ..modules.hltPhase2L3OITrackCandidates_cfi import *
-from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
-from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
-from ..modules.hltRpcRecHits_cfi import *
-from ..modules.MeasurementTrackerEvent_cfi import *
-from ..modules.siPhase2Clusters_cfi import *
-from ..modules.siPixelClusters_cfi import *
-from ..modules.siPixelClusterShapeCache_cfi import *
-from ..modules.siPixelRecHits_cfi import *
-from ..modules.trackerClusterCheck_cfi import *
 
-HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence+hltL1TkDoubleMuFiltered7+hltL1TkSingleMuFiltered15+hltDoubleMuon7DZ1p0+hltL3fL1DoubleMu155fPreFiltered8+hltL3fL1DoubleMu155fFiltered17+hltDiMuon178RelTrkIsoFiltered0p4+hltDiMuon178RelTrkIsoFiltered0p4DzFiltered0p2+HLTEndSequence, cms.ConditionalTask(MeasurementTrackerEvent, hltCsc2DRecHits, hltCscSegments, hltDt1DRecHits, hltDt4DSegments, hltGemRecHits, hltGemSegments, hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks, hltIter0Phase2L3FromL1TkMuonTrackCutClassifier, hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter2Phase2L3FromL1TkMuonClustersRefRemoval, hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent, hltIter2Phase2L3FromL1TkMuonMerged, hltIter2Phase2L3FromL1TkMuonPixelClusterCheck, hltIter2Phase2L3FromL1TkMuonPixelHitDoublets, hltIter2Phase2L3FromL1TkMuonPixelHitTriplets, hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets, hltIter2Phase2L3FromL1TkMuonPixelSeeds, hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered, hltIter2Phase2L3FromL1TkMuonTrackCutClassifier, hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltL2MuonSeedsFromL1TkMuon, hltL2MuonsFromL1TkMuon, hltL2OfflineMuonSeeds, hltPhase2L3FromL1TkMuonPixelLayerQuadruplets, hltPhase2L3FromL1TkMuonPixelTracks, hltPhase2L3FromL1TkMuonPixelTracksHitDoublets, hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets, hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions, hltPhase2L3FromL1TkMuonPixelVertices, hltPhase2L3FromL1TkMuonTrimmedPixelVertices, hltPhase2L3GlbMuon, hltPhase2L3MuonCandidates, hltPhase2L3MuonGeneralTracks, hltPhase2L3MuonHighPtTripletStepClusters, hltPhase2L3MuonHighPtTripletStepHitDoublets, hltPhase2L3MuonHighPtTripletStepHitTriplets, hltPhase2L3MuonHighPtTripletStepSeedLayers, hltPhase2L3MuonHighPtTripletStepSeeds, hltPhase2L3MuonHighPtTripletStepTrackCandidates, hltPhase2L3MuonHighPtTripletStepTrackCutClassifier, hltPhase2L3MuonHighPtTripletStepTrackingRegions, hltPhase2L3MuonHighPtTripletStepTracks, hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity, hltPhase2L3MuonInitialStepSeeds, hltPhase2L3MuonInitialStepTrackCandidates, hltPhase2L3MuonInitialStepTrackCutClassifier, hltPhase2L3MuonInitialStepTracks, hltPhase2L3MuonInitialStepTracksSelectionHighPurity, hltPhase2L3MuonMerged, hltPhase2L3MuonPixelTracks, hltPhase2L3MuonPixelTracksHitDoublets, hltPhase2L3MuonPixelTracksHitQuadruplets, hltPhase2L3MuonPixelTracksSeedLayers, hltPhase2L3MuonPixelTracksTrackingRegions, hltPhase2L3MuonPixelVertices, hltPhase2L3Muons, hltPhase2L3MuonsNoID, hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4, hltPhase2L3OIMuCtfWithMaterialTracks, hltPhase2L3OIMuonTrackCutClassifier, hltPhase2L3OIMuonTrackSelectionHighPurity, hltPhase2L3OISeedsFromL2Muons, hltPhase2L3OITrackCandidates, hltPhase2PixelFitterByHelixProjections, hltPhase2PixelTrackFilterByKinematics, hltRpcRecHits, siPhase2Clusters, siPixelClusterShapeCache, siPixelClusters, siPixelRecHits, trackerClusterCheck))
+HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +hltL1TkDoubleMuFiltered7
+    +hltL1TkSingleMuFiltered15
+    +hltDoubleMuon7DZ1p0
+    +RawToDigiSequence
+    +itLocalRecoSequence
+    +otLocalRecoSequence
+    +HLTL2MuonsFromL1TkSequence
+    +HLTPhase2L3OISequence
+    +hltPhase2PixelFitterByHelixProjections
+    +hltPhase2PixelTrackFilterByKinematics
+    +HLTPhase2L3FromL1TkSequence
+    +HLTIter0Phase2L3FromL1TkSequence
+    +HLTIter2Phase2L3FromL1TkSequence
+    +HLTPhase2L3MuonsSequence
+    +hltL3fL1DoubleMu155fPreFiltered8
+    +hltL3fL1DoubleMu155fFiltered17
+    +HLTPhase2L3MuonGeneralTracksSequence
+    +hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4
+    +hltDiMuon178RelTrkIsoFiltered0p4
+    +hltDiMuon178RelTrkIsoFiltered0p4DzFiltered0p2
+    +HLTEndSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_TriMu_10_5_5_DZ_FromL1TkMuon_cfi.py
@@ -1,63 +1,46 @@
 import FWCore.ParameterSet.Config as cms
 
+from ..sequences.HLTBeginSequence_cfi import *
+from ..sequences.HLTEndSequence_cfi import *
+from ..sequences.RawToDigiSequence_cfi import *
+from ..sequences.itLocalRecoSequence_cfi import *
+from ..sequences.otLocalRecoSequence_cfi import *
+from ..sequences.hgcalLocalRecoSequence_cfi import *
+from ..sequences.HLTDoLocalHcalSequence_cfi import *
+from ..sequences.HLTDoFullUnpackingEgammaEcalSequence_cfi import *
+from ..sequences.HLTFastJetForEgammaSequence_cfi import *
+from ..sequences.HLTIter0Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTIter2Phase2L3FromL1TkSequence_cfi import *
+from ..sequences.pfClusteringHBHEHFSequence_cfi import *
+from ..sequences.HLTPhase2L3FromL1TkSequence_cfi import *
+from ..sequences.HLTPhase2L3OISequence_cfi import *
+from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
+from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
+from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
+from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
+from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltL3fL1TkTripleMu533L31055DZFiltered0p2_cfi import *
 from ..modules.hltL3fL1TkTripleMu533L3Filtered1055_cfi import *
 from ..modules.hltL3fL1TkTripleMu533PreFiltered555_cfi import *
 from ..modules.hltTripleMuon3DR0_cfi import *
 from ..modules.hltTripleMuon3DZ1p0_cfi import *
-from ..sequences.HLTBeginSequence_cfi import *
-from ..sequences.HLTEndSequence_cfi import *
-from ..modules.hltCsc2DRecHits_cfi import *
-from ..modules.hltCscSegments_cfi import *
-from ..modules.hltDt1DRecHits_cfi import *
-from ..modules.hltDt4DSegments_cfi import *
-from ..modules.hltGemRecHits_cfi import *
-from ..modules.hltGemSegments_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonClustersRefRemoval_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonMerged_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelClusterCheck_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitDoublets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelHitTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeeds_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackCutClassifier_cfi import *
-from ..modules.hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltL2MuonSeedsFromL1TkMuon_cfi import *
-from ..modules.hltL2MuonsFromL1TkMuon_cfi import *
-from ..modules.hltL2OfflineMuonSeeds_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelLayerQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracks_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitDoublets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonPixelVertices_cfi import *
-from ..modules.hltPhase2L3FromL1TkMuonTrimmedPixelVertices_cfi import *
-from ..modules.hltPhase2L3GlbMuon_cfi import *
-from ..modules.hltPhase2L3MuonCandidates_cfi import *
-from ..modules.hltPhase2L3MuonMerged_cfi import *
-from ..modules.hltPhase2L3Muons_cfi import *
-from ..modules.hltPhase2L3MuonsNoID_cfi import *
-from ..modules.hltPhase2L3OIMuCtfWithMaterialTracks_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackCutClassifier_cfi import *
-from ..modules.hltPhase2L3OIMuonTrackSelectionHighPurity_cfi import *
-from ..modules.hltPhase2L3OISeedsFromL2Muons_cfi import *
-from ..modules.hltPhase2L3OITrackCandidates_cfi import *
-from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
-from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
-from ..modules.hltRpcRecHits_cfi import *
-from ..modules.MeasurementTrackerEvent_cfi import *
-from ..modules.siPhase2Clusters_cfi import *
-from ..modules.siPixelClusters_cfi import *
-from ..modules.siPixelClusterShapeCache_cfi import *
-from ..modules.siPixelRecHits_cfi import *
 
-HLT_TriMu_10_5_5_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence+hltTripleMuon3DZ1p0+hltTripleMuon3DR0+hltL3fL1TkTripleMu533PreFiltered555+hltL3fL1TkTripleMu533L3Filtered1055+hltL3fL1TkTripleMu533L31055DZFiltered0p2+HLTEndSequence, cms.ConditionalTask(MeasurementTrackerEvent, hltCsc2DRecHits, hltCscSegments, hltDt1DRecHits, hltDt4DSegments, hltGemRecHits, hltGemSegments, hltIter0Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter0Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter0Phase2L3FromL1TkMuonPixelSeedsFromPixelTracks, hltIter0Phase2L3FromL1TkMuonTrackCutClassifier, hltIter0Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltIter2Phase2L3FromL1TkMuonCkfTrackCandidates, hltIter2Phase2L3FromL1TkMuonClustersRefRemoval, hltIter2Phase2L3FromL1TkMuonCtfWithMaterialTracks, hltIter2Phase2L3FromL1TkMuonMaskedMeasurementTrackerEvent, hltIter2Phase2L3FromL1TkMuonMerged, hltIter2Phase2L3FromL1TkMuonPixelClusterCheck, hltIter2Phase2L3FromL1TkMuonPixelHitDoublets, hltIter2Phase2L3FromL1TkMuonPixelHitTriplets, hltIter2Phase2L3FromL1TkMuonPixelLayerTriplets, hltIter2Phase2L3FromL1TkMuonPixelSeeds, hltIter2Phase2L3FromL1TkMuonPixelSeedsFiltered, hltIter2Phase2L3FromL1TkMuonTrackCutClassifier, hltIter2Phase2L3FromL1TkMuonTrackSelectionHighPurity, hltL2MuonSeedsFromL1TkMuon, hltL2MuonsFromL1TkMuon, hltL2OfflineMuonSeeds, hltPhase2L3FromL1TkMuonPixelLayerQuadruplets, hltPhase2L3FromL1TkMuonPixelTracks, hltPhase2L3FromL1TkMuonPixelTracksHitDoublets, hltPhase2L3FromL1TkMuonPixelTracksHitQuadruplets, hltPhase2L3FromL1TkMuonPixelTracksTrackingRegions, hltPhase2L3FromL1TkMuonPixelVertices, hltPhase2L3FromL1TkMuonTrimmedPixelVertices, hltPhase2L3GlbMuon, hltPhase2L3MuonCandidates, hltPhase2L3MuonMerged, hltPhase2L3Muons, hltPhase2L3MuonsNoID, hltPhase2L3OIMuCtfWithMaterialTracks, hltPhase2L3OIMuonTrackCutClassifier, hltPhase2L3OIMuonTrackSelectionHighPurity, hltPhase2L3OISeedsFromL2Muons, hltPhase2L3OITrackCandidates, hltPhase2PixelFitterByHelixProjections, hltPhase2PixelTrackFilterByKinematics, hltRpcRecHits, siPhase2Clusters, siPixelClusterShapeCache, siPixelClusters, siPixelRecHits))
+HLT_TriMu_10_5_5_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +hltTripleMuon3DZ1p0
+    +hltTripleMuon3DR0
+    +RawToDigiSequence
+    +itLocalRecoSequence
+    +otLocalRecoSequence
+    +HLTL2MuonsFromL1TkSequence
+    +HLTPhase2L3MuonsSequence
+    +hltL3fL1TkTripleMu533PreFiltered555
+    +hltL3fL1TkTripleMu533L3Filtered1055
+    +HLTPhase2L3FromL1TkSequence
+    +hltPhase2PixelFitterByHelixProjections
+    +hltPhase2PixelTrackFilterByKinematics
+    +HLTIter0Phase2L3FromL1TkSequence
+    +HLTIter2Phase2L3FromL1TkSequence
+    +HLTPhase2L3OISequence
+    +hltL3fL1TkTripleMu533L31055DZFiltered0p2
+    +HLTEndSequence)
+#

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonGeneralTracksSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonGeneralTracksSequence_cfi.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.trackerClusterCheck_cfi import *
+from ..modules.hltPhase2L3MuonPixelTracksTrackingRegions_cfi import *
+from ..modules.hltPhase2L3MuonPixelTracksSeedLayers_cfi import *
+from ..modules.hltPhase2L3MuonPixelTracksHitDoublets_cfi import *
+from ..modules.hltPhase2L3MuonPixelTracksHitQuadruplets_cfi import *
+from ..modules.hltPhase2L3MuonPixelTracks_cfi import *
+from ..modules.hltPhase2L3MuonPixelVertices_cfi import *
+from ..modules.hltPhase2L3MuonInitialStepSeeds_cfi import *
+from ..modules.hltPhase2L3MuonInitialStepTrackCandidates_cfi import *
+from ..modules.hltPhase2L3MuonInitialStepTracks_cfi import *
+from ..modules.hltPhase2L3MuonInitialStepTrackCutClassifier_cfi import *
+from ..modules.hltPhase2L3MuonInitialStepTracksSelectionHighPurity_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepClusters_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepTrackingRegions_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepSeedLayers_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepHitDoublets_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepHitTriplets_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepSeeds_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCandidates_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepTracks_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity_cfi import *
+from ..modules.hltPhase2L3MuonHighPtTripletStepTrackCutClassifier_cfi import *
+from ..modules.hltPhase2L3MuonGeneralTracks_cfi import *
+
+
+HLTPhase2L3MuonGeneralTracksSequence = cms.Sequence(
+    trackerClusterCheck
+    +hltPhase2L3MuonPixelTracksTrackingRegions
+    +hltPhase2L3MuonPixelTracksSeedLayers
+    +hltPhase2L3MuonPixelTracksHitDoublets
+    +hltPhase2L3MuonPixelTracksHitQuadruplets
+    +hltPhase2L3MuonPixelTracks
+    +hltPhase2L3MuonPixelVertices
+    +hltPhase2L3MuonInitialStepSeeds
+    +hltPhase2L3MuonInitialStepTrackCandidates
+    +hltPhase2L3MuonInitialStepTracks
+    +hltPhase2L3MuonInitialStepTrackCutClassifier
+    +hltPhase2L3MuonInitialStepTracksSelectionHighPurity
+    +hltPhase2L3MuonHighPtTripletStepClusters
+    +hltPhase2L3MuonHighPtTripletStepTrackingRegions
+    +hltPhase2L3MuonHighPtTripletStepSeedLayers
+    +hltPhase2L3MuonHighPtTripletStepHitDoublets
+    +hltPhase2L3MuonHighPtTripletStepHitTriplets
+    +hltPhase2L3MuonHighPtTripletStepSeeds
+    +hltPhase2L3MuonHighPtTripletStepTrackCandidates
+    +hltPhase2L3MuonHighPtTripletStepTracks
+    +hltPhase2L3MuonHighPtTripletStepTrackCutClassifier
+    +hltPhase2L3MuonHighPtTripletStepTracksSelectionHighPurity
+    +hltPhase2L3MuonGeneralTracks
+    )

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonsSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2L3MuonsSequence_cfi.py
@@ -4,5 +4,6 @@ from ..modules.hltPhase2L3GlbMuon_cfi import *
 from ..modules.hltPhase2L3MuonMerged_cfi import *
 from ..modules.hltPhase2L3Muons_cfi import *
 from ..modules.hltPhase2L3MuonsNoID_cfi import *
+from ..modules.hltPhase2L3MuonCandidates_cfi import *
 
-HLTPhase2L3MuonsSequence = cms.Sequence(hltPhase2L3MuonMerged+hltPhase2L3GlbMuon+hltPhase2L3MuonsNoID+hltPhase2L3Muons)
+HLTPhase2L3MuonsSequence = cms.Sequence(hltPhase2L3MuonMerged+hltPhase2L3GlbMuon+hltPhase2L3MuonsNoID+hltPhase2L3Muons+hltPhase2L3MuonCandidates)


### PR DESCRIPTION
#### PR description:

Move the remaining Muon paths in the Phase2 simplified menu to use `cms.Sequence`s.
With this PR, no more `cms.ConditionalTask`s are left in the menu.


#### PR validation:

Tested on some Phase2 workflows running the HLT Menu

