### PR TITLE
CalorimeterDefinitions: don't return -1 as uint32_t

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -101,7 +101,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
         return detId2denseIdHE(detId);
 
       printf("invalid detId: %u\n", detId);
-      return -1;
+      return 0;
     }
   };
 


### PR DESCRIPTION
#### PR description:

I have checked all usages of `detId2denseId`, and there is no explicit comparison with `-1` or similar value, so I think it's safe to return `0` instead of `(unit32_t) -1`.

For reference: gcc13 emits a warning [link](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc13/CMSSW_14_1_X_2024-04-01-2300/RecoParticleFlow/PFRecHitProducer)

```
src/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h(104): warning #68-D: integer conversion resulted in a change of sign
        return -1;
               ^
```

#### PR validation:

Bot tests