### PR TITLE
[14_1_X Phase2 SIM] Fixed Birks saturation constants for HGCal scintillators

### DIFF
--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -71,11 +71,6 @@ HCalSD::HCalSD(const std::string& name,
   m_HFDarkening.reset(nullptr);
   m_HcalTestNS.reset(nullptr);
 
-  //static SimpleConfigurable<double> bk1(0.013, "HCalSD:BirkC1");
-  //static SimpleConfigurable<double> bk2(0.0568,"HCalSD:BirkC2");
-  //static SimpleConfigurable<double> bk3(1.75,  "HCalSD:BirkC3");
-  // Values from NIM 80 (1970) 239-244: as implemented in Geant3
-
   dd4hep_ = p.getParameter<bool>("g4GeometryDD4hepSource");
   edm::ParameterSet m_HC = p.getParameter<edm::ParameterSet>("HCalSD");
   useBirk = m_HC.getParameter<bool>("UseBirkLaw");

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -367,7 +367,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EnergyThresholdForHistoryInGeV = cms.double(0.05)
     ),
     MuonSD = cms.PSet(
-        EnergyThresholdForPersistency = cms.double(1.0),
+        EnergyThresholdForPersistency = cms.double(1.0), # in GeV
         PrintHits = cms.bool(False),
         AllMuonsPersistent = cms.bool(True),
         UseDemoHitRPC = cms.bool(True),
@@ -423,6 +423,9 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     HCalSD = cms.PSet(
         common_UseLuminosity,
         UseBirkLaw                = cms.bool(True),
+        # Values of Birks constants from NIM 80 (1970) 239-244:
+        # as implemented in Geant3 required correction due to
+        # biased computation of enery deposition
         BirkC3                    = cms.double(1.75),
         BirkC2                    = cms.double(0.142),
         BirkC1                    = cms.double(0.0060),
@@ -562,9 +565,12 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         Verbosity        = cms.untracked.int32(0),
         EminHit          = cms.double(0.0),
         UseBirkLaw       = cms.bool(True),
+        # Values of Birks constants from NIM 80 (1970) 239-244:
+        # as implemented in Geant3 required correction due to
+        # biased computation of enery deposition
         BirkC3           = cms.double(1.75),
         BirkC2           = cms.double(0.142),
-        BirkC1           = cms.double(0.0052),
+        BirkC1           = cms.double(0.0060),
         FiducialCut      = cms.bool(False),
         DistanceFromEdge = cms.double(1.0),
         StoreAllG4Hits   = cms.bool(False),


### PR DESCRIPTION
#### PR description:
The value of the main Birks saturation coefficient is taken from classical publications (NIM 80 (1970) 239-244), in which a biased value of the main term was proposed. It was fixed before Run2 for Hcal and now is fixed for  HGCScintSD.

Regression for Phase-2 WFs is not expected.


#### PR validation:
private


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: likely NO

