### PR TITLE
HLT Tau DQM for PNet taus

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
@@ -58,6 +58,7 @@ private:
 
   HLTTauDQMPath hltPath_;
 
+  MonitorElement *hCounter_;
   MonitorElement *hAcceptedEvents_;
   MonitorElement *hTrigTauEt_;
   MonitorElement *hTrigTauEta_;

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cff.py
@@ -7,6 +7,7 @@ from DQMOffline.Trigger.HLTTauCertifier_cfi import *
 
 HLTTauDQMOffline = cms.Sequence(TauRefProducer
                                 +hltTauOfflineMonitor_PFTaus
+                                +hltTauOfflineMonitor_PNetTaus
                                 +hltTauOfflineMonitor_Inclusive
                                 +hltTauOfflineMonitor_TagAndProbe
                                 )

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -116,6 +116,11 @@ hltTauOfflineMonitor_PFTaus = DQMEDAnalyzer('HLTTauDQMOfflineSource',
     ),
 )
 
+hltTauOfflineMonitor_PNetTaus = hltTauOfflineMonitor_PFTaus.clone(
+    DQMBaseFolder = cms.untracked.string("HLT/TAU/PNetTaus"),
+    Paths = cms.untracked.string("PNetTauh")
+)
+
 hltTauOfflineMonitor_Inclusive = hltTauOfflineMonitor_PFTaus.clone(
     DQMBaseFolder = "HLT/TAU/Inclusive",
     Matching = cms.PSet(

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -74,10 +74,12 @@ def makePFTauAnalyzer(monitorModule):
 
 (HLTTauPostAnalysisInclusive, HLTTauPostAnalysisInclusive2) = makeInclusiveAnalyzer(hltTauOfflineMonitor_Inclusive)
 (HLTTauPostAnalysisPFTaus, HLTTauPostAnalysisPFTaus2) = makePFTauAnalyzer(hltTauOfflineMonitor_PFTaus)
+(HLTTauPostAnalysisPNetTaus, HLTTauPostAnalysisPNetTaus2) = makePFTauAnalyzer(hltTauOfflineMonitor_PNetTaus)
 (HLTTauPostAnalysisTP, HLTTauPostAnalysisTP2) = makePFTauAnalyzer(hltTauOfflineMonitor_TagAndProbe)
 
 HLTTauPostSeq = cms.Sequence(
     HLTTauPostAnalysisInclusive+HLTTauPostAnalysisInclusive2+
     HLTTauPostAnalysisPFTaus+HLTTauPostAnalysisPFTaus2+
+    HLTTauPostAnalysisPNetTaus+HLTTauPostAnalysisPNetTaus2+
     HLTTauPostAnalysisTP+HLTTauPostAnalysisTP2
 )

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -56,8 +56,8 @@ namespace {
           continue;
         if (iLabel->find('-') == 0)  // ignore
           continue;
-	if (type == "L2TauTagFilter") // gives L1taus as output
-	  continue;
+        if (type == "L2TauTagFilter")  // gives L1taus as output
+          continue;
         if (type == "HLT2PhotonPFTau" || type == "HLT2ElectronPFTau" || type == "HLT2MuonPFTau" ||
             type == "HLT2PhotonTau" || type == "HLT2ElectronTau" || type == "HLT2MuonTau")
           leptonTauFilters.emplace_back(*iLabel);
@@ -100,7 +100,8 @@ namespace {
 
     bool isL3TauProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
       const std::string type = HLTCP.moduleType(producerLabel);
-      if (type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder" || type == "BTagProbabilityToDiscriminator") {
+      if (type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder" ||
+          type == "BTagProbabilityToDiscriminator") {
         LogDebug("HLTTauDQMOffline") << "Found tau producer " << type << " with label " << producerLabel
                                      << " from path " << name_;
         return true;
@@ -137,7 +138,7 @@ namespace {
       if (pset.exists("inputTag2"))
         return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag2").label());
       if (pset.exists("taus"))
-	return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("taus").label());
+        return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("taus").label());
       return false;
     }
 
@@ -413,7 +414,7 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
     const std::string& moduleType = HLTCP.moduleType(filterName);
 
     TauLeptonMultiplicity n = inferTauLeptonMultiplicity(HLTCP, filterName, moduleType, pathName_);
-    if(n.level > 0){
+    if (n.level > 0) {
       filterTauN_.push_back(n.tau);
       filterElectronN_.push_back(n.electron);
       filterMuonN_.push_back(n.muon);

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -56,6 +56,8 @@ namespace {
           continue;
         if (iLabel->find('-') == 0)  // ignore
           continue;
+	if (type == "L2TauTagFilter") // gives L1taus as output
+	  continue;
         if (type == "HLT2PhotonPFTau" || type == "HLT2ElectronPFTau" || type == "HLT2MuonPFTau" ||
             type == "HLT2PhotonTau" || type == "HLT2ElectronTau" || type == "HLT2MuonTau")
           leptonTauFilters.emplace_back(*iLabel);
@@ -98,7 +100,7 @@ namespace {
 
     bool isL3TauProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
       const std::string type = HLTCP.moduleType(producerLabel);
-      if (type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder") {
+      if (type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder" || type == "BTagProbabilityToDiscriminator") {
         LogDebug("HLTTauDQMOffline") << "Found tau producer " << type << " with label " << producerLabel
                                      << " from path " << name_;
         return true;
@@ -134,6 +136,8 @@ namespace {
         return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag1").label());
       if (pset.exists("inputTag2"))
         return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag2").label());
+      if (pset.exists("taus"))
+	return isL3TauProducer(HLTCP, pset.getParameter<edm::InputTag>("taus").label());
       return false;
     }
 
@@ -257,6 +261,9 @@ namespace {
       if (getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
         n.tau = getParameterSafe(HLTCP, filterName, "MinN");
       }
+    } else if (moduleType == "TauTagFilter") {
+      n.level = 3;
+      n.tau = getParameterSafe(HLTCP, filterName, "nExpected");
     } else if (moduleType == "HLT1PFJet") {
       n.level = 3;
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
@@ -406,11 +413,13 @@ HLTTauDQMPath::HLTTauDQMPath(std::string pathName,
     const std::string& moduleType = HLTCP.moduleType(filterName);
 
     TauLeptonMultiplicity n = inferTauLeptonMultiplicity(HLTCP, filterName, moduleType, pathName_);
-    filterTauN_.push_back(n.tau);
-    filterElectronN_.push_back(n.electron);
-    filterMuonN_.push_back(n.muon);
-    filterMET_.push_back(n.met);
-    filterLevel_.push_back(n.level);
+    if(n.level > 0){
+      filterTauN_.push_back(n.tau);
+      filterElectronN_.push_back(n.electron);
+      filterMuonN_.push_back(n.muon);
+      filterMET_.push_back(n.met);
+      filterLevel_.push_back(n.level);
+    }
 
 #ifdef EDM_ML_DEBUG
     ss << "\n    " << i << " " << std::get<kModuleIndex>(filterIndice) << " " << filterName << " " << moduleType

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -46,6 +46,7 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
   // Book histograms
   iBooker.setCurrentFolder(triggerTag());
 
+  hCounter_ = iWrapper.book1D(iBooker,"EventCounter","Accepted events;;entries",3,0,3,kEverything);
   hAcceptedEvents_ = iWrapper.book1D(iBooker,
                                      "EventsPerFilter",
                                      "Accepted Events per filter;;entries",
@@ -53,6 +54,9 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
                                      0,
                                      hltPath_.filtersSize(),
                                      kEverything);
+  hCounter_->setBinLabel(1,"all events");
+  hCounter_->setBinLabel(2,"ref tau found");
+  hCounter_->setBinLabel(3,"passed trg");
   for (size_t i = 0; i < hltPath_.filtersSize(); ++i) {
     if (hAcceptedEvents_)
       hAcceptedEvents_->setBinLabel(i + 1, hltPath_.getFilterName(i));
@@ -117,7 +121,7 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
                                             ptbins_,
                                             0,
                                             ptmax_,
-                                            kEverything);
+                                            kVital);
       hL3TrigTauEtEffDenom_ = iWrapper.book1D(iBooker,
                                               "L3TrigTauEtEffDenom",
                                               "L3 #tau p_{T} denominator;Ref #tau p_{T};Efficiency",
@@ -451,6 +455,11 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
   int lastMatchedMuonFilter = -1;
   int lastMatchedTauFilter = -1;
   int firstMatchedMETFilter = -1;
+  hCounter_->Fill(0.5);
+  if(refCollection.taus.size() > 0){
+    hCounter_->Fill(1.5);
+    if(hltPath_.fired(triggerResults)) hCounter_->Fill(2.5);
+  }
 
   if (doRefAnalysis_) {
     double matchDr = hltPath_.isFirstFilterL1Seed() ? l1MatchDr_ : hltMatchDr_;
@@ -479,7 +488,9 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
       if (hltPath_.getFilterName(i).find("hltPFTau") < hltPath_.getFilterName(i).length() ||
           hltPath_.getFilterName(i).find("hltHpsPFTau") < hltPath_.getFilterName(i).length() ||
           hltPath_.getFilterName(i).find("hltDoublePFTau") < hltPath_.getFilterName(i).length() ||
-          hltPath_.getFilterName(i).find("hltHpsDoublePFTau") < hltPath_.getFilterName(i).length())
+          hltPath_.getFilterName(i).find("hltHpsDoublePFTau") < hltPath_.getFilterName(i).length() ||
+          hltPath_.getFilterName(i).find("PNetTauhTag") < hltPath_.getFilterName(i).length()
+	  )
         lastMatchedTauFilter = i;
       if (firstMatchedMETFilter < 0 && hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length())
         firstMatchedMETFilter = i;

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -46,7 +46,7 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
   // Book histograms
   iBooker.setCurrentFolder(triggerTag());
 
-  hCounter_ = iWrapper.book1D(iBooker,"EventCounter","Accepted events;;entries",3,0,3,kEverything);
+  hCounter_ = iWrapper.book1D(iBooker, "EventCounter", "Accepted events;;entries", 3, 0, 3, kEverything);
   hAcceptedEvents_ = iWrapper.book1D(iBooker,
                                      "EventsPerFilter",
                                      "Accepted Events per filter;;entries",
@@ -54,9 +54,9 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
                                      0,
                                      hltPath_.filtersSize(),
                                      kEverything);
-  hCounter_->setBinLabel(1,"all events");
-  hCounter_->setBinLabel(2,"ref tau found");
-  hCounter_->setBinLabel(3,"passed trg");
+  hCounter_->setBinLabel(1, "all events");
+  hCounter_->setBinLabel(2, "ref tau found");
+  hCounter_->setBinLabel(3, "passed trg");
   for (size_t i = 0; i < hltPath_.filtersSize(); ++i) {
     if (hAcceptedEvents_)
       hAcceptedEvents_->setBinLabel(i + 1, hltPath_.getFilterName(i));
@@ -115,13 +115,8 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
     }
 
     if (hltPath_.hasL3Taus()) {
-      hL3TrigTauEtEffNum_ = iWrapper.book1D(iBooker,
-                                            "L3TrigTauEtEffNum",
-                                            "L3 #tau p_{T} efficiency;Ref #tau p_{T};entries",
-                                            ptbins_,
-                                            0,
-                                            ptmax_,
-                                            kVital);
+      hL3TrigTauEtEffNum_ = iWrapper.book1D(
+          iBooker, "L3TrigTauEtEffNum", "L3 #tau p_{T} efficiency;Ref #tau p_{T};entries", ptbins_, 0, ptmax_, kVital);
       hL3TrigTauEtEffDenom_ = iWrapper.book1D(iBooker,
                                               "L3TrigTauEtEffDenom",
                                               "L3 #tau p_{T} denominator;Ref #tau p_{T};Efficiency",
@@ -456,9 +451,10 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
   int lastMatchedTauFilter = -1;
   int firstMatchedMETFilter = -1;
   hCounter_->Fill(0.5);
-  if(refCollection.taus.size() > 0){
+  if (refCollection.taus.size() > 0) {
     hCounter_->Fill(1.5);
-    if(hltPath_.fired(triggerResults)) hCounter_->Fill(2.5);
+    if (hltPath_.fired(triggerResults))
+      hCounter_->Fill(2.5);
   }
 
   if (doRefAnalysis_) {
@@ -489,8 +485,7 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
           hltPath_.getFilterName(i).find("hltHpsPFTau") < hltPath_.getFilterName(i).length() ||
           hltPath_.getFilterName(i).find("hltDoublePFTau") < hltPath_.getFilterName(i).length() ||
           hltPath_.getFilterName(i).find("hltHpsDoublePFTau") < hltPath_.getFilterName(i).length() ||
-          hltPath_.getFilterName(i).find("PNetTauhTag") < hltPath_.getFilterName(i).length()
-	  )
+          hltPath_.getFilterName(i).find("PNetTauhTag") < hltPath_.getFilterName(i).length())
         lastMatchedTauFilter = i;
       if (firstMatchedMETFilter < 0 && hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length())
         firstMatchedMETFilter = i;

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -54,9 +54,11 @@ void HLTTauDQMPathPlotter::bookHistograms(HistoWrapper& iWrapper, DQMStore::IBoo
                                      0,
                                      hltPath_.filtersSize(),
                                      kEverything);
-  hCounter_->setBinLabel(1, "all events");
-  hCounter_->setBinLabel(2, "ref tau found");
-  hCounter_->setBinLabel(3, "passed trg");
+  if (hCounter_) {
+    hCounter_->setBinLabel(1, "all events");
+    hCounter_->setBinLabel(2, "ref tau found");
+    hCounter_->setBinLabel(3, "passed trg");
+  }
   for (size_t i = 0; i < hltPath_.filtersSize(); ++i) {
     if (hAcceptedEvents_)
       hAcceptedEvents_->setBinLabel(i + 1, hltPath_.getFilterName(i));
@@ -450,11 +452,13 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults,
   int lastMatchedMuonFilter = -1;
   int lastMatchedTauFilter = -1;
   int firstMatchedMETFilter = -1;
-  hCounter_->Fill(0.5);
-  if (refCollection.taus.size() > 0) {
-    hCounter_->Fill(1.5);
-    if (hltPath_.fired(triggerResults))
-      hCounter_->Fill(2.5);
+  if (hCounter_) {
+    hCounter_->Fill(0.5);
+    if (refCollection.taus.size() > 0) {
+      hCounter_->Fill(1.5);
+      if (hltPath_.fired(triggerResults))
+        hCounter_->Fill(2.5);
+    }
   }
 
   if (doRefAnalysis_) {

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauPostValidation_cfi.py
@@ -5,9 +5,11 @@ import DQMOffline.Trigger.HLTTauPostProcessor_cfi as postProcessor
 
 (HLTTauValPostAnalysisMC, HLTTauValPostAnalysisMC2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorMC)
 (HLTTauValPostAnalysisPF, HLTTauValPostAnalysisPF2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorPF)
+(HLTTauValPostAnalysisPN, HLTTauValPostAnalysisPN2) = postProcessor.makePFTauAnalyzer(hltTauValIdealMonitorPNet)
 (HLTTauValPostAnalysisTP, HLTTauValPostAnalysisTP2) = postProcessor.makePFTauAnalyzer(hltTauValTagAndProbe)
 HLTTauPostVal = cms.Sequence(
     HLTTauValPostAnalysisMC+HLTTauValPostAnalysisMC2+
     HLTTauValPostAnalysisPF+HLTTauValPostAnalysisPF2+
+    HLTTauValPostAnalysisPN+HLTTauValPostAnalysisPN2+
     HLTTauValPostAnalysisTP+HLTTauValPostAnalysisTP2
 )

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
@@ -66,6 +66,11 @@ hltTauValIdealMonitorPF = hltTauValIdealMonitorMC.clone(
     ),
 )
 
+hltTauValIdealMonitorPNet = hltTauValIdealMonitorMC.clone(
+    DQMBaseFolder = cms.untracked.string("HLT/TAU/RelVal/PNet"),
+    Paths = cms.untracked.string("PNetTau")
+)
+
 from DQMOffline.Trigger.HLTTauDQMOffline_cfi import hltTauOfflineMonitor_TagAndProbe
 hltTauValTagAndProbe = hltTauValIdealMonitorMC.clone(
     DQMBaseFolder = cms.untracked.string("HLT/TAU/RelVal/TagAndProbe"),
@@ -94,5 +99,5 @@ hltTauValTagAndProbe = hltTauValIdealMonitorMC.clone(
 )
 
 #hltTauValIdeal = cms.Sequence(hltTauValIdealMonitorMC+hltTauValIdealMonitorPF)
-hltTauValIdeal = cms.Sequence(hltTauValIdealMonitorMC+hltTauValIdealMonitorPF+hltTauValTagAndProbe)
+hltTauValIdeal = cms.Sequence(hltTauValIdealMonitorMC+hltTauValIdealMonitorPF+hltTauValIdealMonitorPNet+hltTauValTagAndProbe)
 


### PR DESCRIPTION

HLTTauDQM
Added support for making DQM plots for PNetTauh paths.
Added event counter for helping to find problems. Not appearing in the final DQM output.
Fixed some empty plots at kEverything level.
Changed one plot level from kEverything to kVital (bugfix)

In addition to the current plots, every HLT path with string PNetTauh in the path name will be picked up and monitoring plots made.

Tested with CMSSW_14_0_4 that the code compiles, runs and produces the plots, including the new plots for PNet taus.
