### PR TITLE
Updated AK8 path names for 2024 data-taking

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -8,8 +8,8 @@ from DQMOffline.Trigger.B2GTnPMonitor_cfi import B2GegmGsfElectronIDsForDQM,B2Ge
 from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 
 ### B2G triggers:
-# HLT_AK8PFJet*_MassSD30
-# HLT_AK8DiPFJet*_*_MassSD*
+# HLT_AK8PFJet*_SoftDropMass*
+# HLT_AK8DiPFJet*_*_SoftDropMass*
 # HLT_Mu37_Ele27_CaloIdL_MW
 # HLT_Mu27_Ele37_CaloIdL_MW
 # HLT_Mu37_TkMu27
@@ -28,7 +28,7 @@ PFHT1050_Mjjmonitoring = hltMjjmonitoring.clone(
 PFHT1050_Softdropmonitoring = hltSoftdropmonitoring.clone(
     FolderName = 'HLT/B2G/PFHT1050',
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT1050_v*"])        
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT1050_v*"])
 )
 
 AK8PFJet500_Mjjmonitoring = hltMjjmonitoring.clone(
@@ -36,6 +36,20 @@ AK8PFJet500_Mjjmonitoring = hltMjjmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     jetSelection = "pt > 200 && eta < 2.4",
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet500_v*"])
+)
+
+AK8PFJet380_SoftDropMass30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet380_SoftDropMass30',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet380_SoftDropMass30_v*"])
+)
+
+AK8DiPFJet260_260_SoftDropMass30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet260_260_SoftDropMass30',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8DiPFJet260_260_SoftDropMass30_v*"])
 )
 
 AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone(
@@ -48,51 +62,38 @@ AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone(
     )
 )
 
+# AK8PFJet380_SoftDropMass30 monitoring
 
-# AK8PFJet420_MassSD30 monitoring
-
-AK8PFJet420_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
+AK8PFJet380_SoftDropMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet380_SoftDropMass30',
     ptcut = 200,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"])
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet380_SoftDropMass30_v*"])
 )
 
-AK8PFJet420_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"])
-)
 
-AK8PFJet420_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet420_MassSD30',
+AK8PFJet380_SoftDropMass30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet380_SoftDropMass30',
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_MassSD30_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet380_SoftDropMass30_v*"]),
     histoPSet = dict(
         htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
         htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
     )
 )
 
-# AK8DiPFJet270_270_MassSD30 monitoring
+# AK8DiPFJet260_260_SoftDropMass30 monitoring
 
-AK8DiPFJet270_270_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
+AK8DiPFJet260_260_SoftDropMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet260_260_SoftDropMass30',
     ptcut = 200,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"])
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet260_260_SoftDropMass30_v*"])
 )
 
-AK8DiPFJet270_270_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"])
-)
 
-AK8DiPFJet270_270_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8DiPFJet270_270_MassSD30',
+AK8DiPFJet260_260_SoftDropMass30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet260_260_SoftDropMass30',
     jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet270_270_MassSD30_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet260_260_SoftDropMass30_v*"]),
     histoPSet = dict(
         htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
         htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
@@ -126,11 +127,11 @@ b2gMonitorHLT = cms.Sequence(
 
     AK8PFJet500_Mjjmonitoring +
 
-    AK8PFJet420_MassSD30_PromptMonitoring +
-    AK8PFJet420_MassSD30_Mjjmonitoring +
+    AK8PFJet380_SoftDropMass30_Mjjmonitoring +
+    AK8DiPFJet260_260_SoftDropMass30_Mjjmonitoring +
 
-    AK8DiPFJet270_270_MassSD30_PromptMonitoring +
-    AK8DiPFJet270_270_MassSD30_Mjjmonitoring +
+    AK8PFJet380_SoftDropMass30_PromptMonitoring +
+    AK8DiPFJet260_260_SoftDropMass30_PromptMonitoring +
 
     B2GegHLTDQMOfflineTnPSource
 
@@ -147,8 +148,8 @@ b2gMonitorHLT = cms.Sequence(
 b2gHLTDQMSourceWithRECO = cms.Sequence(
     PFHT1050_Softdropmonitoring +
     AK8PFJet500_Softdropmonitoring +
-    AK8PFJet420_MassSD30_Softdropmonitoring +
-    AK8DiPFJet270_270_MassSD30_Softdropmonitoring
+    AK8PFJet380_SoftDropMass30_Softdropmonitoring +
+    AK8DiPFJet260_260_SoftDropMass30_Softdropmonitoring
 )
 
 b2gHLTDQMSourceExtra = cms.Sequence(


### PR DESCRIPTION
#### PR description:

* Replaced AK8 paths from B2G DQM monitoring
* The new paths were introduced in [CMSHLT-3028](https://its.cern.ch/jira/browse/CMSHLT-3028)

#### PR validation:

I have tested the changes by re-running the HLT, RECO+DQM and Harvesting steps with cmsDriver and checked that the new folders are now created and filled.

I have also checked: 
runTheMatrix.py -l limited -i all --ibeos

with output:
47 46 45 36 19 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed

The above changes will be backported to:
CMSSW_14_1_X (#44615)
CMSSW_14_0_X (#44617)