### PR TITLE
PFTau.cc: remove pessimizing move

### DIFF
--- a/DataFormats/TauReco/src/PFTau.cc
+++ b/DataFormats/TauReco/src/PFTau.cc
@@ -118,7 +118,7 @@ namespace reco {
     template <typename T>
     T& makeCacheIfNeeded(edm::AtomicPtrCache<T>& oCache) {
       if (not oCache.isSet()) {
-        oCache.set(std::move(std::make_unique<T>()));
+        oCache.set(std::make_unique<T>());
       }
       return *oCache;
     }


### PR DESCRIPTION
#### PR description:

GCC13 complains about pessimizing move in PFTau.cc:

```
>> Compiling LCG dictionary: tmp/el9_amd64_gcc13/src/DataFormats/CTPPSDetId/src/DataFormatsCTPPSDetId/a/DataFormatsCTPPSDetId_xr.cc
src/DataFormats/TauReco/src/PFTau.cc: In instantiation of 'T& reco::{anonymous}::makeCacheIfNeeded(edm::AtomicPtrCache<T>&) [with T = std::vector<reco::RecoTauPiZero>]':
src/DataFormats/TauReco/src/PFTau.cc:248:29:   required from here
src/DataFormats/TauReco/src/PFTau.cc:121:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
  121 |         oCache.set(std::move(std::make_unique<T>()));
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/DataFormats/TauReco/src/PFTau.cc:121:19: note: remove 'std::move' call
src/DataFormats/TauReco/src/PFTau.cc: In instantiation of 'T& reco::{anonymous}::makeCacheIfNeeded(edm::AtomicPtrCache<T>&) [with T = std::vector<reco::PFRecoTauChargedHadron>]':
src/DataFormats/TauReco/src/PFTau.cc:295:29:   required from here
src/DataFormats/TauReco/src/PFTau.cc:121:19: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
src/DataFormats/TauReco/src/PFTau.cc:121:19: note: remove 'std::move' call
```

#### PR validation:

Bot tests