### PR TITLE
Revert "Temporary: abort if cutParser fails to find methods"

### DIFF
--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -9,9 +9,6 @@
 
 #include <string>
 
-//DEBUG THREADING PROBLEM
-#include <cstdlib>
-
 using namespace reco::parser;
 using namespace std;
 
@@ -124,8 +121,6 @@ bool MethodSetter::push(const string& name, const vector<AnyMethodArgument>& arg
     // Not a data member either, fatal error, throw.
     switch (error) {
       case reco::parser::kNameDoesNotExist: {
-        //DEBUG THREADING ISSUE
-        std::abort();
         Exception ex(begin);
         ex << "no method or data member named \"" << name << "\" found for type \"" << type.name() << "\"\n";
         // The following information is for temporary debugging only, intended to be removed later

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -178,8 +178,6 @@ void testCutParser::checkAll() {
 
   // check handling of errors
   //   first those who are the same in lazy and non lazy parsing
-  //DEBUG FOR THREADING
-  /*
   for (int lazy = 0; lazy <= 1; ++lazy) {
     sel.reset();
     CPPUNIT_ASSERT(!reco::parser::cutParser<reco::Track>("1abc", sel, lazy));
@@ -222,7 +220,6 @@ void testCutParser::checkAll() {
 
   sel.reset();
   CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')", sel, false), edm::Exception);
-  */ //DEBUG ENDING
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());


### PR DESCRIPTION
Reverts cms-sw/cmssw#44590

The original PR is meant to be in the IBs temporarily as a debugging tool. Once we've decided the PR has served it's purpose, we want it reverted.