### PR TITLE
Add a test for Alpaka libraries and build rules

### DIFF
--- a/HeterogeneousTest/AlpakaDevice/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaDevice/BuildFile.xml
@@ -1,0 +1,2 @@
+<use name="alpaka"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>

--- a/HeterogeneousTest/AlpakaDevice/README.md
+++ b/HeterogeneousTest/AlpakaDevice/README.md
@@ -1,0 +1,49 @@
+# Introduction
+
+The packages `HeterogeneousTest/AlpakaDevice`, `HeterogeneousTest/AlpakaKernel`,
+`HeterogeneousTest/AlpakaWrapper` and `HeterogeneousTest/AlpakaOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for Alpaka.
+In particular, these tests show what is supported and what are the limitations implementing
+Alpaka-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/AlpakaDevice`
+
+The package `HeterogeneousTest/AlpakaDevice` implements a library that defines and exports Alpaka
+device-side functions:
+```c++
+namespace cms::alpakatest {
+
+  template <typename TAcc>
+  ALPAKA_FN_ACC void add_vectors_f(TAcc const& acc, ...);
+
+  template <typename TAcc>
+  ALPAKA_FN_ACC void add_vectors_d(TAcc const& acc, ...);
+
+}  // namespace cms::alpakatest
+```
+
+The `plugins` directory implements the `AlpakaTestDeviceAdditionModule` `EDAnalyzer` that launches
+an Alpaka kernel using the functions defined in ths library. As a byproduct this plugin also shows
+how to split an `EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and
+a device part (in a `.dev.cc` file).
+
+The `test` directory implements the `testAlpakaDeviceAddition` binary that launches a Alpaka kernel
+using these functions.
+It also contains the `testAlpakaTestDeviceAdditionModule.py` python configuration to exercise the
+`AlpakaTestDeviceAdditionModule` plugin.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/Alpaka...` packages:
+  - [`HeterogeneousTest/AlpakaKernel/README.md`](../../HeterogeneousTest/AlpakaKernel/README.md)
+  - [`HeterogeneousTest/AlpakaWrapper/README.md`](../../HeterogeneousTest/AlpakaWrapper/README.md)
+  - [`HeterogeneousTest/AlpakaOpaque/README.md`](../../HeterogeneousTest/AlpakaOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/AlpakaOpaque/test` contains the `testAlpakaTestAdditionModules.py` python
+configuration that exercise all four plugins in a single application.

--- a/HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h
+++ b/HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h
@@ -1,0 +1,36 @@
+#ifndef HeterogeneousTest_AlpakaDevice_interface_alpaka_DeviceAddition_h
+#define HeterogeneousTest_AlpakaDevice_interface_alpaka_DeviceAddition_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+namespace cms::alpakatest {
+
+  template <typename TAcc>
+  ALPAKA_FN_ACC void add_vectors_f(TAcc const& acc,
+                                   float const* __restrict__ in1,
+                                   float const* __restrict__ in2,
+                                   float* __restrict__ out,
+                                   uint32_t size) {
+    for (auto i : cms::alpakatools::uniform_elements(acc, size)) {
+      out[i] = in1[i] + in2[i];
+    }
+  }
+
+  template <typename TAcc>
+  ALPAKA_FN_ACC void add_vectors_d(TAcc const& acc,
+                                   double const* __restrict__ in1,
+                                   double const* __restrict__ in2,
+                                   double* __restrict__ out,
+                                   uint32_t size) {
+    for (auto i : cms::alpakatools::uniform_elements(acc, size)) {
+      out[i] = in1[i] + in2[i];
+    }
+  }
+
+}  // namespace cms::alpakatest
+
+#endif  // HeterogeneousTest_AlpakaDevice_interface_alpaka_DeviceAddition_h

--- a/HeterogeneousTest/AlpakaDevice/plugins/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaDevice/plugins/BuildFile.xml
@@ -1,0 +1,11 @@
+<library file="alpaka/*.cc" name="HeterogeneousTestAlpakaDevicePlugins">
+  <use name="alpaka"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/AlpakaServices"/>
+  <use name="HeterogeneousTest/AlpakaDevice"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.dev.cc
+++ b/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.dev.cc
@@ -1,0 +1,32 @@
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h"
+
+#include "AlpakaTestDeviceAdditionAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaDevicePlugins {
+
+  struct KernelAddVectorsF {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  const float* __restrict__ in1,
+                                  const float* __restrict__ in2,
+                                  float* __restrict__ out,
+                                  uint32_t size) const {
+      cms::alpakatest::add_vectors_f(acc, in1, in2, out, size);
+    }
+  };
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size) {
+    alpaka::exec<Acc1D>(queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), KernelAddVectorsF{}, in1, in2, out, size);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaDevicePlugins

--- a/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.h
+++ b/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.h
@@ -1,0 +1,18 @@
+#ifndef HeterogeneousTest_AlpakaDevice_plugins_alpaka_AlpakaTestDeviceAdditionAlgo_h
+#define HeterogeneousTest_AlpakaDevice_plugins_alpaka_AlpakaTestDeviceAdditionAlgo_h
+
+#include <cstdint>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaDevicePlugins {
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaDevicePlugins
+
+#endif  // HeterogeneousTest_AlpakaDevice_plugins_alpaka_AlpakaTestDeviceAdditionAlgo_h

--- a/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionModule.cc
@@ -1,0 +1,124 @@
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+#include "AlpakaTestDeviceAdditionAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaTestDeviceAdditionModule : public edm::global::EDAnalyzer<> {
+  public:
+    explicit AlpakaTestDeviceAdditionModule(edm::ParameterSet const& config);
+    ~AlpakaTestDeviceAdditionModule() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+  private:
+    const uint32_t size_;
+  };
+
+  AlpakaTestDeviceAdditionModule::AlpakaTestDeviceAdditionModule(edm::ParameterSet const& config)
+      : size_(config.getParameter<uint32_t>("size")) {}
+
+  void AlpakaTestDeviceAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<uint32_t>("size", 1024 * 1024);
+
+    // ignore the alpaka = cms.untracked.PSet(...) injected by the framework
+    edm::ParameterSetDescription alpaka;
+    alpaka.setAllowAnything();
+    desc.addUntracked<edm::ParameterSetDescription>("alpaka", alpaka);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void AlpakaTestDeviceAdditionModule::analyze(edm::StreamID,
+                                               edm::Event const& event,
+                                               edm::EventSetup const& setup) const {
+    // require a valid Alpaka backend for running
+    edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+    if (not service or not service->enabled()) {
+      std::cout << "The " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService)
+                << " is not available or disabled, the test will be skipped.\n";
+      return;
+    }
+
+    // random number generator with a gaussian distribution
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0., 1.};
+
+    // tolerance
+    constexpr float epsilon = 0.000001;
+
+    // allocate input and output host buffers
+    std::vector<float> in1_h(size_);
+    std::vector<float> in2_h(size_);
+    std::vector<float> out_h(size_);
+
+    // fill the input buffers with random data, and the output buffer with zeros
+    for (uint32_t i = 0; i < size_; ++i) {
+      in1_h[i] = dist(rand);
+      in2_h[i] = dist(rand);
+      out_h[i] = 0.;
+    }
+
+    // run the test on all available devices
+    for (auto const& device : cms::alpakatools::devices<Platform>()) {
+      Queue queue{device};
+
+      // allocate input and output buffers on the device
+      auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+
+      // copy the input data to the device
+      // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+      // The destination view and the extent are required to have compatible index types!
+      alpaka::memcpy(queue, in1_d, in1_h, size_);
+      alpaka::memcpy(queue, in2_d, in2_h, size_);
+
+      // fill the output buffer with zeros
+      alpaka::memset(queue, out_d, 0);
+
+      // launch the 1-dimensional kernel for vector addition
+      HeterogeneousTestAlpakaDevicePlugins::wrapper_add_vectors_f(
+          queue, in1_d.data(), in2_d.data(), out_d.data(), size_);
+
+      // copy the results from the device to the host
+      alpaka::memcpy(queue, out_h, out_d);
+
+      // wait for all the operations to complete
+      alpaka::wait(queue);
+
+      // check the results
+      for (uint32_t i = 0; i < size_; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        assert(out_h[i] < sum + epsilon);
+        assert(out_h[i] > sum - epsilon);
+      }
+    }
+
+    std::cout << "All tests passed.\n";
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(AlpakaTestDeviceAdditionModule);

--- a/HeterogeneousTest/AlpakaDevice/test/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaDevice/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin file="alpaka/testDeviceAddition.dev.cc" name="testAlpakaDeviceAddition">
+  <use name="catch2"/>
+  <use name="alpaka"/>
+  <use name="HeterogeneousTest/AlpakaDevice"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<test name="testAlpakaTestDeviceAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/AlpakaDevice/test/testAlpakaTestDeviceAdditionModule.py"/>

--- a/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
+++ b/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
@@ -1,0 +1,102 @@
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+struct KernelAddVectorsF {
+  template <typename TAcc>
+  ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                const float* __restrict__ in1,
+                                const float* __restrict__ in2,
+                                float* __restrict__ out,
+                                uint32_t size) const {
+    cms::alpakatest::add_vectors_f(acc, in1, in2, out, size);
+  }
+};
+
+TEST_CASE("HeterogeneousTest/AlpakaDevice test", "[alpakaTestDeviceAddition]") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+        "the test will be skipped.");
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr uint32_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (uint32_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // run the test on all available devices
+  for (auto const& device : cms::alpakatools::devices<Platform>()) {
+    SECTION("Test add_vectors_f on " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend") {
+      REQUIRE_NOTHROW([&]() {
+        Queue queue{device};
+
+        // allocate input and output buffers on the device
+        auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+
+        // copy the input data to the device
+        // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+        // The destination view and the extent are required to have compatible index types!
+        alpaka::memcpy(queue, in1_d, in1_h, size);
+        alpaka::memcpy(queue, in2_d, in2_h, size);
+
+        // fill the output buffer with zeros
+        alpaka::memset(queue, out_d, 0);
+
+        // launch the 1-dimensional kernel for vector addition
+        alpaka::exec<Acc1D>(queue,
+                            cms::alpakatools::make_workdiv<Acc1D>(32, 32),
+                            KernelAddVectorsF{},
+                            in1_d.data(),
+                            in2_d.data(),
+                            out_d.data(),
+                            size);
+
+        // copy the results from the device to the host
+        alpaka::memcpy(queue, out_h, out_d, size);
+
+        // wait for all the operations to complete
+        alpaka::wait(queue);
+      }());
+
+      // check the results
+      for (uint32_t i = 0; i < size; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+      }
+    }
+  }
+}

--- a/HeterogeneousTest/AlpakaDevice/test/testAlpakaTestDeviceAdditionModule.py
+++ b/HeterogeneousTest/AlpakaDevice/test/testAlpakaTestDeviceAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestAlpakaTestDeviceAdditionModule')
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.source = cms.Source('EmptySource')
+
+process.alpakaTestDeviceAdditionModule = cms.EDAnalyzer('AlpakaTestDeviceAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.alpakaTestDeviceAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/AlpakaKernel/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaKernel/BuildFile.xml
@@ -1,0 +1,3 @@
+<use name="alpaka"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousTest/AlpakaDevice"/>

--- a/HeterogeneousTest/AlpakaKernel/README.md
+++ b/HeterogeneousTest/AlpakaKernel/README.md
@@ -1,0 +1,53 @@
+# Introduction
+
+The packages `HeterogeneousTest/AlpakaDevice`, `HeterogeneousTest/AlpakaKernel`,
+`HeterogeneousTest/AlpakaWrapper` and `HeterogeneousTest/AlpakaOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for Alpaka.
+In particular, these tests show what is supported and what are the limitations implementing
+Alpaka-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/AlpakaKernel`
+
+The package `HeterogeneousTest/AlpakaKernel` implements a library that defines and exports Alpaka
+kernels that call the device functions defined in the `HeterogeneousTest/AlpakaDevice` library:
+```c++
+namespace cms::alpakatest {
+
+  struct KernelAddVectorsF {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, ...) const;
+  };
+
+  struct KernelAddVectorsD {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, ...) const;
+  };
+
+}  // namespace cms::alpakatest
+```
+
+The `plugins` directory implements the `AlpakaTestKernelAdditionModule` `EDAnalyzer` that launches
+the Alpaka kernels defined in this library. As a byproduct this plugin also shows how to split an
+`EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a device part (in
+a `.dev.cc` file).
+
+The `test` directory implements the `testAlpakaKernelAddition` test binary that launches the Alpaka
+kernel defined in this library.
+It also contains the `testAlpakaTestKernelAdditionModule.py` python configuration to exercise the
+`AlpakaTestKernelAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/Alpaka...` packages:
+  - [`HeterogeneousTest/AlpakaDevice/README.md`](../../HeterogeneousTest/AlpakaDevice/README.md)
+  - [`HeterogeneousTest/AlpakaWrapper/README.md`](../../HeterogeneousTest/AlpakaWrapper/README.md)
+  - [`HeterogeneousTest/AlpakaOpaque/README.md`](../../HeterogeneousTest/AlpakaOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/AlpakaOpaque/test` contains the `testAlpakaTestAdditionModules.py` python
+configuration that exercise all four plugins in a single application.

--- a/HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h
+++ b/HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h
@@ -1,0 +1,36 @@
+#ifndef HeterogeneousTest_AlpakaKernel_interface_alpaka_DeviceAdditionKernel_h
+#define HeterogeneousTest_AlpakaKernel_interface_alpaka_DeviceAdditionKernel_h
+
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h"
+
+namespace cms::alpakatest {
+
+  struct KernelAddVectorsF {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  const float* __restrict__ in1,
+                                  const float* __restrict__ in2,
+                                  float* __restrict__ out,
+                                  uint32_t size) const {
+      add_vectors_f(acc, in1, in2, out, size);
+    }
+  };
+
+  struct KernelAddVectorsD {
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+                                  const double* __restrict__ in1,
+                                  const double* __restrict__ in2,
+                                  double* __restrict__ out,
+                                  uint32_t size) const {
+      add_vectors_d(acc, in1, in2, out, size);
+    }
+  };
+
+}  // namespace cms::alpakatest
+
+#endif  // HeterogeneousTest_AlpakaKernel_interface_alpaka_DeviceAdditionKernel_h

--- a/HeterogeneousTest/AlpakaKernel/plugins/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaKernel/plugins/BuildFile.xml
@@ -1,0 +1,11 @@
+<library file="alpaka/*.cc" name="HeterogeneousTestAlpakaKernelPlugins">
+  <use name="alpaka"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousCore/AlpakaServices"/>
+  <use name="HeterogeneousTest/AlpakaKernel"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.dev.cc
+++ b/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.dev.cc
@@ -1,0 +1,22 @@
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h"
+
+#include "AlpakaTestKernelAdditionAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins {
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size) {
+    alpaka::exec<Acc1D>(
+        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsF{}, in1, in2, out, size);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins

--- a/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.h
+++ b/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.h
@@ -1,0 +1,18 @@
+#ifndef HeterogeneousTest_AlpakaKernel_plugins_alpaka_AlpakaTestKernelAdditionAlgo_h
+#define HeterogeneousTest_AlpakaKernel_plugins_alpaka_AlpakaTestKernelAdditionAlgo_h
+
+#include <cstdint>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins {
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins
+
+#endif  // HeterogeneousTest_AlpakaKernel_plugins_alpaka_AlpakaTestKernelAdditionAlgo_h

--- a/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionModule.cc
+++ b/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionModule.cc
@@ -1,0 +1,124 @@
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+#include "AlpakaTestKernelAdditionAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaTestKernelAdditionModule : public edm::global::EDAnalyzer<> {
+  public:
+    explicit AlpakaTestKernelAdditionModule(edm::ParameterSet const& config);
+    ~AlpakaTestKernelAdditionModule() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+  private:
+    const uint32_t size_;
+  };
+
+  AlpakaTestKernelAdditionModule::AlpakaTestKernelAdditionModule(edm::ParameterSet const& config)
+      : size_(config.getParameter<uint32_t>("size")) {}
+
+  void AlpakaTestKernelAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<uint32_t>("size", 1024 * 1024);
+
+    // ignore the alpaka = cms.untracked.PSet(...) injected by the framework
+    edm::ParameterSetDescription alpaka;
+    alpaka.setAllowAnything();
+    desc.addUntracked<edm::ParameterSetDescription>("alpaka", alpaka);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void AlpakaTestKernelAdditionModule::analyze(edm::StreamID,
+                                               edm::Event const& event,
+                                               edm::EventSetup const& setup) const {
+    // require a valid Alpaka backend for running
+    edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+    if (not service or not service->enabled()) {
+      std::cout << "The " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService)
+                << " is not available or disabled, the test will be skipped.\n";
+      return;
+    }
+
+    // random number generator with a gaussian distribution
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0., 1.};
+
+    // tolerance
+    constexpr float epsilon = 0.000001;
+
+    // allocate input and output host buffers
+    std::vector<float> in1_h(size_);
+    std::vector<float> in2_h(size_);
+    std::vector<float> out_h(size_);
+
+    // fill the input buffers with random data, and the output buffer with zeros
+    for (uint32_t i = 0; i < size_; ++i) {
+      in1_h[i] = dist(rand);
+      in2_h[i] = dist(rand);
+      out_h[i] = 0.;
+    }
+
+    // run the test on all available devices
+    for (auto const& device : cms::alpakatools::devices<Platform>()) {
+      Queue queue{device};
+
+      // allocate input and output buffers on the device
+      auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+
+      // copy the input data to the device
+      // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+      // The destination view and the extent are required to have compatible index types!
+      alpaka::memcpy(queue, in1_d, in1_h, size_);
+      alpaka::memcpy(queue, in2_d, in2_h, size_);
+
+      // fill the output buffer with zeros
+      alpaka::memset(queue, out_d, 0);
+
+      // launch the 1-dimensional kernel for vector addition
+      HeterogeneousTestAlpakaKernelPlugins::wrapper_add_vectors_f(
+          queue, in1_d.data(), in2_d.data(), out_d.data(), size_);
+
+      // copy the results from the device to the host
+      alpaka::memcpy(queue, out_h, out_d);
+
+      // wait for all the operations to complete
+      alpaka::wait(queue);
+
+      // check the results
+      for (uint32_t i = 0; i < size_; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        assert(out_h[i] < sum + epsilon);
+        assert(out_h[i] > sum - epsilon);
+      }
+    }
+
+    std::cout << "All tests passed.\n";
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(AlpakaTestKernelAdditionModule);

--- a/HeterogeneousTest/AlpakaKernel/test/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaKernel/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin file="alpaka/testDeviceAdditionKernel.dev.cc" name="testAlpakaDeviceAdditionKernel">
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousTest/AlpakaKernel"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<test name="testAlpakaTestKernelAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/AlpakaKernel/test/testAlpakaTestKernelAdditionModule.py"/>

--- a/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
+++ b/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
@@ -1,0 +1,91 @@
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+TEST_CASE("HeterogeneousTest/AlpakaKernel test", "[alpakaTestDeviceAdditionKernel]") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+        "the test will be skipped.");
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr uint32_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (uint32_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // run the test on all available devices
+  for (auto const& device : cms::alpakatools::devices<Platform>()) {
+    SECTION("Test add_vectors_f on " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend") {
+      REQUIRE_NOTHROW([&]() {
+        Queue queue{device};
+
+        // allocate input and output buffers on the device
+        auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+
+        // copy the input data to the device
+        // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+        // The destination view and the extent are required to have compatible index types!
+        alpaka::memcpy(queue, in1_d, in1_h, size);
+        alpaka::memcpy(queue, in2_d, in2_h, size);
+
+        // fill the output buffer with zeros
+        alpaka::memset(queue, out_d, 0);
+
+        // launch the 1-dimensional kernel for vector addition
+        alpaka::exec<Acc1D>(queue,
+                            cms::alpakatools::make_workdiv<Acc1D>(32, 32),
+                            cms::alpakatest::KernelAddVectorsF{},
+                            in1_d.data(),
+                            in2_d.data(),
+                            out_d.data(),
+                            size);
+
+        // copy the results from the device to the host
+        alpaka::memcpy(queue, out_h, out_d, size);
+
+        // wait for all the operations to complete
+        alpaka::wait(queue);
+      }());
+
+      // check the results
+      for (uint32_t i = 0; i < size; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+      }
+    }
+  }
+}

--- a/HeterogeneousTest/AlpakaKernel/test/testAlpakaTestKernelAdditionModule.py
+++ b/HeterogeneousTest/AlpakaKernel/test/testAlpakaTestKernelAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestAlpakaTestKernelAdditionModule')
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.source = cms.Source('EmptySource')
+
+process.alpakaTestKernelAdditionModule = cms.EDAnalyzer('AlpakaTestKernelAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.alpakaTestKernelAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/AlpakaOpaque/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaOpaque/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="alpaka"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousTest/AlpakaWrapper"/>
+<flags ALPAKA_BACKENDS="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousTest/AlpakaOpaque/README.md
+++ b/HeterogeneousTest/AlpakaOpaque/README.md
@@ -1,0 +1,46 @@
+# Introduction
+
+The packages `HeterogeneousTest/AlpakaDevice`, `HeterogeneousTest/AlpakaKernel`,
+`HeterogeneousTest/AlpakaWrapper` and `HeterogeneousTest/AlpakaOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for Alpaka.
+In particular, these tests show what is supported and what are the limitations implementing
+Alpaka-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/AlpakaOpaque`
+
+The package `HeterogeneousTest/AlpakaOpaque` implements a non-Alpaka aware library, with functions
+that call the wrappers defined in the `HeterogeneousTest/AlpakaWrapper` library:
+```c++
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void opaque_add_vectors_f(...);
+  void opaque_add_vectors_d(...);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
+```
+
+The `plugins` directory implements the `AlpakaTestOpqaueAdditionModule` `EDAnalyzer` that calls the 
+function defined in this library. This plugin shows how the function can be used directly from a 
+host-only, non-Alpaka aware plugin.
+
+The `test` directory implements the `testAlpakaDeviceAdditionOpqaue` test binary that calls the
+function defined in this library, and shows how they can be used directly from a host-only,
+non-Alpaka aware application.
+It also contains the `testAlpakaTestOpqaueAdditionModule.py` python configuration to exercise the
+`AlpakaTestOpqaueAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/Alpaka...` packages:
+  - [`HeterogeneousTest/AlpakaDevice/README.md`](../../HeterogeneousTest/AlpakaDevice/README.md)
+  - [`HeterogeneousTest/AlpakaKernel/README.md`](../../HeterogeneousTest/AlpakaKernel/README.md)
+  - [`HeterogeneousTest/AlpakaWrapper/README.md`](../../HeterogeneousTest/AlpakaWrapper/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/AlpakaOpaque/test` contains also the `testAlpakaTestAdditionModules.py` python
+configuration that exercise all four plugins in a single application.

--- a/HeterogeneousTest/AlpakaOpaque/interface/alpaka/DeviceAdditionOpaque.h
+++ b/HeterogeneousTest/AlpakaOpaque/interface/alpaka/DeviceAdditionOpaque.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousTest_AlpakaOpaque_interface_alpaka_DeviceAdditionOpaque_h
+#define HeterogeneousTest_AlpakaOpaque_interface_alpaka_DeviceAdditionOpaque_h
+
+#include <cstdint>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void opaque_add_vectors_f(const float* in1, const float* in2, float* out, uint32_t size);
+
+  void opaque_add_vectors_d(const double* in1, const double* in2, double* out, uint32_t size);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
+
+#endif  // HeterogeneousTest_AlpakaOpaque_interface_alpaka_DeviceAdditionOpaque_h

--- a/HeterogeneousTest/AlpakaOpaque/plugins/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaOpaque/plugins/BuildFile.xml
@@ -1,0 +1,10 @@
+<library file="alpaka/*.cc" name="HeterogeneousTestAlpakaOpaquePlugins">
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaServices"/>
+  <use name="HeterogeneousTest/AlpakaOpaque"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousTest/AlpakaOpaque/plugins/alpaka/AlpakaTestOpaqueAdditionModule.cc
+++ b/HeterogeneousTest/AlpakaOpaque/plugins/alpaka/AlpakaTestOpaqueAdditionModule.cc
@@ -1,0 +1,94 @@
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousTest/AlpakaOpaque/interface/alpaka/DeviceAdditionOpaque.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaTestOpaqueAdditionModule : public edm::global::EDAnalyzer<> {
+  public:
+    explicit AlpakaTestOpaqueAdditionModule(edm::ParameterSet const& config);
+    ~AlpakaTestOpaqueAdditionModule() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+  private:
+    const uint32_t size_;
+  };
+
+  AlpakaTestOpaqueAdditionModule::AlpakaTestOpaqueAdditionModule(edm::ParameterSet const& config)
+      : size_(config.getParameter<uint32_t>("size")) {}
+
+  void AlpakaTestOpaqueAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<uint32_t>("size", 1024 * 1024);
+
+    // ignore the alpaka = cms.untracked.PSet(...) injected by the framework
+    edm::ParameterSetDescription alpaka;
+    alpaka.setAllowAnything();
+    desc.addUntracked<edm::ParameterSetDescription>("alpaka", alpaka);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void AlpakaTestOpaqueAdditionModule::analyze(edm::StreamID,
+                                               edm::Event const& event,
+                                               edm::EventSetup const& setup) const {
+    // require a valid Alpaka backend for running
+    edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+    if (not service or not service->enabled()) {
+      std::cout << "The " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService)
+                << " is not available or disabled, the test will be skipped.\n";
+      return;
+    }
+
+    // random number generator with a gaussian distribution
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0., 1.};
+
+    // tolerance
+    constexpr float epsilon = 0.000001;
+
+    // allocate input and output host buffers
+    std::vector<float> in1(size_);
+    std::vector<float> in2(size_);
+    std::vector<float> out(size_);
+
+    // fill the input buffers with random data, and the output buffer with zeros
+    for (uint32_t i = 0; i < size_; ++i) {
+      in1[i] = dist(rand);
+      in2[i] = dist(rand);
+      out[i] = 0.;
+    }
+
+    // launch the 1-dimensional kernel for vector addition on the first available device
+    test::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size_);
+
+    // check the results
+    for (uint32_t i = 0; i < size_; ++i) {
+      float sum = in1[i] + in2[i];
+      assert(out[i] < sum + epsilon);
+      assert(out[i] > sum - epsilon);
+    }
+
+    std::cout << "All tests passed.\n";
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(AlpakaTestOpaqueAdditionModule);

--- a/HeterogeneousTest/AlpakaOpaque/src/alpaka/DeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/AlpakaOpaque/src/alpaka/DeviceAdditionOpaque.cc
@@ -1,0 +1,85 @@
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousTest/AlpakaOpaque/interface/alpaka/DeviceAdditionOpaque.h"
+#include "HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void opaque_add_vectors_f(const float* in1, const float* in2, float* out, uint32_t size) {
+    // run on the first available devices
+    auto const& device = cms::alpakatools::devices<Platform>()[0];
+    Queue queue{device};
+
+    // wrap the input and output data in views
+    auto in1_h = cms::alpakatools::make_host_view<const float>(in1, size);
+    auto in2_h = cms::alpakatools::make_host_view<const float>(in2, size);
+    auto out_h = cms::alpakatools::make_host_view<float>(out, size);
+
+    // allocate input and output buffers on the device
+    auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+    auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+    auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+
+    // copy the input data to the device
+    // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+    // The destination view and the extent are required to have compatible index types!
+    alpaka::memcpy(queue, in1_d, in1_h, size);
+    alpaka::memcpy(queue, in2_d, in2_h, size);
+
+    // fill the output buffer with zeros
+    alpaka::memset(queue, out_d, 0);
+
+    // launch the 1-dimensional kernel for vector addition
+    test::wrapper_add_vectors_f(queue, in1_d.data(), in2_d.data(), out_d.data(), size);
+
+    // copy the results from the device to the host
+    alpaka::memcpy(queue, out_h, out_d);
+
+    // wait for all the operations to complete
+    alpaka::wait(queue);
+
+    // the device buffers are freed automatically
+  }
+
+  void opaque_add_vectors_d(const double* in1, const double* in2, double* out, uint32_t size) {
+    // run on the first available devices
+    auto const& device = cms::alpakatools::devices<Platform>()[0];
+    Queue queue{device};
+
+    // wrap the input and output data in views
+    auto in1_h = cms::alpakatools::make_host_view<const double>(in1, size);
+    auto in2_h = cms::alpakatools::make_host_view<const double>(in2, size);
+    auto out_h = cms::alpakatools::make_host_view<double>(out, size);
+
+    // allocate input and output buffers on the device
+    auto in1_d = cms::alpakatools::make_device_buffer<double[]>(queue, size);
+    auto in2_d = cms::alpakatools::make_device_buffer<double[]>(queue, size);
+    auto out_d = cms::alpakatools::make_device_buffer<double[]>(queue, size);
+
+    // copy the input data to the device
+    // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+    // The destination view and the extent are required to have compatible index types!
+    alpaka::memcpy(queue, in1_d, in1_h, size);
+    alpaka::memcpy(queue, in2_d, in2_h, size);
+
+    // fill the output buffer with zeros
+    alpaka::memset(queue, out_d, 0);
+
+    // launch the 1-dimensional kernel for vector addition
+    test::wrapper_add_vectors_d(queue, in1_d.data(), in2_d.data(), out_d.data(), size);
+
+    // copy the results from the device to the host
+    alpaka::memcpy(queue, out_h, out_d);
+
+    // wait for all the operations to complete
+    alpaka::wait(queue);
+
+    // the device buffers are freed automatically
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test

--- a/HeterogeneousTest/AlpakaOpaque/test/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaOpaque/test/BuildFile.xml
@@ -1,0 +1,10 @@
+<bin file="alpaka/testDeviceAdditionOpaque.cc" name="testAlpakaDeviceAdditionOpaque">
+  <use name="catch2"/>
+  <use name="HeterogeneousTest/AlpakaOpaque"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<test name="testAlpakaTestOpaqueAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestOpaqueAdditionModule.py"/>
+
+<test name="testAlpakaTestAdditionModules" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestAdditionModules.py"/>

--- a/HeterogeneousTest/AlpakaOpaque/test/alpaka/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/AlpakaOpaque/test/alpaka/testDeviceAdditionOpaque.cc
@@ -1,0 +1,54 @@
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousTest/AlpakaOpaque/interface/alpaka/DeviceAdditionOpaque.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+TEST_CASE("HeterogeneousTest/AlpakaOpaque test", "[alpakaTestOpaqueAdditionOpaque]") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+        "the test will be skipped.");
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr uint32_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1(size);
+  std::vector<float> in2(size);
+  std::vector<float> out(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (uint32_t i = 0; i < size; ++i) {
+    in1[i] = dist(rand);
+    in2[i] = dist(rand);
+    out[i] = 0.;
+  }
+
+  SECTION("Test add_vectors_f on " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend") {
+    // launch the 1-dimensional kernel for vector addition
+    REQUIRE_NOTHROW(test::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size));
+
+    // check the results
+    for (uint32_t i = 0; i < size; ++i) {
+      float sum = in1[i] + in2[i];
+      CHECK_THAT(out[i], Catch::Matchers::WithinAbs(sum, epsilon));
+    }
+  }
+}

--- a/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestAdditionModules.py
+++ b/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestAdditionModules.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestAlpakaTestOpaqueAdditionModule')
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.source = cms.Source('EmptySource')
+
+process.alpakaTestDeviceAdditionModule = cms.EDAnalyzer('AlpakaTestDeviceAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.alpakaTestKernelAdditionModule = cms.EDAnalyzer('AlpakaTestKernelAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.alpakaTestWrapperAdditionModule = cms.EDAnalyzer('AlpakaTestWrapperAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.alpakaTestOpaqueAdditionModule = cms.EDAnalyzer('AlpakaTestOpaqueAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(
+    process.alpakaTestDeviceAdditionModule +
+    process.alpakaTestKernelAdditionModule +
+    process.alpakaTestWrapperAdditionModule +
+    process.alpakaTestOpaqueAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestOpaqueAdditionModule.py
+++ b/HeterogeneousTest/AlpakaOpaque/test/testAlpakaTestOpaqueAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestAlpakaTestOpaqueAdditionModule')
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.source = cms.Source('EmptySource')
+
+process.alpakaTestOpaqueAdditionModule = cms.EDAnalyzer('AlpakaTestOpaqueAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.alpakaTestOpaqueAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/AlpakaWrapper/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaWrapper/BuildFile.xml
@@ -1,0 +1,7 @@
+<use name="alpaka"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousTest/AlpakaKernel"/>
+<flags ALPAKA_BACKENDS="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousTest/AlpakaWrapper/README.md
+++ b/HeterogeneousTest/AlpakaWrapper/README.md
@@ -1,0 +1,48 @@
+# Introduction
+
+The packages `HeterogeneousTest/AlpakaDevice`, `HeterogeneousTest/AlpakaKernel`,
+`HeterogeneousTest/AlpakaWrapper` and `HeterogeneousTest/AlpakaOpaque` implement a set of libraries,
+plugins and tests to exercise the build rules for Alpaka.
+In particular, these tests show what is supported and what are the limitations implementing
+Alpaka-based libraries, and using them from multiple plugins.
+
+
+# `HeterogeneousTest/AlpakaWrapper`
+
+The package `HeterogeneousTest/AlpakaWrapper` implements a library that defines and exports
+host-side wrappers that launch the kernels defined in the `HeterogeneousTest/AlpakaKernel` library:
+```c++
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void wrapper_add_vectors_f(...);
+  void wrapper_add_vectors_d(...);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
+```
+These wrappers can be used from host-only, non-Alpaka aware libraries, plugins and applications.
+They can be linked with the standard host linker.
+
+The `plugins` directory implements the `AlpakaTestWrapperAdditionModule` `EDAnalyzer` that calls the
+wrappers defined in this library. This plugin shows how the wrappers can be used directly from a
+host-only, non-Alpaka aware plugin.
+
+The `test` directory implements the `testAlpakaDeviceAdditionWrapper` test binary that calls the
+wrappers defined in this library, and shows how they can be used directly from a host-only,
+non-Alpaka aware application.
+It also contains the `testAlpakaTestWrapperAdditionModule.py` python configuration to exercise the
+`AlpakaTestWrapperAdditionModule` module.
+
+
+# Other packages
+
+For various ways in which this library and plugin can be tested, see also the other
+`HeterogeneousTest/Alpaka...` packages:
+  - [`HeterogeneousTest/AlpakaDevice/README.md`](../../HeterogeneousTest/AlpakaDevice/README.md)
+  - [`HeterogeneousTest/AlpakaKernel/README.md`](../../HeterogeneousTest/AlpakaKernel/README.md)
+  - [`HeterogeneousTest/AlpakaOpaque/README.md`](../../HeterogeneousTest/AlpakaOpaque/README.md)
+
+
+# Combining plugins
+
+`HeterogeneousTest/AlpakaOpaque/test` contains the `testAlpakaTestAdditionModules.py` python
+configuration that exercise all four plugins in a single application.

--- a/HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h
+++ b/HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h
@@ -1,0 +1,24 @@
+#ifndef HeterogeneousTest_AlpakaWrapper_interface_alpaka_DeviceAdditionWrapper_h
+#define HeterogeneousTest_AlpakaWrapper_interface_alpaka_DeviceAdditionWrapper_h
+
+#include <cstdint>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size);
+
+  void wrapper_add_vectors_d(Queue& queue,
+                             const double* __restrict__ in1,
+                             const double* __restrict__ in2,
+                             double* __restrict__ out,
+                             uint32_t size);
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
+
+#endif  // HeterogeneousTest_AlpakaWrapper_interface_alpaka_DeviceAdditionWrapper_h

--- a/HeterogeneousTest/AlpakaWrapper/plugins/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaWrapper/plugins/BuildFile.xml
@@ -1,0 +1,11 @@
+<library file="alpaka/*.cc" name="HeterogeneousTestAlpakaWrapperPlugins">
+  <use name="alpaka"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="HeterogeneousCore/AlpakaServices"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="HeterogeneousTest/AlpakaWrapper"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousTest/AlpakaWrapper/plugins/alpaka/AlpakaTestWrapperAdditionModule.cc
+++ b/HeterogeneousTest/AlpakaWrapper/plugins/alpaka/AlpakaTestWrapperAdditionModule.cc
@@ -1,0 +1,122 @@
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+#include "HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaTestWrapperAdditionModule : public edm::global::EDAnalyzer<> {
+  public:
+    explicit AlpakaTestWrapperAdditionModule(edm::ParameterSet const& config);
+    ~AlpakaTestWrapperAdditionModule() override = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& setup) const override;
+
+  private:
+    const uint32_t size_;
+  };
+
+  AlpakaTestWrapperAdditionModule::AlpakaTestWrapperAdditionModule(edm::ParameterSet const& config)
+      : size_(config.getParameter<uint32_t>("size")) {}
+
+  void AlpakaTestWrapperAdditionModule::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<uint32_t>("size", 1024 * 1024);
+
+    // ignore the alpaka = cms.untracked.PSet(...) injected by the framework
+    edm::ParameterSetDescription alpaka;
+    alpaka.setAllowAnything();
+    desc.addUntracked<edm::ParameterSetDescription>("alpaka", alpaka);
+
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+  void AlpakaTestWrapperAdditionModule::analyze(edm::StreamID,
+                                                edm::Event const& event,
+                                                edm::EventSetup const& setup) const {
+    // require a valid Alpaka backend for running
+    edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+    if (not service or not service->enabled()) {
+      std::cout << "The " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService)
+                << " is not available or disabled, the test will be skipped.\n";
+      return;
+    }
+
+    // random number generator with a gaussian distribution
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0., 1.};
+
+    // tolerance
+    constexpr float epsilon = 0.000001;
+
+    // allocate input and output host buffers
+    std::vector<float> in1_h(size_);
+    std::vector<float> in2_h(size_);
+    std::vector<float> out_h(size_);
+
+    // fill the input buffers with random data, and the output buffer with zeros
+    for (uint32_t i = 0; i < size_; ++i) {
+      in1_h[i] = dist(rand);
+      in2_h[i] = dist(rand);
+      out_h[i] = 0.;
+    }
+
+    // run the test on all available devices
+    for (auto const& device : cms::alpakatools::devices<Platform>()) {
+      Queue queue{device};
+
+      // allocate input and output buffers on the device
+      auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+      auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size_);
+
+      // copy the input data to the device
+      // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+      // The destination view and the extent are required to have compatible index types!
+      alpaka::memcpy(queue, in1_d, in1_h, size_);
+      alpaka::memcpy(queue, in2_d, in2_h, size_);
+
+      // fill the output buffer with zeros
+      alpaka::memset(queue, out_d, 0);
+
+      // launch the 1-dimensional kernel for vector addition
+      test::wrapper_add_vectors_f(queue, in1_d.data(), in2_d.data(), out_d.data(), size_);
+
+      // copy the results from the device to the host
+      alpaka::memcpy(queue, out_h, out_d);
+
+      // wait for all the operations to complete
+      alpaka::wait(queue);
+
+      // check the results
+      for (uint32_t i = 0; i < size_; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        assert(out_h[i] < sum + epsilon);
+        assert(out_h[i] > sum - epsilon);
+      }
+    }
+
+    std::cout << "All tests passed.\n";
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(AlpakaTestWrapperAdditionModule);

--- a/HeterogeneousTest/AlpakaWrapper/src/alpaka/DeviceAdditionWrapper.dev.cc
+++ b/HeterogeneousTest/AlpakaWrapper/src/alpaka/DeviceAdditionWrapper.dev.cc
@@ -1,0 +1,30 @@
+#include <cstdint>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h"
+#include "HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
+
+  void wrapper_add_vectors_f(Queue& queue,
+                             const float* __restrict__ in1,
+                             const float* __restrict__ in2,
+                             float* __restrict__ out,
+                             uint32_t size) {
+    alpaka::exec<Acc1D>(
+        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsF{}, in1, in2, out, size);
+  }
+
+  void wrapper_add_vectors_d(Queue& queue,
+                             const double* __restrict__ in1,
+                             const double* __restrict__ in2,
+                             double* __restrict__ out,
+                             uint32_t size) {
+    alpaka::exec<Acc1D>(
+        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsD{}, in1, in2, out, size);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test

--- a/HeterogeneousTest/AlpakaWrapper/test/BuildFile.xml
+++ b/HeterogeneousTest/AlpakaWrapper/test/BuildFile.xml
@@ -1,0 +1,9 @@
+<bin file="alpaka/testDeviceAdditionWrapper.cc" name="testAlpakaDeviceAdditionWrapper">
+  <use name="catch2"/>
+  <use name="alpaka"/>
+  <use name="HeterogeneousTest/AlpakaWrapper"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
+<test name="testAlpakaTestWrapperAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/AlpakaWrapper/test/testAlpakaTestWrapperAdditionModule.py"/>

--- a/HeterogeneousTest/AlpakaWrapper/test/alpaka/testDeviceAdditionWrapper.cc
+++ b/HeterogeneousTest/AlpakaWrapper/test/alpaka/testDeviceAdditionWrapper.cc
@@ -1,0 +1,85 @@
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/devices.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+#include "HeterogeneousTest/AlpakaWrapper/interface/alpaka/DeviceAdditionWrapper.h"
+
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+TEST_CASE("HeterogeneousTest/AlpakaWrapper test", "[alpakaTestDeviceAdditionWrapper]") {
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+        "the test will be skipped.");
+  }
+
+  // random number generator with a gaussian distribution
+  std::random_device rd{};
+  std::default_random_engine rand{rd()};
+  std::normal_distribution<float> dist{0., 1.};
+
+  // tolerance
+  constexpr float epsilon = 0.000001;
+
+  // buffer size
+  constexpr uint32_t size = 1024 * 1024;
+
+  // allocate input and output host buffers
+  std::vector<float> in1_h(size);
+  std::vector<float> in2_h(size);
+  std::vector<float> out_h(size);
+
+  // fill the input buffers with random data, and the output buffer with zeros
+  for (uint32_t i = 0; i < size; ++i) {
+    in1_h[i] = dist(rand);
+    in2_h[i] = dist(rand);
+    out_h[i] = 0.;
+  }
+
+  // run the test on all available devices
+  for (auto const& device : cms::alpakatools::devices<Platform>()) {
+    SECTION("Test add_vectors_f on " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend") {
+      REQUIRE_NOTHROW([&]() {
+        Queue queue{device};
+
+        // allocate input and output buffers on the device
+        auto in1_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto in2_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+        auto out_d = cms::alpakatools::make_device_buffer<float[]>(queue, size);
+
+        // copy the input data to the device
+        // FIXME: pass the explicit size of type uint32_t to avoid compilation error
+        // The destination view and the extent are required to have compatible index types!
+        alpaka::memcpy(queue, in1_d, in1_h, size);
+        alpaka::memcpy(queue, in2_d, in2_h, size);
+
+        // fill the output buffer with zeros
+        alpaka::memset(queue, out_d, 0);
+
+        // launch the 1-dimensional kernel for vector addition
+        test::wrapper_add_vectors_f(queue, in1_d.data(), in2_d.data(), out_d.data(), size);
+
+        // copy the results from the device to the host
+        alpaka::memcpy(queue, out_h, out_d, size);
+
+        // wait for all the operations to complete
+        alpaka::wait(queue);
+      }());
+
+      // check the results
+      for (uint32_t i = 0; i < size; ++i) {
+        float sum = in1_h[i] + in2_h[i];
+        CHECK_THAT(out_h[i], Catch::Matchers::WithinAbs(sum, epsilon));
+      }
+    }
+  }
+}

--- a/HeterogeneousTest/AlpakaWrapper/test/testAlpakaTestWrapperAdditionModule.py
+++ b/HeterogeneousTest/AlpakaWrapper/test/testAlpakaTestWrapperAdditionModule.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('TestAlpakaTestWrapperAdditionModule')
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.load('HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi')
+
+process.source = cms.Source('EmptySource')
+
+process.alpakaTestWrapperAdditionModule = cms.EDAnalyzer('AlpakaTestWrapperAdditionModule@alpaka',
+    size = cms.uint32( 1024*1024 )
+)
+
+process.path = cms.Path(process.alpakaTestWrapperAdditionModule)
+
+process.maxEvents.input = 1

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.cu
@@ -7,7 +7,7 @@
 
 #include "CUDATestDeviceAdditionAlgo.h"
 
-namespace HeterogeneousCoreCUDATestDevicePlugins {
+namespace HeterogeneousTestCUDADevicePlugins {
 
   __global__ void kernel_add_vectors_f(const float* __restrict__ in1,
                                        const float* __restrict__ in2,
@@ -24,4 +24,4 @@ namespace HeterogeneousCoreCUDATestDevicePlugins {
     cudaCheck(cudaGetLastError());
   }
 
-}  // namespace HeterogeneousCoreCUDATestDevicePlugins
+}  // namespace HeterogeneousTestCUDADevicePlugins

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.h
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionAlgo.h
@@ -3,13 +3,13 @@
 
 #include <cstddef>
 
-namespace HeterogeneousCoreCUDATestDevicePlugins {
+namespace HeterogeneousTestCUDADevicePlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
                              float* __restrict__ out,
                              size_t size);
 
-}  // namespace HeterogeneousCoreCUDATestDevicePlugins
+}  // namespace HeterogeneousTestCUDADevicePlugins
 
 #endif  // HeterogeneousTest_CUDADevice_plugins_CUDATestDeviceAdditionAlgo_h

--- a/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/CUDADevice/plugins/CUDATestDeviceAdditionModule.cc
@@ -84,7 +84,7 @@ void CUDATestDeviceAdditionModule::analyze(edm::StreamID, edm::Event const& even
   cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
-  HeterogeneousCoreCUDATestDevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+  HeterogeneousTestCUDADevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
   cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));

--- a/HeterogeneousTest/CUDAKernel/README.md
+++ b/HeterogeneousTest/CUDAKernel/README.md
@@ -25,8 +25,8 @@ CUDA kernels defined in this library. As a byproduct this plugin also shows how 
 `EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a device part (in
 a `.cu` file).
 
-The `test` directory implements the `testCudaKernelAddition` test binary that launches the CUDA kernel
-defined in this library.
+The `test` directory implements the `testCudaKernelAddition` test binary that launches the CUDA
+kernel defined in this library.
 It also contains the `testCUDATestKernelAdditionModule.py` python configuration to exercise the
 `CUDATestKernelAdditionModule` module.
 

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.cu
@@ -7,7 +7,7 @@
 
 #include "CUDATestKernelAdditionAlgo.h"
 
-namespace HeterogeneousCoreCUDATestKernelPlugins {
+namespace HeterogeneousTestCUDAKernelPlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
@@ -17,4 +17,4 @@ namespace HeterogeneousCoreCUDATestKernelPlugins {
     cudaCheck(cudaGetLastError());
   }
 
-}  // namespace HeterogeneousCoreCUDATestKernelPlugins
+}  // namespace HeterogeneousTestCUDAKernelPlugins

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.h
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionAlgo.h
@@ -3,13 +3,13 @@
 
 #include <cstddef>
 
-namespace HeterogeneousCoreCUDATestKernelPlugins {
+namespace HeterogeneousTestCUDAKernelPlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
                              float* __restrict__ out,
                              size_t size);
 
-}  // namespace HeterogeneousCoreCUDATestKernelPlugins
+}  // namespace HeterogeneousTestCUDAKernelPlugins
 
 #endif  // HeterogeneousTest_CUDAKernel_plugins_CUDATestKernelAdditionAlgo_h

--- a/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
+++ b/HeterogeneousTest/CUDAKernel/plugins/CUDATestKernelAdditionModule.cc
@@ -84,7 +84,7 @@ void CUDATestKernelAdditionModule::analyze(edm::StreamID, edm::Event const& even
   cudaCheck(cudaMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
-  HeterogeneousCoreCUDATestKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+  HeterogeneousTestCUDAKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
   cudaCheck(cudaMemcpy(out_h.data(), out_d, size_ * sizeof(float), cudaMemcpyDeviceToHost));

--- a/HeterogeneousTest/ROCmDevice/README.md
+++ b/HeterogeneousTest/ROCmDevice/README.md
@@ -12,20 +12,20 @@ ROCm-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/ROCmDevice` implements a library that defines and exports ROCm
 device-side functions:
 ```c++
-namespace cms::cudatest {
+namespace cms::rocmtest {
 
   __device__ void add_vectors_f(...);
   __device__ void add_vectors_d(...);
 
-}  // namespace cms::cudatest
+}  // namespace cms::rocmtest
 ```
 
 The `plugins` directory implements the `ROCmTestDeviceAdditionModule` `EDAnalyzer` that launches a
 ROCm kernel using the functions defined in ths library. As a byproduct this plugin also shows how
 to split an `EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a
-device part (in a `.cu` file).
+device part (in a `.hip.cc` file).
 
-The `test` directory implements the `testCudaDeviceAddition` binary that launches a ROCm kernel
+The `test` directory implements the `testRocmDeviceAddition` binary that launches a ROCm kernel
 using these functions.
 It also contains the `testROCmTestDeviceAdditionModule.py` python configuration to exercise the
 `ROCmTestDeviceAdditionModule` plugin.

--- a/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.h
+++ b/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.h
@@ -3,13 +3,13 @@
 
 #include <cstddef>
 
-namespace HeterogeneousCoreROCmTestDevicePlugins {
+namespace HeterogeneousTestROCmDevicePlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
                              float* __restrict__ out,
                              size_t size);
 
-}  // namespace HeterogeneousCoreROCmTestDevicePlugins
+}  // namespace HeterogeneousTestROCmDevicePlugins
 
 #endif  // HeterogeneousTest_ROCmDevice_plugins_ROCmTestDeviceAdditionAlgo_h

--- a/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.hip.cc
+++ b/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionAlgo.hip.cc
@@ -7,7 +7,7 @@
 
 #include "ROCmTestDeviceAdditionAlgo.h"
 
-namespace HeterogeneousCoreROCmTestDevicePlugins {
+namespace HeterogeneousTestROCmDevicePlugins {
 
   __global__ void kernel_add_vectors_f(const float* __restrict__ in1,
                                        const float* __restrict__ in2,
@@ -24,4 +24,4 @@ namespace HeterogeneousCoreROCmTestDevicePlugins {
     hipCheck(hipGetLastError());
   }
 
-}  // namespace HeterogeneousCoreROCmTestDevicePlugins
+}  // namespace HeterogeneousTestROCmDevicePlugins

--- a/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionModule.cc
+++ b/HeterogeneousTest/ROCmDevice/plugins/ROCmTestDeviceAdditionModule.cc
@@ -84,7 +84,7 @@ void ROCmTestDeviceAdditionModule::analyze(edm::StreamID, edm::Event const& even
   hipCheck(hipMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
-  HeterogeneousCoreROCmTestDevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+  HeterogeneousTestROCmDevicePlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
   hipCheck(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));

--- a/HeterogeneousTest/ROCmKernel/README.md
+++ b/HeterogeneousTest/ROCmKernel/README.md
@@ -12,21 +12,21 @@ ROCm-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/ROCmKernel` implements a library that defines and exports ROCm
 kernels that call the device functions defined in the `HeterogeneousTest/ROCmDevice` library:
 ```c++
-namespace cms::cudatest {
+namespace cms::rocmtest {
 
   __global__ void kernel_add_vectors_f(...);
   __global__ void kernel_add_vectors_d(...);
 
-}  // namespace cms::cudatest
+}  // namespace cms::rocmtest
 ```
 
 The `plugins` directory implements the `ROCmTestKernelAdditionModule` `EDAnalyzer` that launches the
 ROCm kernels defined in this library. As a byproduct this plugin also shows how to split an
 `EDAnalyzer` or other framework plugin into a host-only part (in a `.cc` file) and a device part (in
-a `.cu` file).
+a `.hip.cc` file).
 
-The `test` directory implements the `testCudaKernelAddition` test binary that launches the ROCm kernel
-defined in this library.
+The `test` directory implements the `testRocmKernelAddition` test binary that launches the ROCm
+kernel defined in this library.
 It also contains the `testROCmTestKernelAdditionModule.py` python configuration to exercise the
 `ROCmTestKernelAdditionModule` module.
 

--- a/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.h
+++ b/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.h
@@ -3,13 +3,13 @@
 
 #include <cstddef>
 
-namespace HeterogeneousCoreROCmTestKernelPlugins {
+namespace HeterogeneousTestROCmKernelPlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
                              float* __restrict__ out,
                              size_t size);
 
-}  // namespace HeterogeneousCoreROCmTestKernelPlugins
+}  // namespace HeterogeneousTestROCmKernelPlugins
 
 #endif  // HeterogeneousTest_ROCmKernel_plugins_ROCmTestKernelAdditionAlgo_h

--- a/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.hip.cc
+++ b/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionAlgo.hip.cc
@@ -7,7 +7,7 @@
 
 #include "ROCmTestKernelAdditionAlgo.h"
 
-namespace HeterogeneousCoreROCmTestKernelPlugins {
+namespace HeterogeneousTestROCmKernelPlugins {
 
   void wrapper_add_vectors_f(const float* __restrict__ in1,
                              const float* __restrict__ in2,
@@ -17,4 +17,4 @@ namespace HeterogeneousCoreROCmTestKernelPlugins {
     hipCheck(hipGetLastError());
   }
 
-}  // namespace HeterogeneousCoreROCmTestKernelPlugins
+}  // namespace HeterogeneousTestROCmKernelPlugins

--- a/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionModule.cc
+++ b/HeterogeneousTest/ROCmKernel/plugins/ROCmTestKernelAdditionModule.cc
@@ -84,7 +84,7 @@ void ROCmTestKernelAdditionModule::analyze(edm::StreamID, edm::Event const& even
   hipCheck(hipMemset(out_d, 0, size_ * sizeof(float)));
 
   // launch the 1-dimensional kernel for vector addition
-  HeterogeneousCoreROCmTestKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
+  HeterogeneousTestROCmKernelPlugins::wrapper_add_vectors_f(in1_d, in2_d, out_d, size_);
 
   // copy the results from the device to the host
   hipCheck(hipMemcpy(out_h.data(), out_d, size_ * sizeof(float), hipMemcpyDeviceToHost));

--- a/HeterogeneousTest/ROCmOpaque/README.md
+++ b/HeterogeneousTest/ROCmOpaque/README.md
@@ -12,19 +12,19 @@ ROCm-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/ROCmOpaque` implements a non-ROCm aware library, with functions that
 call the wrappers defined in the `HeterogeneousTest/ROCmWrapper` library:
 ```c++
-namespace cms::cudatest {
+namespace cms::rocmtest {
 
   void opaque_add_vectors_f(...);
   void opaque_add_vectors_d(...);
 
-}  // namespace cms::cudatest
+}  // namespace cms::rocmtest
 ```
 
 The `plugins` directory implements the `ROCmTestOpqaueAdditionModule` `EDAnalyzer` that calls the 
 function defined in this library. This plugin shows how the function can be used directly from a 
 host-only, non-ROCm aware plugin.
 
-The `test` directory implements the `testCudaDeviceAdditionOpqaue` test binary that calls the
+The `test` directory implements the `testRocmDeviceAdditionOpqaue` test binary that calls the
 function defined in this library, and shows how they can be used directly from a host-only, non-ROCm
 aware application.
 It also contains the `testROCmTestOpqaueAdditionModule.py` python configuration to exercise the

--- a/HeterogeneousTest/ROCmOpaque/interface/DeviceAdditionOpaque.h
+++ b/HeterogeneousTest/ROCmOpaque/interface/DeviceAdditionOpaque.h
@@ -5,9 +5,9 @@
 
 namespace cms::rocmtest {
 
-  void opqaue_add_vectors_f(const float* in1, const float* in2, float* out, size_t size);
+  void opaque_add_vectors_f(const float* in1, const float* in2, float* out, size_t size);
 
-  void opqaue_add_vectors_d(const double* in1, const double* in2, double* out, size_t size);
+  void opaque_add_vectors_d(const double* in1, const double* in2, double* out, size_t size);
 
 }  // namespace cms::rocmtest
 

--- a/HeterogeneousTest/ROCmOpaque/plugins/ROCmTestOpaqueAdditionModule.cc
+++ b/HeterogeneousTest/ROCmOpaque/plugins/ROCmTestOpaqueAdditionModule.cc
@@ -65,7 +65,7 @@ void ROCmTestOpaqueAdditionModule::analyze(edm::StreamID, edm::Event const& even
   }
 
   // launch the 1-dimensional kernel for vector addition
-  cms::rocmtest::opqaue_add_vectors_f(in1.data(), in2.data(), out.data(), size_);
+  cms::rocmtest::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size_);
 
   // check the results
   for (size_t i = 0; i < size_; ++i) {

--- a/HeterogeneousTest/ROCmOpaque/src/DeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/ROCmOpaque/src/DeviceAdditionOpaque.cc
@@ -8,7 +8,7 @@
 
 namespace cms::rocmtest {
 
-  void opqaue_add_vectors_f(const float* in1_h, const float* in2_h, float* out_h, size_t size) {
+  void opaque_add_vectors_f(const float* in1_h, const float* in2_h, float* out_h, size_t size) {
     // allocate input and output buffers on the device
     float* in1_d;
     float* in2_d;
@@ -39,7 +39,7 @@ namespace cms::rocmtest {
     hipCheck(hipFree(out_d));
   }
 
-  void opqaue_add_vectors_d(const double* in1_h, const double* in2_h, double* out_h, size_t size) {
+  void opaque_add_vectors_d(const double* in1_h, const double* in2_h, double* out_h, size_t size) {
     // allocate input and output buffers on the device
     double* in1_d;
     double* in2_d;

--- a/HeterogeneousTest/ROCmOpaque/test/BuildFile.xml
+++ b/HeterogeneousTest/ROCmOpaque/test/BuildFile.xml
@@ -7,5 +7,5 @@
 
   <test name="testROCmTestOpaqueAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/ROCmOpaque/test/testROCmTestOpaqueAdditionModule.py"/>
 
-  <test name="testROCmTestOpaqueAdditionModule" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/ROCmOpaque/test/testROCmTestAdditionModules.py"/>
+  <test name="testROCmTestAdditionModules" command="cmsRun ${LOCALTOP}/src/HeterogeneousTest/ROCmOpaque/test/testROCmTestAdditionModules.py"/>
 </iftool>

--- a/HeterogeneousTest/ROCmOpaque/test/testDeviceAdditionOpaque.cc
+++ b/HeterogeneousTest/ROCmOpaque/test/testDeviceAdditionOpaque.cc
@@ -37,7 +37,7 @@ TEST_CASE("HeterogeneousTest/ROCmOpaque test", "[rocmTestOpaqueAdditionOpaque]")
 
   SECTION("Test add_vectors_f") {
     // launch the 1-dimensional kernel for vector addition
-    REQUIRE_NOTHROW(cms::rocmtest::opqaue_add_vectors_f(in1.data(), in2.data(), out.data(), size));
+    REQUIRE_NOTHROW(cms::rocmtest::opaque_add_vectors_f(in1.data(), in2.data(), out.data(), size));
 
     // check the results
     for (size_t i = 0; i < size; ++i) {

--- a/HeterogeneousTest/ROCmWrapper/README.md
+++ b/HeterogeneousTest/ROCmWrapper/README.md
@@ -12,12 +12,12 @@ ROCm-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/ROCmWrapper` implements a library that defines and exports host-side
 wrappers that launch the kernels defined in the `HeterogeneousTest/ROCmKernel` library:
 ```c++
-namespace cms::cudatest {
+namespace cms::rocmtest {
 
   void wrapper_add_vectors_f(...);
   void wrapper_add_vectors_d(...);
 
-}  // namespace cms::cudatest
+}  // namespace cms::rocmtest
 ```
 These wrappers can be used from host-only, non-ROCm aware libraries, plugins and applications. They
 can be linked with the standard host linker.
@@ -26,7 +26,7 @@ The `plugins` directory implements the `ROCmTestWrapperAdditionModule` `EDAnalyz
 wrappers defined in this library. This plugin shows how the wrappers can be used directly from a
 host-only, non-ROCm aware plugin.
 
-The `test` directory implements the `testCudaDeviceAdditionWrapper` test binary that calls the
+The `test` directory implements the `testRocmDeviceAdditionWrapper` test binary that calls the
 wrappers defined in this library, and shows how they can be used directly from a host-only, non-ROCm
 aware application.
 It also contains the `testROCmTestWrapperAdditionModule.py` python configuration to exercise the


### PR DESCRIPTION
#### PR description:

The package `HeterogeneousTest/AlpakaDevice` implements a header only library that defines Alpaka device-only functions, and a plugin and test that use them.

The package `HeterogeneousTest/AlpakaKernel` implements a header only library that imports device functions from `HeterogeneousTest/AlpakaDevice` to define Alpaka kernels, and a plugin and test that use them.

The package `HeterogeneousTest/AlpakaWrapper` implements a library that imports kernels from HeterogeneousTest/AlpakaKernel to define and export host-only wrappers around them, usable by non-Alpaka libraries, plugins and applications, and implements a plugin and test that use them.

The package `HeterogeneousTest/AlpakaOpaque` implements a library that imports kernels from `HeterogeneousTest/AlpakaKernel` to define and export host-only wrappers around the whole Alpaka section, usable by libraries, plugins and applications that are not explicitly Alpaka-aware, and implements a plugin and test that use them.

In addition, fix the CUDA and ROCm documentation, and various typos in the ROCm tests.

#### PR validation:

The new unit tests build and pass (on a machine with NVIDIA GPUs):
```
Skip    0s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionROCmAsync (Failed to run rocmIsEnabled)
Skip    0s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelROCmAsync (Failed to run rocmIsEnabled)
Skip    0s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperROCmAsync (Failed to run rocmIsEnabled)
Skip    0s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueROCmAsync (Failed to run rocmIsEnabled)
Pass    0s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionSerialSync
Pass    0s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelSerialSync
Pass    0s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperSerialSync
Pass    0s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueSerialSync
Pass    5s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionCudaAsync
Pass    5s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueCudaAsync
Pass    5s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperCudaAsync
Pass    6s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelCudaAsync
Pass   10s ... HeterogeneousTest/AlpakaDevice/testAlpakaTestDeviceAdditionModule
Pass   10s ... HeterogeneousTest/AlpakaKernel/testAlpakaTestKernelAdditionModule
Pass   10s ... HeterogeneousTest/AlpakaWrapper/testAlpakaTestWrapperAdditionModule
Pass   11s ... HeterogeneousTest/AlpakaOpaque/testAlpakaTestOpaqueAdditionModule
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

These packages are only used as unit tests, so a backport is not essential.
However, since we do use Alpaka-based packages for data taking in CMSSW 14.0.x, it could be a good idea to backport these unit tests as well.