### PR TITLE
Improve behavior after exception in begin/end stream lumi

### DIFF
--- a/FWCore/Framework/interface/WorkerInPath.h
+++ b/FWCore/Framework/interface/WorkerInPath.h
@@ -16,6 +16,8 @@
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 
+#include <utility>
+
 namespace edm {
 
   class PathContext;
@@ -116,7 +118,7 @@ namespace edm {
 
     if constexpr (T::isEvent_) {
       ParentContext parentContext(&placeInPathContext_);
-      worker_->doWorkAsync<T>(iTask, info, token, streamID, parentContext, context);
+      worker_->doWorkAsync<T>(std::move(iTask), info, token, streamID, parentContext, context);
     } else {
       ParentContext parentContext(context);
 
@@ -125,7 +127,7 @@ namespace edm {
       // into the runs or lumis in stream transitions, so there can be
       // no data dependencies which require prefetching. Prefetching is
       // needed for global transitions, but they are run elsewhere.
-      worker_->doWorkNoPrefetchingAsync<T>(iTask, info, token, streamID, parentContext, context);
+      worker_->doWorkNoPrefetchingAsync<T>(std::move(iTask), info, token, streamID, parentContext, context);
     }
   }
 }  // namespace edm

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1773,9 +1773,6 @@ namespace edm {
                                   streamQueues_[i].pause();
 
                                   auto& event = principalCache_.eventPrincipal(i);
-                                  //We need to be sure that 'status' and its internal shared_ptr<LuminosityBlockPrincipal> are only
-                                  // held by the container as this lambda may not finish executing before all the tasks it
-                                  // spawns have already started to run.
                                   auto eventSetupImpls = &status->eventSetupImpls();
                                   auto lp = status->lumiPrincipal().get();
                                   streamLumiStatus_[i] = std::move(status);

--- a/FWCore/Integration/plugins/BuildFile.xml
+++ b/FWCore/Integration/plugins/BuildFile.xml
@@ -22,10 +22,11 @@
       <use name="DataFormats/TestObjects"/>
 </library>
 
-  <library file="AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc, TableTestModules.cc, TestGlobalOutput.cc, TestLimitedOutput.cc, TestOneOutput.cc, PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc,ExceptionThrowingProducer.cc,ProdigalAnalyzer.cc,IntSource.cc,ViewAnalyzer.cc,TestFindProduct.cc,ManyProductProducer.cc,TestParentage.cc,HierarchicalEDProducer.cc,ThrowingSource.cc, DelayedReaderThrowingSource.cc,TestHistoryKeeping.cc,PathAnalyzer.cc,SourceWithWaits.cc" name="FWCoreIntegrationSomeTestModules">
+  <library file="AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc, TableTestModules.cc, TestGlobalOutput.cc, TestLimitedOutput.cc, TestOneOutput.cc, PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc,ExceptionThrowingProducer.cc,TestServiceOne.cc,TestServiceTwo.cc,ProdigalAnalyzer.cc,IntSource.cc,ViewAnalyzer.cc,TestFindProduct.cc,ManyProductProducer.cc,TestParentage.cc,HierarchicalEDProducer.cc,ThrowingSource.cc, DelayedReaderThrowingSource.cc,TestHistoryKeeping.cc,PathAnalyzer.cc,SourceWithWaits.cc" name="FWCoreIntegrationSomeTestModules">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/Framework"/>
     <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
     <use name="FWCore/Sources"/>
     <use name="DataFormats/Provenance"/>
     <use name="FWCore/MessageLogger"/>

--- a/FWCore/Integration/plugins/TestServiceOne.cc
+++ b/FWCore/Integration/plugins/TestServiceOne.cc
@@ -1,0 +1,155 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     TestServiceOne
+//
+// Implementation:
+//     Service initially intended for testing behavior after exceptions.
+//     ExceptionThrowingProducer uses this and is in the same test plugin
+//     library and could be used to access the service if it was ever useful
+//     for debugging issues related to begin/end transitions.
+//
+// Original Author:  W. David Dagenhart
+//         Created:  13 March 2024
+
+#include "FWCore/Integration/plugins/TestServiceOne.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+namespace edmtest {
+
+  TestServiceOne::TestServiceOne(edm::ParameterSet const& iPS, edm::ActivityRegistry& iRegistry)
+      : verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
+    iRegistry.watchPreBeginProcessBlock(this, &TestServiceOne::preBeginProcessBlock);
+    iRegistry.watchPreEndProcessBlock(this, &TestServiceOne::preEndProcessBlock);
+
+    iRegistry.watchPreGlobalBeginRun(this, &TestServiceOne::preGlobalBeginRun);
+    iRegistry.watchPreGlobalEndRun(this, &TestServiceOne::preGlobalEndRun);
+    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceOne::preGlobalBeginLumi);
+    iRegistry.watchPreGlobalEndLumi(this, &TestServiceOne::preGlobalEndLumi);
+
+    iRegistry.watchPreStreamBeginLumi(this, &TestServiceOne::preStreamBeginLumi);
+    iRegistry.watchPostStreamBeginLumi(this, &TestServiceOne::postStreamBeginLumi);
+    iRegistry.watchPreStreamEndLumi(this, &TestServiceOne::preStreamEndLumi);
+    iRegistry.watchPostStreamEndLumi(this, &TestServiceOne::postStreamEndLumi);
+
+    iRegistry.watchPreModuleStreamBeginLumi(this, &TestServiceOne::preModuleStreamBeginLumi);
+    iRegistry.watchPostModuleStreamBeginLumi(this, &TestServiceOne::postModuleStreamBeginLumi);
+    iRegistry.watchPreModuleStreamEndLumi(this, &TestServiceOne::preModuleStreamEndLumi);
+    iRegistry.watchPostModuleStreamEndLumi(this, &TestServiceOne::postModuleStreamEndLumi);
+  }
+
+  void TestServiceOne::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages if true");
+    descriptions.add("TestServiceOne", desc);
+  }
+
+  void TestServiceOne::preBeginProcessBlock(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preBeginProcessBlock";
+    }
+  }
+
+  void TestServiceOne::preEndProcessBlock(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preEndProcessBlock";
+    }
+  }
+
+  void TestServiceOne::preGlobalBeginRun(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalBeginRun";
+    }
+  }
+
+  void TestServiceOne::preGlobalEndRun(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalEndRun";
+    }
+  }
+
+  void TestServiceOne::preGlobalBeginLumi(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalBeginLumi";
+    }
+  }
+
+  void TestServiceOne::preGlobalEndLumi(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalEndLumi";
+    }
+  }
+
+  void TestServiceOne::preStreamBeginLumi(edm::StreamContext const&) {
+    ++nPreStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preStreamBeginLumi";
+    }
+  }
+
+  void TestServiceOne::postStreamBeginLumi(edm::StreamContext const&) {
+    ++nPostStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postStreamBeginLumi";
+    }
+  }
+
+  void TestServiceOne::preStreamEndLumi(edm::StreamContext const&) {
+    ++nPreStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preStreamEndLumi";
+    }
+  }
+
+  void TestServiceOne::postStreamEndLumi(edm::StreamContext const&) {
+    ++nPostStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postStreamEndLumi";
+    }
+  }
+
+  void TestServiceOne::preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPreModuleStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preModuleStreamBeginLumi";
+    }
+  }
+
+  void TestServiceOne::postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPostModuleStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postModuleStreamBeginLumi";
+    }
+  }
+
+  void TestServiceOne::preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPreModuleStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preModuleStreamEndLumi";
+    }
+  }
+
+  void TestServiceOne::postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPostModuleStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postModuleStreamEndLumi";
+    }
+  }
+
+  unsigned int TestServiceOne::nPreStreamBeginLumi() const { return nPreStreamBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPostStreamBeginLumi() const { return nPostStreamBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPreStreamEndLumi() const { return nPreStreamEndLumi_.load(); }
+  unsigned int TestServiceOne::nPostStreamEndLumi() const { return nPostStreamEndLumi_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleStreamBeginLumi() const { return nPreModuleStreamBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPostModuleStreamBeginLumi() const { return nPostModuleStreamBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPreModuleStreamEndLumi() const { return nPreModuleStreamEndLumi_.load(); }
+  unsigned int TestServiceOne::nPostModuleStreamEndLumi() const { return nPostModuleStreamEndLumi_.load(); }
+}  // namespace edmtest
+
+using edmtest::TestServiceOne;
+DEFINE_FWK_SERVICE(TestServiceOne);

--- a/FWCore/Integration/plugins/TestServiceOne.h
+++ b/FWCore/Integration/plugins/TestServiceOne.h
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+#ifndef FWCore_Integration_TestServiceOne_h
+#define FWCore_Integration_TestServiceOne_h
+//
+// Package:     FWCore/Integration
+// Class  :     TestServiceOne
+//
+// Implementation:
+//     Service initially intended for testing behavior after exceptions.
+//     ExceptionThrowingProducer uses this and is in the same test plugin
+//     library and could be used to access the service if it was ever useful
+//     for debugging issues related to begin/end transitions.
+//
+// Original Author:  W. David Dagenhart
+//         Created:  13 March 2024
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
+
+#include <atomic>
+
+namespace edmtest {
+
+  class TestServiceOne {
+  public:
+    TestServiceOne(const edm::ParameterSet&, edm::ActivityRegistry&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    void preBeginProcessBlock(edm::GlobalContext const&);
+    void preEndProcessBlock(edm::GlobalContext const&);
+
+    void preGlobalBeginRun(edm::GlobalContext const&);
+    void preGlobalEndRun(edm::GlobalContext const&);
+    void preGlobalBeginLumi(edm::GlobalContext const&);
+    void preGlobalEndLumi(edm::GlobalContext const&);
+
+    void preStreamBeginLumi(edm::StreamContext const&);
+    void postStreamBeginLumi(edm::StreamContext const&);
+    void preStreamEndLumi(edm::StreamContext const&);
+    void postStreamEndLumi(edm::StreamContext const&);
+
+    void preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
+    unsigned int nPreStreamBeginLumi() const;
+    unsigned int nPostStreamBeginLumi() const;
+    unsigned int nPreStreamEndLumi() const;
+    unsigned int nPostStreamEndLumi() const;
+
+    unsigned int nPreModuleStreamBeginLumi() const;
+    unsigned int nPostModuleStreamBeginLumi() const;
+    unsigned int nPreModuleStreamEndLumi() const;
+    unsigned int nPostModuleStreamEndLumi() const;
+
+  private:
+    bool verbose_;
+
+    std::atomic<unsigned int> nPreStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreStreamEndLumi_ = 0;
+    std::atomic<unsigned int> nPostStreamEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreModuleStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreModuleStreamEndLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamEndLumi_ = 0;
+  };
+}  // namespace edmtest
+#endif

--- a/FWCore/Integration/plugins/TestServiceTwo.cc
+++ b/FWCore/Integration/plugins/TestServiceTwo.cc
@@ -1,0 +1,155 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Integration
+// Class  :     TestServiceTwo
+//
+// Implementation:
+//     Service initially intended for testing behavior after exceptions.
+//     ExceptionThrowingProducer uses this and is in the same test plugin
+//     library and could be used to access the service if it was ever useful
+//     for debugging issues related to begin/end transitions.
+//
+// Original Author:  W. David Dagenhart
+//         Created:  13 March 2024
+
+#include "FWCore/Integration/plugins/TestServiceTwo.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+namespace edmtest {
+
+  TestServiceTwo::TestServiceTwo(edm::ParameterSet const& iPS, edm::ActivityRegistry& iRegistry)
+      : verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
+    iRegistry.watchPreBeginProcessBlock(this, &TestServiceTwo::preBeginProcessBlock);
+    iRegistry.watchPreEndProcessBlock(this, &TestServiceTwo::preEndProcessBlock);
+
+    iRegistry.watchPreGlobalBeginRun(this, &TestServiceTwo::preGlobalBeginRun);
+    iRegistry.watchPreGlobalEndRun(this, &TestServiceTwo::preGlobalEndRun);
+    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceTwo::preGlobalBeginLumi);
+    iRegistry.watchPreGlobalEndLumi(this, &TestServiceTwo::preGlobalEndLumi);
+
+    iRegistry.watchPreStreamBeginLumi(this, &TestServiceTwo::preStreamBeginLumi);
+    iRegistry.watchPostStreamBeginLumi(this, &TestServiceTwo::postStreamBeginLumi);
+    iRegistry.watchPreStreamEndLumi(this, &TestServiceTwo::preStreamEndLumi);
+    iRegistry.watchPostStreamEndLumi(this, &TestServiceTwo::postStreamEndLumi);
+
+    iRegistry.watchPreModuleStreamBeginLumi(this, &TestServiceTwo::preModuleStreamBeginLumi);
+    iRegistry.watchPostModuleStreamBeginLumi(this, &TestServiceTwo::postModuleStreamBeginLumi);
+    iRegistry.watchPreModuleStreamEndLumi(this, &TestServiceTwo::preModuleStreamEndLumi);
+    iRegistry.watchPostModuleStreamEndLumi(this, &TestServiceTwo::postModuleStreamEndLumi);
+  }
+
+  void TestServiceTwo::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages if true");
+    descriptions.add("TestServiceTwo", desc);
+  }
+
+  void TestServiceTwo::preBeginProcessBlock(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preBeginProcessBlock";
+    }
+  }
+
+  void TestServiceTwo::preEndProcessBlock(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preEndProcessBlock";
+    }
+  }
+
+  void TestServiceTwo::preGlobalBeginRun(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalBeginRun";
+    }
+  }
+
+  void TestServiceTwo::preGlobalEndRun(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalEndRun";
+    }
+  }
+
+  void TestServiceTwo::preGlobalBeginLumi(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalBeginLumi";
+    }
+  }
+
+  void TestServiceTwo::preGlobalEndLumi(edm::GlobalContext const&) {
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalEndLumi";
+    }
+  }
+
+  void TestServiceTwo::preStreamBeginLumi(edm::StreamContext const&) {
+    ++nPreStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preStreamBeginLumi";
+    }
+  }
+
+  void TestServiceTwo::postStreamBeginLumi(edm::StreamContext const&) {
+    ++nPostStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postStreamBeginLumi";
+    }
+  }
+
+  void TestServiceTwo::preStreamEndLumi(edm::StreamContext const&) {
+    ++nPreStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preStreamEndLumi";
+    }
+  }
+
+  void TestServiceTwo::postStreamEndLumi(edm::StreamContext const&) {
+    ++nPostStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postStreamEndLumi";
+    }
+  }
+
+  void TestServiceTwo::preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPreModuleStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preModuleStreamBeginLumi";
+    }
+  }
+
+  void TestServiceTwo::postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPostModuleStreamBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postModuleStreamBeginLumi";
+    }
+  }
+
+  void TestServiceTwo::preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPreModuleStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preModuleStreamEndLumi";
+    }
+  }
+
+  void TestServiceTwo::postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+    ++nPostModuleStreamEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postModuleStreamEndLumi";
+    }
+  }
+
+  unsigned int TestServiceTwo::nPreStreamBeginLumi() const { return nPreStreamBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPostStreamBeginLumi() const { return nPostStreamBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPreStreamEndLumi() const { return nPreStreamEndLumi_.load(); }
+  unsigned int TestServiceTwo::nPostStreamEndLumi() const { return nPostStreamEndLumi_.load(); }
+
+  unsigned int TestServiceTwo::nPreModuleStreamBeginLumi() const { return nPreModuleStreamBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPostModuleStreamBeginLumi() const { return nPostModuleStreamBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPreModuleStreamEndLumi() const { return nPreModuleStreamEndLumi_.load(); }
+  unsigned int TestServiceTwo::nPostModuleStreamEndLumi() const { return nPostModuleStreamEndLumi_.load(); }
+}  // namespace edmtest
+
+using edmtest::TestServiceTwo;
+DEFINE_FWK_SERVICE(TestServiceTwo);

--- a/FWCore/Integration/plugins/TestServiceTwo.h
+++ b/FWCore/Integration/plugins/TestServiceTwo.h
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+#ifndef FWCore_Integration_TestServiceTwo_h
+#define FWCore_Integration_TestServiceTwo_h
+//
+// Package:     FWCore/Integration
+// Class  :     TestServiceTwo
+//
+// Implementation:
+//     Service initially intended for testing behavior after exceptions.
+//     ExceptionThrowingProducer uses this and is in the same test plugin
+//     library and could be used to access the service if it was ever useful
+//     for debugging issues related to begin/end transitions.
+//
+// Original Author:  W. David Dagenhart
+//         Created:  13 March 2024
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
+
+#include <atomic>
+
+namespace edmtest {
+
+  class TestServiceTwo {
+  public:
+    TestServiceTwo(const edm::ParameterSet&, edm::ActivityRegistry&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    void preBeginProcessBlock(edm::GlobalContext const&);
+    void preEndProcessBlock(edm::GlobalContext const&);
+
+    void preGlobalBeginRun(edm::GlobalContext const&);
+    void preGlobalEndRun(edm::GlobalContext const&);
+    void preGlobalBeginLumi(edm::GlobalContext const&);
+    void preGlobalEndLumi(edm::GlobalContext const&);
+
+    void preStreamBeginLumi(edm::StreamContext const&);
+    void postStreamBeginLumi(edm::StreamContext const&);
+    void preStreamEndLumi(edm::StreamContext const&);
+    void postStreamEndLumi(edm::StreamContext const&);
+
+    void preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
+    unsigned int nPreStreamBeginLumi() const;
+    unsigned int nPostStreamBeginLumi() const;
+    unsigned int nPreStreamEndLumi() const;
+    unsigned int nPostStreamEndLumi() const;
+
+    unsigned int nPreModuleStreamBeginLumi() const;
+    unsigned int nPostModuleStreamBeginLumi() const;
+    unsigned int nPreModuleStreamEndLumi() const;
+    unsigned int nPostModuleStreamEndLumi() const;
+
+  private:
+    bool verbose_;
+
+    std::atomic<unsigned int> nPreStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreStreamEndLumi_ = 0;
+    std::atomic<unsigned int> nPostStreamEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreModuleStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreModuleStreamEndLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamEndLumi_ = 0;
+  };
+}  // namespace edmtest
+#endif

--- a/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
+++ b/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
@@ -22,6 +22,9 @@ grep "Exception Message:" $logfile || die " - Cannot find the following string i
 
 grep "End Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: End Fatal Exception " $?
 
+grep "ExceptionThrowingProducer PASSED" $logfile || die " - FAILED because cannot find the following string in the log file: ExceptionThrowingProducer PASSED " $?
+grep "ExceptionThrowingProducer FAILED" $logfile && die " - FAILED because found the following string in the log file: ExceptionThrowingProducer FAILED " 1
+
 if [ $1 -eq 1 ]
 then
     grep "Processing  Event run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: Processing  Event run: 3 lumi: 1 event: 5 " $?

--- a/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
+++ b/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
@@ -22,6 +22,14 @@ process = cms.Process("TEST")
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 
+process.TestServiceOne = cms.Service("TestServiceOne",
+    verbose = cms.untracked.bool(False)
+)
+
+process.TestServiceTwo = cms.Service("TestServiceTwo",
+    verbose = cms.untracked.bool(False)
+)
+
 options = VarParsing()
 
 options.register("testNumber", 0,
@@ -53,7 +61,7 @@ process.options = cms.untracked.PSet(
 process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
 
 process.throwException = cms.EDProducer("ExceptionThrowingProducer")
-
+process.doNotThrowException = cms.EDProducer("ExceptionThrowingProducer")
 
 print('testNumber', options.testNumber)
 
@@ -75,10 +83,16 @@ elif options.testNumber == 6:
     process.throwException.eventIDThrowOnStreamBeginRun = cms.untracked.EventID(4, 0, 0)
 elif options.testNumber == 7:
     process.throwException.eventIDThrowOnStreamBeginLumi = cms.untracked.EventID(4, 1, 0)
+    process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(4)
+    process.throwException.expectedOffsetNoStreamEndLumi = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedStreamBeginLumi = cms.untracked.uint32(4)
+    process.doNotThrowException.expectedOffsetNoStreamEndLumi = cms.untracked.uint32(1)
 elif options.testNumber == 8:
     process.throwException.eventIDThrowOnStreamEndRun = cms.untracked.EventID(3, 0, 0)
 elif options.testNumber == 9:
     process.throwException.eventIDThrowOnStreamEndLumi = cms.untracked.EventID(3, 1, 0)
+    process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(4)
+    process.doNotThrowException.expectedStreamBeginLumi = cms.untracked.uint32(4)
 else:
     print("The parameter named testNumber is out of range. An exception will not be thrown. Supported values range from 1 to 9.")
     print("The proper syntax for setting the parameter is:")
@@ -89,3 +103,4 @@ process.path1 = cms.Path(
     process.busy1 *
     process.throwException
 )
+process.path2 = cms.Path(process.doNotThrowException)

--- a/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
@@ -2,6 +2,8 @@
 #define Framework_ServiceRegistry_fwd_h
 
 namespace edm {
+  class ActivityRegistry;
+  class GlobalContext;
   class ModuleCallingContext;
   class StreamContext;
 }  // namespace edm


### PR DESCRIPTION
#### PR description:

Improve the behavior of the Framework after stream begin/end lumi exceptions. This is the first in a series of PRs where we plan to make the behavior after exceptions more consistent in all the begin/end transitions.

The intent is that nothing in the output will change if there are not any exceptions.

This work was motivated by discussions related to Issues #43831  and #42501.

The core group has discussed this. The following is the behavior we plan to implement in all the begin/end transitions eventually. I think this is consistent with our previous discussions with some extra details added that were fleshed out as this PR was implemented:

   1. For a stream begin transition (of any type, run/lumi/processBlock/top level), the Framework will try to execute all modules (possibly concurrently) and continues executing them all even if one or more of the modules throws. The same is true for stream end transitions except if a module in a begin transition throws an exception in a pre module signal, the module itself, or a post module signal, then the corresponding end transition for that module will not execute. This is all also true for global transitions except that a module that depends on a product produced by a module that threw an exception (directly or indirectly) will not execute.

   2. For both stream and global transitions, EventSetup prefetching throwing an exception could cause a module to
not be executed.

   3. If and only if there will be an attempt to execute the module, the pre module and post module signals will execute. If the pre module signal throws, then module does not execute but the post signal executes anyway. If the module throws, then the post signal executes anyway.

   4. If there is any attempt to run a transition at all, then all 4 of the non-module signals will execute (pre and post begin,
pre and post end). Note that streams might entirely skip the transitions associated with a specific lumi (and in the future
this behavior might be extended to runs also). If a stream skips a lumi (or run), then none of the signals is executed and
the modules will not be run. This skipping might occur if another stream has process the last event or thrown an exception (although it might not skip because the notification of this has to propagate to the right location before the stream starts the lumi or run, once a stream starts it keeps going).

   5. If the pre begin signal throws, the  modules begin and end functions are not executed. If the post begin signal throws, the module begin functions may have already run (too late to stop them). It will attempt to run the end module functions for any modules that succeeded with their begin functions (and begin module signals). If the pre end signal throws, none of the module end functions is executed.

   6. If an exception occurs, notification of that is propagated and when it gets to the WaitingTaskHolder created in the
processRuns function, then new runs and lumis and new events will not be started. Before that propagation is complete,
streams other than the one experiencing the exception might or might not start subsequent runs, subsequent lumis, or subsequent events (they could get ahead because the other streams are already ahead when the exception is thrown or just because of the time for the flag to propagate, in general this is not predictable or reproducible). Also note that if an exception occurs during stream end lumi, the stream where the exception occurs would have already started the next run and/or next lumi before the exception occurs.

   7. At endStream and endJob, all exceptions are collected and printed. At other transitions, only the first exception is collected and printed. It is more likely in these cases that the first exception is interesting and the rest are just side effects of the first exception and cause confusion rather than aid debugging.

   8. If one service throws while a signal is handled, the Framework continues trying to run all the other services and will report the first exception.

   9. The global write transitions do not occur at all if the global begin transition did not succeed.

#### PR validation:

An existing unit test covering exceptions in different transitions is extended to cover the most salient cases. Additional manual testing of many various cases was also done. Existing unit tests pass.
