### PR TITLE
Phase2L1CaloJetEmulator: fix maybe-uninitialized warning

### DIFF
--- a/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h
+++ b/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h
@@ -384,7 +384,7 @@ namespace gctobj {
 
   inline jetInfo getJetValues(GCTsupertower_t tempX[nSTEta][nSTPhi], int seed_eta, int seed_phi) {
     float temp[nSTEta + 2][nSTPhi + 2];
-    float eta_slice[3];
+    float eta_slice[3] = {0.f, 0.f, 0.f};
     jetInfo jet_tmp;
 
     for (int i = 0; i < nSTEta + 2; i++) {


### PR DESCRIPTION
#### PR description:

GCC emits the following `maybe-uninitialized`  warnings:

```
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: warning: 'eta_slice[1]' may be used uninitialized [-Wmaybe-uninitialized]
   387 |     float eta_slice[3];
      |           ^
In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:475:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:35: warning: 'eta_slice[0]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                   ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[0]' was declared here
  387 |     float eta_slice[3];
      |           ^
In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:430:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:50: warning: 'eta_slice[2]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                                  ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[2]' was declared here
  387 |     float eta_slice[3];
      |           ^
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: warning: 'eta_slice[1]' may be used uninitialized [-Wmaybe-uninitialized]
 In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:520:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:50: warning: 'eta_slice[2]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                                  ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[2]' was declared here
  387 |     float eta_slice[3];
      |           ^
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: warning: 'eta_slice[1]' may be used uninitialized [-Wmaybe-uninitialized]
 In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:430:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:35: warning: 'eta_slice[0]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                   ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[0]' was declared here
  387 |     float eta_slice[3];
      |           ^
In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:520:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:35: warning: 'eta_slice[0]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                   ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[0]' was declared here
  387 |     float eta_slice[3];
      |           ^
In function 'getJetValues',
    inlined from 'getRegion' at ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:450:23,
    inlined from 'produce' at src/L1Trigger/L1CaloTrigger/plugins/Phase2L1CaloJetEmulator.cc:475:33:
  ...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:421:50: warning: 'eta_slice[2]' may be used uninitialized [-Wmaybe-uninitialized]
   421 |     jet_tmp.energy = eta_slice[0] + eta_slice[1] + eta_slice[2];
      |                                                  ^
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h: In member function 'produce':
...src/L1Trigger/L1CaloTrigger/interface/Phase2L1CaloJetEmulator.h:387:11: note: 'eta_slice[2]' was declared here
  387 |     float eta_slice[3];
      |           ^
```

[log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_DBG_X_2024-04-04-2300/L1Trigger/L1CaloTrigger)

#### PR validation:

Bot tests