### PR TITLE
Add reduced lepton time-life info to NanoAOD

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -195,7 +195,7 @@ steps['BTVNANO_data13.0']=merge([{'-s' : 'NANO:@BTV',
 steps['jmeNano_data13.0'] = merge([{'-s':'NANO:@JME', '-n' : '1000'},
                                  steps['NANO_data13.0']])
 
-steps['lepTimeLifeNANO_data13.0']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM',
+steps['lepTrackInfoNANO_data13.0']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
                                           '-n' : '1000'},
                                          steps['NANO_data13.0']])
 
@@ -218,7 +218,7 @@ steps['BTVNANO_mc13.2']=merge([{'-s' : 'NANO:@BTV',
                                     '-n' : '1000'},
                                     steps['NANO_mc13.2']])
 
-steps['lepTimeLifeNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM', '-n' : '1000'},
+steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n' : '1000'},
                                        steps['NANO_mc13.2']])
 
 steps['jmeNANO_mc13.2']=merge([{'-s' : 'NANO:@JME ', '-n' : '1000'},
@@ -283,7 +283,7 @@ workflows[_wfn()] = ['l1DPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'l1DPGNANO
 workflows[_wfn()] = ['EGMNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'EGMNano_data13.0']]
 workflows[_wfn()] = ['BTVNANO_data13.0', ['MuonEG2023MINIAOD13.0', 'BTVNANO_data13.0']]
 workflows[_wfn()] = ['jmeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNano_data13.0']]
-workflows[_wfn()] = ['lepTimeLifeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTimeLifeNANO_data13.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTrackInfoNANO_data13.0']]
 
 _wfn.next()
 ################
@@ -293,7 +293,7 @@ workflows[_wfn()] = ['muPOGNANOmc132X', ['TTBarMINIAOD13.2', 'muPOGNANO_mc13.2']
 workflows[_wfn()] = ['EGMNANOmc132X', ['TTBarMINIAOD13.2', 'EGMNano_mc13.2']]
 workflows[_wfn()] = ['BTVNANO_mc13.2', ['TTBarMINIAOD13.2', 'BTVNANO_mc13.2']]
 workflows[_wfn()] = ['jmeNANOmc132X', ['TTBarMINIAOD13.2', 'jmeNANO_mc13.2']]
-workflows[_wfn()] = ['lepTimeLifeNANOmc132X', ['TTBarMINIAOD13.2', 'lepTimeLifeNANO_mc13.2']]
+workflows[_wfn()] = ['lepTrackInfoNANOmc132X', ['TTBarMINIAOD13.2', 'lepTrackInfoNANO_mc13.2']]
 
 _wfn.next()
 ################

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -53,9 +53,9 @@ autoNANO = {
     # PromptReco config: PHYS+L1
     'Prompt' : {'sequence': '@PHYS',
                 'customize': '@PHYS+@L1'},
-    # Add lepton time-life info tables through customize combined with PHYS
-    'LepTimeLife' : {'sequence': '@PHYS',
-                     'customize': '@PHYS+PhysicsTools/NanoAOD/leptonTimeLifeInfo_common_cff.addTimeLifeInfo'},
+    # Add lepton track parameters through customize combined with PHYS
+    'LepTrackInfo' : {'sequence': '@PHYS',
+                      'customize': '@PHYS+PhysicsTools/NanoAOD/leptonTimeLifeInfo_common_cff.addTrackVarsToTimeLifeInfo'},
     # Custom BTV Nano for SF measurements or tagger training
     'BTV' : {'sequence': '@PHYS',
              'customize':'@PHYS+PhysicsTools/NanoAOD/custom_btv_cff.BTVCustomNanoAOD'}

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -263,6 +263,10 @@ def nanoAOD_customizeCommon(process):
         process, lambda p : nanoAOD_addBoostedTauIds(p, nanoAOD_boostedTau_switch.idsToAdd.value())
     )
 
+    # Add lepton time-life info
+    from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase
+    process = addTimeLifeInfoBase(process)
+
     return process
 
 ###increasing the precision of selected GenParticles.


### PR DESCRIPTION
#### PR description:

This PR adds base lepton time-life info to common (Phys) NanoAOD tables while lepton track parameters can be added through customization.
The base lepton time-life info increases size of nanoAOD with RelVal TTBar MC by ~3.5% compared to ~11% for the full info containing track parameters (reduction by factor of ~3). Further details in those slides: 
[Tau-Lifetime in NanoAOD.pdf](https://github.com/cms-sw/cmssw/files/14888147/Tau-Lifetime.in.NanoAOD.pdf)

#### PR validation:

Tested with the standard nanoAOD workflow.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

If accepted backport to 14_0_X will be provided.