### PR TITLE
Add L1 objects into Run3Scouting Nano

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -14,15 +14,35 @@ particleTableTask = cms.Task(particleScoutingTable)
 ak4JetTableTask = cms.Task(ak4ScoutingJets,ak4ScoutingJetParticleNetJetTagInfos,ak4ScoutingJetParticleNetJetTags,ak4ScoutingJetTable)
 ak8JetTableTask = cms.Task(ak8ScoutingJets,ak8ScoutingJetsSoftDrop,ak8ScoutingJetsSoftDropMass,ak8ScoutingJetEcfNbeta1,ak8ScoutingJetNjettiness,ak8ScoutingJetParticleNetJetTagInfos,ak8ScoutingJetParticleNetJetTags,ak8ScoutingJetParticleNetMassRegressionJetTags,ak8ScoutingJetTable)
 
+## L1 decisions
 gtStage2DigisScouting = gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
 l1bitsScouting = l1bits.clone(src="gtStage2DigisScouting")
 patTriggerScouting = patTrigger.clone(l1tAlgBlkInputTag="gtStage2DigisScouting",l1tExtBlkInputTag="gtStage2DigisScouting")
+
+## L1 objects
+from PhysicsTools.NanoAOD.l1trig_cff import *
+l1MuScoutingTable = l1MuTable.clone(src=cms.InputTag("gtStage2DigisScouting","Muon"))
+l1JetScoutingTable = l1JetTable.clone(src=cms.InputTag("gtStage2DigisScouting","Jet"))
+l1EGScoutingTable = l1EGTable.clone(src=cms.InputTag("gtStage2DigisScouting","EGamma"))
+l1TauScoutingTable = l1TauTable.clone(src=cms.InputTag("gtStage2DigisScouting","Tau"))
+l1EtSumScoutingTable = l1EtSumTable.clone(src=cms.InputTag("gtStage2DigisScouting","EtSum"))
+
+#reduce the variables to the core variables as only these are available in gtStage2Digis
+l1EGScoutingTable.variables = cms.PSet(l1EGReducedVars)
+l1MuScoutingTable.variables = cms.PSet(l1MuonReducedVars)
+l1JetScoutingTable.variables = cms.PSet(l1JetReducedVars)
+l1TauScoutingTable.variables = cms.PSet(l1TauReducedVars)
+l1EtSumScoutingTable.variables = cms.PSet(l1EtSumReducedVars)
+
 selectedPatTriggerScouting = selectedPatTrigger.clone(src="patTriggerScouting")
 slimmedPatTriggerScouting = slimmedPatTrigger.clone(src="selectedPatTriggerScouting")
 unpackedPatTriggerScouting = unpackedPatTrigger.clone(patTriggerObjectsStandAlone="slimmedPatTriggerScouting")
 triggerObjectTableScouting = triggerObjectTable.clone(src="unpackedPatTriggerScouting")
 
-triggerTask = cms.Task(gtStage2DigisScouting,unpackedPatTriggerScouting,triggerObjectTableScouting,l1bitsScouting)
+triggerTask = cms.Task(
+    gtStage2DigisScouting, l1MuScoutingTable, l1EGScoutingTable, l1TauScoutingTable, l1JetScoutingTable, l1EtSumScoutingTable, 
+    unpackedPatTriggerScouting,triggerObjectTableScouting,l1bitsScouting
+)
 triggerSequence = cms.Sequence(L1TRawToDigi+patTriggerScouting+selectedPatTriggerScouting+slimmedPatTriggerScouting+cms.Sequence(triggerTask))
 
 # MC tasks


### PR DESCRIPTION
#### PR description:

This PR adds the L1 trigger objects to the Run3 scouting NanoAOD. 
This proposal was presented and approved by the scouting group on the 5th of April: https://indico.cern.ch/event/1399442/#6-l1-objects-in-scouting-event

It follows the approach of the main Nano except it takes the L1 objects from the unpacked uGT data record, and not the L1 Muon and Calo systems themselves, since only the uGT FED is stored in the scouting RAW.

#### PR validation:

Tested by producing scouting NanoAOD from a 2023 scouting RAW file as shown in the linked slides. 
The scouting nano size increase is 5%. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will likely need one for this to have an effect for the upcoming data taking in 140x.

FY @elfontan @kelmorab @eyigitba  @slaurila  @aloeliger @epalencia 