### PR TITLE
[GCC13] Temporary convert array-bounds errors into warnings

### DIFF
--- a/DQM/SiTrackerPhase2/BuildFile.xml
+++ b/DQM/SiTrackerPhase2/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags CXXFLAGS="-Wno-error=array-bounds" />
 <use name="DataFormats/TrackerCommon"/>
 <use name="DQMServices/Core"/>
 <export>

--- a/DQMOffline/Alignment/BuildFile.xml
+++ b/DQMOffline/Alignment/BuildFile.xml
@@ -15,3 +15,4 @@
 <use name="TrackingTools/TransientTrack"/>
 <use name="roofit"/>
 <flags EDM_PLUGIN="1"/>
+<flags CXXFLAGS="-Wno-error=array-bounds" />

--- a/DataFormats/TrackingRecHit/BuildFile.xml
+++ b/DataFormats/TrackingRecHit/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags CXXFLAGS="-Wno-error=array-bounds" />
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/GeometrySurface"/>

--- a/L1Trigger/L1TMuonBarrel/BuildFile.xml
+++ b/L1Trigger/L1TMuonBarrel/BuildFile.xml
@@ -8,3 +8,4 @@
 <export>
   <lib name="1"/>
 </export>
+<flags CXXFLAGS="-Wno-error=array-bounds" />

--- a/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecAlgos/BuildFile.xml
@@ -20,3 +20,4 @@
 <export>
   <lib name="1"/>
 </export>
+<flags CXXFLAGS="-Wno-error=array-bounds" />

--- a/RecoTracker/DebugTools/BuildFile.xml
+++ b/RecoTracker/DebugTools/BuildFile.xml
@@ -1,0 +1,1 @@
+<flags CXXFLAGS="-Wno-error=array-bounds" />

--- a/RecoTracker/DebugTools/plugins/BuildFile.xml
+++ b/RecoTracker/DebugTools/plugins/BuildFile.xml
@@ -9,3 +9,4 @@
 <library file="*.cc" name="RecoTrackerDebugToolsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>
+<flags CXXFLAGS="-Wno-error=array-bounds" />

--- a/SimG4CMS/HGCalTestBeam/BuildFile.xml
+++ b/SimG4CMS/HGCalTestBeam/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags CXXFLAGS="-Wno-error=array-bounds" />
 <use name="DataFormats/HcalDetId"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>

--- a/TBDataFormats/HcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/HcalTBObjects/BuildFile.xml
@@ -1,3 +1,4 @@
+<flags CXXFLAGS="-Wno-error=array-bounds" />
 <use name="DataFormats/Common"/>
 <use name="boost"/>
 <export>


### PR DESCRIPTION
#### PR description:

In order to start testing gcc13 IBs, temporary convert array-bounds errors into warnings. See also https://github.com/cms-sw/cmssw/issues/44582. 

#### PR validation:

Bot tests
