### PR TITLE
CepGenInterface: Added missing include

### DIFF
--- a/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
+++ b/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 
+#include <CepGen/Core/ParametersList.h>
 #include <CepGen/Generator.h>
 
 namespace gen {


### PR DESCRIPTION
#### PR description:

This PR fixes the build of CepGen release >= 1.2.2 where the include chain was strongly modified. This should cure [the recent build failure](https://github.com/cms-sw/cmsdist/pull/9122#issuecomment-2041073492) encountered in https://github.com/cms-sw/cmsdist/pull/9122.

#### PR validation:

Builds

FYI: @smuzaffar, @bbilin 