### PR TITLE
[10_6_X] CepGenInterface: Added missing include

### DIFF
--- a/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
+++ b/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 
+#include <CepGen/Core/ParametersList.h>
 #include <CepGen/Generator.h>
 
 namespace gen {


### PR DESCRIPTION
#### PR description:

This PR fixes the build of CepGen release >= 1.2.2 where the include chain was strongly modified. This should cure [the recent build failure](https://github.com/cms-sw/cmsdist/pull/9123#issuecomment-2041062826) encountered in https://github.com/cms-sw/cmsdist/pull/9123.

#### PR validation:

Builds

Backport of #44647 

FYI: @smuzaffar, @bbilin 