### PR TITLE
Fixes for low-level alpaka based utilities [14.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AtomicPairCounter.h
@@ -25,7 +25,7 @@ namespace cms::alpakatools {
       uint32_t second;  // in a "One to Many" association is the total number of associations
     };
 
-    ALPAKA_FN_ACC constexpr Counters get() const { return counter_.as_counters; }
+    ALPAKA_FN_HOST_ACC constexpr Counters get() const { return counter_.as_counters; }
 
     // atomically add as_counters, and return the previous value
     template <typename TAcc>

--- a/HeterogeneousCore/AlpakaInterface/interface/atomicMaxF.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/atomicMaxF.h
@@ -1,13 +1,16 @@
-#ifndef HeterogeneousCore_AlpakaCore_interface_atomicMaxF_h
-#define HeterogeneousCore_AlpakaCore_interface_atomicMaxF_h
+#ifndef HeterogeneousCore_AlpakaInterface_interface_atomicMaxF_h
+#define HeterogeneousCore_AlpakaInterface_interface_atomicMaxF_h
+
 #include <alpaka/alpaka.hpp>
 
 #include "FWCore/Utilities/interface/bit_cast.h"
-#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
-#if defined(__CUDA_ARCH__) or defined(__HIP_DEVICE_COMPILE__)
+// FIXME: this should be rewritten using the correct template specialisation for the different accelerator types
+
 template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-static __device__ __forceinline__ float atomicMaxF(const TAcc& acc, float* address, float val) {
+ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE static float atomicMaxF(const TAcc& acc, float* address, float val) {
+#if defined(__CUDA_ARCH__) or defined(__HIP_DEVICE_COMPILE__)
+  // GPU implementation uses __float_as_int / __int_as_float
   int ret = __float_as_int(*address);
   while (val > __int_as_float(ret)) {
     int old = ret;
@@ -15,10 +18,7 @@ static __device__ __forceinline__ float atomicMaxF(const TAcc& acc, float* addre
       break;
   }
   return __int_as_float(ret);
-}
 #else
-template <typename TAcc, typename = std::enable_if_t<alpaka::isAccelerator<TAcc>>>
-ALPAKA_FN_ACC ALPAKA_FN_INLINE static float atomicMaxF(const TAcc& acc, float* address, float val) {
   // CPU implementation uses edm::bit_cast
   int ret = edm::bit_cast<int>(*address);
   while (val > edm::bit_cast<float>(ret)) {
@@ -27,7 +27,7 @@ ALPAKA_FN_ACC ALPAKA_FN_INLINE static float atomicMaxF(const TAcc& acc, float* a
       break;
   }
   return edm::bit_cast<float>(ret);
-}
 #endif  // __CUDA_ARCH__ or __HIP_DEVICE_COMPILE__
+}
 
-#endif  // HeterogeneousCore_AlpakaCore_interface_atomicMaxF_h
+#endif  // HeterogeneousCore_AlpakaInterface_interface_atomicMaxF_h

--- a/HeterogeneousCore/AlpakaInterface/interface/radixSort.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/radixSort.h
@@ -353,8 +353,8 @@ namespace cms::alpakatools {
             typename T,
             int NS = sizeof(T),  // number of significant bytes to use in sorting
             typename std::enable_if<requires_single_thread_per_block_v<TAcc>, T>::type* = nullptr>
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void radixSort(
-      const TAcc& acc, T const* a, uint16_t* ind, uint16_t* ind2, uint32_t size) {
+  /* not ALPAKA_FN_ACC to avoid trying to compile it for the CUDA or ROCm back-ends */
+  ALPAKA_FN_INLINE void radixSort(const TAcc& acc, T const* a, uint16_t* ind, uint16_t* ind2, uint32_t size) {
     static_assert(requires_single_thread_per_block_v<TAcc>, "CPU sort (not a radixSort) called wtth wrong accelerator");
     // Initialize the index array
     std::iota(ind, ind + size, 0);


### PR DESCRIPTION
#### PR description:

Fix various low-level alpaka based utilities that were inadvertently mixing host and device code.

Required to build with alpaka in GPU-only mode.

#### PR validation:

Unit tests pass.

No impact on the HLT performance, as expected.
`CMSSW_14_0_4`:
```
Running 4 times over all events with 8 jobs, each with 32 threads, 24 streams and 1 GPUs
   514.3 ±   0.4 ev/s (11800 events, 99.8% overlap)
   533.3 ±   0.5 ev/s (11800 events, 99.7% overlap)
   523.0 ±   0.6 ev/s (11800 events, 100.0% overlap)
   514.8 ±   0.6 ev/s (11800 events, 99.3% overlap)
 --------------------
   521.3 ±   8.9 ev/s
```

`CMSSW_14_0_4` with #44650:
```
Running 4 times over all events with 8 jobs, each with 32 threads, 24 streams and 1 GPUs
   520.0 ±   0.5 ev/s (11800 events, 99.8% overlap)
   505.8 ±   0.4 ev/s (11800 events, 99.8% overlap)
   559.7 ±   0.5 ev/s (11800 events, 99.8% overlap)
   514.0 ±   0.5 ev/s (11800 events, 99.9% overlap)
 --------------------
   524.9 ±  23.9 ev/s
```


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44640 to CMSSW 14.0.x for data taking.