### PR TITLE
[CPP20] Remove references to deprecated std::is_pod

### DIFF
--- a/Alignment/Geners/interface/CPP11_type_traits.hh
+++ b/Alignment/Geners/interface/CPP11_type_traits.hh
@@ -5,11 +5,9 @@
 
 #ifdef CPP11_STD_AVAILABLE
 #include <type_traits>
-#define CPP11_is_pod std::is_pod
 #define CPP11_is_pointer std::is_pointer
 #else
 #include <tr1/type_traits>
-#define CPP11_is_pod std::tr1::is_pod
 #define CPP11_is_pointer std::tr1::is_pointer
 #endif
 

--- a/Alignment/Geners/interface/IOIsPOD.hh
+++ b/Alignment/Geners/interface/IOIsPOD.hh
@@ -8,7 +8,7 @@ namespace gs {
   // at compile time if T belongs to one of the known POD types.
   template <typename T>
   struct IOIsPOD {
-    enum { value = CPP11_is_pod<T>::value };
+    enum { value = std::is_standard_layout<T>::value && std::is_trivial<T>::value };
   };
 }  // namespace gs
 


### PR DESCRIPTION
#### PR description:

`std::is_pod` is deprecated in C++20:

```
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/799232d1e03caef2b7c55e82af01e207/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_CPP20_X_2024-04-05-1100/src/Alignment/Geners/interface/CPP11_type_traits.hh:8:27: warning: 'template<class _Tp> struct std::is_pod' is deprecated: use is_standard_layout && is_trivial instead [-Wdeprecated-declarations]
     8 | #define CPP11_is_pod std::is_pod
      |                           ^~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/799232d1e03caef2b7c55e82af01e207/opt/cmssw/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_CPP20_X_2024-04-05-1100/src/Alignment/Geners/interface/IOIsPOD.hh:11:20: note: in expansion of macro 'CPP11_is_pod'
   11 |     enum { value = CPP11_is_pod<T>::value };
      |                    ^~~~~~~~~~~~
```

#### PR validation:

Bot tests
