### PR TITLE
Tunable `PUMax`  in `PrimaryVertexMonitor` and Finer d_xy DQM Tracking Plots

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -62,9 +62,9 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   iBooker.setCurrentFolder(dqmLabel);
 
   //   xPos = iBooker.book1D ("xPos","x Coordinate" ,100, -0.1, 0.1);
-
-  nbvtx = iBooker.book1D("vtxNbr", "Reconstructed Vertices in Event", 80, -0.5, 79.5);
-  nbgvtx = iBooker.book1D("goodvtxNbr", "Reconstructed Good Vertices in Event", 80, -0.5, 79.5);
+  auto maxPU = conf_.getParameter<double>("PUMax");
+  nbvtx = iBooker.book1D("vtxNbr", "Reconstructed Vertices in Event", maxPU, -0.5, maxPU - 0.5);
+  nbgvtx = iBooker.book1D("goodvtxNbr", "Reconstructed Good Vertices in Event", maxPU, -0.5, maxPU - 0.5);
 
   // to be configured each year...
   auto vposx = conf_.getParameter<double>("Xpos");
@@ -144,8 +144,8 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   bsSigmaZ = iBooker.book1D("bsSigmaZ", "BeamSpot sigmaZ", 100, 0., 10.);
   bsDxdz = iBooker.book1D("bsDxdz", "BeamSpot dxdz", 100, -0.0003, 0.0003);
   bsDydz = iBooker.book1D("bsDydz", "BeamSpot dydz", 100, -0.0003, 0.0003);
-  bsBeamWidthX = iBooker.book1D("bsBeamWidthX", "BeamSpot BeamWidthX", 100, 0., 100.);
-  bsBeamWidthY = iBooker.book1D("bsBeamWidthY", "BeamSpot BeamWidthY", 100, 0., 100.);
+  bsBeamWidthX = iBooker.book1D("bsBeamWidthX", "BeamSpot BeamWidthX", 500, 0., 15.);
+  bsBeamWidthY = iBooker.book1D("bsBeamWidthY", "BeamSpot BeamWidthY", 500, 0., 15.);
   bsType = iBooker.book1D("bsType", "BeamSpot type", 4, -1.5, 2.5);
   bsType->setBinLabel(1, "Unknown");
   bsType->setBinLabel(2, "Fake");

--- a/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
@@ -26,7 +26,8 @@ pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
    EtaBin         = cms.int32(26),
    EtaBin2D       = cms.int32(8),
    EtaMax         = cms.double(2.5),
-   EtaMin         = cms.double(-2.5)
+   EtaMin         = cms.double(-2.5),
+   PUMax          = cms.double(80.0),
 )
 
 # same as above, should be in sync with cut used in Vertex finder...
@@ -34,6 +35,6 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase1Pixel.toModify(pvMonitor, EtaBin=28, EtaMin=-2.7, EtaMax=2.7)
-run3_common.toModify(pvMonitor, Xpos = 0.15, Ypos=-0.15)  #recentering since initial Run3 beamspot is at (0.17,-0.18) cm
-phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaBin2D=9, EtaMin=-4.0, EtaMax=4.0)
+run3_common.toModify(pvMonitor, Xpos = 0.15, Ypos=-0.15, PUMax = 150 )  #recentering since initial Run3 beamspot is at (0.17,-0.18) cm
+phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaBin2D=9, EtaMin=-4.0, EtaMax=4.0, PUMax = 250)
 

--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -49,9 +49,9 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
     maxPhi = cms.double(3.1416),
     nintPhi = cms.int32(36),
     #
-    minDxy = cms.double(-25),
-    maxDxy = cms.double(25),
-    nintDxy = cms.int32(100),
+    minDxy = cms.double(-20),
+    maxDxy = cms.double(20),
+    nintDxy = cms.int32(500),
     #
     minDz = cms.double(-30),
     maxDz = cms.double(30),


### PR DESCRIPTION
A couple of minor fixes for tracking DQM plots:
- have tunable PU maximum for `PrimaryVErtexMonitor`;
- have finer dxy binning and smaller range for the MTV.