### PR TITLE
Update ECAL DQM GPU input tag module names for alpaka

### DIFF
--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -79,17 +79,17 @@ process.ecalMonitorTask.commonParameters.onlineMode = True
 # ecalMonitorTask always looks for EcalRawData collection when running, even when not in use
 # Default value is cms.untracked.InputTag("ecalDigis")
 # Tag is changed below to avoid multiple warnings per event
-process.ecalMonitorTask.collectionTags.EcalRawData = cms.untracked.InputTag("hltEcalDigisLegacy")
+process.ecalMonitorTask.collectionTags.EcalRawData = cms.untracked.InputTag("hltEcalDigisSerialSync")
 
 # Streams used for online GPU validation
-process.ecalMonitorTask.collectionTags.EBCpuDigi = cms.untracked.InputTag("hltEcalDigisLegacy", "ebDigis")
-process.ecalMonitorTask.collectionTags.EECpuDigi = cms.untracked.InputTag("hltEcalDigisLegacy", "eeDigis")
-process.ecalMonitorTask.collectionTags.EBGpuDigi = cms.untracked.InputTag("hltEcalDigisFromGPU", "ebDigis")
-process.ecalMonitorTask.collectionTags.EEGpuDigi = cms.untracked.InputTag("hltEcalDigisFromGPU", "eeDigis")
-process.ecalMonitorTask.collectionTags.EBCpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitLegacy", "EcalUncalibRecHitsEB")
-process.ecalMonitorTask.collectionTags.EECpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitLegacy", "EcalUncalibRecHitsEE")
-process.ecalMonitorTask.collectionTags.EBGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEB")
-process.ecalMonitorTask.collectionTags.EEGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitFromSoA", "EcalUncalibRecHitsEE")
+process.ecalMonitorTask.collectionTags.EBCpuDigi = cms.untracked.InputTag("hltEcalDigisSerialSync", "ebDigis")
+process.ecalMonitorTask.collectionTags.EECpuDigi = cms.untracked.InputTag("hltEcalDigisSerialSync", "eeDigis")
+process.ecalMonitorTask.collectionTags.EBGpuDigi = cms.untracked.InputTag("hltEcalDigis", "ebDigis")
+process.ecalMonitorTask.collectionTags.EEGpuDigi = cms.untracked.InputTag("hltEcalDigis", "eeDigis")
+process.ecalMonitorTask.collectionTags.EBCpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitSerialSync", "EcalUncalibRecHitsEB")
+process.ecalMonitorTask.collectionTags.EECpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHitSerialSync", "EcalUncalibRecHitsEE")
+process.ecalMonitorTask.collectionTags.EBGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHit", "EcalUncalibRecHitsEB")
+process.ecalMonitorTask.collectionTags.EEGpuUncalibRecHit = cms.untracked.InputTag("hltEcalUncalibRecHit", "EcalUncalibRecHitsEE")
 
 ### Paths ###
 


### PR DESCRIPTION
#### PR description:

This PR changes the input tag names for the ECAL DQM GPU client so that it can be compatible with the new Alpaka HLT menu that will go online in late April. See JIRA ticket [CMSHLT-3139](https://its.cern.ch/jira/browse/CMSHLT-3139) and [CMSHLT-3132](https://its.cern.ch/jira/browse/CMSHLT-3132) for more information. 

`hltEcalDigisFromGPU` -> `hltEcalDigis`
`hltEcalDigisLegacy` -> `hltEcalDigisSerialSync `
`hltEcalUncalibRecHitLegacy` -> `hltEcalUncalibRecHitSerialSync`
`hltEcalUncalibRecHitFromSoA` -> `hltEcalUncalibRecHit`

#### PR validation:

Once the HLT menu 2024 V1.1 is online, this PR should be validated on the playback with a run which used the Alpaka HLT menu.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the Master PR. Backports are made to `14_0_X` in the PR [#44675](https://github.com/cms-sw/cmssw/pull/44675)