### PR TITLE
Use explicit acelerator types in alpaka tests

### DIFF
--- a/HeterogeneousTest/AlpakaDevice/README.md
+++ b/HeterogeneousTest/AlpakaDevice/README.md
@@ -12,15 +12,13 @@ Alpaka-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/AlpakaDevice` implements a library that defines and exports Alpaka
 device-side functions:
 ```c++
-namespace cms::alpakatest {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
 
-  template <typename TAcc>
-  ALPAKA_FN_ACC void add_vectors_f(TAcc const& acc, ...);
+  inline ALPAKA_FN_ACC void add_vectors_f(Acc1D const& acc, ...) { ... }
 
-  template <typename TAcc>
-  ALPAKA_FN_ACC void add_vectors_d(TAcc const& acc, ...);
+  inline ALPAKA_FN_ACC void add_vectors_d(Acc1D const& acc, ...) { ... }
 
-}  // namespace cms::alpakatest
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
 ```
 
 The `plugins` directory implements the `AlpakaTestDeviceAdditionModule` `EDAnalyzer` that launches

--- a/HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h
+++ b/HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h
@@ -5,32 +5,31 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
 
-namespace cms::alpakatest {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
 
-  template <typename TAcc>
-  ALPAKA_FN_ACC void add_vectors_f(TAcc const& acc,
-                                   float const* __restrict__ in1,
-                                   float const* __restrict__ in2,
-                                   float* __restrict__ out,
-                                   uint32_t size) {
+  inline ALPAKA_FN_ACC void add_vectors_f(Acc1D const& acc,
+                                          float const* __restrict__ in1,
+                                          float const* __restrict__ in2,
+                                          float* __restrict__ out,
+                                          uint32_t size) {
     for (auto i : cms::alpakatools::uniform_elements(acc, size)) {
       out[i] = in1[i] + in2[i];
     }
   }
 
-  template <typename TAcc>
-  ALPAKA_FN_ACC void add_vectors_d(TAcc const& acc,
-                                   double const* __restrict__ in1,
-                                   double const* __restrict__ in2,
-                                   double* __restrict__ out,
-                                   uint32_t size) {
+  inline ALPAKA_FN_ACC void add_vectors_d(Acc1D const& acc,
+                                          double const* __restrict__ in1,
+                                          double const* __restrict__ in2,
+                                          double* __restrict__ out,
+                                          uint32_t size) {
     for (auto i : cms::alpakatools::uniform_elements(acc, size)) {
       out[i] = in1[i] + in2[i];
     }
   }
 
-}  // namespace cms::alpakatest
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
 
 #endif  // HeterogeneousTest_AlpakaDevice_interface_alpaka_DeviceAddition_h

--- a/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.dev.cc
+++ b/HeterogeneousTest/AlpakaDevice/plugins/alpaka/AlpakaTestDeviceAdditionAlgo.dev.cc
@@ -11,13 +11,12 @@
 namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaDevicePlugins {
 
   struct KernelAddVectorsF {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const float* __restrict__ in1,
                                   const float* __restrict__ in2,
                                   float* __restrict__ out,
                                   uint32_t size) const {
-      cms::alpakatest::add_vectors_f(acc, in1, in2, out, size);
+      test::add_vectors_f(acc, in1, in2, out, size);
     }
   };
 

--- a/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
+++ b/HeterogeneousTest/AlpakaDevice/test/alpaka/testDeviceAddition.dev.cc
@@ -16,13 +16,12 @@
 using namespace ALPAKA_ACCELERATOR_NAMESPACE;
 
 struct KernelAddVectorsF {
-  template <typename TAcc>
-  ALPAKA_FN_ACC void operator()(TAcc const& acc,
+  ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                 const float* __restrict__ in1,
                                 const float* __restrict__ in2,
                                 float* __restrict__ out,
                                 uint32_t size) const {
-    cms::alpakatest::add_vectors_f(acc, in1, in2, out, size);
+    test::add_vectors_f(acc, in1, in2, out, size);
   }
 };
 

--- a/HeterogeneousTest/AlpakaKernel/README.md
+++ b/HeterogeneousTest/AlpakaKernel/README.md
@@ -12,19 +12,17 @@ Alpaka-based libraries, and using them from multiple plugins.
 The package `HeterogeneousTest/AlpakaKernel` implements a library that defines and exports Alpaka
 kernels that call the device functions defined in the `HeterogeneousTest/AlpakaDevice` library:
 ```c++
-namespace cms::alpakatest {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
 
   struct KernelAddVectorsF {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, ...) const;
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, ...) const { ... }
   };
 
   struct KernelAddVectorsD {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, ...) const;
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc, ...) const { ... }
   };
 
-}  // namespace cms::alpakatest
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
 ```
 
 The `plugins` directory implements the `AlpakaTestKernelAdditionModule` `EDAnalyzer` that launches

--- a/HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h
+++ b/HeterogeneousTest/AlpakaKernel/interface/alpaka/DeviceAdditionKernel.h
@@ -5,13 +5,13 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousTest/AlpakaDevice/interface/alpaka/DeviceAddition.h"
 
-namespace cms::alpakatest {
+namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
 
   struct KernelAddVectorsF {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const float* __restrict__ in1,
                                   const float* __restrict__ in2,
                                   float* __restrict__ out,
@@ -21,8 +21,7 @@ namespace cms::alpakatest {
   };
 
   struct KernelAddVectorsD {
-    template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
+    ALPAKA_FN_ACC void operator()(Acc1D const& acc,
                                   const double* __restrict__ in1,
                                   const double* __restrict__ in2,
                                   double* __restrict__ out,
@@ -31,6 +30,6 @@ namespace cms::alpakatest {
     }
   };
 
-}  // namespace cms::alpakatest
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test
 
 #endif  // HeterogeneousTest_AlpakaKernel_interface_alpaka_DeviceAdditionKernel_h

--- a/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.dev.cc
+++ b/HeterogeneousTest/AlpakaKernel/plugins/alpaka/AlpakaTestKernelAdditionAlgo.dev.cc
@@ -16,7 +16,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins {
                              float* __restrict__ out,
                              uint32_t size) {
     alpaka::exec<Acc1D>(
-        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsF{}, in1, in2, out, size);
+        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), test::KernelAddVectorsF{}, in1, in2, out, size);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::HeterogeneousTestAlpakaKernelPlugins

--- a/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
+++ b/HeterogeneousTest/AlpakaKernel/test/alpaka/testDeviceAdditionKernel.dev.cc
@@ -68,7 +68,7 @@ TEST_CASE("HeterogeneousTest/AlpakaKernel test", "[alpakaTestDeviceAdditionKerne
         // launch the 1-dimensional kernel for vector addition
         alpaka::exec<Acc1D>(queue,
                             cms::alpakatools::make_workdiv<Acc1D>(32, 32),
-                            cms::alpakatest::KernelAddVectorsF{},
+                            test::KernelAddVectorsF{},
                             in1_d.data(),
                             in2_d.data(),
                             out_d.data(),

--- a/HeterogeneousTest/AlpakaWrapper/src/alpaka/DeviceAdditionWrapper.dev.cc
+++ b/HeterogeneousTest/AlpakaWrapper/src/alpaka/DeviceAdditionWrapper.dev.cc
@@ -14,8 +14,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
                              const float* __restrict__ in2,
                              float* __restrict__ out,
                              uint32_t size) {
-    alpaka::exec<Acc1D>(
-        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsF{}, in1, in2, out, size);
+    alpaka::exec<Acc1D>(queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), KernelAddVectorsF{}, in1, in2, out, size);
   }
 
   void wrapper_add_vectors_d(Queue& queue,
@@ -23,8 +22,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::test {
                              const double* __restrict__ in2,
                              double* __restrict__ out,
                              uint32_t size) {
-    alpaka::exec<Acc1D>(
-        queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), cms::alpakatest::KernelAddVectorsD{}, in1, in2, out, size);
+    alpaka::exec<Acc1D>(queue, cms::alpakatools::make_workdiv<Acc1D>(32, 32), KernelAddVectorsD{}, in1, in2, out, size);
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE::test


### PR DESCRIPTION
#### PR description:

Update the `HeterogeneousTest` alpaka tests to use the explicit accelerator types in alpaka device code:
  - move all alpaka device code to the `ALPAKA_ACCELERATOR_NAMESPACE` namespace;
  - use the explicit accelerator types, like `Acc1D` or `Acc2D`, instead of the generic `TAcc` template argument.

#### PR validation:

The `HeterogeneousTest` unit tests pass:
```
Creating test log file logs/el8_amd64_gcc12/testing.log
Pass    3s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionCudaAsync
Skip    0s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionROCmAsync (Failed to run rocmIsEnabled)
Pass    0s ... HeterogeneousTest/AlpakaDevice/testAlpakaDeviceAdditionSerialSync
Pass   10s ... HeterogeneousTest/AlpakaDevice/testAlpakaTestDeviceAdditionModule
Pass    3s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelCudaAsync
Skip    0s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelROCmAsync (Failed to run rocmIsEnabled)
Pass    0s ... HeterogeneousTest/AlpakaKernel/testAlpakaDeviceAdditionKernelSerialSync
Pass    7s ... HeterogeneousTest/AlpakaKernel/testAlpakaTestKernelAdditionModule
Pass    3s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueCudaAsync
Skip    0s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueROCmAsync (Failed to run rocmIsEnabled)
Pass    0s ... HeterogeneousTest/AlpakaOpaque/testAlpakaDeviceAdditionOpaqueSerialSync
Pass    7s ... HeterogeneousTest/AlpakaOpaque/testAlpakaTestAdditionModules
Pass    7s ... HeterogeneousTest/AlpakaOpaque/testAlpakaTestOpaqueAdditionModule
Pass    3s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperCudaAsync
Skip    0s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperROCmAsync (Failed to run rocmIsEnabled)
Pass    0s ... HeterogeneousTest/AlpakaWrapper/testAlpakaDeviceAdditionWrapperSerialSync
Pass    7s ... HeterogeneousTest/AlpakaWrapper/testAlpakaTestWrapperAdditionModule
>> Test sequence completed for CMSSW CMSSW_14_1_X_2024-04-08-2300
```