### PR TITLE
fixing bugs in track triplet

### DIFF
--- a/DataFormats/L1TCorrelator/interface/TkTriplet.h
+++ b/DataFormats/L1TCorrelator/interface/TkTriplet.h
@@ -34,11 +34,11 @@ namespace l1t {
 
     ~TkTriplet() override{};
 
-    int getTripletCharge() const;
-    double getPairMassMax() const;
-    double getPairMassMin() const;
-    double getPairDzMax() const;
-    double getPairDzMin() const;
+    int getTripletCharge() const { return charge_; }
+    double getPairMassMax() const { return pair_mass_max_; }
+    double getPairMassMin() const { return pair_mass_min_; }
+    double getPairDzMax() const { return pair_dz_max_; }
+    double getPairDzMin() const { return pair_dz_min_; }
     const edm::Ptr<L1TTTrackType>& trkPtr(size_t i) const { return trkPtrList_.at(i); }
     int bx() const;
 

--- a/DataFormats/L1TCorrelator/src/TkTriplet.cc
+++ b/DataFormats/L1TCorrelator/src/TkTriplet.cc
@@ -34,13 +34,3 @@ int TkTriplet::bx() const {
   // in the producer TkJetProducer.cc, we keep only jets with bx = 0
   return 0;
 }
-
-int TkTriplet::getTripletCharge() const { return charge_; }
-
-double TkTriplet::getPairMassMax() const { return pair_mass_max_; }
-
-double TkTriplet::getPairMassMin() const { return pair_mass_min_; }
-
-double TkTriplet::getPairDzMax() const { return pair_dz_max_; }
-
-double TkTriplet::getPairDzMin() const { return pair_dz_min_; }

--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -188,6 +188,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tTrackerEmuEtMiss_*_*',
         'keep *_l1tTrackerEmuHTMiss_*_*',
         'keep *_l1tTrackerEmuHTMissExtended_*_*',
+        'keep *_l1tTrackTripletEmulation_*_*',
         'keep *_l1tTowerCalibration_*_*',
         'keep *_l1tCaloJet_*_*',
         'keep *_l1tCaloJetHTT_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Defines the L1 Emulator sequence for simulation use-case subsystem emulators
 # run on the results of previous (in the hardware chain) subsystem emulator:
-#  
+#
 #     SimL1Emulator = cms.Sequence(...)
 #
 # properly configured for the current Era (e.g. Run1, 2015, or 2016).  Also
@@ -17,7 +17,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Notes on Inputs:
 
-# ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able 
+# ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able
 # to use unsuppressed digis produced by ECAL and HCAL simulation, respectively
 # in Configuration/StandardSequences/python/Digi_cff.py
 # SimCalorimetry.Configuration.SimCalorimetry_cff
@@ -48,7 +48,7 @@ SimL1EmulatorCore = cms.Sequence(SimL1EmulatorCoreTask)
 SimL1EmulatorTask = cms.Task(SimL1EmulatorCoreTask)
 SimL1Emulator = cms.Sequence( SimL1EmulatorTask )
 
-# 
+#
 # Emulators are configured from DB (GlobalTags)
 #
 
@@ -63,7 +63,7 @@ _phase2_siml1emulator = SimL1EmulatorTask.copy()
 # ########################################################################
 # ########################################################################
 #
-# Phase-2 
+# Phase-2
 #
 # ########################################################################
 # ########################################################################
@@ -77,11 +77,11 @@ _phase2_siml1emulator.add(CalibratedDigis)
 from L1Trigger.DTTriggerPhase2.dtTriggerPhase2PrimitiveDigis_cfi import *
 _phase2_siml1emulator.add(dtTriggerPhase2PrimitiveDigis)
 
-# HGCAL TP 
+# HGCAL TP
 # ########################################################################
 from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
 _phase2_siml1emulator.add(L1THGCalTriggerPrimitivesTask)
- 
+
 # ########################################################################
 # Phase 2 L1T
 # ########################################################################
@@ -111,7 +111,7 @@ l1tCaloJet = l1tCaloJetProducer.clone (
 # ----    Produce the simulated CaloJet HTT Sums
 from L1Trigger.L1CaloTrigger.l1tCaloJetHTTProducer_cfi import *
 l1tCaloJetHTT = l1tCaloJetHTTProducer.clone(
-    BXVCaloJetsInputTag = ("L1CaloJet", "CaloJets") 
+    BXVCaloJetsInputTag = ("L1CaloJet", "CaloJets")
 )
 # ----    Produce the NNCaloTau
 from L1Trigger.L1CaloTrigger.l1tNNCaloTauProducer_cfi import *
@@ -121,13 +121,25 @@ from L1Trigger.L1CaloTrigger.l1tNNCaloTauEmulator_cfi import *
 _phase2_siml1emulator.add(l1tNNCaloTauEmulator)
 
 # ---- Produce the emulated CaloJets and Taus
-from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cff import *
 
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
-_phase2_siml1emulator.add(l1tPhase2CaloJetEmulator)
+_phase2_siml1emulator.add(L1TCaloJetsTausTask)
 
+# Overlap and EndCap Muon Track Finder
+# ########################################################################
+from L1Trigger.L1TMuonOverlapPhase2.simOmtfPhase2Digis_cfi import *
+_phase2_siml1emulator.add(simOmtfPhase2Digis)
+
+from L1Trigger.L1TMuonEndCapPhase2.simCscTriggerPrimitiveDigisForEMTF_cfi import *
+from L1Trigger.L1TMuonEndCapPhase2.rpcRecHitsForEMTF_cfi import *
+from L1Trigger.L1TMuonEndCapPhase2.simEmtfDigisPhase2_cfi import *
+
+_phase2_siml1emulator.add(simCscTriggerPrimitiveDigisForEMTF)
+_phase2_siml1emulator.add(rpcRecHitsForEMTF)
+_phase2_siml1emulator.add(simEmtfDigisPhase2)
 
 # ########################################################################
 # Phase-2 L1T - TrackTrigger dependent modules
@@ -150,19 +162,27 @@ _phase2_siml1emulator.add(l1tVertexFinderEmulator)
 # Emulated GMT Muons (Tk + Stub, Tk + MuonTFT, StandaloneMuon)
 # ########################################################################
 from L1Trigger.Phase2L1GMT.gmt_cfi  import *
-l1tTkStubsGmt = l1tGMTStubs.clone()
-l1tTkMuonsGmt = l1tGMTMuons.clone(
-    srcStubs  = 'l1tTkStubsGmt'
+l1tStubsGmt = gmtStubs.clone()
+l1tKMTFMuonsGmt = gmtKMTFMuons.clone(
+  stubs      = cms.InputTag('l1tStubsGmt','kmtf'),
 )
-l1tSAMuonsGmt = l1tStandaloneMuons.clone()
-_phase2_siml1emulator.add( l1tTkStubsGmt )
-_phase2_siml1emulator.add( l1tTkMuonsGmt )
+l1tFwdMuonsGmt = gmtFwdMuons.clone(
+    stubs  = 'l1tStubsGmt:tps'
+)
+l1tSAMuonsGmt = gmtSAMuons.clone(
+  barrelPrompt      = cms.InputTag('l1tKMTFMuonsGmt:prompt'),
+  barrelDisp        = cms.InputTag('l1tKMTFMuonsGmt:displaced'),
+  forwardPrompt     = cms.InputTag('l1tFwdMuonsGmt:prompt'),
+  forwardDisp     = cms.InputTag('l1tFwdMuonsGmt:displaced')
+)
+l1tTkMuonsGmt = gmtTkMuons.clone(
+    srcStubs  = 'l1tStubsGmt:tps'
+)
+_phase2_siml1emulator.add( l1tStubsGmt )
+_phase2_siml1emulator.add( l1tKMTFMuonsGmt )
+_phase2_siml1emulator.add( l1tFwdMuonsGmt )
 _phase2_siml1emulator.add( l1tSAMuonsGmt )
-
-## fix for low-pt muons, this collection is a copy of the l1tTkMuonsGmt collection 
-## in which we only keep those low pt muons with an SA muon associated to it. 
-l1tTkMuonsGmtLowPtFix = l1tGMTFilteredMuons.clone()
-_phase2_siml1emulator.add( l1tTkMuonsGmtLowPtFix )
+_phase2_siml1emulator.add( l1tTkMuonsGmt )
 
 # Tracker Objects
 # ########################################################################
@@ -171,11 +191,14 @@ from L1Trigger.L1TTrackMatch.l1tTrackFastJets_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackerEtMiss_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackerHTMiss_cfi import *
 
+
+
 #Selected and Associated tracks for Jets and Emulated Jets
 _phase2_siml1emulator.add(l1tTrackSelectionProducerForJets)
 _phase2_siml1emulator.add(l1tTrackSelectionProducerExtendedForJets)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerForJets)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerExtendedForJets)
+
 
 #Selected and Associated tracks for EtMiss and Emulated EtMiss
 _phase2_siml1emulator.add(l1tTrackSelectionProducerForEtMiss)
@@ -183,12 +206,14 @@ _phase2_siml1emulator.add(l1tTrackSelectionProducerExtendedForEtMiss)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerForEtMiss)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerExtendedForEtMiss)
 
+
 #Track Jets, Track Only Et Miss, Track Only HT Miss
 _phase2_siml1emulator.add(l1tTrackJets)
 _phase2_siml1emulator.add(l1tTrackJetsExtended)
 _phase2_siml1emulator.add(l1tTrackFastJets)
 _phase2_siml1emulator.add(l1tTrackerEtMiss)
 _phase2_siml1emulator.add(l1tTrackerHTMiss)
+
 
 #Emulated Track Jets, Track Only Et Miss, Track Only HT Miss
 from L1Trigger.L1TTrackMatch.l1tTrackJetsEmulation_cfi import *
@@ -201,6 +226,10 @@ _phase2_siml1emulator.add(l1tTrackerEmuEtMiss)
 from L1Trigger.L1TTrackMatch.l1tTrackerEmuHTMiss_cfi import *
 _phase2_siml1emulator.add(l1tTrackerEmuHTMiss)
 _phase2_siml1emulator.add(l1tTrackerEmuHTMissExtended)
+
+from L1Trigger.L1TTrackMatch.l1tTrackTripletEmulation_cfi import *
+_phase2_siml1emulator.add(l1tTrackTripletEmulation)
+
 
 # PF Candidates
 # ########################################################################
@@ -220,8 +249,8 @@ from L1Trigger.L1CaloTrigger.Phase1L1TJets_9x9trimmed_cff import *
 L1TPFJetsPhase1Task_9x9trimmed = cms.Task(  l1tPhase1JetProducer9x9trimmed, l1tPhase1JetCalibrator9x9trimmed, l1tPhase1JetSumsProducer9x9trimmed)
 _phase2_siml1emulator.add(L1TPFJetsPhase1Task_9x9trimmed)
 
-from L1Trigger.Phase2L1ParticleFlow.l1tHPSPFTauProducer_cfi import *
-_phase2_siml1emulator.add(l1tHPSPFTauProducer)
+from L1Trigger.Phase2L1ParticleFlow.L1HPSPFTauProducer_cfi import *
+_phase2_siml1emulator.add(l1HPSPFTauEmuProducer)
 
 # PF MET
 # ########################################################################

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Defines the L1 Emulator sequence for simulation use-case subsystem emulators
 # run on the results of previous (in the hardware chain) subsystem emulator:
-#
+#  
 #     SimL1Emulator = cms.Sequence(...)
 #
 # properly configured for the current Era (e.g. Run1, 2015, or 2016).  Also
@@ -17,7 +17,7 @@ import FWCore.ParameterSet.Config as cms
 
 # Notes on Inputs:
 
-# ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able
+# ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able 
 # to use unsuppressed digis produced by ECAL and HCAL simulation, respectively
 # in Configuration/StandardSequences/python/Digi_cff.py
 # SimCalorimetry.Configuration.SimCalorimetry_cff
@@ -48,7 +48,7 @@ SimL1EmulatorCore = cms.Sequence(SimL1EmulatorCoreTask)
 SimL1EmulatorTask = cms.Task(SimL1EmulatorCoreTask)
 SimL1Emulator = cms.Sequence( SimL1EmulatorTask )
 
-#
+# 
 # Emulators are configured from DB (GlobalTags)
 #
 
@@ -63,7 +63,7 @@ _phase2_siml1emulator = SimL1EmulatorTask.copy()
 # ########################################################################
 # ########################################################################
 #
-# Phase-2
+# Phase-2 
 #
 # ########################################################################
 # ########################################################################
@@ -77,11 +77,11 @@ _phase2_siml1emulator.add(CalibratedDigis)
 from L1Trigger.DTTriggerPhase2.dtTriggerPhase2PrimitiveDigis_cfi import *
 _phase2_siml1emulator.add(dtTriggerPhase2PrimitiveDigis)
 
-# HGCAL TP
+# HGCAL TP 
 # ########################################################################
 from  L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff import *
 _phase2_siml1emulator.add(L1THGCalTriggerPrimitivesTask)
-
+ 
 # ########################################################################
 # Phase 2 L1T
 # ########################################################################
@@ -111,7 +111,7 @@ l1tCaloJet = l1tCaloJetProducer.clone (
 # ----    Produce the simulated CaloJet HTT Sums
 from L1Trigger.L1CaloTrigger.l1tCaloJetHTTProducer_cfi import *
 l1tCaloJetHTT = l1tCaloJetHTTProducer.clone(
-    BXVCaloJetsInputTag = ("L1CaloJet", "CaloJets")
+    BXVCaloJetsInputTag = ("L1CaloJet", "CaloJets") 
 )
 # ----    Produce the NNCaloTau
 from L1Trigger.L1CaloTrigger.l1tNNCaloTauProducer_cfi import *
@@ -121,25 +121,13 @@ from L1Trigger.L1CaloTrigger.l1tNNCaloTauEmulator_cfi import *
 _phase2_siml1emulator.add(l1tNNCaloTauEmulator)
 
 # ---- Produce the emulated CaloJets and Taus
-from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cff import *
+from L1Trigger.L1CaloTrigger.l1tPhase2CaloJetEmulator_cfi import *
 
 _phase2_siml1emulator.add(l1tTowerCalibration)
 _phase2_siml1emulator.add(l1tCaloJet)
 _phase2_siml1emulator.add(l1tCaloJetHTT)
-_phase2_siml1emulator.add(L1TCaloJetsTausTask)
+_phase2_siml1emulator.add(l1tPhase2CaloJetEmulator)
 
-# Overlap and EndCap Muon Track Finder
-# ########################################################################
-from L1Trigger.L1TMuonOverlapPhase2.simOmtfPhase2Digis_cfi import *
-_phase2_siml1emulator.add(simOmtfPhase2Digis)
-
-from L1Trigger.L1TMuonEndCapPhase2.simCscTriggerPrimitiveDigisForEMTF_cfi import *
-from L1Trigger.L1TMuonEndCapPhase2.rpcRecHitsForEMTF_cfi import *
-from L1Trigger.L1TMuonEndCapPhase2.simEmtfDigisPhase2_cfi import *
-
-_phase2_siml1emulator.add(simCscTriggerPrimitiveDigisForEMTF)
-_phase2_siml1emulator.add(rpcRecHitsForEMTF)
-_phase2_siml1emulator.add(simEmtfDigisPhase2)
 
 # ########################################################################
 # Phase-2 L1T - TrackTrigger dependent modules
@@ -162,27 +150,19 @@ _phase2_siml1emulator.add(l1tVertexFinderEmulator)
 # Emulated GMT Muons (Tk + Stub, Tk + MuonTFT, StandaloneMuon)
 # ########################################################################
 from L1Trigger.Phase2L1GMT.gmt_cfi  import *
-l1tStubsGmt = gmtStubs.clone()
-l1tKMTFMuonsGmt = gmtKMTFMuons.clone(
-  stubs      = cms.InputTag('l1tStubsGmt','kmtf'),
+l1tTkStubsGmt = l1tGMTStubs.clone()
+l1tTkMuonsGmt = l1tGMTMuons.clone(
+    srcStubs  = 'l1tTkStubsGmt'
 )
-l1tFwdMuonsGmt = gmtFwdMuons.clone(
-    stubs  = 'l1tStubsGmt:tps'
-)
-l1tSAMuonsGmt = gmtSAMuons.clone(
-  barrelPrompt      = cms.InputTag('l1tKMTFMuonsGmt:prompt'),
-  barrelDisp        = cms.InputTag('l1tKMTFMuonsGmt:displaced'),
-  forwardPrompt     = cms.InputTag('l1tFwdMuonsGmt:prompt'),
-  forwardDisp     = cms.InputTag('l1tFwdMuonsGmt:displaced')
-)
-l1tTkMuonsGmt = gmtTkMuons.clone(
-    srcStubs  = 'l1tStubsGmt:tps'
-)
-_phase2_siml1emulator.add( l1tStubsGmt )
-_phase2_siml1emulator.add( l1tKMTFMuonsGmt )
-_phase2_siml1emulator.add( l1tFwdMuonsGmt )
-_phase2_siml1emulator.add( l1tSAMuonsGmt )
+l1tSAMuonsGmt = l1tStandaloneMuons.clone()
+_phase2_siml1emulator.add( l1tTkStubsGmt )
 _phase2_siml1emulator.add( l1tTkMuonsGmt )
+_phase2_siml1emulator.add( l1tSAMuonsGmt )
+
+## fix for low-pt muons, this collection is a copy of the l1tTkMuonsGmt collection 
+## in which we only keep those low pt muons with an SA muon associated to it. 
+l1tTkMuonsGmtLowPtFix = l1tGMTFilteredMuons.clone()
+_phase2_siml1emulator.add( l1tTkMuonsGmtLowPtFix )
 
 # Tracker Objects
 # ########################################################################
@@ -191,14 +171,11 @@ from L1Trigger.L1TTrackMatch.l1tTrackFastJets_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackerEtMiss_cfi import *
 from L1Trigger.L1TTrackMatch.l1tTrackerHTMiss_cfi import *
 
-
-
 #Selected and Associated tracks for Jets and Emulated Jets
 _phase2_siml1emulator.add(l1tTrackSelectionProducerForJets)
 _phase2_siml1emulator.add(l1tTrackSelectionProducerExtendedForJets)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerForJets)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerExtendedForJets)
-
 
 #Selected and Associated tracks for EtMiss and Emulated EtMiss
 _phase2_siml1emulator.add(l1tTrackSelectionProducerForEtMiss)
@@ -206,14 +183,12 @@ _phase2_siml1emulator.add(l1tTrackSelectionProducerExtendedForEtMiss)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerForEtMiss)
 _phase2_siml1emulator.add(l1tTrackVertexAssociationProducerExtendedForEtMiss)
 
-
 #Track Jets, Track Only Et Miss, Track Only HT Miss
 _phase2_siml1emulator.add(l1tTrackJets)
 _phase2_siml1emulator.add(l1tTrackJetsExtended)
 _phase2_siml1emulator.add(l1tTrackFastJets)
 _phase2_siml1emulator.add(l1tTrackerEtMiss)
 _phase2_siml1emulator.add(l1tTrackerHTMiss)
-
 
 #Emulated Track Jets, Track Only Et Miss, Track Only HT Miss
 from L1Trigger.L1TTrackMatch.l1tTrackJetsEmulation_cfi import *
@@ -249,8 +224,8 @@ from L1Trigger.L1CaloTrigger.Phase1L1TJets_9x9trimmed_cff import *
 L1TPFJetsPhase1Task_9x9trimmed = cms.Task(  l1tPhase1JetProducer9x9trimmed, l1tPhase1JetCalibrator9x9trimmed, l1tPhase1JetSumsProducer9x9trimmed)
 _phase2_siml1emulator.add(L1TPFJetsPhase1Task_9x9trimmed)
 
-from L1Trigger.Phase2L1ParticleFlow.L1HPSPFTauProducer_cfi import *
-_phase2_siml1emulator.add(l1HPSPFTauEmuProducer)
+from L1Trigger.Phase2L1ParticleFlow.l1tHPSPFTauProducer_cfi import *
+_phase2_siml1emulator.add(l1tHPSPFTauProducer)
 
 # PF MET
 # ########################################################################

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackTripletEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackTripletEmulatorProducer.cc
@@ -277,15 +277,15 @@ void L1TrackTripletEmulatorProducer::produce(Event &iEvent, const EventSetup &iS
 
   if (!event_pass) {
     iEvent.put(std::move(L1TrackTripletContainer), OutputDigisName);
+    iEvent.put(std::move(L1TrackTripletWordContainer), OutputWordName);
     return;
   }
-
   float tripletPx = (pion1 + pion2 + pion3).Pt() * cos((pion1 + pion2 + pion3).Phi());
   float tripletPy = (pion1 + pion2 + pion3).Pt() * sin((pion1 + pion2 + pion3).Phi());
   float tripletPz = (pion1 + pion2 + pion3).Pt() * sinh((pion1 + pion2 + pion3).Eta());
-  float tripletP = (pion1 + pion2 + pion3).Pt() * cosh((pion1 + pion2 + pion3).Eta());
-
-  TkTriplet trkTriplet(math::XYZTLorentzVector(tripletPx, tripletPy, tripletPz, tripletP),
+  float tripletE =
+      sqrt(tripletPx * tripletPx + tripletPy * tripletPy + tripletPz * tripletPz + triplet_mass * triplet_mass);
+  TkTriplet trkTriplet(math::XYZTLorentzVector(tripletPx, tripletPy, tripletPz, tripletE),
                        triplet_charge,
                        pair_masses[0],
                        pair_masses[2],

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -282,6 +282,7 @@ private:
   std::vector<float>* m_gen_phi;
   std::vector<float>* m_gen_pdgid;
   std::vector<float>* m_gen_z0;
+  std::vector<float>* m_gen_mother_pdgid;
 
   // all L1 tracks (prompt)
   std::vector<float>* m_trk_pt;
@@ -308,6 +309,8 @@ private:
   std::vector<int>* m_trk_combinatoric;
   std::vector<int>* m_trk_fake;  //0 fake, 1 track from primary interaction, 2 secondary track
   std::vector<int>* m_trk_matchtp_pdgid;
+  std::vector<int>* m_trk_matchtp_mother_pdgid;
+
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
   std::vector<float>* m_trk_matchtp_phi;
@@ -507,6 +510,30 @@ private:
   std::vector<float>* m_triplet_phi;
   std::vector<float>* m_triplet_eta;
   std::vector<float>* m_triplet_pt;
+  std::vector<float>* m_triplet_mass;
+  std::vector<float>* m_triplet_charge;
+  std::vector<float>* m_triplet_dmassmax;
+  std::vector<float>* m_triplet_dmassmin;
+  std::vector<float>* m_triplet_dzmax;
+  std::vector<float>* m_triplet_dzmin;
+  std::vector<float>* m_triplet_trk1pt;
+  std::vector<float>* m_triplet_trk1eta;
+  std::vector<float>* m_triplet_trk1phi;
+  std::vector<float>* m_triplet_trk1z;
+  std::vector<float>* m_triplet_trk1npar;
+  std::vector<float>* m_triplet_trk1mva;
+  std::vector<float>* m_triplet_trk2pt;
+  std::vector<float>* m_triplet_trk2eta;
+  std::vector<float>* m_triplet_trk2phi;
+  std::vector<float>* m_triplet_trk2z;
+  std::vector<float>* m_triplet_trk2npar;
+  std::vector<float>* m_triplet_trk2mva;
+  std::vector<float>* m_triplet_trk3pt;
+  std::vector<float>* m_triplet_trk3eta;
+  std::vector<float>* m_triplet_trk3phi;
+  std::vector<float>* m_triplet_trk3z;
+  std::vector<float>* m_triplet_trk3npar;
+  std::vector<float>* m_triplet_trk3mva;
 
   std::vector<float>* m_trkjetExt_vz;
   std::vector<float>* m_trkjetExt_p;
@@ -738,6 +765,8 @@ void L1TrackObjectNtupleMaker::endJob() {
   delete m_trk_combinatoric;
   delete m_trk_fake;
   delete m_trk_matchtp_pdgid;
+  delete m_trk_matchtp_mother_pdgid;
+
   delete m_trk_matchtp_pt;
   delete m_trk_matchtp_eta;
   delete m_trk_matchtp_phi;
@@ -821,6 +850,8 @@ void L1TrackObjectNtupleMaker::endJob() {
   delete m_gen_pt;
   delete m_gen_phi;
   delete m_gen_pdgid;
+  delete m_gen_mother_pdgid;
+
   delete m_gen_z0;
 
   delete m_matchtrk_pt;
@@ -901,6 +932,30 @@ void L1TrackObjectNtupleMaker::endJob() {
   delete m_triplet_eta;
   delete m_triplet_phi;
   delete m_triplet_pt;
+  delete m_triplet_mass;
+  delete m_triplet_charge;
+  delete m_triplet_dmassmax;
+  delete m_triplet_dmassmin;
+  delete m_triplet_dzmax;
+  delete m_triplet_dzmin;
+  delete m_triplet_trk1pt;
+  delete m_triplet_trk1eta;
+  delete m_triplet_trk1phi;
+  delete m_triplet_trk1z;
+  delete m_triplet_trk1npar;
+  delete m_triplet_trk1mva;
+  delete m_triplet_trk2pt;
+  delete m_triplet_trk2eta;
+  delete m_triplet_trk2phi;
+  delete m_triplet_trk2z;
+  delete m_triplet_trk2npar;
+  delete m_triplet_trk2mva;
+  delete m_triplet_trk3pt;
+  delete m_triplet_trk3eta;
+  delete m_triplet_trk3phi;
+  delete m_triplet_trk3z;
+  delete m_triplet_trk3npar;
+  delete m_triplet_trk3mva;
 
   delete m_trkfastjet_eta;
   delete m_trkfastjet_vz;
@@ -977,6 +1032,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_trk_combinatoric = new std::vector<int>;
   m_trk_fake = new std::vector<int>;
   m_trk_matchtp_pdgid = new std::vector<int>;
+  m_trk_matchtp_mother_pdgid = new std::vector<int>;
+
   m_trk_matchtp_pt = new std::vector<float>;
   m_trk_matchtp_eta = new std::vector<float>;
   m_trk_matchtp_phi = new std::vector<float>;
@@ -1060,6 +1117,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_gen_pt = new std::vector<float>;
   m_gen_phi = new std::vector<float>;
   m_gen_pdgid = new std::vector<float>;
+  m_gen_mother_pdgid = new std::vector<float>;
+
   m_gen_z0 = new std::vector<float>;
 
   m_matchtrk_pt = new std::vector<float>;
@@ -1133,6 +1192,30 @@ void L1TrackObjectNtupleMaker::beginJob() {
   m_triplet_eta = new std::vector<float>;
   m_triplet_phi = new std::vector<float>;
   m_triplet_pt = new std::vector<float>;
+  m_triplet_mass = new std::vector<float>;
+  m_triplet_charge = new std::vector<float>;
+  m_triplet_dmassmax = new std::vector<float>;
+  m_triplet_dmassmin = new std::vector<float>;
+  m_triplet_dzmax = new std::vector<float>;
+  m_triplet_dzmin = new std::vector<float>;
+  m_triplet_trk1pt = new std::vector<float>;
+  m_triplet_trk1eta = new std::vector<float>;
+  m_triplet_trk1phi = new std::vector<float>;
+  m_triplet_trk1z = new std::vector<float>;
+  m_triplet_trk1npar = new std::vector<float>;
+  m_triplet_trk1mva = new std::vector<float>;
+  m_triplet_trk2pt = new std::vector<float>;
+  m_triplet_trk2eta = new std::vector<float>;
+  m_triplet_trk2phi = new std::vector<float>;
+  m_triplet_trk2z = new std::vector<float>;
+  m_triplet_trk2npar = new std::vector<float>;
+  m_triplet_trk2mva = new std::vector<float>;
+  m_triplet_trk3pt = new std::vector<float>;
+  m_triplet_trk3eta = new std::vector<float>;
+  m_triplet_trk3phi = new std::vector<float>;
+  m_triplet_trk3z = new std::vector<float>;
+  m_triplet_trk3npar = new std::vector<float>;
+  m_triplet_trk3mva = new std::vector<float>;
 
   m_trkjetem_pt = new std::vector<float>;
   m_trkjetem_phi = new std::vector<float>;
@@ -1204,6 +1287,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("trk_combinatoric", &m_trk_combinatoric);
     eventTree->Branch("trk_fake", &m_trk_fake);
     eventTree->Branch("trk_matchtp_pdgid", &m_trk_matchtp_pdgid);
+    eventTree->Branch("trk_matchtp_mother_pdgid", &m_trk_matchtp_mother_pdgid);
+
     eventTree->Branch("trk_matchtp_pt", &m_trk_matchtp_pt);
     eventTree->Branch("trk_matchtp_eta", &m_trk_matchtp_eta);
     eventTree->Branch("trk_matchtp_phi", &m_trk_matchtp_phi);
@@ -1355,6 +1440,8 @@ void L1TrackObjectNtupleMaker::beginJob() {
   eventTree->Branch("gen_pt", &m_gen_pt);
   eventTree->Branch("gen_phi", &m_gen_phi);
   eventTree->Branch("gen_pdgid", &m_gen_pdgid);
+  eventTree->Branch("gen_mother_pdgid", &m_gen_mother_pdgid);
+
   eventTree->Branch("gen_z0", &m_gen_z0);
 
   if (SaveTrackJets) {
@@ -1387,6 +1474,31 @@ void L1TrackObjectNtupleMaker::beginJob() {
     eventTree->Branch("triplet_eta", &m_triplet_eta);
     eventTree->Branch("triplet_pt", &m_triplet_pt);
     eventTree->Branch("triplet_phi", &m_triplet_phi);
+    eventTree->Branch("triplet_mass", &m_triplet_mass);
+    eventTree->Branch("triplet_charge", &m_triplet_charge);
+    eventTree->Branch("triplet_dmassmax", &m_triplet_dmassmax);
+    eventTree->Branch("triplet_dmassmin", &m_triplet_dmassmin);
+    eventTree->Branch("triplet_dzmax", &m_triplet_dzmax);
+    eventTree->Branch("triplet_dzmin", &m_triplet_dzmin);
+    eventTree->Branch("triplet_trk1pt", &m_triplet_trk1pt);
+    eventTree->Branch("triplet_trk1eta", &m_triplet_trk1eta);
+    eventTree->Branch("triplet_trk1phi", &m_triplet_trk1phi);
+    eventTree->Branch("triplet_trk1z", &m_triplet_trk1z);
+    eventTree->Branch("triplet_trk1npar", &m_triplet_trk1npar);
+    eventTree->Branch("triplet_trk1mva", &m_triplet_trk1mva);
+    eventTree->Branch("triplet_trk2pt", &m_triplet_trk2pt);
+    eventTree->Branch("triplet_trk2eta", &m_triplet_trk2eta);
+    eventTree->Branch("triplet_trk2phi", &m_triplet_trk2phi);
+    eventTree->Branch("triplet_trk2z", &m_triplet_trk2z);
+    eventTree->Branch("triplet_trk2npar", &m_triplet_trk2npar);
+    eventTree->Branch("triplet_trk2mva", &m_triplet_trk2mva);
+    eventTree->Branch("triplet_trk3pt", &m_triplet_trk3pt);
+    eventTree->Branch("triplet_trk3eta", &m_triplet_trk3eta);
+    eventTree->Branch("triplet_trk3phi", &m_triplet_trk3phi);
+    eventTree->Branch("triplet_trk3z", &m_triplet_trk3z);
+    eventTree->Branch("triplet_trk3npar", &m_triplet_trk3npar);
+    eventTree->Branch("triplet_trk3mva", &m_triplet_trk3mva);
+
     if (Displaced == "Displaced" || Displaced == "Both") {
       eventTree->Branch("trkfastjetExt_eta", &m_trkfastjetExt_eta);
       eventTree->Branch("trkfastjetExt_vz", &m_trkfastjetExt_vz);
@@ -1480,6 +1592,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_trk_combinatoric->clear();
     m_trk_fake->clear();
     m_trk_matchtp_pdgid->clear();
+    m_trk_matchtp_mother_pdgid->clear();
+
     m_trk_matchtp_pt->clear();
     m_trk_matchtp_eta->clear();
     m_trk_matchtp_phi->clear();
@@ -1564,6 +1678,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
   m_gen_pt->clear();
   m_gen_phi->clear();
   m_gen_pdgid->clear();
+  m_gen_mother_pdgid->clear();
+
   m_gen_z0->clear();
 
   if (Displaced == "Prompt" || Displaced == "Both") {
@@ -1652,6 +1768,31 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     m_triplet_eta->clear();
     m_triplet_pt->clear();
     m_triplet_phi->clear();
+    m_triplet_mass->clear();
+    m_triplet_charge->clear();
+    m_triplet_dmassmax->clear();
+    m_triplet_dmassmin->clear();
+    m_triplet_dzmax->clear();
+    m_triplet_dzmin->clear();
+    m_triplet_trk1pt->clear();
+    m_triplet_trk1eta->clear();
+    m_triplet_trk1phi->clear();
+    m_triplet_trk1z->clear();
+    m_triplet_trk1npar->clear();
+    m_triplet_trk1mva->clear();
+    m_triplet_trk2pt->clear();
+    m_triplet_trk2eta->clear();
+    m_triplet_trk2phi->clear();
+    m_triplet_trk2z->clear();
+    m_triplet_trk2npar->clear();
+    m_triplet_trk2mva->clear();
+    m_triplet_trk3pt->clear();
+    m_triplet_trk3eta->clear();
+    m_triplet_trk3phi->clear();
+    m_triplet_trk3z->clear();
+    m_triplet_trk3npar->clear();
+    m_triplet_trk3mva->clear();
+
     if (Displaced == "Displaced" || Displaced == "Both") {
       m_trkjetExt_eta->clear();
       m_trkjetExt_pt->clear();
@@ -1859,6 +2000,12 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_gen_pt->push_back(genpartIter->pt());
       m_gen_phi->push_back(genpartIter->phi());
       m_gen_pdgid->push_back(genpartIter->pdgId());
+      if (genpartIter->numberOfMothers() > 0) {
+        m_gen_mother_pdgid->push_back(genpartIter->mother(0)->pdgId());
+      } else {
+        m_gen_mother_pdgid->push_back(-999);
+      }
+
       m_gen_z0->push_back(zvtx_gen);
     }
 
@@ -1978,7 +2125,6 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     for (iterL1Track = TTTrackHandle->begin(); iterL1Track != TTTrackHandle->end(); iterL1Track++) {
       L1TrackPtr l1track_ptr(TTTrackHandle, this_l1track);
       L1TrackRef l1track_ref(TTTrackGTTHandle, this_l1track);
-      this_l1track++;
 
       float tmp_trk_pt = iterL1Track->momentum().perp();
       float tmp_trk_eta = iterL1Track->momentum().eta();
@@ -2106,6 +2252,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
       int myFake = 0;
       int myTP_pdgid = -999;
+      int myTP_mother_pdgid = -999;
+
       float myTP_pt = -999;
       float myTP_eta = -999;
       float myTP_phi = -999;
@@ -2122,6 +2270,9 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
           myFake = 1;
 
         myTP_pdgid = my_tp->pdgId();
+        if (my_tp->genParticles().size() > 0) {
+          myTP_mother_pdgid = my_tp->genParticles().at(0)->mother(0)->pdgId();
+        }
         myTP_pt = my_tp->p4().pt();
         myTP_eta = my_tp->p4().eta();
         myTP_phi = my_tp->p4().phi();
@@ -2141,6 +2292,8 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
 
       m_trk_fake->push_back(myFake);
       m_trk_matchtp_pdgid->push_back(myTP_pdgid);
+      m_trk_matchtp_mother_pdgid->push_back(myTP_mother_pdgid);
+
       m_trk_matchtp_pt->push_back(myTP_pt);
       m_trk_matchtp_eta->push_back(myTP_eta);
       m_trk_matchtp_phi->push_back(myTP_phi);
@@ -2153,25 +2306,32 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trk_gtt_pt->push_back(l1track_ref->momentum().perp());
       m_trk_gtt_eta->push_back(l1track_ref->momentum().eta());
       m_trk_gtt_phi->push_back(l1track_ref->momentum().phi());
-      m_trk_selected_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackSelectedHandle));
-      m_trk_selected_emulation_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationHandle));
-      m_trk_selected_associated_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedHandle));
-      m_trk_selected_associated_emulation_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationHandle));
-      m_trk_selected_forjets_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackSelectedForJetsHandle));
-      m_trk_selected_emulation_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationForJetsHandle));
-      m_trk_selected_associated_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedForJetsHandle));
-      m_trk_selected_associated_emulation_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationForJetsHandle));
-      m_trk_selected_foretmiss_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackSelectedForEtMissHandle));
-      m_trk_selected_emulation_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationForEtMissHandle));
-      m_trk_selected_associated_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedForEtMissHandle));
-      m_trk_selected_associated_emulation_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationForEtMissHandle));
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedHandle) >= 0)
+        m_trk_selected_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationHandle) >= 0)
+        m_trk_selected_emulation_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedHandle) >= 0)
+        m_trk_selected_associated_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationHandle) >= 0)
+        m_trk_selected_associated_emulation_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedForJetsHandle) >= 0)
+        m_trk_selected_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationForJetsHandle) >= 0)
+        m_trk_selected_emulation_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedForJetsHandle) >= 0)
+        m_trk_selected_associated_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationForJetsHandle) >= 0)
+        m_trk_selected_associated_emulation_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedForEtMissHandle) >= 0)
+        m_trk_selected_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedEmulationForEtMissHandle) >= 0)
+        m_trk_selected_emulation_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedForEtMissHandle) >= 0)
+        m_trk_selected_associated_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackSelectedAssociatedEmulationForEtMissHandle) >= 0)
+        m_trk_selected_associated_emulation_foretmiss_index->push_back(this_l1track);
+
+      this_l1track++;
     }  //end track loop
   }    //end if SaveAllTracks
 
@@ -3011,6 +3171,30 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_triplet_phi->push_back(tripletIter->phi());
       m_triplet_eta->push_back(tripletIter->eta());
       m_triplet_pt->push_back(tripletIter->pt());
+      m_triplet_mass->push_back(tripletIter->mass());
+      m_triplet_charge->push_back(tripletIter->getTripletCharge());
+      m_triplet_dmassmax->push_back(tripletIter->getPairMassMax());
+      m_triplet_dmassmin->push_back(tripletIter->getPairMassMin());
+      m_triplet_dzmax->push_back(tripletIter->getPairDzMax());
+      m_triplet_dzmin->push_back(tripletIter->getPairDzMin());
+      m_triplet_trk1pt->push_back(tripletIter->trkPtr(0)->momentum().perp());
+      m_triplet_trk1eta->push_back(tripletIter->trkPtr(0)->momentum().eta());
+      m_triplet_trk1phi->push_back(tripletIter->trkPtr(0)->momentum().phi());
+      m_triplet_trk1z->push_back(tripletIter->trkPtr(0)->z0());
+      m_triplet_trk1npar->push_back(tripletIter->trkPtr(0)->nFitPars());
+      m_triplet_trk1mva->push_back(tripletIter->trkPtr(0)->trkMVA1());
+      m_triplet_trk2pt->push_back(tripletIter->trkPtr(1)->momentum().perp());
+      m_triplet_trk2eta->push_back(tripletIter->trkPtr(1)->momentum().eta());
+      m_triplet_trk2phi->push_back(tripletIter->trkPtr(1)->momentum().phi());
+      m_triplet_trk2z->push_back(tripletIter->trkPtr(1)->z0());
+      m_triplet_trk2npar->push_back(tripletIter->trkPtr(1)->nFitPars());
+      m_triplet_trk2mva->push_back(tripletIter->trkPtr(1)->trkMVA1());
+      m_triplet_trk3pt->push_back(tripletIter->trkPtr(2)->momentum().perp());
+      m_triplet_trk3eta->push_back(tripletIter->trkPtr(2)->momentum().eta());
+      m_triplet_trk3phi->push_back(tripletIter->trkPtr(2)->momentum().phi());
+      m_triplet_trk3z->push_back(tripletIter->trkPtr(2)->z0());
+      m_triplet_trk3npar->push_back(tripletIter->trkPtr(2)->nFitPars());
+      m_triplet_trk3mva->push_back(tripletIter->trkPtr(2)->trkMVA1());
     }
     if (TrackJetsExtendedHandle.isValid() && (Displaced == "Displaced" || Displaced == "Both")) {
       for (jetIter = TrackJetsExtendedHandle->begin(); jetIter != TrackJetsExtendedHandle->end(); ++jetIter) {


### PR DESCRIPTION
Fixed few small bugs on l1 track triplet code. Those consists of:
1) Small improvement in data formats adding one liners in header
2) Fix in a calculation of energy
3) Add empty container in case no triplet is found for the HW-like output

This PR is also made in l1t-offline
