### PR TITLE
[14_0_X] Add orbitNumber to NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -85,12 +85,14 @@ private:
       tree.Branch("luminosityBlock", &m_luminosityBlock, "luminosityBlock/i");
       tree.Branch("event", &m_event, "event/l");
       tree.Branch("bunchCrossing", &m_bunchCrossing, "bunchCrossing/i");
+      tree.Branch("orbitNumber", &m_orbitNumber, "orbitNumber/i");
     }
     void fill(const edm::EventAuxiliary& aux) {
       m_run = aux.id().run();
       m_luminosityBlock = aux.id().luminosityBlock();
       m_event = aux.id().event();
       m_bunchCrossing = aux.bunchCrossing();
+      m_orbitNumber = aux.orbitNumber();
     }
 
   private:
@@ -98,6 +100,7 @@ private:
     UInt_t m_luminosityBlock;
     ULong64_t m_event;
     UInt_t m_bunchCrossing;
+    UInt_t m_orbitNumber;
   } m_commonBranches;
 
   class CommonLumiBranches {


### PR DESCRIPTION
#### PR description:

Add orbitNumber to NanoAOD as requested by ECAL for selecting BXs after calibration triggers.

Backport of https://github.com/cms-sw/cmssw/pull/44667.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
