### PR TITLE
Add reduced lepton time-life info to NanoAOD (14_0_X)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -182,7 +182,7 @@ steps['BTVNANO_data13.0']=merge([{'-s' : 'NANO:@BTV',
 steps['jmeNano_data13.0'] = merge([{'-s':'NANO:@JME', '-n' : '1000'},
                                   steps['NANO_data13.0']])
 
-steps['lepTimeLifeNANO_data13.0']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM',
+steps['lepTrackInfoNANO_data13.0']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
                                           '-n' : '1000'},
                                          steps['NANO_data13.0']])
 
@@ -207,7 +207,7 @@ steps['BTVNANO_mc13.2']=merge([{'-s' : 'NANO:@BTV',
 steps['jmeNANO_mc13.2']=merge([{'-s' : 'NANO:@JME ', '-n' : '1000'},
                                      steps['NANO_mc13.2']])
 
-steps['lepTimeLifeNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTimeLife,DQM:@nanoAODDQM',
+steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
                                         '-n' : '1000'},
                                        steps['NANO_mc13.2']])
 
@@ -264,7 +264,7 @@ workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGNANO
 workflows[_wfn()] = ['muPOGNANO130Xrun3', ['MuonEG2023MINIAOD13.0', 'muPOGNANO_data13.0']]
 workflows[_wfn()] = ['EGMNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'EGMNano_data13.0']]
 workflows[_wfn()] = ['jmeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNano_data13.0']]
-workflows[_wfn()] = ['lepTimeLifeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTimeLifeNANO_data13.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTrackInfoNANO_data13.0']]
 workflows[_wfn()] = ['BTVNANO_data130Xrun3', ['MuonEG2023MINIAOD13.0', 'BTVNANO_data13.0']]
 
 _wfn.next()
@@ -274,7 +274,7 @@ workflows[_wfn()] = ['NANOmc132X', ['TTBarMINIAOD13.2', 'NANO_mc13.2', 'HRV_NANO
 workflows[_wfn()] = ['muPOGNANOmc132X', ['TTBarMINIAOD13.2', 'muPOGNANO_mc13.2']]
 workflows[_wfn()] = ['EGMNANOmc132X', ['TTBarMINIAOD13.2', 'EGMNano_mc13.2']]
 workflows[_wfn()] = ['jmeNANOmc132X', ['TTBarMINIAOD13.2', 'jmeNANO_mc13.2']]
-workflows[_wfn()] = ['lepTimeLifeNANOmc132X', ['TTBarMINIAOD13.2', 'lepTimeLifeNANO_mc13.2']]
+workflows[_wfn()] = ['lepTrackInfoNANOmc132X', ['TTBarMINIAOD13.2', 'lepTrackInfoNANO_mc13.2']]
 workflows[_wfn()] = ['BTVNANO_mc132X', ['TTBarMINIAOD13.2', 'BTVNANO_mc13.2']]
 
 _wfn.next()

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -47,9 +47,9 @@ autoNANO = {
     # PromptReco config: PHYS+L1
     'Prompt' : {'sequence': '@PHYS',
                 'customize': '@PHYS+@L1'},
-    # Add lepton time-life info tables through customize combined with PHYS
-    'LepTimeLife' : {'sequence': '@PHYS',
-                     'customize': '@PHYS+PhysicsTools/NanoAOD/leptonTimeLifeInfo_common_cff.addTimeLifeInfo'},
+    # Add lepton track parameters through customize combined with PHYS
+    'LepTrackInfo' : {'sequence': '@PHYS',
+                      'customize': '@PHYS+PhysicsTools/NanoAOD/leptonTimeLifeInfo_common_cff.addTrackVarsToTimeLifeInfo'},
     # Custom BTV Nano for SF measurements or tagger training
     'BTV' : {'sequence': '@PHYS',
              'customize':'@PHYS+PhysicsTools/NanoAOD/custom_btv_cff.BTVCustomNanoAOD'}

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -265,6 +265,10 @@ def nanoAOD_customizeCommon(process):
         process, lambda p : nanoAOD_addBoostedTauIds(p, nanoAOD_boostedTau_switch.idsToAdd.value())
     )
 
+    # Add lepton time-life info
+    from PhysicsTools.NanoAOD.leptonTimeLifeInfo_common_cff import addTimeLifeInfoBase
+    process = addTimeLifeInfoBase(process)
+
     return process
 
 ###increasing the precision of selected GenParticles.


### PR DESCRIPTION
#### PR description:

This PR adds base lepton time-life info to common (Phys) NanoAOD tables while lepton track parameters can be added through customization.
This is backport of #44637 to 14_0_X; further details in the original PR.

#### PR validation:

Tested with the standard nanoAOD workflow.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44637 for 2024 nanoAOD.