### PR TITLE
Fix crash in PF Clustering due to empty HCAL RecHits collection

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LegacyPFClusterProducer.cc
@@ -198,44 +198,44 @@ void LegacyPFClusterProducer::produce(edm::Event& event, const edm::EventSetup& 
   auto const& pfRecHitFractionSoA = event.get(pfRecHitFractionSoAToken_).const_view();
 
   int nRH = 0;
-    if (pfRecHits->metadata().size() != 0)
-      nRH = pfRecHits.view().size();
+  if (pfRecHits->metadata().size() != 0)
+    nRH = pfRecHits.view().size();
   reco::PFClusterCollection out;
   out.reserve(nRH);
 
   auto const rechitsHandle = event.getHandle(recHitsLabel_);
-    
+
   if (nRH != 0) {
-      // Build PFClusters in legacy format
-      std::vector<int> nTopoSeeds(nRH, 0);
+    // Build PFClusters in legacy format
+    std::vector<int> nTopoSeeds(nRH, 0);
 
-      for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
-        nTopoSeeds[pfClusterSoA[i].topoId()]++;
+    for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
+      nTopoSeeds[pfClusterSoA[i].topoId()]++;
+    }
+
+    // Looping over SoA PFClusters to produce legacy PFCluster collection
+    for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
+      unsigned int n = pfClusterSoA[i].seedRHIdx();
+      reco::PFCluster temp;
+      temp.setSeed((*rechitsHandle)[n].detId());  // Pulling the detId of this PFRecHit from the legacy format input
+      int offset = pfClusterSoA[i].rhfracOffset();
+      for (int k = offset; k < (offset + pfClusterSoA[i].rhfracSize()) && k >= 0;
+           k++) {  // Looping over PFRecHits in the same topo cluster
+        if (pfRecHitFractionSoA[k].pfrhIdx() < nRH && pfRecHitFractionSoA[k].pfrhIdx() > -1 &&
+            pfRecHitFractionSoA[k].frac() > 0.0) {
+          const reco::PFRecHitRef& refhit = reco::PFRecHitRef(rechitsHandle, pfRecHitFractionSoA[k].pfrhIdx());
+          temp.addRecHitFraction(reco::PFRecHitFraction(refhit, pfRecHitFractionSoA[k].frac()));
+        }
       }
 
-      // Looping over SoA PFClusters to produce legacy PFCluster collection
-      for (int i = 0; i < pfClusterSoA.nSeeds(); i++) {
-        unsigned int n = pfClusterSoA[i].seedRHIdx();
-        reco::PFCluster temp;
-        temp.setSeed((*rechitsHandle)[n].detId());  // Pulling the detId of this PFRecHit from the legacy format input
-        int offset = pfClusterSoA[i].rhfracOffset();
-        for (int k = offset; k < (offset + pfClusterSoA[i].rhfracSize()) && k >= 0;
-             k++) {  // Looping over PFRecHits in the same topo cluster
-          if (pfRecHitFractionSoA[k].pfrhIdx() < nRH && pfRecHitFractionSoA[k].pfrhIdx() > -1 &&
-              pfRecHitFractionSoA[k].frac() > 0.0) {
-            const reco::PFRecHitRef& refhit = reco::PFRecHitRef(rechitsHandle, pfRecHitFractionSoA[k].pfrhIdx());
-            temp.addRecHitFraction(reco::PFRecHitFraction(refhit, pfRecHitFractionSoA[k].frac()));
-          }
-        }
-
-        // Now PFRecHitFraction of this PFCluster is set. Now compute calculateAndSetPosition (energy, position etc)
-        if (nTopoSeeds[pfClusterSoA[i].topoId()] == 1 && allCellsPositionCalc_) {
-          allCellsPositionCalc_->calculateAndSetPosition(temp, paramPF);
-        } else {
-          positionCalc_->calculateAndSetPosition(temp, paramPF);
-        }
-        out.emplace_back(std::move(temp));
+      // Now PFRecHitFraction of this PFCluster is set. Now compute calculateAndSetPosition (energy, position etc)
+      if (nTopoSeeds[pfClusterSoA[i].topoId()] == 1 && allCellsPositionCalc_) {
+        allCellsPositionCalc_->calculateAndSetPosition(temp, paramPF);
+      } else {
+        positionCalc_->calculateAndSetPosition(temp, paramPF);
       }
+      out.emplace_back(std::move(temp));
+    }
   }
 
   event.emplace(legacyPfClustersToken_, std::move(out));

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -29,16 +29,20 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       const reco::PFClusterParamsDeviceCollection& params = setup.getData(pfClusParamsToken);
       const reco::PFRecHitHCALTopologyDeviceCollection& topology = setup.getData(topologyToken_);
       const reco::PFRecHitHostCollection& pfRecHits = event.get(inputPFRecHitSoA_Token_);
-      const int nRH = pfRecHits->size();
+      int nRH = 0;
+      if (pfRecHits->metadata().size() != 0)
+        nRH = pfRecHits->size();
 
       reco::PFClusteringVarsDeviceCollection pfClusteringVars{nRH, event.queue()};
       reco::PFClusteringEdgeVarsDeviceCollection pfClusteringEdgeVars{(nRH * 8), event.queue()};
       reco::PFClusterDeviceCollection pfClusters{nRH, event.queue()};
       reco::PFRecHitFractionDeviceCollection pfrhFractions{nRH * pfRecHitFractionAllocation_, event.queue()};
 
-      PFClusterProducerKernel kernel(event.queue(), pfRecHits);
-      kernel.execute(
-          event.queue(), params, topology, pfClusteringVars, pfClusteringEdgeVars, pfRecHits, pfClusters, pfrhFractions);
+      if (nRH != 0) {
+        PFClusterProducerKernel kernel(event.queue(), pfRecHits);
+        kernel.execute(
+            event.queue(), params, topology, pfClusteringVars, pfClusteringEdgeVars, pfRecHits, pfClusters, pfrhFractions);
+      }
 
       if (synchronise_)
         alpaka::wait(event.queue());

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -40,8 +40,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       if (nRH != 0) {
         PFClusterProducerKernel kernel(event.queue(), pfRecHits);
-        kernel.execute(
-            event.queue(), params, topology, pfClusteringVars, pfClusteringEdgeVars, pfRecHits, pfClusters, pfrhFractions);
+        kernel.execute(event.queue(),
+                       params,
+                       topology,
+                       pfClusteringVars,
+                       pfClusteringEdgeVars,
+                       pfRecHits,
+                       pfClusters,
+                       pfrhFractions);
       }
 
       if (synchronise_)

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -55,27 +55,27 @@ void LegacyPFRecHitProducer::produce(edm::Event& event, const edm::EventSetup& s
 
   reco::PFRecHitCollection out;
   int reserveSize = 0;
-  if (alpakaPfRecHits.metadata().size() != 0) 
-      reserveSize = alpakaPfRecHits.size();
+  if (alpakaPfRecHits.metadata().size() != 0)
+    reserveSize = alpakaPfRecHits.size();
   out.reserve(reserveSize);
 
   if (alpakaPfRecHits.metadata().size() != 0) {
-      for (size_t i = 0; i < alpakaPfRecHits.size(); i++) {
-        reco::PFRecHit& pfrh =
-            out.emplace_back(caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),
-                             alpakaPfRecHits[i].detId(),
-                             alpakaPfRecHits[i].layer(),
-                             alpakaPfRecHits[i].energy());
-        pfrh.setTime(alpakaPfRecHits[i].time());
-        pfrh.setDepth(alpakaPfRecHits[i].depth());
+    for (size_t i = 0; i < alpakaPfRecHits.size(); i++) {
+      reco::PFRecHit& pfrh =
+          out.emplace_back(caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),
+                           alpakaPfRecHits[i].detId(),
+                           alpakaPfRecHits[i].layer(),
+                           alpakaPfRecHits[i].energy());
+      pfrh.setTime(alpakaPfRecHits[i].time());
+      pfrh.setDepth(alpakaPfRecHits[i].depth());
 
-        // order in Alpaka:   N, S, E, W,NE,SW,SE,NW
-        const short eta[8] = {0, 0, 1, -1, 1, -1, 1, -1};
-        const short phi[8] = {1, -1, 0, 0, 1, -1, -1, 1};
-        for (size_t k = 0; k < 8; k++)
-          if (alpakaPfRecHits[i].neighbours()(k) != -1)
-            pfrh.addNeighbour(eta[k], phi[k], 0, alpakaPfRecHits[i].neighbours()(k));
-      }
+      // order in Alpaka:   N, S, E, W,NE,SW,SE,NW
+      const short eta[8] = {0, 0, 1, -1, 1, -1, 1, -1};
+      const short phi[8] = {1, -1, 0, 0, 1, -1, -1, 1};
+      for (size_t k = 0; k < 8; k++)
+        if (alpakaPfRecHits[i].neighbours()(k) != -1)
+          pfrh.addNeighbour(eta[k], phi[k], 0, alpakaPfRecHits[i].neighbours()(k));
+    }
   }
 
   event.emplace(legacyPfRecHitsToken_, out);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/LegacyPFRecHitProducer.cc
@@ -54,12 +54,9 @@ void LegacyPFRecHitProducer::produce(edm::Event& event, const edm::EventSetup& s
   const reco::PFRecHitHostCollection::ConstView& alpakaPfRecHits = pfRecHitsAlpakaSoA.const_view();
 
   reco::PFRecHitCollection out;
-  int reserveSize = 0;
-  if (alpakaPfRecHits.metadata().size() != 0)
-    reserveSize = alpakaPfRecHits.size();
-  out.reserve(reserveSize);
 
   if (alpakaPfRecHits.metadata().size() != 0) {
+    out.reserve(alpakaPfRecHits.size());
     for (size_t i = 0; i < alpakaPfRecHits.size(); i++) {
       reco::PFRecHit& pfrh =
           out.emplace_back(caloGeo_.at(alpakaPfRecHits[i].layer())->getGeometry(alpakaPfRecHits[i].detId()),

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -38,11 +38,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         num_recHits += event.get(token.first)->metadata().size();
 
       reco::PFRecHitDeviceCollection pfRecHits{(int)num_recHits, event.queue()};
-    
+
       if (pfRecHits->metadata().size() != 0) {
         PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
         for (const auto& token : recHitsToken_)
-            kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
+          kernel.processRecHits(
+              event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
         kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
       }
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -39,7 +39,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       reco::PFRecHitDeviceCollection pfRecHits{(int)num_recHits, event.queue()};
 
-      if (pfRecHits->metadata().size() != 0) {
+      if (num_recHits != 0) {
         PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
         for (const auto& token : recHitsToken_)
           kernel.processRecHits(

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -38,11 +38,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         num_recHits += event.get(token.first)->metadata().size();
 
       reco::PFRecHitDeviceCollection pfRecHits{(int)num_recHits, event.queue()};
-
-      PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
-      for (const auto& token : recHitsToken_)
-        kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
-      kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
+    
+      if (pfRecHits->metadata().size() != 0) {
+        PFRecHitProducerKernel<CAL> kernel{event.queue(), num_recHits};
+        for (const auto& token : recHitsToken_)
+            kernel.processRecHits(event.queue(), event.get(token.first), setup.getData(token.second), topology, pfRecHits);
+        kernel.associateTopologyInfo(event.queue(), topology, pfRecHits);
+      }
 
       if (synchronise_)
         alpaka::wait(event.queue());


### PR DESCRIPTION
#### PR description:

This fix addresses https://github.com/cms-sw/cmssw/issues/44668 where Alpaka-based PF Clustering was crashing at HLT when HCAL is off. The reason was due to the input HCAL RecHit number being used to specify the work division for kernels, and it was not protected against a case of requesting 0 blocks when there are no RecHits.

Included now are checks on the number of rechits and the SoA size to only launch the Alpaka kernels if they are non-zero.

#### PR validation:

In `14_1_0_pre2`, tested on matrix workflows `12434.422, 12434.424`. The missing HCAL validation for HLT is done in the backport.