### PR TITLE
[14_0_X] Removed pixelLayers requirement in MuonSelectors.cc

### DIFF
--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -867,8 +867,7 @@ bool muon::isLooseTriggerMuon(const reco::Muon& muon) {
   bool tk_id = muon::isGoodMuon(muon, TMOneStationTight);
   if (not tk_id)
     return false;
-  bool layer_requirements = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-                            muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
+  bool layer_requirements = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5;
   bool match_requirements =
       (muon.expectedNnumberOfMatchedStations() < 2) or (muon.numberOfMatchedStations() > 1) or (muon.pt() < 8);
   return layer_requirements and match_requirements;


### PR DESCRIPTION
#### PR description:

Removed pixelLayers requirement in loose muon Trigger ID to improve the efficiency for low pt muons.

HLT efficiency, rate, and timing estimates are given at https://its.cern.ch/jira/browse/CMSHLT-3079

#### PR validation:

https://its.cern.ch/jira/browse/CMSHLT-3079

@cmssw/hlt-l2

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/44692