### PR TITLE
[14_0_X] Workaround to produce exactly same data products in Serial and CUDA backends in Alpaka modules possibly used at HLT

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
@@ -64,6 +64,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         fedsToUnpack_{ps.getParameter<std::vector<int>>("FEDs")} {
     config_.maxChannelsEB = ps.getParameter<uint32_t>("maxChannelsEB");
     config_.maxChannelsEE = ps.getParameter<uint32_t>("maxChannelsEE");
+
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>",
+                        ps.getParameter<std::string>("digisLabelEB"));
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>",
+                        ps.getParameter<std::string>("digisLabelEE"));
+#endif
   }
 
   void EcalRawToDigiPortable::produce(device::Event& event, device::EventSetup const& setup) {

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -57,6 +57,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       return ProducerBaseAdaptor<ProducerBase, Tr>(*this, std::move(instanceName));
     }
 
+    // For a workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+    void producesTemporarily(std::string const& iTypeName, std::string instanceName = std::string()) {
+      auto td = edm::TypeWithDict::byName(iTypeName);
+      Base::template produces<edm::Transition::Event>(edm::TypeID(td.typeInfo()), std::move(instanceName));
+    }
+
     static void prevalidate(edm::ConfigurationDescriptions& descriptions) {
       Base::prevalidate(descriptions);
       cms::alpakatools::module_backend_config(descriptions);

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
@@ -87,6 +87,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         multifitParametersToken_{esConsumes()},
         ebDigisSizeHostBuf_{cms::alpakatools::make_host_buffer<uint32_t>()},
         eeDigisSizeHostBuf_{cms::alpakatools::make_host_buffer<uint32_t>()} {
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>",
+                        ps.getParameter<std::string>("recHitsLabelEB"));
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>",
+                        ps.getParameter<std::string>("recHitsLabelEE"));
+#endif
+
     std::pair<double, double> EBtimeFitLimits, EEtimeFitLimits;
     EBtimeFitLimits.first = ps.getParameter<double>("EBtimeFitLimits_Lower");
     EBtimeFitLimits.second = ps.getParameter<double>("EBtimeFitLimits_Upper");

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -94,6 +94,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronGain_L1")),
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronOffset")),
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronOffset_L1"))} {
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelDigisSoACollection>");
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelDigiErrorsSoACollection>");
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelClustersSoACollection>");
+#endif
+
     if (includeErrors_) {
       digiErrorPutToken_ = produces();
       fmtErrorToken_ = produces();

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -60,7 +60,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         tBeamSpot(consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))),
         tokenClusters_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
         tokenDigi_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
-        tokenHit_(produces()) {}
+        tokenHit_(produces()) {
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1>) {
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAPhase1>");
+    }
+#endif
+  }
 
   template <typename TrackerTraits>
   void SiPixelRecHitAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -23,7 +23,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           outputPFClusterSoA_Token_{produces()},
           outputPFRHFractionSoA_Token_{produces()},
           synchronise_(config.getParameter<bool>("synchronise")),
-          pfRecHitFractionAllocation_(config.getParameter<int>("pfRecHitFractionAllocation")) {}
+          pfRecHitFractionAllocation_(config.getParameter<int>("pfRecHitFractionAllocation")) {
+      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFClusterDeviceCollection>");
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFRecHitFractionDeviceCollection>");
+#endif
+    }
 
     void produce(device::Event& event, device::EventSetup const& setup) override {
       const reco::PFClusterParamsDeviceCollection& params = setup.getData(pfClusParamsToken);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -25,7 +25,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     CaloRecHitSoAProducer(edm::ParameterSet const& config)
         : recHitsToken_(consumes(config.getParameter<edm::InputTag>("src"))),
           deviceToken_(produces()),
-          synchronise_(config.getUntrackedParameter<bool>("synchronise")) {}
+          synchronise_(config.getUntrackedParameter<bool>("synchronise")) {
+      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::CaloRecHitDeviceCollection>");
+#endif
+    }
 
     void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {
       const edm::SortedCollection<typename CAL::CaloRecHitType>& recHits = event.get(recHitsToken_);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -22,6 +22,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
           pfRecHitsToken_(produces()),
           synchronise_(config.getUntrackedParameter<bool>("synchronise")) {
+      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFRecHitDeviceCollection>");
+#endif
+
       const std::vector<edm::ParameterSet> producers = config.getParameter<std::vector<edm::ParameterSet>>("producers");
       recHitsToken_.reserve(producers.size());
       for (const edm::ParameterSet& producer : producers) {

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
@@ -58,7 +58,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
         tokenHit_(consumes(iConfig.getParameter<edm::InputTag>("pixelRecHitSrc"))),
         tokenTrack_(produces()),
-        deviceAlgo_(iConfig) {}
+        deviceAlgo_(iConfig) {
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1>) {
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase1>");
+    }
+#endif
+  }
 
   template <typename TrackerTraits>
   void CAHitNtupletAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoTracker/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
+++ b/RecoTracker/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
@@ -64,7 +64,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ptMin_(conf.getParameter<double>("PtMin")),  // 0.5 GeV
         ptMax_(conf.getParameter<double>("PtMax")),  // 75. Onsumes
         tokenDeviceTrack_(consumes(conf.getParameter<edm::InputTag>("pixelTrackSrc"))),
-        tokenDeviceVertex_(produces()) {}
+        tokenDeviceVertex_(produces()) {
+    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::ZVertexSoACollection>");
+#endif
+  }
 
   template <typename TrackerTraits>
   void PixelVertexProducerAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
@@ -15,7 +15,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class BeamSpotDeviceProducer : public global::EDProducer<> {
   public:
     BeamSpotDeviceProducer(edm::ParameterSet const& config)
-        : legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))}, deviceToken_{produces()} {}
+        : legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))}, deviceToken_{produces()} {
+      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::BeamSpotDevice>");
+#endif
+    }
 
     void produce(edm::StreamID, device::Event& event, device::EventSetup const& setup) const override {
       reco::BeamSpot const& beamspot = event.get(legacyToken_);


### PR DESCRIPTION
#### PR description:

This PR is a backport of https://github.com/cms-sw/cmssw/pull/44698. Original description
> This PR is a temporary workaround for the issue discussed in #44643. In short, with an HLT menu that uses Alpaka modules, when some HLT processes use GPU and some do not, the fact that the different backends of Alpaka modules produce different transient data products cause the ProductIDs to be different between the CPU-only and CPU+GPU processes, and presently there is not enough metadata available in the final streamer file for the framework to keep properly track of the various indices, that leads to de-referencing of `edm::Ref` to fail in a subsequent job (for longer description see [#44643 (comment)](https://github.com/cms-sw/cmssw/issues/44643#issuecomment-2046098157)).
> 
> This PR works around the problem by making a subset(*) of the Alpaka EDProducers on the CPU serial backend, for each "device-side data product" they produce (that in reality are the "host-side data products" directly) they register the production of the corresponding CUDA backend data product. This hack makes the CPU-serial and CUDA backend EDProducers to register the production of exactly the same data products, that leads to equal ProductIDs for the same data products between CPU-only and CPU+GPU jobs, circumventing the problem.
> 
> (*) ECAL, PF, and phase1 Pixel EDProducers, that are either being used in the present HLT menu, or are planned to be used in the near future
> 
> The use of strings for the CUDA backend data products is ugly, but avoids the need to have a compile-time dependence on the CUDA backend code in the CPU serial backend code (I actually tried that first, but ran into compilation issues; probably our present build rules prevent the use of Alpaka CUDA backend types in the CPU serial backend code). At runtime the added explicit CUDA dependence will likely break on platforms that do not support CUDA (all our code directly depending on CUDA would be broken anyway, so the temporary loss of functionality seems acceptable).
> 
> This PR is intended to be reverted when the necessary metadata to deal with the different ProductIDs in different HLT processes (CPU-only vs. CPU+GPU) gets propagated to the framework), whose details are being discussed in #44643 .




#### PR validation:

See https://github.com/cms-sw/cmssw/pull/44698

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/44698