### PR TITLE
4 minor improvements to Online DQM Pixel Summary (BP)

### DIFF
--- a/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
+++ b/DQM/SiPixelPhase1Summary/interface/SiPixelPhase1Summary.h
@@ -81,7 +81,7 @@ private:
   //Book trend plots
   void bookTrendPlots(DQMStore::IBooker& iBooker);
 
-  void fillSummaries(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter);
+  void fillSummaries(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, int lumiSeg = 0);
 
   void fillTrendPlots(DQMStore::IBooker& iBooker, DQMStore::IGetter& iGetter, int lumiSeg = 0);
 };


### PR DESCRIPTION
#### PR description:

Minor improvements in the Online DQM Pixel Summary for 13.6 TeV runs:
1. Avoid effect of sudden peaks in dead ROC Trend: from last Trend point to average/median of last 5 points
2. Change deadROC Summary: from dead ROC (Good, but Red) to ‘‘live’’ ROC fraction (Good and Green)
3. Change Summary map (copy of ‘‘live’’ ROC Summary): from 3 values (0, 0.8 and 1) to full range
4. Fix ‘‘No DAQ’’ in Online Reports Workspace: fill value of Summary report (now missing)

#### PR validation:

Data produced with cmsRun, i.e.:

cmsRun DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py dataset=/ZeroBias/Run2024B-v1/RAW runNumber=379031 

Results checked in [private Online QUI](http://provola.cern.ch:8070/dqm/online-dev/) (no change in plot naming/rendering) for two 2024 runs:

- [378238 (900 GeV)](http://provola.cern.ch:8070/dqm/online-dev/start?runnr=378238;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=PixelPhase1;size=M;root=PixelPhase1/Layouts;focus=PixelPhase1/EventInfo/reportSummaryMap;zoom=yes;)
- [379031 (13.6 TeV)](http://provola.cern.ch:8070/dqm/online-dev/start?runnr=379031;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=PixelPhase1;size=M;root=PixelPhase1/Layouts;focus=PixelPhase1/EventInfo/reportSummaryMap;zoom=yes;)


Details of SW changes and results in [these slides](https://alaperto.web.cern.ch/Online_Pixel_Summary_Apr24.pdf).


#### About backport

This is a backport to 14_0_X of #44701