### PR TITLE
[14.0.X] add a unit test for conversion of `millepede.res` files into DB payloads

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -11,6 +11,9 @@
   <use name="millepede"/>
 </test>
 <test name="testPedeCampaign" command="test_pede.sh"/>
+<test name="testPedeConversion" command="test_pedeConversion.sh">
+  <flags PRE_TEST="testPedeCampaign"/>
+</test>
 <test name="testPayloadSanity" command="test_payload_sanity.sh">
   <flags PRE_TEST="testPedeCampaign"/>
 </test>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/align_params_cff.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/align_params_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+_alignParams = cms.PSet(
+    alignParams = cms.vstring(
+        "TrackerP1PXBHalfBarrel,111111",
+        "TrackerP1PXECHalfCylinder,111111",
+        "TrackerTIBHalfBarrel,111111",
+        "TrackerTOBHalfBarrel,rrrrrr",
+        "TrackerTIDEndcap,111111",
+        "TrackerTECEndcap,111111",
+    )
+)

--- a/Alignment/MillePedeAlignmentAlgorithm/test/convertMPresToDB_cfg.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/convertMPresToDB_cfg.py
@@ -1,0 +1,111 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("Alignment", Run3)
+
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring("ProductNotFound") # do not accept this exception
+    )
+
+######################################################
+# initialize  MessageLogger
+######################################################
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.files.alignment = cms.untracked.PSet(
+    DEBUG = cms.untracked.PSet(
+        limit = cms.untracked.int32(-1)
+        ),
+    INFO = cms.untracked.PSet(
+        limit = cms.untracked.int32(5),
+        reportEvery = cms.untracked.int32(5)
+        ),
+    WARNING = cms.untracked.PSet(
+        limit = cms.untracked.int32(10)
+        ),
+    ERROR = cms.untracked.PSet(
+        limit = cms.untracked.int32(-1)
+        ),
+    Alignment = cms.untracked.PSet(
+        limit = cms.untracked.int32(-1),
+        reportEvery = cms.untracked.int32(1)
+        ),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+######################################################
+# Design GT (in order to fetch the design geometry)
+######################################################
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2024_design', '')  # take your favourite
+
+######################################################
+# Starting alignment of the campaign
+######################################################
+from CondCore.CondDB.CondDB_cfi import *
+CondDBConnection = CondDB.clone( connect = cms.string( 'sqlite_file:alignment_input.db' ) )
+process.trackerAlignment = cms.ESSource("PoolDBESSource",
+                                        CondDBConnection,
+                                        toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
+                                                                   tag = cms.string("TrackerAlignment_PCL_byRun_v2_express_348155")
+                                                                   )
+                                        ))
+
+process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
+
+######################################################
+# Alignment producer
+######################################################
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")
+
+######################################################
+#
+# !!! This has to match the alignable selection
+#          of the pede configuration !!!
+#
+######################################################
+from align_params_cff import _alignParams
+process.AlignmentProducer.ParameterBuilder.Selector = _alignParams
+
+######################################################
+# Alignment Producer options
+######################################################
+process.AlignmentProducer.doMisalignmentScenario = False #True
+process.AlignmentProducer.applyDbAlignment = True # either globalTag or trackerAlignment
+
+######################################################
+# assign by reference (i.e. could change MillePedeAlignmentAlgorithm as well):
+######################################################
+process.AlignmentProducer.algoConfig = process.MillePedeAlignmentAlgorithm
+process.AlignmentProducer.algoConfig.mode = 'pedeRead'     # reads millepede.res
+process.AlignmentProducer.algoConfig.pedeReader.readFile = 'millepede.res'
+process.AlignmentProducer.algoConfig.treeFile = 'my_treeFile.root'
+
+######################################################
+# Source
+######################################################
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(1) # choose your run!
+                            )
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1) )
+
+process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+process.p = cms.Path(process.dump)
+
+# should not be needed, but is:
+# otherwise AlignmentProducer does not  call relevant algorithm part
+process.AlignmentProducer.saveToDB = True
+
+######################################################
+# Output alignment payload from reading file
+######################################################
+CondDBConnectionOut = CondDB.clone( connect = cms.string( 'sqlite_file:convertedFromResFile.db' ) )
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          CondDBConnectionOut,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
+                                                                     tag = cms.string('Alignments')
+                                                                     )
+                                                            )
+                                          )

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+
 process = cms.Process("Alignment")
 
 ################################################################################
@@ -36,7 +37,6 @@ readFiles.extend([
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
 generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
 
-
 ################################################################################
 # setup alignment producer
 # ------------------------------------------------------------------------------
@@ -49,7 +49,6 @@ confAliProducer.setConfiguration(process,
     binaryFile   = setupBinaryFile,
     primaryWidth = setupPrimaryWidth,
     cosmicsZeroTesla = setupCosmicsZeroTesla)
-
 
 ################################################################################
 # Overwrite some conditions in global tag
@@ -69,16 +68,8 @@ process.AlignmentProducer.ParameterBuilder.parameterTypes = [
     ]
 #
 # # Define the high-level structure alignables
-process.AlignmentProducer.ParameterBuilder.SelectorRigid = cms.PSet(
-    alignParams = cms.vstring(
-        "TrackerP1PXBHalfBarrel,111111",
-        "TrackerP1PXECHalfCylinder,111111",
-        "TrackerTIBHalfBarrel,111111",
-        "TrackerTOBHalfBarrel,rrrrrr",
-        "TrackerTIDEndcap,111111",
-        "TrackerTECEndcap,111111",
-        )
-    )
+from align_params_cff import _alignParams
+process.AlignmentProducer.ParameterBuilder.SelectorRigid = _alignParams
 
 #########################
 ## insert Pedesettings ##

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
@@ -7,7 +7,7 @@ clean_up(){
     echo -e "\nCleaning the local test area"
     rm -fr milleBinary00* 
     rm -fr pedeSteer* 
-    rm -fr millepede.*
+    #rm -fr millepede.*
     rm -fr *.root
     rm -fr *.log
     rm -fr *.dat

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pedeConversion.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pedeConversion.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+
+LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
+
+echo "============== testing conversion to DB file from millepede.res"
+(cmsRun ${LOCAL_TEST_DIR}/convertMPresToDB_cfg.py) || die 'failed running convertMPresToDB_cfg.py' $?
+
+echo -e "Content of the current directory is: "`ls .`
+
+INPUTFILE=convertedFromResFile.db
+
+echo -e "\n\n============== testing converted file corresponds to input"
+(cmsRun ${SCRAM_TEST_PATH}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker' $?


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44570

#### PR description:

This PR is a continuation of the series started with https://github.com/cms-sw/cmssw/pull/37211 and continued with https://github.com/cms-sw/cmssw/pull/43935 and  https://github.com/cms-sw/cmssw/pull/44434 about unit tests for the MP-II based alignment workflow and adds a new unit test to allow the testing of the conversion of `millepede.res` files into DB (`sqlite` payloads). This is performed using the option

```
process.AlignmentProducer.algoConfig.mode = 'pedeRead'     
```

of `AlignmentProducer` and it's a useful to avoid re-running the pede step once a `millepede.res` is already avaialbles.

#### PR validation:

Run successfully:

```console
scram b runtests_test_PedeConversion
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/44570