### PR TITLE
Find testFWCoreSharedMemoryMonitorThread from PATH instead of local/test dir

### DIFF
--- a/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
+++ b/FWCore/SharedMemory/test/test_monitor_thread_signals.sh
@@ -7,7 +7,7 @@ dir=${PWD}
 cd ${LOCALTOP}
 
 #need to find a test program which we do not put on the PATH
-${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+testFWCoreSharedMemoryMonitorThread 6 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
 
 retValue=$?
 if [ "$retValue" != "134" ]; then
@@ -19,7 +19,7 @@ else
 fi
 
 
-${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
+testFWCoreSharedMemoryMonitorThread 11 >& testFWCoreSharedMemoryMonitorThread.log && die "did not return signal" 1
 
 retValue=$?
 if [ "$retValue" != "139" ]; then


### PR DESCRIPTION
This unit test was failing in 10.6.X IBs as it assums that unit test executable is available under `${CMSSW_BASE}/test/${SCRAM_ARCH}/` but for IB tests we do not rebuild every thing and just pick up executables from the release area test directory. This PR updates the unit tests to run `testFWCoreSharedMemoryMonitorThread` instead of  `${CMSSW_BASE}/test/${SCRAM_ARCH}/testFWCoreSharedMemoryMonitorThread`

FYI @antoniovilela