### PR TITLE
Support for Phase-2 mkFit initialStep track building

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -26,6 +26,7 @@ numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
 numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
 numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
+numWFIB.extend([24834.702]) #2026D98 mkFit tracking (initialStep)
 numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
 numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([24834.21,25034.21,25034.9921]) #2026D98 prodlike, prodlike PU, prodlike premix stage1+stage2

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -437,6 +437,28 @@ upgradeWFs['trackingMkFit'].step3 = {
     '--procModifiers': 'trackingMkFitDevel'
 }
 
+# mkFit for phase-2 initialStep tracking
+class UpgradeWorkflow_trackingMkFitPhase2(UpgradeWorkflowTracking):
+    def setup__(self, step, stepName, stepDict, k, properties):
+        if 'Reco' in step: stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
+    def condition_(self, fragment, stepList, key, hasHarvest):
+        return ('2026' in key)
+upgradeWFs['trackingMkFitPhase2'] = UpgradeWorkflow_trackingMkFitPhase2(
+    steps = [
+        'Reco',
+        'RecoFakeHLT',
+        'RecoGlobal',
+        'RecoNano',
+        'RecoNanoFakeHLT',
+    ],
+    PU = [],
+    suffix = '_trackingMkFitPhase2',
+    offset = 0.702,
+)
+upgradeWFs['trackingMkFitPhase2'].step3 = {
+    '--procModifiers': 'trackingMkFitCommon,trackingMkFitInitialStep'
+}
+
 #DeepCore seeding for JetCore iteration workflow
 class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/RecoTracker/MkFit/interface/MkFitGeometry.h
+++ b/RecoTracker/MkFit/interface/MkFitGeometry.h
@@ -31,6 +31,8 @@ public:
 
   int mkFitLayerNumber(DetId detId) const;
   mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
+  bool isPhase1() const;
+  bool isPhase2() const;
   mkfit::TrackerInfo const& trackerInfo() const { return *trackerInfo_; }
   const std::vector<const DetLayer*>& detLayers() const { return dets_; }
   unsigned int uniqueIdInLayer(int layer, unsigned int detId) const {

--- a/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitEventOfHitsProducer.cc
@@ -115,7 +115,7 @@ void MkFitEventOfHitsProducer::produce(edm::StreamID iID, edm::Event& iEvent, co
           deadvectors[ilay].push_back({surf.phiSpan().first, surf.phiSpan().second, q1, q2});
       }
     }
-
+    // For Phase-2, disable (momentarily?) SiStrip quality check
     if (useStripStripQualityDB_) {
       const auto& siStripQuality = iSetup.getData(stripQualityToken_);
       const auto& badStrips = siStripQuality.getBadComponentList();

--- a/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitGeometryESProducer.cc
@@ -207,11 +207,6 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
   else if (detid.subdetId() == SiStripSubdetector::TEC)
     doubleSide = trackerTopo_->tecIsDoubleSide(detid);
 
-  // Double-sided entries (join of two modules) are not used in mkFit and are
-  // also not needed for the material calculation.
-  if (doubleSide)
-    return;
-
   float xy[4][2];
   float half_length, dz;
   const Bounds *b = &((det->surface()).bounds());
@@ -294,6 +289,12 @@ void MkFitGeometryESProducer::fillShapeAndPlacement(const GeomDet *det,
   if (lgc_map) {
     (*lgc_map)[lay].add_current();
   }
+
+  // Double-sided module (join of two modules) information is not used in mkFit and
+  // also not needed for the material calculation.
+  if (doubleSide)
+    return;
+
   // Module information
   const auto &p = det->position();
   auto z = det->rotation().z();

--- a/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitPhase2HitConverter.cc
@@ -1,0 +1,103 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/Phase2TrackerRecHit1D.h"
+
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+
+#include "RecoTracker/MkFit/interface/MkFitHitWrapper.h"
+#include "RecoTracker/MkFit/interface/MkFitClusterIndexToHit.h"
+#include "RecoTracker/MkFit/interface/MkFitGeometry.h"
+#include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
+
+#include "convertHits.h"
+
+namespace {
+  class ConvertHitTraitsPhase2 {
+  public:
+    static constexpr bool applyCCC() { return false; }
+    static std::nullptr_t clusterCharge(const Phase2TrackerRecHit1D& hit, DetId hitId) { return nullptr; }
+    static bool passCCC(std::nullptr_t) { return true; }
+    static void setDetails(mkfit::Hit& mhit, const Phase2TrackerCluster1D& cluster, int shortId, std::nullptr_t) {
+      mhit.setupAsStrip(shortId, (1 << 8) - 1, cluster.size());
+    }
+  };
+}  // namespace
+
+class MkFitPhase2HitConverter : public edm::global::EDProducer<> {
+public:
+  explicit MkFitPhase2HitConverter(edm::ParameterSet const& iConfig);
+  ~MkFitPhase2HitConverter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+  const edm::EDGetTokenT<Phase2TrackerRecHit1DCollectionNew> siPhase2RecHitToken_;
+  const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> ttrhBuilderToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
+  const edm::EDPutTokenT<MkFitHitWrapper> wrapperPutToken_;
+  const edm::EDPutTokenT<MkFitClusterIndexToHit> clusterIndexPutToken_;
+  const edm::EDPutTokenT<std::vector<float>> clusterChargePutToken_;
+  const ConvertHitTraitsPhase2 convertTraits_;
+};
+
+MkFitPhase2HitConverter::MkFitPhase2HitConverter(edm::ParameterSet const& iConfig)
+    : siPhase2RecHitToken_{consumes<Phase2TrackerRecHit1DCollectionNew>(
+          iConfig.getParameter<edm::InputTag>("siPhase2Hits"))},
+      ttrhBuilderToken_{esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(
+          iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
+      ttopoToken_{esConsumes<TrackerTopology, TrackerTopologyRcd>()},
+      mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
+      wrapperPutToken_{produces<MkFitHitWrapper>()},
+      clusterIndexPutToken_{produces<MkFitClusterIndexToHit>()},
+      clusterChargePutToken_{produces<std::vector<float>>()},
+      convertTraits_{} {}
+
+void MkFitPhase2HitConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add("siPhase2Hits", edm::InputTag{"siPhase2RecHits"});
+  desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
+
+  descriptions.add("mkFitPhase2HitConverterDefault", desc);
+}
+
+void MkFitPhase2HitConverter::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  const auto& ttrhBuilder = iSetup.getData(ttrhBuilderToken_);
+  const auto& ttopo = iSetup.getData(ttopoToken_);
+  const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
+
+  MkFitHitWrapper hitWrapper;
+  MkFitClusterIndexToHit clusterIndexToHit;
+  std::vector<float> clusterCharge;
+
+  edm::ProductID stripClusterID;
+  const auto& phase2Hits = iEvent.get(siPhase2RecHitToken_);
+  std::vector<float> dummy;
+  if (not phase2Hits.empty()) {
+    stripClusterID = mkfit::convertHits(ConvertHitTraitsPhase2{},
+                                        phase2Hits,
+                                        hitWrapper.hits(),
+                                        clusterIndexToHit.hits(),
+                                        dummy,
+                                        ttopo,
+                                        ttrhBuilder,
+                                        mkFitGeom);
+  }
+
+  hitWrapper.setClustersID(stripClusterID);
+
+  iEvent.emplace(wrapperPutToken_, std::move(hitWrapper));
+  iEvent.emplace(clusterIndexPutToken_, std::move(clusterIndexToHit));
+  iEvent.emplace(clusterChargePutToken_, std::move(clusterCharge));
+}
+
+DEFINE_FWK_MODULE(MkFitPhase2HitConverter);

--- a/RecoTracker/MkFit/plugins/MkFitProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitProducer.cc
@@ -175,7 +175,8 @@ void MkFitProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::Ev
       stripContainerMask.copyMaskTo(stripMask);
     }
   } else {
-    stripClusterChargeCut(iEvent.get(stripClusterChargeToken_), stripMask);
+    if (mkFitGeom.isPhase1())
+      stripClusterChargeCut(iEvent.get(stripClusterChargeToken_), stripMask);
   }
 
   // seeds need to be mutable because of the possible cleaning

--- a/RecoTracker/MkFit/python/mkFitPhase2HitConverter_cfi.py
+++ b/RecoTracker/MkFit/python/mkFitPhase2HitConverter_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.MkFit.mkFitPhase2HitConverterDefault_cfi import mkFitPhase2HitConverterDefault as _mkFitPhase2HitConverterDefault
+
+mkFitPhase2HitConverter = _mkFitPhase2HitConverterDefault.clone()

--- a/RecoTracker/MkFit/src/MkFitGeometry.cc
+++ b/RecoTracker/MkFit/src/MkFitGeometry.cc
@@ -62,3 +62,7 @@ int MkFitGeometry::mkFitLayerNumber(DetId detId) const {
   return lnc_->convertLayerNumber(
       detId.subdetId(), ttopo_->layer(detId), false, ttopo_->isStereo(detId), isPlusSide(*ttopo_, detId));
 }
+
+bool MkFitGeometry::isPhase1() const { return lnc_->isPhase1(); }
+
+bool MkFitGeometry::isPhase2() const { return lnc_->isPhase2(); }

--- a/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
+++ b/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
@@ -21,6 +21,8 @@ namespace mkfit {
       return 10;
     }
     TkLayout getEra() const { return lo_; }
+    bool isPhase1() const { return lo_ == TkLayout::phase1; }
+    bool isPhase2() const { return lo_ == TkLayout::phase2; }
     int convertLayerNumber(int det, int lay, bool useMatched, int isStereo, bool posZ) const {
       if (lo_ == TkLayout::phase2) {
         if (det == 1)

--- a/RecoTracker/MkFitCMS/standalone/Makefile
+++ b/RecoTracker/MkFitCMS/standalone/Makefile
@@ -34,8 +34,8 @@ WriteMemFileDict.cc ${WMF_DICT_PCM} &: ${SACMS}/tkNtuple/DictsLinkDef.h
 	mv WriteMemFileDict_rdict.pcm ${WMF_DICT_PCM}
 
 SRCS += ShellDict.cc
-ShellDict.cc ${SHELL_DICT_PCM} &: ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
-	rootcling -I=${SRCDIR} -f ShellDict.cc ${SACMS}/Shell.h ${SACMS}/ShellLinkDef.h
+ShellDict.cc ${SHELL_DICT_PCM} &: ${SACMS}/ShellDict.h ${SACMS}/ShellLinkDef.h
+	rootcling -I=${SRCDIR} -f ShellDict.cc $^
 	mv ShellDict_rdict.pcm ${SHELL_DICT_PCM}
 endif
 
@@ -70,7 +70,7 @@ ${MAIN}: ${MAIN_DEPS} mkFit.o
 	${CXX} ${CXXFLAGS} ${VEC_HOST} ${LDFLAGS} mkFit.o -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
 
 ${WRMEMF}: ${MAIN_DEPS} WriteMemoryFile.o WriteMemFileDict.o
-	${CXX} ${CXXFLAGS} ${LDFLAGS} $^ -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
+	${CXX} ${CXXFLAGS} ${LDFLAGS} WriteMemoryFile.o WriteMemFileDict.o -o $@ ${LDFLAGS_HOST} -ltbb -L.. ${MAIN_LIBS} -Wl,-rpath=.
 
 ${OBJS}: %.o: %.cc %.d
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${VEC_HOST} -c -o $@ $<

--- a/RecoTracker/MkFitCMS/standalone/Shell.h
+++ b/RecoTracker/MkFitCMS/standalone/Shell.h
@@ -40,8 +40,8 @@ namespace mkfit {
     EventOfHits *eoh() { return m_eoh; }
     MkBuilder *builder() { return m_builder; }
 
-    const TrackVec& seeds() const { return m_seeds; }
-    const TrackVec& tracks() const { return m_tracks; }
+    const TrackVec &seeds() const { return m_seeds; }
+    const TrackVec &tracks() const { return m_tracks; }
 
     // --------------------------------------------------------
     // Analysis helpers

--- a/RecoTracker/MkFitCMS/standalone/Shell.h
+++ b/RecoTracker/MkFitCMS/standalone/Shell.h
@@ -40,6 +40,9 @@ namespace mkfit {
     EventOfHits *eoh() { return m_eoh; }
     MkBuilder *builder() { return m_builder; }
 
+    const TrackVec& seeds() const { return m_seeds; }
+    const TrackVec& tracks() const { return m_tracks; }
+
     // --------------------------------------------------------
     // Analysis helpers
 

--- a/RecoTracker/MkFitCMS/standalone/ShellDict.h
+++ b/RecoTracker/MkFitCMS/standalone/ShellDict.h
@@ -1,0 +1,2 @@
+#include "RecoTracker/MkFitCMS/standalone/Shell.h"
+#include "RecoTracker/MkFitCore/standalone/Event.h"

--- a/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
+++ b/RecoTracker/MkFitCMS/standalone/ShellLinkDef.h
@@ -1,1 +1,4 @@
 #pragma link C++ class mkfit::Shell;
+#pragma link C++ class mkfit::Event;
+#pragma link C++ class mkfit::Hit;
+#pragma link C++ class mkfit::Track;

--- a/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
+++ b/RecoTracker/MkFitCMS/standalone/buildtestMPlex.cc
@@ -229,7 +229,6 @@ namespace mkfit {
     bool seeds_sorted = false;
     // CCCC builder.PrepareSeeds();
     ev.setCurrentSeedTracks(ev.seedTracks_);
-    ev.simLabelForCurrentSeed(0);
 
     builder.find_tracks_load_seeds(ev.seedTracks_, seeds_sorted);
 
@@ -477,7 +476,6 @@ namespace mkfit {
       if (seeds.size() <= 0)
         continue;
       ev.setCurrentSeedTracks(seeds);
-      ev.simLabelForCurrentSeed(0);
 
       builder.find_tracks_load_seeds(seeds, do_seed_clean);
 

--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -44,7 +44,7 @@ using namespace mkfit;
 namespace mkfit::internal {
   // Filled in geometry plugin.
   std::vector<DeadVec> deadvectors;
-}
+}  // namespace mkfit::internal
 
 void initGeom() {
   std::cout << "Constructing geometry '" << Config::geomPlugin << "'\n";

--- a/RecoTracker/MkFitCMS/standalone/mkFit.cc
+++ b/RecoTracker/MkFitCMS/standalone/mkFit.cc
@@ -41,11 +41,9 @@ using namespace mkfit;
 
 //==============================================================================
 
-std::vector<DeadVec> deadvectors;
-
-void init_deadvectors() {
-  deadvectors.resize(Config::TrkInfo.n_layers());
-#include "RecoTracker/MkFitCMS/standalone/deadmodules.h"
+namespace mkfit::internal {
+  // Filled in geometry plugin.
+  std::vector<DeadVec> deadvectors;
 }
 
 void initGeom() {
@@ -113,10 +111,6 @@ void initGeom() {
   }
 
   Config::ItrInfo.setupStandardFunctionsFromNames();
-
-  // We always initialize the dead modules. Actual loading into each event is
-  // controlled via Config::useDeadModules.
-  init_deadvectors();
 
   // Test functions for ConfigJsonPatcher
   // cj.test_Direct (Config::ItrInfo[0]);
@@ -321,7 +315,7 @@ void test_standard() {
             StdSeq::loadHitsAndBeamSpot(ev, eoh);
 
             if (Config::useDeadModules) {
-              StdSeq::loadDeads(eoh, deadvectors);
+              StdSeq::loadDeads(eoh, mkfit::internal::deadvectors);
             }
 
             double t_best[NT] = {0}, t_cur[NT] = {0};
@@ -1018,7 +1012,7 @@ int main(int argc, const char* argv[]) {
     tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, Config::numThreadsFinder);
 
     initGeom();
-    Shell s(deadvectors, g_input_file, g_start_event);
+    Shell s(mkfit::internal::deadvectors, g_input_file, g_start_event);
     s.Run();
   } else {
     test_standard();

--- a/RecoTracker/MkFitCore/interface/HitStructures.h
+++ b/RecoTracker/MkFitCore/interface/HitStructures.h
@@ -112,7 +112,7 @@ namespace mkfit {
     // Geometry / LayerInfo accessors
     //--------------------------------
 
-    const LayerInfo* layer_info() const { return m_layer_info; }
+    const LayerInfo& layer_info() const { return *m_layer_info; }
     int layer_id() const { return m_layer_info->layer_id(); }
 
     bool is_barrel() const { return m_is_barrel; }

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -17,9 +17,6 @@ namespace mkfit {
     float chi2_hit;       // chi2 of the added hit
     float score;          // score used for candidate ranking
 
-    IdxChi2List() = default;
-    IdxChi2List& operator=(const IdxChi2List&) = default;
-
     // Zero initialization
     void reset() {
       module = 0u;

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -29,6 +29,6 @@ namespace mkfit {
     }
   };
 
-}
+}  // namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/interface/IdxChi2List.h
+++ b/RecoTracker/MkFitCore/interface/IdxChi2List.h
@@ -1,0 +1,34 @@
+#ifndef RecoTracker_MkFitCore_interface_IdxChi2List_h
+#define RecoTracker_MkFitCore_interface_IdxChi2List_h
+
+namespace mkfit {
+
+  struct IdxChi2List {
+  public:
+    unsigned int module;  // module id
+    int hitIdx;           // hit index
+    int trkIdx;           // candidate index
+    int nhits;            // number of hits (used for sorting)
+    int ntailholes;       // number of holes at the end of the track (used for sorting)
+    int noverlaps;        // number of overlaps (used for sorting)
+    int nholes;           // number of holes (used for sorting)
+    float pt;             // pt (used for sorting)
+    float chi2;           // total chi2 (used for sorting)
+    float chi2_hit;       // chi2 of the added hit
+    float score;          // score used for candidate ranking
+
+    IdxChi2List() = default;
+    IdxChi2List& operator=(const IdxChi2List&) = default;
+
+    // Zero initialization
+    void reset() {
+      module = 0u;
+      hitIdx = trkIdx = 0;
+      nhits = ntailholes = noverlaps = nholes = 0;
+      pt = chi2 = chi2_hit = score = 0;
+    }
+  };
+
+}
+
+#endif

--- a/RecoTracker/MkFitCore/interface/Track.h
+++ b/RecoTracker/MkFitCore/interface/Track.h
@@ -5,6 +5,7 @@
 #include "RecoTracker/MkFitCore/interface/MatrixSTypes.h"
 #include "RecoTracker/MkFitCore/interface/FunctionTypes.h"
 #include "RecoTracker/MkFitCore/interface/Hit.h"
+#include "RecoTracker/MkFitCore/interface/IdxChi2List.h"
 #include "RecoTracker/MkFitCore/interface/TrackerInfo.h"
 
 #include <vector>
@@ -29,21 +30,6 @@ namespace mkfit {
                              const float hit2_y) {
     return ((hit2_y - hit0_y) * (hit2_x - hit1_x) > (hit2_y - hit1_y) * (hit2_x - hit0_x) ? 1 : -1);
   }
-
-  struct IdxChi2List {
-  public:
-    int trkIdx;           // candidate index
-    int hitIdx;           // hit index
-    unsigned int module;  // module id
-    int nhits;            // number of hits (used for sorting)
-    int ntailholes;       // number of holes at the end of the track (used for sorting)
-    int noverlaps;        // number of overlaps (used for sorting)
-    int nholes;           // number of holes (used for sorting)
-    float pt;             // pt (used for sorting)
-    float chi2;           // total chi2 (used for sorting)
-    float chi2_hit;       // chi2 of the added hit
-    float score;          // score used for candidate ranking
-  };
 
   //==============================================================================
   // TrackState

--- a/RecoTracker/MkFitCore/interface/TrackerInfo.h
+++ b/RecoTracker/MkFitCore/interface/TrackerInfo.h
@@ -61,6 +61,7 @@ namespace mkfit {
     void set_subdet(int sd) { m_subdet = sd; }
     void set_is_pixel(bool p) { m_is_pixel = p; }
     void set_is_stereo(bool s) { m_is_stereo = s; }
+    void set_has_charge(bool c) { m_has_charge = c; }
 
     int layer_id() const { return m_layer_id; }
     LayerType_e layer_type() const { return m_layer_type; }
@@ -77,6 +78,7 @@ namespace mkfit {
     bool is_barrel() const { return m_layer_type == Barrel; }
     bool is_pixel() const { return m_is_pixel; }
     bool is_stereo() const { return m_is_stereo; }
+    bool has_charge() const { return m_has_charge; }
 
     bool is_within_z_limits(float z) const { return z > m_zmin && z < m_zmax; }
     bool is_within_r_limits(float r) const { return r > m_rin && r < m_rout; }
@@ -141,6 +143,7 @@ namespace mkfit {
     bool m_has_r_range_hole = false;
     bool m_is_stereo = false;
     bool m_is_pixel = false;
+    bool m_has_charge = true;
 
     std::unordered_map<unsigned int, unsigned int> m_detid2sid;
     std::vector<ModuleInfo> m_modules;

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -155,6 +155,11 @@ namespace {
     return mkfit::sortByScoreTrackCand(cand1, cand2);
   }
 
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+  constexpr bool alwaysUseHitSelectionV2 = true;
+#else
+  constexpr bool alwaysUseHitSelectionV2 = false;
+#endif
 }  // end unnamed namespace
 
 //------------------------------------------------------------------------------
@@ -855,7 +860,11 @@ namespace mkfit {
             dcall(post_prop_print(curr_layer, mkfndr.get()));
 
             dprint("now get hit range");
-            mkfndr->selectHitIndices(layer_of_hits, end - itrack);
+
+            if (alwaysUseHitSelectionV2 || iter_params.useHitSelectionV2)
+              mkfndr->selectHitIndicesV2(layer_of_hits, end - itrack);
+            else
+              mkfndr->selectHitIndices(layer_of_hits, end - itrack);
 
             find_tracks_handle_missed_layers(
                 mkfndr.get(), layer_info, tmp_cands, seed_cand_idx, region, start_seed, itrack, end);
@@ -1088,7 +1097,7 @@ namespace mkfit {
 
         dprint("now get hit range");
 
-        if (iter_params.useHitSelectionV2)
+        if (alwaysUseHitSelectionV2 || iter_params.useHitSelectionV2)
           mkfndr->selectHitIndicesV2(layer_of_hits, end - itrack);
         else
           mkfndr->selectHitIndices(layer_of_hits, end - itrack);

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -401,8 +401,8 @@ namespace mkfit {
 
         const float z = m_Par[iI].constAt(itrack, 2, 0);
         const float dz = std::abs(nSigmaZ * std::sqrt(m_Err[iI].constAt(itrack, 2, 2)));
-        const float edgeCorr = std::abs(0.5f * (L.layer_info().rout() - L.layer_info().rin()) /
-                                        std::tan(m_Par[iI].constAt(itrack, 5, 0)));
+        const float edgeCorr =
+            std::abs(0.5f * (L.layer_info().rout() - L.layer_info().rin()) / std::tan(m_Par[iI].constAt(itrack, 5, 0)));
         // XXX-NUM-ERR above, m_Err(2,2) gets negative!
 
         m_XWsrResult[itrack] = L.is_within_z_sensitive_region(z, std::sqrt(dz * dz + edgeCorr * edgeCorr));

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -68,7 +68,7 @@ namespace mkfit {
   void MkFinder::begin_layer(const LayerOfHits &layer_of_hits) {
 #ifdef RNT_DUMP_MkF_SelHitIdcs
     const LayerOfHits &L = layer_of_hits;
-    const LayerInfo &LI = *L.layer_info();
+    const LayerInfo &LI = L.layer_info();
     rnt_shi.ResetH();
     rnt_shi.ResetF();
     *rnt_shi.h = {m_event->evtID(),
@@ -243,7 +243,7 @@ namespace mkfit {
       if (hit_cnt < m_XHitSize[itrack]) {
         const auto &hit = layer_of_hits.refHit(m_XHitArr.constAt(itrack, hit_cnt, 0));
         unsigned int mid = hit.detIDinLayer();
-        const ModuleInfo &mi = layer_of_hits.layer_info()->module_info(mid);
+        const ModuleInfo &mi = layer_of_hits.layer_info().module_info(mid);
         norm.At(itrack, 0, 0) = mi.zdir[0];
         norm.At(itrack, 1, 0) = mi.zdir[1];
         norm.At(itrack, 2, 0) = mi.zdir[2];
@@ -401,7 +401,7 @@ namespace mkfit {
 
         const float z = m_Par[iI].constAt(itrack, 2, 0);
         const float dz = std::abs(nSigmaZ * std::sqrt(m_Err[iI].constAt(itrack, 2, 2)));
-        const float edgeCorr = std::abs(0.5f * (L.layer_info()->rout() - L.layer_info()->rin()) /
+        const float edgeCorr = std::abs(0.5f * (L.layer_info().rout() - L.layer_info().rin()) /
                                         std::tan(m_Par[iI].constAt(itrack, 5, 0)));
         // XXX-NUM-ERR above, m_Err(2,2) gets negative!
 
@@ -409,14 +409,14 @@ namespace mkfit {
         assignbins(itrack, z, dz, phi, dphi, min_dq, max_dq, min_dphi, max_dphi);
 
         // Relax propagation-fail detection to be in line with pre-43145.
-        if (m_FailFlag[itrack] && std::sqrt(r2) >= L.layer_info()->rin()) {
+        if (m_FailFlag[itrack] && std::sqrt(r2) >= L.layer_info().rin()) {
           m_FailFlag[itrack] = 0;
         }
       }
     } else  // endcap
     {
       //layer half-thikness for dphi spread calculation; only for very restrictive iters
-      const float layerD = std::abs(L.layer_info()->zmax() - L.layer_info()->zmin()) * 0.5f *
+      const float layerD = std::abs(L.layer_info().zmax() - L.layer_info().zmin()) * 0.5f *
                            (m_iteration_params->maxConsecHoles == 0 || m_iteration_params->maxHolesPerCand == 0);
       // Pull out the part of the loop that vectorizes with icc and gcc
 #if !defined(__clang__)
@@ -456,7 +456,7 @@ namespace mkfit {
                                                       y * y * m_Err[iI].constAt(itrack, 1, 1) +
                                                       2 * x * y * m_Err[iI].constAt(itrack, 0, 1)) /
                                              r2);
-        const float edgeCorr = std::abs(0.5f * (L.layer_info()->zmax() - L.layer_info()->zmin()) *
+        const float edgeCorr = std::abs(0.5f * (L.layer_info().zmax() - L.layer_info().zmin()) *
                                         std::tan(m_Par[iI].constAt(itrack, 5, 0)));
 
         m_XWsrResult[itrack] = L.is_within_r_sensitive_region(r, std::sqrt(dr * dr + edgeCorr * edgeCorr));
@@ -549,7 +549,7 @@ namespace mkfit {
 
             if (m_iteration_hit_mask && (*m_iteration_hit_mask)[hi_orig]) {
               dprintf(
-                  "Yay, denying masked hit on layer %u, hi %u, orig idx %u\n", L.layer_info()->layer_id(), hi, hi_orig);
+                  "Yay, denying masked hit on layer %u, hi %u, orig idx %u\n", L.layer_info().layer_id(), hi, hi_orig);
               continue;
             }
 
@@ -753,7 +753,7 @@ namespace mkfit {
     using bidx_t = LayerOfHits::bin_index_t;
     using bcnt_t = LayerOfHits::bin_content_t;
     const LayerOfHits &L = layer_of_hits;
-    const LayerInfo &LI = *L.layer_info();
+    const LayerInfo &LI = L.layer_info();
 
     const int iI = iP;
 
@@ -764,16 +764,20 @@ namespace mkfit {
 
 #ifdef RNT_DUMP_MkF_SelHitIdcs
     rnt_shi.InnerIdcsReset(N_proc);
+    Event::SimLabelFromHits sim_lbls[NN];
     for (int i = 0; i < N_proc; ++i) {
-      auto slfh = m_event->simLabelForCurrentSeed(m_SeedOriginIdx[i]);
+      sim_lbls[i] = m_event->simLabelForCurrentSeed(m_SeedOriginIdx[i]);
       if (m_FailFlag[i]) {
         rnt_shi.RegisterFailedProp(i, m_Par[1 - iI], m_Par[iI], m_event, m_SeedOriginIdx[i]);
-      } else if (slfh.is_set()) {
-        rnt_shi.RegisterGoodProp(i, m_Par[iI], m_event, m_SeedOriginIdx[i]);
-        // get BinSearch result from V1.
-        selectHitIndices(layer_of_hits, N_proc, true);
+      } else if (sim_lbls[i].is_set()) {
+        CandInfo &ci = rnt_shi.RegisterGoodProp(i, m_Par[iI], m_event, m_SeedOriginIdx[i]);
+        ci.ic2list.reset();  // zero initialize
       }  // else ... could do something about the bad seeds ... probably better to collect elsewhere.
     }
+    // Get BinSearch result from V1. Note -- it can clear m_FailFlag for some cands!
+    auto ff_stash = m_FailFlag;
+    selectHitIndices(layer_of_hits, N_proc, true);
+    m_FailFlag = ff_stash;
 #endif
 
     constexpr int NEW_MAX_HIT = 6;  // 4 - 6 give about the same # of tracks in quality-val
@@ -946,8 +950,15 @@ namespace mkfit {
 
       // clang-format off
       dprintf("  %2d/%2d: %6.3f %6.3f %6.6f %7.5f %3u %3u %4u %4u\n",
-              L.layer_id(), itrack, qv[itrack], phi[itrack], dqv[itrack], dphiv[itrack],
+              L.layer_id(), itrack, B.q_c[itrack], B.phi_c[itrack],
+              B.qmax[itrack] - B.qmin[itrack], B.dphi[itrack],
               qb1, qb2, pb1, pb2);
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+      int hit_out_idx = 0;
+      // phi-sorted position of matched hits
+      struct pos_match { float dphi, dq; int idx; bool matched; };
+      std::vector<pos_match> pos_match_vec;
+#endif
       // clang-format on
 
       mp::InitialState mp_is(m_Par[iI], m_Chg, itrack);
@@ -957,8 +968,8 @@ namespace mkfit {
         for (bidx_t pi = pb1; pi != pb2; pi = L.phiMaskApply(pi + 1)) {
           // Limit to central Q-bin
           if (qi == qb && L.isBinDead(pi, qi) == true) {
-            dprint("dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pi=" << pi << " q=" << q
-                                                     << " phi=" << phi);
+            dprint("dead module for track in layer=" << L.layer_id() << " qb=" << qi << " pi=" << pi
+                                                     << " q=" << B.q_c[itrack] << " phi=" << B.phi_c[itrack]);
             m_XWsrResult[itrack].m_in_gap = true;
           }
 
@@ -976,12 +987,9 @@ namespace mkfit {
 
             if (m_iteration_hit_mask && (*m_iteration_hit_mask)[hi_orig]) {
               dprintf(
-                  "Yay, denying masked hit on layer %u, hi %u, orig idx %u\n", L.layer_info()->layer_id(), hi, hi_orig);
+                  "Yay, denying masked hit on layer %u, hi %u, orig idx %u\n", L.layer_info().layer_id(), hi, hi_orig);
               continue;
             }
-
-            if (m_XHitSize[itrack] >= MPlexHitIdxMax)
-              break;
 
             float new_q, new_phi, new_ddphi, new_ddq;
             bool prop_fail;
@@ -1004,7 +1012,50 @@ namespace mkfit {
             // clang-format off
             dprintf("     SHI %3u %4u %5u  %6.3f %6.3f %6.4f %7.5f  PROP-%s  %s\n",
                     qi, pi, hi, L.hit_q(hi), L.hit_phi(hi),
-                    ddq, ddphi, prop_fail ? "FAIL" : "OK", dqdphi_presel ? "PASS" : "REJECT");
+                    new_ddq, new_ddphi, prop_fail ? "FAIL" : "OK", dqdphi_presel ? "PASS" : "REJECT");
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+            if (rnt_shi.f_h_remap[itrack] >= 0) {
+              int sim_lbl = sim_lbls[itrack].label;
+              const Hit &thishit = L.refHit(hi_orig);
+              m_msErr.copyIn(itrack, thishit.errArray());
+              m_msPar.copyIn(itrack, thishit.posArray());
+
+              MPlexQF thisOutChi2;
+              MPlexQI propFail(0);
+              MPlexLV tmpPropPar;
+              const FindingFoos &fnd_foos = FindingFoos::get_finding_foos(L.is_barrel());
+              (*fnd_foos.m_compute_chi2_foo)(
+                m_Err[iI], m_Par[iI], m_Chg, m_msErr, m_msPar,
+                thisOutChi2, tmpPropPar, propFail, N_proc,
+                m_prop_config->finding_intra_layer_pflags,
+                m_prop_config->finding_requires_propagation_to_hit_pos);
+              float hchi2 = thisOutChi2[itrack];
+
+              CandInfo &ci = (*rnt_shi.ci)[rnt_shi.f_h_remap[itrack]];
+
+              const MCHitInfo &mchinfo = m_event->simHitsInfo_[L.refHit(hi_orig).mcHitID()];
+              int hit_lbl = mchinfo.mcTrackID();
+              ci.hmi.emplace_back(HitMatchInfo{ HitInfo
+                { hit2pos(thishit),
+                  new_q, L.hit_q_half_length(hi), L.hit_qbar(hi), new_phi,
+                  hit_lbl },
+                state2pos(mp_s), state2mom(mp_s),
+                new_ddq, new_ddphi, hchi2, (int) hi_orig,
+                (sim_lbl == hit_lbl), dqdphi_presel, !prop_fail
+              });
+
+              bool new_dec = dqdphi_presel && !prop_fail;
+              ++ci.n_all_hits;
+              if (sim_lbl == hit_lbl) {
+                ++ci.n_hits_match;
+                if (new_dec) ++ci.n_hits_pass_match;
+              }
+              if (new_dec) ++ci.n_hits_pass;
+              if (new_dec)
+                pos_match_vec.emplace_back(pos_match{ new_ddphi, new_ddq, hit_out_idx++,
+                                             sim_lbl == hit_lbl });
+            } // if cand is saved
+#endif
             // clang-format on
 
             if (prop_fail || !dqdphi_presel)
@@ -1021,6 +1072,26 @@ namespace mkfit {
       }      //qi
 
       dprintf(" PQUEUE (%d)", pqueue_size);
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+      // clang-format off
+      if (sim_lbls[itrack].is_set()) {
+        // Find ord number of matched hits.
+        std::sort(pos_match_vec.begin(), pos_match_vec.end(),
+                  [](auto &a, auto &b){return a.dphi < b.dphi;});
+        int pmvs = pos_match_vec.size();
+
+        CandInfo &ci = (*rnt_shi.ci)[rnt_shi.f_h_remap[itrack]];
+        for (int i = 0; i < pmvs; ++i) {
+          if (pos_match_vec[i].matched) {
+            ci.ord_first_match = i;
+            ci.dphi_first_match = pos_match_vec[i].dphi;
+            ci.dq_first_match = pos_match_vec[i].dq;
+            break;
+          }
+        }
+      }
+      // clang-format off
+#endif
       // Reverse hits so best dphis/scores come first in the hit-index list.
       m_XHitSize[itrack] = pqueue_size;
       while (pqueue_size) {
@@ -1402,19 +1473,21 @@ namespace mkfit {
             if (chi2 < max_c2) {
               bool isCompatible = true;
               if (!layer_of_hits.is_pixel()) {
-                //check module compatibility via long strip side = L/sqrt(12)
-                isCompatible =
-                    isStripQCompatible(itrack, layer_of_hits.is_barrel(), m_Err[iP], propPar, m_msErr, m_msPar);
-
-                //rescale strip charge to track parameters and reapply the cut
-                isCompatible &= passStripChargePCMfromTrack(
-                    itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
-              }
-              // Select only SiStrip hits with cluster size < maxClusterSize
-              if (!layer_of_hits.is_pixel()) {
+                // select only SiStrip hits with cluster size < maxClusterSize
                 if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
-                    m_iteration_params->maxClusterSize)
+                    m_iteration_params->maxClusterSize) {
+                  // isTooLargeCluster[itrack] = true; -- only in CloneEngine
                   isCompatible = false;
+                }
+                // check module compatibility via long strip side = L/sqrt(12)
+                if (isCompatible)
+                  isCompatible =
+                    isStripQCompatible(itrack, layer_of_hits.is_barrel(), m_Err[iP], propPar, m_msErr, m_msPar);
+                // rescale strip charge to track parameters and reapply the cut
+                if (isCompatible && layer_of_hits.layer_info().has_charge()) {
+                  isCompatible = passStripChargePCMfromTrack(
+                    itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
+                }
               }
 
               if (isCompatible) {
@@ -1607,25 +1680,24 @@ namespace mkfit {
           const float chi2 = std::abs(outChi2[itrack]);  //fixme negative chi2 sometimes...
           // XXX-NUM-ERR assert(chi2 >= 0);
 
-          dprint("chi2=" << chi2 << " for trkIdx=" << itrack << " hitIdx=" << m_XHitArr.At(itrack, hit_cnt, 0));
+          dprintf("  chi2=%.3f (%.3f)  trkIdx=%d hitIdx=%d\n", chi2, max_c2, itrack,  m_XHitArr.At(itrack, hit_cnt, 0));
           if (chi2 < max_c2) {
             bool isCompatible = true;
             if (!layer_of_hits.is_pixel()) {
-              //check module compatibility via long strip side = L/sqrt(12)
-              isCompatible =
-                  isStripQCompatible(itrack, layer_of_hits.is_barrel(), m_Err[iP], propPar, m_msErr, m_msPar);
-
-              //rescale strip charge to track parameters and reapply the cut
-              isCompatible &= passStripChargePCMfromTrack(
-                  itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
-            }
-
-            // Select only SiStrip hits with cluster size < maxClusterSize
-            if (!layer_of_hits.is_pixel()) {
+              // select only SiStrip hits with cluster size < maxClusterSize
               if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
                   m_iteration_params->maxClusterSize) {
                 isTooLargeCluster[itrack] = true;
                 isCompatible = false;
+              }
+              // check module compatibility via long strip side = L/sqrt(12)
+              if (isCompatible)
+                isCompatible =
+                  isStripQCompatible(itrack, layer_of_hits.is_barrel(), m_Err[iP], propPar, m_msErr, m_msPar);
+              // rescale strip charge to track parameters and reapply the cut
+              if (isCompatible && layer_of_hits.layer_info().has_charge()) {
+                isCompatible = passStripChargePCMfromTrack(
+                  itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
               }
             }
 
@@ -1672,6 +1744,13 @@ namespace mkfit {
 
               dprint("  adding hit with hit_cnt=" << hit_cnt << " for trkIdx=" << tmpList.trkIdx
                                                   << " orig Seed=" << m_Label(itrack, 0, 0));
+
+#ifdef RNT_DUMP_MkF_SelHitIdcs
+              if (rnt_shi.f_h_remap[itrack] >= 0) {
+                CandInfo &ci = (*rnt_shi.ci)[rnt_shi.f_h_remap[itrack]];
+                ci.assignIdxChi2List(tmpList);
+              }
+#endif
             }
           }
         }
@@ -1949,7 +2028,7 @@ namespace mkfit {
       const int layer = lp_iter->m_layer;
 
       const LayerOfHits &L = eventofhits[layer];
-      const LayerInfo &LI = *L.layer_info();
+      const LayerInfo &LI = L.layer_info();
 
       int count = 0;
       for (int i = 0; i < N_proc; ++i) {
@@ -2111,7 +2190,7 @@ namespace mkfit {
       const int layer = lp_iter.layer();
 
       const LayerOfHits &L = eventofhits[layer];
-      const LayerInfo &LI = *L.layer_info();
+      const LayerInfo &LI = L.layer_info();
 
 #if defined(DEBUG_BACKWARD_FIT)
       const Hit *last_hit_ptr[NN];

--- a/RecoTracker/MkFitCore/standalone/Event.cc
+++ b/RecoTracker/MkFitCore/standalone/Event.cc
@@ -870,9 +870,7 @@ namespace mkfit {
     currentSeedSimFromHits_.clear();
   }
 
-  const Track &Event::currentSeed(int i) const {
-    return (*currentSeedTracks_)[i];
-  }
+  const Track &Event::currentSeed(int i) const { return (*currentSeedTracks_)[i]; }
 
   Event::SimLabelFromHits Event::simLabelForCurrentSeed(int i) const {
     assert(currentSeedTracks_ != nullptr);

--- a/RecoTracker/MkFitCore/standalone/Makefile.config
+++ b/RecoTracker/MkFitCore/standalone/Makefile.config
@@ -92,10 +92,10 @@ LDFLAGS_HOST :=
 CPPFLAGS += ${INWARD_FIT}
 
 # Dump hit selection window tuples
-CPPFLAGS += -DDUMPHITWINDOW # -DDUMP_HIT_PRESEL
+# CPPFLAGS += -DDUMPHITWINDOW
 # The new dumpers
 ifdef WITH_ROOT
-  CPPFLAGS += -DRNT_DUMP_MkF_SelHitIdcs
+  # CPPFLAGS += -DRNT_DUMP_MkF_SelHitIdcs
 endif
 
 ifdef USE_VTUNE_NOTIFY
@@ -117,7 +117,9 @@ ifeq ($(CXX), g++)
   # -msse3 is enabled above, if so configured (i.e., not avx)
   # -Ofast is specified above in section 3.
   # -std is set to c++1z below (was c++17 here)
-  CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
+  # MT 2023-12-11: Had to remove -Werror=missing-braces ... triggered by RNTuple/REntry
+  # CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
+  CXXFLAGS += -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -ftree-vectorize -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -fuse-ld=bfd -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
   CXXFLAGS += -fdiagnostics-color=auto -fdiagnostics-show-option -fopenmp-simd
   # Disable reciprocal math for Intel/AMD consistency, see cms-sw/cmsdist#8280
   CXXFLAGS += -fno-reciprocal-math -mrecip=none

--- a/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/MkFinder_selectHitIndices.icc
@@ -3,10 +3,7 @@
 
 #include "RecoTracker/MkFitCore/standalone/RntDumper/RntDumper.h"
 #include "RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h"
-
-#include "RecoTracker/MkFitCore/src/Matrix.h"
-#include "RecoTracker/MkFitCore/interface/Track.h"
-#include "RecoTracker/MkFitCore/src/MiniPropagators.h"
+#include "RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h"
 
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -14,42 +11,7 @@
 #include <TTree.h>
 
 namespace {
-  namespace miprops = mkfit::mini_propagators;
   using namespace mkfit;
-
-  RVec state2pos(const miprops::State &s) { return {s.x, s.y, s.z}; }
-  RVec state2mom(const miprops::State &s) { return {s.px, s.py, s.pz}; }
-  State state2state(const miprops::State &s) { return {state2pos(s), state2mom(s)}; }
-
-  RVec statep2pos(const miprops::StatePlex &s, int i) { return {s.x[i], s.y[i], s.z[i]}; }
-  RVec statep2mom(const miprops::StatePlex &s, int i) { return {s.px[i], s.py[i], s.pz[i]}; }
-  State statep2state(const miprops::StatePlex &s, int i) { return {statep2pos(s, i), statep2mom(s, i)}; }
-  PropState statep2propstate(const miprops::StatePlex &s, int i) {
-    return {statep2state(s, i), s.dalpha[i], s.fail_flag[i]};
-  }
-
-  RVec track2pos(const TrackBase &s) { return {s.x(), s.y(), s.z()}; }
-  RVec track2mom(const TrackBase &s) { return {s.px(), s.py(), s.pz()}; }
-  State track2state(const TrackBase &s) { return {track2pos(s), track2mom(s)}; }
-
-  SimSeedInfo evsi2ssinfo(const Event *ev, int seed_idx) {
-    SimSeedInfo ssi;
-    Event::SimLabelFromHits slfh = ev->simLabelForCurrentSeed(seed_idx);
-    if (slfh.is_set()) {
-      ssi.s_sim = track2state(ev->simTracks_[slfh.label]);
-      ssi.sim_lbl = slfh.label;
-      ssi.n_hits = slfh.n_hits;
-      ssi.n_match = slfh.n_match;
-      ssi.has_sim = true;
-    }
-    auto seed = ev->currentSeed(seed_idx);
-    ssi.s_seed = track2state(seed);
-    ssi.seed_lbl = seed.label();
-    ssi.seed_idx = seed_idx;
-    return ssi;
-  }
-
-  // --- === ---
 
   struct RntIfc_selectHitIndices {
     using RNTupleWriter = ROOT::Experimental::RNTupleWriter;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
@@ -1,0 +1,47 @@
+#ifndef RecoTracker_MkFitCore_standalone_RntDumper_RntConversions_h
+#define RecoTracker_MkFitCore_standalone_RntDumper_RRntConversions_h
+
+#include "RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h"
+
+#include "RecoTracker/MkFitCore/interface/Track.h"
+#include "RecoTracker/MkFitCore/src/Matrix.h"
+#include "RecoTracker/MkFitCore/src/MiniPropagators.h"
+
+namespace mkfit {
+  namespace miprops = mkfit::mini_propagators;
+
+  RVec state2pos(const miprops::State &s) { return {s.x, s.y, s.z}; }
+  RVec state2mom(const miprops::State &s) { return {s.px, s.py, s.pz}; }
+  State state2state(const miprops::State &s) { return {state2pos(s), state2mom(s)}; }
+
+  RVec statep2pos(const miprops::StatePlex &s, int i) { return {s.x[i], s.y[i], s.z[i]}; }
+  RVec statep2mom(const miprops::StatePlex &s, int i) { return {s.px[i], s.py[i], s.pz[i]}; }
+  State statep2state(const miprops::StatePlex &s, int i) { return {statep2pos(s, i), statep2mom(s, i)}; }
+  PropState statep2propstate(const miprops::StatePlex &s, int i) {
+    return {statep2state(s, i), s.dalpha[i], s.fail_flag[i]};
+  }
+
+  RVec hit2pos(const Hit &h) { return {h.x(), h.y(), h.z()}; }
+  RVec track2pos(const TrackBase &s) { return {s.x(), s.y(), s.z()}; }
+  RVec track2mom(const TrackBase &s) { return {s.px(), s.py(), s.pz()}; }
+  State track2state(const TrackBase &s) { return {track2pos(s), track2mom(s)}; }
+
+  SimSeedInfo evsi2ssinfo(const Event *ev, int seed_idx) {
+    SimSeedInfo ssi;
+    Event::SimLabelFromHits slfh = ev->simLabelForCurrentSeed(seed_idx);
+    if (slfh.is_set()) {
+      ssi.s_sim = track2state(ev->simTracks_[slfh.label]);
+      ssi.sim_lbl = slfh.label;
+      ssi.n_hits = slfh.n_hits;
+      ssi.n_match = slfh.n_match;
+      ssi.has_sim = true;
+    }
+    auto seed = ev->currentSeed(seed_idx);
+    ssi.s_seed = track2state(seed);
+    ssi.seed_lbl = seed.label();
+    ssi.seed_idx = seed_idx;
+    return ssi;
+  }
+}
+
+#endif

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntConversions.h
@@ -42,6 +42,6 @@ namespace mkfit {
     ssi.seed_idx = seed_idx;
     return ssi;
   }
-}
+}  // namespace mkfit
 
 #endif

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs.h
@@ -118,7 +118,7 @@ struct CandInfo {
   }
 
   bool assignIdxChi2List(const mkfit::IdxChi2List& ic2l) {
-    for (auto & hm : hmi) {
+    for (auto& hm : hmi) {
       if (hm.hit_index == ic2l.hitIdx) {
         hm.has_ic2list = true;
         hm.ic2list = ic2l;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
@@ -1,11 +1,18 @@
 // #pragma link C++ class ROOT::Experimental::REveVector+;
 
+#pragma link C++ class mkfit::IdxChi2List + ;
+
 #pragma link C++ class HeaderLayer + ;
 
 #pragma link C++ class State + ;
 #pragma link C++ class PropState + ;
 #pragma link C++ class SimSeedInfo + ;
 #pragma link C++ class BinSearch + ;
+
+#pragma link C++ class HitInfo+;
+#pragma link C++ class HitMatchInfo+;
+#pragma link C++ class std::vector<HitInfo>+;
+#pragma link C++ class std::vector<HitMatchInfo>+;
 
 #pragma link C++ class CandInfo + ;
 #pragma link C++ class std::vector < CandInfo> + ;

--- a/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
+++ b/RecoTracker/MkFitCore/standalone/RntDumper/RntStructs_Linkdef.h
@@ -9,10 +9,10 @@
 #pragma link C++ class SimSeedInfo + ;
 #pragma link C++ class BinSearch + ;
 
-#pragma link C++ class HitInfo+;
-#pragma link C++ class HitMatchInfo+;
-#pragma link C++ class std::vector<HitInfo>+;
-#pragma link C++ class std::vector<HitMatchInfo>+;
+#pragma link C++ class HitInfo + ;
+#pragma link C++ class HitMatchInfo + ;
+#pragma link C++ class std::vector < HitInfo> + ;
+#pragma link C++ class std::vector < HitMatchInfo> + ;
 
 #pragma link C++ class CandInfo + ;
 #pragma link C++ class std::vector < CandInfo> + ;

--- a/RecoTracker/MkFitCore/standalone/val_scripts/validation-cmssw-benchmarks-multiiter.sh
+++ b/RecoTracker/MkFitCore/standalone/val_scripts/validation-cmssw-benchmarks-multiiter.sh
@@ -53,6 +53,18 @@ case ${inputBin} in
         # that does not work with MIMI at this point.
         export MKFIT_MIMI=1
         ;;
+"Mu_phase2")
+        dir=/ceph/cms/store/user/legianni/generate-phase2/10mu
+        subdir=
+        file=ntuple_pt0p1to1_eta0p0to0p4.bin
+        nevents=100
+        extraargs="--geom CMS-phase2"
+        numiters=1
+        # Pass MIMI flag to ROOT plotting functions -- some will insert STD
+        # that does not work with MIMI at this point.
+        export MKFIT_MIMI=1
+        ;;
+# "Mu_phase2_XYZ" samples - see https://gist.github.com/osschar/7cd037f6fcdd05ccf11586fdaadab377
 *)
         echo "INPUT BIN IS UNKNOWN"
         exit 12
@@ -78,8 +90,13 @@ then
     maxth=1
     maxev=1
 fi
+
+silent="--silent"
 seeds="--cmssw-n2seeds"
-exe="./mkFit --silent ${seeds} --num-thr ${maxth} --num-thr-ev ${maxev} --input-file ${dir}/${subdir}/${file} --num-events ${nevents} --remove-dup ${extraargs}"
+input_data="--input-file ${dir}/${subdir}/${file} --num-events ${nevents}"
+threads="--num-thr ${maxth} --num-thr-ev ${maxev}"
+
+exe="./mkFit ${silent} ${seeds} ${input_data} ${threads} --remove-dup ${extraargs}"
 
 ## Common output setup
 tmpdir="tmp"
@@ -121,7 +138,7 @@ SIMPLOTSEED10="SIMVALSEED iter10 0 10 0"
 SIMPLOT6="SIMVAL iter6 0 6 0"
 SIMPLOTSEED6="SIMVALSEED iter6 0 6 0"
 
-if [[ "${inputBin}" == "TTbar_phase2" ]]
+if [[ ${numiters} -eq 1 ]]
 then
     declare -a plots=(SIMPLOT4 SIMPLOTSEED4)
 else
@@ -146,10 +163,12 @@ function doVal()
 
     local oBase=${val_arch}_${sample}_${bN}
     local bExe="${exe} ${vO} --build-${bO}"
-    
+
     echo "${oBase}: ${vN} [nTH:${maxth}, nVU:${maxvu}int, nEV:${maxev}]"
-    ${bExe} >& log_${oBase}_NVU${maxvu}int_NTH${maxth}_NEV${maxev}_${vN}.txt || (echo "Crashed on CMD: "${bExe}; exit 2)
-    
+    logfile=log_${oBase}_NVU${maxvu}int_NTH${maxth}_NEV${maxev}_${vN}.txt
+    echo logfile ${logfile}
+    ${bExe} > ${logfile} || (echo "Crashed on CMD: "${bExe}; exit 2)
+
     if (( ${maxev} > 1 ))
     then
         # hadd output files from different threads for this test, then move to temporary directory
@@ -224,6 +243,8 @@ do echo ${!plot} | while read -r pN suff pO iter cancel
         ## Compute observables for special dummy CMSSW
 	if [[ "${pN}" == "SIMVAL" || "${pN}" == "SIMVAL_"* ]]
 	then
+        echo In SIMVAL plot loop
+        echo CMSSW=${CMSSW}
 	    echo ${CMSSW} | while read -r bN bO val_extras
 	    do
 		plotVal "${base}" "${bN}" "${pN}" "${pO}" "${iter}" "${cancel}" "${rmsuff}"
@@ -231,6 +252,8 @@ do echo ${!plot} | while read -r pN suff pO iter cancel
 	fi
 	if [[ "${pN}" == "SIMVALSEED"* ]]
 	then
+        echo In SIMVALSEED plot loop
+        echo CMSSW2=${CMSSW2}
 	    echo ${CMSSW2} | while read -r bN bO val_extras
 	    do
 		plotVal "${base}" "${bN}" "${pN}" "${pO}" "${iter}" "${cancel}" "${rmsuff}"

--- a/RecoTracker/MkFitCore/standalone/validation-desc.txt
+++ b/RecoTracker/MkFitCore/standalone/validation-desc.txt
@@ -21,7 +21,7 @@ ln -s ../RecoTracker/MkFitCore/standalone/plotting .
 ln -s ../RecoTracker/MkFitCore/standalone/web .
 
 rm -rf valtree_*.root log_*.txt
-val_scripts/validation-cmssw-benchmarks-multiiter.sh forPR --mtv-like-val TTbar_Phase2
+val_scripts/validation-cmssw-benchmarks-multiiter.sh forPR --mtv-like-val TTbar_phase2
 
 web/collectBenchmarks-multi.sh Phase2-0 forPR
 

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-if [[ `[ -f /usr/bin/lsb_release ] && lsb_release -si` == \
-        "Fedora" ||
-      `[ -f /etc/redhat-release ] && awk '{print $1}' /etc/redhat-release` == \
-        "AlmaLinux" ]]
+if [[ `[ -f /usr/bin/lsb_release ] && lsb_release -si` == "Fedora" ]]
 then
-  os_arch_comp="el8_amd64_gcc11"
+  os_arch_comp="el9_amd64_gcc13"
+elif [[ `[ -f /etc/redhat-release ] && awk '{print $1}' /etc/redhat-release` == "AlmaLinux" ]]
+then
+  os_arch_comp="el8_amd64_gcc12"
 else
   os_arch_comp="slc7_amd64_gcc11"
 fi
-  source /cvmfs/cms.cern.ch/${os_arch_comp}/lcg/root/6.26.07-e76d33b57cbf5a1c12b870df2a6ebb79/etc/profile.d/init.sh
-  export TBB_GCC=/cvmfs/cms.cern.ch/${os_arch_comp}/external/tbb/v2021.8.0-791ebc4967ab49af60ca9ad2aa021259
+
+source /cvmfs/cms.cern.ch/${os_arch_comp}/lcg/root/6.28.07-573b0d3de9894ea2ab667c0d36cf4882/etc/profile.d/init.sh
+export TBB_GCC=/cvmfs/cms.cern.ch/${os_arch_comp}/external/tbb/v2021.9.0-295412b9bb1d6b3275d2ace3e62c1faa


### PR DESCRIPTION
### PR description:

This PR adds the ability to run mkFit on Phase-2 data / geometry. Only initialStep iteration is supported so far, with a dedicated workflow (`24834.702`).

* Add CMSSW Phase-2 hit and seed converters.

* Properly support binary readout for Phase-2 strips where cluster-charge cut can
not be applied.

* Improve standalone performance monitoring & debugging tools.

**It requires also a new JSON file in cmssw/data repository:**
https://github.com/cms-data/RecoTracker-MkFit/pull/14

### PR validation:
In TTbar events, with PU:
- Phase-2 (PU200, where mkFit is only used for initialStep track building): http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/MTV_TTbar_PU200_Run4_mkFitInitialStep_April16/
- Phase-1 (2024; no change, as expected): http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/Phase2/MTV_TTbar_PU_Run3_April16/

FYI: @osschar, @slava77, @kskovpen 