### PR TITLE
Prevent geniso to be run in nanogen

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -98,6 +98,8 @@ def customizeNanoGEN(process):
     process.nanogenSequence.remove(process.genParticles2HepMCHiggsVtx)
     process.nanogenSequence.remove(process.genParticles2HepMC)
     process.nanogenSequence.remove(process.mergedGenParticles)
+    process.nanogenSequence.remove(process.genIso)
+    delattr(process.genParticleTable.externalVariables,"iso")
     nanoGenCommonCustomize(process)
     return process
 


### PR DESCRIPTION
#### PR description:
Address #44664. 
The fix just prevents genIso to be run in the nanogen sequence as suggested by @vlimant [[here](https://github.com/cms-sw/cmssw/issues/44664#issuecomment-2044437420)].

The genIso module might be refactored at a later time to make it work also in the nanogen sequence by relying only on genparticles.

