### PR TITLE
updated parameters and model for photon XGboost MVA (HLT) [14_0_X (backport)]

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaDoubleXGBoostCombFilter.cc
@@ -36,14 +36,6 @@ private:
   const std::vector<double> leadCutHighMass3_;
   const std::vector<double> subCutHighMass3_;
 
-  const double lowMassCut_;
-  const std::vector<double> leadCutLowMass1_;
-  const std::vector<double> subCutLowMass1_;
-  const std::vector<double> leadCutLowMass2_;
-  const std::vector<double> subCutLowMass2_;
-  const std::vector<double> leadCutLowMass3_;
-  const std::vector<double> subCutLowMass3_;
-
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candToken_;
   const edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> mvaToken_;
 };
@@ -57,15 +49,6 @@ HLTEgammaDoubleXGBoostCombFilter::HLTEgammaDoubleXGBoostCombFilter(edm::Paramete
       subCutHighMass2_(config.getParameter<std::vector<double>>("subCutHighMass2")),
       leadCutHighMass3_(config.getParameter<std::vector<double>>("leadCutHighMass3")),
       subCutHighMass3_(config.getParameter<std::vector<double>>("subCutHighMass3")),
-
-      lowMassCut_(config.getParameter<double>("lowMassCut")),
-      leadCutLowMass1_(config.getParameter<std::vector<double>>("leadCutLowMass1")),
-      subCutLowMass1_(config.getParameter<std::vector<double>>("subCutLowMass1")),
-      leadCutLowMass2_(config.getParameter<std::vector<double>>("leadCutLowMass2")),
-      subCutLowMass2_(config.getParameter<std::vector<double>>("subCutLowMass2")),
-      leadCutLowMass3_(config.getParameter<std::vector<double>>("leadCutLowMass3")),
-      subCutLowMass3_(config.getParameter<std::vector<double>>("subCutLowMass3")),
-
       candToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("candTag"))),
       mvaToken_(consumes<reco::RecoEcalCandidateIsolationMap>(config.getParameter<edm::InputTag>("mvaPhotonTag"))) {}
 
@@ -73,21 +56,13 @@ void HLTEgammaDoubleXGBoostCombFilter::fillDescriptions(edm::ConfigurationDescri
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
 
-  desc.add<double>("highMassCut", 95.0);
-  desc.add<std::vector<double>>("leadCutHighMass1", {0.98, 0.95});
-  desc.add<std::vector<double>>("subCutHighMass1", {0.0, 0.04});
+  desc.add<double>("highMassCut", 90.0);
+  desc.add<std::vector<double>>("leadCutHighMass1", {0.92, 0.95});
+  desc.add<std::vector<double>>("subCutHighMass1", {0.02, 0.04});
   desc.add<std::vector<double>>("leadCutHighMass2", {0.85, 0.85});
   desc.add<std::vector<double>>("subCutHighMass2", {0.04, 0.08});
   desc.add<std::vector<double>>("leadCutHighMass3", {0.30, 0.50});
-  desc.add<std::vector<double>>("subCutHighMass3", {0.15, 0.20});
-
-  desc.add<double>("lowMassCut", 60.0);
-  desc.add<std::vector<double>>("leadCutLowMass1", {0.98, 0.90});
-  desc.add<std::vector<double>>("subCutLowMass1", {0.04, 0.05});
-  desc.add<std::vector<double>>("leadCutLowMass2", {0.90, 0.80});
-  desc.add<std::vector<double>>("subCutLowMass2", {0.10, 0.10});
-  desc.add<std::vector<double>>("leadCutLowMass3", {0.60, 0.60});
-  desc.add<std::vector<double>>("subCutLowMass3", {0.30, 0.30});
+  desc.add<std::vector<double>>("subCutHighMass3", {0.14, 0.20});
 
   desc.add<edm::InputTag>("candTag", edm::InputTag("hltEgammaCandidatesUnseeded"));
   desc.add<edm::InputTag>("mvaPhotonTag", edm::InputTag("PhotonXGBoostProducer"));
@@ -136,18 +111,6 @@ bool HLTEgammaDoubleXGBoostCombFilter::hltFilter(edm::Event& event,
           accept = true;
         }  // if scoreJ > scoreI
       }    //If high mass
-      else if (mass > lowMassCut_ && mass < highMassCut_) {
-        if (mvaScorei >= mvaScorej && ((mvaScorei > leadCutLowMass1_[eta1] && mvaScorej > subCutLowMass1_[eta2]) ||
-                                       (mvaScorei > leadCutLowMass2_[eta1] && mvaScorej > subCutLowMass2_[eta2]) ||
-                                       (mvaScorei > leadCutLowMass3_[eta1] && mvaScorej > subCutLowMass3_[eta2]))) {
-          accept = true;
-        }  //if scoreI > scoreJ
-        else if (mvaScorej > mvaScorei && ((mvaScorej > leadCutLowMass1_[eta1] && mvaScorei > subCutLowMass1_[eta2]) ||
-                                           (mvaScorej > leadCutLowMass2_[eta1] && mvaScorei > subCutLowMass2_[eta2]) ||
-                                           (mvaScorej > leadCutLowMass3_[eta1] && mvaScorei > subCutLowMass3_[eta2]))) {
-          accept = true;
-        }  //if scoreJ > scoreI
-      }    //If low mass
     }      //j loop
   }        //i loop
   return accept;

--- a/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
+++ b/RecoEgamma/PhotonIdentification/test/test_PhotonMvaXgb.cc
@@ -11,6 +11,9 @@
 #define NTREE_LIMIT_B_V1 168
 #define NTREE_LIMIT_E_V1 158
 
+#define NTREE_LIMIT_B_V2 144
+#define NTREE_LIMIT_E_V2 99
+
 float const vars_in[INPUT_LEN][9] = {
     {134.303, 0.945981, 0.0264346, 0.012448, 0.0208734, 113.405, 1.7446, 0.00437808, 0.303464},
     {95.8896, 0.988677, 0.0217735, 0.0137696, 0.0441448, 90.7534, 1.85852, 0.0176929, 0},
@@ -26,13 +29,16 @@ float const vars_in[INPUT_LEN][9] = {
 const float mva_score_v1[INPUT_LEN] = {
     0.98634, 0.97501, 0.00179, 0.70818, 0.98374, 0.00153, 0.97103, 0.00009, 0.00626, 0.95222};
 
-TEST_CASE("RecoEgamma/PhotonIdentification testXGBPhoton", "[TestPhotonMvaXgb]") {
-  auto mvaEstimatorB = std::make_unique<PhotonXGBoostEstimator>(
-      edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_168_Barrel_v1.bin"), NTREE_LIMIT_B_V1);
-  auto mvaEstimatorE = std::make_unique<PhotonXGBoostEstimator>(
-      edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_158_Endcap_v1.bin"), NTREE_LIMIT_E_V1);
+const float mva_score_v2[INPUT_LEN] = {
+    0.98382, 0.94038, 0.59126, 0.91911, 0.98032, 0.18934, 0.99078, 0.60751, 0.00389, 0.96929};
 
-  SECTION("Test mva_compute") {
+TEST_CASE("RecoEgamma/PhotonIdentification testXGBPhoton", "[TestPhotonMvaXgb]") {
+  SECTION("Test mva_compute v1") {
+    auto mvaEstimatorB = std::make_unique<PhotonXGBoostEstimator>(
+        edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_168_Barrel_v1.bin"), NTREE_LIMIT_B_V1);
+    auto mvaEstimatorE = std::make_unique<PhotonXGBoostEstimator>(
+        edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_158_Endcap_v1.bin"), NTREE_LIMIT_E_V1);
+
     for (unsigned int i = 0; i < INPUT_LEN; i++) {
       float xgbScore;
       const float *v = vars_in[i];
@@ -42,6 +48,24 @@ TEST_CASE("RecoEgamma/PhotonIdentification testXGBPhoton", "[TestPhotonMvaXgb]")
       else
         xgbScore = mvaEstimatorE->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
       CHECK_THAT(xgbScore, Catch::Matchers::WithinAbs(mva_score_v1[i], 0.0001));
+    }
+  }
+
+  SECTION("Test mva_compute v2") {
+    auto mvaEstimatorB = std::make_unique<PhotonXGBoostEstimator>(
+        edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_144_Barrel_v2.bin"), NTREE_LIMIT_B_V2);
+    auto mvaEstimatorE = std::make_unique<PhotonXGBoostEstimator>(
+        edm::FileInPath("RecoEgamma/PhotonIdentification/data/XGBoost/Photon_NTL_99_Endcap_v2.bin"), NTREE_LIMIT_E_V2);
+
+    for (unsigned int i = 0; i < INPUT_LEN; i++) {
+      float xgbScore;
+      const float *v = vars_in[i];
+      float etaSC = v[6];
+      if (std::abs(etaSC) < 1.5)
+        xgbScore = mvaEstimatorB->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+      else
+        xgbScore = mvaEstimatorE->computeMva(v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8]);
+      CHECK_THAT(xgbScore, Catch::Matchers::WithinAbs(mva_score_v2[i], 0.0001));
     }
   }
 }


### PR DESCRIPTION
#### PR description:
* Latest XGBoost model in cms-data added to the unit test. Requires: https://github.com/cms-data/RecoEgamma-PhotonIdentification/pull/15
* Removed unused parameters and updating relevant parameters to the values intended for inclusion into the pp HLT menu.

#### PR validation:

Unit test added for the new model file.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of:
https://github.com/cms-sw/cmssw/pull/44719
Reason: integration into the next 14_0 release for the proton-proton HLT menu