### PR TITLE
HGCAL Electronics mapping (v2)

### DIFF
--- a/CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h
+++ b/CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h
@@ -1,0 +1,24 @@
+#ifndef CondFormatsModuleRcd_HGCalElectronicsMappingRcd_h
+#define CondFormatsModuleRcd_HGCalElectronicsMappingRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecords
+// Class  :     HGCalElectronicsMappingRcd
+//
+/**\class HGCalElectronicsMappingRcd HGCalElectronicsMappingRcd.h CondFormats/DataRecords/interface/HGCalElectronicsMappingRcd.h
+ Description: This record *is temporary* and it is used to store the parameters which are used to describe 
+ - dense indexing of HGCAL modules and corresponding cells in the readound sequence
+ - module and cell information in the electronics mapping
+ The record will change to its final format(s) once the we settle on the final formats to be used in CondDB
+*/
+//
+// Author:      Pedro Vieira De Castro Ferreira Da Silva
+// Created:     Mon, 13 Nov 2023 12:02:11 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HGCalElectronicsMappingRcd : public edm::eventsetup::EventSetupRecordImplementation<HGCalElectronicsMappingRcd> {
+};
+
+#endif

--- a/CondFormats/DataRecord/src/HGCalElectronicsMappingRcd.cc
+++ b/CondFormats/DataRecord/src/HGCalElectronicsMappingRcd.cc
@@ -1,0 +1,13 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HGCalElectronicsMappingRcd
+//
+//
+// Author:      Pedro Vieira De Castro Ferreira Da Silva
+// Created:     Mon, 13 Nov 2023 12:02:11 GMT
+
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HGCalElectronicsMappingRcd);

--- a/CondFormats/HGCalObjects/BuildFile.xml
+++ b/CondFormats/HGCalObjects/BuildFile.xml
@@ -1,8 +1,14 @@
-<use   name="FWCore/Utilities"/>
-<use   name="FWCore/MessageLogger"/>
-<use   name="HeterogeneousCore/CUDACore"/>
-<use   name="CUDADataFormats/HGCal"/>
-<use   name="Geometry/HGCalCommonData"/>
+<use name="CondFormats/Serialization"/>
+<use name="Geometry/HGCalCommonData"/>
+<use name="boost_serialization"/>
+<use name="DataFormats/HGCalDigi"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Utilities"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<use name="HeterogeneousCore/CUDACore"/>
+<flags ALPAKA_BACKENDS="1"/>
 <export>
-  <lib   name="1"/>
+  <lib name="1"/>
 </export>

--- a/CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h
+++ b/CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h
@@ -1,0 +1,66 @@
+#ifndef CondFormats_HGCalObjects_interface_HGCalDenseIndexerBase_h
+#define CondFormats_HGCalObjects_interface_HGCalDenseIndexerBase_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include <array>
+#include <numeric>
+
+/**
+   @short this is a simple class that takes care of building a dense index for a set of categories
+   the maximum number of items expected in each category is encoded in the IndexRanges_t
+   the class is templated for the number of categories to use
+ */
+class HGCalDenseIndexerBase {
+public:
+  HGCalDenseIndexerBase() : HGCalDenseIndexerBase(0) {}
+
+  HGCalDenseIndexerBase(int n) : n_(n), maxIdx_(0), vmax_(n, 0) {}
+
+  HGCalDenseIndexerBase(std::vector<uint32_t> const &o) : n_(o.size()) { updateRanges(o); }
+
+  void updateRanges(std::vector<uint32_t> const &o) {
+    check(o.size());
+    vmax_ = o;
+    maxIdx_ = std::accumulate(vmax_.begin(), vmax_.end(), 1, std::multiplies<uint32_t>());
+  }
+
+  uint32_t denseIndex(std::vector<uint32_t> v) const {
+    uint32_t rtn = v[0];
+    for (size_t i = 1; i < n_; i++)
+      rtn = rtn * vmax_[i] + v[i];
+    return rtn;
+  }
+
+  std::vector<uint32_t> unpackDenseIndex(uint32_t rtn) const {
+    std::vector<uint32_t> codes(n_, 0);
+
+    const auto rend = vmax_.rend();
+    for (auto rit = vmax_.rbegin(); rit != rend; ++rit) {
+      size_t i = rend - rit - 1;
+      codes[i] = rtn % (*rit);
+      rtn = rtn / (*rit);
+    }
+
+    return codes;
+  }
+
+  uint32_t getMaxIndex() const { return maxIdx_; }
+
+  ~HGCalDenseIndexerBase() = default;
+
+private:
+  void check(size_t osize) const {
+    if (osize != n_)
+      throw cms::Exception("ValueError") << " unable to update indexer max values. Expected " << n_ << " received "
+                                         << osize;
+  }
+
+  uint32_t n_;
+  uint32_t maxIdx_;
+  std::vector<uint32_t> vmax_;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h
@@ -1,0 +1,164 @@
+#ifndef CondFormats_HGCalObjects_interface_HGCalMappingCellParameterIndex_h
+#define CondFormats_HGCalObjects_interface_HGCalMappingCellParameterIndex_h
+
+#include <iostream>
+#include <cstdint>
+#include <vector>
+#include <numeric>
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
+
+/**
+   @short utility class to assign dense readout cell indexing
+ */
+class HGCalMappingCellIndexer {
+public:
+  // typedef HGCalDenseIndexerBase WaferDenseIndexerBase;
+
+  HGCalMappingCellIndexer() = default;
+
+  /**
+     adds to map of type codes (= module types) to handle and updatest the max. number of eRx 
+   */
+  void processNewCell(std::string typecode, uint16_t chip, uint16_t half) {
+    //assign index to this typecode and resize the max e-Rx vector
+    if (typeCodeIndexer_.count(typecode) == 0) {
+      typeCodeIndexer_[typecode] = typeCodeIndexer_.size();
+      maxErx_.resize(typeCodeIndexer_.size(), 0);
+    }
+
+    size_t idx = typeCodeIndexer_[typecode];
+    uint16_t erx = chip * 2 + half + 1;  //use the number not the index here
+    maxErx_[idx] = std::max(maxErx_[idx], erx);
+  }
+
+  /**
+     @short process the current list of type codes handled and updates the dense indexers
+  */
+  void update() {
+    uint32_t n = typeCodeIndexer_.size();
+    offsets_ = std::vector<uint32_t>(n, 0);
+    di_ = std::vector<HGCalDenseIndexerBase>(n, HGCalDenseIndexerBase(2));
+    for (uint32_t idx = 0; idx < n; idx++) {
+      uint16_t nerx = maxErx_[idx];
+      di_[idx].updateRanges({{nerx, maxChPerErx_}});
+      if (idx < n - 1)
+        offsets_[idx + 1] = di_[idx].getMaxIndex();
+    }
+
+    //accumulate the offsets in the array
+    std::partial_sum(offsets_.begin(), offsets_.end(), offsets_.begin());
+  }
+
+  /**
+     @short gets index given typecode string
+   */
+  size_t getEnumFromTypecode(std::string typecode) const {
+    auto it = typeCodeIndexer_.find(typecode);
+    if (it == typeCodeIndexer_.end())
+      throw cms::Exception("ValueError") << " unable to find typecode=" << typecode << " in cell indexer";
+    return it->second;
+  }
+
+  /**
+     @short checks if there is a typecode corresponding to an index
+   */
+  std::string getTypecodeFromEnum(size_t idx) const {
+    for (const auto& it : typeCodeIndexer_)
+      if (it.second == idx)
+        return it.first;
+    throw cms::Exception("ValueError") << " unable to find typecode corresponding to idx=" << idx;
+  }
+
+  /**
+     @short returns the dense indexer for a typecode
+   */
+  HGCalDenseIndexerBase getDenseIndexFor(std::string typecode) const {
+    return getDenseIndexerFor(getEnumFromTypecode(typecode));
+  }
+
+  /**
+     @short returns the dense indexer for a given internal index
+  */
+  HGCalDenseIndexerBase getDenseIndexerFor(size_t idx) const {
+    if (idx >= di_.size())
+      throw cms::Exception("ValueError") << " index requested for cell dense indexer (i=" << idx
+                                         << ") is larger than allocated";
+    return di_[idx];
+  }
+
+  /**
+     @short builders for the dense index
+   */
+  uint32_t denseIndex(std::string typecode, uint32_t chip, uint32_t half, uint32_t seq) const {
+    return denseIndex(getEnumFromTypecode(typecode), chip, half, seq);
+  }
+  uint32_t denseIndex(std::string typecode, uint32_t erx, uint32_t seq) const {
+    return denseIndex(getEnumFromTypecode(typecode), erx, seq);
+  }
+  uint32_t denseIndex(size_t idx, uint32_t chip, uint32_t half, uint32_t seq) const {
+    uint16_t erx = chip * maxHalfPerROC_ + half;
+    return denseIndex(idx, erx, seq);
+  }
+  uint32_t denseIndex(size_t idx, uint32_t erx, uint32_t seq) const {
+    return di_[idx].denseIndex({{erx, seq}}) + offsets_[idx];
+  }
+
+  /**
+     @short decodes the dense index code
+   */
+  uint32_t elecIdFromIndex(uint32_t rtn, std::string typecode) const {
+    return elecIdFromIndex(rtn, getEnumFromTypecode(typecode));
+  }
+  uint32_t elecIdFromIndex(uint32_t rtn, size_t idx) const {
+    if (idx >= di_.size())
+      throw cms::Exception("ValueError") << " index requested for cell dense indexer (i=" << idx
+                                         << ") is larger than allocated";
+    rtn -= offsets_[idx];
+    auto rtn_codes = di_[idx].unpackDenseIndex(rtn);
+    return HGCalElectronicsId(false, 0, 0, 0, rtn_codes[0], rtn_codes[1]).raw();
+  }
+
+  /**
+     @short returns the max. dense index expected
+   */
+  uint32_t maxDenseIndex() const {
+    size_t i = maxErx_.size();
+    if (i == 0)
+      return 0;
+    return offsets_.back() + maxErx_.back() * maxChPerErx_;
+  }
+
+  /**
+     @short gets the number of words for a given typecode
+  */
+  size_t getNWordsExpectedFor(std::string typecode) const {
+    auto it = getEnumFromTypecode(typecode);
+    return getNWordsExpectedFor(it);
+  }
+  size_t getNWordsExpectedFor(size_t typecodeidx) const { return maxErx_[typecodeidx] * maxChPerErx_; }
+
+  /**
+     @short gets the number of e-Rx for a given typecode
+  */
+  size_t getNErxExpectedFor(std::string typecode) const {
+    auto it = getEnumFromTypecode(typecode);
+    return getNErxExpectedFor(it);
+  }
+  size_t getNErxExpectedFor(size_t typecodeidx) const { return maxErx_[typecodeidx]; }
+
+  constexpr static char maxHalfPerROC_ = 2;
+  constexpr static uint16_t maxChPerErx_ = 37;  //36 channels + 1 calib
+
+  std::map<std::string, size_t> typeCodeIndexer_;
+  std::vector<uint16_t> maxErx_;
+  std::vector<uint32_t> offsets_;
+  std::vector<HGCalDenseIndexerBase> di_;
+
+  ~HGCalMappingCellIndexer() {}
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h
@@ -1,0 +1,234 @@
+#ifndef CondFormats_HGCalObjects_interface_HGCalMappingParameterIndex_h
+#define CondFormats_HGCalObjects_interface_HGCalMappingParameterIndex_h
+
+#include <cstdint>
+#include <vector>
+#include <algorithm>
+
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+/**
+   @short this structure holds the indices and types in the readout sequence
+   as the 12 capture blocks may not all be used and the each capture block may also be under-utilized
+   a lookup table is used to hold the compact index
+ */
+struct HGCalFEDReadoutSequence_t {
+  uint32_t id;
+  ///>look-up table (capture block, econd idx) -> internal dense index
+  std::vector<int> moduleLUT_;
+  ///>dense sequence of modules in the readout: the type is the one in use in the cell mapping
+  std::vector<int> readoutTypes_;
+  ///>dense sequence of offsets for modules, e-Rx and channel data
+  std::vector<uint32_t> modOffsets_, erxOffsets_, chDataOffsets_;
+  COND_SERIALIZABLE;
+};
+
+/**
+   @short utility class to assign dense readout module indexing
+   the class holds the information on the expected readout sequence (module types) per FED and their offset in the SoAs of data
+ */
+class HGCalMappingModuleIndexer {
+public:
+  HGCalMappingModuleIndexer() : modFedIndexer_({maxCBperFED_, maxECONDperCB_}) {}
+
+  ~HGCalMappingModuleIndexer() = default;
+
+  /**
+     @short for a new module it adds it's type to the readaout sequence vector
+     if the fed id is not yet existing in the mapping it's added
+     a dense indexer is used to create the necessary indices for the new module
+     unused indices will be set with -1
+   */
+  void processNewModule(uint32_t fedid,
+                        uint16_t captureblockIdx,
+                        uint16_t econdIdx,
+                        uint32_t typecodeIdx,
+                        uint32_t nerx,
+                        uint32_t nwords) {
+    //add fed if needed
+    if (fedid >= fedReadoutSequences_.size()) {
+      fedReadoutSequences_.resize(fedid + 1);
+    }
+    HGCalFEDReadoutSequence_t &frs = fedReadoutSequences_[fedid];
+    frs.id = fedid;
+
+    //assign position, resize if needed, and fill the type code
+    uint32_t idx = modFedIndexer_.denseIndex({{captureblockIdx, econdIdx}});
+    if (idx >= frs.readoutTypes_.size()) {
+      frs.readoutTypes_.resize(idx + 1, -1);
+    }
+    frs.readoutTypes_[idx] = typecodeIdx;
+
+    //count another typecodein the global list
+    if (typecodeIdx >= globalTypesCounter_.size()) {
+      globalTypesCounter_.resize(typecodeIdx + 1, 0);
+      globalTypesNErx_.resize(typecodeIdx + 1, 0);
+      globalTypesNWords_.resize(typecodeIdx + 1, 0);
+      dataOffsets_.resize(typecodeIdx + 1, 0);
+    }
+    globalTypesCounter_[typecodeIdx]++;
+    globalTypesNErx_[typecodeIdx] = nerx;
+    globalTypesNWords_[typecodeIdx] = nwords;
+  }
+
+  /**
+     @short
+   */
+  void finalize() {
+    //max indices at different levels
+    nfeds_ = fedReadoutSequences_.size();
+    maxModulesIdx_ = std::accumulate(globalTypesCounter_.begin(), globalTypesCounter_.end(), 0);
+    maxErxIdx_ =
+        std::inner_product(globalTypesCounter_.begin(), globalTypesCounter_.end(), globalTypesNErx_.begin(), 0);
+    maxDataIdx_ =
+        std::inner_product(globalTypesCounter_.begin(), globalTypesCounter_.end(), globalTypesNWords_.begin(), 0);
+
+    //compute the global offset to assign per board type, eRx and channel data
+    moduleOffsets_.resize(maxModulesIdx_, 0);
+    erxOffsets_.resize(maxModulesIdx_, 0);
+    dataOffsets_.resize(maxModulesIdx_, 0);
+    for (size_t i = 1; i < globalTypesCounter_.size(); i++) {
+      moduleOffsets_[i] = globalTypesCounter_[i - 1];
+      erxOffsets_[i] = globalTypesCounter_[i - 1] * globalTypesNErx_[i - 1];
+      dataOffsets_[i] = globalTypesCounter_[i - 1] * globalTypesNWords_[i - 1];
+    }
+    std::partial_sum(moduleOffsets_.begin(), moduleOffsets_.end(), moduleOffsets_.begin());
+    std::partial_sum(erxOffsets_.begin(), erxOffsets_.end(), erxOffsets_.begin());
+    std::partial_sum(dataOffsets_.begin(), dataOffsets_.end(), dataOffsets_.begin());
+
+    //now go through the FEDs and ascribe the offsets per module in the readout sequence
+    std::vector<uint32_t> typeCounters(globalTypesCounter_.size(), 0);
+    for (auto &fedit : fedReadoutSequences_) {
+      //assign the indexing in the look-up table
+      size_t nconn(0);
+      fedit.moduleLUT_.resize(fedit.readoutTypes_.size(), -1);
+      for (size_t i = 0; i < fedit.readoutTypes_.size(); i++) {
+        if (fedit.readoutTypes_[i] == -1)
+          continue;  //unexisting
+        fedit.moduleLUT_[i] = nconn;
+        nconn++;
+      }
+
+      //remove unexisting ECONs building a final compact readout sequence
+      std::remove_if(
+          fedit.readoutTypes_.begin(), fedit.readoutTypes_.end(), [&](int val) -> bool { return val == -1; });
+
+      //assign the final offsets at the different levels
+      size_t nmods = fedit.readoutTypes_.size();
+      fedit.modOffsets_.resize(nmods, 0);
+      fedit.erxOffsets_.resize(nmods, 0);
+      fedit.chDataOffsets_.resize(nmods, 0);
+      for (size_t i = 0; i < nmods; i++) {
+        uint32_t type_val = fedit.readoutTypes_[i];
+
+        //module offset : global offset for this type + current index for this type
+        uint32_t baseMod_offset = moduleOffsets_[type_val] + typeCounters[type_val];
+        fedit.modOffsets_[i] = baseMod_offset;  // + internalMod_offset;
+
+        //erx-level offset : global offset of e-Rx of this type + #e-Rrx * current index for this type
+        uint32_t baseErx_offset = erxOffsets_[type_val];
+        uint32_t internalErx_offset = globalTypesNErx_[type_val] * typeCounters[type_val];
+        fedit.erxOffsets_[i] = baseErx_offset + internalErx_offset;
+
+        //channel data offset: global offset for data of this type + #words * current index for this type
+        uint32_t baseData_offset = dataOffsets_[type_val];
+        uint32_t internalData_offset = globalTypesNWords_[type_val] * typeCounters[type_val];
+        fedit.chDataOffsets_[i] = baseData_offset + internalData_offset;
+
+        typeCounters[type_val]++;
+      }
+    }
+  }
+
+  /**
+     @short decodes silicon or sipm type and cell type for the detector id 
+     from the typecode string
+   */
+  static std::pair<bool, int> convertTypeCode(std::string_view typecode) {
+    if (typecode.size() < 5)
+      throw cms::Exception("InvalidHGCALTypeCode") << typecode << " is invalid for decoding readout cell type";
+
+    bool isSiPM = {typecode.find("TM") != std::string::npos ? true : false};
+    int celltype;
+    if (isSiPM) {
+      celltype = 0;  // Assign SiPM type coarse or molded with next version of modulelocator
+    } else {
+      celltype = {typecode[4] == '1' ? 0 : typecode[4] == '2' ? 1 : 2};
+    }
+    return std::pair<bool, bool>(isSiPM, celltype);
+  }
+
+  /**
+     @short returns the index for the n-th module in the readout sequence of a FED
+     if the index in the readout sequence is unknown alternative methods which take the (capture block, econd idx) are provided
+     which will find first what should be the internal dense index (index in the readout sequence)
+   */
+  uint32_t getIndexForModule(uint32_t fedid, uint32_t nmod) const {
+    return fedReadoutSequences_[fedid].modOffsets_[nmod];
+  };
+  uint32_t getIndexForModule(uint32_t fedid, uint16_t captureblockIdx, uint16_t econdIdx) const {
+    uint32_t nmod = denseIndexingFor(fedid, captureblockIdx, econdIdx);
+    return getIndexForModule(fedid, nmod);
+  };
+  uint32_t getIndexForModuleErx(uint32_t fedid, uint32_t nmod, uint32_t erxidx) const {
+    return fedReadoutSequences_[fedid].erxOffsets_[nmod] + erxidx;
+  };
+  uint32_t getIndexForModuleErx(uint32_t fedid, uint16_t captureblockIdx, uint16_t econdIdx, uint32_t erxidx) const {
+    uint32_t nmod = denseIndexingFor(fedid, captureblockIdx, econdIdx);
+    return getIndexForModuleErx(fedid, nmod, erxidx);
+  }
+  uint32_t getIndexForModuleData(uint32_t fedid, uint32_t nmod, uint32_t erxidx, uint32_t chidx) const {
+    return fedReadoutSequences_[fedid].chDataOffsets_[nmod] + erxidx * HGCalMappingCellIndexer::maxChPerErx_ + chidx;
+  };
+  uint32_t getIndexForModuleData(
+      uint32_t fedid, uint16_t captureblockIdx, uint16_t econdIdx, uint32_t erxidx, uint32_t chidx) const {
+    uint32_t nmod = denseIndexingFor(fedid, captureblockIdx, econdIdx);
+    return getIndexForModuleData(fedid, nmod, erxidx, chidx);
+  };
+
+  int getTypeForModule(uint32_t fedid, uint32_t nmod) const { return fedReadoutSequences_[fedid].readoutTypes_[nmod]; }
+  int getTypeForModule(uint32_t fedid, uint16_t captureblockIdx, uint16_t econdIdx) const {
+    uint32_t nmod = denseIndexingFor(fedid, captureblockIdx, econdIdx);
+    return getTypeForModule(fedid, nmod);
+  }
+
+  ///< internal indexer
+  HGCalDenseIndexerBase modFedIndexer_;
+  ///< the sequence of FED readout sequence descriptors
+  std::vector<HGCalFEDReadoutSequence_t> fedReadoutSequences_;
+  ///< global counters for types of modules, number of e-Rx and words
+  std::vector<uint32_t> globalTypesCounter_, globalTypesNErx_, globalTypesNWords_;
+  ///< base offsets to apply per module type with different granularity : module, e-Rx, channel data
+  std::vector<uint32_t> moduleOffsets_, erxOffsets_, dataOffsets_;
+  ///< global counters (sizes of vectors)
+  uint32_t nfeds_, maxDataIdx_, maxErxIdx_, maxModulesIdx_;
+
+  ///< max number of main buffers/capture blocks per FED
+  constexpr static uint32_t maxCBperFED_ = 10;
+  ///< max number of ECON-Ds processed by a main buffer/capture block
+  constexpr static uint32_t maxECONDperCB_ = 12;
+
+private:
+  /**
+     @short given capture block and econd indices returns the dense indexer
+   */
+  uint32_t denseIndexingFor(uint32_t fedid, uint16_t captureblockIdx, uint16_t econdIdx) const {
+    if (fedid > nfeds_)
+      throw cms::Exception("ValueError") << "FED ID=" << fedid << " is unknown to current mapping";
+    uint32_t idx = modFedIndexer_.denseIndex({{captureblockIdx, econdIdx}});
+    auto dense_idx = fedReadoutSequences_[fedid].moduleLUT_[idx];
+    if (dense_idx < 0)
+      throw cms::Exception("ValueError") << "FED ID=" << fedid << " capture block=" << captureblockIdx
+                                         << " econ=" << econdIdx << "has not been assigned a dense indexing"
+                                         << std::endl;
+    return uint32_t(dense_idx);
+  }
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h
@@ -1,0 +1,17 @@
+#ifndef CondFormats_HGCalObjects_interface_HGCalMappingParameterHostCollection_h
+#define CondFormats_HGCalObjects_interface_HGCalMappingParameterHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h"
+
+namespace hgcal {
+
+  // SoA with channel-level module mapping parameters in host memory:
+  using HGCalMappingModuleParamHostCollection = PortableHostCollection<HGCalMappingModuleParamSoA>;
+
+  // SoA with channel-level cell mapping parameters in host memory for both Si and SiPM channels:
+  using HGCalMappingCellParamHostCollection = PortableHostCollection<HGCalMappingCellParamSoA>;
+
+}  // namespace hgcal
+
+#endif  // CondFormats_HGCalObjects_interface_HGCalMappingParameterHostCollection_h

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
@@ -1,0 +1,56 @@
+#ifndef CondFormats_HGCalObjects_interface_HGCalMappingParameterSoA_h
+#define CondFormats_HGCalObjects_interface_HGCalMappingParameterSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+
+namespace hgcal {
+
+  // Generate structure of channel-level arrays (SoA) layout with module mapping information
+  GENERATE_SOA_LAYOUT(HGCalMappingModuleParamSoALayout,
+                      SOA_COLUMN(bool, valid),
+                      SOA_COLUMN(bool, zside),
+                      SOA_COLUMN(bool, isSiPM),
+                      SOA_COLUMN(int, plane),
+                      SOA_COLUMN(int, i1),
+                      SOA_COLUMN(int, i2),
+                      SOA_COLUMN(int, celltype),
+                      SOA_COLUMN(uint16_t, typeidx),
+                      SOA_COLUMN(uint16_t, fedid),
+                      SOA_COLUMN(uint16_t, slinkidx),
+                      SOA_COLUMN(uint16_t, captureblock),
+                      SOA_COLUMN(uint16_t, econdidx),
+                      SOA_COLUMN(uint16_t, captureblockidx),
+                      SOA_COLUMN(uint32_t, eleid),
+                      SOA_COLUMN(uint32_t, detid))
+  using HGCalMappingModuleParamSoA = HGCalMappingModuleParamSoALayout<>;
+
+  // Generate structure of channel-level arrays (SoA) layout with cell mapping information for both silicon and SiPM
+  GENERATE_SOA_LAYOUT(HGCalMappingCellParamSoALayout,
+                      SOA_COLUMN(bool, valid),
+                      SOA_COLUMN(bool, isHD),
+                      SOA_COLUMN(bool, iscalib),
+                      SOA_COLUMN(bool, isSiPM),
+                      SOA_COLUMN(uint16_t, typeidx),
+                      SOA_COLUMN(uint16_t, chip),
+                      SOA_COLUMN(uint16_t, half),
+                      SOA_COLUMN(uint16_t, seq),
+                      SOA_COLUMN(uint16_t, rocpin),
+                      SOA_COLUMN(int, sensorcell),
+                      SOA_COLUMN(int, triglink),
+                      SOA_COLUMN(int, trigcell),
+                      SOA_COLUMN(int, i1),  // iu/iring
+                      SOA_COLUMN(int, i2),  // iv/iphi
+                      SOA_COLUMN(int, t),
+                      SOA_COLUMN(float, trace),
+                      SOA_COLUMN(uint32_t, eleid),
+                      SOA_COLUMN(uint32_t, detid))
+  using HGCalMappingCellParamSoA = HGCalMappingCellParamSoALayout<>;
+
+}  // namespace hgcal
+
+#endif  // CondFormats_HGCalObjects_interface_HGCalMappingParameterSoA_h

--- a/CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDeviceCollection.h
+++ b/CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDeviceCollection.h
@@ -1,0 +1,23 @@
+#ifndef CondFormats_HGCalObjects_interface_alpaka_HGCalMappingParameterDeviceCollection_h
+#define CondFormats_HGCalObjects_interface_alpaka_HGCalMappingParameterDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hgcal {
+
+    using HGCalMappingModuleParamDeviceCollection = PortableCollection<::hgcal::HGCalMappingModuleParamSoA>;
+    using HGCalMappingCellParamDeviceCollection = PortableCollection<::hgcal::HGCalMappingCellParamSoA>;
+
+    using HGCalMappingModuleParamHostCollection = ::hgcal::HGCalMappingModuleParamHostCollection;
+    using HGCalMappingCellParamHostCollection = ::hgcal::HGCalMappingCellParamHostCollection;
+
+  }  // namespace hgcal
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // CondFormats_HGCalObjects_interface_alpaka_HGCalMappingParameterDeviceCollection_h

--- a/CondFormats/HGCalObjects/src/ES_HGCalMappingParameter.cc
+++ b/CondFormats/HGCalObjects/src/ES_HGCalMappingParameter.cc
@@ -1,0 +1,5 @@
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(hgcal::HGCalMappingModuleParamHostCollection);
+TYPELOOKUP_DATA_REG(hgcal::HGCalMappingCellParamHostCollection);

--- a/CondFormats/HGCalObjects/src/T_EventSetup_HGCalMappingIndexers.cc
+++ b/CondFormats/HGCalObjects/src/T_EventSetup_HGCalMappingIndexers.cc
@@ -1,0 +1,8 @@
+#include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HGCalDenseIndexerBase);
+TYPELOOKUP_DATA_REG(HGCalMappingCellIndexer);
+TYPELOOKUP_DATA_REG(HGCalMappingModuleIndexer);

--- a/CondFormats/HGCalObjects/src/alpaka/ES_HGCalMappingParameter.cc
+++ b/CondFormats/HGCalObjects/src/alpaka/ES_HGCalMappingParameter.cc
@@ -1,0 +1,5 @@
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/typelookup.h"
+#include "CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDeviceCollection.h"
+
+TYPELOOKUP_ALPAKA_DATA_REG(hgcal::HGCalMappingModuleParamDeviceCollection);
+TYPELOOKUP_ALPAKA_DATA_REG(hgcal::HGCalMappingCellParamDeviceCollection);

--- a/CondFormats/HGCalObjects/src/classes.h
+++ b/CondFormats/HGCalObjects/src/classes.h
@@ -1,0 +1,1 @@
+#include "CondFormats/HGCalObjects/src/headers.h"

--- a/CondFormats/HGCalObjects/src/classes_def.xml
+++ b/CondFormats/HGCalObjects/src/classes_def.xml
@@ -1,0 +1,28 @@
+<lcgdict>
+
+  <class name="HGCalDenseIndexerBase" class_version="0">
+    <field name="vmax_" mapping="blob"/>
+  </class> 
+  
+  <class name="HGCalMappingCellIndexer" class_version="0">
+    <field name="typeCodeIndexer_" mapping="blob"/>
+    <field name="maxErx_" mapping="blob"/>
+    <field name="offsets_" mapping="blob"/>
+    <field name="di_" mapping="blob"/>
+  </class> 
+
+  <class name="HGCalFEDReadoutSequence_t" class_version="0">
+    <field name="readoutTypes_" mapping="blob"/>
+    <field name="modOffsets_" mapping="blob"/>
+    <field name="erxOffsets_" mapping="blob"/>
+    <field name="chDataOffsets_" mapping="blob"/>
+  </class> 
+  
+  <class name="HGCalMappingModuleIndexer" class_version="0">
+    <field name="fedReadoutSequences_" mapping="blob"/>
+    <field name="globalTypesCounter_" mapping="blob"/>
+    <field name="globalTypesNWords_" mapping="blob"/>
+    <field name="globalTypesOffsets_" mapping="blob"/>
+  </class>
+
+</lcgdict>

--- a/CondFormats/HGCalObjects/src/headers.h
+++ b/CondFormats/HGCalObjects/src/headers.h
@@ -1,0 +1,3 @@
+#include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"

--- a/CondFormats/HGCalObjects/test/BuildFile.xml
+++ b/CondFormats/HGCalObjects/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<bin file="testSerializationHGCalCondDataFormats.cc">
+  <use name="CondFormats/HGCalObjects"/>
+</bin>
+<bin file="testDenseIndexerBase.cc">
+  <use name="CondFormats/HGCalObjects"/>
+</bin>

--- a/CondFormats/HGCalObjects/test/testDenseIndexerBase.cc
+++ b/CondFormats/HGCalObjects/test/testDenseIndexerBase.cc
@@ -1,0 +1,44 @@
+#include "CondFormats/HGCalObjects/interface/HGCalDenseIndexerBase.h"
+#include <iostream>
+#include <iterator>
+#include <set>
+#include <cassert>
+
+int main() {
+  //init an indexer for a MH (HD) module
+  //which has 6 ROCs, each with 2 halfs, each with 37 channels
+  std::vector<uint32_t> rans{{6, 2, 37}};
+  HGCalDenseIndexerBase di(rans);
+
+  //a lambda to print arrays
+  auto parray = [](auto v) { std::copy(std::begin(v), std::end(v), std::ostream_iterator<uint32_t>(std::cout, " ")); };
+
+  //test coding/decoding different values
+  std::set<uint32_t> allidx;
+  for (uint32_t i = 0; i < rans[0]; i++) {
+    for (uint32_t j = 0; j < rans[1]; j++) {
+      for (uint32_t k = 0; k < rans[2]; k++) {
+        std::vector<uint32_t> vals{{i, j, k}};
+        uint32_t rtn = di.denseIndex(vals);
+        allidx.insert(rtn);
+        auto decoded_vals = di.unpackDenseIndex(rtn);
+
+        if (vals == decoded_vals)
+          continue;
+        std::cout << "Dense indexing failed @ ";
+        parray(vals);
+        std::cout << " -> " << rtn << " -> ";
+        parray(decoded_vals);
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  //check that all values were unique
+  assert(allidx.size() == di.getMaxIndex());
+
+  //check that values were sequential (last value==size)
+  assert((*allidx.end()) == di.getMaxIndex());
+
+  return 0;
+}

--- a/CondFormats/HGCalObjects/test/testSerializationHGCalCondDataFormats.cc
+++ b/CondFormats/HGCalObjects/test/testSerializationHGCalCondDataFormats.cc
@@ -1,0 +1,12 @@
+#include "CondFormats/Serialization/interface/Test.h"
+#include "CondFormats/HGCalObjects/src/headers.h"
+
+int main() {
+  //dense indexers
+  testSerialization<HGCalDenseIndexerBase>();
+  testSerialization<HGCalMappingCellIndexer>();
+  testSerialization<HGCalFEDReadoutSequence_t>();
+  testSerialization<HGCalMappingModuleIndexer>();
+
+  return 0;
+}

--- a/DataFormats/HGCalDigi/interface/HGCalElectronicsId.h
+++ b/DataFormats/HGCalDigi/interface/HGCalElectronicsId.h
@@ -9,8 +9,9 @@
    @class HGCalElectronicsId
    @short wrapper for a 32b data word identifying a readout channel in the raw data
    The format is the following:
-   Reserved: b'[28,31]
-   FED ID: b'[18,27]
+   Reserved: b'[29,31]
+   z side: b'[28]
+   Local FED ID: b'[18,27]
    Capture Block ID: b'[14,17]
    ECON-D idx: b'[10,13]
    ECON-D eRx: b'[6,9]
@@ -20,14 +21,16 @@
 class HGCalElectronicsId {
 public:
   enum HGCalElectronicsIdMask {
-    kFEDIDMask = 0x3ff,
+    kZsideMask = 0x1,
+    kLocalFEDIDMask = 0x3ff,
     kCaptureBlockMask = 0xf,
     kECONDIdxMask = 0xf,
     kECONDeRxMask = 0xf,
     kHalfROCChannelMask = 0x3f
   };
   enum HGCalElectronicsIdShift {
-    kFEDIDShift = 18,
+    kZsideShift = 28,
+    kLocalFEDIDShift = 18,
     kCaptureBlockShift = 14,
     kECONDIdxShift = 10,
     kECONDeRxShift = 6,
@@ -39,27 +42,31 @@ public:
   */
   HGCalElectronicsId() : value_(0) {}
   explicit HGCalElectronicsId(
-      uint16_t fedid, uint8_t captureblock, uint8_t econdidx, uint8_t econderx, uint8_t halfrocch);
+      bool zside, uint16_t localfedid, uint8_t captureblock, uint8_t econdidx, uint8_t econderx, uint8_t halfrocch);
   explicit HGCalElectronicsId(uint32_t value) : value_(value) {}
-  HGCalElectronicsId(const HGCalElectronicsId& o) : value_(o.value_) {}
 
   /**
      @short getters
   */
+
   uint32_t operator()() const { return value_; }
   bool operator<(const HGCalElectronicsId& oth) const { return value_ < oth.value_; }
+  bool operator==(const HGCalElectronicsId& oth) const { return value_ == oth.value_; }
   uint32_t raw() const { return value_; }
-  uint16_t fedId() const;
+  bool zSide() const;
+  uint16_t localFEDId() const;
   uint8_t captureBlock() const;
   uint8_t econdIdx() const;
   uint8_t econdeRx() const;
   uint8_t halfrocChannel() const;
-
+  uint8_t rocChannel() const;
+  uint8_t cmWord() const;
+  bool isCM() const;
   void print(std::ostream& out = std::cout) const {
     out << "Raw=0x" << std::hex << raw() << std::dec << std::endl
-        << "\tFED-ID: " << (uint32_t)fedId() << " Capture Block: " << (uint32_t)captureBlock()
+        << "\tLocal FED-ID: " << (uint32_t)localFEDId() << " Capture Block: " << (uint32_t)captureBlock()
         << " ECON-D idx: " << (uint32_t)econdIdx() << " eRx: " << (uint32_t)econdeRx()
-        << " 1/2 ROC ch.: " << (uint32_t)halfrocChannel() << std::endl;
+        << " 1/2 ROC ch.: " << (uint32_t)halfrocChannel() << " isCM=" << isCM() << " zSide=" << zSide() << std::endl;
   }
 
 private:

--- a/DataFormats/HGCalDigi/src/HGCalElectronicsId.cc
+++ b/DataFormats/HGCalDigi/src/HGCalElectronicsId.cc
@@ -2,14 +2,23 @@
 
 //
 HGCalElectronicsId::HGCalElectronicsId(
-    uint16_t fedid, uint8_t captureblock, uint8_t econdidx, uint8_t econderx, uint8_t halfrocch) {
-  value_ = ((fedid & kFEDIDMask) << kFEDIDShift) | ((captureblock & kCaptureBlockMask) << kCaptureBlockShift) |
-           ((econdidx & kECONDIdxMask) << kECONDIdxShift) | ((econderx & kECONDeRxMask) << kECONDeRxShift) |
-           ((halfrocch & kHalfROCChannelMask) << kHalfROCChannelShift);
+    bool zside, uint16_t fedid, uint8_t captureblock, uint8_t econdidx, uint8_t econderx, uint8_t halfrocch) {
+  value_ = ((zside & kZsideMask) << kZsideShift) | ((fedid & kLocalFEDIDMask) << kLocalFEDIDShift) |
+           ((captureblock & kCaptureBlockMask) << kCaptureBlockShift) | ((econdidx & kECONDIdxMask) << kECONDIdxShift) |
+           ((econderx & kECONDeRxMask) << kECONDeRxShift) | ((halfrocch & kHalfROCChannelMask) << kHalfROCChannelShift);
 }
 
 //
-uint16_t HGCalElectronicsId::fedId() const { return (value_ >> kFEDIDShift) & kFEDIDMask; }
+uint16_t HGCalElectronicsId::localFEDId() const { return (value_ >> kLocalFEDIDShift) & kLocalFEDIDMask; }
+
+//
+bool HGCalElectronicsId::zSide() const { return (value_ >> kZsideShift) & kZsideMask; }
+
+//
+bool HGCalElectronicsId::isCM() const {
+  uint8_t halfrocch = halfrocChannel();
+  return (halfrocch == 37) || (halfrocch == 38);
+}
 
 //
 uint8_t HGCalElectronicsId::captureBlock() const { return (value_ >> kCaptureBlockShift) & kCaptureBlockMask; }
@@ -22,3 +31,13 @@ uint8_t HGCalElectronicsId::econdeRx() const { return (value_ >> kECONDeRxShift)
 
 //
 uint8_t HGCalElectronicsId::halfrocChannel() const { return (value_ >> kHalfROCChannelShift) & kHalfROCChannelMask; }
+
+//
+uint8_t HGCalElectronicsId::cmWord() const { return halfrocChannel() - 37; }
+
+//
+uint8_t HGCalElectronicsId::rocChannel() const {
+  if (isCM())
+    return cmWord() + 2 * (econdeRx() % 2);
+  return halfrocChannel() + 37 * (econdeRx() % 2);
+}

--- a/DataFormats/HGCalDigi/test/HGCalElectronicsIdTest.cc
+++ b/DataFormats/HGCalDigi/test/HGCalElectronicsIdTest.cc
@@ -25,7 +25,8 @@ int main(int argc, char** argv) {
     verbosity = std::stoul(argv[2], nullptr, 0);
 
   // init static values
-  uint16_t fedid(0);
+  bool zside(false);
+  uint16_t localfedid(0);
   uint8_t captureblock(0), econdidx(0), econderx(0), halfrocch(0);
 
   // http://www.cplusplus.com/reference/random/linear_congruential_engine/
@@ -35,14 +36,18 @@ int main(int argc, char** argv) {
   // do the trials: time/performance test and exploit randomisation to check
   unsigned long int u = 0;
   for (; u < repetitions; u++) {
-    fedid = myrand() % 576;
+    zside = (bool)myrand() % 2;
+    localfedid = myrand() % 576;
     captureblock = myrand() % 10;
     econdidx = myrand() % 12;
     econderx = myrand() % 12;
     halfrocch = myrand() % 39;
+    bool cmflag = ((halfrocch == 37) || (halfrocch == 38));
 
-    HGCalElectronicsId eid(fedid, captureblock, econdidx, econderx, halfrocch);
-    assert(fedid == eid.fedId());
+    HGCalElectronicsId eid(zside, localfedid, captureblock, econdidx, econderx, halfrocch);
+    assert(zside == eid.zSide());
+    assert(cmflag == eid.isCM());
+    assert(localfedid == eid.localFEDId());
     assert(captureblock == eid.captureBlock());
     assert(econdidx == eid.econdIdx());
     assert(econderx == eid.econdeRx());

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -152,7 +152,7 @@ void HGCalUnpacker<D>::parseSLink(
             for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through all channels in eRx
               if (((erxHeader >> channel) & 1) == 0)
                 continue;  // only pick active channels
-              const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+              const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
               commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
               const uint32_t tempIndex = bitCounter / 32 + iword;
               const uint8_t tempBit = bitCounter % 32;
@@ -222,7 +222,7 @@ void HGCalUnpacker<D>::parseSLink(
             }
             iword += 2;  // length of the standard eRx header (2 * 32 bits)
             for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through all channels in eRx
-              const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+              const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
               commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
               channelData_[channelDataSize_] =
                   HGCROCChannelDataFrame<HGCalElectronicsId>(logicalMapping(id), inputArray[iword]);
@@ -396,7 +396,7 @@ void HGCalUnpacker<D>::parseCaptureBlock(
           for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through channels in eRx
             if (((erxHeader >> channel) & 1) == 0)
               continue;  // only pick active channels
-            const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+            const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
             commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
             const uint32_t tempIndex = bitCounter / 32 + iword;
             const uint8_t tempBit = bitCounter % 32;
@@ -465,7 +465,7 @@ void HGCalUnpacker<D>::parseCaptureBlock(
           iword += 2;  // length of a standard eRx header (2 * 32 bits)
 
           for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through all channels in eRx
-            const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+            const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
             commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
             channelData_[channelDataSize_] =
                 HGCROCChannelDataFrame<HGCalElectronicsId>(logicalMapping(id), inputArray[iword]);
@@ -604,7 +604,7 @@ void HGCalUnpacker<D>::parseECOND(
         for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through all channels in eRx
           if (((erxHeader >> channel) & 1) == 0)
             continue;  // only pick active channels
-          const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+          const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
           commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
           const uint32_t tempIndex = bitCounter / 32 + iword;
           const uint8_t tempBit = bitCounter % 32;
@@ -671,7 +671,7 @@ void HGCalUnpacker<D>::parseECOND(
         iword += 2;  // length of the standard eRx header (2 * 32 bits)
 
         for (uint8_t channel = 0; channel < config_.erxChannelMax; channel++) {  // loop through all channels in eRx
-          const HGCalElectronicsId id(sLink, captureBlock, econd, erx, channel);
+          const HGCalElectronicsId id(true, sLink, captureBlock, econd, erx, channel);
           commonModeIndex_[channelDataSize_] = commonModeDataSize_ / 4 * 4;
           channelData_[channelDataSize_] =
               HGCROCChannelDataFrame<HGCalElectronicsId>(logicalMapping(id), inputArray[iword]);

--- a/Geometry/HGCalMapping/BuildFile.xml
+++ b/Geometry/HGCalMapping/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="DataFormats/HGCalDigi"/>
+<use name="DataFormats/ForwardDetId"/>
+<export>
+  <lib name="GeometryHGCalMappingTools"/>
+</export>

--- a/Geometry/HGCalMapping/interface/HGCalMappingTools.h
+++ b/Geometry/HGCalMapping/interface/HGCalMappingTools.h
@@ -1,0 +1,118 @@
+#ifndef _geometry_hgcalmapping_hgcalmappingtools_h_
+#define _geometry_hgcalmapping_hgcalmappingtools_h_
+
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include <map>
+
+namespace hgcal {
+
+  namespace mappingtools {
+
+    /**
+     * @class HGCalEntityList is a helper class is used to hold the values of the different rows
+     * as strings. The class builds its structure and indexing from parsing ascii files separated by spaces
+     * assuming the first row is the header
+    */
+    class HGCalEntityList {
+    public:
+      typedef std::string HGCalEntityAttr;
+      typedef std::vector<HGCalEntityAttr> HGCalEntityRow;
+
+      HGCalEntityList() {}
+
+      /**
+           * @short builds the entity list from a file
+          */
+      void buildFrom(std::string url);
+
+      /**
+           * @short gets the attribute corresponding the column col in a row
+          */
+      HGCalEntityAttr getAttr(std::string col, HGCalEntityRow &row) {
+        auto it = columnIndex_.find(col);
+        if (it == columnIndex_.end()) {
+          throw cms::Exception("ValueError") << "Request for unknown column " << col;
+        }
+        return row[it->second];
+      }
+      float getFloatAttr(std::string col, HGCalEntityRow &row) { return (float)atof(getAttr(col, row).c_str()); }
+      float getIntAttr(std::string col, HGCalEntityRow &row) { return atoi(getAttr(col, row).c_str()); }
+      const std::vector<HGCalEntityRow> &getEntries() { return entities_; }
+      HGCalEntityRow getColumnNames() { return colNames_; }
+
+    private:
+      HGCalEntityRow colNames_;
+      std::map<HGCalEntityAttr, size_t> columnIndex_;
+      std::vector<HGCalEntityRow> entities_;
+      void setHeader(HGCalEntityRow &header) {
+        for (size_t i = 0; i < header.size(); i++) {
+          std::string cname = header[i];
+          colNames_.push_back(cname);
+          columnIndex_[cname] = i;
+        }
+      }
+      void addRow(HGCalEntityRow &row) { entities_.push_back(row); }
+    };
+
+    uint16_t getEcondErx(uint16_t chip, uint16_t half);
+    uint32_t getElectronicsId(
+        bool zside, uint16_t fedid, uint16_t captureblock, uint16_t econdidx, int cellchip, int cellhalf, int cellseq);
+    uint32_t getSiDetId(bool zside, int moduleplane, int moduleu, int modulev, int celltype, int celliu, int celliv);
+    uint32_t getSiPMDetId(bool zside, int moduleplane, int modulev, int celltype, int celliu, int celliv);
+
+    /**
+     * @short matches the module and cell info by detId and returns their indices (-1 is used in case index was not found)
+     */
+    template <class T1, class T2>
+    std::pair<int32_t, int32_t> getModuleCellIndicesForSiCell(const T1 &modules, const T2 &cells, uint32_t detid) {
+      std::pair<int32_t, int32_t> key(-1, -1);
+
+      //get the module and cell parts of the id
+      HGCSiliconDetId siid(detid);
+
+      // match module det id
+      uint32_t modid = siid.moduleId().rawId();
+      for (int i = 0; i < modules.view().metadata().size(); i++) {
+        auto imod = modules.view()[i];
+        if (imod.detid() != modid)
+          continue;
+
+        key.first = i;
+
+        //match cell by type of module and by cell det id
+        DetId::Detector det(DetId::Detector::HGCalEE);
+        uint32_t cellid = 0x3ff & HGCSiliconDetId(det, 0, 0, 0, 0, 0, siid.cellU(), siid.cellV()).rawId();
+        for (int j = 0; j < cells.view().metadata().size(); j++) {
+          auto jcell = cells.view()[j];
+          if (jcell.typeidx() != imod.typeidx())
+            continue;
+          if (jcell.detid() != cellid)
+            continue;
+          key.second = j;
+          return key;
+        }
+
+        return key;
+      }
+
+      return key;
+    }
+
+    /**
+     * @short after getting the module/cell indices it returns the sum of the corresponding electronics ids
+    */
+    template <class T1, class T2>
+    uint32_t getElectronicsIdForSiCell(const T1 &modules, const T2 &cells, uint32_t detid) {
+      std::pair<int32_t, int32_t> idx = getModuleCellIndicesForSiCell<T1, T2>(modules, cells, detid);
+      if (idx.first < 0 || idx.first < 0)
+        return 0;
+      return modules.view()[idx.first].eleid() + cells.view()[idx.second].eleid();
+    }
+
+  }  // namespace mappingtools
+
+}  // namespace hgcal
+
+#endif

--- a/Geometry/HGCalMapping/plugins/BuildFile.xml
+++ b/Geometry/HGCalMapping/plugins/BuildFile.xml
@@ -1,0 +1,20 @@
+<use name="CondFormats/DataRecord"/>
+<use name="CondFormats/HGCalObjects"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/HGCalMapping"/>
+<use name="FWCore/Utilities"/>
+
+<!-- indexer plugin -->
+<library file="HGCalMappingESProducer.cc">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<!-- alpaka-based portable plugins -->
+<library file="alpaka/*.cc" name="GeometryHGCalMappingPluginsPortable">
+  <use name="alpaka"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
@@ -1,0 +1,136 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/SourceFactory.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/do_nothing_deleter.h"
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+
+/**
+   @short plugin parses the module/cell locator files to produce the indexer records
+ */
+class HGCalMappingESProducer : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  explicit HGCalMappingESProducer(const edm::ParameterSet& iConfig) {
+    //parse the files and hold the list of entities in memory
+    for (auto v : {"modules", "si", "sipm"}) {
+      edm::FileInPath fip = iConfig.getParameter<edm::FileInPath>(v);
+      hgcal::mappingtools::HGCalEntityList pmap;
+      pmap.buildFrom(fip.fullPath());
+      parsedMaps_[v] = pmap;
+    }
+
+    setWhatProduced(this, &HGCalMappingESProducer::produceCellMapIndexer);
+    setWhatProduced(this, &HGCalMappingESProducer::produceModuleMapIndexer);
+
+    findingRecord<HGCalElectronicsMappingRcd>();
+
+    prepareCellMapperIndexer();
+    prepareModuleMapperIndexer();
+  }
+
+  std::shared_ptr<HGCalMappingModuleIndexer> produceModuleMapIndexer(const HGCalElectronicsMappingRcd&) {
+    return std::shared_ptr<HGCalMappingModuleIndexer>(&modIndexer_, edm::do_nothing_deleter());
+  }
+
+  std::shared_ptr<HGCalMappingCellIndexer> produceCellMapIndexer(const HGCalElectronicsMappingRcd&) {
+    return std::shared_ptr<HGCalMappingCellIndexer>(&cellIndexer_, edm::do_nothing_deleter());
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::FileInPath>("modules")->setComment("module locator file");
+    desc.add<edm::FileInPath>("si")->setComment("file containing the mapping of the readout cells in Si modules");
+    desc.add<edm::FileInPath>("sipm")->setComment(
+        "file containing the mapping of the readout cells in SiPM-on-tile modules");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue&,
+                      edm::ValidityInterval& oValidity) override {
+    oValidity = edm::ValidityInterval(edm::IOVSyncValue::beginOfTime(), edm::IOVSyncValue::endOfTime());
+  }
+
+  void prepareCellMapperIndexer();
+  void prepareModuleMapperIndexer();
+
+  std::map<std::string, hgcal::mappingtools::HGCalEntityList> parsedMaps_;
+  HGCalMappingCellIndexer cellIndexer_;
+  HGCalMappingModuleIndexer modIndexer_;
+};
+
+//
+void HGCalMappingESProducer::prepareCellMapperIndexer() {
+  for (auto v : {"si", "sipm"}) {
+    auto& pmap = parsedMaps_[v];
+    const auto& entities = pmap.getEntries();
+    for (auto row : entities) {
+      std::string typecode = pmap.getAttr("Typecode", row);
+      int chip = pmap.getIntAttr("ROC", row);
+      int half = pmap.getIntAttr("HalfROC", row);
+      cellIndexer_.processNewCell(typecode, chip, half);
+    }
+  }
+
+  // all {hex,tile}board types are loaded finalize the mapping indexer
+  cellIndexer_.update();
+}
+
+//
+void HGCalMappingESProducer::prepareModuleMapperIndexer() {
+  //default values to assign in case module type has not yet been mapped
+  //a high density module (max possible) will be assigned so that the mapping doesn't block
+  auto defaultTypeCodeIdx = cellIndexer_.getEnumFromTypecode("MH-F");
+  auto typecodeidx = defaultTypeCodeIdx;
+  auto defaultNerx = cellIndexer_.getNErxExpectedFor(defaultTypeCodeIdx);
+  auto nerx = defaultNerx;
+  auto defaultTypeNWords = cellIndexer_.getNWordsExpectedFor(defaultTypeCodeIdx);
+  auto nwords = defaultTypeNWords;
+
+  auto& pmap = parsedMaps_["modules"];
+  auto& entities = pmap.getEntries();
+  for (auto row : entities) {
+    std::string typecode = pmap.getAttr("typecode", row);
+
+    if (typecode.find('M') == 0 && typecode.size() > 4)
+      typecode = typecode.substr(0, 4);
+
+    try {
+      typecodeidx = cellIndexer_.getEnumFromTypecode(typecode);
+      nwords = cellIndexer_.getNWordsExpectedFor(typecode);
+      nerx = cellIndexer_.getNErxExpectedFor(typecode);
+    } catch (cms::Exception& e) {
+      int plane = pmap.getIntAttr("plane", row);
+      int u = pmap.getIntAttr("u", row);
+      int v = pmap.getIntAttr("v", row);
+      edm::LogWarning("HGCalMappingESProducer") << "Exception caught decoding index for typecode=" << typecode
+                                                << " @ plane=" << plane << " u=" << u << " v=" << v << "\n"
+                                                << e.what() << "\n"
+                                                << "===> will assign default (MH-F) which may be inefficient";
+      typecodeidx = defaultTypeCodeIdx;
+      nwords = defaultTypeNWords;
+      nerx = defaultNerx;
+    }
+
+    int fedid = pmap.getIntAttr("fedid", row);
+    int captureblockidx = pmap.getIntAttr("captureblockidx", row);
+    int econdidx = pmap.getIntAttr("econdidx", row);
+    modIndexer_.processNewModule(fedid, captureblockidx, econdidx, typecodeidx, nerx, nwords);
+  }
+
+  modIndexer_.finalize();
+}
+
+DEFINE_FWK_EVENTSETUP_SOURCE(HGCalMappingESProducer);

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingCellESProducer.cc
@@ -1,0 +1,131 @@
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDeviceCollection.h"
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hgcal {
+
+    class HGCalMappingCellESProducer : public ESProducer {
+    public:
+      //
+      HGCalMappingCellESProducer(const edm::ParameterSet& iConfig)
+          : ESProducer(iConfig), filelist_(iConfig.getParameter<std::vector<std::string> >("filelist")) {
+        auto cc = setWhatProduced(this);
+        cellIndexTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("cellindexer"));
+      }
+
+      //
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<std::vector<std::string> >("filelist", std::vector<std::string>({}))
+            ->setComment("list of files with the readout cells of each module");
+        desc.add<edm::ESInputTag>("cellindexer", edm::ESInputTag(""))->setComment("Dense cell index tool");
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+      //
+      std::optional<HGCalMappingCellParamHostCollection> produce(const HGCalElectronicsMappingRcd& iRecord) {
+        //get cell indexer
+        const HGCalMappingCellIndexer& cellIndexer = iRecord.get(cellIndexTkn_);
+        const uint32_t size = cellIndexer.maxDenseIndex();  // channel-level size
+        HGCalMappingCellParamHostCollection cellParams(size, cms::alpakatools::host());
+        for (uint32_t i = 0; i < size; i++)
+          cellParams.view()[i].valid() = false;
+
+        //loop over cell types and then over cells
+        for (auto url : filelist_) {
+          ::hgcal::mappingtools::HGCalEntityList pmap;
+          edm::FileInPath fip(url);
+          pmap.buildFrom(fip.fullPath());
+          auto& entities = pmap.getEntries();
+          for (auto row : entities) {
+            //identify special cases (Si vs SiPM, calib vs normal)
+            std::string typecode = pmap.getAttr("Typecode", row);
+            auto typeidx = cellIndexer.getEnumFromTypecode(typecode);
+            bool isSiPM = typecode.find("TM") != std::string::npos;
+            int rocpin = pmap.getIntAttr("ROCpin", row);
+            int celltype = pmap.getIntAttr("t", row);
+            int i1(0), i2(0), sensorcell(0);
+            bool isHD(false), iscalib(false);
+            uint32_t detid(0);
+            if (isSiPM) {
+              i1 = pmap.getIntAttr("iring", row);
+              i2 = pmap.getIntAttr("iphi", row);
+            } else {
+              i1 = pmap.getIntAttr("iu", row);
+              i2 = pmap.getIntAttr("iv", row);
+              isHD = {typecode.find("MH") != std::string::npos ? true : false};
+              sensorcell = pmap.getIntAttr("SiCell", row);
+              if (celltype == 0) {
+                iscalib = true;
+                std::string rocpinstr = pmap.getAttr("ROCpin", row);
+                rocpin = uint16_t(rocpinstr[rocpinstr.size() - 1]);
+              }
+
+              //detector id is initiated for a random sub-detector with Si wafers
+              //we only care about the first 10bits where the cell u-v are stored
+              DetId::Detector det(DetId::Detector::HGCalEE);
+              detid = 0x3ff & HGCSiliconDetId(det, 0, 0, 0, 0, 0, i1, i2).rawId();
+            }
+
+            //fill cell info in the appopriate dense index
+            int chip = pmap.getIntAttr("ROC", row);
+            int half = pmap.getIntAttr("HalfROC", row);
+            int seq = pmap.getIntAttr("Seq", row);
+            int idx = cellIndexer.denseIndex(typecode, chip, half, seq);
+            auto cell = cellParams.view()[idx];
+            cell.valid() = true;
+            cell.isHD() = isHD;
+            cell.iscalib() = iscalib;
+            cell.isSiPM() = isSiPM;
+            cell.typeidx() = typeidx;
+            cell.chip() = chip;
+            cell.half() = half;
+            cell.seq() = seq;
+            cell.rocpin() = rocpin;
+            cell.sensorcell() = sensorcell;
+            cell.triglink() = pmap.getIntAttr("TrLink", row);
+            cell.trigcell() = pmap.getIntAttr("TrCell", row);
+            cell.i1() = i1;
+            cell.i2() = i2;
+            cell.t() = celltype;
+            cell.trace() = pmap.getFloatAttr("trace", row);
+            cell.eleid() = HGCalElectronicsId(false, 0, 0, 0, chip * 2 + half, seq).raw();
+            cell.detid() = detid;
+          }  //end loop over entities
+        }    //end loop over cell types
+
+        return cellParams;
+      }  // end of produce()
+
+    private:
+      edm::ESGetToken<HGCalMappingCellIndexer, HGCalElectronicsMappingRcd> cellIndexTkn_;
+      const std::vector<std::string> filelist_;
+    };
+
+  }  // namespace hgcal
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(hgcal::HGCalMappingCellESProducer);

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalMappingModuleESProducer.cc
@@ -1,0 +1,113 @@
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDeviceCollection.h"
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hgcal {
+
+    class HGCalMappingModuleESProducer : public ESProducer {
+    public:
+      //
+      HGCalMappingModuleESProducer(const edm::ParameterSet& iConfig)
+          : ESProducer(iConfig), filename_(iConfig.getParameter<edm::FileInPath>("filename")) {
+        auto cc = setWhatProduced(this);
+        moduleIndexTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("moduleindexer"));
+      }
+
+      //
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<edm::FileInPath>("filename")->setComment("module locator file");
+        desc.add<edm::ESInputTag>("moduleindexer", edm::ESInputTag(""))->setComment("Dense module index tool");
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+      //
+      std::optional<HGCalMappingModuleParamHostCollection> produce(const HGCalElectronicsMappingRcd& iRecord) {
+        //get cell and module indexer
+        auto modIndexer = iRecord.get(moduleIndexTkn_);
+
+        // load dense indexing
+        const uint32_t size = modIndexer.maxModulesIdx_;
+        HGCalMappingModuleParamHostCollection moduleParams(size, cms::alpakatools::host());
+        for (size_t i = 0; i < size; i++)
+          moduleParams.view()[i].valid() = false;
+
+        ::hgcal::mappingtools::HGCalEntityList pmap;
+        pmap.buildFrom(filename_.fullPath());
+        auto& entities = pmap.getEntries();
+        for (auto row : entities) {
+          int fedid = pmap.getIntAttr("fedid", row);
+          int captureblockidx = pmap.getIntAttr("captureblockidx", row);
+          int econdidx = pmap.getIntAttr("econdidx", row);
+          int idx = modIndexer.getIndexForModule(fedid, captureblockidx, econdidx);
+          int typeidx = modIndexer.getTypeForModule(fedid, captureblockidx, econdidx);
+          std::string typecode = pmap.getAttr("typecode", row);
+          auto celltypes = modIndexer.convertTypeCode(typecode);
+          bool isSiPM = celltypes.first;
+          int celltype = celltypes.second;
+          int zside = pmap.getIntAttr("zside", row);
+          int plane = pmap.getIntAttr("plane", row);
+          int i1 = pmap.getIntAttr("u", row);
+          int i2 = pmap.getIntAttr("v", row);
+          uint32_t eleid = HGCalElectronicsId((zside > 0), fedid, captureblockidx, econdidx, 0, 0).raw();
+          uint32_t detid(0);
+          if (!isSiPM) {
+            int zp(zside > 0 ? 1 : -1);
+            DetId::Detector det = plane <= 26 ? DetId::Detector::HGCalEE : DetId::Detector::HGCalHSi;
+            detid = HGCSiliconDetId(det, zp, celltype, plane, i1, i2, 0, 0).rawId();
+          }
+
+          auto module = moduleParams.view()[idx];
+          module.valid() = true;
+          module.zside() = (zside > 0);
+          module.isSiPM() = isSiPM;
+          module.celltype() = celltype;
+          module.plane() = plane;
+          module.i1() = i1;
+          module.i2() = i2;
+          module.typeidx() = typeidx;
+          module.fedid() = fedid;
+          module.slinkidx() = pmap.getIntAttr("slinkidx", row);
+          module.captureblock() = pmap.getIntAttr("captureblock", row);
+          ;
+          module.econdidx() = econdidx;
+          module.captureblockidx() = captureblockidx;
+          module.eleid() = eleid;
+          module.detid() = detid;
+        }
+
+        return moduleParams;
+
+      }  // end of produce()
+
+    private:
+      edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> moduleIndexTkn_;
+      const edm::FileInPath filename_;
+    };
+
+  }  // namespace hgcal
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(hgcal::HGCalMappingModuleESProducer);

--- a/Geometry/HGCalMapping/src/HGCalMappingTools.cc
+++ b/Geometry/HGCalMapping/src/HGCalMappingTools.cc
@@ -1,0 +1,64 @@
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+namespace hgcal {
+
+  namespace mappingtools {
+
+    //
+    void HGCalEntityList::buildFrom(std::string url) {
+      std::string line;
+      std::ifstream file(url);
+
+      //parse the lines to build the list of entities
+      size_t iline(0);
+      while (std::getline(file, line)) {
+        HGCalEntityRow row;
+        std::stringstream s;
+        s << line;
+        HGCalEntityAttr attr;
+        while (s >> attr)
+          row.push_back(attr);
+
+        if (iline == 0)
+          setHeader(row);
+        else
+          addRow(row);
+        iline += 1;
+      }
+    }
+
+    //
+    uint16_t getEcondErx(uint16_t chip, uint16_t half) { return chip * 2 + half; }
+
+    //
+    uint32_t getElectronicsId(
+        bool zside, uint16_t fedid, uint16_t captureblock, uint16_t econdidx, int cellchip, int cellhalf, int cellseq) {
+      uint16_t econderx = getEcondErx(cellchip, cellhalf);
+
+      return HGCalElectronicsId(zside, fedid, captureblock, econdidx, econderx, cellseq).raw();
+    }
+
+    //
+    uint32_t getSiDetId(bool zside, int moduleplane, int moduleu, int modulev, int celltype, int celliu, int celliv) {
+      DetId::Detector det = moduleplane <= 26 ? DetId::Detector::HGCalEE : DetId::Detector::HGCalHSi;
+      int zp(zside ? 1 : -1);
+
+      return HGCSiliconDetId(det, zp, celltype, moduleplane, moduleu, modulev, celliu, celliv).rawId();
+    }
+
+    //
+    uint32_t getSiPMDetId(bool zside, int moduleplane, int modulev, int celltype, int celliu, int celliv) {
+      int layer = moduleplane - 25;
+      int type = 0;  // depends on SiPM size to be updated with new geometry
+
+      int ring = (zside ? celliu : (-1) * celliu);
+      int iphi = modulev * 8 + celliv + 1;
+
+      return HGCScintillatorDetId(type, layer, ring, iphi, false, celltype).rawId();
+    }
+
+  }  // namespace mappingtools
+}  // namespace hgcal

--- a/Geometry/HGCalMapping/test/BuildFile.xml
+++ b/Geometry/HGCalMapping/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <bin file="testHGCalMapFileParser.cc">
+  <flags TEST_RUNNER_ARGS=" Geometry/HGCalMapping/data/ModuleMaps/modulelocator_CEminus_V15p5.txt"/>
   <use name="Geometry/HGCalMapping"/>
   <use name="FWCore/ParameterSet"/>
 </bin>

--- a/Geometry/HGCalMapping/test/BuildFile.xml
+++ b/Geometry/HGCalMapping/test/BuildFile.xml
@@ -1,0 +1,15 @@
+<bin file="testHGCalMapFileParser.cc">
+  <use name="Geometry/HGCalMapping"/>
+  <use name="FWCore/ParameterSet"/>
+</bin>
+
+<library file="HGCalMappingESSourceTester.cc">
+  <use name="CondFormats/DataRecord"/>
+  <use name="CondFormats/HGCalObjects"/>
+  <use name="Geometry/HGCalMapping"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -1,0 +1,432 @@
+#include <cstdio>
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+
+// #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+// #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+// #include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
+// #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+// #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
+
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+
+namespace {
+  template <class T>
+  double duration(T t0, T t1) {
+    auto elapsed_secs = t1 - t0;
+    typedef std::chrono::duration<float> float_seconds;
+    auto secs = std::chrono::duration_cast<float_seconds>(elapsed_secs);
+    return secs.count();
+  }
+
+  inline std::chrono::time_point<std::chrono::steady_clock> now() { return std::chrono::steady_clock::now(); }
+}  // namespace
+
+class HGCalMappingESSourceTester : public edm::one::EDAnalyzer<> {
+public:
+  explicit HGCalMappingESSourceTester(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+  std::map<uint32_t, uint32_t> mapGeoToElectronics(const hgcal::HGCalMappingModuleParamHostCollection& modules,
+                                                   const hgcal::HGCalMappingCellParamHostCollection& cells,
+                                                   bool geo2ele,
+                                                   bool sipm);
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  edm::ESWatcher<HGCalElectronicsMappingRcd> cfgWatcher_;
+  edm::ESGetToken<HGCalMappingCellIndexer, HGCalElectronicsMappingRcd> cellIndexTkn_;
+  edm::ESGetToken<hgcal::HGCalMappingCellParamHostCollection, HGCalElectronicsMappingRcd> cellTkn_;
+  edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> moduleIndexTkn_;
+  edm::ESGetToken<hgcal::HGCalMappingModuleParamHostCollection, HGCalElectronicsMappingRcd> moduleTkn_;
+};
+
+//
+HGCalMappingESSourceTester::HGCalMappingESSourceTester(const edm::ParameterSet& iConfig)
+    : cellIndexTkn_(esConsumes()), cellTkn_(esConsumes()), moduleIndexTkn_(esConsumes()), moduleTkn_(esConsumes()) {}
+
+//
+void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // if the cfg didn't change there's nothing else to do
+  if (!cfgWatcher_.check(iSetup))
+    return;
+
+  //get cell indexers and SoA
+  auto cellIdx = iSetup.getData(cellIndexTkn_);
+  auto const& cells = iSetup.getData(cellTkn_);
+  printf("[HGCalMappingIndexESSourceTester][analyze] Cell dense indexers and associated SoA retrieved for HGCAL\n");
+  int nmodtypes = cellIdx.typeCodeIndexer_.size();
+  printf("[HGCalMappingIndexESSourceTester][analyze] module cell indexer has %d module types\n", nmodtypes);
+
+  //printout and test the indexer contents for cells
+  printf("[HGCalMappingIndexESSourceTester][analyze] Test indexer\n");
+  uint32_t totOffset(0);
+  for (size_t idx = 0; idx < cellIdx.di_.size(); idx++) {
+    //check typecode exists
+    auto typecode = cellIdx.getTypecodeFromEnum(idx);
+    assert(cellIdx.typeCodeIndexer_.count(typecode) == 1);
+
+    //check that the current offset is consistent with the increment from cells from the previous module
+    if (idx > 0) {
+      uint32_t nch_prev = cellIdx.maxErx_[idx - 1] * cellIdx.maxChPerErx_;
+      uint32_t delta_offset = cellIdx.offsets_[idx] - cellIdx.offsets_[idx - 1];
+      assert(delta_offset == nch_prev);
+    }
+
+    //assert offset is consistent with the accumulation
+    auto off = cellIdx.offsets_[idx];
+    assert(off == totOffset);
+
+    totOffset += cellIdx.maxErx_[idx] * cellIdx.maxChPerErx_;
+
+    //print
+    printf("[HGCalMappingIndexESSourceTester][analyze][%s] has index(internal)=%ld #eRx=%d #cells=%d offset=%d\n",
+           typecode.c_str(),
+           idx,
+           cellIdx.maxErx_[idx],
+           cellIdx.di_[idx].getMaxIndex(),
+           cellIdx.offsets_[idx]);
+  }
+
+  assert(totOffset == cellIdx.maxDenseIndex());
+  printf("[HGCalMappingIndexESSourceTester][analyze] SoA size for module cell mapping will be %d\n", totOffset);
+
+  //printout and test module cells SoA contents
+  uint32_t ncells = cells.view().metadata().size();
+  uint32_t validCells = 0;
+  assert(ncells == cellIdx.maxDenseIndex());  //check for consistent size
+  printf("[HGCalMappingIndexESSourceTester][analyze] Module cell mapping contents\n");
+  for (uint32_t i = 0; i < ncells; i++) {
+    auto icell = cells.view()[i];
+    if (!cells.view()[i].valid())
+      continue;
+    validCells++;
+    printf(
+        "\t idx=%d isHD=%d iscalib=%d isSiPM=%d typeidx=%d chip=%d half=%d seq=%d rocpin=%d sensorcell=%d triglink=%d "
+        "trigcell=%d i1=%d i2=%d t=%d trace=%f eleid=0x%x detid=0x%x\n",
+        i,
+        icell.isHD(),
+        icell.iscalib(),
+        icell.isSiPM(),
+        icell.typeidx(),
+        icell.chip(),
+        icell.half(),
+        icell.seq(),
+        icell.rocpin(),
+        icell.sensorcell(),
+        icell.triglink(),
+        icell.trigcell(),
+        icell.i1(),
+        icell.i2(),
+        icell.t(),
+        icell.trace(),
+        icell.eleid(),
+        icell.detid());
+  }
+
+  //module mapping
+  auto modulesIdx = iSetup.getData(moduleIndexTkn_);
+  printf("[HGCalMappingIndexESSourceTester][analyze] Module indexer has FEDs=%d Types in sequences=%ld max idx=%d\n",
+         modulesIdx.nfeds_,
+         modulesIdx.globalTypesCounter_.size(),
+         modulesIdx.maxModulesIdx_);
+  printf("[HGCalMappingIndexESSourceTester][analyze] FED Readout sequence\n");
+  std::unordered_set<uint32_t> unique_modOffsets, unique_erxOffsets, unique_chDataOffsets;
+  uint32_t totalmods(0);
+  for (const auto& frs : modulesIdx.fedReadoutSequences_) {
+    std::copy(
+        frs.modOffsets_.begin(), frs.modOffsets_.end(), std::inserter(unique_modOffsets, unique_modOffsets.end()));
+    std::copy(
+        frs.erxOffsets_.begin(), frs.erxOffsets_.end(), std::inserter(unique_erxOffsets, unique_erxOffsets.end()));
+    std::copy(frs.chDataOffsets_.begin(),
+              frs.chDataOffsets_.end(),
+              std::inserter(unique_chDataOffsets, unique_chDataOffsets.end()));
+
+    size_t nmods = frs.readoutTypes_.size();
+    totalmods += nmods;
+    printf("\t[FED %d] packs data from %ld ECON-Ds - readout types -> (offsets) :", frs.id, nmods);
+    for (size_t i = 0; i < nmods; i++) {
+      printf("\t%d -> (%d;%d;%d)", frs.readoutTypes_[i], frs.modOffsets_[i], frs.erxOffsets_[i], frs.chDataOffsets_[i]);
+    }
+    printf("\n");
+  }
+  //check that there are unique offsets per modules in the full system
+  assert(unique_modOffsets.size() == totalmods);
+  assert(unique_erxOffsets.size() == totalmods);
+  assert(unique_chDataOffsets.size() == totalmods);
+
+  //get the module mapper SoA
+  auto const& modules = iSetup.getData(moduleTkn_);
+  int nmodules = modulesIdx.maxModulesIdx_;
+  int validModules = 0;
+  assert(nmodules == modules.view().metadata().size());  //check for consistent size
+  printf("[HGCalMappingIndexESSourceTester][analyze] Module mapping contents\n");
+  for (int i = 0; i < nmodules; i++) {
+    auto imod = modules.view()[i];
+    if (!modules.view()[i].valid())
+      continue;
+    validModules++;
+    printf(
+        "\t idx=%d zside=%d isSiPM=%d plane=%d i1=%d i2=%d celltype=%d typeidx=%d fedid=%d localfedid=%d "
+        "captureblock=%d capturesblockidx=%d econdidx=%d eleid=0x%x detid=0x%d\n",
+        i,
+        imod.zside(),
+        imod.isSiPM(),
+        imod.plane(),
+        imod.i1(),
+        imod.i2(),
+        imod.celltype(),
+        imod.typeidx(),
+        imod.fedid(),
+        imod.slinkidx(),
+        imod.captureblock(),
+        imod.captureblockidx(),
+        imod.econdidx(),
+        imod.eleid(),
+        imod.detid());
+  }
+
+  printf(
+      "[HGCalMappingIndexESSourceTester][analyze] Module and cells maps retrieved for HGCAL %d/%d valid modules "
+      "%d/%d valid cells",
+      validModules,
+      modules.view().metadata().size(),
+      validCells,
+      cells.view().metadata().size());
+
+  //test DetId to ElectronicsId mapping
+  auto tmap = [](auto geo2ele, auto ele2geo) {
+    //sizes must match
+    assert(geo2ele.size() == ele2geo.size());
+
+    //test uniqueness of keys
+    for (auto it : geo2ele) {
+      assert(ele2geo.count(it.second) == 1);
+      assert(ele2geo[it.second] == it.first);
+    }
+    for (auto it : ele2geo) {
+      assert(geo2ele.count(it.second) == 1);
+      assert(geo2ele[it.second] == it.first);
+    }
+
+    return true;
+  };
+
+  //apply test to Si
+  std::map<uint32_t, uint32_t> sigeo2ele = this->mapGeoToElectronics(modules, cells, true, false);
+  std::map<uint32_t, uint32_t> siele2geo = this->mapGeoToElectronics(modules, cells, false, false);
+  printf("[HGCalMappingIndexESSourceTester][produce] Silicon electronics<->geometry map\n");
+  printf("\tID maps ele2geo=%ld ID maps geo2ele=%ld\n", siele2geo.size(), sigeo2ele.size());
+  tmap(sigeo2ele, siele2geo);
+
+  //apply test to SiPMs
+  std::map<uint32_t, uint32_t> sipmgeo2ele = this->mapGeoToElectronics(modules, cells, true, true);
+  std::map<uint32_t, uint32_t> sipmele2geo = this->mapGeoToElectronics(modules, cells, false, true);
+  printf("[HGCalMappingIndexESSourceTester][produce] SiPM-on-tile electronics<->geometry map\n");
+  printf("\tID maps ele2geo=%ld ID maps geo2ele=%ld\n", sipmele2geo.size(), sipmgeo2ele.size());
+  tmap(sipmgeo2ele, sipmele2geo);
+
+  // Timing studies
+  uint16_t fedid(175), econdidx(2), captureblockidx(0), chip(0), half(1), seq(12), rocpin(48);
+  int zside(0), n_i(6000000);
+  printf("[HGCalMappingIndexESSourceTester][produce]  Creating %d number of raw ElectronicsIds\n", n_i);
+  uint32_t elecid(0);
+  auto start = now();
+  for (int i = 0; i < n_i; i++) {
+    elecid = ::hgcal::mappingtools::getElectronicsId(zside, fedid, captureblockidx, econdidx, chip, half, seq);
+  }
+  auto stop = now();
+  printf("\tTime: %f seconds\n", duration(start, stop));
+
+  HGCalElectronicsId eid(elecid);
+  assert(eid.localFEDId() == fedid);
+  assert((uint32_t)eid.captureBlock() == captureblockidx);
+  assert((uint32_t)eid.econdIdx() == econdidx);
+  assert((uint32_t)eid.econdeRx() == (uint32_t)(2 * chip + half));
+  assert((uint32_t)eid.halfrocChannel() == seq);
+  float eidrocpin = (uint32_t)eid.halfrocChannel() + 36 * ((uint32_t)eid.econdeRx() % 2) -
+                    ((uint32_t)eid.halfrocChannel() > 17) * ((uint32_t)eid.econdeRx() % 2 + 1);
+  assert(eidrocpin == rocpin);
+
+  int plane(1), u(-9), v(-6), celltype(2), celliu(3), celliv(7);
+  printf("[HGCalMappingIndexESSourceTester][produce]  Creating %d number of raw  HGCSiliconDetIds\n", n_i);
+  uint32_t geoid(0);
+  start = now();
+  for (int i = 0; i < n_i; i++) {
+    geoid = ::hgcal::mappingtools::getSiDetId(zside, plane, u, v, celltype, celliu, celliv);
+  }
+  stop = now();
+  printf("\tTime: %f seconds\n", duration(start, stop));
+  HGCSiliconDetId gid(geoid);
+  assert(gid.type() == celltype);
+  assert(gid.layer() == plane);
+  assert(gid.cellU() == celliu);
+  assert(gid.cellV() == celliv);
+
+  int modidx(0), cellidx(1);
+  printf(
+      "[HGCalMappingIndexESSourceTester][produce]  Creating %d number of raw ElectronicsIds from SoAs module idx: "
+      "%d, cell idx: %d\n",
+      n_i,
+      modidx,
+      cellidx);
+  elecid = 0;
+  start = now();
+  for (int i = 0; i < n_i; i++) {
+    elecid = modules.view()[modidx].eleid() + cells.view()[cellidx].eleid();
+  }
+  stop = now();
+  printf("\tTime: %f seconds\n", duration(start, stop));
+  eid = HGCalElectronicsId(elecid);
+  assert(eid.localFEDId() == modules.view()[modidx].fedid());
+  assert((uint32_t)eid.captureBlock() == modules.view()[modidx].captureblockidx());
+  assert((uint32_t)eid.econdIdx() == modules.view()[modidx].econdidx());
+  assert((uint32_t)eid.halfrocChannel() == cells.view()[cellidx].seq());
+  uint16_t econderx = cells.view()[cellidx].chip() * 2 + cells.view()[cellidx].half();
+  assert((uint32_t)eid.econdeRx() == econderx);
+
+  printf(
+      "[HGCalMappingIndexESSourceTester][produce] Creating %d number of raw HGCSiliconDetId from SoAs module idx: "
+      "%d, cell idx: %d\n",
+      n_i,
+      modidx,
+      cellidx);
+  uint32_t detid(0);
+  start = now();
+  for (int i = 0; i < n_i; i++) {
+    detid = modules.view()[modidx].detid() + cells.view()[cellidx].detid();
+  }
+  stop = now();
+  printf("\tTime: %f seconds\n", duration(start, stop));
+  HGCSiliconDetId did(detid);
+  assert(did.type() == modules.view()[modidx].celltype());
+  assert(did.layer() == modules.view()[modidx].plane());
+  assert(did.cellU() == cells.view()[cellidx].i1());
+  assert(did.cellV() == cells.view()[cellidx].i2());
+}
+
+//
+void HGCalMappingESSourceTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//
+std::map<uint32_t, uint32_t> HGCalMappingESSourceTester::mapGeoToElectronics(
+    const hgcal::HGCalMappingModuleParamHostCollection& modules,
+    const hgcal::HGCalMappingCellParamHostCollection& cells,
+    bool geo2ele,
+    bool sipm) {
+  //loop over different modules
+  std::map<uint32_t, uint32_t> idmap;
+  uint32_t ndups(0);
+  printf("\n");
+  for (int i = 0; i < modules.view().metadata().size(); i++) {
+    auto imod = modules.view()[i];
+
+    if (!imod.valid())
+      continue;
+
+    //require match to si or SiPM
+    if (sipm != imod.isSiPM())
+      continue;
+
+    if (imod.plane() == 0) {
+      printf("WARNING: found plane=0 for i1=%d i2=%d siPM=%d @ index=%i\n", imod.i1(), imod.i2(), imod.isSiPM(), i);
+      continue;
+    }
+
+    //loop over cells in the module
+    for (int j = 0; j < cells.view().metadata().size(); j++) {
+      auto jcell = cells.view()[j];
+
+      //use only the information for cells which match the module type index
+      if (jcell.typeidx() != imod.typeidx())
+        continue;
+
+      //require that it's a valid cell
+      if (!jcell.valid())
+        continue;
+
+      //assert type of sensor
+      assert(imod.isSiPM() == jcell.isSiPM());
+
+      // make sure the cell is part of the module and it's not a calibration cell
+      if (jcell.t() != 1)
+        continue;
+
+      // uint32_t elecid = ::hgcal::mappingtools::getElectronicsId(imod.zside(),
+      //                                                         imod.fedid(),
+      //                                                         imod.captureblockidx(),
+      //                                                         imod.econdidx(),
+      //                                                         jcell.chip(),
+      //                                                         jcell.half(),
+      //                                                         jcell.seq());
+
+      uint32_t elecid = imod.eleid() + jcell.eleid();
+
+      uint32_t geoid(0);
+
+      if (sipm) {
+        geoid = ::hgcal::mappingtools::getSiPMDetId(
+            imod.zside(), imod.plane(), imod.i2(), imod.celltype(), jcell.i1(), jcell.i2());
+      } else {
+        // geoid = ::hgcal::mappingtools::getSiDetId(imod.zside(),
+        //                                         imod.plane(),
+        //                                         imod.i1(),
+        //                                         imod.i2(),
+        //                                         imod.celltype(),
+        //                                         jcell.i1(),
+        //                                         jcell.i2());
+
+        geoid = imod.detid() + jcell.detid();
+      }
+
+      if (geo2ele) {
+        auto it = idmap.find(geoid);
+        ndups += (it != idmap.end());
+        if (!sipm && it != idmap.end() && imod.plane() <= 26) {
+          HGCSiliconDetId detid(geoid);
+          printf("WARNING duplicate found for plane=%d u=%d v=%d cellU=%d cellV=%d valid=%d -> detid=0x%x\n",
+                 imod.plane(),
+                 imod.i1(),
+                 imod.i2(),
+                 jcell.i1(),
+                 jcell.i2(),
+                 jcell.valid(),
+                 detid.rawId());
+        }
+      }
+      if (!geo2ele) {
+        auto it = idmap.find(elecid);
+        ndups += (it != idmap.end());
+      }
+
+      //map
+      idmap[geo2ele ? geoid : elecid] = geo2ele ? elecid : geoid;
+    }
+  }
+
+  if (ndups > 0) {
+    printf("[HGCalMappingESSourceTester][mapGeoToElectronics] found %d duplicates with geo2ele=%d for sipm=%d\n",
+           ndups,
+           geo2ele,
+           sipm);
+  }
+
+  return idmap;
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HGCalMappingESSourceTester);

--- a/Geometry/HGCalMapping/test/testHGCalMapFileParser.cc
+++ b/Geometry/HGCalMapping/test/testHGCalMapFileParser.cc
@@ -1,0 +1,34 @@
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include <iostream>
+#include <algorithm>
+#include <iterator>
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    std::cout << "Need a mapping file as argument!" << std::endl;
+    return -1;
+  }
+
+  //build entity list map
+  hgcal::mappingtools::HGCalEntityList map;
+  edm::FileInPath fip(argv[1]);
+  std::string url(fip.fullPath());
+  map.buildFrom(url);
+
+  //print out for debugging purposes
+  auto cols = map.getColumnNames();
+  auto entities = map.getEntries();
+  std::cout << "Read " << entities.size() << " entities from " << url << std::endl << "Columns available are {";
+  std::copy(cols.begin(), cols.end(), std::ostream_iterator<std::string>(std::cout, ","));
+  std::cout << "}" << std::endl;
+
+  //line-by-line
+  for (auto r : entities) {
+    for (auto c : cols)
+      std::cout << map.getAttr(c, r) << " ";
+    std::cout << std::endl;
+  }
+
+  return 0;
+}

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing('python')
+options.register('modules','Geometry/HGCalMapping/data/ModuleMaps/modulelocator_test.txt',mytype=VarParsing.varType.string,
+                 info="Path to module mapper. Absolute, or relative to CMSSW src directory")
+options.register('sicells','Geometry/HGCalMapping/data/CellMaps/WaferCellMapTraces.txt',mytype=VarParsing.varType.string,
+                 info="Path to Si cell mapper. Absolute, or relative to CMSSW src directory")
+options.register('sipmcells','Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt',mytype=VarParsing.varType.string,
+                 info="Path to SiPM-on-tile cell mapper. Absolute, or relative to CMSSW src directory")
+options.parseArguments()
+
+process.source = cms.Source('EmptySource')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+#ESSources/Producers for the logical mapping
+#indexers
+process.load('Geometry.HGCalMapping.hgCalMappingESProducer_cfi')
+process.hgCalMappingESProducer.modules = cms.FileInPath(options.modules)
+process.hgCalMappingESProducer.si = cms.FileInPath(options.sicells)
+process.hgCalMappingESProducer.sipm = cms.FileInPath(options.sipmcells)
+
+#cells and modules info
+process.load('Configuration.StandardSequences.Accelerators_cff')
+process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
+                                                      filelist=cms.vstring(options.sicells,options.sipmcells),
+                                                      cellindexer=cms.ESInputTag('') )
+process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
+                                                      filename=cms.FileInPath(options.modules),
+                                                      moduleindexer=cms.ESInputTag('') )
+
+#tester
+process.tester = cms.EDAnalyzer('HGCalMappingESSourceTester')
+
+process.p = cms.Path(process.tester)

--- a/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="CommonTools/UtilAlgos"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/HGCalObjects"/>
+<use name="CUDADataFormats/HGCal"/>
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/HGCDigi"/>
 <use name="DataFormats/HGCRecHit"/>


### PR DESCRIPTION
This PR supersedes #43751. It is rebased on top of `CMSSW_14_1_0_pre2` and it's made of a single commit which squashes all the ones in #43751. Below the description and the validation of #43751 are copied and updated

#### PR description:

Adding the infrastructure needed to

- provide the electronics to detector identifier mapping
- provide the dense indexer for unpacked data and conditions (made available through EventSetup)
- provide detailed information on the cell and modules (made available through EventSetup in SoAs)

The tool has been discussed in 

- HGCAL DPG [slides](https://indico.cern.ch/event/1358621/) and provisional documentation in [google doc](https://docs.google.com/document/d/1kGKsMBQ8CWC7kJN71aJmsUv4vVDJ8ZlG_D1ColCEuAk/edit#bookmark=id.8ys9dfg99vqv) 
- AlCaDB [slides 1](https://indico.cern.ch/event/1372780/) [slides 2](https://indico.cern.ch/event/1386295/) 
- #43751

It relies on the mappings in https://github.com/cms-data/Geometry-HGCalMapping/pull/1

The requests to leave EVENTSETUP_RECORD_REG and COND_SERIALIZABLE commented are not implemented as they generate compilation errors and break the testers. The HGCAL DPG is however aware that the move to CondDB is to occur in a future time-scale (end of this year/begin on next year). 

#### PR validation:

This PR is not expected to impact any workflow thus we expect 100% success in the tests. The PR is however accompanied by a series of unit tests and analyzers (under the test) sub-directories. They have been used to validate the content produced by the new pieces of code being added to the repository.

@kerstinlovisa @jalimena