### PR TITLE
Ignore errors from `alpaka::enqueue()` in `CachingAllocator::free()`

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaInterface/test/BuildFile.xml
@@ -24,6 +24,12 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
 </bin>
 
+<bin name="alpakaTestBuffer" file="alpaka/testBuffer.dev.cc">
+  <use name="catch2"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>
+
 <bin name="alpakaTestAtomicPairCounter" file="alpaka/testAtomicPairCounter.dev.cc">
   <use name="alpaka"/>
   <use name="catch2"/>

--- a/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
+++ b/HeterogeneousCore/AlpakaInterface/test/alpaka/testBuffer.dev.cc
@@ -1,0 +1,91 @@
+#include <alpaka/alpaka.hpp>
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+// each test binary is built for a single Alpaka backend
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace {
+  constexpr size_t SIZE = 32;
+
+  void testDeviceSideError(Device const& device) {
+    auto queue = Queue(device);
+    auto buf_h = cms::alpakatools::make_host_buffer<int[]>(queue, SIZE);
+    auto buf_d = cms::alpakatools::make_device_buffer<int[]>(queue, SIZE);
+    alpaka::memset(queue, buf_h, 0);
+    alpaka::memcpy(queue, buf_d, buf_h);
+    // On the host device I don't know how to fabricate a device-side
+    // error for which the Alpaka API calls would then throw an
+    // exception. Therefore I just throw the std::runtime_error to
+    // keep the caller side the same for all backends. At least the
+    // test ensures the buffer destructors won't throw exceptions
+    // during the stack unwinding of the thrown runtime_error.
+    if constexpr (std::is_same_v<Device, alpaka::DevCpu>) {
+      throw std::runtime_error("assert");
+    } else {
+      auto div = cms::alpakatools::make_workdiv<Acc1D>(1, 1);
+      alpaka::exec<Acc1D>(
+          queue,
+          div,
+          [] ALPAKA_FN_ACC(Acc1D const& acc, int* data, size_t size) {
+            for (auto index : cms::alpakatools::uniform_elements(acc, size)) {
+              assert(data[index] != 0);
+            }
+          },
+          buf_d.data(),
+          SIZE);
+      alpaka::wait(queue);
+    }
+  }
+}  // namespace
+
+TEST_CASE("Test alpaka buffers for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend",
+          "[" EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) "]") {
+  // get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+         "the test will be skipped.");
+  }
+
+  SECTION("Single device buffer") {
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto buf = cms::alpakatools::make_device_buffer<int[]>(queue, SIZE);
+      alpaka::memset(queue, buf, 0);
+      alpaka::wait(queue);
+    }
+  }
+
+  SECTION("Single host buffer") {
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto buf = cms::alpakatools::make_host_buffer<int[]>(queue, SIZE);
+      buf[0] = 0;
+      alpaka::wait(queue);
+    }
+  }
+
+  SECTION("Host and device buffers") {
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto buf_h = cms::alpakatools::make_host_buffer<int[]>(queue, SIZE);
+      auto buf_d = cms::alpakatools::make_device_buffer<int[]>(queue, SIZE);
+      alpaka::memset(queue, buf_h, 0);
+      alpaka::memcpy(queue, buf_d, buf_h);
+      alpaka::wait(queue);
+    }
+  }
+
+  SECTION("Buffer destruction after a device-side error") {
+    for (auto const& device : devices) {
+      REQUIRE_THROWS_AS(testDeviceSideError(device), std::runtime_error);
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/44634 reported an HLT job failure caused by an illegal memory access on a GPU. The failure was reported as a crash instead of a caught exception because of a second exception being thrown from `CachingAllocator<T>::free()` by `alpaka::enqueue()` when objects using cached allocations were being deleted as part of the stack unwinding of the original exception.

The `alpaka::enqueue()` is used in `CachingAllocator<T>::free()` to "record" the alpaka Event in the Queue when the freed memory block is supposed to be recached. This PR changes the behavior such that if `alpaka::enqueue()` throws an exception, the memory block is treated as freed instead of recached.

I checked the alpaka Buffers, Queues, and Events that their destructors do not throw exceptions, but report any errors from the underlying APIs as printouts.

#### PR validation:

I tested the reproducer in https://github.com/cms-sw/cmssw/issues/44634 on a GPU node with `CUDA_LAUNCH_BLOCKING=1 cmsRun ...`, and now the job reports the exception in a useful way
```
----- Begin Fatal Exception 05-Apr-2024 20:44:47 CEST-----------------------
An exception of category 'StdException' occurred while
   [0] Processing  Event run: 378940 lumi: 21 event: 5339574 stream: 0
   [1] Running path 'DST_PFScouting_JetHT_v1'
   [2] Calling method for module PFClusterSoAProducer@alpaka/'hltParticleFlowClusterHBHESoA'
Exception Message:
A std::exception was thrown.
/cvmfs/cms.cern.ch/el8_amd64_gcc12/external/alpaka/1.1.0-c6af69ddd6f2ee5be4f2b069590bae19/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp(259) 'TApi::setDevice(queue.m_spQueueImpl->m_dev.getNativeHandle())' A previous API call (not this one) set the error  : 'cudaErrorIllegalAddress': 'an illegal memory access was encountered'!
----- End Fatal Exception -------------------------------------------------
```

Afterwards the job still crashes, but in direct CUDA code (`cms::cuda::abortOnCudaError()` in `SiPixelGainCalibrationForHLTGPU::~SiPixelGainCalibrationForHLTGPU()`), but that is probably not worth of addressing at this time, when the direct CUDA code is expected to be removed later on.

Without `CUDA_LAUNCH_BLOCKING=1` the reported exception message is no longer useful, but at least the job contains printouts from Alpaka code that include the `cudaErrorIllegalAddress` error name. So while not ideal, the log contains more useful information than before this PR.

The added unit test succeeds on Serial and CUDA backends (and without the change of this PR the unit test fails on CUDA backend, and succeeds on Serial backend).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_0_X