### PR TITLE
Fix LHCInfoPerLS PopCon duringFill startSampleTime error

### DIFF
--- a/CondTools/RunInfo/python/LHCInfoPerLSPopConAnalyzer_cfg.py
+++ b/CondTools/RunInfo/python/LHCInfoPerLSPopConAnalyzer_cfg.py
@@ -60,6 +60,12 @@ options.register( 'endTime'
                      processes only fills starting before endTime;
                      default to empty string which sets no restriction"""
                   )
+options.register( 'debugLogic'
+                , False
+                , VarParsing.VarParsing.multiplicity.singleton
+                , VarParsing.VarParsing.varType.bool
+                , """Enables debug logic, meant to be used only for tests"""
+                  )
 options.parseArguments()
 if options.mode is None:
   raise ValueError("mode argument not provided. Supported modes are: duringFill endFill")
@@ -108,7 +114,8 @@ process.Test1 = cms.EDAnalyzer("LHCInfoPerLSPopConAnalyzer",
                                    connectionString = cms.untracked.string("oracle://cms_orcon_adg/CMS_RUNTIME_LOGGER"),
                                    omsBaseUrl = cms.untracked.string("http://vocms0184.cern.ch/agg/api/v1"),
                                    authenticationPath = cms.untracked.string(""),
-                                   debug=cms.untracked.bool(False)
+                                   debug=cms.untracked.bool(False), # Additional logs
+                                   debugLogic=cms.untracked.bool(options.debugLogic),
                                                  ),
                                loggingOn = cms.untracked.bool(True),
                                IsDestDbCheckedInQueryLog = cms.untracked.bool(False)


### PR DESCRIPTION
#### PR description:

Fixes a bug that made the `LHCInfoPerLS` PopCon in duringFill mode write a payload from outside of the currently processed fill. The error occurred when at PopCon execution there was already a payload from this fill in the destination tag and the fill was still ongoing. 

The error was caused by converting the IOV of the last payload of the tag to an invalid time value because duringFill mode uses IOVs of type `lumiid` and not timestamp. Conversion from lumiid to time using cond::to_boost is invalid. The faulty line:
```
startSampleTime = cond::time::to_boost(lastSince);
```

The PR also introduces `debugLogic` argument to the `LHCInfoPerLS` PopCon allowing for simple tests of the duringFill mode even when there is no ongoing stable beams fill in LHC. While the capability of such tests is limited the `debugLogic`  mode allowed reproducing of the error regardless of the LHC state.

#### PR validation:

Tested in debugLogic mode and in production mode during stable beam fills. 

The `debugLogic = True` tests were conducted by preparing an SQLite file with a payload from the fill 9400 (which was not the last LS) and checking if PopCon correctly appended the last LS of this fill to the tag. 

The production logic tests were conducted by manually running the PopCon multiple times throughout fills 9475 9496 and 9497. The correct behavior of the PopCon was confirmed in the logs and by validating the IOVs and data of produced payloads (cross-checking with PPS dB). 


### Backport

The `LHCInfoPerLS` PopCon in `duringFill` mode is currently deployed for testing on CMSSW_14_0_2
TODO: do we need to backport it to this release?