### PR TITLE
fix PSet of `EvFDaqDirector` in `convertToRaw.py` [`14_0_X`]

### DIFF
--- a/HLTrigger/Tools/python/convertToRaw.py
+++ b/HLTrigger/Tools/python/convertToRaw.py
@@ -26,19 +26,11 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring()                             # to be overwritten after parsing the command line options
 )
 
-process.EvFDaqDirector = cms.Service( "EvFDaqDirector",
-    runNumber = cms.untracked.uint32( 0 ),                          # to be overwritten after parsing the command line options
-    baseDir = cms.untracked.string( "" ),                           # to be overwritten after parsing the command line options
-    buBaseDir = cms.untracked.string( "" ),                         # to be overwritten after parsing the command line options
-    useFileBroker = cms.untracked.bool( False ),
-    fileBrokerKeepAlive = cms.untracked.bool( True ),
-    fileBrokerPort = cms.untracked.string( "8080" ),
-    fileBrokerUseLocalLock = cms.untracked.bool( True ),
-    fuLockPollInterval = cms.untracked.uint32( 2000 ),
-    requireTransfersPSet = cms.untracked.bool( False ),
-    selectedTransferMode = cms.untracked.string( "" ),
-    mergingPset = cms.untracked.string( "" ),
-    outputAdler32Recheck = cms.untracked.bool( False ),
+from EventFilter.Utilities.EvFDaqDirector_cfi import EvFDaqDirector as _EvFDaqDirector
+process.EvFDaqDirector = _EvFDaqDirector.clone(
+    baseDir = "",                                                   # to be overwritten after parsing the command line options
+    buBaseDir = "",                                                 # to be overwritten after parsing the command line options
+    runNumber = 0                                                   # to be overwritten after parsing the command line options
 )
 
 process.writer = cms.OutputModule("RawStreamFileWriterForBU",

--- a/HLTrigger/Tools/scripts/convertToRaw
+++ b/HLTrigger/Tools/scripts/convertToRaw
@@ -142,12 +142,12 @@ for f in files:
         if parsing:
             run, lumi, events = tuple(map(int, line.split()))
             if not args.range.is_in_range(run, lumi):
-                print(f'  run {run}, lumisetion {lumi} is outside of the given range and will be skipped')
+                print(f'  run {run}, lumisection {lumi} is outside of the given range and will be skipped')
                 continue
             if events == 0:
-                print(f'  run {run}, lumisetion {lumi} is empty and will be skipped')
+                print(f'  run {run}, lumisection {lumi} is empty and will be skipped')
                 continue
-            print(f'  run {run}, lumisetion {lumi} with {events} events will be processed')
+            print(f'  run {run}, lumisection {lumi} with {events} events will be processed')
             if not run in content:
                 content[run] = {}
             if not lumi in content[run]:
@@ -215,7 +215,7 @@ for run in sorted(content):
             os.makedirs(lumi_path)
             cmsRun(config_py, args.verbose, inputFiles = ','.join(content[run][lumi].files), runNumber = run, lumiNumber = lumi, eventsPerLumi = args.events_per_lumi, eventsPerFile = args.events_per_file, rawDataCollection = args.raw_data_collection, outputPath = lumi_path)
 
-            # merge all lumisetions data
+            # merge all lumisections data
 
             # number of events expected to be processed
             if args.events_per_lumi < 0:


### PR DESCRIPTION
backport of #44735

#### PR description:

From the description of #44735.

> This PR updates `convertToRaw.py` in order to adapt to the `fillDescriptions` changes introduced in #43850. The utility `convertToRaw` does not currently work in `14_0_X` and `14_1_X` without this change. The change is merely technical: none of the values of the existing parameters are changed. A typo in `convertToRaw` is also fixed.
>
> Merely technical. No changes expected.
>
> (It would be good to add a unit test for this utility, but I currently do not have enough time to implement a proper one, and I would not delay this fix.)

FYI: @fwyzard 

#### PR validation:

None beyond the validation done for #44735.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#44735

Backported for trigger studies on 2024 data.
