### PR TITLE
[13_3_X] Remove unused variable

### DIFF
--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -579,7 +579,6 @@
     /* ROOT read streamer */                                                                                           \
     template <typename T>                                                                                              \
     void ROOTReadStreamer(T & onfile) {                                                                                \
-      auto size = onfile.metadata().size();                                                                            \
       _ITERATE_ON_ALL(_STREAMER_READ_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                  \
     }                                                                                                                  \
                                                                                                                        \


### PR DESCRIPTION
#### PR description:

In 13_3_X IBs, the following warning is emitted by GCC:

```
<...>/src/DataFormats/PortableTestObjects/src/classes.cc:4:1:   required from here
  <...>/src/DataFormats/SoATemplate/interface/SoALayout.h:582:12: warning: unused variable 'size' [-Wunused-variable]
   582 |       auto size = onfile.metadata().size();                                                                            \
      |            ^~~~
<...>/src/DataFormats/SoATemplate/interface/SoALayout.h:582:12: note: in definition of macro 'GENERATE_SOA_LAYOUT'
  582 |       auto size = onfile.metadata().size();                                                                            \
      |            ^~~~
```

[full log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc12/CMSSW_13_3_X_2024-04-14-2300/DataFormats/PortableTestObjects)

See also `master` version of this function: https://github.com/cms-sw/cmssw/blob/master/DataFormats/SoATemplate/interface/SoALayout.h#L584-L588

#### PR validation:

Bot tests