### PR TITLE
Fix memory use when writing ParameterSets to files [13_3]

### DIFF
--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -507,7 +507,7 @@ namespace edm {
       if (useAll || b->second.isTracked()) {
         size += 2;
         size += b->first.size();
-        size += sizeof(ParameterSetID) * b->second.vpset().size();
+        size += sizeof(ParameterSetID) * b->second.size();
       }
     }
 

--- a/FWCore/ParameterSet/src/VParameterSetEntry.cc
+++ b/FWCore/ParameterSet/src/VParameterSetEntry.cc
@@ -98,7 +98,9 @@ namespace edm {
     return theVPSet_->at(i);
   }
 
-  std::vector<ParameterSet>::size_type VParameterSetEntry::size() const { return vpset().size(); }
+  std::vector<ParameterSet>::size_type VParameterSetEntry::size() const {
+    return theIDs_ ? theIDs_->size() : (theVPSet_ ? vpset().size() : 0);
+  }
 
   void VParameterSetEntry::registerPsetsAndUpdateIDs() {
     fillVPSet();


### PR DESCRIPTION
#### PR description:

When forwarding a VPSet from the input file to the output, avoid calling vpset() which triggers creating the entire vector.

#### PR validation:

Code compiles.

backport of https://github.com/cms-sw/cmssw/pull/44727