### PR TITLE
Fix for `EndPath`s in `DependecyGraph`

### DIFF
--- a/FWCore/Services/plugins/DependencyGraph.cc
+++ b/FWCore/Services/plugins/DependencyGraph.cc
@@ -295,8 +295,8 @@ void DependencyGraph::preBeginJob(PathsAndConsumesOfModulesBase const &pathsAndC
     auto &graph = m_graph.create_subgraph();
 
     // set the subgraph name property to the EndPath name
-    boost::get_property(graph, boost::graph_name) = paths[i];
-    boost::get_property(graph, boost::graph_graph_attribute)["label"] = "EndPath " + paths[i];
+    boost::get_property(graph, boost::graph_name) = endps[i];
+    boost::get_property(graph, boost::graph_graph_attribute)["label"] = "EndPath " + endps[i];
     boost::get_property(graph, boost::graph_graph_attribute)["labelloc"] = "bottom";
 
     // add to the subgraph the node corresponding to the scheduled modules on the EndPath


### PR DESCRIPTION
#### PR description:

Trivial fix for `DependencyGraph` when looping on `EndPath`s. Spotted because when there are more `EndPath`s than `Path`s it throws:

```
std::bad_alloc exception
----- Begin Fatal Exception 15-Apr-2024 16:51:10 CEST-----------------------
An exception of category 'BadAlloc' occurred while
   [0] Calling beginJob
Exception Message:
A std::bad_alloc exception was thrown.
The job has probably exhausted the virtual memory available to the process.
----- End Fatal Exception -------------------------------------------------
```

To test one can run:

```
cmsDriver.py step3 -s RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM --conditions 140X_mcRun3_2023_realistic_v3 --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3_2023 --filein /store/relval/CMSSW_14_0_0/RelValSingleMuPt10/GEN-SIM-DIGI-RAW/140X_mcRun3_2023_realistic_v3_STD_2023_noPU-v1/2580000/34fca56a-1726-4a1a-b607-a23588c76f5c.root --fileout file:step3.root --python_filename step3_pixel.py --customise_commands 'process.load("FWCore.Services.DependencyGraph_cfi")'
```

that will crash in `master` and with this PR will produce this (unreadable but correct) graph:

![image](https://github.com/cms-sw/cmssw/assets/16901146/869bd4e5-2ba9-47ed-8acd-4697083135f1)
