### PR TITLE
[14.0.X] store the hltobjects for Mass50 triggers

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -345,6 +345,13 @@ def customizeHLTfor45302(process):
     return process
 
     
+def customizeHLTfor44746(process):
+    for modLabel in ['hltDoubleEle10Mass50PPOnAAFilter', 'hltDoubleEle15Mass50PPOnAAFilter']:
+        if hasattr(process, modLabel):
+            mod = getattr(process, modLabel)
+            mod.l1EGCand = cms.InputTag('hltEgammaCandidatesPPOnAA')
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -355,5 +362,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = checkHLTfor43774(process)
     process = customizeHLTfor45302(process)
+    process = customizeHLTfor44746(process)
 
     return process

--- a/HLTrigger/Egamma/plugins/HLTEgammaCombMassFilter.cc
+++ b/HLTrigger/Egamma/plugins/HLTEgammaCombMassFilter.cc
@@ -24,6 +24,7 @@ HLTEgammaCombMassFilter::HLTEgammaCombMassFilter(const edm::ParameterSet& iConfi
   firstLegLastFilterTag_ = iConfig.getParameter<edm::InputTag>("firstLegLastFilter");
   secondLegLastFilterTag_ = iConfig.getParameter<edm::InputTag>("secondLegLastFilter");
   minMass_ = iConfig.getParameter<double>("minMass");
+  l1EGTag_ = iConfig.getParameter<edm::InputTag>("l1EGCand");
   firstLegLastFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(firstLegLastFilterTag_);
   secondLegLastFilterToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(secondLegLastFilterTag_);
 }
@@ -35,6 +36,7 @@ void HLTEgammaCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& d
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("firstLegLastFilter", edm::InputTag("firstFilter"));
   desc.add<edm::InputTag>("secondLegLastFilter", edm::InputTag("secondFilter"));
+  desc.add<edm::InputTag>("l1EGCand", edm::InputTag("hltEgammaCandidates"));
   desc.add<double>("minMass", -1.0);
   descriptions.add("hltEgammaCombMassFilter", desc);
 }
@@ -43,30 +45,73 @@ void HLTEgammaCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& d
 bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent,
                                         const edm::EventSetup& iSetup,
                                         trigger::TriggerFilterObjectWithRefs& filterproduct) const {
-  //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
+  using namespace trigger;
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1EGTag_);
+  }
 
-  //trigger::TriggerObjectType firstLegTrigType;
   std::vector<math::XYZTLorentzVector> firstLegP4s;
-
-  //trigger::TriggerObjectType secondLegTrigType;
   std::vector<math::XYZTLorentzVector> secondLegP4s;
-
-  math::XYZTLorentzVector pairP4;
 
   getP4OfLegCands(iEvent, firstLegLastFilterToken_, firstLegP4s);
   getP4OfLegCands(iEvent, secondLegLastFilterToken_, secondLegP4s);
 
   bool accept = false;
-  for (auto& firstLegP4 : firstLegP4s) {
-    for (auto& secondLegP4 : secondLegP4s) {
-      math::XYZTLorentzVector pairP4 = firstLegP4 + secondLegP4;
+  std::set<math::XYZTLorentzVector, LorentzVectorComparator> addedLegP4s;
+
+  for (size_t i = 0; i < firstLegP4s.size(); i++) {
+    for (size_t j = 0; j < secondLegP4s.size(); j++) {
+      // Skip if it's the same object
+      if (firstLegP4s[i] == secondLegP4s[j])
+        continue;
+
+      math::XYZTLorentzVector pairP4 = firstLegP4s[i] + secondLegP4s[j];
       double mass = pairP4.M();
-      if (mass >= minMass_)
+      if (mass >= minMass_) {
         accept = true;
+
+        // Add first leg object if not already added
+        if (addedLegP4s.insert(firstLegP4s[i]).second) {
+          addObjectToFilterProduct(iEvent, filterproduct, firstLegLastFilterToken_, i);
+        }
+
+        // Add second leg object if not already added
+        if (addedLegP4s.insert(secondLegP4s[j]).second) {
+          addObjectToFilterProduct(iEvent, filterproduct, secondLegLastFilterToken_, j);
+        }
+      }
     }
   }
 
   return accept;
+}
+
+void HLTEgammaCombMassFilter::addObjectToFilterProduct(
+    const edm::Event& iEvent,
+    trigger::TriggerFilterObjectWithRefs& filterproduct,
+    const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& token,
+    size_t index) {
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
+  iEvent.getByToken(token, PrevFilterOutput);
+
+  // Get all types of objects
+  std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > phoCandsPrev;
+  PrevFilterOutput->getObjects(trigger::TriggerPhoton, phoCandsPrev);
+  std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > clusCandsPrev;
+  PrevFilterOutput->getObjects(trigger::TriggerCluster, clusCandsPrev);
+  std::vector<edm::Ref<reco::ElectronCollection> > eleCandsPrev;
+  PrevFilterOutput->getObjects(trigger::TriggerElectron, eleCandsPrev);
+
+  // Check which type of object corresponds to the given index
+  if (index < phoCandsPrev.size()) {
+    filterproduct.addObject(trigger::TriggerPhoton, phoCandsPrev[index]);
+  } else if (index < phoCandsPrev.size() + clusCandsPrev.size()) {
+    filterproduct.addObject(trigger::TriggerCluster, clusCandsPrev[index - phoCandsPrev.size()]);
+  } else if (index < phoCandsPrev.size() + clusCandsPrev.size() + eleCandsPrev.size()) {
+    filterproduct.addObject(trigger::TriggerElectron, eleCandsPrev[index - phoCandsPrev.size() - clusCandsPrev.size()]);
+  } else {
+    edm::LogWarning("HLTEgammaCombMassFilter") << "Could not find object at index " << index;
+  }
 }
 
 void HLTEgammaCombMassFilter::getP4OfLegCands(const edm::Event& iEvent,
@@ -84,16 +129,16 @@ void HLTEgammaCombMassFilter::getP4OfLegCands(const edm::Event& iEvent,
   filterOutput->getObjects(trigger::TriggerElectron, eleCands);
 
   if (!phoCands.empty()) {  //its photons
-    for (auto& phoCand : phoCands) {
+    for (auto const& phoCand : phoCands) {
       p4s.push_back(phoCand->p4());
     }
   } else if (!clusCands.empty()) {
     //try trigger cluster (should never be this, at the time of writing (17/1/11) this would indicate an error)
-    for (auto& clusCand : clusCands) {
+    for (auto const& clusCand : clusCands) {
       p4s.push_back(clusCand->p4());
     }
   } else if (!eleCands.empty()) {
-    for (auto& eleCand : eleCands) {
+    for (auto const& eleCand : eleCands) {
       p4s.push_back(eleCand->p4());
     }
   }

--- a/HLTrigger/Egamma/plugins/HLTEgammaCombMassFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTEgammaCombMassFilter.h
@@ -26,6 +26,10 @@ public:
                               const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken,
                               std::vector<math::XYZTLorentzVector>& p4s);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void addObjectToFilterProduct(const edm::Event& iEvent,
+                                       trigger::TriggerFilterObjectWithRefs& filterproduct,
+                                       const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& token,
+                                       size_t index);
 
 private:
   edm::InputTag firstLegLastFilterTag_;
@@ -33,6 +37,12 @@ private:
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> firstLegLastFilterToken_;
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> secondLegLastFilterToken_;
   double minMass_;
+  edm::InputTag l1EGTag_;
+  struct LorentzVectorComparator {
+    bool operator()(const math::XYZTLorentzVector& lhs, const math::XYZTLorentzVector& rhs) const {
+      return lhs.pt() < rhs.pt();
+    }
+  };
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

We've encountered an issue with the Mass50 HLT triggers for double electrons (Ele15Ele10GsfMass50, DoubleEle10GsfMass50, and DoubleEle15GsfMass50) in both ppref and HI HLT menus. These HLT triggers are not storing any information in the hltobject trees, even though the events are being triggered. After investigating, we have identified that the problem lies with HLTEgammaCombMassFilter.

I have made some modifications to HLTEgammaCombMassFilter, and now the information is being stored in hltobject. 

See slides: https://twiki.cern.ch/twiki/pub/CMS/HLT_HIon_Run3/pinchun20230928.pdf (P.8)
