### PR TITLE
High pT Tracks resolved: Fitting each track as a Helix! Dropping the …

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/src/Trajectory.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Trajectory.cc
@@ -19,10 +19,6 @@ std::unique_ptr<fastsim::Trajectory> fastsim::Trajectory::createTrajectory(const
   if (particle.charge() == 0. || magneticFieldZ == 0.) {
     LogDebug("FastSim") << "create straight trajectory";
     return std::unique_ptr<fastsim::Trajectory>(new fastsim::StraightTrajectory(particle));
-  } else if (std::abs(particle.momentum().Pt() /
-                      (fastsim::Constants::speedOfLight * 1e-4 * particle.charge() * magneticFieldZ)) > 1e5) {
-    LogDebug("FastSim") << "create straight trajectory (huge radius)";
-    return std::unique_ptr<fastsim::Trajectory>(new fastsim::StraightTrajectory(particle));
   } else {
     LogDebug("FastSim") << "create helix trajectory";
     return std::unique_ptr<fastsim::Trajectory>(new fastsim::HelixTrajectory(particle, magneticFieldZ));


### PR DESCRIPTION
…Huge radius expression.

#### PR description: 
- High pT muon tracks (>1.2 TeV) were reconstructed with values twice that of their generated counterparts.
- Other high pT tracks in the inner region diverged completely, behaving as they traveled in straight lines.
- The issue was traced to an expression in the `Trajectory. cc` file located at `FastSimulation/SimplifiedGeometryPropagator/src`, which imposed a threshold causing tracks beyond a certain value to be assumed straight (with a huge radius).
- By removing this condition, I observed that the reconstructed pT aligned properly with the simulated generated pT.
