### PR TITLE
Adding CSC MEs to per-LS scope in Offline DQM - backport to 14_0_X

### DIFF
--- a/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
+++ b/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py
@@ -57,6 +57,15 @@ nanoDQMIO_perLSoutput = cms.PSet(
     "PixelPhase1/Tracks/PXForward/size_PXDisk_-2",
     "PixelPhase1/Tracks/PXForward/size_PXDisk_-3",
 
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalm1",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalm2",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalm3",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalm4",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalp1",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalp2",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalp3",
+    "CSC/CSCOfflineMonitor/recHits/hRHGlobalp4",
+
     "HLT/Vertexing/hltPixelVertices/hltPixelVertices/goodvtxNbr",
     "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV/mon_eta",
     "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV/mon_hits",


### PR DESCRIPTION
#### PR description:

Adding the following CSC MEs to per-LS scope in Offline DQM:

```
CSC/CSCOfflineMonitor/recHits/hRHGlobalm1
CSC/CSCOfflineMonitor/recHits/hRHGlobalm2
CSC/CSCOfflineMonitor/recHits/hRHGlobalm3
CSC/CSCOfflineMonitor/recHits/hRHGlobalm4
CSC/CSCOfflineMonitor/recHits/hRHGlobalp1
CSC/CSCOfflineMonitor/recHits/hRHGlobalp2
CSC/CSCOfflineMonitor/recHits/hRHGlobalp3
CSC/CSCOfflineMonitor/recHits/hRHGlobalp4
```
#### PR validation:

```
echo '{
"369978" : [[1, 800]]
}' > step1_lumiRanges.log  2>&1

cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2023 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2023 -n 100 --filein file:/eos/cms/store/user/cmsbuild/store/data/Run2023D/JetMET0/RAW/v1/000/369/978/00000/00b9eba7-c847-465b-a6de-98bceae93613.root --lumiToProcess step1_lumiRanges.log --fileout file:step2.root  --nThreads 8

cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@muon --datatier RECO,MINIAOD,NANOAOD,DQMIO --eventcontent RECO,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3_2023 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT -n 100 --filein  file:step2.root  --fileout file:step3.root  --nThreads 8

cmsDriver.py step4  -s HARVESTING:@muon --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3_2023 -n 100 --filein file:step3_inDQM.root --fileout file:step4.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of PR#44610