### PR TITLE
Adding PUPPI jets and METs to offline DQM - backport to 14_0_X

### DIFF
--- a/DQMOffline/JetMET/interface/JetAnalyzer.h
+++ b/DQMOffline/JetMET/interface/JetAnalyzer.h
@@ -108,10 +108,12 @@ private:
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtToken_;
   edm::EDGetTokenT<reco::CaloJetCollection> caloJetsToken_;
   edm::EDGetTokenT<reco::PFJetCollection> pfJetsToken_;
+  edm::EDGetTokenT<reco::PFJetCollection> puppiJetsToken_;
 
   edm::EDGetTokenT<reco::PFMETCollection> pfMetToken_;
   edm::EDGetTokenT<reco::CaloMETCollection> caloMetToken_;
   edm::EDGetTokenT<pat::METCollection> patMetToken_;
+  edm::EDGetTokenT<reco::PFMETCollection> puppiMetToken_;
 
   edm::EDGetTokenT<reco::MuonCollection> MuonsToken_;
   edm::EDGetTokenT<pat::JetCollection> patJetsToken_;
@@ -786,6 +788,7 @@ private:
   bool isCaloJet_;
   bool isPFJet_;
   bool isMiniAODJet_;
+  bool isPUPPIJet_;
 
   bool fill_jet_high_level_histo;
 

--- a/DQMOffline/JetMET/python/jetAnalyzer_cff.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cff.py
@@ -9,6 +9,11 @@ jetDQMAnalyzerSequence = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
                                       *jetDQMAnalyzerAk4PFCHSCleaned
                                    )
 
+_jetDQMAnalyzerSequenceWithPUPPI = cms.Sequence(jetDQMAnalyzerAk4CaloCleaned
+                                      *jetDQMAnalyzerAk4PFUncleaned*jetDQMAnalyzerAk4PFCleaned
+                                      *jetDQMAnalyzerAk4PFCHSCleaned*jetDQMAnalizerAk4PUPPICleaned
+                                   )
+
 jetDQMAnalyzerSequenceCosmics = cms.Sequence(jetDQMAnalyzerAk4CaloUncleaned)
 
 jetDQMAnalyzerSequenceMiniAOD = cms.Sequence(jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD*jetDQMAnalyzerAk4PFCHSCleanedMiniAOD*jetDQMAnalyzerAk8PFPUPPICleanedMiniAOD*jetDQMAnalyzerAk4PFCHSPuppiCleanedMiniAOD)
@@ -37,6 +42,7 @@ _jetDQMAnalyzerSequenceHI = cms.Sequence(jetDQMMatchAkPu4CaloAkPu4PF
         * jetDQMAnalyzerAkCs4PF
 )
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+(~pp_on_AA).toReplaceWith(jetDQMAnalyzerSequence, _jetDQMAnalyzerSequenceWithPUPPI)
 pp_on_AA.toReplaceWith( jetDQMAnalyzerSequence, _jetDQMAnalyzerSequenceHI )
 pp_on_AA.toModify( jetDQMAnalyzerAkPU4Calo, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )
 pp_on_AA.toModify( jetDQMAnalyzerAkPU3PF, srcVtx = cms.untracked.InputTag("offlinePrimaryVertices") )

--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -144,6 +144,16 @@ jetDQMAnalyzerAk4PFCHSCleaned=jetDQMAnalyzerAk4PFCleaned.clone(
     fillCHShistos = True
 )
 
+jetDQMAnalizerAk4PUPPICleaned=jetDQMAnalyzerAk4PFCleaned.clone(
+    JetType = cms.string('puppi'),
+    jetsrc = "ak4PFJetsPuppi",
+    METCollectionLabel = "pfMetPuppi",
+    JetCorrections = "ak4PFPuppiL1FastL2L3ResidualCorrector",
+    JetIDVersion = "RUN2ULPUPPI",
+    JetIDQuality = cms.string("TIGHT"),
+    fillCHShistos = True,
+)
+
 jetDQMAnalyzerAk4PFCHSUncleanedMiniAOD=jetDQMAnalyzerAk4PFUncleaned.clone(
     filljetHighLevel = True,
     CleaningParameters = cleaningParameters.clone(

--- a/DQMOffline/JetMET/python/metDQMConfig_cff.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cff.py
@@ -1,12 +1,17 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 
 from DQMOffline.JetMET.metDQMConfig_cfi import *
 
 #correction for type 1 done in JetMETDQMOfflineSource now
 METDQMAnalyzerSequence = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer)
 
+_METDQMAnalyzerSequenceWithPUPPI = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer*pfChMetDQMAnalyzer*pfMetT1DQMAnalyzer*pfMetPUPPIDQMAnalyzer)
+
 METDQMAnalyzerSequenceMiniAOD = cms.Sequence(pfMetDQMAnalyzerMiniAOD*pfPuppiMetDQMAnalyzerMiniAOD)
 
 METDQMAnalyzerSequenceCosmics = cms.Sequence(caloMetDQMAnalyzer)
 
 METDQMAnalyzerSequenceHI = cms.Sequence(caloMetDQMAnalyzer*pfMetDQMAnalyzer)
+
+(~pp_on_AA).toReplaceWith(METDQMAnalyzerSequence, _METDQMAnalyzerSequenceWithPUPPI)

--- a/DQMOffline/JetMET/python/metDQMConfig_cfi.py
+++ b/DQMOffline/JetMET/python/metDQMConfig_cfi.py
@@ -207,6 +207,12 @@ pfMetT1DQMAnalyzer = caloMetDQMAnalyzer.clone(
         Filter = True
         ),
 )
+pfMetPUPPIDQMAnalyzer = pfMetDQMAnalyzer.clone(
+    METType = 'pf',
+    METCollectionLabel     = "pfMetPuppi",
+    JetCollectionLabel  = "ak4PFJetsPuppi",
+    JetCorrections = "dqmAk4PuppiL2L3ResidualCorrector",
+)
 pfMetDQMAnalyzerMiniAOD = pfMetDQMAnalyzer.clone(
     fillMetHighLevel = True,#fills only lumisec plots
     fillCandidateMaps = False,


### PR DESCRIPTION
#### PR description:

Adding the PUPPI collection for both jets and METs to the offline DQM JetMET sequence, as presented [here](https://indico.cern.ch/event/1386418/#3-updates-on-puppi-for-dc).

#### PR validation:

```
echo '{
"369978" : [[1, 800]]
}' > step1_lumiRanges.log  2>&1

(dasgoclient --limit 0 --query 'lumi,file dataset=/JetMET0/Run2023D-v1/RAW run=369978' --format json | das-selected-lumis.py 1,800 ) | sort -u > step1_dasquery.log  2>&1

cmsDriver.py step2  --process reHLT -s L1REPACK:Full,HLT:@relval2023 --conditions auto:run3_hlt_relval --data  --eventcontent FEVTDEBUGHLT --datatier FEVTDEBUGHLT --era Run3_2023 -n 1000 --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root  --nThreads 8

cmsDriver.py step3  --conditions auto:run3_data_prompt_relval -s RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@jetmet --datatier RECO,MINIAOD,NANOAOD,DQMIO --eventcontent RECO,MINIAOD,NANOEDMAOD,DQM --data  --process reRECO --scenario pp --era Run3_2023 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run3 --hltProcess reHLT -n 1000 --filein  file:step2.root  --fileout file:step3.root  --nThreads 8

cmsDriver.py step4  -s HARVESTING:@jetmet --conditions auto:run3_data --data  --filetype DQM --scenario pp --era Run3_2023 -n 1000 --filein file:step3_inDQM.root --fileout file:step4.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of PR#44336