### PR TITLE
Add tests for ProductID metadata consistency for ROOT and streamer formats

### DIFF
--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -63,6 +63,14 @@ namespace edmtest {
     ProductWithNoDictionary dummy;
   };
 
+  struct ATransientIntProduct {  // just to have a name earlier in alphabetic
+    explicit ATransientIntProduct(int i = 0) : value(i) {}
+    ~ATransientIntProduct() {}
+
+    cms_int32_t value;
+    ProductWithNoDictionary dummy;
+  };
+
   template <int TAG>
   struct TransientIntParentT {
     explicit TransientIntParentT(int i = 0) : value(i) {}

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -23,6 +23,10 @@
   <version ClassVersion="11" checksum="639295444"/>
   <field name="dummy" transient="true"/>
  </class>
+ <class name="edmtest::ATransientIntProduct" ClassVersion="3">
+  <version ClassVersion="3" checksum="2661369959"/>
+  <field name="dummy" transient="true"/>
+ </class>
  <class name="edmtest::Int16_tProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="1443289058"/>
  </class>
@@ -83,6 +87,7 @@
  <class name="edm::Wrapper<std::vector<std::unique_ptr<edmtest::IntProduct>>>"/>
  <class name="edm::Wrapper<edmtest::UInt64Product>"/>
  <class name="edm::Wrapper<edmtest::TransientIntProduct>" persistent="false"/>
+ <class name="edm::Wrapper<edmtest::ATransientIntProduct>" persistent="false"/>
  <class name="edm::Wrapper<edmtest::Int16_tProduct>"/>
  <class name="edm::Wrapper<edmtest::DoubleProduct>"/>
  <class name="edm::Wrapper<edmtest::StringProduct>"/>

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -996,6 +996,29 @@ namespace edm::test {
       edm::EDPutTokenT<edmtest::IntProduct> token_;
       int value_;
     };
+
+    class IntTransformer : public edm::global::EDProducer<edm::Transformer> {
+    public:
+      explicit IntTransformer(edm::ParameterSet const& p)
+          : token_{produces()}, value_(p.getParameter<int>("valueOther")) {
+        registerTransform(token_,
+                          [](edmtest::ATransientIntProduct const& iV) { return edmtest::IntProduct(iV.value); });
+      }
+      void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const final { e.emplace(token_, value_); }
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<int>("valueOther");
+        desc.add<int>("valueCpu");
+        desc.addUntracked<std::string>("variant", "");
+
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+    private:
+      edm::EDPutTokenT<edmtest::ATransientIntProduct> token_;
+      int value_;
+    };
   }  // namespace other
   namespace cpu {
     class IntProducer : public edm::global::EDProducer<> {
@@ -1016,6 +1039,12 @@ namespace edm::test {
       edm::EDPutTokenT<edmtest::IntProduct> token_;
       int value_;
     };
+    // The idea is that the other::IntTransformer produces an
+    // additional *transient* data product compared to
+    // cpu::IntTransformer. The cpu::IntTransformer would be
+    // functionally equivalent to cpu::IntProducer, so can simply use
+    // a type alias.
+    using IntTransformer = IntProducer;
   }  // namespace cpu
 }  // namespace edm::test
 
@@ -1066,3 +1095,5 @@ DEFINE_FWK_MODULE(TransientIntProducerEndProcessBlock);
 DEFINE_FWK_MODULE(edmtest::MustRunIntProducer);
 DEFINE_FWK_MODULE(edm::test::other::IntProducer);
 DEFINE_FWK_MODULE(edm::test::cpu::IntProducer);
+DEFINE_FWK_MODULE(edm::test::other::IntTransformer);
+DEFINE_FWK_MODULE(edm::test::cpu::IntTransformer);

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -25,4 +25,7 @@
   <test name="TestIOPoolInputNoParentDictionary" command="testNoParentDictionary.sh"/>
   <test name="TestFileOpenErrorExitCode" command="testFileOpenErrorExitCode.sh"/>
   <test name="TestIOPoolInputSchemaEvolution" command="testSchemaEvolution.sh"/>
+
+  <test name="TestIOPoolInputRefProductIDMetadataConsistency" command="run_TestRefProductIDMetadataConsistencyRoot.sh"/>
+
 </environment>

--- a/IOPool/Input/test/run_TestRefProductIDMetadataConsistencyRoot.sh
+++ b/IOPool/Input/test/run_TestRefProductIDMetadataConsistencyRoot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+function runSuccess {
+    echo "cmsRun $@"
+    cmsRun $@ || die "cmsRun $*" $?
+    echo
+}
+
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRoot_cfg.py
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRoot_cfg.py --enableOther
+
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRootMerge_cfg.py
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyRootTest_cfg.py

--- a/IOPool/Input/test/testRefProductIDMetadataConsistencyRootMerge_cfg.py
+++ b/IOPool/Input/test/testRefProductIDMetadataConsistencyRootMerge_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MERGE")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:refconsistency_1.root",
+                                      "file:refconsistency_10.root")
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("refconsistency_merge.root")
+)
+
+process.tester = cms.EDAnalyzer("OtherThingAnalyzer",
+    other = cms.untracked.InputTag("otherThing","testUserTag")
+)
+
+process.o = cms.EndPath(process.out+process.tester)
+

--- a/IOPool/Input/test/testRefProductIDMetadataConsistencyRootTest_cfg.py
+++ b/IOPool/Input/test/testRefProductIDMetadataConsistencyRootTest_cfg.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:refconsistency_merge.root")
+)
+
+process.tester = cms.EDAnalyzer("OtherThingAnalyzer",
+    other = cms.untracked.InputTag("otherThing","testUserTag")
+)
+
+process.e = cms.EndPath(process.tester)

--- a/IOPool/Input/test/testRefProductIDMetadataConsistencyRoot_cfg.py
+++ b/IOPool/Input/test/testRefProductIDMetadataConsistencyRoot_cfg.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ModuleTypeResolver and Ref')
+parser.add_argument("--enableOther", action="store_true", help="Enable other accelerator. Also sets Lumi to 2")
+args = parser.parse_args()
+
+class ModuleTypeResolverTest:
+    def __init__(self, accelerators):
+        self._variants = []
+        if "other" in accelerators:
+            self._variants.append("other")
+        if "cpu" in accelerators:
+            self._variants.append("cpu")
+        if len(self._variants) == 0:
+            raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "No 'cpu' or 'other' accelerator available")
+
+    def plugin(self):
+        return "edm::test::ConfigurableTestTypeResolverMaker"
+
+    def setModuleVariant(self, module):
+        if module.type_().startswith("generic::"):
+            if hasattr(module, "variant"):
+                if module.variant.value() not in self._variants:
+                    raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Module {} has the Test variant set explicitly to {}, but its accelerator is not available for the job".format(module.label_(), module.variant.value()))
+            else:
+                module.variant = cms.untracked.string(self._variants[0])
+
+class ProcessAcceleratorTest(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorTest,self).__init__()
+        self._labels = ["other"]
+        self._enabled = []
+        if args.enableOther:
+            self._enabled.append("other")
+    def labels(self):
+        return self._labels
+    def enabledLabels(self):
+        return self._enabled
+    def moduleTypeResolver(self, accelerators):
+        return ModuleTypeResolverTest(accelerators)
+
+process = cms.Process("PROD1")
+process.add_(ProcessAcceleratorTest())
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint32(10 if args.enableOther else 1),
+)
+process.maxEvents.input = 3
+
+process.intprod = cms.EDProducer("generic::IntTransformer", valueCpu = cms.int32(1), valueOther = cms.int32(2))
+
+process.thing = cms.EDProducer("ThingProducer")
+
+process.otherThing = cms.EDProducer("OtherThingProducer",
+    thingTag=cms.InputTag("thing")
+)
+
+process.t = cms.Task(
+    process.intprod,
+    process.thing,
+    process.otherThing
+)
+process.p = cms.Path(process.t)
+
+fname = "refconsistency_{}".format(process.source.firstEvent.value())
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string(fname+".root")
+)
+
+process.ep = cms.EndPath(process.out)

--- a/IOPool/Streamer/bin/BuildFile.xml
+++ b/IOPool/Streamer/bin/BuildFile.xml
@@ -4,6 +4,11 @@
     <use name="IOPool/Streamer"/>
   </bin>
 
+  <bin file="CatStreamerFiles.cpp">
+    <use name="FWCore/Utilities"/>
+    <use name="IOPool/Streamer"/>
+  </bin>
+
   <bin file="CalcAdler32.cpp">
     <use name="FWCore/Utilities"/>
   </bin>

--- a/IOPool/Streamer/bin/CatStreamerFiles.cpp
+++ b/IOPool/Streamer/bin/CatStreamerFiles.cpp
@@ -1,0 +1,69 @@
+#include "FWCore/Utilities/interface/Exception.h"
+#include "IOPool/Streamer/interface/DumpTools.h"
+#include "IOPool/Streamer/interface/EventMessage.h"
+#include "IOPool/Streamer/interface/InitMessage.h"
+#include "IOPool/Streamer/interface/MsgTools.h"
+#include "IOPool/Streamer/interface/StreamerInputFile.h"
+#include "IOPool/Streamer/interface/StreamerOutputFile.h"
+
+// Utility to concatenate streamer files outside of the framework
+// Mimics the behavior of DAQ
+// Largely copied from DiagStreamerFile
+
+void help();
+void mergefile(StreamerOutputFile&, std::string const&, bool);
+
+//==========================================================================
+int main(int argc, char* argv[]) {
+  if (argc < 3) {
+    std::cout << "No command line argument supplied\n";
+    help();
+    return 1;
+  }
+
+  std::string outfile(argv[1]);
+  std::vector<std::string> streamfiles(argv + 2, argv + argc);
+
+  StreamerOutputFile stream_output(outfile);
+  bool first = true;
+  for (auto const& sf : streamfiles) {
+    mergefile(stream_output, sf, first);
+    first = false;
+  }
+
+  return 0;
+}
+
+//==========================================================================
+void help() {
+  std::cout << "Usage: CatStreamerFile output_file_name streamer_file_name"
+            << " [streamer_file_name ...]" << std::endl;
+}
+
+//==========================================================================
+void mergefile(StreamerOutputFile& stream_output, std::string const& filename, bool includeheader) {
+  uint32 num_events(0);
+
+  try {
+    edm::StreamerInputFile stream_reader(filename);
+
+    std::cout << "Trying to Read The Init message from Streamer File: " << std::endl << filename << std::endl;
+    InitMsgView const* init = stream_reader.startMessage();
+    if (includeheader) {
+      std::cout << "Writing Init message to output file" << std::endl;
+      stream_output.write(*init);
+    }
+
+    std::cout << "Trying to read the Event messages" << std::endl;
+    EventMsgView const* eview(nullptr);
+    while (edm::StreamerInputFile::Next::kEvent == stream_reader.next()) {
+      eview = stream_reader.currentRecord();
+      ++num_events;
+      stream_output.write(*eview);
+    }
+    std::cout << "Finished processing " << num_events << " events" << std::endl;
+  } catch (cms::Exception& e) {
+    std::cerr << "Exception caught:  " << e.what() << std::endl
+              << "After reading " << num_events << "from file " << filename << std::endl;
+  }
+}

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -26,6 +26,8 @@
 
   <test name="NewStreamerZSTD" command="RunZSTD.sh"/>
 
+  <test name="TestIOPoolStreamerRefProductIDMetadataConsistency" command="run_TestRefProductIDMetadataConsistencyStreamer.sh"/>
+  
   <library file="StreamThingProducer.cc" name="StreamThingProducer">
     <flags EDM_PLUGIN="1"/>
     <use name="DataFormats/TestObjects"/>

--- a/IOPool/Streamer/test/run_TestRefProductIDMetadataConsistencyStreamer.sh
+++ b/IOPool/Streamer/test/run_TestRefProductIDMetadataConsistencyStreamer.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+function runSuccess {
+    echo "cmsRun $@"
+    cmsRun $@ || die "cmsRun $*" $?
+    echo
+}
+function runFailure {
+    echo "cmsRun $@ (exepcted to fail)"
+    cmsRun $@ && die "cmsRun $*" 1
+    echo
+}
+
+# Produce two files with different ProductID metadata
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyStreamer_cfg.py
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyStreamer_cfg.py --enableOther
+
+# Processing the two files together works
+runSuccess ${SCRAM_TEST_PATH}/testRefProductIDMetadataConsistencyStreamerTest_cfg.py --input refconsistency_1.dat --input refconsistency_10.dat
+
+# Concatenating the two files by keeping the Init message of only first file ...
+echo "Concatenating streamer files"
+CatStreamerFiles refconsistency_cat.dat refconsistency_1.dat refconsistency_10.dat
+echo
+
+# ... fails
+runFailure ${SCRAM_TEST_PATH}/testModuleTypeResolverRefTest_cfg.py --input moduletyperesolver_ref_cat.dat

--- a/IOPool/Streamer/test/testRefProductIDMetadataConsistencyStreamerTest_cfg.py
+++ b/IOPool/Streamer/test/testRefProductIDMetadataConsistencyStreamerTest_cfg.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("TEST")
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ModuleTypeResolver and Ref')
+parser.add_argument("--input", action="append", default=[], help="Input files")
+args = parser.parse_args()
+if len(args.input) == 0:
+    parser.error("No input files")
+
+process.source = cms.Source("NewEventStreamFileReader",
+    fileNames = cms.untracked.vstring(["file:"+f for f in args.input])
+)
+
+process.tester = cms.EDAnalyzer("OtherThingAnalyzer",
+    other = cms.untracked.InputTag("otherThing","testUserTag")
+)
+
+process.e = cms.EndPath(process.tester)

--- a/IOPool/Streamer/test/testRefProductIDMetadataConsistencyStreamer_cfg.py
+++ b/IOPool/Streamer/test/testRefProductIDMetadataConsistencyStreamer_cfg.py
@@ -1,0 +1,72 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ModuleTypeResolver and Ref')
+parser.add_argument("--enableOther", action="store_true", help="Enable other accelerator. Also sets Lumi to 2")
+args = parser.parse_args()
+
+class ModuleTypeResolverTest:
+    def __init__(self, accelerators):
+        self._variants = []
+        if "other" in accelerators:
+            self._variants.append("other")
+        if "cpu" in accelerators:
+            self._variants.append("cpu")
+        if len(self._variants) == 0:
+            raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "No 'cpu' or 'other' accelerator available")
+
+    def plugin(self):
+        return "edm::test::ConfigurableTestTypeResolverMaker"
+
+    def setModuleVariant(self, module):
+        if module.type_().startswith("generic::"):
+            if hasattr(module, "variant"):
+                if module.variant.value() not in self._variants:
+                    raise cms.EDMException(cms.edm.errors.UnavailableAccelerator, "Module {} has the Test variant set explicitly to {}, but its accelerator is not available for the job".format(module.label_(), module.variant.value()))
+            else:
+                module.variant = cms.untracked.string(self._variants[0])
+
+class ProcessAcceleratorTest(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorTest,self).__init__()
+        self._labels = ["other"]
+        self._enabled = []
+        if args.enableOther:
+            self._enabled.append("other")
+    def labels(self):
+        return self._labels
+    def enabledLabels(self):
+        return self._enabled
+    def moduleTypeResolver(self, accelerators):
+        return ModuleTypeResolverTest(accelerators)
+
+process = cms.Process("PROD1")
+process.add_(ProcessAcceleratorTest())
+
+process.source = cms.Source("EmptySource",
+    firstEvent = cms.untracked.uint32(10 if args.enableOther else 1),
+)
+process.maxEvents.input = 3
+
+process.intprod = cms.EDProducer("generic::IntTransformer", valueCpu = cms.int32(1), valueOther = cms.int32(2))
+
+process.thing = cms.EDProducer("ThingProducer")
+
+process.otherThing = cms.EDProducer("OtherThingProducer",
+                                   thingTag=cms.InputTag("thing"))
+
+process.t = cms.Task(
+    process.intprod,
+    process.thing,
+    process.otherThing
+)
+process.p = cms.Path(process.t)
+
+fname = "refconsistency_{}".format(process.source.firstEvent.value())
+process.out = cms.OutputModule("EventStreamFileWriter",
+    fileName = cms.untracked.string(fname+".dat"),
+)
+
+process.ep = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

This PR adds the reproducer I mentioned in https://github.com/cms-sw/cmssw/issues/44643#issuecomment-2046131487 as a unit test. It also adds a utility `CatStreamerFiles` to concatenate streamer files such that the InitMessage of only the first file is kept (which is effectively what DAQ does online).

Resolves https://github.com/cms-sw/framework-team/issues/887

#### PR validation:

Added unit tests run

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Eventually to be backported to 14_0_X
