### PR TITLE
Adding PNET scores to offline HLT DQM

### DIFF
--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -76,7 +76,7 @@ hltBTVmonitoring = topMonitoring.clone(
     electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
     muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !     
     
-    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    btagAlgos = ["pfParticleNetAK4DiscriminatorsJetTagsForRECO:BvsAll"],
     workingpoint = -1., #no cut applied
     
     HTdefinition = 'pt>30 & abs(eta)<2.5',

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
@@ -41,7 +41,7 @@ BTVEfficiency_BTagMu_DiJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet csv; bjet CSV; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
         "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
         "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
@@ -49,6 +49,15 @@ BTVEfficiency_BTagMu_DiJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
+)
+
+BTVEfficiency_BTagMu_DiJet_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_DiJet/*_DeepJet"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )    
 )
 
 BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
@@ -83,7 +92,7 @@ BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet csv; bjet CSV; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
         "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
         "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
@@ -92,6 +101,16 @@ BTVEfficiency_BTagMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
 )
+
+BTVEfficiency_BTagMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagMu_Jet/*_DeepJet"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
+)
+
 
 BTVEfficiency_BTagDiMu_Jet = DQMEDHarvester("DQMGenericClient",
     subDirs        = cms.untracked.vstring("HLT/BTV/BTagDiMu_Jet/*"),
@@ -132,7 +151,7 @@ BTVEfficiency_BTagDiMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet csv; bjet CSV; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
         "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
         "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
@@ -140,6 +159,15 @@ BTVEfficiency_BTagDiMu_Jet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
+)
+
+BTVEfficiency_BTagDiMu_Jet_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/BTagDiMu_Jet/*_DeepJet"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
 )
 
 BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
@@ -165,7 +193,7 @@ BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetPt_1      'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_numerator  bjetPt_1_denominator",
         "effic_bjetEta_1     'efficiency vs 1st b-jet eta; bjet eta ; efficiency'  bjetEta_1_numerator   bjetEta_1_denominator",
         "effic_bjetPhi_1     'efficiency vs 1st b-jet phi; bjet phi ; efficiency'  bjetPhi_1_numerator   bjetPhi_1_denominator",
-        "effic_bjetCSV_1     'efficiency vs 1st b-jet csv; bjet CSV; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet PNet Score; bjet PNet Score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator",
         "effic_bjetPt_1_variableBinning   'efficiency vs 1st b-jet pt; bjet pt [GeV]; efficiency' bjetPt_1_variableBinning_numerator   bjetPt_1_variableBinning_denominator",
         "effic_bjetEta_1_variableBinning  'efficiency vs 1st b-jet eta; bjet eta ; efficiency' bjetEta_1_variableBinning_numerator     bjetEta_1_variableBinning_denominator",
         "effic_bjetMulti      'efficiency vs b-jet multiplicity; bjet multiplicity; efficiency' bjetMulti_numerator   bjetMulti_denominator",
@@ -173,6 +201,15 @@ BTVEfficiency_PFJet = DQMEDHarvester("DQMGenericClient",
         "effic_bjetEtaPhi_1    'efficiency vs 1st b-jet #eta-#phi; bjet #eta ; bjet #phi' bjetEtaPhi_1_numerator  bjetEtaPhi_1_denominator",
         "effic_DeltaR_jet_Mu    'efficiency vs #DeltaR between jet and mu; #DeltaR(jet,mu) ; efficiency' DeltaR_jet_Mu_numerator  DeltaR_jet_Mu_denominator",
     ),
+)
+
+BTVEfficiency_PFJet_DeepJet = DQMEDHarvester("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/BTV/PFJet/*_DeepJet"),
+    verbose        = cms.untracked.uint32(0),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        "effic_bjetCSV_1     'efficiency vs 1st b-jet DeepJet score; DeepJet score; efficiency' bjetCSV_1_numerator  bjetCSV_1_denominator"
+    )
 )
 
 BTVEfficiency_TurnOnCurves = DQMEDHarvester("DQMGenericClient",
@@ -239,5 +276,9 @@ btaggingClient = cms.Sequence(
   + BTVEfficiency_BTagMu_Jet
   + BTVEfficiency_BTagDiMu_Jet
   + BTVEfficiency_PFJet
+  + BTVEfficiency_BTagMu_DiJet_DeepJet
+  + BTVEfficiency_BTagMu_Jet_DeepJet
+  + BTVEfficiency_BTagDiMu_Jet_DeepJet
+  + BTVEfficiency_PFJet_DeepJet
   + BJetTrackToTrackEfficiencies
 )

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -16,7 +16,7 @@ BTagMu_AK4DiJet20_Mu5 = hltBTVmonitoring.clone(
 )
 
 BTagMu_AK4DiJet20_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet20_Mu5_DeepJet',
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet20_Mu5_DeepJet',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,
@@ -41,7 +41,7 @@ BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
 )
 
 BTagMu_AK4DiJet40_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5_DeepJet',
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet40_Mu5_DeepJet',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,
@@ -65,7 +65,7 @@ BTagMu_AK4DiJet70_Mu5 = hltBTVmonitoring.clone(
 )
 
 BTagMu_AK4DiJet70_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet70_Mu5_DeepJet',
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet70_Mu5_DeepJet',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,
@@ -88,7 +88,7 @@ BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
 )
 
 BTagMu_AK4DiJet110_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5_DeepJet',
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet110_Mu5_DeepJet',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,
@@ -111,7 +111,7 @@ BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone(
 )
 
 BTagMu_AK4DiJet170_Mu5_DeepJet = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet170_Mu5_DeepJet',
+    FolderName = 'HLT/BTV/BTagMu_DiJet/AK4DiJet170_Mu5_DeepJet',
     nmuons = 1,
     nelectrons = 0,
     njets = 2,

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -15,6 +15,19 @@ BTagMu_AK4DiJet20_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet20_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet20_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>10 & abs(eta)<2.4',
+    bjetSelection = 'pt>5 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet20_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
+)
+
 BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5',
     nmuons = 1,
@@ -23,6 +36,19 @@ BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>30 & abs(eta)<2.4',
     bjetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
+)
+
+BTagMu_AK4DiJet40_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
 )
@@ -38,6 +64,18 @@ BTagMu_AK4DiJet70_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet70_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet70_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet70_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
+)
+
 BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5',
     nmuons = 1,
@@ -49,6 +87,17 @@ BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet110_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>90 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
+)
 
 BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet170_Mu5',
@@ -61,6 +110,17 @@ BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone(
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
 
+BTagMu_AK4DiJet170_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet170_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>150 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet170_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
+)
 
 BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5',
@@ -69,6 +129,18 @@ BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
     njets = 1,
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>250 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4Jet300_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
+)
+
+BTagMu_AK4Jet300_Mu5_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5_DeepJet',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 1,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>250 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4Jet300_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
 )
@@ -83,6 +155,7 @@ BTagMu_AK8DiJet170_Mu5 = hltBTVmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>150 & abs(eta)<2.4',
+    btagAlgos = ["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8DiJet170_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
@@ -96,6 +169,7 @@ BTagMu_AK8Jet300_Mu5 = hltBTVmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
     jetSelection = 'pt>250 & abs(eta)<2.4',
+    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet300_Mu5_v*']),
     histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
 )
@@ -109,6 +183,7 @@ BTagMu_AK8Jet170_DoubleMu5 = hltBTVmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     muoSelection = 'pt>7 & abs(eta)<2.4 & isPFMuon & isGlobalMuon & innerTrack.hitPattern.numberOfValidTrackerHits>7 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & numberOfMatchedStations>1 &globalTrack.normalizedChi2<10',
     jetSelection = 'pt>150 & abs(eta)<2.4',
+    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet170_DoubleMu5_v*']),
     histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
 )
@@ -125,6 +200,18 @@ BTagMonitor_PFJet40 = hltBTVmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
 )
 
+BTagMonitor_PFJet40_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet40_DeepJet',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
+    histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
+)
+
 # PFJet AK8
 BTagMonitor_AK8PFJet40 = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJet40',
@@ -134,18 +221,20 @@ BTagMonitor_AK8PFJet40 = hltBTVmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     jetSelection = 'pt>30 & abs(eta)<2.4',
     bjetSelection = 'pt>20 & abs(eta)<2.4',
+    btagAlgos =	["pfMassDecorrelatedParticleNetDiscriminatorsJetTags:XbbvsQCD"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet40_v*']),
     histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000])
 )
 
 # PFJetFwd AK4
-BTagMonitor_PFJetFwd40 = hltBTVmonitoring.clone(
-    FolderName = 'HLT/BTV/PFJet/PFJetFwd40',
+BTagMonitor_PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd40_DeepJet',
     nmuons = 0,
     nelectrons = 0,
     njets = 1,
     jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
     bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
     histoPSet = dict(
         jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
@@ -156,7 +245,7 @@ BTagMonitor_PFJetFwd40 = hltBTVmonitoring.clone(
 )
 
 # PFJetFwd AK8
-BTagMonitor_AK8PFJetFwd40 = hltBTVmonitoring.clone(
+BTagMonitor_AK8PFJetFwd40_DeepJet = hltBTVmonitoring.clone(
     FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd40',
     nmuons = 0,
     nelectrons = 0,
@@ -164,6 +253,7 @@ BTagMonitor_AK8PFJetFwd40 = hltBTVmonitoring.clone(
     jets = "ak8PFJetsPuppi",
     jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
     bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
+    btagAlgos = ["pfDeepFlavourJetTags:probb", "pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb"],
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd40_v*']),
     histoPSet = dict(
         jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
@@ -177,19 +267,26 @@ BTagMonitor_AK8PFJetFwd40 = hltBTVmonitoring.clone(
 
 btagMonitorHLT = cms.Sequence(
     BTagMu_AK4DiJet20_Mu5
+  + BTagMu_AK4DiJet20_Mu5_DeepJet
   + BTagMu_AK4DiJet40_Mu5
+  + BTagMu_AK4DiJet40_Mu5_DeepJet
   + BTagMu_AK4DiJet70_Mu5
+  + BTagMu_AK4DiJet70_Mu5_DeepJet
   + BTagMu_AK4DiJet110_Mu5
+  + BTagMu_AK4DiJet110_Mu5_DeepJet
   + BTagMu_AK4DiJet170_Mu5
+  + BTagMu_AK4DiJet170_Mu5_DeepJet
   + BTagMu_AK8DiJet170_Mu5
   + BTagMu_AK8Jet170_DoubleMu5
   + BTagMu_AK4Jet300_Mu5
+  + BTagMu_AK4Jet300_Mu5_DeepJet
   + BTagMu_AK8Jet300_Mu5
 )
 
 btvHLTDQMSourceExtra = cms.Sequence(
     BTagMonitor_PFJet40
+  + BTagMonitor_PFJet40_DeepJet
   + BTagMonitor_AK8PFJet40
-  + BTagMonitor_PFJetFwd40
-  + BTagMonitor_AK8PFJetFwd40
+  + BTagMonitor_PFJetFwd40_DeepJet
+  + BTagMonitor_AK8PFJetFwd40_DeepJet
 )


### PR DESCRIPTION
**PR Description**

This PR aims to replace ParticleNet(PNET) as the default offline HLT b-tagging algorithm updating [#42937 ](https://github.com/cms-sw/cmssw/pull/42937), while creating new folders for each path inside HLT/BTV to keep the current DeepJet histograms for groups that still use it. 

It also updates the titles and x-axis labels for the b-tagging efficiency histograms (currently mislabeled as CSV). 

The expected changes are as follows: 
1. The already existing folders inside HLT/BTV will contain PNET input plots instead of DeepJet.
2. For each path, we now have a separate '*_DeepJet' folder that contains plots with DeepJet inputs (note: some paths malfunction with PNET, so they only contain DeepJet folders)
3. The histograms with name effic_bjetCSV now have appropriate titles and x-axis labels for both PNET and DeepJet. 

**PR Validation**

The changes pass the basic tests suggested in https://cms-sw.github.io/PRWorkflow.html. 
12834.0 workflow runs without error and all the changes are visible in local GUI. 
