### PR TITLE
[14.0.X] modified for Phase2 `DeepJet` retraining model 

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTagsModEta2p4_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTagsModEta2p4_cfi.py
@@ -17,7 +17,7 @@ hltPfDeepFlavourJetTagsModEta2p4 = cms.EDProducer("DeepFlavourONNXJetTagsProduce
         'input_5'
     ),
     mightGet = cms.optional.untracked.vstring,
-    model_path = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourV01_PhaseII/model.onnx'),
+    model_path = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourV02_PhaseII/DeepJet_retraining_phase2_new_inputs.onnx'),
     output_names = cms.vstring(),
     src = cms.InputTag("hltPfDeepFlavourTagInfosModEta2p4")
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTags_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTags_cfi.py
@@ -17,7 +17,7 @@ hltPfDeepFlavourJetTags = cms.EDProducer("DeepFlavourONNXJetTagsProducer",
         'input_5'
     ),
     mightGet = cms.optional.untracked.vstring,
-    model_path = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourV01_PhaseII/model.onnx'),
+    model_path = cms.FileInPath('RecoBTag/Combined/data/DDeepFlavourV02_PhaseII/DeepJet_retraining_phase2_new_inputs.onnx'),
     output_names = cms.vstring(),
     src = cms.InputTag("hltPfDeepFlavourTagInfos")
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTags_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPfDeepFlavourJetTags_cfi.py
@@ -17,7 +17,7 @@ hltPfDeepFlavourJetTags = cms.EDProducer("DeepFlavourONNXJetTagsProducer",
         'input_5'
     ),
     mightGet = cms.optional.untracked.vstring,
-    model_path = cms.FileInPath('RecoBTag/Combined/data/DDeepFlavourV02_PhaseII/DeepJet_retraining_phase2_new_inputs.onnx'),
+    model_path = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourV02_PhaseII/DeepJet_retraining_phase2_new_inputs.onnx'),
     output_names = cms.vstring(),
     src = cms.InputTag("hltPfDeepFlavourTagInfos")
 )


### PR DESCRIPTION
backport of #44431

#### PR description:

The BTV@HLT group has a Phase2 DeepJet retrained model.
The target for this retraining is to retrain DeepJet and recreate/Improve TDR performance.
The retraining online performance is compared to the TDR/offline model. Please see the details [here](https://indico.cern.ch/event/1327490/contributions/5586686/subcontributions/442720/attachments/2717518/4720407/230920_retraining_Upgrade.pdf) and [here](https://indico.cern.ch/event/1344917/contributions/5765942/attachments/2802563/4890080/HLT_upgrade_workshop%20(1).pdf).
This PR is associated with the Phase2 DeepJet retraining model integration https://github.com/cms-sw/cmsdist/pull/9140

#### PR validation:

The model was tested locally in CMSSW_13_1_0.
Follow the [Phase 2 HLT simplified menu](https://twiki.cern.ch/twiki/bin/view/CMS/HighLevelTriggerPhase2SimplifiedMenu) and `edmConfigDump` to get the configuration file and the HLT dump `phase2_hlt.py`, and in `process.hltPfDeepFlavourJetTagsModEta2p4` and
`process.hltPfDeepFlavourJetTags`, change the model_path to retained model.
Please see the details in the [presentation](https://indico.cern.ch/event/1393422/contributions/5856887/attachments/2817963/4920406/HLT_upgrade_report_March10.pdf).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/44431 for 2024 phase-2 HLT production