### PR TITLE
[14_0_X] DQM: reportSummaryMap: change the sqrt(s) energy from 13 to 13.6 TeV

### DIFF
--- a/DQMServices/Components/plugins/DQMProvInfo.cc
+++ b/DQMServices/Components/plugins/DQMProvInfo.cc
@@ -102,7 +102,7 @@ private:
 
   // Beam momentum at flat top, used to determine if collisions are
   // occurring with the beams at the energy allowed for physics production.
-  const static int MAX_MOMENTUM = 6500;
+  const static int MAX_MOMENTUM = 6800;
 
   // Beam momentum allowed offset: it is a momentum value subtracted to
   // maximum momentum in order to decrease the threshold for beams going to
@@ -309,7 +309,7 @@ void DQMProvInfo::bookHistogramsEventInfo(DQMStore::IBooker& iBooker) {
   reportSummaryMap_->setBinLabel(VBIN_GEM_P, "GEMp", 2);
   reportSummaryMap_->setBinLabel(VBIN_GEM_M, "GEMm", 2);
   reportSummaryMap_->setBinLabel(VBIN_PHYSICS_DECLARED, "PhysDecl", 2);
-  reportSummaryMap_->setBinLabel(VBIN_MOMENTUM, "13 TeV", 2);
+  reportSummaryMap_->setBinLabel(VBIN_MOMENTUM, "13.6 TeV", 2);
   reportSummaryMap_->setBinLabel(VBIN_STABLE_BEAM, "Stable B", 2);
   reportSummaryMap_->setBinLabel(VBIN_VALID, "Valid", 2);
 
@@ -383,7 +383,7 @@ void DQMProvInfo::analyzeLhcInfo(const edm::Event& event) {
     hIntensity2_->setBinContent(currentLSNumber, intensity2);
 
     // Part3: Using LHC status info, fill in VBIN_MOMENTUM and VBIN_STABLE_BEAM
-    // Fill 13 TeV bit in y bin VBIN_MOMENTUM
+    // Fill 13.6 TeV bit in y bin VBIN_MOMENTUM
     if (momentum >= MAX_MOMENTUM - MOMENTUM_OFFSET) {
       fillSummaryMapBin(currentLSNumber, VBIN_MOMENTUM, 1.);
     } else {


### PR DESCRIPTION
#### PR description:

This PR  changes the display of sqrt(s) energy in the reportSummaryMap from 13 TeV to 13.6 TeV. Before this PR request, an update of DQMGUI layout was already committed and merged: [github link](https://github.com/dmwm/deployment/pull/1311). The PR in DQMGUI layout ensures there is no problem when rendering two different version of root files (one with 13 TeV and the other with 13.6 TeV). 

#### PR validation:

We have tested this PR at the playback machines using DQM streamers of cosmic run 378711, 900 GeV pp run 378239, 13.6 TeV pp run 379315. All displayed as expected in the reportSummaryMap.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a 14_0_X backport of [PR 44757](https://github.com/cms-sw/cmssw/pull/44757).
