### PR TITLE
[14.0] Added missing header to fix header consistency

### DIFF
--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/moduleAbilities.h"
 #include "FWCore/Utilities/interface/EDPutToken.h"
 #include "FWCore/Utilities/interface/Transition.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/DeviceProductType.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataAcquireSentry.h"
 #include "HeterogeneousCore/AlpakaCore/interface/EventCache.h"


### PR DESCRIPTION
This should fix the [header consistency](https://cmssdt.cern.ch/SDT/jenkins-artifacts/check_headers/CMSSW_14_0_X_2024-04-17-1100/el8_amd64_gcc12/build.log) error we have in 14.0.X IBs
```
src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h: In member function 'void alpaka_serial_sync::ProducerBase<BaseT, Args>::producesTemporarily(const std::string&, std::string)':
src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h:62:22: error: 'edm::TypeWithDict' has not been declared
   62 |       auto td = edm::TypeWithDict::byName(iTypeName);
      |                      ^~~~~~~~~~~~
src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h:63:60: error: 'TypeID' is not a member of 'edm'
   63 |       Base::template produces<edm::Transition::Event>(edm::TypeID(td.typeInfo()), std::move(instanceName));
      |                                                            ^~~~~~
src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h: In member function 'void alpaka_serial_sync::ProducerBase<BaseT, Args>::putBackend(edm::Event&) const':
src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h:73:7: warning: invalid use of incomplete type 'class edm::Event'
   73 |       iEvent.emplace(this->backendToken_, static_cast<unsigned short>(kBackend));
      |       ^~~~~~
In file included from src/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h:5:
/data/cmsbld/jenkins/workspace/ib-run-check-headers/CMSSW_14_0_X_2024-04-17-1100/src/FWCore/Framework/interface/FrameworkfwdMostUsed.h:12:9: note: forward declaration of 'class edm::Event'
   12 |   class Event;
      |         ^~~~~
gmake: *** [config/SCRAM/GMake/Makefile.rules:1847: tmp/el8_amd64_gcc12/src/HeterogeneousCore/AlpakaCore/src/HeterogeneousCoreAlpakaCore/alpaka/ProducerBase.h.chk_header] Error 1

```