### PR TITLE
Throw a clear exception if OutputModule SelectEvents refers to a non-existent Path or Process

### DIFF
--- a/FWCore/Framework/interface/WorkerInPath.h
+++ b/FWCore/Framework/interface/WorkerInPath.h
@@ -33,7 +33,7 @@ namespace edm {
                         typename T::TransitionInfoType const&,
                         ServiceToken const&,
                         StreamID,
-                        typename T::Context const*);
+                        typename T::Context const*) noexcept;
 
     bool checkResultsOfRunWorker(bool wasEvent);
 
@@ -109,7 +109,7 @@ namespace edm {
                                     typename T::TransitionInfoType const& info,
                                     ServiceToken const& token,
                                     StreamID streamID,
-                                    typename T::Context const* context) {
+                                    typename T::Context const* context) noexcept {
     if constexpr (T::isEvent_) {
       ++timesVisited_;
     }

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -163,19 +163,31 @@ namespace edm {
     auto choiceTask =
         edm::make_waiting_task([id, successTask, iPrincipal, this, weakToken, &group](std::exception_ptr const*) {
           ServiceRegistry::Operate guard(weakToken.lock());
-          // There is no reasonable place to rethrow, and implDoPrePrefetchSelection() should not throw in the first place.
-          CMS_SA_ALLOW try {
-            if (not implDoPrePrefetchSelection(id, *iPrincipal, &moduleCallingContext_)) {
-              timesRun_.fetch_add(1, std::memory_order_relaxed);
-              setPassed<true>();
-              waitingTasks_.doneWaiting(nullptr);
-              //TBB requires that destroyed tasks have count 0
-              if (0 == successTask->decrement_ref_count()) {
-                TaskSentry s(successTask);
+          try {
+            convertException::wrap([&]() {
+              if (not implDoPrePrefetchSelection(id, *iPrincipal, &moduleCallingContext_)) {
+                timesRun_.fetch_add(1, std::memory_order_relaxed);
+                setPassed<true>();
+                waitingTasks_.doneWaiting(nullptr);
+                //TBB requires that destroyed tasks have count 0
+                if (0 == successTask->decrement_ref_count()) {
+                  TaskSentry s(successTask);
+                }
+                return;
               }
-              return;
+            });
+
+          } catch (cms::Exception& e) {
+            e.addContext("Calling OutputModule prePrefetchSelection()");
+            if (moduleCallingContext_.type() == ModuleCallingContext::Type::kPlaceInPath) {
+              auto pathContext = moduleCallingContext_.placeInPathContext()->pathContext();
+              e.addContext("Running path '" + pathContext->pathName() + "'");
+              auto streamContext = moduleCallingContext_.getStreamContext();
+              std::ostringstream ost;
+              exceptionContext(ost, *streamContext);
+              e.addContext(ost.str());
             }
-          } catch (...) {
+            waitingTasks_.doneWaiting(std::current_exception());
           }
           if (0 == successTask->decrement_ref_count()) {
             group.run([successTask]() {
@@ -193,7 +205,8 @@ namespace edm {
     for (auto const& item : items) {
       ProductResolverIndex productResolverIndex = item.productResolverIndex();
       bool skipCurrentProcess = item.skipCurrentProcess();
-      if (productResolverIndex != ProductResolverIndexAmbiguous) {
+      if (productResolverIndex != ProductResolverIndexAmbiguous and
+          productResolverIndex != ProductResolverIndexInvalid) {
         iPrincipal->prefetchAsync(
             choiceHolder, productResolverIndex, skipCurrentProcess, token, &moduleCallingContext_);
       }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -331,7 +331,28 @@
 <test name="testFWCoreFrameworkNonEventOrdering" command="test_non_event_ordering.sh"/>
 <test name="testFWCoreFramework1ThreadESPrefetch" command="run_test_1_thread_es_prefetching.sh"/>
 <test name="testFWCoreFrameworkModuleDeletion" command="run_module_delete_tests.sh"/>
+
 <test name="testFWCoreFrameworkExternalWorkOutputModule" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testExternalWorkGlobalOutputModule_cfg.py"/>
+
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathSameProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=sameProcess 2>&amp;1 | grep 'to request a trigger name that does not exist'"/>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathSameProcessAnotherModuleBefore" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=sameProcess --anotherModule=before 2>&amp;1 | grep 'to request a trigger name that does not exist'"/>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathSameProcessAnotherModuleAfter" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=sameProcess --anotherModule=after 2>&amp;1 | grep 'to request a trigger name that does not exist'"/>
+
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlier" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPathEarlier_cfg.py"/>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlierProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=earlierProcess 2>&amp;1 | grep 'to request a trigger name that does not exist'">
+  <flags PRE_TEST="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlier"/>
+</test>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlierProcessBefore" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=earlierProcess --anotherModule=before 2>&amp;1 | grep 'to request a trigger name that does not exist'">
+  <flags PRE_TEST="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlier"/>
+</test>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlierProcessAfter" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=earlierProcess --anotherModule=after 2>&amp;1 | grep 'to request a trigger name that does not exist'">
+  <flags PRE_TEST="testFWCoreFrameworkOutputModuleSelectEventsMissingPathEarlier"/>
+</test>
+
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathMissingProcess" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=missingProcess 2>&amp;1 | grep 'An exception of category .ProductNotFound'"/>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathMissingProcessAnotherModuleBefore" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=missingProcess --anotherModule=before 2>&amp;1 | grep 'An exception of category .ProductNotFound'"/>
+<test name="testFWCoreFrameworkOutputModuleSelectEventsMissingPathMissingProcessAnotherModuleAfter" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py --missingPath=missingProcess --anotherModule=after 2>&amp;1 | grep 'An exception of category .ProductNotFound'"/>
+
 <test name="testFWCoreFrameworkBadScheduleException0" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 0; grep -v 'Fatal Exception' test_bad_schedule_0.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_0.log -"/>
 <test name="testFWCoreFrameworkBadScheduleException1" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 1; grep -v 'Fatal Exception' test_bad_schedule_1.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_1.log -"/>
 <test name="testFWCoreFrameworkBadScheduleException2" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 2; grep -v 'Fatal Exception' test_bad_schedule_2.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_2.log -"/>

--- a/FWCore/Framework/test/testOutputModuleSelectEventsMissingPathEarlier_cfg.py
+++ b/FWCore/Framework/test/testOutputModuleSelectEventsMissingPathEarlier_cfg.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("EARLIER")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents.input = 3
+
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName = cms.untracked.string("testOutputModuleSelectEventsMissingPath.root")
+)
+
+process.intprod = cms.EDProducer("IntProducer", ivalue=cms.int32(3))
+
+process.p = cms.Path(process.intprod)
+
+process.ep3 = cms.EndPath(process.out)
+

--- a/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py
+++ b/FWCore/Framework/test/testOutputModuleSelectEventsMissingPath_cfg.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test OutputModule SelectEvents referring to a non-existent Path and/or Process ')
+parser.add_argument("--missingPath", type=str, required=True, help="Specify how the specified Path is missing. Can be 'sameProcess', 'earlierProcess', 'missingProcess'")
+parser.add_argument("--anotherModule", type=str, default="", help="Specify placement of another producer. Can be empty (default), 'before', 'after")
+args = parser.parse_args()
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+if args.missingPath == "earlierProcess":
+    process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring("file:testOutputModuleSelectEventsMissingPath.root"))
+process.maxEvents.input = 3
+
+selectEvents = {
+    "sameProcess" : "nonexistent_path:TEST",
+    "earlierProcess" : "nonexistent_path:EARLIER",
+    "missingProcess" : "nonexistent_path:NONEXISTENT_PROCESS",
+}
+
+process.out = cms.OutputModule("SewerModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring(selectEvents[args.missingPath])
+    ),
+    name = cms.string("out"),
+    shouldPass = cms.int32(1)
+)
+
+process.ep = cms.EndPath(process.out)
+
+process.intprod = cms.EDProducer("IntProducer", ivalue=cms.int32(3))
+if args.anotherModule == "before":
+    process.ep.insert(0, process.intprod)
+elif args.anotherModule == "after":
+    process.ep += process.intprod
+elif args.anotherModule != "":
+    raise Exception("Invalid value for anotherModule '{}'".format(args.anotherModule))
+
+process.add_(cms.Service('ZombieKillerService', secondsBetweenChecks=cms.untracked.uint32(2)))


### PR DESCRIPTION
#### PR description:

This was already the case for a non-existent Path of the present process. For non-existent Path of an earlier Process, or a non-existent Process, lead to a confusing exception message, and in some cases the job got stuck. An example of such stuck job was having an unrelated module in front of the OutputModule in the same EndPath.

Resolves https://github.com/cms-sw/cmssw/issues/44743
Resolves https://github.com/cms-sw/cmssw/issues/44744
Resolves https://github.com/cms-sw/framework-team/issues/886

#### PR validation:

Added unit tests pass
