### PR TITLE
[14.0.X] fixup eta lookup in `absEtaLowEdges_` in miscellaneous `RecoEgamma/EgammaHLTProducers` plugins 

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTBcHcalIsolationProducersRegional.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTBcHcalIsolationProducersRegional.cc
@@ -162,14 +162,13 @@ void EgammaHLTBcHcalIsolationProducersRegional::produce(edm::StreamID,
       int iEA = -1;
       auto scEta = std::abs(recoEcalCandRef->superCluster()->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if (scEta > absEtaLowEdges_.at(bIt)) {
+        if (scEta >= absEtaLowEdges_[bIt]) {
           iEA = bIt;
           break;
         }
       }
-      isol = isol - rho * effectiveAreas_.at(iEA);
+      isol = isol - rho * effectiveAreas_[iEA];
     }
-
     isoMap.insert(recoEcalCandRef, isol);
   }
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHcalVarProducerFromRecHit.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHcalVarProducerFromRecHit.cc
@@ -229,12 +229,12 @@ void EgammaHLTHcalVarProducerFromRecHit::produce(edm::StreamID,
       int iEA = -1;
       auto scEta = std::abs(recoEcalCandRef->superCluster()->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if (scEta > absEtaLowEdges_.at(bIt)) {
+        if (scEta >= absEtaLowEdges_[bIt]) {
           iEA = bIt;
           break;
         }
       }
-      isol = isol - rho * effectiveAreas_.at(iEA);
+      isol = isol - rho * effectiveAreas_[iEA];
     }
 
     isoMap.insert(recoEcalCandRef, isol);

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTEcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTEcalPFClusterIsolationProducer.cc
@@ -174,13 +174,12 @@ void HLTEcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const ed
       int iEA = -1;
       auto cEta = std::abs(candRef->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if (cEta > absEtaLowEdges_.at(bIt)) {
+        if (cEta >= absEtaLowEdges_[bIt]) {
           iEA = bIt;
           break;
         }
       }
-
-      sum = sum - rho * effectiveAreas_.at(iEA);
+      sum = sum - rho * effectiveAreas_[iEA];
     }
 
     recoCandMap.insert(candRef, sum);

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHcalPFClusterIsolationProducer.cc
@@ -200,13 +200,12 @@ void HLTHcalPFClusterIsolationProducer<T1>::produce(edm::StreamID sid,
       int iEA = -1;
       auto cEta = std::abs(candRef->eta());
       for (int bIt = absEtaLowEdges_.size() - 1; bIt > -1; bIt--) {
-        if (cEta > absEtaLowEdges_.at(bIt)) {
+        if (cEta >= absEtaLowEdges_[bIt]) {
           iEA = bIt;
           break;
         }
       }
-
-      sum = sum - rho * effectiveAreas_.at(iEA);
+      sum = sum - rho * effectiveAreas_[iEA];
     }
 
     recoCandMap.insert(candRef, sum);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44764

#### PR description:

Implements what's discussed in https://github.com/cms-sw/cmssw/issues/44759#issuecomment-2061159529 and https://github.com/cms-sw/cmssw/issues/44759#issuecomment-2061205599. Avoids bound check failures when having input candidate with `eta()` exactly equal to 0.

#### PR validation:

Run the following script:

```bash
#!/bin/bash -ex

# CMSSW_14_0_5_patch1

hltGetConfiguration run:379530 \
  --globaltag 140X_dataRun3_HLT_v3 \
  --data \
  --no-prescale \
  --no-output \
  --max-events -1 \
  --input /store/group/tsg/FOG/debug/2024-04-17_run379530/run379530_ls0556.root  > hlt.py
  
cat <<@EOF >> hlt.py
process.options.wantSummary = True

process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF

cmsRun hlt.py &> hlt.log
```

in this branch and verified that there are no failures.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of #44764 to the 2024 data-taking release.