### PR TITLE
Fix L1NNCaloTau verbosity

### DIFF
--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauEmulator.cc
@@ -243,6 +243,8 @@ private:
   IEta_t intEtaRestriction;
   IEta_t intCB_CE_split;
 
+  bool DEBUG;
+
   // Class for the towers info as they should be in GCT
   class SimpleTowerHit {
   public:
@@ -420,7 +422,9 @@ L1NNCaloTauEmulator::L1NNCaloTauEmulator(const edm::ParameterSet& iConfig, const
 
       IdWp90_CE(iConfig.getParameter<double>("IdWp90_CE")),
       IdWp95_CE(iConfig.getParameter<double>("IdWp95_CE")),
-      IdWp99_CE(iConfig.getParameter<double>("IdWp99_CE")) {
+      IdWp99_CE(iConfig.getParameter<double>("IdWp99_CE")),
+
+      DEBUG(iConfig.getParameter<bool>("DEBUG")) {
   // Initialize HGCAL BDTs
   if (!VsPuId.method().empty()) {
     VsPuId.prepareTMVA();
@@ -469,7 +473,7 @@ void L1NNCaloTauEmulator::produce(edm::Event& iEvent, const edm::EventSetup& eSe
 
     l1CaloTowers.push_back(l1Hit);
   }
-  if (warnings != 0) {
+  if (warnings != 0 && DEBUG) {
     edm::LogWarning("BrokenTowers") << " ** WARNING : FOUND " << warnings
                                     << " TOWERS WITH towerIeta=-1016 AND towerIphi=-962" << std::endl;
   }

--- a/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauProducer.cc
+++ b/L1Trigger/L1CaloTrigger/plugins/L1NNCaloTauProducer.cc
@@ -135,6 +135,8 @@ private:
   double IdWp95_CE;
   double IdWp99_CE;
 
+  bool DEBUG;
+
   // hardoced dimensions of the tower clusters
   const int seedIdx = 22;
   const int IEta_dim = 5;
@@ -262,7 +264,9 @@ L1NNCaloTauProducer::L1NNCaloTauProducer(const edm::ParameterSet& iConfig, const
 
       IdWp90_CE(iConfig.getParameter<double>("IdWp90_CE")),
       IdWp95_CE(iConfig.getParameter<double>("IdWp95_CE")),
-      IdWp99_CE(iConfig.getParameter<double>("IdWp99_CE")) {
+      IdWp99_CE(iConfig.getParameter<double>("IdWp99_CE")),
+
+      DEBUG(iConfig.getParameter<bool>("DEBUG")) {
   // Initialize HGCAL BDTs
   if (!VsPuId.method().empty()) {
     VsPuId.prepareTMVA();
@@ -307,7 +311,7 @@ void L1NNCaloTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& eSe
 
     l1CaloTowers.push_back(l1Hit);
   }
-  if (warnings != 0) {
+  if (warnings != 0 && DEBUG) {
     edm::LogWarning("BrokenTowers") << " ** WARNING : FOUND " << warnings
                                     << " TOWERS WITH towerIeta=-1016 AND towerIphi=-962" << std::endl;
   }


### PR DESCRIPTION
#### PR description:

This PR fixes the verbosity of the TauMinator (L1NNCaloTau) producers as requested in [Issue#44766](https://github.com/cms-sw/cmssw/issues/44766).
The highly verbose log is not under the `DEBUG` condition which is by default `false`.

#### PR validation:

The code has been validated with the use of the following two standard commands:
`scram build code-checks`
`scram build code-format`
and in both cases no error or warning was prompted by the code in this PR.