### PR TITLE
add a unit test for `convertToRaw`

### DIFF
--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -309,8 +309,8 @@ void RawEventFileWriterForBU::stop() {
 //TODO:get from DaqDirector !
 void RawEventFileWriterForBU::makeRunPrefix(std::string const& destinationDir) {
   //dirty hack: extract run number from destination directory
-  std::string::size_type pos = destinationDir.find("run");
-  std::string run = destinationDir.substr(pos + 3);
+  std::string::size_type pos = destinationDir.rfind("/run");
+  std::string run = destinationDir.substr(pos + 4);
   run_ = atoi(run.c_str());
   std::stringstream ss;
   ss << "run" << std::setfill('0') << std::setw(6) << run_;

--- a/HLTrigger/Tools/test/BuildFile.xml
+++ b/HLTrigger/Tools/test/BuildFile.xml
@@ -1,0 +1,2 @@
+<!-- tests convertToRaw utility script -->
+<test name="testConvertToRaw" command="testConvertToRaw.sh"/>

--- a/HLTrigger/Tools/test/testConvertToRaw.sh
+++ b/HLTrigger/Tools/test/testConvertToRaw.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Pass in name and status
+function die {
+  printf "\n%s: status %s\n" "$1" "$2"
+  exit $2
+}
+
+check_for_success() {
+    "${@}" && echo -e "\n ---> Passed test of '${@}'\n\n" || exit 1
+}
+
+check_for_failure() {
+    "${@}" && exit 1 || echo -e "\n ---> Passed test of '${@}'\n\n"
+}
+
+inputfile=/store/data/Run2024C/EphemeralHLTPhysics0/RAW/v1/000/379/416/00000/e8dd5e3c-216f-4545-acb6-ab86c9161085.root
+
+echo "========================================"
+echo "Testing convertToRaw in ${SCRAM_TEST_PATH}."
+echo "----------------------------------------"
+echo
+
+echo "========================================"
+echo "testing help function "
+echo "----------------------------------------"
+echo
+
+convertToRaw --help  || die "Failure running convertToRaw --help" $?
+
+echo "========================================"
+echo "testing successful conversion"
+echo "----------------------------------------"
+echo
+
+check_for_success convertToRaw -f 1 -l=1 -v $inputfile
+
+echo "========================================"
+echo "testing failing conversion"
+echo "----------------------------------------"
+echo
+
+check_for_failure convertToRaw -f 1 -l=-1 -s rawDataRepacker $inputfile


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/44735 in particular to the comment:

> (It would be good to add a unit test for this utility, but I currently do not have enough time to implement a proper one, and I would not delay this fix.)

add a basic unit test for the `convertToRaw` utility. 

#### PR validation:

`scram b runtests_testConvertToRaw` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A