### PR TITLE
Allow Runtime Number of Hits for Alpaka Pixel Reconstruction

### DIFF
--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -323,7 +323,6 @@ namespace pixelTopology {
     using tindex_type = uint32_t;  // for tuples
     using cindex_type = uint32_t;  // for cells
 
-    static constexpr uint32_t maxNumberOfHits = 256 * 1024;
     static constexpr uint32_t maxCellNeighbors = 64;
     static constexpr uint32_t maxCellTracks = 302;
     static constexpr uint32_t maxHitsOnTrack = 15;
@@ -417,7 +416,6 @@ namespace pixelTopology {
     using tindex_type = uint16_t;  // for tuples
     using cindex_type = uint32_t;  // for cells
 
-    static constexpr uint32_t maxNumberOfHits = 48 * 1024;
     static constexpr uint32_t maxCellNeighbors = 36;
     static constexpr uint32_t maxCellTracks = 48;
     static constexpr uint32_t maxHitsOnTrack = 10;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc
@@ -488,9 +488,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           alpaka::syncBlockThreads(acc);
         }
 #ifdef GPU_DEBUG
-        ALPAKA_ASSERT_ACC(0 == clus_view[0].moduleStart());
-        auto c0 = std::min(maxHitsInModule, clus_view[1].clusModuleStart());
-        ALPAKA_ASSERT_ACC(c0 == clus_view[1].moduleStart());
+        ALPAKA_ASSERT_ACC(0 == clus_view[1].moduleStart());
+        auto c0 = std::min(maxHitsInModule, clus_view[2].clusModuleStart());
+        ALPAKA_ASSERT_ACC(c0 == clus_view[2].moduleStart());
         ALPAKA_ASSERT_ACC(clus_view[1024].moduleStart() >= clus_view[1023].moduleStart());
         ALPAKA_ASSERT_ACC(clus_view[1025].moduleStart() >= clus_view[1024].moduleStart());
         ALPAKA_ASSERT_ACC(clus_view[numberOfModules].moduleStart() >= clus_view[1025].moduleStart());
@@ -504,13 +504,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           if (i == bpix2 || i == fpix1)
             printf("moduleStart %d %d\n", i, clus_view[i].moduleStart());
         }
+
 #endif
-        // avoid overflow
-        constexpr auto MAX_HITS = TrackerTraits::maxNumberOfHits;
-        for (uint32_t i : cms::alpakatools::independent_group_elements(acc, numberOfModules + 1)) {
-          if (clus_view[i].clusModuleStart() > MAX_HITS)
-            clus_view[i].clusModuleStart() = MAX_HITS;
-        }
 
       }  // end of FillHitsModuleStart kernel operator()
     };   // end of FillHitsModuleStart struct

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitKernels.dev.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/PixelRecHitKernels.dev.cc
@@ -113,15 +113,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           hrv_d.contentSize = nHits;
           hrv_d.contentStorage = hits_d.view().phiBinnerStorage();
 
-          // fillManyFromVector<Acc1D>(h_d.data(), nParts, v_d.data(), offsets_d.data(), offsets[10], 256, queue);
-          /*          cms::alpakatools::fillManyFromVector<Acc1D>(&(hits_d.view().phiBinner()),
-                                                      nLayers,
-                                                      hits_d.view().iphi(),
-                                                      hits_d.view().hitsLayerStart().data(),
-                                                      nHits,
-                                                      (uint32_t)256,
-                                                      queue);
-*/
           cms::alpakatools::fillManyFromVector<Acc1D>(&(hits_d.view().phiBinner()),
                                                       hrv_d,
                                                       nLayers,

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtupletGeneratorKernels.h
@@ -253,6 +253,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     // workspace
     cms::alpakatools::device_buffer<Device, HitToTuple> device_hitToTuple_;
+    cms::alpakatools::device_buffer<Device, uint32_t[]> device_hitToTupleStorage_;
+    typename HitToTuple::View device_hitToTupleView_;
     cms::alpakatools::device_buffer<Device, TupleMultiplicity> device_tupleMultiplicity_;
     cms::alpakatools::device_buffer<Device, CACell[]> device_theCells_;
     cms::alpakatools::device_buffer<Device, OuterHitOfCellContainer[]> device_isOuterHitOfCell_;

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAStructures.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAStructures.h
@@ -31,7 +31,7 @@ namespace caStructures {
   template <typename TrackerTraits>
   using HitToTupleT =
       cms::alpakatools::OneToManyAssocRandomAccess<typename TrackerTraits::tindex_type,
-                                                   TrackerTraits::maxNumberOfHits,
+                                                   -1,
                                                    TrackerTraits::maxHitsForContainers>;  // 3.5 should be enough
 
   template <typename TrackerTraits>


### PR DESCRIPTION
This PR proposes a solution for https://github.com/cms-sw/cmssw/issues/44769. The culprit there is https://github.com/cms-sw/cmssw/blob/6e82cc8aa6fff019b94eb34a5b5297c2eaa62573/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.dev.cc#L509-L513

where we cut the number of hits to "only":

https://github.com/cms-sw/cmssw/blob/6e82cc8aa6fff019b94eb34a5b5297c2eaa62573/Geometry/CommonTopologies/interface/SimplePixelTopology.h#L420

And the event of the crash has:

```
SiPixelClusterizerAlpaka results:
 > no. of digis: 301020
 > no. of active modules: 1794
 > no. of clusters: 50684
 > bpix2 offset: 19595
```

The poor man solution would be to rise the max to something safer  such as`static constexpr uint32_t maxNumberOfHits = 96 * 1024;`. But seems to me a waste also because this procedure is anyway a remnant of that intermediate phase of the Alpaka port when we had no runtime sized histograms (before https://github.com/cms-sw/cmssw/pull/43064). 

So this PR involves a slightly bigger code refactoring in order to drop the fixed number of hits and use the runtime sized histograms where needed (namely for the hit to tuple map).

#### PR validation:

The setup in https://github.com/cms-sw/cmssw/issues/44769 with this PR (on top of `master` or `14_0_X`) doesn't crash anymore.

Backported to 14_0_X in #44774.

solves https://github.com/cms-sw/cmssw/issues/44769.
