### PR TITLE
Update the #include files for ROCm v6.x

### DIFF
--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include <hip/hip_runtime.h>
-#include <rocm_version.h>
+#include <rocm-core/rocm_version.h>
 #include <rocm_smi/rocm_smi.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"


### PR DESCRIPTION
#### PR description:

ROCm 6.0 moved `rocm_version.h` to `rocm-core/rocm_version.h`.

#### PR validation:

The modified code builds with https://github.com/cms-sw/cmsdist/pull/9143 .

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport is foreseen.