### PR TITLE
Using explicit lazy parsing & concrete data types in SimpleFlatTableProducer

### DIFF
--- a/CalibTracker/SiStripCommon/plugins/SealModules.cc
+++ b/CalibTracker/SiStripCommon/plugins/SealModules.cc
@@ -20,7 +20,3 @@ DEFINE_FWK_MODULE(ShallowSimhitClustersProducer);
 DEFINE_FWK_MODULE(ShallowTracksProducer);
 DEFINE_FWK_MODULE(ShallowSimTracksProducer);
 DEFINE_FWK_MODULE(ShallowGainCalibration);
-
-#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
-typedef SimpleFlatTableProducer<reco::Track> SimpleTrackFlatTableProducer;
-DEFINE_FWK_MODULE(SimpleTrackFlatTableProducer);

--- a/DPGAnalysis/MuonTools/interface/MuDigiBaseProducer.h
+++ b/DPGAnalysis/MuonTools/interface/MuDigiBaseProducer.h
@@ -67,6 +67,7 @@ public:
 
     variable.add<std::string>("expr")->setComment("a function to define the content of the branch in the flat table");
     variable.add<std::string>("doc")->setComment("few words description of the branch content");
+    variable.addUntracked<bool>("lazyEval")->setComment("set to True if the type read from the Event is unknown");
 
     variable.ifValue(edm::ParameterDescription<std::string>("type", "int", true, comType),
                      edm::allowedValues<std::string>("int", "uint", "int16", "uint8"));

--- a/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
+++ b/DPGAnalysis/MuonTools/interface/MuLocalRecoBaseProducer.h
@@ -105,6 +105,7 @@ public:
 
       varBase.add<std::string>("expr")->setComment("a function to define the content of the branch in the flat table");
       varBase.add<std::string>("doc")->setComment("few words description of the branch content");
+      varBase.addUntracked<bool>("lazyEval")->setComment("if True, check object type during Event processing.");
 
       return varBase;
     };

--- a/DPGAnalysis/MuonTools/python/common_cff.py
+++ b/DPGAnalysis/MuonTools/python/common_cff.py
@@ -10,7 +10,7 @@ class DEFAULT_VAL(NamedTuple):
 
 defaults = DEFAULT_VAL()
 
-def DetIdVar(expr, type, doc=None):
+def DetIdVar(expr, type, doc=None, lazyEval=False):
     """ Create a PSet for a DetId variable in the tree:
         - expr is the expression to evaluate to compute the variable,
         - type of the value (int, bool, or a string that the table producer understands),
@@ -22,10 +22,11 @@ def DetIdVar(expr, type, doc=None):
     return cms.PSet(
                 type = cms.string(type),
                 expr = cms.string(expr),
-                doc = cms.string(doc if doc else expr)
+                doc = cms.string(doc if doc else expr),
+                lazyEval = cms.untracked.bool(lazyEval)
            )
 
-def GlobGeomVar(expr, doc=None, precision=-1):
+def GlobGeomVar(expr, doc=None, precision=-1, lazyEval=False):
     """ Create a PSet for a Global position/direction variable in the tree ,
         - expr is the expression to evaluate to compute the variable,
         - doc is a docstring, that will be passed to the table producer,
@@ -34,7 +35,8 @@ def GlobGeomVar(expr, doc=None, precision=-1):
     return cms.PSet(
                 expr = cms.string(expr),
                 doc = cms.string(doc if doc else expr),
-	        precision=cms.string(precision) if type(precision)==str else cms.int32(precision)
+                precision = cms.string(precision) if type(precision)==str else cms.int32(precision),
+                lazyEval = cms.untracked.bool(lazyEval)
            )
 
 

--- a/DPGAnalysis/MuonTools/python/nano_mu_reco_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_reco_cff.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from DPGAnalysis.MuonTools.common_cff import *
 
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATMuonFlatTableProducer_cfi import simplePATMuonFlatTableProducer
 
 from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import *
 
-muonFlatTableProducer = simpleCandidateFlatTableProducer.clone(
+muonFlatTableProducer = simplePATMuonFlatTableProducer.clone(
     src = cms.InputTag("patMuons"),
     name = cms.string("muon"),
     doc  = cms.string("RECO muon information"),

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -254,6 +254,8 @@
   <class name="edm::reftobase::RefHolder<reco::VertexCompositePtrCandidateRef>" />
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::VertexCompositePtrCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::VertexCompositePtrCandidateRefVector>" />
+  <class name="edm::PtrVector<reco::VertexCompositePtrCandidate>" />
+  <class name="edm::Wrapper<edm::PtrVector<reco::VertexCompositePtrCandidate> >" />
 
 
   <class name="reco::NamedCompositeCandidateCollection" />

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -9,38 +9,14 @@ typedef SimpleFlatTableProducer<reco::Track> SimpleTrackFlatTableProducer;
 #include "DataFormats/JetReco/interface/PFJet.h"
 typedef SimpleFlatTableProducer<reco::PFJet> SimplePFJetFlatTableProducer;
 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+typedef SimpleFlatTableProducer<reco::Vertex> SimpleVertexFlatTableProducer;
+
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 typedef SimpleFlatTableProducer<reco::VertexCompositePtrCandidate> SimpleSecondaryVertexFlatTableProducer;
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 typedef SimpleFlatTableProducer<reco::GenParticle> SimpleGenParticleFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/Electron.h"
-typedef SimpleFlatTableProducer<pat::Electron> SimplePATElectronFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/Muon.h"
-typedef SimpleFlatTableProducer<pat::Muon> SimplePATMuonFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/Tau.h"
-typedef SimpleFlatTableProducer<pat::Tau> SimplePATTauFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/Photon.h"
-typedef SimpleFlatTableProducer<pat::Photon> SimplePATPhotonFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/Jet.h"
-typedef SimpleFlatTableProducer<pat::Jet> SimplePATJetFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
-typedef SimpleFlatTableProducer<pat::IsolatedTrack> SimplePATIsolatedTrackFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/GenericParticle.h"
-typedef SimpleFlatTableProducer<pat::GenericParticle> SimplePATGenericParticleFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-typedef SimpleFlatTableProducer<pat::PackedCandidate> SimplePATCandidateFlatTableProducer;
-
-#include "DataFormats/PatCandidates/interface/MET.h"
-typedef SimpleFlatTableProducer<pat::MET> SimplePATMETFlatTableProducer;
 
 typedef SimpleTypedExternalFlatTableProducer<reco::Candidate, reco::Candidate>
     SimpleCandidate2CandidateFlatTableProducer;
@@ -69,64 +45,13 @@ typedef EventSingletonSimpleFlatTableProducer<OnlineLuminosityRecord> SimpleOnli
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 typedef EventSingletonSimpleFlatTableProducer<reco::BeamSpot> SimpleBeamspotFlatTableProducer;
 
-#include "DataFormats/L1Trigger/interface/EGamma.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::EGamma> SimpleTriggerL1EGFlatTableProducer;
-
-#include "DataFormats/L1Trigger/interface/Jet.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::Jet> SimpleTriggerL1JetFlatTableProducer;
-
-#include "DataFormats/L1Trigger/interface/Tau.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::Tau> SimpleTriggerL1TauFlatTableProducer;
-
-#include "DataFormats/L1Trigger/interface/Muon.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::Muon> SimpleTriggerL1MuonFlatTableProducer;
-
-#include "DataFormats/L1Trigger/interface/EtSum.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::EtSum> SimpleTriggerL1EtSumFlatTableProducer;
-
-#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
-typedef SimpleFlatTableProducer<Run3ScoutingVertex> SimpleRun3ScoutingVertexFlatTableProducer;
-
-#include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
-typedef SimpleFlatTableProducer<Run3ScoutingPhoton> SimpleRun3ScoutingPhotonFlatTableProducer;
-
-#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
-typedef SimpleFlatTableProducer<Run3ScoutingMuon> SimpleRun3ScoutingMuonFlatTableProducer;
-
-#include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
-typedef SimpleFlatTableProducer<Run3ScoutingElectron> SimpleRun3ScoutingElectronFlatTableProducer;
-
-#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
-typedef SimpleFlatTableProducer<Run3ScoutingTrack> SimpleRun3ScoutingTrackFlatTableProducer;
-
-#include "DataFormats/VertexReco/interface/Vertex.h"
-typedef SimpleFlatTableProducer<reco::Vertex> SimpleVertexFlatTableProducer;
-
-#include "DataFormats/VertexReco/interface/TrackTimeLifeInfo.h"
-typedef SimpleTypedExternalFlatTableProducer<reco::Candidate, TrackTimeLifeInfo>
-    SimpleCandidate2TrackTimeLifeInfoFlatTableProducer;
-typedef SimpleTypedExternalFlatTableProducer<pat::Electron, TrackTimeLifeInfo>
-    SimplePATElectron2TrackTimeLifeInfoFlatTableProducer;
-typedef SimpleTypedExternalFlatTableProducer<pat::Muon, TrackTimeLifeInfo>
-    SimplePATMuon2TrackTimeLifeInfoFlatTableProducer;
-typedef SimpleTypedExternalFlatTableProducer<pat::Tau, TrackTimeLifeInfo>
-    SimplePATTau2TrackTimeLifeInfoFlatTableProducer;
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimplePFJetFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleVertexFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleSecondaryVertexFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenParticleFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATElectronFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATMuonFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATTauFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATPhotonFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATJetFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATIsolatedTrackFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATGenericParticleFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATCandidateFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATMETFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleCandidate2CandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenFilterFlatTableProducerLumi);
@@ -136,18 +61,3 @@ DEFINE_FWK_MODULE(SimpleLocalTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleXYZPointFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleOnlineLuminosityFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleBeamspotFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleTriggerL1MuonFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleRun3ScoutingVertexFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleRun3ScoutingPhotonFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleRun3ScoutingMuonFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleRun3ScoutingElectronFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleRun3ScoutingTrackFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleVertexFlatTableProducer);
-DEFINE_FWK_MODULE(SimpleCandidate2TrackTimeLifeInfoFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATElectron2TrackTimeLifeInfoFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATMuon2TrackTimeLifeInfoFlatTableProducer);
-DEFINE_FWK_MODULE(SimplePATTau2TrackTimeLifeInfoFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleFlatTableProducerPlugins.cc
@@ -3,6 +3,45 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 typedef SimpleFlatTableProducer<reco::Candidate> SimpleCandidateFlatTableProducer;
 
+#include "DataFormats/TrackReco/interface/Track.h"
+typedef SimpleFlatTableProducer<reco::Track> SimpleTrackFlatTableProducer;
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+typedef SimpleFlatTableProducer<reco::PFJet> SimplePFJetFlatTableProducer;
+
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+typedef SimpleFlatTableProducer<reco::VertexCompositePtrCandidate> SimpleSecondaryVertexFlatTableProducer;
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+typedef SimpleFlatTableProducer<reco::GenParticle> SimpleGenParticleFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+typedef SimpleFlatTableProducer<pat::Electron> SimplePATElectronFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+typedef SimpleFlatTableProducer<pat::Muon> SimplePATMuonFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Tau.h"
+typedef SimpleFlatTableProducer<pat::Tau> SimplePATTauFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Photon.h"
+typedef SimpleFlatTableProducer<pat::Photon> SimplePATPhotonFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+typedef SimpleFlatTableProducer<pat::Jet> SimplePATJetFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+typedef SimpleFlatTableProducer<pat::IsolatedTrack> SimplePATIsolatedTrackFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/GenericParticle.h"
+typedef SimpleFlatTableProducer<pat::GenericParticle> SimplePATGenericParticleFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+typedef SimpleFlatTableProducer<pat::PackedCandidate> SimplePATCandidateFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/MET.h"
+typedef SimpleFlatTableProducer<pat::MET> SimplePATMETFlatTableProducer;
+
 typedef SimpleTypedExternalFlatTableProducer<reco::Candidate, reco::Candidate>
     SimpleCandidate2CandidateFlatTableProducer;
 
@@ -66,9 +105,28 @@ typedef SimpleFlatTableProducer<reco::Vertex> SimpleVertexFlatTableProducer;
 #include "DataFormats/VertexReco/interface/TrackTimeLifeInfo.h"
 typedef SimpleTypedExternalFlatTableProducer<reco::Candidate, TrackTimeLifeInfo>
     SimpleCandidate2TrackTimeLifeInfoFlatTableProducer;
+typedef SimpleTypedExternalFlatTableProducer<pat::Electron, TrackTimeLifeInfo>
+    SimplePATElectron2TrackTimeLifeInfoFlatTableProducer;
+typedef SimpleTypedExternalFlatTableProducer<pat::Muon, TrackTimeLifeInfo>
+    SimplePATMuon2TrackTimeLifeInfoFlatTableProducer;
+typedef SimpleTypedExternalFlatTableProducer<pat::Tau, TrackTimeLifeInfo>
+    SimplePATTau2TrackTimeLifeInfoFlatTableProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTrackFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePFJetFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleSecondaryVertexFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleGenParticleFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATElectronFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATTauFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATPhotonFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATJetFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATIsolatedTrackFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATGenericParticleFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMETFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleCandidate2CandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenEventFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleGenFilterFlatTableProducerLumi);
@@ -90,3 +148,6 @@ DEFINE_FWK_MODULE(SimpleRun3ScoutingElectronFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleRun3ScoutingTrackFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleVertexFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleCandidate2TrackTimeLifeInfoFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATElectron2TrackTimeLifeInfoFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMuon2TrackTimeLifeInfoFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATTau2TrackTimeLifeInfoFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/SimpleL1TFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleL1TFlatTableProducerPlugins.cc
@@ -1,0 +1,24 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::EGamma> SimpleTriggerL1EGFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Jet.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Jet> SimpleTriggerL1JetFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Tau.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Tau> SimpleTriggerL1TauFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::Muon> SimpleTriggerL1MuonFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::EtSum> SimpleTriggerL1EtSumFlatTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1MuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/SimplePATFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimplePATFlatTableProducerPlugins.cc
@@ -1,0 +1,50 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+typedef SimpleFlatTableProducer<pat::Electron> SimplePATElectronFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Muon.h"
+typedef SimpleFlatTableProducer<pat::Muon> SimplePATMuonFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Tau.h"
+typedef SimpleFlatTableProducer<pat::Tau> SimplePATTauFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Photon.h"
+typedef SimpleFlatTableProducer<pat::Photon> SimplePATPhotonFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/Jet.h"
+typedef SimpleFlatTableProducer<pat::Jet> SimplePATJetFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/IsolatedTrack.h"
+typedef SimpleFlatTableProducer<pat::IsolatedTrack> SimplePATIsolatedTrackFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/GenericParticle.h"
+typedef SimpleFlatTableProducer<pat::GenericParticle> SimplePATGenericParticleFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+typedef SimpleFlatTableProducer<pat::PackedCandidate> SimplePATCandidateFlatTableProducer;
+
+#include "DataFormats/PatCandidates/interface/MET.h"
+typedef SimpleFlatTableProducer<pat::MET> SimplePATMETFlatTableProducer;
+
+#include "DataFormats/VertexReco/interface/TrackTimeLifeInfo.h"
+typedef SimpleTypedExternalFlatTableProducer<pat::Electron, TrackTimeLifeInfo>
+    SimplePATElectron2TrackTimeLifeInfoFlatTableProducer;
+typedef SimpleTypedExternalFlatTableProducer<pat::Muon, TrackTimeLifeInfo>
+    SimplePATMuon2TrackTimeLifeInfoFlatTableProducer;
+typedef SimpleTypedExternalFlatTableProducer<pat::Tau, TrackTimeLifeInfo>
+    SimplePATTau2TrackTimeLifeInfoFlatTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SimplePATElectronFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATTauFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATPhotonFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATJetFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATIsolatedTrackFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATGenericParticleFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMETFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATElectron2TrackTimeLifeInfoFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATMuon2TrackTimeLifeInfoFlatTableProducer);
+DEFINE_FWK_MODULE(SimplePATTau2TrackTimeLifeInfoFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/SimpleScoutingFlatTableProducerPlugins.cc
+++ b/PhysicsTools/NanoAOD/plugins/SimpleScoutingFlatTableProducerPlugins.cc
@@ -1,0 +1,23 @@
+#include "PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h"
+
+#include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
+typedef SimpleFlatTableProducer<Run3ScoutingVertex> SimpleRun3ScoutingVertexFlatTableProducer;
+
+#include "DataFormats/Scouting/interface/Run3ScoutingPhoton.h"
+typedef SimpleFlatTableProducer<Run3ScoutingPhoton> SimpleRun3ScoutingPhotonFlatTableProducer;
+
+#include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
+typedef SimpleFlatTableProducer<Run3ScoutingMuon> SimpleRun3ScoutingMuonFlatTableProducer;
+
+#include "DataFormats/Scouting/interface/Run3ScoutingElectron.h"
+typedef SimpleFlatTableProducer<Run3ScoutingElectron> SimpleRun3ScoutingElectronFlatTableProducer;
+
+#include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"
+typedef SimpleFlatTableProducer<Run3ScoutingTrack> SimpleRun3ScoutingTrackFlatTableProducer;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SimpleRun3ScoutingVertexFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleRun3ScoutingPhotonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleRun3ScoutingMuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleRun3ScoutingElectronFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleRun3ScoutingTrackFlatTableProducer);

--- a/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/VertexTableProducer.cc
@@ -93,7 +93,7 @@ VertexTableProducer::VertexTableProducer(const edm::ParameterSet& params)
   produces<nanoaod::FlatTable>("pv");
   produces<nanoaod::FlatTable>("otherPVs");
   produces<nanoaod::FlatTable>("svs");
-  produces<edm::PtrVector<reco::Candidate>>();
+  produces<edm::PtrVector<reco::VertexCompositePtrCandidate>>();
 }
 
 //
@@ -167,7 +167,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   otherPVsTable->addColumn<float>("score", pvscores, "scores of other primary vertices, excluding the main PV", 8);
 
   const auto& svsProd = iEvent.get(svs_);
-  auto selCandSv = std::make_unique<PtrVector<reco::Candidate>>();
+  auto selCandSv = std::make_unique<PtrVector<reco::VertexCompositePtrCandidate>>();
   std::vector<float> dlen, dlenSig, pAngle, dxy, dxySig;
   std::vector<int16_t> charge;
   VertexDistance3D vdist;
@@ -182,8 +182,7 @@ void VertexTableProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       if (dl.value() > dlenMin_ and dl.significance() > dlenSigMin_) {
         dlen.push_back(dl.value());
         dlenSig.push_back(dl.significance());
-        edm::Ptr<reco::Candidate> c = svsProd.ptrAt(i);
-        selCandSv->push_back(c);
+        selCandSv->push_back(svsProd.ptrAt(i));
         double dx = (PV0.x() - sv.vx()), dy = (PV0.y() - sv.vy()), dz = (PV0.z() - sv.vz());
         double pdotv = (dx * sv.px() + dy * sv.py() + dz * sv.pz()) / sv.p() / sqrt(dx * dx + dy * dy + dz * dz);
         pAngle.push_back(std::acos(pdotv));

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATTauFlatTableProducer_cfi import simplePATTauFlatTableProducer
 
 ##################### Import reusable funtions and objects from std taus ########
 from PhysicsTools.NanoAOD.taus_cff import _tauIdWPMask, tausMCMatchLepTauForTable, tausMCMatchHadTauForTable,tauMCTable
@@ -18,7 +18,7 @@ run2_nanoAOD_106Xv2.toModify(
     cut = "pt > 40 && tauID('decayModeFindingNewDMs') && (tauID('byVVLooseIsolationMVArun2DBoldDMwLT') || tauID('byVVLooseIsolationMVArun2DBoldDMdR0p3wLT') || tauID('byVVLooseIsolationMVArun2DBnewDMwLT'))"
 )
 
-boostedTauTable = simpleCandidateFlatTableProducer.clone(
+boostedTauTable = simplePATTauFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects", "boostedTaus"),
     name= cms.string("boostedTau"),
     doc = cms.string("slimmedBoostedTaus after basic selection (" + finalBoostedTaus.cut.value()+")"),

--- a/PhysicsTools/NanoAOD/python/btvMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/btvMC_cff.py
@@ -14,7 +14,7 @@ finalGenParticles.select +=[
     ]
 
 btvGenTable =  cms.EDProducer(
-        "SimpleCandidateFlatTableProducer",
+        "SimpleGenParticleFlatTableProducer",
         src=finalGenParticles.src,
         name= cms.string("GenPart"),
         doc = cms.string("interesting gen particles "),
@@ -31,7 +31,7 @@ genParticleTablesTask.replace(genParticleTable,btvGenTable)
 btvMCTable = cms.EDProducer("BTVMCFlavourTableProducer",name=jetPuppiTable.name,src=cms.InputTag("linkedObjects","jets"),genparticles=cms.InputTag("prunedGenParticles"))
 
 btvAK4JetExtTable = cms.EDProducer(
-        "SimpleCandidateFlatTableProducer",
+        "SimplePATJetFlatTableProducer",
         src=jetPuppiTable.src,
         cut=jetPuppiTable.cut,
         name=jetPuppiTable.name,
@@ -48,7 +48,7 @@ btvAK4JetExtTable = cms.EDProducer(
         ))
 
 btvSubJetMCExtTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    "SimplePATJetFlatTableProducer",
     src = subJetTable.src,
     cut = subJetTable.cut,
         name = subJetTable.name,

--- a/PhysicsTools/NanoAOD/python/common_cff.py
+++ b/PhysicsTools/NanoAOD/python/common_cff.py
@@ -11,9 +11,10 @@ def OVar(valtype, doc=None, precision=-1):
     return cms.PSet(
                 type = cms.string(valtype),
                 doc = cms.string(doc if doc else expr),
-	        precision=cms.optional.allowed(cms.string, cms.int32, default = (cms.string(precision) if type(precision)==str else cms.int32(precision)
-           )))
-def Var(expr, valtype, doc=None, precision=-1):
+                precision=cms.optional.allowed(cms.string, cms.int32, default = (cms.string(precision) if type(precision)==str else cms.int32(precision)))
+           )
+
+def Var(expr, valtype, doc=None, precision=-1, lazyEval=False):
     """Create a PSet for a variable computed with the string parser
 
        expr is the expression to evaluate to compute the variable
@@ -22,7 +23,7 @@ def Var(expr, valtype, doc=None, precision=-1):
        see OVar above for all the other arguments
     """
     return OVar(valtype, doc=(doc if doc else expr), precision=precision).clone(
-                expr = cms.string(expr))
+                expr = cms.string(expr), lazyEval=cms.untracked.bool(lazyEval))
 
 def ExtVar(tag, valtype, doc=None, precision=-1):
     """Create a PSet for a variable read from the event

--- a/PhysicsTools/NanoAOD/python/custom_btv_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_btv_cff.py
@@ -482,7 +482,7 @@ def add_BTV(process,  addAK4=False, addAK8=False, scheme="btvSF"):
         process = update_jets_AK4(process)
             
         process.customJetExtTable = cms.EDProducer(
-            "SimpleCandidateFlatTableProducer",
+            "SimplePATJetFlatTableProducer",
             src=jetPuppiTable.src,
             cut=jetPuppiTable.cut,
             name=jetPuppiTable.name,
@@ -522,7 +522,7 @@ def add_BTV(process,  addAK4=False, addAK8=False, scheme="btvSF"):
         process = update_jets_AK8(process)
         process = update_jets_AK8_subjet(process)
         process.customFatJetExtTable = cms.EDProducer(
-            "SimpleCandidateFlatTableProducer",
+            "SimplePATJetFlatTableProducer",
             src=fatJetTable.src,
             cut=fatJetTable.cut,
             name=fatJetTable.name,
@@ -538,7 +538,7 @@ def add_BTV(process,  addAK4=False, addAK8=False, scheme="btvSF"):
 
         # Subjets
         process.customSubJetExtTable = cms.EDProducer(
-            "SimpleCandidateFlatTableProducer",
+            "SimplePATJetFlatTableProducer",
             src=subJetTable.src,
             cut=subJetTable.cut,
             name=subJetTable.name,
@@ -587,7 +587,7 @@ def addPFCands(process, allPF = False, addAK4=False, addAK8=False):
         process.finalJetsConstituentsTable = cms.EDProducer("PackedCandidatePtrMerger", src = candList, skipNulls = cms.bool(True), warnOnSkip = cms.bool(True))
         candInput = cms.InputTag("finalJetsConstituentsTable")
     
-    process.customConstituentsExtTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+    process.customConstituentsExtTable = cms.EDProducer("SimplePATCandidateFlatTableProducer",
                                                         src = candInput,
                                                         cut = cms.string(""), #we should not filter after pruning
                                                         name = cms.string("PFCands"),

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
 
 from RecoJets.JetProducers.hfJetShowerShape_cfi import hfJetShowerShape
 from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdCalculator, pileupJetId
@@ -570,7 +570,7 @@ def SavePatJets(proc, jetName, payload, patJetFinalColl, jetTablePrefix, jetTabl
     jetTableDocDefault = jetTableDoc
 
   jetTableName = "jet{}Table".format(jetName)
-  setattr(proc,jetTableName, simpleCandidateFlatTableProducer.clone(
+  setattr(proc,jetTableName, simplePATJetFlatTableProducer.clone(
       src = cms.InputTag(finalJetsForTable),
       cut = cms.string(jetTableCutDefault),
       name = cms.string(jetTablePrefix),
@@ -585,7 +585,7 @@ def SavePatJets(proc, jetName, payload, patJetFinalColl, jetTablePrefix, jetTabl
   # Save MC-only jet variables in table
   #
   jetMCTableName = "jet{}MCTable".format(jetName)
-  setattr(proc, jetMCTableName, simpleCandidateFlatTableProducer.clone(
+  setattr(proc, jetMCTableName, simplePATJetFlatTableProducer.clone(
       src = cms.InputTag(finalJetsForTable),
       cut = getattr(proc,jetTableName).cut,
       name = cms.string(jetTablePrefix),

--- a/PhysicsTools/NanoAOD/python/custom_muon_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_muon_cff.py
@@ -255,10 +255,10 @@ def AddVariablesForMuon(proc):
     proc.muonTable.variables.innerTrackExtraIdx = Var('? innerTrack().isNonnull() ? innerTrack().extra().key() : -99', 'int', precision=-1, doc='Index of the innerTrack TrackExtra in the original collection')
 
     #Jet Related Variables
+    # lazyEval=True: userCand() returns the base type `reco::CandidatePtr`, needs to be dynamically casted to pat::Jet to call the userFloat() / bDiscriminator() methods
     proc.muonTable.variables.jetPtRatio = Var("?userCand('jetForLepJetVar').isNonnull()?min(userFloat('ptRatio'),1.5):1.0/(1.0+(pfIsolationR04().sumChargedHadronPt + max(pfIsolationR04().sumNeutralHadronEt + pfIsolationR04().sumPhotonEt - pfIsolationR04().sumPUPt/2,0.0))/pt)", float, doc="ptRatio using the LepAware JEC approach, for muon MVA", lazyEval=True)
     proc.muonTable.variables.jetDF = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probbb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:problepb'),0.0):0.0",float,doc="b-tagging discriminator of the jet matched to the lepton, for muon MVA", lazyEval=True)
     proc.muonTable.variables.jetCSVv2 = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfCombinedSecondaryVertexV2BJetTags'),0.0):0.0",float,doc="CSVv2 b-tagging discriminator of the jet matched to the lepton, for muon MVA", lazyEval=True)
-    
 
     #nSegments
     proc.muonTable.variables.nsegments = Var("userInt('nsegments')", int, doc = "nsegments as of Spark-tool")

--- a/PhysicsTools/NanoAOD/python/custom_muon_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_muon_cff.py
@@ -1,11 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
 
-from PhysicsTools.NanoAOD.common_cff import Var, P3Vars, P4Vars
-from PhysicsTools.NanoAOD.muons_cff import muonTable, finalMuons
-from PhysicsTools.NanoAOD.triggerObjects_cff import triggerObjectTable, mksel
+from PhysicsTools.NanoAOD.common_cff import Var, P3Vars
+from PhysicsTools.NanoAOD.triggerObjects_cff import mksel
 
 def Custom_Muon_Task(process):
     process.nanoTableTaskCommon.remove(process.electronTablesTask)
@@ -257,9 +255,9 @@ def AddVariablesForMuon(proc):
     proc.muonTable.variables.innerTrackExtraIdx = Var('? innerTrack().isNonnull() ? innerTrack().extra().key() : -99', 'int', precision=-1, doc='Index of the innerTrack TrackExtra in the original collection')
 
     #Jet Related Variables
-    proc.muonTable.variables.jetPtRatio = Var("?userCand('jetForLepJetVar').isNonnull()?min(userFloat('ptRatio'),1.5):1.0/(1.0+(pfIsolationR04().sumChargedHadronPt + max(pfIsolationR04().sumNeutralHadronEt + pfIsolationR04().sumPhotonEt - pfIsolationR04().sumPUPt/2,0.0))/pt)", float, doc="ptRatio using the LepAware JEC approach, for muon MVA")
-    proc.muonTable.variables.jetDF = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probbb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:problepb'),0.0):0.0",float,doc="b-tagging discriminator of the jet matched to the lepton, for muon MVA")
-    proc.muonTable.variables.jetCSVv2 = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfCombinedSecondaryVertexV2BJetTags'),0.0):0.0",float,doc="CSVv2 b-tagging discriminator of the jet matched to the lepton, for muon MVA")
+    proc.muonTable.variables.jetPtRatio = Var("?userCand('jetForLepJetVar').isNonnull()?min(userFloat('ptRatio'),1.5):1.0/(1.0+(pfIsolationR04().sumChargedHadronPt + max(pfIsolationR04().sumNeutralHadronEt + pfIsolationR04().sumPhotonEt - pfIsolationR04().sumPUPt/2,0.0))/pt)", float, doc="ptRatio using the LepAware JEC approach, for muon MVA", lazyEval=True)
+    proc.muonTable.variables.jetDF = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probbb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:probb')+userCand('jetForLepJetVar').bDiscriminator('pfDeepFlavourJetTags:problepb'),0.0):0.0",float,doc="b-tagging discriminator of the jet matched to the lepton, for muon MVA", lazyEval=True)
+    proc.muonTable.variables.jetCSVv2 = Var("?userCand('jetForLepJetVar').isNonnull()?max(userCand('jetForLepJetVar').bDiscriminator('pfCombinedSecondaryVertexV2BJetTags'),0.0):0.0",float,doc="CSVv2 b-tagging discriminator of the jet matched to the lepton, for muon MVA", lazyEval=True)
     
 
     #nSegments

--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATElectronFlatTableProducer_cfi import simplePATElectronFlatTableProducer
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
 from math import ceil,log
@@ -292,7 +292,7 @@ run2_egamma_2016.toModify(
 ################################################electronPROMPTMVA end#####################
 
 ################################################electronTable defn #####################
-electronTable = simpleCandidateFlatTableProducer.clone(
+electronTable = simplePATElectronFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","electrons"),
     name= cms.string("Electron"),
     doc = cms.string("slimmedElectrons after basic selection (" + finalElectrons.cut.value()+")"),

--- a/PhysicsTools/NanoAOD/python/fsrPhotons_cff.py
+++ b/PhysicsTools/NanoAOD/python/fsrPhotons_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATGenericParticleFlatTableProducer_cfi import simplePATGenericParticleFlatTableProducer
 
 from CommonTools.RecoUtils.leptonFSRProducer_cfi import leptonFSRProducer
 leptonFSRphotons = leptonFSRProducer.clone(
@@ -10,7 +10,7 @@ leptonFSRphotons = leptonFSRProducer.clone(
   electrons = "linkedObjects:electrons",
 )
 
-fsrTable = simpleCandidateFlatTableProducer.clone(
+fsrTable = simplePATGenericParticleFlatTableProducer.clone(
     src = cms.InputTag("leptonFSRphotons"),
     name = cms.string("FsrPhoton"),
     doc  = cms.string("Final state radiation photons emitted by muons or electrons"),

--- a/PhysicsTools/NanoAOD/python/genparticles_cff.py
+++ b/PhysicsTools/NanoAOD/python/genparticles_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simpleGenParticleFlatTableProducer_cfi import simpleGenParticleFlatTableProducer
 
 
 ##################### User floats producers, selectors ##########################
@@ -29,7 +29,7 @@ finalGenParticles = cms.EDProducer("GenParticlePruner",
 
 
 ##################### Tables for final output and docs ##########################
-genParticleTable = simpleCandidateFlatTableProducer.clone(
+genParticleTable = simpleGenParticleFlatTableProducer.clone(
     src = cms.InputTag("finalGenParticles"),
     name= cms.string("GenPart"),
     doc = cms.string("interesting gen particles "),

--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATIsolatedTrackFlatTableProducer_cfi import simplePATIsolatedTrackFlatTableProducer
 
 finalIsolatedTracks = cms.EDProducer("IsolatedTrackCleaner",
     tracks = cms.InputTag("isolatedTracks"),
@@ -23,7 +23,7 @@ isFromLostTrackForIsoTk = cms.EDProducer("IsFromLostTrackMapProducer",
     lostTracks = cms.InputTag("lostTracks"),
 )
 
-isoTrackTable = simpleCandidateFlatTableProducer.clone(
+isoTrackTable = simplePATIsolatedTrackFlatTableProducer.clone(
     src = cms.InputTag("finalIsolatedTracks"),
     name = cms.string("IsoTrack"),
     doc  = cms.string("isolated tracks after basic selection (" + finalIsolatedTracks.cut.value() + ") and lepton veto"),

--- a/PhysicsTools/NanoAOD/python/jetMC_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetMC_cff.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
 from PhysicsTools.NanoAOD.jetsAK8_cff import fatJetTable as _fatJetTable
 from PhysicsTools.NanoAOD.jetsAK8_cff import subJetTable as _subJetTable
 
-jetMCTable = simpleCandidateFlatTableProducer.clone(
+jetMCTable = simplePATJetFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","jets"),
     name = cms.string("Jet"),
     extension = cms.bool(True), # this is an extension  table for the jets
@@ -82,7 +83,7 @@ genJetAK8FlavourTable = cms.EDProducer("GenJetFlavourTableProducer",
     deltaR = cms.double(0.1),
     jetFlavourInfos = cms.InputTag("genJetAK8FlavourAssociation"),
 )
-fatJetMCTable = simpleCandidateFlatTableProducer.clone(
+fatJetMCTable = simplePATJetFlatTableProducer.clone(
     src = _fatJetTable.src,
     cut = _fatJetTable.cut,
     name = _fatJetTable.name,
@@ -102,7 +103,7 @@ genSubJetAK8Table = simpleCandidateFlatTableProducer.clone(
 	#anything else?
     )
 )
-subjetMCTable = simpleCandidateFlatTableProducer.clone(
+subjetMCTable = simplePATJetFlatTableProducer.clone(
     src = _subJetTable.src,
     cut = _subJetTable.cut,
     name = _subJetTable.name,

--- a/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_CHS_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
 
 ##################### User floats producers, selectors ##########################
 
@@ -113,7 +113,7 @@ finalJets = cms.EDFilter("PATJetRefSelector",
 ##################### Tables for final output and docs ##########################
 
 
-jetTable = simpleCandidateFlatTableProducer.clone(
+jetTable = simplePATJetFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","jets"),
     name = cms.string("Jet"),
     doc  = cms.string("slimmedJets, i.e. ak4 PFJets CHS with JECs applied, after basic selection (" + finalJets.cut.value()+")"),
@@ -522,7 +522,7 @@ basicJetsForMetForT1METNano = cms.EDProducer("PATJetCleanerForType1MET",
 
 updatedJetsWithUserData.userFloats.muonSubtrRawPt = cms.InputTag("basicJetsForMetForT1METNano:MuonSubtrRawPt")
 
-corrT1METJetTable = simpleCandidateFlatTableProducer.clone(
+corrT1METJetTable = simplePATJetFlatTableProducer.clone(
     src = finalJets.src,
     cut = cms.string("pt<15 && abs(eta)<9.9"),
     name = cms.string("CorrT1METJet"),

--- a/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK4_Puppi_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.nano_eras_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
 
 ##################### User floats producers, selectors ##########################
 
@@ -83,7 +83,7 @@ finalJetsPuppi = cms.EDFilter("PATJetRefSelector",
 )
 
 ##################### Tables for final output and docs ##########################
-jetPuppiTable = simpleCandidateFlatTableProducer.clone(
+jetPuppiTable = simplePATJetFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","jets"),
     name = cms.string("Jet"),
     doc  = cms.string("slimmedJetsPuppi, i.e. ak4 PFJets Puppi with JECs applied, after basic selection (" + finalJetsPuppi.cut.value()+")"),
@@ -233,7 +233,7 @@ basicJetsPuppiForMetForT1METNano = cms.EDProducer("PATJetCleanerForType1MET",
 
 updatedJetsPuppiWithUserData.userFloats.muonSubtrRawPt = cms.InputTag("basicJetsPuppiForMetForT1METNano:MuonSubtrRawPt")
 
-corrT1METJetPuppiTable = simpleCandidateFlatTableProducer.clone(
+corrT1METJetPuppiTable = simplePATJetFlatTableProducer.clone(
     src = finalJetsPuppi.src,
     cut = cms.string("pt<15 && abs(eta)<9.9"),
     name = cms.string("CorrT1METJet"),

--- a/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
+++ b/PhysicsTools/NanoAOD/python/jetsAK8_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATJetFlatTableProducer_cfi import simplePATJetFlatTableProducer
 
 from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
 # Note: Safe to always add 'L2L3Residual' as MC contains dummy L2L3Residual corrections (always set to 1)
@@ -87,7 +87,7 @@ lepInAK8JetVars = cms.EDProducer("LepInJetProducer",
     srcMu = cms.InputTag("finalMuons")
 )
 
-fatJetTable = simpleCandidateFlatTableProducer.clone(
+fatJetTable = simplePATJetFlatTableProducer.clone(
     src = cms.InputTag("finalJetsAK8"),
     cut = cms.string(" pt > 170"), #probably already applied in miniaod
     name = cms.string("FatJet"),
@@ -284,7 +284,7 @@ run2_nanoAOD_106Xv2.toModify(
 ## DeepInfoAK8:End
 #################################################
 
-subJetTable = simpleCandidateFlatTableProducer.clone(
+subJetTable = simplePATJetFlatTableProducer.clone(
     src = cms.InputTag("slimmedJetsAK8PFPuppiSoftDropPacked","SubJets"),
     name = cms.string("SubJet"),
     doc  = cms.string("slimmedJetsAK8PFPuppiSoftDropPacked::SubJets, i.e. soft-drop subjets for ak8 fat jets for boosted analysis"),

--- a/PhysicsTools/NanoAOD/python/leptonTimeLifeInfo_common_cff.py
+++ b/PhysicsTools/NanoAOD/python/leptonTimeLifeInfo_common_cff.py
@@ -10,7 +10,9 @@ from PhysicsTools.NanoAOD.simpleVertexFlatTableProducer_cfi import simpleVertexF
 from PhysicsTools.PatAlgos.patElectronTimeLifeInfoProducer_cfi import patElectronTimeLifeInfoProducer
 from PhysicsTools.PatAlgos.patMuonTimeLifeInfoProducer_cfi import patMuonTimeLifeInfoProducer
 from PhysicsTools.PatAlgos.patTauTimeLifeInfoProducer_cfi import patTauTimeLifeInfoProducer
-from PhysicsTools.NanoAOD.simpleCandidate2TrackTimeLifeInfoFlatTableProducer_cfi import simpleCandidate2TrackTimeLifeInfoFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATElectron2TrackTimeLifeInfoFlatTableProducer_cfi import simplePATElectron2TrackTimeLifeInfoFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATMuon2TrackTimeLifeInfoFlatTableProducer_cfi import simplePATMuon2TrackTimeLifeInfoFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATTau2TrackTimeLifeInfoFlatTableProducer_cfi import simplePATTau2TrackTimeLifeInfoFlatTableProducer
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from PhysicsTools.NanoAOD.nanoDQM_tools_cff import *
 
@@ -22,7 +24,7 @@ prod_common = cms.PSet(
 
 # impact parameter
 ipVars = cms.PSet(
-    #ipLength = Var("ipLength().value()", float, doc="lenght of impact parameter (3d)", precision=10),#MB: redundant
+    #ipLength = Var("ipLength().value()", float, doc="lenght of impact parameter (3d)", precision=10),
     ipLengthSig = Var("ipLength().significance()", float, doc="significance of impact parameter", precision=10),
     IPx = Var("ipVector().x()", float, doc="x coordinate of impact parameter vector", precision=10),
     IPy = Var("ipVector().y()", float, doc="y coordinate of impact parameter vector", precision=10),
@@ -53,7 +55,7 @@ svVars = cms.PSet(
     refitSVy = Var("?hasSV()?sv().y():0", float, doc="y coordinate of SV", precision=10),
     refitSVz = Var("?hasSV()?sv().z():0", float, doc="z coordinate of SV", precision=10),
     refitSVchi2 = Var("?hasSV()?sv().normalizedChi2():0", float, doc="reduced chi2, i.e. chi2/ndof, of SV fit", precision=8),
-    #refitSVndof = Var("?hasSV()?sv().ndof():0", float, doc="ndof of SV fit", precision=8),#MB: not important
+    #refitSVndof = Var("?hasSV()?sv().ndof():0", float, doc="ndof of SV fit", precision=8),
     # flight-length
     #refitFlightLength = Var("?hasSV()?flightLength().value():0", float, doc="flight-length,i.e. the PV to SV distance", precision=10),
     #refitFlightLengthSig = Var("?hasSV()?flightLength().significance():0", float, doc="Significance of flight-length", precision=10)
@@ -122,7 +124,7 @@ def addElectronTimeLifeInfoTask(process):
         pvSource = prod_common.pvSource,
         pvChoice = prod_common.pvChoice
     )
-    process.electronTimeLifeInfoTable = simpleCandidate2TrackTimeLifeInfoFlatTableProducer.clone(
+    process.electronTimeLifeInfoTable = simplePATElectron2TrackTimeLifeInfoFlatTableProducer.clone(
         name = process.electronTable.name,
         src = process.electronTable.src,
         doc = cms.string("Additional time-life info for non-prompt electrons"),
@@ -187,7 +189,7 @@ def addMuonTimeLifeInfoTask(process):
         pvSource = prod_common.pvSource,
         pvChoice = prod_common.pvChoice
     )
-    process.muonTimeLifeInfoTable = simpleCandidate2TrackTimeLifeInfoFlatTableProducer.clone(
+    process.muonTimeLifeInfoTable = simplePATMuon2TrackTimeLifeInfoFlatTableProducer.clone(
         name = process.muonTable.name,
         src = process.muonTable.src,
         doc = cms.string("Additional time-life info for non-prompt muon"),
@@ -251,7 +253,7 @@ def addTauTimeLifeInfoTask(process):
         pvSource = prod_common.pvSource,
         pvChoice = prod_common.pvChoice
     )
-    process.tauTimeLifeInfoTable = simpleCandidate2TrackTimeLifeInfoFlatTableProducer.clone(
+    process.tauTimeLifeInfoTable = simplePATTau2TrackTimeLifeInfoFlatTableProducer.clone(
         name = process.tauTable.name,
         src = process.tauTable.src,
         doc = cms.string("Additional tau time-life info"),

--- a/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/lowPtElectrons_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATElectronFlatTableProducer_cfi import simplePATElectronFlatTableProducer
 
 ################################################################################
 # Modules
@@ -60,7 +60,7 @@ finalLowPtElectrons = cms.EDFilter(
 # electronTable
 ################################################################################
 
-lowPtElectronTable = simpleCandidateFlatTableProducer.clone(
+lowPtElectronTable = simplePATElectronFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","lowPtElectrons"),
     name= cms.string("LowPtElectron"),
     doc = cms.string("slimmedLowPtElectrons after basic selection (" + finalLowPtElectrons.cut.value()+")"),

--- a/PhysicsTools/NanoAOD/python/met_cff.py
+++ b/PhysicsTools/NanoAOD/python/met_cff.py
@@ -1,14 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 from  PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleSingletonCandidateFlatTableProducer_cfi import simpleSingletonCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATMETFlatTableProducer_cfi import simplePATMETFlatTableProducer
+
+simpleSingletonPATMETFlatTableProducer = simplePATMETFlatTableProducer.clone(
+    singleton = cms.bool(True),
+    cut = None,
+    lazyEval = None
+)
 
 ##################### Tables for final output and docs ##########################
-pfmetTable = simpleSingletonCandidateFlatTableProducer.clone(
+pfmetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = cms.InputTag("slimmedMETs"),
     name = cms.string("PFMET"),
     doc = cms.string("slimmedMET, type-1 corrected PF MET"),
     variables = cms.PSet(PTVars,
-      
        covXX = Var("getSignificanceMatrix().At(0,0)",float,doc="xx element of met covariance matrix", precision=8),
        covXY = Var("getSignificanceMatrix().At(0,1)",float,doc="xy element of met covariance matrix", precision=8),
        covYY = Var("getSignificanceMatrix().At(1,1)",float,doc="yy element of met covariance matrix", precision=8),
@@ -19,12 +24,11 @@ pfmetTable = simpleSingletonCandidateFlatTableProducer.clone(
        ptUnclusteredDown = Var("shiftedPt('UnclusteredEnDown')", float, doc="Unclustered down pt",precision=10),
        phiUnclusteredUp = Var("shiftedPhi('UnclusteredEnUp')", float, doc="Unclustered up phi",precision=10),
        phiUnclusteredDown = Var("shiftedPhi('UnclusteredEnDown')", float, doc="Unclustered down phi",precision=10),
-
     ),
 )
 
 
-rawMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+rawMetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = pfmetTable.src,
     name = cms.string("RawPFMET"),
     doc = cms.string("raw PF MET"),
@@ -36,7 +40,7 @@ rawMetTable = simpleSingletonCandidateFlatTableProducer.clone(
 )
 
 
-caloMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+caloMetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = pfmetTable.src,
     name = cms.string("CaloMET"),
     doc = cms.string("Offline CaloMET (muon corrected)"),
@@ -47,7 +51,7 @@ caloMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),
 )
 
-puppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+puppiMetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = cms.InputTag("slimmedMETsPuppi"),
     name = cms.string("PuppiMET"),
     doc = cms.string("PUPPI  MET"),
@@ -62,11 +66,10 @@ puppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
        ptUnclusteredDown = Var("shiftedPt('UnclusteredEnDown')", float, doc="Unclustered down pt",precision=10),
        phiUnclusteredUp = Var("shiftedPhi('UnclusteredEnUp')", float, doc="Unclustered up phi",precision=10),
        phiUnclusteredDown = Var("shiftedPhi('UnclusteredEnDown')", float, doc="Unclustered down phi",precision=10),
-
     ),
 )
 
-rawPuppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+rawPuppiMetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = puppiMetTable.src,
     name = cms.string("RawPuppiMET"),
     doc = cms.string("raw Puppi MET"),
@@ -77,7 +80,7 @@ rawPuppiMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),)
 
 
-trkMetTable = simpleSingletonCandidateFlatTableProducer.clone(
+trkMetTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = pfmetTable.src,
     name = cms.string("TrkMET"),
     doc = cms.string("Track MET computed with tracks from PV0 ( pvAssociationQuality()>=4 ) "),
@@ -88,8 +91,7 @@ trkMetTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),
 )
 
-
-deepMetResolutionTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
+deepMetResolutionTuneTable = simpleSingletonPATMETFlatTableProducer.clone(
     # current deepMets are saved in slimmedMETs in MiniAOD,
     # in the same way as chsMet/TrkMET
     src = pfmetTable.src,
@@ -101,7 +103,7 @@ deepMetResolutionTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),
 )
 
-deepMetResponseTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
+deepMetResponseTuneTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = pfmetTable.src,
     name = cms.string("DeepMETResponseTune"),
     doc = cms.string("Deep MET trained with extra response tune"),
@@ -111,7 +113,7 @@ deepMetResponseTuneTable = simpleSingletonCandidateFlatTableProducer.clone(
     ),
 )
 
-metMCTable = simpleSingletonCandidateFlatTableProducer.clone(
+metMCTable = simpleSingletonPATMETFlatTableProducer.clone(
     src = pfmetTable.src,
     name = cms.string("GenMET"),
     doc = cms.string("Gen MET"),

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATMuonFlatTableProducer_cfi import simplePATMuonFlatTableProducer
 
 import PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi
 
@@ -150,7 +150,7 @@ muonBSConstrain = cms.EDProducer("MuonBeamspotConstraintValueMapProducer",
     src = cms.InputTag("linkedObjects","muons"),
 )
 
-muonTable = simpleCandidateFlatTableProducer.clone(
+muonTable = simplePATMuonFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","muons"),
     name = cms.string("Muon"),
     doc  = cms.string("slimmedMuons after basic selection (" + finalMuons.cut.value()+")"),

--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATPhotonFlatTableProducer_cfi import simplePATPhotonFlatTableProducer
 from math import ceil,log
 
 
@@ -184,7 +184,7 @@ finalPhotons = cms.EDFilter("PATPhotonRefSelector",
     cut = cms.string("pt > 5 ")
 )
 
-photonTable = simpleCandidateFlatTableProducer.clone(
+photonTable = simplePATPhotonFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","photons"),
     name= cms.string("Photon"),
     doc = cms.string("slimmedPhotons after basic selection (" + finalPhotons.cut.value()+")"),

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -306,7 +306,7 @@ ak4ScoutingJetParticleNetJetTags = cms.EDProducer("BoostedJetONNXJetTagsProducer
       debugMode = cms.untracked.bool(False),
 )
 
-ak4ScoutingJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+ak4ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak4ScoutingJets"),
       name = cms.string("ScoutingJet"),
       cut = cms.string(""),
@@ -443,7 +443,7 @@ ak8ScoutingJetParticleNetMassRegressionJetTags = cms.EDProducer("BoostedJetONNXJ
       debugMode = cms.untracked.bool(False),
   )
 
-ak8ScoutingJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
+ak8ScoutingJetTable = cms.EDProducer("SimplePFJetFlatTableProducer",
       src = cms.InputTag("ak8ScoutingJets"),
       name = cms.string("ScoutingFatJet"),
       cut = cms.string(""),

--- a/PhysicsTools/NanoAOD/python/simpleSingletonCandidateFlatTableProducer_cfi.py
+++ b/PhysicsTools/NanoAOD/python/simpleSingletonCandidateFlatTableProducer_cfi.py
@@ -4,5 +4,7 @@ from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCand
 
 simpleSingletonCandidateFlatTableProducer = default.clone(
   singleton = cms.bool(True),
+  cut = None,
+  lazyEval = None
 )
-del simpleSingletonCandidateFlatTableProducer.cut
+

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -68,6 +68,7 @@ _tauVarsBase = cms.PSet(P4Vars,
        leadTkDeltaEta = Var("?leadChargedHadrCand.isNonnull()?(leadChargedHadrCand.eta - eta):0",float, doc="eta of the leading track, minus tau eta",precision=8),
        leadTkDeltaPhi = Var("?leadChargedHadrCand.isNonnull()?deltaPhi(leadChargedHadrCand.phi, phi):0",float, doc="phi of the leading track, minus tau phi",precision=8),
 
+       # lazyEval=True: leadChargedHadrCand() returns the base type `reco::CandidatePtr`, needs to be dynamically casted to PackedCandidate to call dxy() / dz()
        dxy = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dxy():0",float, doc="d_{xy} of lead track with respect to PV, in cm (with sign)",precision=10, lazyEval=True),
        dz = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dz():0",float, doc="d_{z} of lead track with respect to PV, in cm (with sign)",precision=14, lazyEval=True),
 

--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
 from PhysicsTools.NanoAOD.nano_eras_cff import run3_nanoAOD_124
 from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simpleGenParticleFlatTableProducer_cfi import simpleGenParticleFlatTableProducer
+from PhysicsTools.NanoAOD.simplePATTauFlatTableProducer_cfi import simplePATTauFlatTableProducer
 
 from PhysicsTools.JetMCAlgos.TauGenJets_cfi import tauGenJets
 from PhysicsTools.JetMCAlgos.TauGenJetsDecayModeSelectorAllHadrons_cfi import tauGenJetsSelectorAllHadrons
@@ -45,7 +47,7 @@ def _tauIdWPMask(pattern, choices, doc="", from_raw=False, wp_thrs=None):
     return Var(var_definition, "uint8", doc=doc)
 
 
-tauTable = simpleCandidateFlatTableProducer.clone(
+tauTable = simplePATTauFlatTableProducer.clone(
     src = cms.InputTag("linkedObjects","taus"),
     name= cms.string("Tau"),
     doc = cms.string("slimmedTaus after basic selection (" + finalTaus.cut.value()+")")
@@ -66,8 +68,8 @@ _tauVarsBase = cms.PSet(P4Vars,
        leadTkDeltaEta = Var("?leadChargedHadrCand.isNonnull()?(leadChargedHadrCand.eta - eta):0",float, doc="eta of the leading track, minus tau eta",precision=8),
        leadTkDeltaPhi = Var("?leadChargedHadrCand.isNonnull()?deltaPhi(leadChargedHadrCand.phi, phi):0",float, doc="phi of the leading track, minus tau phi",precision=8),
 
-       dxy = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dxy():0",float, doc="d_{xy} of lead track with respect to PV, in cm (with sign)",precision=10),
-       dz = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dz():0",float, doc="d_{z} of lead track with respect to PV, in cm (with sign)",precision=14),
+       dxy = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dxy():0",float, doc="d_{xy} of lead track with respect to PV, in cm (with sign)",precision=10, lazyEval=True),
+       dz = Var("?leadChargedHadrCand.isNonnull()?leadChargedHadrCand().dz():0",float, doc="d_{z} of lead track with respect to PV, in cm (with sign)",precision=14, lazyEval=True),
 
        # these are too many, we may have to suppress some
        rawIso = Var("?isTauIDAvailable('byCombinedIsolationDeltaBetaCorrRaw3Hits')?tauID('byCombinedIsolationDeltaBetaCorrRaw3Hits'):-1", float, doc = "combined isolation (deltaBeta corrections)", precision=10),
@@ -182,7 +184,7 @@ genVisTaus = cms.EDProducer("GenVisTauProducer",
     srcGenParticles = cms.InputTag("finalGenParticles")
 )
 
-genVisTauTable = simpleCandidateFlatTableProducer.clone(
+genVisTauTable = simpleGenParticleFlatTableProducer.clone(
     src = cms.InputTag("genVisTaus"),
     cut = cms.string("pt > 10."),
     name = cms.string("GenVisTau"),

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import *
-from PhysicsTools.NanoAOD.simpleCandidateFlatTableProducer_cfi import simpleCandidateFlatTableProducer
+from PhysicsTools.NanoAOD.simpleSecondaryVertexFlatTableProducer_cfi import simpleSecondaryVertexFlatTableProducer
 
 
 ##################### User floats producers, selectors ##########################
@@ -20,7 +20,7 @@ vertexTable = cms.EDProducer("VertexTableProducer",
     svDoc  = cms.string("secondary vertices from IVF algorithm"),
 )
 
-svCandidateTable =  simpleCandidateFlatTableProducer.clone(
+svCandidateTable = simpleSecondaryVertexFlatTableProducer.clone(
     src = cms.InputTag("vertexTable"),
     name = cms.string("SV"),
     extension = cms.bool(True),


### PR DESCRIPTION
#### PR description:

Building on the implementation by @Dr15Jones in https://github.com/cms-sw/cmssw/pull/44575 and some discussions there, I modified the usage of `SimpleFlatTableProducer` to read concrete data types instead of the base `reco::Candidate`.  This avoids the large number of `lazyEval = True` previously needed in https://github.com/cms-sw/cmssw/pull/44575.

#### PR validation:

Tested for all NANO workflows:

```
runTheMatrix.py --ibeos --nEvents 100 -w nano -i all -l 2500.0,2500.001,2500.002,2500.01,2500.011,2500.012,2500.1,2500.2,2500.21,2500.211,2500.3,2500.301,2500.31,2500.311,2500.312,2500.313,2500.32,2500.321,2500.322,2500.323,2500.324,2500.325,2500.326,2500.327,2500.4,2500.401,2500.402,2500.403,2500.404,2500.405,2500.5,2500.51
```