### PR TITLE
HLT Menu check for the PCL Tracker Alignment

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
+++ b/Alignment/CommonAlignmentProducer/plugins/BuildFile.xml
@@ -53,5 +53,6 @@
 </library>
 
 <library file="LSNumberFilter.cc" name="AlignmentCommonAlignmentProducerFilter">
+  <use name="HLTrigger/HLTcore"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -55,6 +55,7 @@ void LSNumberFilter::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetu
       edm::LogWarning("LSNumberFilter") << "Detected " << veto_HLT_Menu[i]
                                         << " in HLT Config tableName(): " << hltConfig_.tableName()
                                         << "; Events of this run will be ignored" << std::endl;
+      break;
     }
   }
 }

--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -22,13 +22,13 @@ private:
   bool filter(edm::Event&, const edm::EventSetup&) override;
   bool is_HLT_vetoed;
   unsigned int minLS;
-  const std::string veto_HLT_Menu;
+  const std::vector<std::string> veto_HLT_Menu;
   HLTConfigProvider hltConfig_;
 };
 
 LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig)
     : minLS(iConfig.getUntrackedParameter<unsigned>("minLS", 21)),
-      veto_HLT_Menu(iConfig.getUntrackedParameter<std::string>("veto_HLT_Menu", "LumiScan")) {}
+      veto_HLT_Menu(iConfig.getUntrackedParameter<std::vector<std::string>>("veto_HLT_Menu")) {}
 
 LSNumberFilter::~LSNumberFilter() {}
 
@@ -47,12 +47,15 @@ bool LSNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 void LSNumberFilter::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
   bool changed(false);
   hltConfig_.init(iRun, iSetup, "HLT", changed);
-  std::size_t found = hltConfig_.tableName().find(veto_HLT_Menu);
-  is_HLT_vetoed = (found != std::string::npos);
-  if (is_HLT_vetoed) {
-    edm::LogWarning("LSNumberFilter") << "Detected " << veto_HLT_Menu
-                                      << " in HLT Config tableName(): " << hltConfig_.tableName()
-                                      << "; Events of this run will be ignored" << std::endl;
+  is_HLT_vetoed = false;
+  for (unsigned int i = 0; i < veto_HLT_Menu.size(); i++) {
+    std::size_t found = hltConfig_.tableName().find(veto_HLT_Menu[i]);
+    if (found != std::string::npos) {
+      is_HLT_vetoed = true;
+      edm::LogWarning("LSNumberFilter") << "Detected " << veto_HLT_Menu[i]
+                                        << " in HLT Config tableName(): " << hltConfig_.tableName()
+                                        << "; Events of this run will be ignored" << std::endl;
+    }
   }
 }
 //define this as a plug-in

--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -5,6 +5,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include <iostream>
 
 //
 // class declaration
@@ -16,12 +18,17 @@ public:
   ~LSNumberFilter() override;
 
 private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool is_HLT_vetoed;
   unsigned int minLS;
+  const std::string veto_HLT_Menu;
+  HLTConfigProvider hltConfig_;
 };
 
 LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig)
-    : minLS(iConfig.getUntrackedParameter<unsigned>("minLS", 21)) {}
+    : minLS(iConfig.getUntrackedParameter<unsigned>("minLS", 21)),
+      veto_HLT_Menu(iConfig.getUntrackedParameter<std::string>("veto_HLT_Menu", "LumiScan")) {}
 
 LSNumberFilter::~LSNumberFilter() {}
 
@@ -31,11 +38,22 @@ LSNumberFilter::~LSNumberFilter() {}
 
 // ------------ method called on each new Event  ------------
 bool LSNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  if (iEvent.luminosityBlock() < minLS)
+  if ((iEvent.luminosityBlock() < minLS) || is_HLT_vetoed)
     return false;
 
   return true;
 }
 
+void LSNumberFilter::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  bool changed(false);
+  hltConfig_.init(iRun, iSetup, "HLT", changed);
+  std::size_t found = hltConfig_.tableName().find(veto_HLT_Menu);
+  is_HLT_vetoed = (found != std::string::npos);
+  if (is_HLT_vetoed) {
+    edm::LogWarning("LSNumberFilter") << "Detected " << veto_HLT_Menu
+                                      << " in HLT Config tableName(): " << hltConfig_.tableName()
+                                      << "; Events of this run will be ignored" << std::endl;
+  }
+}
 //define this as a plug-in
 DEFINE_FWK_MODULE(LSNumberFilter);

--- a/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 lsNumberFilter = cms.EDFilter("LSNumberFilter",
                               minLS = cms.untracked.uint32(21),
-                              veto_HLT_Menu = cms.untracked.string("LumiScan")
+                              veto_HLT_Menu = cms.untracked.vstring("LumiScan")
                               )

--- a/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 lsNumberFilter = cms.EDFilter("LSNumberFilter",
-                              minLS = cms.untracked.uint32(21)
+                              minLS = cms.untracked.uint32(21),
+                              veto_HLT_Menu = cms.untracked.string("LumiScan")
                               )


### PR DESCRIPTION
#### PR description:

Added new option to  veto specific run for PCL alignment based on their HLT Menu. Implemented using a new variable `veto_HLT_Menu` in LSNumberFilter config. 
This change was made, since the PCL Alignment triggered an update based on a Lumiscan run (Run 379524, https://cmsoms.cern.ch/cms/runs/report?cms_run=379524).

#### PR validation:

PR was validated by testing the MilleStep for one nominal run (Run 379530) and the Lumiscan run (Run 379524), using the following command:
```
cmsDriver.py milleStep -s ALCA:PromptCalibProdSiPixelAli --conditions 140X_dataRun3_Express_v2 --scenario pp --data --era Run3 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100 --dasquery='file dataset=/StreamExpress/Run2024C-TkAlMinBias-Express-v1/ALCARECO run=<379524, 379530>'
```
@mmusich @dmeuser @henriettepetersen @TomasKello 
