### PR TITLE
Revert "CalorimeterDefinitions: don't return -1 as uint32_t"

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -101,7 +101,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
         return detId2denseIdHE(detId);
 
       printf("invalid detId: %u\n", detId);
-      return 0;
+      return -1;
     }
   };
 


### PR DESCRIPTION
#### PR description:

This reverts commit f0e4f78ff824bd5ecd60a3cd03c6886eef19ad7f.

The change introduced by f0e4f78ff824bd5ecd60a3cd03c6886eef19ad7f / #44608 returns a dense id of 0 for an invalid det id. However, 0 is a valid dense id, and should not be used for an invalid det id.

#### PR validation:

None.