### PR TITLE
Skip invalid HCAL PF rechits in PFRecHitTopologyESProducer

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -104,6 +104,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           for (auto const detId : geom.getValidDetIds(CAL::kDetectorId, subdet)) {
             const uint32_t denseId = CAL::detId2denseId(detId);
             for (uint32_t n = 0; n < 8; n++) {
+              if (view.neighbours(denseId)[n] == 0xffffffff)
+                continue;
               const ::reco::PFRecHitsTopologyNeighbours& neighboursOfNeighbour =
                   view.neighbours(view.neighbours(denseId)[n]);
               if (std::find(neighboursOfNeighbour.begin(), neighboursOfNeighbour.end(), denseId) ==


### PR DESCRIPTION
#### PR description:

Skip invalid HCAL PF rechits in `PFRecHitTopologyESProducer` while looking for neighbours.

Fixes #44789 .

#### PR validation:

Enabling range checks shows that `PFRecHitTopologyESProducer` no longer accesses an invalid SoA index.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW 14.0.x for data taking.