### PR TITLE
ECAL : Tool to create sqlite files for DB

### DIFF
--- a/CondTools/Ecal/interface/EcalTimeCalibHandler.h
+++ b/CondTools/Ecal/interface/EcalTimeCalibHandler.h
@@ -1,0 +1,37 @@
+#ifndef CondTools_Ecal_EcalTimeCalibHandler_h
+#define CondTools_Ecal_EcalTimeCalibHandler_h
+
+#include "CondCore/PopCon/interface/PopConSourceHandler.h"
+#include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
+#include "CondTools/Ecal/interface/EcalCondHeader.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "OnlineDB/EcalCondDB/interface/all_monitoring_types.h"
+#include "OnlineDB/EcalCondDB/interface/EcalCondDBInterface.h"
+
+#include <string>
+
+namespace popcon {
+  class EcalTimeCalibHandler : public popcon::PopConSourceHandler<EcalTimeCalibConstants> {
+  public:
+    EcalTimeCalibHandler(edm::ParameterSet const&);
+    ~EcalTimeCalibHandler() override = default;
+
+    void getNewObjects() override;
+    void readXML(const std::string& filename, EcalFloatCondObjectContainer& record);
+    void readTXT(const std::string& filename, EcalFloatCondObjectContainer& record);
+
+    std::string id() const override { return m_name; }
+    EcalCondDBInterface* econn;
+
+  private:
+    const std::string m_name;
+    const unsigned int m_firstRun;
+    const std::string m_file_name;
+    const std::string m_file_type;
+  };
+}  // namespace popcon
+#endif

--- a/CondTools/Ecal/plugins/TestEcalTimeCalibAnalyzer.cc
+++ b/CondTools/Ecal/plugins/TestEcalTimeCalibAnalyzer.cc
@@ -1,0 +1,8 @@
+#include "CondCore/PopCon/interface/PopConAnalyzer.h"
+#include "CondTools/Ecal/interface/EcalTimeCalibHandler.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef popcon::PopConAnalyzer<popcon::EcalTimeCalibHandler> ExTestEcalTimeCalibAnalyzer;
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExTestEcalTimeCalibAnalyzer);

--- a/CondTools/Ecal/python/updateTimeCalib_cfg.py
+++ b/CondTools/Ecal/python/updateTimeCalib_cfg.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ProcessOne")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.cout.enable = True
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('*')
+
+process.source = cms.Source("EmptyIOVSource",
+    lastValue = cms.uint64(100000000000),
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(100000000000),
+    interval = cms.uint64(1)
+)
+
+process.load("CondCore.CondDB.CondDB_cfi")
+
+process.CondDB.connect = 'sqlite_file:EcalTimeCalibConstants_minus_delays.db'
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+  process.CondDB, 
+  logconnect = cms.untracked.string('sqlite_file:log.db'),   
+  toPut = cms.VPSet(
+    cms.PSet(
+      record = cms.string('EcalTimeCalibConstantsRcd'),
+      tag = cms.string('EcalTimeCalibConstants')
+    )
+  )
+)
+
+process.Test1 = cms.EDAnalyzer("ExTestEcalTimeCalibAnalyzer",
+  record = cms.string('EcalTimeCalibConstantsRcd'),
+  loggingOn= cms.untracked.bool(True),
+  IsDestDbCheckedInQueryLog=cms.untracked.bool(True),
+  SinceAppendMode=cms.bool(True),
+  Source=cms.PSet(
+    firstRun = cms.string('1'),
+    type = cms.string('txt'),
+    fileName = cms.string('dump_EcalTimeCalibConstants__new_minus_delays.dat'),
+#    type = cms.string('xml'),
+#    fileName = cms.string('EcalTimeCalibConstants_minus_delays.xml'),
+  )                            
+)
+
+process.p = cms.Path(process.Test1)

--- a/CondTools/Ecal/src/EcalTimeCalibHandler.cc
+++ b/CondTools/Ecal/src/EcalTimeCalibHandler.cc
@@ -1,0 +1,112 @@
+#include "CondTools/Ecal/interface/EcalTimeCalibHandler.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <cstddef>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <utility>
+
+const Int_t kEBChannels = 61200, kEEChannels = 14648;
+
+popcon::EcalTimeCalibHandler::EcalTimeCalibHandler(const edm::ParameterSet& ps)
+    : m_name(ps.getUntrackedParameter<std::string>("name", "EcalTimeCalibHandler")),
+      m_firstRun(static_cast<unsigned int>(atoi(ps.getParameter<std::string>("firstRun").c_str()))),
+      m_file_name(ps.getParameter<std::string>("fileName")),
+      m_file_type(ps.getParameter<std::string>("type"))  // xml/txt
+{
+  edm::LogInfo("EcalTimeCalib Source handler constructor\n");
+}
+
+void popcon::EcalTimeCalibHandler::getNewObjects() {
+  edm::LogInfo("going to open file ") << m_file_name;
+
+  //      EcalCondHeader   header;
+  EcalTimeCalibConstants* payload = new EcalTimeCalibConstants;
+  if (m_file_type == "xml")
+    readXML(m_file_name, *payload);
+  else
+    readTXT(m_file_name, *payload);
+  Time_t snc = (Time_t)m_firstRun;
+
+  popcon::PopConSourceHandler<EcalTimeCalibConstants>::m_to_transfer.push_back(std::make_pair(payload, snc));
+}
+
+void popcon::EcalTimeCalibHandler::readXML(const std::string& file_, EcalFloatCondObjectContainer& record) {
+  std::string dummyLine, bid;
+  std::ifstream fxml;
+  fxml.open(file_);
+  if (!fxml.is_open()) {
+    throw cms::Exception("ERROR : cannot open file ") << file_;
+  }
+  // header
+  for (int i = 0; i < 6; i++) {
+    getline(fxml, dummyLine);  // skip first lines
+  }
+  fxml >> bid;
+  std::string stt = bid.substr(7, 5);
+  std::istringstream iEB(stt);
+  int nEB;
+  iEB >> nEB;
+  if (nEB != kEBChannels) {
+    throw cms::Exception("Strange number of EB channels ") << nEB;
+  }
+  fxml >> bid;  // <item_version>0</item_version>
+  for (int iChannel = 0; iChannel < kEBChannels; iChannel++) {
+    EBDetId myEBDetId = EBDetId::unhashIndex(iChannel);
+    fxml >> bid;
+    std::size_t found = bid.find("</");
+    stt = bid.substr(6, found - 6);
+    float val = std::stof(stt);
+    record[myEBDetId] = val;
+  }
+  for (int i = 0; i < 5; i++) {
+    getline(fxml, dummyLine);  // skip first lines
+  }
+  fxml >> bid;
+  stt = bid.substr(7, 5);
+  std::istringstream iEE(stt);
+  int nEE;
+  iEE >> nEE;
+  if (nEE != kEEChannels) {
+    throw cms::Exception("Strange number of EE channels ") << nEE;
+  }
+  fxml >> bid;  // <item_version>0</item_version>
+  // now endcaps
+  for (int iChannel = 0; iChannel < kEEChannels; iChannel++) {
+    EEDetId myEEDetId = EEDetId::unhashIndex(iChannel);
+    fxml >> bid;
+    std::size_t found = bid.find("</");
+    stt = bid.substr(6, found - 6);
+    float val = std::stof(stt);
+    record[myEEDetId] = val;
+  }
+}
+
+void popcon::EcalTimeCalibHandler::readTXT(const std::string& file_, EcalFloatCondObjectContainer& record) {
+  std::ifstream ftxt;
+  ftxt.open(file_);
+  if (!ftxt.is_open()) {
+    throw cms::Exception("ERROR : cannot open file ") << file_;
+  }
+  int number_of_lines = 0, eta, phi, x, y, z;
+  float val;
+  std::string line;
+  while (std::getline(ftxt, line)) {
+    if (number_of_lines < kEBChannels) {  // barrel
+      std::sscanf(line.c_str(), "%i %i %i %f", &eta, &phi, &z, &val);
+      EBDetId ebdetid(eta, phi, EBDetId::ETAPHIMODE);
+      record[ebdetid] = val;
+    } else {  // endcaps
+      std::sscanf(line.c_str(), "%i %i %i %f", &x, &y, &z, &val);
+      EEDetId eedetid(x, y, z, EEDetId::XYMODE);
+      record[eedetid] = val;
+    }
+    number_of_lines++;
+  }
+  edm::LogInfo("Number of lines in text file: ") << number_of_lines;
+  int kChannels = kEBChannels + kEEChannels;
+  if (number_of_lines != kChannels)
+    throw cms::Exception("Wrong number of channels!  Please check ");
+}


### PR DESCRIPTION
#### PR description:

ECAL : for appending EcalTimeCalibConstants tags with new payloads : tool to create sqlite files from raw xxx.dat or xxx.xml files.

#### PR validation:

Tested (cmsRun updateTimeCalib.py) in CMSSW_13 and 14_0_5 with xxx.dat and xxx.xml source files  : same payloads generated (hashes).
Comments about const suggestion in #PR 44713 don't work, after many attempts.  Still compilation errors.  N.B. All other ...Handler.cc of CondTools/Ecal/src have the same structure , without const.
