### PR TITLE
[UBSAN] Initialize missing PixelBarrelValues members for phase1

### DIFF
--- a/DataFormats/TrackerCommon/interface/TrackerTopology.h
+++ b/DataFormats/TrackerCommon/interface/TrackerTopology.h
@@ -19,11 +19,11 @@ public:
     unsigned int layerStartBit_;
     unsigned int ladderStartBit_;
     unsigned int moduleStartBit_;
-    unsigned int doubleStartBit_;
+    unsigned int doubleStartBit_ = 0;
     unsigned int layerMask_;
     unsigned int ladderMask_;
     unsigned int moduleMask_;
-    unsigned int doubleMask_;
+    unsigned int doubleMask_ = 0;
   };
 
   struct PixelEndcapValues {


### PR DESCRIPTION
UBSAN IBs have a lot of runtime errors like [a]. This is because [PixelBarrelValues::doubleStartBit_](https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L22) and [PixelBarrelValues::doubleMask_](https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L26) are not initialized for [phase 1](https://github.com/cms-sw/cmssw/blob/master/Geometry/TrackerNumberingBuilder/plugins/TrackerTopologyEP.cc#L73-L89).  This PR proposes to explicitly initialize these data members to fix the UBSAN runtime errors. 

@cms-sw/reconstruction-l2  , may be we should avoid calling [TrackerTopology::pixFirst](https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L300) and [TrackerTopology::pixSecond](https://github.com/cms-sw/cmssw/blob/master/DataFormats/TrackerCommon/interface/TrackerTopology.h#L343) for phase 1?


[a]
- https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_1_X_2024-04-19-2300/logs/13/130056ff43b5fb11117368b02677f718/log
```
10001.0/step3:DataFormats/TrackerCommon/interface/TrackerTopology.h:301:26: runtime error: shift exponent 5308 is too large for 32-bit type 'unsigned int'
```
- https://cmssdt.cern.ch/SDT/jenkins-artifacts/ubsan_logs/CMSSW_14_1_X_2024-04-19-2300/logs/9f/9fa9693b3cf4e316bf26a37c2bd23ecf/log
```
10001.0/step3:DataFormats/TrackerCommon/interface/TrackerTopology.h:344:22: runtime error: shift exponent 5308 is too large for 32-bit type 'unsigned int'
```