### PR TITLE
RecHit based Ecal/Hcal muon isolation

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/genericTrackCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/genericTrackCandidates_cff.py
@@ -23,12 +23,18 @@ patAODTrackIsoDepositCtfTk = cms.EDProducer("CandIsoDepositProducer",
 )
 
 ## Configure calorimetric isolation
-from RecoMuon.MuonIsolationProducers.caloExtractorByAssociatorBlocks_cff import MIsoCaloExtractorByAssociatorTowersBlock
+from RecoMuon.MuonIsolationProducers.caloExtractorByAssociatorBlocks_cff import *
 patAODTrackIsoDepositCalByAssociatorTowers = cms.EDProducer("CandIsoDepositProducer",
     src                  = cms.InputTag("patAODTrackCands"),
     trackType            = cms.string('best'),
     MultipleDepositsFlag = cms.bool(True),
     ExtractorPSet        = cms.PSet( MIsoCaloExtractorByAssociatorTowersBlock )
+)
+patAODTrackIsoDepositCalByAssociatorHits = cms.EDProducer("CandIsoDepositProducer",
+    src                  = cms.InputTag("patAODTrackCands"),
+    trackType            = cms.string('best'),
+    MultipleDepositsFlag = cms.bool(True),
+    ExtractorPSet        = cms.PSet( MIsoCaloExtractorByAssociatorHitsBlock )
 )
 
 ## Select isolation labels to use
@@ -58,6 +64,7 @@ patAODTrackCandSequence = cms.Sequence(
         patAODTrackCandsUnfiltered *
         patAODTrackCands *
         patAODTrackIsoDepositCalByAssociatorTowers *
+        patAODTrackIsoDepositCalByAssociatorHits *
         patAODTrackIsoDepositCtfTk *
         patAODTrackIsolations
 )

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -71,6 +71,8 @@ from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 muIsoDepositTk.inputTags = ['muons:tracker']
 muIsoDepositJets.inputTags = ['muons:jets']
 muIsoDepositCalByAssociatorTowers.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
+#muIsoDepositCalByAssociatorHits.inputTags = cms.untracked.VInputTag(['muons:ecal', 'muons:hcal', 'muons:ho'])
+muIsoDepositCalByAssociatorHits.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
 
 # TeV refinement
 from RecoMuon.GlobalMuonProducer.tevMuons_cfi import *

--- a/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonCosmics_cff.py
@@ -71,7 +71,6 @@ from RecoMuon.MuonIsolationProducers.muIsolation_cff import *
 muIsoDepositTk.inputTags = ['muons:tracker']
 muIsoDepositJets.inputTags = ['muons:jets']
 muIsoDepositCalByAssociatorTowers.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
-#muIsoDepositCalByAssociatorHits.inputTags = cms.untracked.VInputTag(['muons:ecal', 'muons:hcal', 'muons:ho'])
 muIsoDepositCalByAssociatorHits.inputTags = ['muons:ecal', 'muons:hcal', 'muons:ho']
 
 # TeV refinement

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -62,14 +62,17 @@ MuonProducer::MuonProducer(const edm::ParameterSet& pSet)
 
   if (fillDetectorBasedIsolation_) {
     theTrackDepositName = pSet.getParameter<edm::InputTag>("TrackIsoDeposits");
+    std::cout << "*** theTrackDepositName: " << theTrackDepositName << std::endl;
     theTrackDepositToken_ = consumes<reco::IsoDepositMap>(theTrackDepositName);
     produces<reco::IsoDepositMap>(labelOrInstance(theTrackDepositName));
 
     theJetDepositName = pSet.getParameter<edm::InputTag>("JetIsoDeposits");
+    std::cout << "*** theJetDepositName: " << theJetDepositName << std::endl;
     theJetDepositToken_ = consumes<reco::IsoDepositMap>(theJetDepositName);
     produces<reco::IsoDepositMap>(labelOrInstance(theJetDepositName));
 
     theEcalDepositName = pSet.getParameter<edm::InputTag>("EcalIsoDeposits");
+    std::cout << "*** theEcalDepositName: " << theEcalDepositName << std::endl;
     theEcalDepositToken_ = consumes<reco::IsoDepositMap>(theEcalDepositName);
     produces<reco::IsoDepositMap>(theEcalDepositName.instance());
 

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -62,17 +62,14 @@ MuonProducer::MuonProducer(const edm::ParameterSet& pSet)
 
   if (fillDetectorBasedIsolation_) {
     theTrackDepositName = pSet.getParameter<edm::InputTag>("TrackIsoDeposits");
-    std::cout << "*** theTrackDepositName: " << theTrackDepositName << std::endl;
     theTrackDepositToken_ = consumes<reco::IsoDepositMap>(theTrackDepositName);
     produces<reco::IsoDepositMap>(labelOrInstance(theTrackDepositName));
 
     theJetDepositName = pSet.getParameter<edm::InputTag>("JetIsoDeposits");
-    std::cout << "*** theJetDepositName: " << theJetDepositName << std::endl;
     theJetDepositToken_ = consumes<reco::IsoDepositMap>(theJetDepositName);
     produces<reco::IsoDepositMap>(labelOrInstance(theJetDepositName));
 
     theEcalDepositName = pSet.getParameter<edm::InputTag>("EcalIsoDeposits");
-    std::cout << "*** theEcalDepositName: " << theEcalDepositName << std::endl;
     theEcalDepositToken_ = consumes<reco::IsoDepositMap>(theEcalDepositName);
     produces<reco::IsoDepositMap>(theEcalDepositName.instance());
 

--- a/RecoMuon/MuonIdentification/python/displacedMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/displacedMuons_cfi.py
@@ -10,9 +10,9 @@ displacedMuons = cms.EDProducer("MuonProducer",
                        FillTimingInfo = cms.bool(True),
                        
                        FillDetectorBasedIsolation = cms.bool(True),
-                       EcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorTowersDisplaced","ecal"),
-                       HcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorTowersDisplaced","hcal"),
-                       HoIsoDeposits    = cms.InputTag("muIsoDepositCalByAssociatorTowersDisplaced","ho"),
+                       EcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorHitsDisplaced","ecal"),
+                       HcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorHitsDisplaced","hcal"),
+                       HoIsoDeposits    = cms.InputTag("muIsoDepositCalByAssociatorHitsDisplaced","ho"),
                        TrackIsoDeposits = cms.InputTag("muIsoDepositTkDisplaced"),
                        JetIsoDeposits   = cms.InputTag("muIsoDepositJetsDisplaced"),
 

--- a/RecoMuon/MuonIdentification/python/isolation_cff.py
+++ b/RecoMuon/MuonIdentification/python/isolation_cff.py
@@ -5,7 +5,7 @@ from RecoMuon.MuonIsolationProducers.trackExtractorBlocks_cff import *
 from RecoMuon.MuonIsolationProducers.jetExtractorBlock_cff import *
 MIdIsoExtractorPSetBlock = cms.PSet(
     CaloExtractorPSet = cms.PSet(
-        MIsoCaloExtractorByAssociatorTowersBlock
+        MIsoCaloExtractorByAssociatorHitsBlock
     ),
     TrackExtractorPSet = cms.PSet(
         MIsoTrackExtractorBlock

--- a/RecoMuon/MuonIdentification/python/muons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons_cfi.py
@@ -13,9 +13,9 @@ muons = cms.EDProducer("MuonProducer",
                        FillTimingInfo = cms.bool(True),
                        
                        FillDetectorBasedIsolation = cms.bool(True),
-                       EcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorTowers","ecal"),
-                       HcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorTowers","hcal"),
-                       HoIsoDeposits    = cms.InputTag("muIsoDepositCalByAssociatorTowers","ho"),
+                       EcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorHits","ecal"),
+                       HcalIsoDeposits  = cms.InputTag("muIsoDepositCalByAssociatorHits","hcal"),
+                       HoIsoDeposits    = cms.InputTag("muIsoDepositCalByAssociatorHits","ho"),
                        TrackIsoDeposits = cms.InputTag("muIsoDepositTk"),
                        JetIsoDeposits   = cms.InputTag("muIsoDepositJets"),
 

--- a/RecoMuon/MuonIsolationProducers/python/muIsoDepositCopies_cfi.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoDepositCopies_cfi.py
@@ -25,7 +25,17 @@ muIsoDepositCalByAssociatorTowers = cms.EDProducer("MuIsoDepositCopyProducer",
   depositNames = cms.vstring('ecal', 'hcal', 'ho')
 )
 
+muIsoDepositCalByAssociatorHits = cms.EDProducer("MuIsoDepositCopyProducer",
+  inputTags = cms.VInputTag(cms.InputTag("muons1stStep:ecal"), cms.InputTag("muons1stStep:hcal"), cms.InputTag("muons1stStep:ho")),
+  depositNames = cms.vstring('ecal', 'hcal', 'ho')
+)
+
 muIsoDepositCalByAssociatorTowersDisplaced = cms.EDProducer("MuIsoDepositCopyProducer",
+  inputTags = cms.VInputTag(cms.InputTag("displacedMuons1stStep:ecal"), cms.InputTag("displacedMuons1stStep:hcal"), cms.InputTag("displacedMuons1stStep:ho")),
+  depositNames = cms.vstring('ecal', 'hcal', 'ho')
+)
+
+muIsoDepositCalByAssociatorHitsDisplaced = cms.EDProducer("MuIsoDepositCopyProducer",
   inputTags = cms.VInputTag(cms.InputTag("displacedMuons1stStep:ecal"), cms.InputTag("displacedMuons1stStep:hcal"), cms.InputTag("displacedMuons1stStep:ho")),
   depositNames = cms.vstring('ecal', 'hcal', 'ho')
 )

--- a/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
@@ -30,15 +30,15 @@ muParamGlobalIsoDepositCalByAssociatorHits   = RecoMuon.MuonIsolationProducers.m
 #
 #------------------------------
 # "standard sequences"
-muIsoDeposits_muonsTask = cms.Task(muIsoDepositTk,muIsoDepositCalByAssociatorTowers,muIsoDepositJets)
+muIsoDeposits_muonsTask = cms.Task(muIsoDepositTk,muIsoDepositCalByAssociatorHits,muIsoDepositJets)
 muIsoDeposits_muons = cms.Sequence(muIsoDeposits_muonsTask)
 # "displaced sequences"
-muIsoDeposits_displacedMuonsTask = cms.Task(muIsoDepositTkDisplaced,muIsoDepositCalByAssociatorTowersDisplaced,muIsoDepositJetsDisplaced)
+muIsoDeposits_displacedMuonsTask = cms.Task(muIsoDepositTkDisplaced,muIsoDepositCalByAssociatorHitsDisplaced,muIsoDepositJetsDisplaced)
 muIsoDeposits_displacedMuons = cms.Sequence(muIsoDeposits_displacedMuonsTask)
 #old one, using a reduced config set
 muIsoDeposits_ParamGlobalMuonsOldTask = cms.Task(muParamGlobalIsoDepositGsTk,muParamGlobalIsoDepositCalEcal,muParamGlobalIsoDepositCalHcal)
 muIsoDeposits_ParamGlobalMuonsOld = cms.Sequence(muIsoDeposits_ParamGlobalMuonsOldTask)
-muIsoDeposits_ParamGlobalMuonsTask = cms.Task(muParamGlobalIsoDepositTk,muParamGlobalIsoDepositCalByAssociatorTowers,muParamGlobalIsoDepositJets)
+muIsoDeposits_ParamGlobalMuonsTask = cms.Task(muParamGlobalIsoDepositTk,muParamGlobalIsoDepositCalByAssociatorHits,muParamGlobalIsoDepositJets)
 muIsoDeposits_ParamGlobalMuons = cms.Sequence(muIsoDeposits_ParamGlobalMuonsTask)
 muParamGlobalIsoDepositCtfTk.IOPSet = cms.PSet(
     MIsoDepositParamGlobalViewIOBlock

--- a/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
@@ -11,7 +11,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoMuon.MuonIsolationProducers.muIsoDeposits_setup_cff import *
 #the default set of modules first
 from RecoMuon.MuonIsolationProducers.muIsoDepositCopies_cfi import *
-#from RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorHits_cfi import *
 import RecoMuon.MuonIsolationProducers.muIsoDepositTk_cfi
 import RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorTowers_cfi
 import RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorHits_cfi

--- a/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoDeposits_cff.py
@@ -11,9 +11,10 @@ import FWCore.ParameterSet.Config as cms
 from RecoMuon.MuonIsolationProducers.muIsoDeposits_setup_cff import *
 #the default set of modules first
 from RecoMuon.MuonIsolationProducers.muIsoDepositCopies_cfi import *
-from RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorHits_cfi import *
+#from RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorHits_cfi import *
 import RecoMuon.MuonIsolationProducers.muIsoDepositTk_cfi
 import RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorTowers_cfi
+import RecoMuon.MuonIsolationProducers.muIsoDepositCalByAssociatorHits_cfi
 import RecoMuon.MuonIsolationProducers.muIsoDepositJets_cfi
 import RecoMuon.MuonIsolationProducers.muIsoDepositCal_cfi
 

--- a/RecoMuon/MuonIsolationProducers/python/muIsoResultInputBlocks_cfi.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoResultInputBlocks_cfi.py
@@ -16,5 +16,13 @@ UnweightedInputTowHcalDeps = cms.PSet(
     DepositThreshold = cms.double(-1.0),
     DepositWeight = cms.double(1.0)
 )
-
-
+UnweightedInputHitEcalDeps = cms.PSet(
+    DepositTag = cms.InputTag("muIsoDepositCalByAssociatorHits","ecal"),
+    DepositThreshold = cms.double(-1.0),
+    DepositWeight = cms.double(1.0)
+)
+UnweightedInputTowHcalDeps = cms.PSet(
+    DepositTag = cms.InputTag("muIsoDepositCalByAssociatorHits","hcal"),
+    DepositThreshold = cms.double(-1.0),
+    DepositWeight = cms.double(1.0)
+)

--- a/RecoMuon/MuonIsolationProducers/python/muIsoResultInputBlocks_cfi.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoResultInputBlocks_cfi.py
@@ -21,7 +21,7 @@ UnweightedInputHitEcalDeps = cms.PSet(
     DepositThreshold = cms.double(-1.0),
     DepositWeight = cms.double(1.0)
 )
-UnweightedInputTowHcalDeps = cms.PSet(
+UnweightedInputHitHcalDeps = cms.PSet(
     DepositTag = cms.InputTag("muIsoDepositCalByAssociatorHits","hcal"),
     DepositThreshold = cms.double(-1.0),
     DepositWeight = cms.double(1.0)

--- a/RecoMuon/MuonIsolationProducers/python/muIsoResultM2C_cfi.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoResultM2C_cfi.py
@@ -14,10 +14,10 @@ muIsoResultM2C = cms.EDProducer("MuIsoCandidateResultProducer",
         UnweightedInputTkDeps
     ), 
         cms.PSet(
-            UnweightedInputTowEcalDeps
+            UnweightedInputHitEcalDeps
         ), 
         cms.PSet(
-            UnweightedInputTowHcalDeps
+            UnweightedInputHitHcalDeps
         )),
     BeamlineOption = cms.string('BeamSpotFromEvent')
 )

--- a/RecoMuon/MuonIsolationProducers/python/muIsoResultM2T_cfi.py
+++ b/RecoMuon/MuonIsolationProducers/python/muIsoResultM2T_cfi.py
@@ -13,10 +13,10 @@ muIsoResultM2T = cms.EDProducer("MuIsoTrackResultProducer",
         UnweightedInputTkDeps
     ), 
         cms.PSet(
-            UnweightedInputTowEcalDeps
+            UnweightedInputHitEcalDeps
         ), 
         cms.PSet(
-            UnweightedInputTowHcalDeps
+            UnweightedInputHitHcalDeps
         ))
 )
 


### PR DESCRIPTION
#### PR description:

This PR modifies muon isolation sequences to compute muon isolation using RecHits instead of CaloTowers, since CaloTower code is not maintained anymore. It affects prompt muons, displaced muons and cosmics.
The PR was triggered by issue #43858.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Run over dataset: `/RelValZMM_14/CMSSW_14_1_0_pre2-140X_mcRun4_realistic_v3_STD_2026D98_noPU-v6/GEN-SIM-DIGI-RAW`
Isolation plots before presented weird structures, now they look more natural and close to expected.
[1] CaloTower based Ecal iso, [2] RecHit based Ecal iso
[3] CaloTower based Hcal iso, [4] RecHit based Hcal iso

[1] <img src="https://github.com/cms-sw/cmssw/assets/68101581/6e20483d-6ed4-477d-920a-b8b21dc72e44"  width="360"> [2] <img src="https://github.com/cms-sw/cmssw/assets/68101581/324a2b74-8860-4e19-92b8-aca749c08e84" width="360">
[3] <img src="https://github.com/cms-sw/cmssw/assets/68101581/e73346aa-9d62-44b7-bfba-cb3966a96c55" width="360"> [4] <img src="https://github.com/cms-sw/cmssw/assets/68101581/eb54f8a7-facc-4b7f-b4d7-c9d1031cd353" width="360">

Apart from this, standard tests with runTheMatrix WFs have been run.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and in principle it is not intended to be backported.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
