### PR TITLE
Fix position of unconstrained pT coming from OMTF (backport for 14_0_X)

### DIFF
--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -42,7 +42,7 @@ namespace l1t {
                                           bool isKbmtf,
                                           bool useOmtfDisplacementInfo,
                                           bool useEmtfDisplacementInfo);
-    static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman, bool useOmtfDisplacementInfo);
+    static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
 
     static constexpr unsigned ptMask_ = 0x1FF;
     static constexpr unsigned ptShift_ = 0;
@@ -63,7 +63,7 @@ namespace l1t {
     static constexpr unsigned emtfDxyShift_ = 29;
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
     static constexpr unsigned bmtfPtUnconstrainedShift_ = 23;
-    static constexpr unsigned kOmtfPtUnconstrainedShift_ = 18;
+    static constexpr unsigned kOmtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -65,7 +65,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
         }
         l1upgradetfmuon_.tfMuonDecodedTrAdd.push_back(decoded_track_address);
         l1upgradetfmuon_.tfMuonHwTrAdd.push_back(
-            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isRun3_, isRun3_));
+            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isRun3_));
         l1upgradetfmuon_.nTfMuons++;
       }
     }


### PR DESCRIPTION
#### PR description:

Due to a miscommunication the incoming unconstrained pT from OMTF as expected at the wrong position in the bitword on the link. This PR fixes this.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/44798