### PR TITLE
[UBSAN] Fix shift exponent 64 is too large for 32-bit

### DIFF
--- a/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFgvbEE.h
+++ b/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFgvbEE.h
@@ -24,11 +24,8 @@ class EcalTPGFineGrainTowerEE;
 class EcalFenixTcpFgvbEE {
 private:
   uint32_t fgee_lut_;
-  std::vector<int> indexLut_;
 
 public:
-  EcalFenixTcpFgvbEE(int maxNrSamples);
-  virtual ~EcalFenixTcpFgvbEE();
   void setParameters(uint32_t towid, const EcalTPGFineGrainTowerEE *ecaltpgFineGrainTowerEE);
 
   void process(std::vector<std::vector<int>> &bypasslin_out, int nStr, int bitMask, std::vector<int> &output);

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc
@@ -24,7 +24,7 @@ EcalFenixTcp::EcalFenixTcp(
   formatter_EB_ = new EcalFenixTcpFormatEB(tcpFormat, debug_, famos, binOfMax);
   formatter_EE_ = new EcalFenixTcpFormatEE(tcpFormat, debug_, famos, binOfMax);
   fgvbEB_ = new EcalFenixFgvbEB(maxNrSamples);
-  fgvbEE_ = new EcalFenixTcpFgvbEE(maxNrSamples);
+  fgvbEE_ = new EcalFenixTcpFgvbEE();
   sfgvbEB_ = new EcalFenixTcpsFgvbEB();
 
   // permanent data structures

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc
@@ -4,31 +4,28 @@
 #include <iostream>
 
 //---------------------------------------------------------------
-EcalFenixTcpFgvbEE::EcalFenixTcpFgvbEE(int maxNrSamples) {
-  indexLut_.resize(maxNrSamples);
-}  //---------------------------------------------------------------
-EcalFenixTcpFgvbEE::~EcalFenixTcpFgvbEE() {}
-//---------------------------------------------------------------
 void EcalFenixTcpFgvbEE::process(std::vector<std::vector<int>> &bypasslin_out,
                                  int nStr,
                                  int bitMask,
                                  std::vector<int> &output) {
-  //  std::vector<int> indexLut(output.size());
-
   for (unsigned int i = 0; i < output.size(); i++) {
     output[i] = 0;
-    indexLut_[i] = 0;
   }
 
+  //Return if fgee_lut_ is 0
+  if (fgee_lut_ == 0) {
+    return;
+  }
+
+  int indexLut = 0;
   for (unsigned int i = 0; i < output.size(); i++) {
+    indexLut = 0;
     for (int istrip = 0; istrip < nStr; istrip++) {
       int res = (bypasslin_out[istrip])[i];
       res = (res >> bitMask) & 1;  // res is FGVB at this stage
-      indexLut_[i] = indexLut_[i] | (res << istrip);
+      indexLut = indexLut | (res << istrip);
     }
-    indexLut_[i] = indexLut_[i] | (nStr << 5);
-
-    int mask = 1 << indexLut_[i];
+    int mask = 1 << indexLut;
     output[i] = fgee_lut_ & mask;
     if (output[i] > 0)
       output[i] = 1;


### PR DESCRIPTION
In UBSAN IBs, we have  runtime errors like [a]. This PR proposes the following changes

- No need to have [`std::vector<int> EcalFenixTcpFgvbEE::indexLut_`](https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/EcalTrigPrimAlgos/interface/EcalFenixTcpFgvbEE.h#L27) to keep track on temp `indexLut`
- No need to do any processing if `EcalFenixTcpFgvbEE::fgee_lut_==0` 
- For [nStr>0](https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc#L29), `(nStr<<5) will be >=32` causing [`1<<indexLut`](https://github.com/cms-sw/cmssw/blob/master/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc#L31) to have undefined dehaviour (shifting more than the size of the integer is undefined behavior)
- Cleanup unnecessary constructor/destructor

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/raw/el8_amd64_gcc12/CMSSW_14_1_UBSAN_X_2024-04-19-2300/pyRelValMatrixLogs/run/5.1_TTbarFS/step1_TTbarFS.log
```
src/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc:31:18: runtime error: shift exponent 64 is too large for 32-bit type 'int'
    #0 0x154723ca8350 in EcalFenixTcpFgvbEE::process(std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&, int, int, std::vector<int, std::allocator<int> >&) src/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcpFgvbEE.cc:31
    #1 0x154723d57ec9 in EcalFenixTcp::process_part2_endcap(std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&, int, int, int, EcalTPGLutGroup const*, EcalTPGLutIdMap const*, EcalTPGFineGrainTowerEE const*, EcalTPGTowerStatus const*, std::vector<EcalTriggerPrimitiveSample, std::allocator<EcalTriggerPrimitiveSample> >&, std::vector<EcalTriggerPrimitiveSample, std::allocator<EcalTriggerPrimitiveSample> >&, bool, EcalTrigTowerDetId) src/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc:229
    #2 0x154723d5d16d in EcalFenixTcp::process(std::vector<EEDataFrame, std::allocator<EEDataFrame> >&, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >&, int, std::vector<EcalTriggerPrimitiveSample, std::allocator<EcalTriggerPrimitiveSample> >&, std::vector<EcalTriggerPrimitiveSample, std::allocator<EcalTriggerPrimitiveSample> >&, bool, EcalTrigTowerDetId) src/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixTcp.cc:96
```