### PR TITLE
Update ROOT::TAttMarker class version

### DIFF
--- a/DQMServices/Components/test/testSchemaEvolution.cpp
+++ b/DQMServices/Components/test/testSchemaEvolution.cpp
@@ -64,7 +64,11 @@ void TestSchemaEvolution::fillBaseline() {
   unique_classes_current_.insert(std::make_pair("TH2", 5));
   unique_classes_current_.insert(std::make_pair("TH1", 8));
   unique_classes_current_.insert(std::make_pair("TProfile", 7));
+#if ROOT_VERSION_CODE < ROOT_VERSION(6, 33, 0)
   unique_classes_current_.insert(std::make_pair("TAttMarker", 2));
+#else
+  unique_classes_current_.insert(std::make_pair("TAttMarker", 3));
+#endif
   unique_classes_current_.insert(std::make_pair("TArray", 1));
   unique_classes_current_.insert(std::make_pair("TAxis", 10));
   unique_classes_current_.insert(std::make_pair("TProfile2D", 8));


### PR DESCRIPTION
For root master branch `TAttMarker` [class def version has been updated](https://github.com/root-project/root/pull/15021/files). This change is needed to integrate latest ROOT master changes in ROOT6 IBs (https://github.com/cms-sw/cmsdist/pull/9151).

