### PR TITLE
[14.0.X] `BrokenLineFit` and `RiemannFit`: mask asserts behind `DEBUG` flags

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/BrokenLineFit.dev.cc
@@ -160,11 +160,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }
         brokenline::fastFit(acc, hits, fast_fit);
 
-        // no NaN here....
-        ALPAKA_ASSERT_ACC(fast_fit(0) == fast_fit(0));
-        ALPAKA_ASSERT_ACC(fast_fit(1) == fast_fit(1));
-        ALPAKA_ASSERT_ACC(fast_fit(2) == fast_fit(2));
-        ALPAKA_ASSERT_ACC(fast_fit(3) == fast_fit(3));
+#ifdef BROKENLINE_DEBUG
+        // any NaN value should cause the track to be rejected at a later stage
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(0)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(1)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(2)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(3)));
+#endif
       }
     }
   };

--- a/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/RiemannFit.dev.cc
@@ -82,11 +82,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         }
         riemannFit::fastFit(acc, hits, fast_fit);
 
-        // no NaN here....
-        ALPAKA_ASSERT_ACC(fast_fit(0) == fast_fit(0));
-        ALPAKA_ASSERT_ACC(fast_fit(1) == fast_fit(1));
-        ALPAKA_ASSERT_ACC(fast_fit(2) == fast_fit(2));
-        ALPAKA_ASSERT_ACC(fast_fit(3) == fast_fit(3));
+#ifdef RIEMANN_DEBUG
+        // any NaN value should cause the track to be rejected at a later stage
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(0)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(1)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(2)));
+        ALPAKA_ASSERT_ACC(not alpaka::math::isnan(acc, fast_fit(3)));
+#endif
       }
     }
   };


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44801

#### PR description:

Fixes https://github.com/cms-sw/cmssw/issues/44786.
As described in the issue this will avoid triggering assertion failures on GPU when running the example in https://github.com/cms-sw/cmssw/issues/44786#issue-2253910665, this - incidentally - is also the status quo on CUDA, see https://github.com/cms-sw/cmssw/issues/44786#issuecomment-2068008046.
Implements masking assertions behind compilation flag `BROKENLINE_DEBUG` as per https://github.com/cms-sw/cmssw/issues/44786#issuecomment-2069592783.

#### PR validation:

```bash
#!/bin/bash -ex

# CMSSW_14_0_5_patch2

hltGetConfiguration run:379617 \
  --globaltag 140X_dataRun3_HLT_v3 \
  --data \
  --no-prescale \
  --no-output \
  --max-events -1 \
  --input /store/group/tsg/FOG/debug/240417_run379617/run379617_ls0329_index000242_fu-c2b02-12-01_pid3327112.root  > hlt.py
  
cmsRun hlt.py &> hlt.log
```

runs fine in this branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/44801 to 14.0.X for HLT online data-taking purposes.