### PR TITLE
Correct one filterBit name in EGMNano and add one more

### DIFF
--- a/PhysicsTools/NanoAOD/python/egamma_custom_cff.py
+++ b/PhysicsTools/NanoAOD/python/egamma_custom_cff.py
@@ -45,8 +45,8 @@ customElectronFilterBits = cms.PSet(
         mksel("filter('hltEG50EBEtFilter')","1e Photon50EB"),
         #HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL
         mksel("filter('hltEle16Ele12Ele8CaloIdLTrackIdLDphiLeg3Filter')","3e Leg3"),
-        #HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL
-        mksel("filter('hltMu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter')","1mu-1e eLeg"),
+        #HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL (wildcarded as the name is likely going to change soon)
+        mksel("filter('hltMu*TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter')","1mu-1e eLeg"),
         #HLT_Ele24_eta2p1_WPTight_Gsf_PNetTauhPFJet30_*_eta2p3_CrossL1 OR HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1
         mksel("filter('hltEle24erWPTightGsfTrackIsoFilterForTau')","1e-1tau eLeg"), 
     )

--- a/PhysicsTools/NanoAOD/python/egamma_custom_cff.py
+++ b/PhysicsTools/NanoAOD/python/egamma_custom_cff.py
@@ -48,7 +48,9 @@ customElectronFilterBits = cms.PSet(
         #HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL (wildcarded as the name is likely going to change soon)
         mksel("filter('hltMu*TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter')","1mu-1e eLeg"),
         #HLT_Ele24_eta2p1_WPTight_Gsf_PNetTauhPFJet30_*_eta2p3_CrossL1 OR HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1
-        mksel("filter('hltEle24erWPTightGsfTrackIsoFilterForTau')","1e-1tau eLeg"), 
+        mksel("filter('hltEle24erWPTightGsfTrackIsoFilterForTau')","1e-1tau eLeg"),
+        #HLT_Ele115_CaloIdVT_GsfTrkIdT
+        mksel("filter('hltEle115CaloIdVTGsfTrkIdTGsfDphiFilter')","1e high pT noIso"),
     )
 )
 


### PR DESCRIPTION
#### PR description:

Make the final filter of `HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoV` consistent with the new naming convention, as pointed out by @missirol in https://github.com/cms-sw/cmssw/pull/44524#discussion_r1536670975. The name had already been changed in 140X.

Moreover, I have added another filterBit for `HLT_Ele115_CaloIdVT_GsfTrkIdT`.

#### PR validation:

Nothing special to validate besides what was already done in #44496 and #44524.