### PR TITLE
miscellaneous improvements to `LSNumberFilter`

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/LSNumberFilter.cc
@@ -1,12 +1,11 @@
-#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include <iostream>
 
 //
 // class declaration
@@ -15,22 +14,30 @@
 class LSNumberFilter : public edm::stream::EDFilter<> {
 public:
   explicit LSNumberFilter(const edm::ParameterSet&);
-  ~LSNumberFilter() override;
+  ~LSNumberFilter() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   bool filter(edm::Event&, const edm::EventSetup&) override;
-  bool is_HLT_vetoed;
-  unsigned int minLS;
-  const std::vector<std::string> veto_HLT_Menu;
+  bool is_HLT_vetoed_;
+  const unsigned int minLS_;
+  const std::vector<std::string> veto_HLT_Menu_;
   HLTConfigProvider hltConfig_;
 };
 
-LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig)
-    : minLS(iConfig.getUntrackedParameter<unsigned>("minLS", 21)),
-      veto_HLT_Menu(iConfig.getUntrackedParameter<std::vector<std::string>>("veto_HLT_Menu")) {}
+void LSNumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Filters the first minLS lumisections and reject the run according to the HLT menu name");
+  desc.addUntracked<unsigned int>("minLS", 21)->setComment("first LS to accept");
+  desc.addUntracked<std::vector<std::string>>("veto_HLT_Menu", {})->setComment("list of HLT menus to reject");
+  descriptions.addWithDefaultLabel(desc);
+}
 
-LSNumberFilter::~LSNumberFilter() {}
+LSNumberFilter::LSNumberFilter(const edm::ParameterSet& iConfig)
+    : minLS_(iConfig.getUntrackedParameter<unsigned>("minLS", 21)),
+      veto_HLT_Menu_(iConfig.getUntrackedParameter<std::vector<std::string>>("veto_HLT_Menu")) {}
 
 //
 // member functions
@@ -38,21 +45,22 @@ LSNumberFilter::~LSNumberFilter() {}
 
 // ------------ method called on each new Event  ------------
 bool LSNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  if ((iEvent.luminosityBlock() < minLS) || is_HLT_vetoed)
+  if ((iEvent.luminosityBlock() < minLS_) || is_HLT_vetoed_) {
     return false;
+  }
 
   return true;
 }
 
 void LSNumberFilter::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
-  bool changed(false);
+  bool changed{false};
   hltConfig_.init(iRun, iSetup, "HLT", changed);
-  is_HLT_vetoed = false;
-  for (unsigned int i = 0; i < veto_HLT_Menu.size(); i++) {
-    std::size_t found = hltConfig_.tableName().find(veto_HLT_Menu[i]);
+  is_HLT_vetoed_ = false;
+  for (const auto& veto : veto_HLT_Menu_) {
+    std::size_t found = hltConfig_.tableName().find(veto);
     if (found != std::string::npos) {
-      is_HLT_vetoed = true;
-      edm::LogWarning("LSNumberFilter") << "Detected " << veto_HLT_Menu[i]
+      is_HLT_vetoed_ = true;
+      edm::LogWarning("LSNumberFilter") << "Detected " << veto
                                         << " in HLT Config tableName(): " << hltConfig_.tableName()
                                         << "; Events of this run will be ignored" << std::endl;
       break;

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli0T_cff.py
@@ -151,7 +151,7 @@ SiPixelAliMillePedeFileConverter = cms.EDProducer("MillePedeFileConverter",
 
 
 seqALCARECOPromptCalibProdSiPixelAli = cms.Sequence(ALCARECOTkAlMinBiasFilterForSiPixelAli*
-                                                    lsNumberFilter*
+                                                    LSNumberFilter*
                                                     offlineBeamSpot*
                                                     SiPixelAliHighPuritySelector*
                                                     SiPixelAliTrackRefitter0*

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHGDiMuon_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHGDiMuon_cff.py
@@ -123,7 +123,7 @@ SiPixelAliMillePedeFileConverterHGDimuon = cms.EDProducer("MillePedeFileConverte
                                                          fileBlobLabel = cms.string(''))
 
 seqALCARECOPromptCalibProdSiPixelAliHGDiMu = cms.Sequence(ALCARECOTkAlZMuMuFilterForSiPixelAli*
-                                                          lsNumberFilter*
+                                                          LSNumberFilter*
                                                           offlineBeamSpot*
                                                           SiPixelAliHighPuritySelectorHGDimuon*
                                                           SiPixelAliTrackRefitterHGDimuon0*

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHG_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAliHG_cff.py
@@ -64,7 +64,7 @@ SiPixelAliMillePedeFileConverterHG = cms.EDProducer("MillePedeFileConverter",
                                                     fileBlobLabel = cms.string(''))
 
 seqALCARECOPromptCalibProdSiPixelAliHG = cms.Sequence(ALCARECOTkAlMinBiasFilterForSiPixelAliHG*
-                                                      lsNumberFilter*
+                                                      LSNumberFilter*
                                                       offlineBeamSpot*
                                                       SiPixelAliHighPuritySelectorHG*
                                                       SiPixelAliTrackRefitterHG0*

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOPromptCalibProdSiPixelAli_cff.py
@@ -149,7 +149,7 @@ SiPixelAliMillePedeFileConverter = cms.EDProducer("MillePedeFileConverter",
 
 
 seqALCARECOPromptCalibProdSiPixelAli = cms.Sequence(ALCARECOTkAlMinBiasFilterForSiPixelAli*
-                                                    lsNumberFilter*
+                                                    LSNumberFilter*
                                                     offlineBeamSpot*
                                                     SiPixelAliHighPuritySelector*
                                                     SiPixelAliTrackRefitter0*

--- a/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-lsNumberFilter = cms.EDFilter("LSNumberFilter",
-                              minLS = cms.untracked.uint32(21),
-                              veto_HLT_Menu = cms.untracked.vstring("LumiScan")
-                              )
+from Alignment.CommonAlignmentProducer.lsNumberFilter_cfi import lsNumberFilter
+LSNumberFilter = lsNumberFilter.clone(minLS = 21,
+                                      veto_HLT_Menu = ["LumiScan"])

--- a/Alignment/CommonAlignmentProducer/python/customizeLSNumberFilterForRelVals.py
+++ b/Alignment/CommonAlignmentProducer/python/customizeLSNumberFilterForRelVals.py
@@ -6,8 +6,8 @@ import FWCore.ParameterSet.Config as cms
 ##
 
 def doNotFilterLS(process):
-    if hasattr(process,'lsNumberFilter'):
-        process.lsNumberFilter.minLS = 1
+    if hasattr(process,'LSNumberFilter'):
+        process.LSNumberFilter.minLS = 1
     return process
 
 ##


### PR DESCRIPTION
#### PR description:

Quick followup on top of https://github.com/cms-sw/cmssw/pull/44783. 
Some miscellaneous improvements to the `LSNumberFilter` (mainly adding a `fillDescriptions` method and use it for configuring the Tk Al PCL modules).

#### PR validation:

PR was validated by testing the MilleStep for one nominal run (Run 379530) and the Lumiscan run (Run 379524), using the following command:

```
cmsDriver.py milleStep \
	     -s ALCA:PromptCalibProdSiPixelAli \
	     --conditions 140X_dataRun3_Express_v2 \
	     --scenario pp \
	     --data \
	     --era Run3 \
	     --datatier ALCARECO \
	     --eventcontent ALCARECO \
	     --processName=ReAlCa \
	     -n 100 \
	     --dasquery='file dataset=/StreamExpress/Run2024C-TkAlMinBias-Express-v1/ALCARECO run=379530'
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported together with https://github.com/cms-sw/cmssw/pull/44783 to CMSSW_14_0_X.