### PR TITLE
fix skipping qBin when reading template info

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -220,11 +220,20 @@ void PixelCPEFastParamsHost<TrackerTraits>::fillParamsForDevice() {
     // sample x by charge
     int qbin = pixelCPEforDevice::kGenErrorQBins;  // low charge
     int k = 0;
-    for (int qclus = 1000; qclus < 200000; qclus += 1000) {
+    int qClusIncrement = 100;
+    for (int qclus = 1000; k < pixelCPEforDevice::kGenErrorQBins;
+         qclus += qClusIncrement) {  //increase charge until we cover all qBin categories
       errorFromTemplates(p, cp, qclus);
       if (cp.qBin_ == qbin)
         continue;
       qbin = cp.qBin_;
+      //There are two qBin categories with low charge. Their qBins are 5 and 4 (pixelCPEforDevice::kGenErrorQBins, pixelCPEforDevice::kGenErrorQBins-1)
+      //We increment charge until qBin gets switched from 5 and then we start writing detParams as we are not interested in cases with qBin=5
+      //The problem is that with a too large qClusIncrement, we may go directly from 5 to 3, breaking the logic of the for loop
+      //Therefore, we start with lower increment (100) until we get to qBin=4
+      if (qbin < pixelCPEforDevice::kGenErrorQBins) {
+        qClusIncrement = 1000;
+      }
       g.xfact[k] = cp.sigmax;
       g.yfact[k] = cp.sigmay;
       g.minCh[k++] = qclus;


### PR DESCRIPTION
#### PR description:

Fixes a bug in the alpaka workflow when filling out template information used for error estimation in the generic algorithm for cluster parameter estimation. The current implementation would, for specific module and template combinations, fill information in wrong qBin categories. The effect of this is small as it only affects RecHit position errors for certain modules.

This fix was part of [Irradiation Bias Correction at Alpaka PR](https://github.com/cms-sw/cmssw/pull/44569). I am splitting it in two because IBC needs further studies.

#### PR validation:

`runTheMatrix.py -l limited -i all --ibeos` returns `47 46 45 36 19 1 1 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 0 failed`

HLT timing comparison was made in 14_0_5 with the `/dev/CMSSW_14_0_0/GRun` configuration. Throughput between [release](https://cmshlttiming.app.cern.ch/display/mrogulji/CMSSW_14_0_5_skimtest.20240422_174538) and [release + PR](https://cmshlttiming.app.cern.ch/display/mrogulji/CMSSW_14_0_5_qbin_fix.20240423_090656) is 587.8 +/- 0.4 evt/s versus 587.0 +/- 2.9

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will backport to 14_0_X