### PR TITLE
[MTD] Mtd association maps: remove energy selection for ETL clusters

### DIFF
--- a/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
+++ b/SimFastTiming/MtdAssociatorProducers/plugins/MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl.cc
@@ -111,9 +111,9 @@ reco::RecoToSimCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
           float dtSig = std::abs((recoClus.time() - simClus.simLCTime()) / recoClus.timeError());
 
           // -- If the sim and reco clusters have common hits, fill the std:vector of sim clusters refs
-          if (!sharedHitIds.empty() && dE < energyCut_ &&
-              dtSig < timeCut_) {  // at least one hit in common + requirement on energy and time compatibility
-
+          if (!sharedHitIds.empty() &&
+              ((clusId.mtdSubDetector() == MTDDetId::BTL && dE < energyCut_ && dtSig < timeCut_) ||
+               (clusId.mtdSubDetector() == MTDDetId::ETL && dtSig < timeCut_))) {
             simClusterRefs.push_back(simClusterRef);
 
             LogDebug("MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl")
@@ -214,7 +214,9 @@ reco::SimToRecoCollectionMtd MtdRecoClusterToSimLayerClusterAssociatorByHitsImpl
           float dtSig = std::abs((recoClus.time() - simClus.simLCTime()) / recoClus.timeError());
 
           // -- If the sim and reco clusters have common hits, fill the std:vector of reco clusters refs
-          if (!sharedHitIds.empty() && dE < energyCut_ && dtSig < timeCut_) {
+          if (!sharedHitIds.empty() &&
+              ((clusId.mtdSubDetector() == MTDDetId::BTL && dE < energyCut_ && dtSig < timeCut_) ||
+               (clusId.mtdSubDetector() == MTDDetId::ETL && dtSig < timeCut_))) {
             // Create a persistent edm::Ref to the cluster
             edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> recoClusterRef =
                 edmNew::makeRefTo(recoClusH, &recoClus);


### PR DESCRIPTION
#### PR description:
This pull requests updates MtdAssociationMaps by removing the selection on the energy ratio between the reco cluster and MtdSimLayerCluster for ETL clusters. This follows from the ETL digitization model update of PR https://github.com/cms-sw/cmssw/pull/43762.

#### PR validation:
The code compiles and runs.
It was validated on a RelValSinglePiFlatPt0p7To10 sample.  The efficiency of reco-sim cluster association is recovered. 

![testPR](https://github.com/cms-sw/cmssw/assets/4562259/b2dad96b-8743-4e2c-b73b-ed245e954c4e)

