### PR TITLE
Update rocm_version.h include so that it works for ROCm 5.6 and above

### DIFF
--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include <hip/hip_runtime.h>
-#include <rocm-core/rocm_version.h>
+#include <rocm_version.h>
 #include <rocm_smi/rocm_smi.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
+++ b/HeterogeneousCore/ROCmServices/plugins/ROCmService.cc
@@ -6,7 +6,12 @@
 #include <vector>
 
 #include <hip/hip_runtime.h>
+#if HIP_VERSION_MAJOR >= 6
+// the location of rocm_version.h changed in HIP/ROCm 6.0
+#include <rocm-core/rocm_version.h>
+#else
 #include <rocm_version.h>
+#endif  // HIP_VERSION_MAJOR
 #include <rocm_smi/rocm_smi.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"


### PR DESCRIPTION
As suggested by @fwyzard , this change allows cmssw to build with both ROCm 5.6 and 6.X.