### PR TITLE
Do not include EventSetup record definitions in device code

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -9,11 +9,15 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/CaloRecHitDeviceCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyHostCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
+
+// Forward declaration of EventSetup records, to avoid propagating the dependency on framework headers to device code
+class PFRecHitHCALParamsRecord;
+class PFRecHitHCALTopologyRecord;
+class EcalPFRecHitThresholdsRcd;
+class PFRecHitECALTopologyRecord;
 
 // This file defines two structs:
 // 1) ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer::HCAL

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -8,8 +8,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
-#include "CalorimeterDefinitions.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 
+#include "CalorimeterDefinitions.h"
 #include "PFRecHitProducerKernel.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -4,9 +4,9 @@
 #include <utility>
 #include <variant>
 
-#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
 #include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -18,6 +18,9 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
+
 #include "CalorimeterDefinitions.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {


### PR DESCRIPTION
#### PR description:

Do not include `EventSetup` record definitions in device code.

To minimise the code changes, forward-declare the records in a common header, and include their definition only in host code.


#### PR validation:

Builds on top of CMSSW_14_1_X_2024-04-23-2300.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport is not required, though it may be prepared to keep the 14.0.x and 14.1.x alpaka code base consistent.