### PR TITLE
[14.0.X] `TrackingMonitoringClient`: fix axis labels for fake rate vs OnlineLumi, LS and PU

### DIFF
--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -57,9 +57,9 @@ TrackToTrackEfficiencies = DQMEDHarvester("DQMGenericClient",
         "FakeRate_dzWRTpv    'Relative Fake Rate vs dzWRTpv;d_{z};relative fake rate'           mon_unMatched_dzWRTpv   mon_dzWRTpv     eff",
         "FakeRate_charge     'Relative Fake Rate vs charge;charge;relative fake rate'           mon_unMatched_charge    mon_charge      eff",
         "FakeRate_hits       'Relative Fake Rate vs hits;number of hits;relative fake rate'     mon_unMatched_hits      mon_hits        eff",
-        "FakeRate_OnlineLumi 'Relative Fake Rate vs OnlineLumi;OnlineLumi E30 [Hz cm^{-2}];relative efficiency' mon_unMatched_onlinelumi mon_onlinelumi  eff",
-        "FakeRate_LS         'Relative Fake Rate vs LS;LS;relative efficiency'                  mon_unMatched_ls        mon_ls          eff",
-        "FakeRate_PU         'Relative Fake Rate vs PU;PU;relative efficiency'                  mon_unMatched_PU        mon_PU          eff",
+        "FakeRate_OnlineLumi 'Relative Fake Rate vs OnlineLumi;OnlineLumi E30 [Hz cm^{-2}];relative fake rate' mon_unMatched_onlinelumi mon_onlinelumi  eff",
+        "FakeRate_LS         'Relative Fake Rate vs LS;LS;relative fake rate'                  mon_unMatched_ls        mon_ls          eff",
+        "FakeRate_PU         'Relative Fake Rate vs PU;PU;relative fake rate'                  mon_unMatched_PU        mon_PU          eff",
     ),
 )
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44832

#### PR description:

Trivial bug-fix, noticed when looking at the recent (2024C) runs https://tinyurl.com/26yk5toj in the `HLTMonitor` DQM. These plots have been introduced from https://github.com/cms-sw/cmssw/pull/42547.

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of https://github.com/cms-sw/cmssw/pull/44832 to 2024 data-taking release (CMSSW_14_0_X)
