### PR TITLE
Make "Extended Vector" Default

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -137,12 +137,15 @@ inline auto dot(V x, V y) -> typename std::remove_reference<decltype(x[0])>::typ
 
 template <typename V1, typename V2>
 inline auto dot2(V1 x, V2 y) -> typename std::remove_reference<decltype(x[0])>::type {
-  typedef typename std::remove_reference<decltype(x[0])>::type T;
-  T ret = 0;
-  for (int i = 0; i != 2; ++i)
-    ret += x[i] * y[i];
-  return ret;
+  return  x[0] * y[0] + x[1] * y[1];
 }
+
+template <typename V1, typename V2>
+inline auto dot3(V1 x, V2 y) -> typename std::remove_reference<decltype(x[0])>::type {
+  auto z = x*y; 
+  return  z[0] + z[1] + z[2];
+}
+
 
 typedef Vec2<float> Vec2F;
 typedef Vec4<float> Vec4F;

--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -137,15 +137,14 @@ inline auto dot(V x, V y) -> typename std::remove_reference<decltype(x[0])>::typ
 
 template <typename V1, typename V2>
 inline auto dot2(V1 x, V2 y) -> typename std::remove_reference<decltype(x[0])>::type {
-  return  x[0] * y[0] + x[1] * y[1];
+  return x[0] * y[0] + x[1] * y[1];
 }
 
 template <typename V1, typename V2>
 inline auto dot3(V1 x, V2 y) -> typename std::remove_reference<decltype(x[0])>::type {
-  auto z = x*y; 
-  return  z[0] + z[1] + z[2];
+  auto z = x * y;
+  return z[0] + z[1] + z[2];
 }
-
 
 typedef Vec2<float> Vec2F;
 typedef Vec4<float> Vec4F;

--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -9,9 +9,9 @@
 #elif defined(__INTEL_COMPILER)
 // intel compiler does not support the extended vector syntax
 #define USE_SSEVECT
-#elif defined(__GNUC__) || defined(__clang__) 
+#elif defined(__GNUC__) || defined(__clang__)
 #if defined(__x86_64__) && defined(__SSE__) && defined(CMS_PREFER_SSEVECT)
- #define USE_SSEVECT
+#define USE_SSEVECT
 #else
 #define USE_EXTVECT
 #endif
@@ -60,8 +60,8 @@ namespace mathSSE {
 
 #if defined(USE_EXTVECT)
 #include "DataFormats/Math/interface/ExtVec.h"
-#elif defined(USE_SSEVECT) 
-#if !defined(CMS_PREFER_SSEVECT)  || !defined(__INTEL_COMPILER)
+#elif defined(USE_SSEVECT)
+#if !defined(CMS_PREFER_SSEVECT) || !defined(__INTEL_COMPILER)
 #warning "using SSEVECT even if not requirested?????"
 #endif
 #include "DataFormats/Math/interface/SSEVec.h"

--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -1,10 +1,17 @@
 #ifndef DataFormat_Math_SIMDVec_H
 #define DataFormat_Math_SIMDVec_H
-
+//
+//  For sustenaibility prefer the use of hte implementation based on the extended vector syntax
+//  supported by gcc and clang on all architectures
+//
+//
 #if (defined(__CLING__) || defined(__MIC__) || defined(__NVCC__)) || (__BIGGEST_ALIGNMENT__ < 16)
-#elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
-#if defined(__x86_64__) && defined(__SSE__)
+#elif defined(__INTEL_COMPILER)
+// intel compiler does not support the extended vector syntax
 #define USE_SSEVECT
+#elif defined(__GNUC__) || defined(__clang__) 
+#if defined(__x86_64__) && defined(__SSE__) && defined(CMS_PREFER_SSEVECT)
+ #define USE_SSEVECT
 #else
 #define USE_EXTVECT
 #endif
@@ -53,7 +60,10 @@ namespace mathSSE {
 
 #if defined(USE_EXTVECT)
 #include "DataFormats/Math/interface/ExtVec.h"
-#elif defined(USE_SSEVECT)
+#elif defined(USE_SSEVECT) 
+#if !defined(CMS_PREFER_SSEVECT)  || !defined(__INTEL_COMPILER)
+#warning "using SSEVECT even if not requirested?????"
+#endif
 #include "DataFormats/Math/interface/SSEVec.h"
 #include "DataFormats/Math/interface/SSERot.h"
 #endif

--- a/DataFormats/Math/interface/SSERot.h
+++ b/DataFormats/Math/interface/SSERot.h
@@ -72,7 +72,6 @@ namespace mathSSE {
 
   typedef Rot3<double> Rot3D;
 
-
 #ifdef CMS_USE_SSE4
   template <>
   inline Vec4<float> Rot3<float>::rotate(Vec4<float> v) const {
@@ -85,7 +84,6 @@ namespace mathSSE {
   }
 
 #endif
-
 
 }  // namespace mathSSE
 

--- a/DataFormats/Math/interface/SSERot.h
+++ b/DataFormats/Math/interface/SSERot.h
@@ -72,7 +72,8 @@ namespace mathSSE {
 
   typedef Rot3<double> Rot3D;
 
-#ifdef __SSE4_1__
+
+#ifdef CMS_USE_SSE4
   template <>
   inline Vec4<float> Rot3<float>::rotate(Vec4<float> v) const {
     return _mm_or_ps(_mm_or_ps(_mm_dp_ps(axis[0].vec, v.vec, 0x71), _mm_dp_ps(axis[1].vec, v.vec, 0x72)),
@@ -84,6 +85,7 @@ namespace mathSSE {
   }
 
 #endif
+
 
 }  // namespace mathSSE
 

--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -7,7 +7,7 @@
 #include <x86intrin.h>
 #define CMS_USE_SSE
 #ifdef __SSE4_1__
-// slower than sse3 
+// slower than sse3
 // #define CMS_USE_SSE4
 #endif
 #ifdef __AVX2__
@@ -29,7 +29,6 @@ namespace mathSSE {
 #ifdef CMS_USE_SSE
   //dot
   inline __m128 __attribute__((always_inline)) __attribute__((pure)) _mm_dot_ps(__m128 v1, __m128 v2) {
-
 #ifdef CMS_USE_SSE4
     /// this is slower than the scalar version!
     return _mm_dp_ps(v1, v2, 0xff);
@@ -555,9 +554,7 @@ inline float dot(mathSSE::Vec4F a, mathSSE::Vec4F b) {
   return s;
 }
 
-inline float dot3(mathSSE::Vec4F a, mathSSE::Vec4F b) {
-  return dot(a,b);
-}
+inline float dot3(mathSSE::Vec4F a, mathSSE::Vec4F b) { return dot(a, b); }
 
 inline mathSSE::Vec4F cross(mathSSE::Vec4F a, mathSSE::Vec4F b) {
   using mathSSE::_mm_cross_ps;
@@ -763,7 +760,7 @@ inline mathSSE::Vec4D operator-(mathSSE::Vec4D b, mathSSE::Vec4F a) {
 inline double dot(mathSSE::Vec4D a, mathSSE::Vec4D b) __attribute__((always_inline)) __attribute__((pure));
 
 inline double __attribute__((always_inline)) __attribute__((pure)) dot3(mathSSE::Vec4D a, mathSSE::Vec4D b) {
-  return dot(a,b);
+  return dot(a, b);
 }
 
 inline double dot(mathSSE::Vec4D a, mathSSE::Vec4D b) {

--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -6,6 +6,10 @@
 #if defined(__GNUC__)
 #include <x86intrin.h>
 #define CMS_USE_SSE
+#ifdef __SSE4_1__
+// slower than sse3 
+// #define CMS_USE_SSE4
+#endif
 #ifdef __AVX2__
 #define CMS_USE_AVX2
 #endif /* __AVX2__ */
@@ -25,9 +29,12 @@ namespace mathSSE {
 #ifdef CMS_USE_SSE
   //dot
   inline __m128 __attribute__((always_inline)) __attribute__((pure)) _mm_dot_ps(__m128 v1, __m128 v2) {
-#ifdef __SSE4_1__
+
+#ifdef CMS_USE_SSE4
+    /// this is slower than the scalar version!
     return _mm_dp_ps(v1, v2, 0xff);
 #else
+
     __m128 mul = _mm_mul_ps(v1, v2);
 #ifdef __SSE3__
     mul = _mm_hadd_ps(mul, mul);
@@ -548,6 +555,10 @@ inline float dot(mathSSE::Vec4F a, mathSSE::Vec4F b) {
   return s;
 }
 
+inline float dot3(mathSSE::Vec4F a, mathSSE::Vec4F b) {
+  return dot(a,b);
+}
+
 inline mathSSE::Vec4F cross(mathSSE::Vec4F a, mathSSE::Vec4F b) {
   using mathSSE::_mm_cross_ps;
   return _mm_cross_ps(a.vec, b.vec);
@@ -750,6 +761,10 @@ inline mathSSE::Vec4D operator-(mathSSE::Vec4D b, mathSSE::Vec4F a) {
 */
 
 inline double dot(mathSSE::Vec4D a, mathSSE::Vec4D b) __attribute__((always_inline)) __attribute__((pure));
+
+inline double __attribute__((always_inline)) __attribute__((pure)) dot3(mathSSE::Vec4D a, mathSSE::Vec4D b) {
+  return dot(a,b);
+}
 
 inline double dot(mathSSE::Vec4D a, mathSSE::Vec4D b) {
   __m128d res = _mm_add_sd(_mm_mul_pd(a.vec[0], b.vec[0]), _mm_mul_sd(a.vec[1], b.vec[1]));

--- a/DataFormats/Math/test/BuildFile.xml
+++ b/DataFormats/Math/test/BuildFile.xml
@@ -35,10 +35,15 @@
 
 <release name="!.*ICC_X.*">
   <bin file="ExtVec_t.cpp" name="DataFormatsExtVec_t">
+  <use name="ofast-flag"/>
+  <flags CXXFLAGS="-march=native"/>
 </bin>
-
 </release>
+
+
 <bin file="SSEVec_t.cpp" name="DataFormatsSSEVec_t">
+  <use name="ofast-flag"/> 
+  <flags CXXFLAGS="-march=native"/>
 </bin>
 
 <bin file="crossV4_t.cpp" name="DataFormatscrossV4_t">

--- a/DataFormats/Math/test/ExtVec_t.cpp
+++ b/DataFormats/Math/test/ExtVec_t.cpp
@@ -166,6 +166,7 @@ void go(bool dovec = true) {
   std::cout << apply(x, [](T x) { return std::sqrt(x); }) << std::endl;
 
   std::cout << dot(x, y) << std::endl;
+  std::cout << dot3(x, y) << std::endl;
   std::cout << dotSimple(x, y) << std::endl;
 
   //  std::cout << "equal" << (x==x ? " " : " not ") << "ok" << std::endl;

--- a/DataFormats/Math/test/SSEVec_t.cpp
+++ b/DataFormats/Math/test/SSEVec_t.cpp
@@ -99,7 +99,10 @@ void go2d() {
   vec3.reserve(50234);
 
   Vec2d k(-2.0, 3.14);
+  Vec2d nk = -k;
   std::cout << k << std::endl;
+  std::cout << -k << std::endl;
+  std::cout << nk << std::endl;
   std::cout << k + k << std::endl;
   std::cout << k * k << std::endl;
   Vec3d x(2.0, 4.0, 5.0);
@@ -145,10 +148,12 @@ void go(bool dovect = true) {
 
   Vec x(2.0, 4.0, 5.0);
   Vec y(-3.0, 2.0, -5.0);
+  Vec nx = -x;
   std::cout << x << std::endl;
   std::cout << Vec4<float>(x) << std::endl;
   std::cout << Vec4<double>(x) << std::endl;
   std::cout << -x << std::endl;
+  std::cout << nx << std::endl;
   std::cout << x.template get1<2>() << std::endl;
   std::cout << y << std::endl;
   std::cout << T(3.) * x << std::endl;
@@ -157,6 +162,7 @@ void go(bool dovect = true) {
   std::cout << mathSSE::sqrt(x) << std::endl;
 
   std::cout << dot(x, y) << std::endl;
+  std::cout << dot3(x, y) << std::endl;
   std::cout << dotSimple(x, y) << std::endl;
 
   std::cout << "equal" << (x == x ? " " : " not ") << "ok" << std::endl;

--- a/TrackingTools/AnalyticalJacobians/BuildFile.xml
+++ b/TrackingTools/AnalyticalJacobians/BuildFile.xml
@@ -10,3 +10,4 @@
 <use name="MagneticField/Engine"/>
 <use name="vdt_headers"/>
 <use name="rootmath"/>
+<use name="ofast-flag"/>

--- a/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianEXT.icc
+++ b/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianEXT.icc
@@ -49,9 +49,13 @@ void AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryPa
   double gamma = dot(hn, t2);
   Vec3D an = cross3(hn, t2);
 
+#ifdef __clang__
+  Vec4D t = __builtin_shufflevector(t1, t2, 1, 0, 5, 4);
+#else
   typedef unsigned long long v4sl __attribute__((vector_size(32)));
   v4sl mask{1, 0, 5, 4};
   Vec4D t = __builtin_shuffle(t1, t2, mask);
+#endif
   Vec4D tt = t * t;
 
   double au1 = std::sqrt(tt[0] + tt[1]);

--- a/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
@@ -52,11 +52,11 @@ void JacobianCurvilinearToLocal::compute(Surface::RotationType const& rot,
   if (cosl < 1.e-30)
     cosl = 1.e-30;
   double cosl1 = 1. / cosl;
-  GlobalVector un(-tn.y() * cosl1, tn.x() * cosl1, 0.);
-  GlobalVector vn(-tn.z() * un.y(), tn.z() * un.x(), cosl);
+  const GlobalVector un(-tn.y() * cosl1, tn.x() * cosl1, 0.);
+  const GlobalVector vn(-tn.z() * un.y(), tn.z() * un.x(), cosl);
 
-  auto u = rot.rotate(un.basicVector());
-  auto v = rot.rotate(vn.basicVector());
+  auto const u = rot.rotate(un.basicVector());
+  auto const v = rot.rotate(vn.basicVector());
 
   int j = 0, k = 1, i = 2;
 

--- a/TrackingTools/AnalyticalJacobians/test/Jacobian_t.cpp
+++ b/TrackingTools/AnalyticalJacobians/test/Jacobian_t.cpp
@@ -23,8 +23,18 @@ namespace {
 }  // namespace
 
 #include "FWCore/Utilities/interface/HRRealTime.h"
-void st() {}
-void en() {}
+void st(void* ptr) {
+  asm("" /* no instructions */
+      :  /* no inputs */
+      : /* output */ "rax"(ptr)
+      : /* pretend to clobber */ "memory");
+}
+void en(void const* ptr) {
+  asm("" /* no instructions */
+      :  /* no inputs */
+      : /* output */ "rax"(ptr)
+      : /* pretend to clobber */ "memory");
+}
 
 int main() {
   // GlobalVector xx(0.5,1.,1.);
@@ -92,73 +102,93 @@ int main() {
   // verify cart to curv and back....
   // AlgebraicMatrixID();
 
-  // L ->Cart
+  int N = 1000000;
+
+  // L =>Cart
   {
-    std::cout << "L ->Cart" << std::endl;
+    std::cout << "L =>Cart ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianLocalToCartesian __attribute__((aligned(16))) jl2c(plane, tp);
+      en(&jl2c.jacobian());
+    }
+    edm::HRTimeType e = edm::hrRealTime();
+    std::cout << double(e - s) / N << std::endl;
     JacobianLocalToCartesian __attribute__((aligned(16))) jl2c(plane, tp);
-    en();
-    edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
     std::cout << jl2c.jacobian() << std::endl;
   }
 
-  // L -> Curv
+  // L => Curv
   {
-    std::cout << "L ->Curv from loc" << std::endl;
+    std::cout << "L =>Curv from loc ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianLocalToCurvilinear __attribute__((aligned(16))) jl2c(plane, tp, m);
+      en(&jl2c.jacobian());
+    }
+    edm::HRTimeType e = edm::hrRealTime();
+    std::cout << double(e - s) / N << std::endl;
     JacobianLocalToCurvilinear __attribute__((aligned(16))) jl2c(plane, tp, m);
-    en();
-    edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
     std::cout << jl2c.jacobian() << std::endl;
   }
 
   {
-    std::cout << "L ->Curv from loc+glob" << std::endl;
+    std::cout << "L =>Curv from loc+glob ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianLocalToCurvilinear __attribute__((aligned(16))) jl2c(plane, tp, gp, m);
+      en(&jl2c.jacobian());
+    }
+    edm::HRTimeType e = edm::hrRealTime();
+    std::cout << double(e - s) / N << std::endl;
     JacobianLocalToCurvilinear __attribute__((aligned(16))) jl2c(plane, tp, gp, m);
-    en();
-    edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
     std::cout << jl2c.jacobian() << std::endl;
   }
 
-  // Cart -> Loc
+  // Cart => Loc
   {
-    std::cout << "Cart -> Loc" << std::endl;
+    std::cout << "Cart => Loc ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianCartesianToLocal __attribute__((aligned(16))) jl2c(plane, tp);
+      en(&jl2c.jacobian());
+    }
+    edm::HRTimeType e = edm::hrRealTime();
+    std::cout << double(e - s) / N << std::endl;
     JacobianCartesianToLocal __attribute__((aligned(16))) jl2c(plane, tp);
-    en();
-    edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
     std::cout << jl2c.jacobian() << std::endl;
   }
 
-  // Curv -> Loc
+  // Curv => Loc
   {
-    std::cout << "Curv -> Loc from loc" << std::endl;
+    std::cout << "Curv => Loc from loc ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianCurvilinearToLocal __attribute__((aligned(16))) jl2c(plane, tp, m);
+      en(&jl2c.jacobian());
+    }
+    edm::HRTimeType e = edm::hrRealTime();
+    std::cout << double(e - s) / N << std::endl;
     JacobianCurvilinearToLocal __attribute__((aligned(16))) jl2c(plane, tp, m);
-    en();
-    edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
     std::cout << jl2c.jacobian() << std::endl;
   }
 
   {
-    std::cout << "Curv -> Loc from loc + glob" << std::endl;
+    std::cout << "Curv => Loc from loc + glob ";
     edm::HRTimeType s = edm::hrRealTime();
-    st();
-    JacobianCurvilinearToLocal __attribute__((aligned(16))) jl2c(plane, tp, gp, m);
-    en();
+    for (int i = 0; i < N; ++i) {
+      st(&tp);
+      JacobianCurvilinearToLocal __attribute__((aligned(16))) jl2c(plane, tp, gp, m);
+      en(&jl2c.jacobian());
+    }
     edm::HRTimeType e = edm::hrRealTime();
-    std::cout << e - s << std::endl;
+    std::cout << double(e - s) / N << std::endl;
+    JacobianCurvilinearToLocal __attribute__((aligned(16))) jl2c(plane, tp, gp, m);
     std::cout << jl2c.jacobian() << std::endl;
   }
 


### PR DESCRIPTION
Following the presentations and discussion at the last 2 XCs
( see https://indico.cern.ch/event/1406814/#2-inputs-from-software-and-rec )
I propose here to make "ExtVec" default.

This choice is more sustainable in the long term as uses a single code-base for all platforms and versions (but ICC compiler).

I've also (re-)introduced fast in AnalyticJacobians as tests show a clear benefit.

regression expected (regression triggered the discussion after all!)