### PR TITLE
Propagate child process exit code properly in edmPluginRefresh

### DIFF
--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -272,9 +272,13 @@ int main(int argc, char** argv) try {
         // Throw if any of the child died with non 0 status.
         int status = 0;
         waitpid(worker, &status, 0);
-        if (WIFEXITED(status) == true && status != 0) {
-          std::cerr << "Error while processing." << std::endl;
-          exit(status);
+        if (WIFEXITED(status) != 0 and WEXITSTATUS(status) != 0) {
+          std::cerr << "Error in child process while processing: " << WEXITSTATUS(status) << std::endl;
+          exit(WEXITSTATUS(status));
+        }
+        if (WIFSIGNALED(status) != 0) {
+          std::cerr << "Child process got signal while processing: " << WTERMSIG(status) << std::endl;
+          exit(128 + WTERMSIG(status));
         }
       }
     }


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/44821#issuecomment-2072901862 reports the `edmPluginRefresh` returns a zero exit code even if a child process crashes. This PR propagates the non-zero exit code from the child process properly to the main process' `exit()` by using the `WEXITSTATUS()` macro as instructed in https://man7.org/linux/man-pages/man3/wait.3p.html.

Resolves https://github.com/cms-sw/framework-team/issues/901

#### PR validation:

The reproducer in https://github.com/cms-sw/cmssw/issues/44821#issuecomment-2072948835 returns non-zero exit code.
