### PR TITLE
Improve behavior after exception in begin/end global lumi

### DIFF
--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -540,9 +540,18 @@ void testGlobalFilter::testTransitions(std::shared_ptr<T> iMod, Expectations con
     edm::maker::ModuleHolderT<edm::global::EDFilterBase> h(iMod, nullptr);
     h.preallocate(edm::PreallocationConfiguration{});
 
-    edm::WorkerT<edm::global::EDFilterBase> w{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDFilterBase> wOther{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDFilterBase> wGlobalLumi{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDFilterBase> wStreamLumi{iMod, m_desc, nullptr};
     for (auto& keyVal : m_transToFunc) {
-      testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
+      edm::Worker* worker = &wOther;
+      if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+        worker = &wStreamLumi;
+      } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock ||
+                 keyVal.first == Trans::kGlobalEndLuminosityBlock) {
+        worker = &wGlobalLumi;
+      }
+      testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
     }
   });
 }

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -506,9 +506,18 @@ void testGlobalProducer::testTransitions(std::shared_ptr<T> iMod, Expectations c
     edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(iMod, nullptr);
     h.preallocate(edm::PreallocationConfiguration{});
 
-    edm::WorkerT<edm::global::EDProducerBase> w{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDProducerBase> wOther{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDProducerBase> wGlobalLumi{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDProducerBase> wStreamLumi{iMod, m_desc, nullptr};
     for (auto& keyVal : m_transToFunc) {
-      testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
+      edm::Worker* worker = &wOther;
+      if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+        worker = &wStreamLumi;
+      } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock ||
+                 keyVal.first == Trans::kGlobalEndLuminosityBlock) {
+        worker = &wGlobalLumi;
+      }
+      testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
     }
   });
 }

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -547,9 +547,17 @@ void testLimitedFilter::testTransitions(std::shared_ptr<T> iMod, Expectations co
 
   edm::maker::ModuleHolderT<edm::limited::EDFilterBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
-  edm::WorkerT<edm::limited::EDFilterBase> w{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDFilterBase> wOther{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDFilterBase> wGlobalLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDFilterBase> wStreamLumi{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
-    testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
+    edm::Worker* worker = &wOther;
+    if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+      worker = &wStreamLumi;
+    } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
+      worker = &wGlobalLumi;
+    }
+    testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
   }
 }
 

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -512,9 +512,17 @@ void testLimitedProducer::testTransitions(std::shared_ptr<T> iMod, Expectations 
 
   edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
-  edm::WorkerT<edm::limited::EDProducerBase> w{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDProducerBase> wOther{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDProducerBase> wGlobalLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDProducerBase> wStreamLumi{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
-    testTransition(iMod, &w, keyVal.first, iExpect, keyVal.second);
+    edm::Worker* worker = &wOther;
+    if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+      worker = &wStreamLumi;
+    } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
+      worker = &wGlobalLumi;
+    }
+    testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
   }
 }
 

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -587,9 +587,17 @@ template <typename T, typename U>
 void testStreamFilter::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
   oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
-  edm::WorkerT<edm::stream::EDFilterAdaptorBase> w{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wOther{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wGlobalLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wStreamLumi{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
-    testTransition<T>(&w, keyVal.first, iExpect, keyVal.second);
+    edm::Worker* worker = &wOther;
+    if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+      worker = &wStreamLumi;
+    } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
+      worker = &wGlobalLumi;
+    }
+    testTransition<T>(worker, keyVal.first, iExpect, keyVal.second);
   }
 }
 template <typename T>

--- a/FWCore/Integration/plugins/TestServiceOne.cc
+++ b/FWCore/Integration/plugins/TestServiceOne.cc
@@ -14,22 +14,54 @@
 
 #include "FWCore/Integration/plugins/TestServiceOne.h"
 
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/TimeOfDay.h"
+
+#include <ostream>
+
+using edm::GlobalContext;
+using edm::ModuleCallingContext;
+using edm::StreamContext;
+
+namespace {
+
+  class TimeStamper {
+  public:
+    TimeStamper(bool enable) : enabled_(enable) {}
+
+    friend std::ostream& operator<<(std::ostream& out, TimeStamper const& timestamp) {
+      if (timestamp.enabled_)
+        out << std::setprecision(2) << edm::TimeOfDay() << "  ";
+      return out;
+    }
+
+  private:
+    bool enabled_;
+  };
+
+  const char* globalIndent = "    ";
+  const char* globalModuleIndent = "        ";
+  const char* streamIndent = "            ";
+  const char* streamModuleIndent = "                ";
+}  // namespace
 
 namespace edmtest {
 
   TestServiceOne::TestServiceOne(edm::ParameterSet const& iPS, edm::ActivityRegistry& iRegistry)
-      : verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
+      : verbose_(iPS.getUntrackedParameter<bool>("verbose")),
+        printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps")) {
     iRegistry.watchPreBeginProcessBlock(this, &TestServiceOne::preBeginProcessBlock);
     iRegistry.watchPreEndProcessBlock(this, &TestServiceOne::preEndProcessBlock);
 
     iRegistry.watchPreGlobalBeginRun(this, &TestServiceOne::preGlobalBeginRun);
     iRegistry.watchPreGlobalEndRun(this, &TestServiceOne::preGlobalEndRun);
-    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceOne::preGlobalBeginLumi);
-    iRegistry.watchPreGlobalEndLumi(this, &TestServiceOne::preGlobalEndLumi);
 
     iRegistry.watchPreStreamBeginLumi(this, &TestServiceOne::preStreamBeginLumi);
     iRegistry.watchPostStreamBeginLumi(this, &TestServiceOne::postStreamBeginLumi);
@@ -40,103 +72,224 @@ namespace edmtest {
     iRegistry.watchPostModuleStreamBeginLumi(this, &TestServiceOne::postModuleStreamBeginLumi);
     iRegistry.watchPreModuleStreamEndLumi(this, &TestServiceOne::preModuleStreamEndLumi);
     iRegistry.watchPostModuleStreamEndLumi(this, &TestServiceOne::postModuleStreamEndLumi);
+
+    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceOne::preGlobalBeginLumi);
+    iRegistry.watchPostGlobalBeginLumi(this, &TestServiceOne::postGlobalBeginLumi);
+    iRegistry.watchPreGlobalEndLumi(this, &TestServiceOne::preGlobalEndLumi);
+    iRegistry.watchPostGlobalEndLumi(this, &TestServiceOne::postGlobalEndLumi);
+
+    iRegistry.watchPreModuleGlobalBeginLumi(this, &TestServiceOne::preModuleGlobalBeginLumi);
+    iRegistry.watchPostModuleGlobalBeginLumi(this, &TestServiceOne::postModuleGlobalBeginLumi);
+    iRegistry.watchPreModuleGlobalEndLumi(this, &TestServiceOne::preModuleGlobalEndLumi);
+    iRegistry.watchPostModuleGlobalEndLumi(this, &TestServiceOne::postModuleGlobalEndLumi);
+
+    iRegistry.watchPreGlobalWriteLumi(this, &TestServiceOne::preGlobalWriteLumi);
+    iRegistry.watchPostGlobalWriteLumi(this, &TestServiceOne::postGlobalWriteLumi);
   }
 
   void TestServiceOne::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages if true");
+    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages for every transition");
+    desc.addUntracked<bool>("printTimestamps", false)
+        ->setComment("Include a time stamp in message printed for every transition");
     descriptions.add("TestServiceOne", desc);
   }
 
-  void TestServiceOne::preBeginProcessBlock(edm::GlobalContext const&) {
+  void TestServiceOne::preBeginProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preBeginProcessBlock";
     }
   }
 
-  void TestServiceOne::preEndProcessBlock(edm::GlobalContext const&) {
+  void TestServiceOne::preEndProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preEndProcessBlock";
     }
   }
 
-  void TestServiceOne::preGlobalBeginRun(edm::GlobalContext const&) {
+  void TestServiceOne::preGlobalBeginRun(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalBeginRun";
     }
   }
 
-  void TestServiceOne::preGlobalEndRun(edm::GlobalContext const&) {
+  void TestServiceOne::preGlobalEndRun(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalEndRun";
     }
   }
 
-  void TestServiceOne::preGlobalBeginLumi(edm::GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalBeginLumi";
-    }
-  }
-
-  void TestServiceOne::preGlobalEndLumi(edm::GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalEndLumi";
-    }
-  }
-
-  void TestServiceOne::preStreamBeginLumi(edm::StreamContext const&) {
+  void TestServiceOne::preStreamBeginLumi(StreamContext const& sc) {
     ++nPreStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::postStreamBeginLumi(edm::StreamContext const&) {
+  void TestServiceOne::postStreamBeginLumi(StreamContext const& sc) {
     ++nPostStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::preStreamEndLumi(edm::StreamContext const&) {
+  void TestServiceOne::preStreamEndLumi(StreamContext const& sc) {
     ++nPreStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preStreamEndLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::postStreamEndLumi(edm::StreamContext const&) {
+  void TestServiceOne::postStreamEndLumi(StreamContext const& sc) {
     ++nPostStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postStreamEndLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceOne::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPreModuleStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preModuleStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceOne::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPostModuleStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postModuleStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceOne::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPreModuleStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preModuleStreamEndLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceOne::postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceOne::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPostModuleStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::postModuleStreamEndLumi";
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::preGlobalBeginLumi(GlobalContext const& gc) {
+    ++nPreGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::postGlobalBeginLumi(GlobalContext const& gc) {
+    ++nPostGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::preGlobalEndLumi(GlobalContext const& gc) {
+    ++nPreGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::postGlobalEndLumi(GlobalContext const& gc) {
+    ++nPostGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::preGlobalWriteLumi(GlobalContext const& gc) {
+    ++nPreGlobalWriteLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalWriteLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceOne::postGlobalWriteLumi(GlobalContext const& gc) {
+    ++nPostGlobalWriteLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalWriteLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
     }
   }
 
@@ -149,6 +302,19 @@ namespace edmtest {
   unsigned int TestServiceOne::nPostModuleStreamBeginLumi() const { return nPostModuleStreamBeginLumi_.load(); }
   unsigned int TestServiceOne::nPreModuleStreamEndLumi() const { return nPreModuleStreamEndLumi_.load(); }
   unsigned int TestServiceOne::nPostModuleStreamEndLumi() const { return nPostModuleStreamEndLumi_.load(); }
+
+  unsigned int TestServiceOne::nPreGlobalBeginLumi() const { return nPreGlobalBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPostGlobalBeginLumi() const { return nPostGlobalBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPreGlobalEndLumi() const { return nPreGlobalEndLumi_.load(); }
+  unsigned int TestServiceOne::nPostGlobalEndLumi() const { return nPostGlobalEndLumi_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleGlobalBeginLumi() const { return nPreModuleGlobalBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPostModuleGlobalBeginLumi() const { return nPostModuleGlobalBeginLumi_.load(); }
+  unsigned int TestServiceOne::nPreModuleGlobalEndLumi() const { return nPreModuleGlobalEndLumi_.load(); }
+  unsigned int TestServiceOne::nPostModuleGlobalEndLumi() const { return nPostModuleGlobalEndLumi_.load(); }
+
+  unsigned int TestServiceOne::nPreGlobalWriteLumi() const { return nPreGlobalWriteLumi_.load(); }
+  unsigned int TestServiceOne::nPostGlobalWriteLumi() const { return nPostGlobalWriteLumi_.load(); }
 }  // namespace edmtest
 
 using edmtest::TestServiceOne;

--- a/FWCore/Integration/plugins/TestServiceOne.h
+++ b/FWCore/Integration/plugins/TestServiceOne.h
@@ -33,8 +33,6 @@ namespace edmtest {
 
     void preGlobalBeginRun(edm::GlobalContext const&);
     void preGlobalEndRun(edm::GlobalContext const&);
-    void preGlobalBeginLumi(edm::GlobalContext const&);
-    void preGlobalEndLumi(edm::GlobalContext const&);
 
     void preStreamBeginLumi(edm::StreamContext const&);
     void postStreamBeginLumi(edm::StreamContext const&);
@@ -46,6 +44,19 @@ namespace edmtest {
     void preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
     void postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
 
+    void preGlobalBeginLumi(edm::GlobalContext const&);
+    void postGlobalBeginLumi(edm::GlobalContext const&);
+    void preGlobalEndLumi(edm::GlobalContext const&);
+    void postGlobalEndLumi(edm::GlobalContext const&);
+
+    void preModuleGlobalBeginLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalBeginLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void preModuleGlobalEndLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalEndLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalWriteLumi(edm::GlobalContext const&);
+    void postGlobalWriteLumi(edm::GlobalContext const&);
+
     unsigned int nPreStreamBeginLumi() const;
     unsigned int nPostStreamBeginLumi() const;
     unsigned int nPreStreamEndLumi() const;
@@ -56,8 +67,22 @@ namespace edmtest {
     unsigned int nPreModuleStreamEndLumi() const;
     unsigned int nPostModuleStreamEndLumi() const;
 
+    unsigned int nPreGlobalBeginLumi() const;
+    unsigned int nPostGlobalBeginLumi() const;
+    unsigned int nPreGlobalEndLumi() const;
+    unsigned int nPostGlobalEndLumi() const;
+
+    unsigned int nPreModuleGlobalBeginLumi() const;
+    unsigned int nPostModuleGlobalBeginLumi() const;
+    unsigned int nPreModuleGlobalEndLumi() const;
+    unsigned int nPostModuleGlobalEndLumi() const;
+
+    unsigned int nPreGlobalWriteLumi() const;
+    unsigned int nPostGlobalWriteLumi() const;
+
   private:
     bool verbose_;
+    bool printTimestamps_;
 
     std::atomic<unsigned int> nPreStreamBeginLumi_ = 0;
     std::atomic<unsigned int> nPostStreamBeginLumi_ = 0;
@@ -68,6 +93,19 @@ namespace edmtest {
     std::atomic<unsigned int> nPostModuleStreamBeginLumi_ = 0;
     std::atomic<unsigned int> nPreModuleStreamEndLumi_ = 0;
     std::atomic<unsigned int> nPostModuleStreamEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreGlobalEndLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreModuleGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreModuleGlobalEndLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalWriteLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalWriteLumi_ = 0;
   };
 }  // namespace edmtest
 #endif

--- a/FWCore/Integration/plugins/TestServiceTwo.cc
+++ b/FWCore/Integration/plugins/TestServiceTwo.cc
@@ -14,22 +14,54 @@
 
 #include "FWCore/Integration/plugins/TestServiceTwo.h"
 
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/TimeOfDay.h"
+
+#include <ostream>
+
+using edm::GlobalContext;
+using edm::ModuleCallingContext;
+using edm::StreamContext;
+
+namespace {
+
+  class TimeStamper {
+  public:
+    TimeStamper(bool enable) : enabled_(enable) {}
+
+    friend std::ostream& operator<<(std::ostream& out, TimeStamper const& timestamp) {
+      if (timestamp.enabled_)
+        out << std::setprecision(2) << edm::TimeOfDay() << "  ";
+      return out;
+    }
+
+  private:
+    bool enabled_;
+  };
+
+  const char* globalIndent = "    ";
+  const char* globalModuleIndent = "        ";
+  const char* streamIndent = "            ";
+  const char* streamModuleIndent = "                ";
+}  // namespace
 
 namespace edmtest {
 
   TestServiceTwo::TestServiceTwo(edm::ParameterSet const& iPS, edm::ActivityRegistry& iRegistry)
-      : verbose_(iPS.getUntrackedParameter<bool>("verbose")) {
+      : verbose_(iPS.getUntrackedParameter<bool>("verbose")),
+        printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps")) {
     iRegistry.watchPreBeginProcessBlock(this, &TestServiceTwo::preBeginProcessBlock);
     iRegistry.watchPreEndProcessBlock(this, &TestServiceTwo::preEndProcessBlock);
 
     iRegistry.watchPreGlobalBeginRun(this, &TestServiceTwo::preGlobalBeginRun);
     iRegistry.watchPreGlobalEndRun(this, &TestServiceTwo::preGlobalEndRun);
-    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceTwo::preGlobalBeginLumi);
-    iRegistry.watchPreGlobalEndLumi(this, &TestServiceTwo::preGlobalEndLumi);
 
     iRegistry.watchPreStreamBeginLumi(this, &TestServiceTwo::preStreamBeginLumi);
     iRegistry.watchPostStreamBeginLumi(this, &TestServiceTwo::postStreamBeginLumi);
@@ -40,103 +72,224 @@ namespace edmtest {
     iRegistry.watchPostModuleStreamBeginLumi(this, &TestServiceTwo::postModuleStreamBeginLumi);
     iRegistry.watchPreModuleStreamEndLumi(this, &TestServiceTwo::preModuleStreamEndLumi);
     iRegistry.watchPostModuleStreamEndLumi(this, &TestServiceTwo::postModuleStreamEndLumi);
+
+    iRegistry.watchPreGlobalBeginLumi(this, &TestServiceTwo::preGlobalBeginLumi);
+    iRegistry.watchPostGlobalBeginLumi(this, &TestServiceTwo::postGlobalBeginLumi);
+    iRegistry.watchPreGlobalEndLumi(this, &TestServiceTwo::preGlobalEndLumi);
+    iRegistry.watchPostGlobalEndLumi(this, &TestServiceTwo::postGlobalEndLumi);
+
+    iRegistry.watchPreModuleGlobalBeginLumi(this, &TestServiceTwo::preModuleGlobalBeginLumi);
+    iRegistry.watchPostModuleGlobalBeginLumi(this, &TestServiceTwo::postModuleGlobalBeginLumi);
+    iRegistry.watchPreModuleGlobalEndLumi(this, &TestServiceTwo::preModuleGlobalEndLumi);
+    iRegistry.watchPostModuleGlobalEndLumi(this, &TestServiceTwo::postModuleGlobalEndLumi);
+
+    iRegistry.watchPreGlobalWriteLumi(this, &TestServiceTwo::preGlobalWriteLumi);
+    iRegistry.watchPostGlobalWriteLumi(this, &TestServiceTwo::postGlobalWriteLumi);
   }
 
   void TestServiceTwo::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages if true");
+    desc.addUntracked<bool>("verbose", false)->setComment("Prints LogAbsolute messages for every transition");
+    desc.addUntracked<bool>("printTimestamps", false)
+        ->setComment("Include a time stamp in message printed for every transition");
     descriptions.add("TestServiceTwo", desc);
   }
 
-  void TestServiceTwo::preBeginProcessBlock(edm::GlobalContext const&) {
+  void TestServiceTwo::preBeginProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preBeginProcessBlock";
     }
   }
 
-  void TestServiceTwo::preEndProcessBlock(edm::GlobalContext const&) {
+  void TestServiceTwo::preEndProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preEndProcessBlock";
     }
   }
 
-  void TestServiceTwo::preGlobalBeginRun(edm::GlobalContext const&) {
+  void TestServiceTwo::preGlobalBeginRun(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalBeginRun";
     }
   }
 
-  void TestServiceTwo::preGlobalEndRun(edm::GlobalContext const&) {
+  void TestServiceTwo::preGlobalEndRun(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalEndRun";
     }
   }
 
-  void TestServiceTwo::preGlobalBeginLumi(edm::GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalBeginLumi";
-    }
-  }
-
-  void TestServiceTwo::preGlobalEndLumi(edm::GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalEndLumi";
-    }
-  }
-
-  void TestServiceTwo::preStreamBeginLumi(edm::StreamContext const&) {
+  void TestServiceTwo::preStreamBeginLumi(StreamContext const& sc) {
     ++nPreStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::preStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::postStreamBeginLumi(edm::StreamContext const&) {
+  void TestServiceTwo::postStreamBeginLumi(StreamContext const& sc) {
     ++nPostStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::postStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::preStreamEndLumi(edm::StreamContext const&) {
+  void TestServiceTwo::preStreamEndLumi(StreamContext const& sc) {
     ++nPreStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preStreamEndLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::preStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::postStreamEndLumi(edm::StreamContext const&) {
+  void TestServiceTwo::postStreamEndLumi(StreamContext const& sc) {
     ++nPostStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postStreamEndLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::postStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run()
+          << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::preModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceTwo::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPreModuleStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preModuleStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::preModuleStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::postModuleStreamBeginLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceTwo::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPostModuleStreamBeginLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postModuleStreamBeginLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::postModuleStreamBeginLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceTwo::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPreModuleStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preModuleStreamEndLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::preModuleStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
     }
   }
 
-  void TestServiceTwo::postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&) {
+  void TestServiceTwo::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
     ++nPostModuleStreamEndLumi_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::postModuleStreamEndLumi";
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::postModuleStreamEndLumi " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run() << " lumi = " << sc.eventID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::preGlobalBeginLumi(GlobalContext const& gc) {
+    ++nPreGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::postGlobalBeginLumi(GlobalContext const& gc) {
+    ++nPostGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::preGlobalEndLumi(GlobalContext const& gc) {
+    ++nPreGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::postGlobalEndLumi(GlobalContext const& gc) {
+    ++nPostGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::preModuleGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalBeginLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::postModuleGlobalBeginLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::preModuleGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalEndLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::postModuleGlobalEndLumi " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run()
+          << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::preGlobalWriteLumi(GlobalContext const& gc) {
+    ++nPreGlobalWriteLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalWriteLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
+    }
+  }
+
+  void TestServiceTwo::postGlobalWriteLumi(GlobalContext const& gc) {
+    ++nPostGlobalWriteLumi_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalWriteLumi " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run() << " lumi = " << gc.luminosityBlockID().luminosityBlock();
     }
   }
 
@@ -149,6 +302,19 @@ namespace edmtest {
   unsigned int TestServiceTwo::nPostModuleStreamBeginLumi() const { return nPostModuleStreamBeginLumi_.load(); }
   unsigned int TestServiceTwo::nPreModuleStreamEndLumi() const { return nPreModuleStreamEndLumi_.load(); }
   unsigned int TestServiceTwo::nPostModuleStreamEndLumi() const { return nPostModuleStreamEndLumi_.load(); }
+
+  unsigned int TestServiceTwo::nPreGlobalBeginLumi() const { return nPreGlobalBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalBeginLumi() const { return nPostGlobalBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPreGlobalEndLumi() const { return nPreGlobalEndLumi_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalEndLumi() const { return nPostGlobalEndLumi_.load(); }
+
+  unsigned int TestServiceTwo::nPreModuleGlobalBeginLumi() const { return nPreModuleGlobalBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPostModuleGlobalBeginLumi() const { return nPostModuleGlobalBeginLumi_.load(); }
+  unsigned int TestServiceTwo::nPreModuleGlobalEndLumi() const { return nPreModuleGlobalEndLumi_.load(); }
+  unsigned int TestServiceTwo::nPostModuleGlobalEndLumi() const { return nPostModuleGlobalEndLumi_.load(); }
+
+  unsigned int TestServiceTwo::nPreGlobalWriteLumi() const { return nPreGlobalWriteLumi_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalWriteLumi() const { return nPostGlobalWriteLumi_.load(); }
 }  // namespace edmtest
 
 using edmtest::TestServiceTwo;

--- a/FWCore/Integration/plugins/TestServiceTwo.h
+++ b/FWCore/Integration/plugins/TestServiceTwo.h
@@ -11,6 +11,11 @@
 //     library and could be used to access the service if it was ever useful
 //     for debugging issues related to begin/end transitions.
 //
+//     This is almost identical to TestServiceOne. It was initially used to
+//     test that after a signal all services get executed even if one of the
+//     service functions throws.
+//
+//
 // Original Author:  W. David Dagenhart
 //         Created:  13 March 2024
 
@@ -33,8 +38,6 @@ namespace edmtest {
 
     void preGlobalBeginRun(edm::GlobalContext const&);
     void preGlobalEndRun(edm::GlobalContext const&);
-    void preGlobalBeginLumi(edm::GlobalContext const&);
-    void preGlobalEndLumi(edm::GlobalContext const&);
 
     void preStreamBeginLumi(edm::StreamContext const&);
     void postStreamBeginLumi(edm::StreamContext const&);
@@ -46,6 +49,19 @@ namespace edmtest {
     void preModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
     void postModuleStreamEndLumi(edm::StreamContext const&, edm::ModuleCallingContext const&);
 
+    void preGlobalBeginLumi(edm::GlobalContext const&);
+    void postGlobalBeginLumi(edm::GlobalContext const&);
+    void preGlobalEndLumi(edm::GlobalContext const&);
+    void postGlobalEndLumi(edm::GlobalContext const&);
+
+    void preModuleGlobalBeginLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalBeginLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void preModuleGlobalEndLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalEndLumi(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalWriteLumi(edm::GlobalContext const&);
+    void postGlobalWriteLumi(edm::GlobalContext const&);
+
     unsigned int nPreStreamBeginLumi() const;
     unsigned int nPostStreamBeginLumi() const;
     unsigned int nPreStreamEndLumi() const;
@@ -56,8 +72,22 @@ namespace edmtest {
     unsigned int nPreModuleStreamEndLumi() const;
     unsigned int nPostModuleStreamEndLumi() const;
 
+    unsigned int nPreGlobalBeginLumi() const;
+    unsigned int nPostGlobalBeginLumi() const;
+    unsigned int nPreGlobalEndLumi() const;
+    unsigned int nPostGlobalEndLumi() const;
+
+    unsigned int nPreModuleGlobalBeginLumi() const;
+    unsigned int nPostModuleGlobalBeginLumi() const;
+    unsigned int nPreModuleGlobalEndLumi() const;
+    unsigned int nPostModuleGlobalEndLumi() const;
+
+    unsigned int nPreGlobalWriteLumi() const;
+    unsigned int nPostGlobalWriteLumi() const;
+
   private:
     bool verbose_;
+    bool printTimestamps_;
 
     std::atomic<unsigned int> nPreStreamBeginLumi_ = 0;
     std::atomic<unsigned int> nPostStreamBeginLumi_ = 0;
@@ -68,6 +98,19 @@ namespace edmtest {
     std::atomic<unsigned int> nPostModuleStreamBeginLumi_ = 0;
     std::atomic<unsigned int> nPreModuleStreamEndLumi_ = 0;
     std::atomic<unsigned int> nPostModuleStreamEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreGlobalEndLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreModuleGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalBeginLumi_ = 0;
+    std::atomic<unsigned int> nPreModuleGlobalEndLumi_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalEndLumi_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalWriteLumi_ = 0;
+    std::atomic<unsigned int> nPostGlobalWriteLumi_ = 0;
   };
 }  // namespace edmtest
 #endif

--- a/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
+++ b/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
@@ -23,11 +23,13 @@ process = cms.Process("TEST")
 from FWCore.ParameterSet.VarParsing import VarParsing
 
 process.TestServiceOne = cms.Service("TestServiceOne",
-    verbose = cms.untracked.bool(False)
+    verbose = cms.untracked.bool(False),
+    printTimestamps = cms.untracked.bool(True)
 )
 
 process.TestServiceTwo = cms.Service("TestServiceTwo",
-    verbose = cms.untracked.bool(False)
+    verbose = cms.untracked.bool(False),
+    printTimestamps = cms.untracked.bool(True)
 )
 
 options = VarParsing()
@@ -75,10 +77,18 @@ elif options.testNumber == 2:
     process.throwException.eventIDThrowOnGlobalBeginRun = cms.untracked.EventID(4, 0, 0)
 elif options.testNumber == 3:
     process.throwException.eventIDThrowOnGlobalBeginLumi = cms.untracked.EventID(4, 1, 0)
+    process.throwException.expectedGlobalBeginLumi = cms.untracked.uint32(4)
+    process.throwException.expectedOffsetNoGlobalEndLumi = cms.untracked.uint32(1)
+    process.throwException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoGlobalEndLumi = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
 elif options.testNumber == 4:
     process.throwException.eventIDThrowOnGlobalEndRun = cms.untracked.EventID(3, 0, 0)
 elif options.testNumber == 5:
     process.throwException.eventIDThrowOnGlobalEndLumi = cms.untracked.EventID(3, 1, 0)
+    process.throwException.expectedGlobalBeginLumi = cms.untracked.uint32(3)
+    process.throwException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
 elif options.testNumber == 6:
     process.throwException.eventIDThrowOnStreamBeginRun = cms.untracked.EventID(4, 0, 0)
 elif options.testNumber == 7:


### PR DESCRIPTION
#### PR description:

Improve the behavior of the Framework after global begin/end lumi exceptions. This is the second in a series of PRs where we plan to make the behavior after exceptions more consistent in all the begin/end transitions. The first PR handled stream begin/end lumi exceptions (see #44624). The comments at the head of that PR state the design for this behavior we are implementing.

The intent is that nothing in the output will change if there are not any exceptions.

This work was motivated by discussions related to Issues https://github.com/cms-sw/cmssw/issues/43831 and https://github.com/cms-sw/cmssw/issues/42501.

This PR also adds some new exception context information for exceptions occurring in service functions related to begin/end transitions.

#### PR validation:

An existing unit test covering exceptions in different transitions is extended to cover the most salient cases. Additional manual testing of many various cases was also done. Existing unit tests pass.
