### PR TITLE
[RFC] Add tests and rudimentary protections for default-constructed PortableCollections

### DIFF
--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -58,3 +58,7 @@
 <bin file="StdArray_t.cpp">
   <use name="catch2"/>
 </bin>
+
+<bin file="DeviceProduct_t.cpp">
+  <use name="catch2"/>
+</bin>

--- a/DataFormats/Common/test/DeviceProduct_t.cpp
+++ b/DataFormats/Common/test/DeviceProduct_t.cpp
@@ -1,0 +1,70 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "DataFormats/Common/interface/DeviceProduct.h"
+
+namespace {
+  class Metadata {
+  public:
+    Metadata(int v = 0) : value_(v) {}
+    void synchronize(int& ret) const { ret = value_; }
+
+  private:
+    int const value_;
+  };
+
+  class Product {
+  public:
+    Product() = default;
+    Product(int v) : value_(v) {}
+
+    int value() const { return value_; }
+
+  private:
+    int value_ = 0;
+  };
+
+  class ProductNoDefault {
+  public:
+    ProductNoDefault(int v) : value_(v) {}
+
+    int value() const { return value_; }
+
+  private:
+    int value_;
+  };
+
+}  // namespace
+
+TEST_CASE("DeviceProduct", "[DeviceProduct]") {
+  SECTION("Default constructor") { [[maybe_unused]] edm::DeviceProduct<int> prod; }
+
+  SECTION("Default-constructible data product") {
+    SECTION("Default constructed") {
+      edm::DeviceProduct<Product> prod(std::make_shared<Metadata>(3));
+
+      int md = 0;
+      auto const& data = prod.getSynchronized<Metadata>(md);
+      REQUIRE(md == 3);
+      REQUIRE(data.value() == 0);
+    }
+
+    SECTION("Explicitly constructed") {
+      edm::DeviceProduct<Product> prod(std::make_shared<Metadata>(4), 42);
+
+      int md = 0;
+      auto const& data = prod.getSynchronized<Metadata>(md);
+      REQUIRE(md == 4);
+      REQUIRE(data.value() == 42);
+    }
+  }
+
+  SECTION("Non-default-constructible data product") {
+    edm::DeviceProduct<ProductNoDefault> prod(std::make_shared<Metadata>(5), 314);
+
+    int md = 0;
+    auto const& data = prod.getSynchronized<Metadata>(md);
+    REQUIRE(md == 5);
+    REQUIRE(data.value() == 314);
+  }
+}

--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -50,6 +50,9 @@ namespace cms::alpakatools {
   struct CopyToHost<PortableDeviceCollection<TLayout, TDevice>> {
     template <typename TQueue>
     static auto copyAsync(TQueue& queue, PortableDeviceCollection<TLayout, TDevice> const& srcData) {
+      if (not srcData.isValid()) {
+        return PortableHostCollection<TLayout>();
+      }
       PortableHostCollection<TLayout> dstData(srcData->metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;
@@ -71,6 +74,9 @@ namespace cms::alpakatools {
     template <typename TQueue>
     static auto copyAsync(TQueue& queue, PortableHostCollection<TLayout> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
+      if (not srcData.isValid()) {
+        return PortableDeviceCollection<TLayout, TDevice>();
+      }
       PortableDeviceCollection<TLayout, TDevice> dstData(srcData->metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;

--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -50,9 +50,6 @@ namespace cms::alpakatools {
   struct CopyToHost<PortableDeviceCollection<TLayout, TDevice>> {
     template <typename TQueue>
     static auto copyAsync(TQueue& queue, PortableDeviceCollection<TLayout, TDevice> const& srcData) {
-      if (not srcData.isValid()) {
-        return PortableHostCollection<TLayout>();
-      }
       PortableHostCollection<TLayout> dstData(srcData->metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;
@@ -74,9 +71,7 @@ namespace cms::alpakatools {
     template <typename TQueue>
     static auto copyAsync(TQueue& queue, PortableHostCollection<TLayout> const& srcData) {
       using TDevice = typename alpaka::trait::DevType<TQueue>::type;
-      if (not srcData.isValid()) {
-        return PortableDeviceCollection<TLayout, TDevice>();
-      }
+      assert(srcData.isValid());
       PortableDeviceCollection<TLayout, TDevice> dstData(srcData->metadata().size(), queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
       return dstData;

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -24,23 +24,21 @@ public:
   using Buffer = cms::alpakatools::device_buffer<TDev, std::byte[]>;
   using ConstBuffer = cms::alpakatools::const_device_buffer<TDev, std::byte[]>;
 
-  PortableDeviceCollection() = default;
-
   PortableDeviceCollection(int32_t elements, TDev const& device)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(device, Layout::computeDataSize(elements))},
-        layout_{buffer_->data(), elements},
+        layout_{buffer_.data(), elements},
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
-    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+    assert(reinterpret_cast<uintptr_t>(buffer_.data()) % Layout::alignment == 0);
   }
 
   template <typename TQueue, typename = std::enable_if_t<alpaka::isQueue<TQueue>>>
   PortableDeviceCollection(int32_t elements, TQueue const& queue)
       : buffer_{cms::alpakatools::make_device_buffer<std::byte[]>(queue, Layout::computeDataSize(elements))},
-        layout_{buffer_->data(), elements},
+        layout_{buffer_.data(), elements},
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
-    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+    assert(reinterpret_cast<uintptr_t>(buffer_.data()) % Layout::alignment == 0);
   }
 
   // non-copyable
@@ -55,61 +53,31 @@ public:
   ~PortableDeviceCollection() = default;
 
   // has a valid buffer?
-  bool isValid() const { return buffer_.has_value(); }
+  bool isValid() const { return true; }
 
   // a way to access the number of elements without the buffer validity assertion
   auto size() const { return view_.metadata().size(); }
 
   // access the View
-  View& view() {
-    assert(isValid());
-    return view_;
-  }
-  ConstView const& view() const {
-    assert(isValid());
-    return view_;
-  }
-  ConstView const& const_view() const {
-    assert(isValid());
-    return view_;
-  }
+  View& view() { return view_; }
+  ConstView const& view() const { return view_; }
+  ConstView const& const_view() const { return view_; }
 
-  View& operator*() {
-    assert(isValid());
-    return view_;
-  }
-  ConstView const& operator*() const {
-    assert(isValid());
-    return view_;
-  }
+  View& operator*() { return view_; }
+  ConstView const& operator*() const { return view_; }
 
-  View* operator->() {
-    assert(isValid());
-    return &view_;
-  }
-  ConstView const* operator->() const {
-    assert(isValid());
-    return &view_;
-  }
+  View* operator->() { return &view_; }
+  ConstView const* operator->() const { return &view_; }
 
   // access the Buffer
-  Buffer buffer() {
-    assert(isValid());
-    return *buffer_;
-  }
-  ConstBuffer buffer() const {
-    assert(isValid());
-    return *buffer_;
-  }
-  ConstBuffer const_buffer() const {
-    assert(isValid());
-    return *buffer_;
-  }
+  Buffer buffer() { return buffer_; }
+  ConstBuffer buffer() const { return buffer_; }
+  ConstBuffer const_buffer() const { return buffer_; }
 
 private:
-  std::optional<Buffer> buffer_;  //!
-  Layout layout_;                 //
-  View view_;                     //!
+  Buffer buffer_;  //!
+  Layout layout_;  //
+  View view_;      //!
 };
 
 // generic SoA-based product in device memory

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -54,21 +54,57 @@ public:
   // default destructor
   ~PortableDeviceCollection() = default;
 
+  // has a valid buffer?
+  bool isValid() const { return buffer_.has_value(); }
+
+  // a way to access the number of elements without the buffer validity assertion
+  auto size() const { return view_.metadata().size(); }
+
   // access the View
-  View& view() { return view_; }
-  ConstView const& view() const { return view_; }
-  ConstView const& const_view() const { return view_; }
+  View& view() {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& view() const {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& const_view() const {
+    assert(isValid());
+    return view_;
+  }
 
-  View& operator*() { return view_; }
-  ConstView const& operator*() const { return view_; }
+  View& operator*() {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& operator*() const {
+    assert(isValid());
+    return view_;
+  }
 
-  View* operator->() { return &view_; }
-  ConstView const* operator->() const { return &view_; }
+  View* operator->() {
+    assert(isValid());
+    return &view_;
+  }
+  ConstView const* operator->() const {
+    assert(isValid());
+    return &view_;
+  }
 
   // access the Buffer
-  Buffer buffer() { return *buffer_; }
-  ConstBuffer buffer() const { return *buffer_; }
-  ConstBuffer const_buffer() const { return *buffer_; }
+  Buffer buffer() {
+    assert(isValid());
+    return *buffer_;
+  }
+  ConstBuffer buffer() const {
+    assert(isValid());
+    return *buffer_;
+  }
+  ConstBuffer const_buffer() const {
+    assert(isValid());
+    return *buffer_;
+  }
 
 private:
   std::optional<Buffer> buffer_;  //!

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -53,21 +53,57 @@ public:
   // default destructor
   ~PortableHostCollection() = default;
 
+  // has a valid buffer?
+  bool isValid() const { return buffer_.has_value(); }
+
+  // a way to access the number of elements without the buffer validity assertion
+  auto size() const { return view_.metadata().size(); }
+
   // access the View
-  View& view() { return view_; }
-  ConstView const& view() const { return view_; }
-  ConstView const& const_view() const { return view_; }
+  View& view() {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& view() const {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& const_view() const {
+    assert(isValid());
+    return view_;
+  }
 
-  View& operator*() { return view_; }
-  ConstView const& operator*() const { return view_; }
+  View& operator*() {
+    assert(isValid());
+    return view_;
+  }
+  ConstView const& operator*() const {
+    assert(isValid());
+    return view_;
+  }
 
-  View* operator->() { return &view_; }
-  ConstView const* operator->() const { return &view_; }
+  View* operator->() {
+    assert(isValid());
+    return &view_;
+  }
+  ConstView const* operator->() const {
+    assert(isValid());
+    return &view_;
+  }
 
   // access the Buffer
-  Buffer buffer() { return *buffer_; }
-  ConstBuffer buffer() const { return *buffer_; }
-  ConstBuffer const_buffer() const { return *buffer_; }
+  Buffer buffer() {
+    assert(isValid());
+    return *buffer_;
+  }
+  ConstBuffer buffer() const {
+    assert(isValid());
+    return *buffer_;
+  }
+  ConstBuffer const_buffer() const {
+    assert(isValid());
+    return *buffer_;
+  }
 
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostCollection* newObj, Layout& layout) {

--- a/DataFormats/Portable/test/BuildFile.xml
+++ b/DataFormats/Portable/test/BuildFile.xml
@@ -3,3 +3,12 @@
   <use name="DataFormats/SoATemplate"/>
   <use name="catch2"/>
 </bin>
+
+<bin name="TestDataFormatsPortableCollection" file="alpaka/test_catch2_*.cc">
+  <use name="DataFormats/Portable"/>
+  <use name="DataFormats/SoATemplate"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name="alpaka"/>
+  <use name="catch2"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/DataFormats/Portable/test/alpaka/test_catch2_main.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_main.cc
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/DataFormats/Portable/test/alpaka/test_catch2_portableCollection.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_portableCollection.dev.cc
@@ -36,16 +36,8 @@ TEST_CASE("PortableCollection<T, TDev>", s_tag) {
     //coll->num() = 42;
     //REQUIRE(coll->num() == 42);
 
-    // CopyToDevice<PortableHostCollection<T>> is not defined
-#ifndef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    for (auto const& device : devices) {
-      auto queue = Queue(device);
-      auto coll_d = cms::alpakatools::CopyToDevice<PortableHostCollection<TestSoA>>::copyAsync(queue, coll_h);
-      REQUIRE(coll_d.size() == 0);
-      REQUIRE(not coll_d.isValid());
-      alpaka::wait(queue);
-    }
-#endif
+    // This would lead to an assertion failure
+    // cms::alpakatools::CopyToDevice<PortableHostCollection<TestSoA>>::copyAsync(queue, coll_h)
   }
 
   SECTION("Zero size") {

--- a/DataFormats/Portable/test/alpaka/test_catch2_portableCollection.dev.cc
+++ b/DataFormats/Portable/test/alpaka/test_catch2_portableCollection.dev.cc
@@ -1,0 +1,121 @@
+#include <catch.hpp>
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+#include "FWCore/Utilities/interface/stringize.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/workdivision.h"
+
+// each test binary is built for a single Alpaka backend
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+
+namespace {
+  GENERATE_SOA_LAYOUT(TestLayout, SOA_COLUMN(double, x), SOA_COLUMN(int32_t, id), SOA_SCALAR(uint32_t, num))
+
+  using TestSoA = TestLayout<>;
+
+  constexpr auto s_tag = "[PortableCollection]";
+}  // namespace
+
+TEST_CASE("PortableCollection<T, TDev>", s_tag) {
+  // get the list of devices on the current platform
+  auto const& devices = cms::alpakatools::devices<Platform>();
+  if (devices.empty()) {
+    FAIL("No devices available for the " EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE) " backend, "
+         "the test will be skipped.");
+  }
+
+  SECTION("Default constructor") {
+    PortableHostCollection<TestSoA> coll_h;
+    REQUIRE(coll_h.size() == 0);
+    REQUIRE(not coll_h.isValid());
+
+    // Following lines would be undefined behavior, and could lead to crashes
+    //coll->num() = 42;
+    //REQUIRE(coll->num() == 42);
+
+    // CopyToDevice<PortableHostCollection<T>> is not defined
+#ifndef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto coll_d = cms::alpakatools::CopyToDevice<PortableHostCollection<TestSoA>>::copyAsync(queue, coll_h);
+      REQUIRE(coll_d.size() == 0);
+      REQUIRE(not coll_d.isValid());
+      alpaka::wait(queue);
+    }
+#endif
+  }
+
+  SECTION("Zero size") {
+    int constexpr size = 0;
+    PortableHostCollection<TestSoA> coll_h(size, cms::alpakatools::host());
+    REQUIRE(coll_h.isValid());
+    REQUIRE(coll_h->metadata().size() == size);
+    coll_h->num() = 42;
+
+    // CopyToDevice<PortableHostCollection<T>> is not defined
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    REQUIRE(coll_h->num() == 42);
+#else
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto coll_d = cms::alpakatools::CopyToDevice<PortableHostCollection<TestSoA>>::copyAsync(queue, coll_h);
+      REQUIRE(coll_d.isValid());
+      REQUIRE(coll_d.size() == size);
+
+      auto div = cms::alpakatools::make_workdiv<Acc1D>(1, 1);
+      alpaka::exec<Acc1D>(
+          queue,
+          div,
+          [] ALPAKA_FN_ACC(Acc1D const& acc, TestSoA::ConstView view) {
+            assert(view.metadata().size() == size);
+            assert(view.num() == 42);
+          },
+          coll_d.const_view());
+      alpaka::wait(queue);
+    }
+#endif
+  }
+
+  SECTION("Non-zero size") {
+    int constexpr size = 10;
+    PortableHostCollection<TestSoA> coll_h(size, cms::alpakatools::host());
+    REQUIRE(coll_h.isValid());
+    coll_h->num() = 20;
+
+    for (int i = 0; i < size; ++i) {
+      coll_h->id(i) = i * 2 + 1;
+    }
+
+    // CopyToDevice<PortableHostCollection<T>> is not defined
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    for (int i = 0; i < size; ++i) {
+      assert(coll_h->id(i) == i * 2 + 1);
+    }
+#else
+    for (auto const& device : devices) {
+      auto queue = Queue(device);
+      auto coll_d = cms::alpakatools::CopyToDevice<PortableHostCollection<TestSoA>>::copyAsync(queue, coll_h);
+      REQUIRE(coll_d.isValid());
+      REQUIRE(coll_d.size() == size);
+
+      auto div = cms::alpakatools::make_workdiv<Acc1D>(1, size);
+      alpaka::exec<Acc1D>(
+          queue,
+          div,
+          [] ALPAKA_FN_ACC(Acc1D const& acc, TestSoA::ConstView view) {
+            assert(view.metadata().size() == size);
+            assert(view.num() == 20);
+            for (int i : cms::alpakatools::uniform_elements(acc)) {
+              assert(view.id(i) == i * 2 + 1);
+            }
+          },
+          coll_d.const_view());
+
+      alpaka::wait(queue);
+    }
+#endif
+  }
+}

--- a/DataFormats/Portable/test/test_catch2_portableHostCollection.cc
+++ b/DataFormats/Portable/test/test_catch2_portableHostCollection.cc
@@ -1,0 +1,53 @@
+#include <catch.hpp>
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+
+namespace {
+  GENERATE_SOA_LAYOUT(TestLayout, SOA_COLUMN(double, x), SOA_COLUMN(int32_t, id), SOA_SCALAR(uint32_t, num))
+
+  using TestSoA = TestLayout<>;
+
+  constexpr auto s_tag = "[PortableHostCollection]";
+}  // namespace
+
+TEST_CASE("PortableHostCollection<T>", s_tag) {
+  SECTION("Default constructor") {
+    PortableHostCollection<TestSoA> coll;
+    REQUIRE(coll.size() == 0);
+    REQUIRE(not coll.isValid());
+
+    // Following lines would be undefined behavior, and could lead to crashes
+    //coll->num() = 42;
+    //REQUIRE(coll->num() == 42);
+  }
+
+  SECTION("Zero size") {
+    int constexpr size = 0;
+    PortableHostCollection<TestSoA> coll(size, cms::alpakatools::host());
+    REQUIRE(coll.size() == size);
+    REQUIRE(coll.isValid());
+
+    coll->num() = 42;
+    REQUIRE(coll->num() == 42);
+  }
+
+  SECTION("Non-zero size") {
+    int constexpr size = 10;
+    PortableHostCollection<TestSoA> coll(size, cms::alpakatools::host());
+    REQUIRE(coll.size() == size);
+    REQUIRE(coll.isValid());
+
+    coll->num() = 42;
+    for (int i = 0; i < size; ++i) {
+      coll->id()[i] = i * 2;
+    }
+
+    REQUIRE(coll->num() == 42);
+    for (int i = 0; i < size; ++i) {
+      REQUIRE(coll->id()[i] == i * 2);
+    }
+  }
+}

--- a/DataFormats/Portable/test/test_catch2_portableHostCollection.cc
+++ b/DataFormats/Portable/test/test_catch2_portableHostCollection.cc
@@ -49,5 +49,38 @@ TEST_CASE("PortableHostCollection<T>", s_tag) {
     for (int i = 0; i < size; ++i) {
       REQUIRE(coll->id()[i] == i * 2);
     }
+
+    SECTION("Move constructor") {
+      PortableHostCollection<TestSoA> coll2(std::move(coll));
+      REQUIRE(coll2.size() == size);
+      REQUIRE(coll2.isValid());
+
+      REQUIRE(coll.size() == 0);
+      REQUIRE(not coll.isValid());
+    }
+
+    SECTION("Move assignment") {
+      PortableHostCollection<TestSoA> coll2(2*size, cms::alpakatools::host());
+      REQUIRE(coll2.size() == 2*size);
+      REQUIRE(coll2.isValid());
+
+      coll2 = std::move(coll);
+      REQUIRE(coll2.size() == size);
+      REQUIRE(coll2.isValid());
+
+      REQUIRE(coll.size() == 0);
+      REQUIRE(not coll.isValid());
+
+      SECTION("Self assignment") {
+        coll2 = std::move(coll2);
+        REQUIRE(coll2.size() == size);
+        REQUIRE(coll2.isValid());
+
+        REQUIRE(coll2->num() == 42);
+        for (int i = 0; i < size; ++i) {
+          REQUIRE(coll2->id()[i] == i * 2);
+        }
+      }
+    }
   }
 }

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigiErrorsDevice.h
@@ -14,7 +14,6 @@
 template <typename TDev>
 class SiPixelDigiErrorsDevice : public PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev> {
 public:
-  SiPixelDigiErrorsDevice() = default;
   template <typename TQueue>
   explicit SiPixelDigiErrorsDevice(size_t maxFedWords, TQueue queue)
       : PortableDeviceCollection<SiPixelDigiErrorsSoA, TDev>(maxFedWords, queue), maxFedWords_(maxFedWords) {}

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
@@ -12,7 +12,6 @@
 template <typename TDev>
 class SiPixelDigisDevice : public PortableDeviceCollection<SiPixelDigisSoA, TDev> {
 public:
-  SiPixelDigisDevice() = default;
   template <typename TQueue>
   explicit SiPixelDigisDevice(size_t maxFedWords, TQueue queue)
       : PortableDeviceCollection<SiPixelDigisSoA, TDev>(maxFedWords + 1, queue) {}

--- a/DataFormats/SoATemplate/test/SoAUnitTests.cc
+++ b/DataFormats/SoATemplate/test/SoAUnitTests.cc
@@ -11,11 +11,27 @@ GENERATE_SOA_LAYOUT(SimpleLayoutTemplate,
   SOA_COLUMN(float, y),
   SOA_COLUMN(float, z),
   SOA_COLUMN(float, t))
+
+GENERATE_SOA_LAYOUT(SimpleLayoutTemplateWithScalar,
+  SOA_COLUMN(float, x),
+  SOA_SCALAR(unsigned int, s))
 // clang-format on
 
 using SimpleLayout = SimpleLayoutTemplate<>;
 
 TEST_CASE("SoATemplate") {
+  SECTION("Zero size") {
+    REQUIRE(SimpleLayoutTemplate<>::computeDataSize(0) == 0);
+    REQUIRE(SimpleLayoutTemplateWithScalar<>::computeDataSize(0) != 0);
+  }
+
+  SECTION("Default-constructed view") {
+    SimpleLayout sl;
+    REQUIRE(sl.metadata().size() == 0);
+    SimpleLayoutTemplateWithScalar<> sls;
+    REQUIRE(sls.metadata().size() == 0);
+  }
+
   const std::size_t slSize = 10;
   const std::size_t slBufferSize = SimpleLayout::computeDataSize(slSize);
   std::unique_ptr<std::byte, decltype(std::free) *> slBuffer{

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -272,7 +272,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       iEvent.emplace(digiPutToken_, nDigis_, iEvent.queue());
       iEvent.emplace(clusterPutToken_, pixelTopology::Phase1::numberOfModules, iEvent.queue());
       if (includeErrors_) {
-        iEvent.emplace(digiErrorPutToken_);
+        iEvent.emplace(digiErrorPutToken_, 0, iEvent.queue());
         iEvent.emplace(fmtErrorToken_);
       }
       return;


### PR DESCRIPTION
#### PR description:

The HCAL CUDA->Alpaka porting work by @kakwok demonstrated bad behavior with default-constructed PortableCollection, so I added some tests to demonstrate those (at one point the HCAL work seemed to point to some strange behavior also for zero-sized PortableCollection, but I was not able to replicate that, and the strange behavior also didn't repeat later with the HCAL Alpaka code).

A default-constructed PortableCollection is in a state where it has no buffer. The PortableCollection interface does not provide a way to check the state, and therefore a caller has no way to know if `PortableCollection::buffer()` leads to defined or undefined behavior (because [`std::optional<T>::operator*()` leads to undefined behavior if the `optional` does not contain value](https://en.cppreference.com/w/cpp/utility/optional/operator*)). This PR takes one attempt to add a function `PortableCollection::isValid()` that allows checking the validity, and adds `assert()`s to all accessors (plus `size()` to be able to access the SoA size without the `assert()`. I'm not sure if this the behavior we really want, but at least it is a starting point for a discussion.

The tests for 0-size SoA Layout and PortableCollection are for ensuring valid behavior when the SoA has also scalars in addition to columns. (and now I'm wondering what should be the behavior of a 0-size PortableCollection for a SoA that has only columns?)

The PortableObject and PortableMultiCollection should also be treated consistently, but I wanted to get feedback first on the direction we want to go first.

#### PR validation:

Unit tests pass

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Possibly to be backported to 14_0_X