### PR TITLE
[14_1_X] Apply MUDPGNANO EventContent customizations to EDMNANO and NANOSIM as well

### DIFF
--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -11,7 +11,7 @@ muDPGNanoProducerBkg = cms.Sequence(lhcInfoTableProducer
 
 def muDPGNanoBkgCustomize(process) :
 
-     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOAODSIMoutput"]:
+     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOEDMAODSIMoutput", "NANOAODSIMoutput"]:
           if hasattr(process, output):
                getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
                getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")           

--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -11,8 +11,9 @@ muDPGNanoProducerBkg = cms.Sequence(lhcInfoTableProducer
 
 def muDPGNanoBkgCustomize(process) :
 
-     if hasattr(process, "NANOAODoutput"):
-          process.NANOAODoutput.outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
-          process.NANOAODoutput.outputCommands.append("drop edmTriggerResults_*_*_*")
+     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOAODSIMoutput"]:
+          if hasattr(process, output):
+               getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
+               getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")           
      
      return process

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -34,8 +34,9 @@ def muDPGNanoCustomize(process) :
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
 
-     if hasattr(process, "NANOAODoutput"):
-          process.NANOAODoutput.outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
-          process.NANOAODoutput.outputCommands.append("drop edmTriggerResults_*_*_*")
+     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOAODSIMoutput"]:
+          if hasattr(process, output):
+               getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
+               getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")
 
      return process

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -34,7 +34,7 @@ def muDPGNanoCustomize(process) :
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
 
-     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOAODSIMoutput"]:
+     for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOEDMAODSIMoutput", "NANOAODSIMoutput"]:
           if hasattr(process, output):
                getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
                getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")


### PR DESCRIPTION
#### PR description:

This is a bugfix, basted on the results of the first tentative of automating the production of the MUDPG custom NANO ntuples described in [this JIRA ticket](https://its.cern.ch/jira/browse/PDMVRERECO-83).

#### PR validation:

No changes expected in `runTheMartrix.py` workflows `-w nano -l 2500.31,2500.311`.

Change in event content if the `cmsDriver.py` command picked [here](https://cms-pdmv-prod.web.cern.ch/rereco/api/requests/get_cmsdriver/ReReco-Run2024B-Muon0-ZMu_PromptMUODPGNano-00001) is ran under `CMSSW_14_0_X`.

Were both verified.