### PR TITLE
[14_0_X] Fix metMCTable in NanoGEN

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -7,6 +7,7 @@ from PhysicsTools.NanoAOD.particlelevel_cff import *
 from PhysicsTools.NanoAOD.genWeightsTable_cfi import *
 from PhysicsTools.NanoAOD.genVertex_cff import *
 from PhysicsTools.NanoAOD.common_cff import Var,CandVars
+from PhysicsTools.NanoAOD.simpleSingletonCandidateFlatTableProducer_cfi import simpleSingletonCandidateFlatTableProducer
 
 nanoMetadata = cms.EDProducer("UniqueStringProducer",
     strings = cms.PSet(
@@ -81,8 +82,12 @@ def customizeNanoGENFromMini(process):
     return process
 
 def customizeNanoGEN(process):
-    process.metMCTable.src = "genMetTrue"
-    process.metMCTable.variables = cms.PSet(PTVars)
+    process.metMCTable = simpleSingletonCandidateFlatTableProducer.clone(
+        src = "genMetTrue",
+        name = process.metMCTable.name,
+        doc = process.metMCTable.doc,
+        variables = cms.PSet(PTVars)
+    )
 
     process.rivetProducerHTXS.HepMCCollection = "generatorSmeared"
     process.genParticleTable.src = "genParticles"


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/44850


> #### PR description:
> 
> Fixes the `ProductNotFound` error in relval wf 546.0, as reported in https://github.com/cms-sw/cmssw/pull/44782#issuecomment-2077038234.
> 
> Cause of the error: In  we changed `metMCTable` to take input of the specific `pat::MET` type. However, in the `NanoGEN` customization, the input is changed to `genMetTrue` which is of a different type (`reco::MET`), thus the `ProductNotFound ` error.
> 
> #### PR validation:
> 
> `runTheMatrix.py -l 546.0,547.0,548.0 --ibeos`