### PR TITLE
Reduce Alpaka event synchronization calls via EDMetadata [14.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaCore/README.md
+++ b/HeterogeneousCore/AlpakaCore/README.md
@@ -170,7 +170,7 @@ Also note that the `fillDescription()` function must have the same content for a
 * All Event data products in the host memory space are guaranteed to be accessible for all operations (after the data product has been obtained from the `edm::Event` or `device::Event`).
 * All EventSetup data products in the device memory space are guaranteed to be accessible only for operations enqueued in the `Queue` given by `device::Event::queue()` when accessed via the `device::EventSetup` (ED modules), or by `device::Record<TRecord>::queue()` when accessed via the `device::Record<TRecord>` (ESProducers).
 * The EDM Stream does not proceed to the next Event until after all asynchronous work of the current Event has finished.
-  * **Note**: currently this guarantee does not hold if the job has any EDModule that launches asynchronous work but does not explicitly synchronize or produce any device-side data products.
+  * **Note**: this implies if an EDProducer in its `produce()` function uses the `Event::queue()` or gets a device-side data product, and does not produce any device-side data products, the `produce()` call will be synchronous (i.e. will block the CPU thread until the asynchronous work finishes)
 
 ## Examples
 

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
@@ -94,6 +94,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // consumer or not. The goal is to have a "chain" of modules to
     // queue their work to the same queue.
     mutable std::atomic<bool> mayReuseQueue_ = true;
+    // Cache to potentially reduce alpaka::wait() calls
+    mutable std::atomic<bool> eventComplete_ = false;
   };
 #endif
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadata.h
@@ -48,6 +48,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     Queue& queue() const { return *queue_; }
 
     void recordEvent() {}
+    void discardEvent() {}
 
   private:
     std::shared_ptr<Queue> queue_;
@@ -73,6 +74,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     void enqueueCallback(edm::WaitingTaskWithArenaHolder holder);
 
     void recordEvent() { alpaka::enqueue(*queue_, *event_); }
+    void discardEvent() { event_.reset(); }
 
     /**
      * Synchronizes 'consumer' metadata wrt. 'this' in the event product

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/EDMetadataSentry.h
@@ -26,7 +26,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
       std::shared_ptr<EDMetadata> metadata() { return metadata_; }
 
-      void finish();
+      // true if asynchronous work was (possibly) launched
+      void finish(bool launchedAsyncWork);
 
     private:
       std::shared_ptr<EDMetadata> metadata_;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/Event.h
@@ -137,6 +137,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
       }
     }
 
+    // implementation details
+    bool wasQueueUsed() const { return queueUsed_; }
+
   private:
     // Having both const and non-const here in order to serve the
     // clients with one device::Event class
@@ -144,6 +147,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::device {
     edm::Event* event_ = nullptr;
 
     std::shared_ptr<EDMetadata> metadata_;
+
     // device::Event is not supposed to be const-thread-safe, so no
     // additional protection is needed.
     mutable bool queueUsed_ = false;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h
@@ -23,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::EventSetup const es(iSetup, ev.device());
         produce(sid, ev, es);
         this->putBackend(iEvent);
-        sentry.finish();
+        sentry.finish(ev.wasQueueUsed());
       }
 
       virtual void produce(edm::StreamID sid, device::Event& iEvent, device::EventSetup const& iSetup) const = 0;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/EDProducer.h
@@ -23,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::EventSetup const es(iSetup, ev.device());
         produce(ev, es);
         this->putBackend(iEvent);
-        sentry.finish();
+        sentry.finish(ev.wasQueueUsed());
       }
 
       virtual void produce(device::Event& iEvent, device::EventSetup const& iSetup) = 0;

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h
@@ -36,7 +36,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         device::EventSetup const es(iSetup, ev.device());
         produce(ev, es);
         this->putBackend(iEvent);
-        sentry.finish();
+        sentry.finish(ev.wasQueueUsed());
       }
 
       virtual void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) = 0;

--- a/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadata.cc
+++ b/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadata.cc
@@ -14,7 +14,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     // TODO: a callback notifying a WaitingTaskHolder (or similar)
     // would avoid blocking the CPU, but would also require more work.
 
-    if (event_ and not eventComplete_) {
+    // If event_ is null, the EDMetadata was either
+    // default-constructed, or fully synchronized before leaving the
+    // produce() call, so no synchronization is needed.
+    // If the queue was re-used, then some other EDMetadata object in
+    // the same edm::Event records the event_ (in the same queue) and
+    // calls alpaka::wait(), and therefore this wait() call can be
+    // skipped).
+    if (event_ and not eventComplete_ and mayReuseQueue_) {
       // Must not throw in a destructor, and if there were an
       // exception could not really propagate it anyway.
       CMS_SA_ALLOW try { alpaka::wait(*event_); } catch (...) {

--- a/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadata.cc
+++ b/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadata.cc
@@ -47,6 +47,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       throw edm::Exception(edm::errors::LogicError) << "Handling data from multiple devices is not yet supported";
     }
 
+    // If the event has been discarded, the produce() function that
+    // constructed this EDMetadata object did not launch any
+    // asynchronous work.
+    if (not event_) {
+      return;
+    }
+
     if (not alpaka::isComplete(*event_)) {
       // Event not yet occurred, so need to add synchronization
       // here. Sychronization is done by making the queue to wait

--- a/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadataSentry.cc
+++ b/HeterogeneousCore/AlpakaCore/src/alpaka/EDMetadataSentry.cc
@@ -15,6 +15,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 #endif
     }
 
-    void EDMetadataSentry::finish() { metadata_->recordEvent(); }
+    void EDMetadataSentry::finish(bool launchedAsyncWork) {
+      if (launchedAsyncWork) {
+        metadata_->recordEvent();
+      } else {
+        // If we are certain no asynchronous work was launched (i.e.
+        // the Queue was not used in any way), there is no need to
+        // synchronize, and the Event can be discarded.
+        metadata_->discardEvent();
+      }
+    }
   }  // namespace detail
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerNoOutput.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaGlobalProducerNoOutput.cc
@@ -1,0 +1,38 @@
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESGetToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This EDProducer only consumes a device EDProduct, and is intended
+   * only for testing purposes. Do not use it as an example.
+   */
+  class TestAlpakaGlobalProducerNoOutput : public global::EDProducer<> {
+  public:
+    TestAlpakaGlobalProducerNoOutput(edm::ParameterSet const& config)
+        : getToken_(consumes(config.getParameter<edm::InputTag>("source"))) {}
+
+    void produce(edm::StreamID, device::Event& iEvent, device::EventSetup const& iSetup) const override {
+      [[maybe_unused]] auto const& input = iEvent.get(getToken_);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add("source", edm::InputTag{});
+
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const device::EDGetToken<portabletest::TestDeviceCollection> getToken_;
+  };
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaGlobalProducerNoOutput);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducerToDevice.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaStreamSynchronizingProducerToDevice.cc
@@ -1,0 +1,62 @@
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/stream/SynchronizingEDProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/EDPutToken.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "TestAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+  /**
+   * This class demonstrates a stream EDProducer that
+   * - produces a device EDProduct (that can get transferred to host automatically)
+   * - synchronizes in a non-blocking way with the ExternalWork module
+   *   ability (via the SynchronizingEDProcucer base class)
+   */
+  class TestAlpakaStreamSynchronizingProducerToDevice : public stream::SynchronizingEDProducer<> {
+  public:
+    TestAlpakaStreamSynchronizingProducerToDevice(edm::ParameterSet const& iConfig)
+        : putToken_{produces()},
+          size_{iConfig.getParameter<edm::ParameterSet>("size").getParameter<int32_t>(
+              EDM_STRINGIZE(ALPAKA_ACCELERATOR_NAMESPACE))} {}
+
+    void acquire(device::Event const& iEvent, device::EventSetup const& iSetup) override {
+      deviceProduct_ = std::make_unique<portabletest::TestDeviceCollection>(size_, iEvent.queue());
+
+      // run the algorithm, potentially asynchronously
+      algo_.fill(iEvent.queue(), *deviceProduct_);
+    }
+
+    void produce(device::Event& iEvent, device::EventSetup const& iSetup) override {
+      iEvent.put(putToken_, std::move(deviceProduct_));
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+
+      edm::ParameterSetDescription psetSize;
+      psetSize.add<int32_t>("alpaka_serial_sync");
+      psetSize.add<int32_t>("alpaka_cuda_async");
+      psetSize.add<int32_t>("alpaka_rocm_async");
+      desc.add("size", psetSize);
+
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const device::EDPutToken<portabletest::TestDeviceCollection> putToken_;
+    const int32_t size_;
+
+    // implementation of the algorithm
+    TestAlgo algo_;
+
+    std::unique_ptr<portabletest::TestDeviceCollection> deviceProduct_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaStreamSynchronizingProducerToDevice);


### PR DESCRIPTION
#### PR description:

Backport #44841 by @makortel to CMSSW 14.0.x:

> Prompted by [#44769 (comment)](https://github.com/cms-sw/cmssw/issues/44769#issuecomment-2067257800) this PR reduces the amount of blocking `alpaka::wait()` calls (leading to `cudaEventSynchronize()` on NVIDIA GPU) via the EDMetadata destructor. To check the impact I used the reproducer #44769 (even if it eventually leads to an assertion failure). Initially the reproducer lead to 2470 calls to `cudaEventSynchronize()`.
> 
> The first commit avoids calling `alpaka::wait()` in `EDProducer::produce()` when no asynchronous work was launched (possible async work is identified by the use of `device::Event::queue()` in any way, including consuming a device side data product). In this case there is no need to synchronize the device and host. This commit reduced the number of `cudaEventSynchronize()` calls to 2284 (-7.5 %).
> 
> The second commit caches the alpaka::Event completion, so that `alpaka::wait()` does not need to be called again on an already-completed alpaka Event. This commit reduced the number of `cudaEventSynchronize()` calls to 2019 (-18 % wrt the starting point).
> 
> The third commit avoids calling `alpaka::wait()` on the destructor of an `EDMetadata` when the Queue of the `EDMetadata` object has been re-used by another `EDMetadata` (in an `EDProducer::produce()` that consumed the device-side data product holding the first `EDMetadata` object). Since the only purpose of the `alpaka::wait()` in the `~EDMetadata()` is to ensure all asynchronous work of an edm::Event has completed before the edm::Stream moves to the next edm::Event, for any Queue it is enough to `wait()` on the alpaka::Event that was last recorded on that Queue. This commit reduced the number of `cudaEventSynchronize()` calls to 1462 (-40 % wrt the starting point).
> 
> There is one case left (on purpose) where the `EDProducer::produce()` still calls `alpaka::wait()`. This happens when the `produce()` launches asynchronous work (i.e. calls `device::Event::queue()`), but does not produce any device-side data products. I can't imagine a good use case for such an EDProducer (except maybe a DQM-style module, but that would need a separate module base class in any case that could then deal with the necessary edm::Event-level synchronization
> 
> I don't expect a huge impact from the reduction of these calls, as in the present cases in HLT the alpaka::Events should have completed by the time the `alpaka::wait()` is called. The stack traces in [#44769 (comment)](https://github.com/cms-sw/cmssw/issues/44769#issuecomment-2066613569) nevertheless show the `cudaEventSynchronize()` acquiring a lock even when the CUDA event was complete at the time the event was recorded, so at least this PR should reduce the contention on that lock.
> 
> Resolves [cms-sw/framework-team#902](https://github.com/cms-sw/framework-team/issues/902)

#### PR validation:

`HeterogeneousCore/Alpaka{Core,Test}` unit tests pass.

Test with a recent HLT menu on top of `CMSSW_14_0_5_patch2` shows a minor improvement in throughout:
  - `CMSSW_14_0_5_patch2`: 670.5 ± 1.9 ev/s
  - with these changes: 673.0 ± 2.0 ev/s

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44841 to CMSSW 14.0.x for data taking.