### PR TITLE
Computation of silicon strip hit efficiency : Consecutive missing hits recovery

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -396,6 +396,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
         unsigned int iidd = theHit->geographicalId().rawId();
         int layer = ::checkLayer(iidd, tTopo);
         int missedLayer = (layer + 1);
+        int previousMissedLayer = (layer + 2);
         int diffPreviousLayer = (layer - previous_layer);
         if (doMissingHitsRecovery_) {
           //Layers from TIB + TOB
@@ -425,7 +426,26 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             missHitPerLayer[14] += 1;
             hasMissingHits = true;
           }
+
+          //####### Consecutive missing hits case #######
+
+          //##### Layers from TIB + TOB
+          if (diffPreviousLayer == -3 && missedLayer > k_LayersStart && missedLayer < k_LayersAtTOBEnd &&
+              previousMissedLayer > k_LayersStart && previousMissedLayer < k_LayersAtTOBEnd) {
+            missHitPerLayer[missedLayer] += 1;
+            missHitPerLayer[previousMissedLayer] += 1;
+            hasMissingHits = true;
+          }
+
+          //##### Layers from TEC
+          if (diffPreviousLayer == -3 && missedLayer > k_LayersAtTIDEnd && missedLayer <= k_LayersAtTECEnd &&
+              previousMissedLayer > k_LayersAtTIDEnd && previousMissedLayer <= k_LayersAtTECEnd) {
+            missHitPerLayer[missedLayer] += 1;
+            missHitPerLayer[previousMissedLayer] += 1;
+            hasMissingHits = true;
+          }
         }
+
         if (theHit->getType() == TrackingRecHit::Type::missing)
           hasMissingHits = true;
 
@@ -443,7 +463,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
         LogDebug("SiStripHitEfficiency:HitEff") << "theInHit is valid = " << theInHit->isValid() << endl;
 
         unsigned int iidd = theInHit->geographicalId().rawId();
-
+        bool foundConsMissingHits = false;
         unsigned int TKlayers = ::checkLayer(iidd, tTopo);
         LogDebug("SiStripHitEfficiency:HitEff") << "TKlayer from trajectory: " << TKlayers << "  from module = " << iidd
                                                 << "   matched/stereo/rphi = " << ((iidd & 0x3) == 0) << "/"
@@ -496,8 +516,9 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
         }
         bool missingHitAdded = false;
 
-        vector<TrajectoryMeasurement> tmpTmeas;
+        vector<TrajectoryMeasurement> tmpTmeas, prev_tmpTmeas;
         unsigned int misLayer = TKlayers + 1;
+        unsigned int previousMisLayer = TKlayers + 2;
         //Use bool doMissingHitsRecovery to add possible missing hits based on actual/previous hit
         if (doMissingHitsRecovery_) {
           if (int(TKlayers) - int(prev_TKlayers) == -2) {
@@ -592,7 +613,56 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             }
           }
 
-          if (!tmpTmeas.empty()) {
+          //Test for two consecutive missing hits
+          if (int(TKlayers) - int(prev_TKlayers) == -3) {
+            foundConsMissingHits = true;
+            const DetLayer* detlayer = itm->layer();
+            const LayerMeasurements layerMeasurements{*measurementTrackerHandle, *measurementTrackerEvent};
+            const TrajectoryStateOnSurface tsos = itm->updatedState();
+            std::vector<DetLayer::DetWithState> compatDets = detlayer->compatibleDets(tsos, *thePropagator, *estimator);
+
+            if (misLayer > k_LayersStart && misLayer < k_LayersAtTOBEnd && previousMisLayer > k_LayersStart &&
+                previousMisLayer < k_LayersAtTOBEnd) {  //Barrel case
+              std::vector<BarrelDetLayer const*> barrelTIBLayers =
+                  measurementTrackerHandle->geometricSearchTracker()->tibLayers();
+              std::vector<BarrelDetLayer const*> barrelTOBLayers =
+                  measurementTrackerHandle->geometricSearchTracker()->tobLayers();
+              if (misLayer > k_LayersStart && misLayer < k_LayersAtTIBEnd) {
+                const DetLayer* tibLayer = barrelTIBLayers[misLayer - k_LayersStart - 1];
+                const DetLayer* prevTibLayer = barrelTIBLayers[previousMisLayer - k_LayersStart - 1];
+
+                tmpTmeas = layerMeasurements.measurements(*tibLayer, tsos, *thePropagator, *estimator);
+                prev_tmpTmeas = layerMeasurements.measurements(*prevTibLayer, tsos, *thePropagator, *estimator);
+              } else if (misLayer > k_LayersAtTIBEnd && misLayer < k_LayersAtTOBEnd) {
+                const DetLayer* tobLayer = barrelTOBLayers[misLayer - k_LayersAtTIBEnd - 1];
+                const DetLayer* prevTobLayer = barrelTOBLayers[previousMisLayer - k_LayersAtTIBEnd - 1];
+                tmpTmeas = layerMeasurements.measurements(*tobLayer, tsos, *thePropagator, *estimator);
+                prev_tmpTmeas = layerMeasurements.measurements(*prevTobLayer, tsos, *thePropagator, *estimator);
+              }
+            }
+            if (misLayer > k_LayersAtTIDEnd && misLayer < k_LayersAtTECEnd && previousMisLayer > k_LayersAtTIDEnd &&
+                previousMisLayer < k_LayersAtTECEnd) {  //TEC
+              std::vector<ForwardDetLayer const*> negTECLayers =
+                  measurementTrackerHandle->geometricSearchTracker()->negTecLayers();
+              std::vector<ForwardDetLayer const*> posTECLayers =
+                  measurementTrackerHandle->geometricSearchTracker()->posTecLayers();
+
+              const DetLayer* tecLayerneg = negTECLayers[misLayer - k_LayersAtTIDEnd - 1];
+              const DetLayer* prevTecLayerneg = negTECLayers[previousMisLayer - k_LayersAtTIDEnd - 1];
+
+              const DetLayer* tecLayerpos = posTECLayers[misLayer - k_LayersAtTIDEnd - 1];
+              const DetLayer* prevTecLayerpos = posTECLayers[previousMisLayer - k_LayersAtTIDEnd - 1];
+
+              if (tTopo->tecSide(iidd) == 1) {
+                tmpTmeas = layerMeasurements.measurements(*tecLayerneg, tsos, *thePropagator, *estimator);
+                prev_tmpTmeas = layerMeasurements.measurements(*prevTecLayerneg, tsos, *thePropagator, *estimator);
+              } else if (tTopo->tecSide(iidd) == 2) {
+                tmpTmeas = layerMeasurements.measurements(*tecLayerpos, tsos, *thePropagator, *estimator);
+                prev_tmpTmeas = layerMeasurements.measurements(*prevTecLayerpos, tsos, *thePropagator, *estimator);
+              }
+            }
+          }
+          if (!tmpTmeas.empty() && !foundConsMissingHits) {
             TrajectoryMeasurement TM_tmp(tmpTmeas.back());
             unsigned int iidd_tmp = TM_tmp.recHit()->geographicalId().rawId();
             if (iidd_tmp != 0) {
@@ -606,6 +676,59 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                 TMs.push_back(TrajectoryAtInvalidHit(TM_tmp, tTopo, tkgeom, propagator));
               missingHitAdded = true;
               hitRecoveryCounters[misLayer] += 1;
+            }
+          }
+
+          if (!tmpTmeas.empty() && !prev_tmpTmeas.empty() &&
+              foundConsMissingHits) {  //Found two consecutive missing hits
+            TrajectoryMeasurement TM_tmp1(tmpTmeas.back());
+            TrajectoryMeasurement TM_tmp2(prev_tmpTmeas.back());
+            //Inner and outer hits module IDs
+            unsigned int modIdInner = TM_tmp1.recHit()->geographicalId().rawId();
+            unsigned int modIdOuter = TM_tmp2.recHit()->geographicalId().rawId();
+            bool innerModInactive = false, outerModInactive = false;
+            for (const auto& tm : tmpTmeas) {  //Check if inner module is inactive
+              unsigned int tmModId = tm.recHit()->geographicalId().rawId();
+              if (tmModId == modIdInner && tm.recHit()->getType() == 2) {
+                innerModInactive = true;
+                break;
+              }
+            }
+            for (const auto& tm : prev_tmpTmeas) {  //Check if outer module is inactive
+              unsigned int tmModId = tm.recHit()->geographicalId().rawId();
+              if (tmModId == modIdOuter && tm.recHit()->getType() == 2) {
+                outerModInactive = true;
+                break;  //Found the inactive module
+              }
+            }
+
+            if (outerModInactive) {  //If outer missing hit is in inactive module, recover the inner one
+              if (modIdInner != 0) {
+                LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";
+                if ((!useAllHitsFromTracksWithMissingHits_ || (!useFirstMeas_ && isFirstMeas)))
+                  TMs.clear();
+                if (::isDoubleSided(modIdInner, tTopo)) {
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp1, tTopo, tkgeom, propagator, 1));
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp1, tTopo, tkgeom, propagator, 2));
+                } else
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp1, tTopo, tkgeom, propagator));
+                missingHitAdded = true;
+                hitRecoveryCounters[misLayer] += 1;
+              }
+            }
+            if (innerModInactive) {  //If inner missing hit is in inactive module, recover the outer one
+              if (modIdOuter != 0) {
+                LogDebug("SiStripHitEfficiency:HitEff") << " hit actually being added to TM vector";
+                if ((!useAllHitsFromTracksWithMissingHits_ || (!useFirstMeas_ && isFirstMeas)))
+                  TMs.clear();
+                if (::isDoubleSided(modIdOuter, tTopo)) {
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp2, tTopo, tkgeom, propagator, 1));
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp2, tTopo, tkgeom, propagator, 2));
+                } else
+                  TMs.push_back(TrajectoryAtInvalidHit(TM_tmp2, tTopo, tkgeom, propagator));
+                missingHitAdded = true;
+                hitRecoveryCounters[previousMisLayer] += 1;
+              }
             }
           }
         }

--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -438,7 +438,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
           }
 
           //##### Layers from TEC
-          if (diffPreviousLayer == -3 && missedLayer > k_LayersAtTIDEnd && missedLayer <= k_LayersAtTECEnd &&
+          else if (diffPreviousLayer == -3 && missedLayer > k_LayersAtTIDEnd && missedLayer <= k_LayersAtTECEnd &&
               previousMissedLayer > k_LayersAtTIDEnd && previousMissedLayer <= k_LayersAtTECEnd) {
             missHitPerLayer[missedLayer] += 1;
             missHitPerLayer[previousMissedLayer] += 1;

--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -621,8 +621,8 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
             const TrajectoryStateOnSurface tsos = itm->updatedState();
             std::vector<DetLayer::DetWithState> compatDets = detlayer->compatibleDets(tsos, *thePropagator, *estimator);
 
-            if (misLayer > k_LayersStart && misLayer < k_LayersAtTOBEnd && previousMisLayer > k_LayersStart &&
-                previousMisLayer < k_LayersAtTOBEnd) {  //Barrel case
+            if (misLayer > k_LayersStart && misLayer <= k_LayersAtTOBEnd && previousMisLayer > k_LayersStart &&
+                previousMisLayer <= k_LayersAtTOBEnd) {  //Barrel case
               std::vector<BarrelDetLayer const*> barrelTIBLayers =
                   measurementTrackerHandle->geometricSearchTracker()->tibLayers();
               std::vector<BarrelDetLayer const*> barrelTOBLayers =

--- a/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/HitEff.cc
@@ -640,7 +640,7 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                 prev_tmpTmeas = layerMeasurements.measurements(*prevTobLayer, tsos, *thePropagator, *estimator);
               }
             }
-            if (misLayer > k_LayersAtTIDEnd && misLayer < k_LayersAtTECEnd && previousMisLayer > k_LayersAtTIDEnd &&
+            else if (misLayer > k_LayersAtTIDEnd && misLayer < k_LayersAtTECEnd && previousMisLayer > k_LayersAtTIDEnd &&
                 previousMisLayer < k_LayersAtTECEnd) {  //TEC
               std::vector<ForwardDetLayer const*> negTECLayers =
                   measurementTrackerHandle->geometricSearchTracker()->negTecLayers();


### PR DESCRIPTION
#### PR description:

- Improvement of the missing hits recovery within the strips, to take into account two consecutive missing hits when one is located in an inactive modules.
- Expected output is a slight change in the hit efficiency per layer, as shown in the slides presented during the Strip calibration and local reconstruction meeting here : https://indico.cern.ch/event/1396784/#b-556867-strip-calibration-loc ( Recovery of consecutive missing hits )

#### PR validation:

Ran the updated recovery on run 370772 with the PR code, output results are eactly the same as the one obtained when developing the algorithm as shown in slide 7 here : https://indico.cern.ch/event/1396784/#b-556867-strip-calibration-loc