### PR TITLE
ETL hits accumulation on a pixel-basis in MTD Validation

### DIFF
--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -52,11 +52,10 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
   unsigned char flag = 0;
 
   LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << time_over_threshold << ' ' << sample.tot() << ' '
-                               << toaLSBToNS_ << ' ' << std::endl;
+                               << toaLSBToNS_;
 
   if (time_over_threshold == 0) {
-    LogDebug("ETLUncalibRecHit") << "ADC+: set the time to: " << time << ' ' << sample.toa() << ' ' << toaLSBToNS_
-                                 << ' ' << std::endl;
+    LogDebug("ETLUncalibRecHit") << "ADC+: set the time to: " << time << ' ' << sample.toa() << ' ' << toaLSBToNS_;
 
   } else {
     // Time-walk correction for toa
@@ -67,10 +66,10 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
     time -= timeWalkCorr;
 
     LogDebug("ETLUncalibRecHit") << "ADC+: set the time to: " << time << ' ' << sample.toa() << ' ' << toaLSBToNS_
-                                 << " .Timewalk correction: " << timeWalkCorr << std::endl;
+                                 << " .Timewalk correction: " << timeWalkCorr;
   }
 
-  LogDebug("ETLUncalibRecHit") << "Final uncalibrated time_over_threshold: " << time_over_threshold << std::endl;
+  LogDebug("ETLUncalibRecHit") << "Final uncalibrated time_over_threshold: " << time_over_threshold;
 
   const std::array<double, 1> emptyV = {{0.}};
 

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -51,8 +51,8 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
 
   unsigned char flag = 0;
 
-  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << time_over_threshold << ' ' << sample.tot() << ' ' << toaLSBToNS_
-                               << ' ' << std::endl;
+  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << time_over_threshold << ' ' << sample.tot() << ' '
+                               << toaLSBToNS_ << ' ' << std::endl;
 
   if (time_over_threshold == 0) {
     LogDebug("ETLUncalibRecHit") << "ADC+: set the time to: " << time << ' ' << sample.toa() << ' ' << toaLSBToNS_

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/ETLUncalibRecHitAlgo.cc
@@ -44,13 +44,14 @@ private:
 FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataFrame) const {
   constexpr int iSample = 2;  //only in-time sample
   const auto& sample = dataFrame.sample(iSample);
-  const std::array<double, 1> amplitudeV = {{double(sample.data()) * adcLSB_}};
 
   double time = double(sample.toa()) * toaLSBToNS_ - tofDelay_;
   double time_over_threshold = double(sample.tot()) * toaLSBToNS_;
+  const std::array<double, 1> time_over_threshold_V = {{time_over_threshold}};
+
   unsigned char flag = 0;
 
-  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << amplitudeV[0] << ' ' << sample.data() << ' ' << adcLSB_
+  LogDebug("ETLUncalibRecHit") << "ADC+: set the charge to: " << time_over_threshold << ' ' << sample.tot() << ' ' << toaLSBToNS_
                                << ' ' << std::endl;
 
   if (time_over_threshold == 0) {
@@ -69,16 +70,16 @@ FTLUncalibratedRecHit ETLUncalibRecHitAlgo::makeRecHit(const ETLDataFrame& dataF
                                  << " .Timewalk correction: " << timeWalkCorr << std::endl;
   }
 
-  LogDebug("ETLUncalibRecHit") << "Final uncalibrated amplitude : " << amplitudeV[0] << std::endl;
+  LogDebug("ETLUncalibRecHit") << "Final uncalibrated time_over_threshold: " << time_over_threshold << std::endl;
 
   const std::array<double, 1> emptyV = {{0.}};
 
-  double timeError = timeError_.evaluate(amplitudeV, emptyV);
+  double timeError = timeError_.evaluate(time_over_threshold_V, emptyV);
 
   return FTLUncalibratedRecHit(dataFrame.id(),
                                dataFrame.row(),
                                dataFrame.column(),
-                               {amplitudeV[0], 0.f},
+                               {time_over_threshold_V[0], 0.f},
                                {time, 0.f},
                                timeError,
                                -1.f,

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -67,7 +67,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
     }
     // ETL, BTL tile geometry, BTL bar geometry with only the left SiPM information available
     default: {
-      energy = uRecHit.amplitude().first; //for ETL, it is the time_over_threshold
+      energy = uRecHit.amplitude().first;  //for ETL, it is the time_over_threshold
       time = uRecHit.time().first;
 
       break;

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -67,7 +67,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
     }
     // ETL, BTL tile geometry, BTL bar geometry with only the left SiPM information available
     default: {
-      energy = uRecHit.amplitude().first;
+      energy = uRecHit.amplitude().first; //for ETL, it is the time_over_threshold
       time = uRecHit.time().first;
 
       break;

--- a/SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h
+++ b/SimFastTiming/FastTimingCommon/interface/ETLElectronicsSim.h
@@ -49,7 +49,6 @@ private:
   const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
   const MTDGeometry* geom_;
 
-  const bool debug_;
   const float bxTime_;
   const float integratedLum_;
 

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -88,7 +88,7 @@ _endcap_MTDDigitizer = cms.PSet(
         # n bits for the TDC
         tdcNbits             = cms.uint32(11),
         # ADC saturation
-        adcSaturation_MIP  = cms.double(25),
+        adcSaturation_MIP  = cms.double(100),
         # for different thickness
         adcThreshold_MIP   = cms.double(0.025),
         iThreshold_MIP     = cms.double(0.9525),

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -123,8 +123,10 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
     const auto& thepixel = topo.pixelIndex(simscaled);
     const uint8_t row = static_cast<uint8_t>(thepixel.first);
     const uint8_t col = static_cast<uint8_t>(thepixel.second);
-    LogDebug("ETLDeviceSim") << "Processing hit in pixel # " << hitidx << " DetId " << etlid.rawId() << " row/col "
-                             << (uint32_t)row << " " << (uint32_t)col << " tof " << toa;
+    LogTrace("ETLDeviceSim") << "Processing hit in pixel # " << hitidx << " DetId " << etlid.rawId() << " row/col "
+                             << (uint32_t)row << " " << (uint32_t)col << " inPixel " << topo.isInPixel(simscaled)
+                             << " tof " << toa << " ene " << hit.energyLoss() << " MIP " << MIPPerMeV_ << " gain "
+                             << gain[0] << " charge " << charge << " MPV " << MPV_charge;
 
     auto simHitIt =
         simHitAccumulator->emplace(mtd_digitizer::MTDCellId(id, row, col), mtd_digitizer::MTDCellInfo()).first;

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -132,15 +132,15 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
                                          const uint8_t row,
                                          const uint8_t col) const {
 #ifdef EDM_ML_DEBUG
-  bool debug(false);
+  bool dumpInfo(false);
   for (int it = 0; it < (int)(chargeColl.size()); it++) {
     if (chargeColl[it] > adcThreshold_MIP_) {
-      debug = true;
+      dumpInfo = true;
       break;
     }
   }
-  if (debug) {
-    LogTrace("ETLElectronicsSim") << "[runTrivialShaper]" << std::endl;
+  if (dumpInfo) {
+    LogTrace("ETLElectronicsSim") << "[runTrivialShaper]";
   }
 #endif
 
@@ -162,17 +162,17 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
     dataFrame.setSample(it, newSample);
 
 #ifdef EDM_ML_DEBUG
-    if (debug) {
+    if (dumpInfo) {
       LogTrace("ETLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
     }
 #endif
   }
 
 #ifdef EDM_ML_DEBUG
-  if (debug) {
+  if (dumpInfo) {
     std::ostringstream msg;
     dataFrame.print(msg);
-    LogTrace("ETLElectronicsSim") << msg.str() << std::endl;
+    LogTrace("ETLElectronicsSim") << msg.str();
   }
 #endif
 }

--- a/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLElectronicsSim.cc
@@ -9,7 +9,6 @@ using namespace mtd;
 ETLElectronicsSim::ETLElectronicsSim(const edm::ParameterSet& pset, edm::ConsumesCollector iC)
     : geomToken_(iC.esConsumes()),
       geom_(nullptr),
-      debug_(pset.getUntrackedParameter<bool>("debug", false)),
       bxTime_(pset.getParameter<double>("bxTime")),
       integratedLum_(pset.getParameter<double>("IntegratedLuminosity")),
       adcNbits_(pset.getParameter<uint32_t>("adcNbits")),
@@ -132,14 +131,18 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
                                          const mtd::MTDSimHitData& tot,
                                          const uint8_t row,
                                          const uint8_t col) const {
-  bool debug = debug_;
 #ifdef EDM_ML_DEBUG
-  for (int it = 0; it < (int)(chargeColl.size()); it++)
-    debug |= (chargeColl[it] > adcThreshold_MIP_);
+  bool debug(false);
+  for (int it = 0; it < (int)(chargeColl.size()); it++) {
+    if (chargeColl[it] > adcThreshold_MIP_) {
+      debug = true;
+      break;
+    }
+  }
+  if (debug) {
+    LogTrace("ETLElectronicsSim") << "[runTrivialShaper]" << std::endl;
+  }
 #endif
-
-  if (debug)
-    edm::LogVerbatim("ETLElectronicsSim") << "[runTrivialShaper]" << std::endl;
 
   //set new ADCs. Notice that we are only interested in the first element of the array for the ETL
   for (int it = 0; it < (int)(chargeColl.size()); it++) {
@@ -158,15 +161,20 @@ void ETLElectronicsSim::runTrivialShaper(ETLDataFrame& dataFrame,
     //ETLSample newSample;
     dataFrame.setSample(it, newSample);
 
-    if (debug)
-      edm::LogVerbatim("ETLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
+#ifdef EDM_ML_DEBUG
+    if (debug) {
+      LogTrace("ETLElectronicsSim") << adc << " (" << chargeColl[it] << "/" << adcLSB_MIP_ << ") ";
+    }
+#endif
   }
 
+#ifdef EDM_ML_DEBUG
   if (debug) {
     std::ostringstream msg;
     dataFrame.print(msg);
-    edm::LogVerbatim("ETLElectronicsSim") << msg.str() << std::endl;
+    LogTrace("ETLElectronicsSim") << msg.str() << std::endl;
   }
+#endif
 }
 
 void ETLElectronicsSim::updateOutput(ETLDigiCollection& coll, const ETLDataFrame& rawDataFrame) const {

--- a/Validation/MtdValidation/plugins/BuildFile.xml
+++ b/Validation/MtdValidation/plugins/BuildFile.xml
@@ -29,4 +29,5 @@
 <use name="root"/>
 <use name="gsl"/>
 <use name="fastjet"/>
+<use name="SimFastTiming/FastTimingCommon"/>
 <flags EDM_PLUGIN="1"/>

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -267,17 +267,17 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("EtlHitTimeZposD2", "ETL DIGI hits ToA (+Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
 
   meHitToT_[0] = ibook.book1D("EtlHitToTZnegD1",
-                               "ETL DIGI hits ToT (-Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
-                               100,
-                               0.,
-                               500.);
+                              "ETL DIGI hits ToT (-Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
+                              100,
+                              0.,
+                              500.);
   meHitToT_[1] =
       ibook.book1D("EtlHitToTZnegD2", "ETL DIGI hits ToT (-Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 500.);
   meHitToT_[2] = ibook.book1D("EtlHitToTZposD1",
-                               "ETL DIGI hits ToT (+Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
-                               100,
-                               0.,
-                               500.);
+                              "ETL DIGI hits ToT (+Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
+                              100,
+                              0.,
+                              500.);
   meHitToT_[3] =
       ibook.book1D("EtlHitToTZposD2", "ETL DIGI hits ToT (+Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 500.);
 
@@ -408,7 +408,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                         256.,
                         0.,
                         1024.);
-meHitToTvsQ_[0] = ibook.bookProfile(
+  meHitToTvsQ_[0] = ibook.bookProfile(
       "EtlHitToTvsQZnegD1",
       "ETL DIGI ToT vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
       50,

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -75,6 +75,7 @@ private:
   MonitorElement* meHitEta_[4];
 
   MonitorElement* meHitTvsQ_[4];
+  MonitorElement* meHitToTvsQ_[4];
   MonitorElement* meHitQvsPhi_[4];
   MonitorElement* meHitQvsEta_[4];
   MonitorElement* meHitTvsPhi_[4];
@@ -176,6 +177,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     meHitEta_[idet]->Fill(global_point.eta());
 
     meHitTvsQ_[idet]->Fill(sample.data(), sample.toa());
+    meHitToTvsQ_[idet]->Fill(sample.data(), sample.tot());
     meHitQvsPhi_[idet]->Fill(global_point.phi(), sample.data());
     meHitQvsEta_[idet]->Fill(global_point.eta(), sample.data());
     meHitTvsPhi_[idet]->Fill(global_point.phi(), sample.toa());
@@ -268,16 +270,16 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                "ETL DIGI hits ToT (-Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
                                100,
                                0.,
-                               2000.);
+                               500.);
   meHitToT_[1] =
-      ibook.book1D("EtlHitToTZnegD2", "ETL DIGI hits ToT (-Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 2000.);
+      ibook.book1D("EtlHitToTZnegD2", "ETL DIGI hits ToT (-Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 500.);
   meHitToT_[2] = ibook.book1D("EtlHitToTZposD1",
                                "ETL DIGI hits ToT (+Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
                                100,
                                0.,
-                               2000.);
+                               500.);
   meHitToT_[3] =
-      ibook.book1D("EtlHitToTZposD2", "ETL DIGI hits ToT (+Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 2000.);
+      ibook.book1D("EtlHitToTZposD2", "ETL DIGI hits ToT (+Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 500.);
 
   meOccupancy_[0] =
       ibook.book2D("EtlOccupancyZnegD1",
@@ -401,6 +403,38 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTvsQ_[3] =
       ibook.bookProfile("EtlHitTvsQZposD2",
                         "ETL DIGI ToA vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                        50,
+                        0.,
+                        256.,
+                        0.,
+                        1024.);
+meHitToTvsQ_[0] = ibook.bookProfile(
+      "EtlHitToTvsQZnegD1",
+      "ETL DIGI ToT vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
+      50,
+      0.,
+      256.,
+      0.,
+      1024.);
+  meHitToTvsQ_[1] =
+      ibook.bookProfile("EtlHitToTvsQZnegD2",
+                        "ETL DIGI ToT vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
+                        50,
+                        0.,
+                        256.,
+                        0.,
+                        1024.);
+  meHitToTvsQ_[2] = ibook.bookProfile(
+      "EtlHitToTvsQZposD1",
+      "ETL DIGI ToT vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
+      50,
+      0.,
+      256.,
+      0.,
+      1024.);
+  meHitToTvsQ_[3] =
+      ibook.bookProfile("EtlHitToTvsQZposD2",
+                        "ETL DIGI ToT vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToT_{DIGI} [TDC counts]",
                         50,
                         0.,
                         256.,

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -60,6 +60,7 @@ private:
 
   MonitorElement* meHitCharge_[4];
   MonitorElement* meHitTime_[4];
+  MonitorElement* meHitToT_[4];
 
   MonitorElement* meOccupancy_[4];
 
@@ -152,6 +153,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
     meHitCharge_[idet]->Fill(sample.data());
     meHitTime_[idet]->Fill(sample.toa());
+    meHitToT_[idet]->Fill(sample.tot());
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
 
     if (optionalPlots_) {
@@ -246,6 +248,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  256.);
   meHitCharge_[3] =
       ibook.book1D("EtlHitChargeZposD2", "ETL DIGI hits charge (+Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+
   meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1",
                                "ETL DIGI hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]",
                                100,
@@ -260,6 +263,21 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                2000.);
   meHitTime_[3] =
       ibook.book1D("EtlHitTimeZposD2", "ETL DIGI hits ToA (+Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+
+  meHitToT_[0] = ibook.book1D("EtlHitToTZnegD1",
+                               "ETL DIGI hits ToT (-Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
+                               100,
+                               0.,
+                               2000.);
+  meHitToT_[1] =
+      ibook.book1D("EtlHitToTZnegD2", "ETL DIGI hits ToT (-Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitToT_[2] = ibook.book1D("EtlHitToTZposD1",
+                               "ETL DIGI hits ToT (+Z, Single(topo1D)/First(topo2D) disk);ToT_{DIGI} [TDC counts]",
+                               100,
+                               0.,
+                               2000.);
+  meHitToT_[3] =
+      ibook.book1D("EtlHitToTZposD2", "ETL DIGI hits ToT (+Z, Second disk);ToT_{DIGI} [TDC counts]", 100, 0., 2000.);
 
   meOccupancy_[0] =
       ibook.book2D("EtlOccupancyZnegD1",

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -28,6 +28,8 @@
 #include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
 #include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
+#include "SimFastTiming/FastTimingCommon/interface/MTDDigitizerTypes.h"
+
 #include "SimDataFormats/CaloAnalysis/interface/MtdSimLayerCluster.h"
 #include "SimDataFormats/Associations/interface/MtdRecoClusterToSimLayerClusterAssociationMap.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -40,6 +42,7 @@
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
+#include "Geometry/MTDGeometryBuilder/interface/MTDGeomUtil.h"
 
 #include "RecoLocalFastTime/Records/interface/MTDCPERecord.h"
 #include "RecoLocalFastTime/FTLClusterizer/interface/MTDClusterParameterEstimator.h"
@@ -192,9 +195,13 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   using namespace edm;
   using namespace std;
   using namespace geant_units::operators;
+  using namespace mtd;
 
   auto geometryHandle = iSetup.getTransientHandle(mtdgeoToken_);
   const MTDGeometry* geom = geometryHandle.product();
+
+  MTDGeomUtil geomUtil;
+  geomUtil.setGeometry(geom);
 
   auto const& cpe = iSetup.getData(cpeToken_);
 
@@ -220,7 +227,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 #endif
 
   // --- Loop over the ETL SIM hits
-  std::unordered_map<uint32_t, MTDHit> m_etlSimHits[4];
+  std::unordered_map<mtd_digitizer::MTDCellId, MTDHit> m_etlSimHits[4];
   for (auto const& simHit : etlSimHits) {
     // --- Use only hits compatible with the in-time bunch-crossing
     if (simHit.tof() < 0 || simHit.tof() > 25.)
@@ -243,7 +250,13 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       continue;
     }
 
-    auto simHitIt = m_etlSimHits[idet].emplace(id.rawId(), MTDHit()).first;
+    const auto &position = simHit.localPosition();
+
+    LocalPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
+    std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(id, simscaled);
+
+    mtd_digitizer::MTDCellId pixelId(id.rawId(), pixel.first, pixel.second);
+    auto simHitIt = m_etlSimHits[idet].emplace(pixelId, MTDHit()).first;
 
     // --- Accumulate the energy (in MeV) of SIM hits in the same detector cell
     (simHitIt->second).energy += convertUnitsTo(0.001_MeV, simHit.energyLoss());
@@ -330,16 +343,19 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitTvsEta_[idet]->Fill(global_point.eta(), recHit.time());
 
     // Resolution histograms
-    if (m_etlSimHits[idet].count(detId.rawId()) == 1) {
-      if (m_etlSimHits[idet][detId.rawId()].energy > hitMinEnergy2Dis_) {
-        float time_res = recHit.time() - m_etlSimHits[idet][detId.rawId()].time;
-        float energy_res = recHit.energy() - m_etlSimHits[idet][detId.rawId()].energy;
+    std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+    mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
+
+    if (m_etlSimHits[idet].count(pixelId) == 1) {
+      if (m_etlSimHits[idet][pixelId].energy > hitMinEnergy2Dis_) {
+        float time_res = recHit.time() - m_etlSimHits[idet][pixelId].time;
+        float energy_res = recHit.energy() - m_etlSimHits[idet][pixelId].energy;
 
         meTimeRes_->Fill(time_res);
         meEnergyRes_->Fill(energy_res);
 
         meTPullvsEta_->Fill(std::abs(global_point.eta()), time_res / recHit.timeError());
-        meTPullvsE_->Fill(m_etlSimHits[idet][detId.rawId()].energy, time_res / recHit.timeError());
+        meTPullvsE_->Fill(m_etlSimHits[idet][pixelId].energy, time_res / recHit.timeError());
       }
     }
 
@@ -419,13 +435,23 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
         // Match the RECO hit to the corresponding SIM hit
         for (const auto& recHit : *etlRecHitsHandle) {
-          ETLDetId hitId(recHit.id().rawId());
+          ETLDetId detId(recHit.id().rawId());
 
-          if (m_etlSimHits[idet].count(hitId.rawId()) == 0)
+          DetId geoId = detId.geographicalId();
+          const MTDGeomDet* thedet = geom->idToDet(geoId);
+          const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
+          const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
+
+          Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
+
+          std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+          mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
+
+          if (m_etlSimHits[idet].count(pixelId) == 0)
             continue;
 
           // Check the hit position
-          if (hitId.zside() != cluId.zside() || hitId.mtdRR() != cluId.mtdRR() || hitId.module() != cluId.module() ||
+          if (detId.zside() != cluId.zside() || detId.mtdRR() != cluId.mtdRR() || detId.module() != cluId.module() ||
               recHit.row() != hit_row || recHit.column() != hit_col)
             continue;
 
@@ -434,18 +460,18 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             continue;
 
           // SIM hit's position in the module reference frame
-          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].x),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].y),
-                                       convertMmToCm(m_etlSimHits[idet][recHit.id().rawId()].z));
+          Local3DPoint local_point_sim(convertMmToCm(m_etlSimHits[idet][pixelId].x),
+                                       convertMmToCm(m_etlSimHits[idet][pixelId].y),
+                                       convertMmToCm(m_etlSimHits[idet][pixelId].z));
 
           // Calculate the SIM cluster's position in the module reference frame
-          cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][recHit.id().rawId()].energy;
-          cluLocYSIM += local_point_sim.y() * m_etlSimHits[idet][recHit.id().rawId()].energy;
-          cluLocZSIM += local_point_sim.z() * m_etlSimHits[idet][recHit.id().rawId()].energy;
+          cluLocXSIM += local_point_sim.x() * m_etlSimHits[idet][pixelId].energy;
+          cluLocYSIM += local_point_sim.y() * m_etlSimHits[idet][pixelId].energy;
+          cluLocZSIM += local_point_sim.z() * m_etlSimHits[idet][pixelId].energy;
 
           // Calculate the SIM cluster energy and time
-          cluEneSIM += m_etlSimHits[idet][recHit.id().rawId()].energy;
-          cluTimeSIM += m_etlSimHits[idet][recHit.id().rawId()].time * m_etlSimHits[idet][recHit.id().rawId()].energy;
+          cluEneSIM += m_etlSimHits[idet][pixelId].energy;
+          cluTimeSIM += m_etlSimHits[idet][pixelId].time * m_etlSimHits[idet][pixelId].energy;
 
           break;
 
@@ -558,31 +584,33 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
     for (const auto& uRecHit : *etlUncalibRecHitsHandle) {
       ETLDetId detId = uRecHit.id();
-
       int idet = detId.zside() + detId.nDisc();
-
-      // --- Skip UncalibratedRecHits not matched to SimHits
-      if (m_etlSimHits[idet].count(detId.rawId()) != 1)
-        continue;
 
       DetId geoId = detId.geographicalId();
       const MTDGeomDet* thedet = geom->idToDet(geoId);
-      if (thedet == nullptr)
-        throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
-                                                       << detId.rawId() << ") is invalid!" << std::dec << std::endl;
-
       const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(thedet->topology());
       const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
 
       Local3DPoint local_point(topo.localX(uRecHit.row()), topo.localY(uRecHit.column()), 0.);
       const auto& global_point = thedet->toGlobal(local_point);
 
+      std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(detId, local_point);
+      mtd_digitizer::MTDCellId pixelId(detId.rawId(), pixel.first, pixel.second);
+
+      // --- Skip UncalibratedRecHits not matched to SimHits
+      if (m_etlSimHits[idet].count(pixelId) == 0)
+        continue;
+
+      if (thedet == nullptr)
+        throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
+                                                       << detId.rawId() << ") is invalid!" << std::dec << std::endl;
+
       // --- Fill the histograms
 
       if (uRecHit.amplitude().first < hitMinAmplitude_)
         continue;
 
-      float time_res = uRecHit.time().first - m_etlSimHits[idet][detId.rawId()].time;
+      float time_res = uRecHit.time().first - m_etlSimHits[idet][pixelId].time;
 
       int iside = (detId.zside() == -1 ? 0 : 1);
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -241,7 +241,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       continue;
     }
 
-    const auto &position = simHit.localPosition();
+    const auto& position = simHit.localPosition();
 
     LocalPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
     std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(id, simscaled);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -56,7 +56,7 @@ private:
   const std::string folder_;
   const float hitMinEnergy2Dis_;
 
-  edm::EDGetTokenT<CrossingFrame<PSimHit> > etlSimHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> etlSimHitsToken_;
 
   edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
   edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
@@ -92,7 +92,7 @@ private:
 EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")) {
-  etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("inputTag"));
+  etlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("inputTag"));
   mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
   mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
 }
@@ -148,7 +148,7 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       continue;
     }
 
-    const auto &position = simHit.localPosition();
+    const auto& position = simHit.localPosition();
 
     LocalPoint simscaled(convertMmToCm(position.x()), convertMmToCm(position.y()), convertMmToCm(position.z()));
     std::pair<uint8_t, uint8_t> pixel = geomUtil.pixelInModule(id, simscaled);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -267,13 +267,13 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meNtrkPerCell_[3] =
       ibook.book1D("EtlNtrkPerCellZposD2", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
   meHitEnergy_[0] = ibook.book1D(
-      "EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+      "EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 1.5);
   meHitEnergy_[1] =
-      ibook.book1D("EtlHitEnergyZnegD2", "ETL SIM hits energy (-Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+      ibook.book1D("EtlHitEnergyZnegD2", "ETL SIM hits energy (-Z, Second disk);E_{SIM} [MeV]", 100, 0., 1.5);
   meHitEnergy_[2] = ibook.book1D(
-      "EtlHitEnergyZposD1", "ETL SIM hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+      "EtlHitEnergyZposD1", "ETL SIM hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 1.5);
   meHitEnergy_[3] =
-      ibook.book1D("EtlHitEnergyZposD2", "ETL SIM hits energy (+Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+      ibook.book1D("EtlHitEnergyZposD2", "ETL SIM hits energy (+Z, Second disk);E_{SIM} [MeV]", 100, 0., 1.5);
   meHitTime_[0] = ibook.book1D(
       "EtlHitTimeZnegD1", "ETL SIM hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL SIM hits ToA (-Z, Second disk);ToA_{SIM} [ns]", 100, 0., 25.);

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -2104,6 +2104,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
               d3D = -d3D;
             }
 
+            // select TPs associated to the signal event
             bool selectTP = mvaTPSel(**tp_info);
 
             if (selectedLVMatching && selectRecoTrk && selectTP) {


### PR DESCRIPTION
PR description:
The accumulation process in MTD validation, based on modules (DetId), is updated to be pixel-level during SimHits processing, aligning it with the digitization of ETL[1]; in particular, this may impact processes under high pile-up conditions.
To be consistent with PR #43762, which changes the ETL digitization, it is important to rectify this discrepancy.
A correction attempt has already been made with the failed pull request #43928.
The Digi structure (ETLSample) has been also updated to accomodate for one additional parameter, the time over threshold, therefore some plots to monitor Tot are added in EtlDigiHitsValidation.
Moreover, debugging verbosity in ETL digitization and adcSaturation_MIP in mtdDigitizer_cfg.py are updated.
In ETLUnalibratedRecHitAlgo, amplitude for ETL is set to be the time_over_threshold, because reco energy will not be reconstructed; for the same reason, in EtlLocalecoValidation, some plots about reco energy are removed.
Finally, the use of MC truth for tracks and Primary Vertices is updated, to be consistent with PR #43913.

PR validation:
The code was tested on the workflow
24834.0_TTbar_14TeV+2026D98 

[1] https://github.com/cms-sw/cmssw/blob/master/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc