### PR TITLE
[CMSSW_14_0_X] Update L1T menu tag to L1Menu_Collisions2024_v1_2_0_xml

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -90,13 +90,13 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
-    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v9',
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v10',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v10',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v12',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v8',
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v10',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_1_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-03-20 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-04-28 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
#### PR description:

Update L1T menu with L1Menu_Collisions2024_v1_2_0_xml, as from cmsTalk https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-2024-l1t-menu-tag-l1menu-collisions2024-v1-2-0/39826

The new L1T menu tag is `L1Menu_Collisions2024_v1_2_0_xml` which replaces the previous `L1Menu_Collisions2024_v1_1_0_xml.` The difference wrt the previous tag is just the [addition of a few L1 HQ bits](https://its.cern.ch/jira/browse/CMSLITDPG-1251) for lumi-decay.

All the differences w.r.t. the previous L1T menu are summarized [here](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/development/L1Menu_Collisions2024_v1_2_0) , and can be visible also via the Payload Inspector:

![PLI_L1TriggerMenu2024](https://github.com/cms-sw/cmssw/assets/4069749/a14788ca-d92f-46d0-99f5-9bc589c1c809)

GT differences with the previous ones only relate to the updated L1T menu tag:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v9/140X_mcRun3_2024_design_v10
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v10/140X_mcRun3_2024_realistic_v11
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v10/140X_mcRun3_2024cosmics_realistic_deco_v12
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v8/140X_mcRun3_2024cosmics_design_deco_v10

#### PR validation:

See master branch.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #44860