### PR TITLE
Add check on PATLeptonTimeLifeInfoProducer closestState valid state

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
@@ -12,6 +12,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
@@ -169,6 +170,14 @@ void PATLeptonTimeLifeInfoProducer<T>::produceAndFillIPInfo(const T& lepton,
     AnalyticalImpactPointExtrapolator extrapolator(transTrack.field());
     TrajectoryStateOnSurface closestState =
         extrapolator.extrapolate(transTrack.impactPointState(), RecoVertex::convertPos(pv.position()));
+    if (!closestState.isValid()) {
+      edm::LogError("PATLeptonTimeLifeInfoProducer")
+          << "closestState not valid! From:\n"
+          << "transTrack.impactPointState():\n"
+          << transTrack.impactPointState() << "RecoVertex::convertPos(pv.position()):\n"
+          << RecoVertex::convertPos(pv.position());
+      return;
+    }
     GlobalPoint pca = closestState.globalPosition();
     GlobalError pca_cov = closestState.cartesianError().position();
     GlobalVector ip_vec = GlobalVector(pca.x() - pv.x(), pca.y() - pv.y(), pca.z() - pv.z());


### PR DESCRIPTION
#### PR description:
This PR addresses https://github.com/cms-sw/cmssw/issues/44862 as suggested in https://github.com/cms-sw/cmssw/issues/44862#issuecomment-2082217130, in order to cure the crash observed in the CMSSW_14_0_6 replay (see [CMSTalk](https://cms-talk.web.cern.ch/t/replay-request-for-cmssw-14-0-6/39939/4)).

It simply adds an `isValid()` check to the `closestState` object before accessing its members and emits an `edm::LogError` in case it's not valid.

@cms-sw/tracking-pog-l2 @mbluj please advise if a better solution is needed to fix the issue at its root.

#### PR validation:
Code compiles.
Additionally, I re-run successfully on the crashing event following the recipe from https://github.com/cms-sw/cmssw/issues/44862#issuecomment-2082166554 and, as expected, I got:
```
%MSG-e PATLeptonTimeLifeInfoProducer:   PATElectronTimeLifeInfoProducer:electronTimeLifeInfos  29-Apr-2024 11:56:53 CEST Run: 369998 Event: 31680062
closestState not valid!
%MSG
```
but no crash.

#### Backport:
A 14_0_X backport is needed in order to be deployed in production in Tier0 (thus allowing deployment of 14_0_6_MULTIARCHS in HLT)


FYI @mandrenguyen @missirol 