### PR TITLE
Do not include EventSetup record definitions in device code [14.0.x]

### DIFF
--- a/DataFormats/TrackSoA/interface/TrackDefinitions.h
+++ b/DataFormats/TrackSoA/interface/TrackDefinitions.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <algorithm>
 #include <stdexcept>
+#include <cstdint>
 
 namespace pixelTrack {
 

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -9,11 +9,15 @@
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/CaloRecHitHostCollection.h"
 #include "DataFormats/ParticleFlowReco/interface/alpaka/CaloRecHitDeviceCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyHostCollection.h"
-#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
+
+// Forward declaration of EventSetup records, to avoid propagating the dependency on framework headers to device code
+class PFRecHitHCALParamsRecord;
+class PFRecHitHCALTopologyRecord;
+class EcalPFRecHitThresholdsRcd;
+class PFRecHitECALTopologyRecord;
 
 // This file defines two structs:
 // 1) ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer::HCAL

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -8,8 +8,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
-#include "CalorimeterDefinitions.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
 
+#include "CalorimeterDefinitions.h"
 #include "PFRecHitProducerKernel.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -4,9 +4,9 @@
 #include <utility>
 #include <variant>
 
-#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "CondFormats/DataRecord/interface/HcalPFCutsRcd.h"
 #include "CondTools/Hcal/interface/HcalPFCutsHandler.h"
+#include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -18,6 +18,9 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitParamsRecord.h"
+#include "RecoParticleFlow/PFRecHitProducer/interface/PFRecHitTopologyRecord.h"
+
 #include "CalorimeterDefinitions.h"
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {


### PR DESCRIPTION
#### PR description:

Backport of #44682 by @iarspider:

> As suggested in [#44645 (comment)](https://github.com/cms-sw/cmssw/issues/44645#issuecomment-2045554062)

Includes the following clean up from #44870.

#### PR validation:

Unit tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR.

Backport of #44682 and #44870 to CMSSW 14.0.x to keep the alpaka code consistent.