### PR TITLE
MTD: fix phase-2 config for RecoVertex and RecoTrack

### DIFF
--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -84,6 +84,10 @@ phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4D, offlinePrimaryVertic
 phase2_timing_layer.toReplaceWith(offlinePrimaryVertices4DWithBS, offlinePrimaryVertices4DwithPIDWithBS.clone())
 phase2_timing_layer.toModify(offlinePrimaryVertices4D, vertices = "unsortedOfflinePrimaryVertices4D", particles = "trackRefsForJetsBeforeSorting4D")
 phase2_timing_layer.toModify(offlinePrimaryVertices4DWithBS, vertices = "unsortedOfflinePrimaryVertices4D:WithBS", particles = "trackRefsForJetsBeforeSorting4D")
+phase2_timing_layer.toModify(unsortedOfflinePrimaryVertices,
+    vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID'))),
+                         1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID')))}
+)
 
 from Configuration.ProcessModifiers.vertex4DTrackSelMVA_cff import vertex4DTrackSelMVA
 vertex4DTrackSelMVA.toModify(unsortedOfflinePrimaryVertices4D, useMVACut = True)

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -11,6 +11,9 @@ unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone(
     ),
     TrackTimesLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),
     TrackTimeResosLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),
+    trackMTDTimeQualityVMapTag = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
+    useMVACut = cms.bool(False),
+    minTrackTimeQuality = cms.double(0.8),
     vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D'))),
                          1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D')))}
     )
@@ -67,7 +70,3 @@ tofPID3D=tofPIDProducer.clone(vtxsSrc='unsortedOfflinePrimaryVertices')
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
 phase2_timing_layer.toModify(tofPID, vtxsSrc='unsortedOfflinePrimaryVertices4D', vertexReassignment=False)
 phase2_timing_layer.toModify(tofPID3D, vertexReassignment=False)
-phase2_timing_layer.toModify(unsortedOfflinePrimaryVertices,
-    vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID'))),
-                         1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID')))}
-)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -1217,10 +1217,6 @@ tracksValidationLite = cms.Sequence(
 
 ## customization for timing
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
-phase2_timing_layer.toModify( generalTracksFromPV, 
-                              timesTag  = cms.InputTag('tofPID:t0'), 
-                              timeResosTag = cms.InputTag('tofPID:sigmat0'),
-                              nSigmaDtVertex = cms.double(3) )
 phase2_timing_layer.toModify( trackValidatorStandalone,
                               label_vertex = cms.untracked.InputTag('offlinePrimaryVertices4D') )
 phase2_timing_layer.toModify( trackValidatorFromPVStandalone,


### PR DESCRIPTION
#### PR description:

In this PR a fix to RecoVertex and RecoTrack configuration files for phase-2 is made, following the changes made in https://github.com/cms-sw/cmssw/pull/43592.

For RecoVertex:
- address the comment from @slava77 in https://github.com/cms-sw/cmssw/pull/43592/files/e3e5c3ed60324c70b0f407820e10c6c5785863b3#diff-df2a0a87cb45575436295cfaa7ef61d4fcd0026ac5b9fc7351121de26ced0ef0
- add parameters for the use of MVA quality cut in 4D vertex reconstruction. The parameters were missing after the changes made in https://github.com/cms-sw/cmssw/pull/43846 for the configurations reorganization. 
 
For TrackValidation:
- remove time selection on generalTracksFromPV, enabled after the changes in https://github.com/cms-sw/cmssw/pull/43592. Since 3D vertices now have time, the tracks from 3D vertices have an additional time selection enabled, which causes a loss in efficiency of 5-10%. The time selection is removed for the validation of tracksFromPV.

#### PR validation:

Tested on TTbar_14TeV+PU200, expected changes in Tracking/TracksFromPV with the recovery of track efficiency loss.
