### PR TITLE
Fixes for Alpaka Phase2 Pixel Reco

### DIFF
--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisDevice.h
@@ -21,17 +21,13 @@ public:
   explicit SiPixelDigisDevice(size_t maxFedWords, TDev const &device)
       : PortableDeviceCollection<SiPixelDigisSoA, TDev>(maxFedWords + 1, device) {}
 
-  void setNModulesDigis(uint32_t nModules, uint32_t nDigis) {
-    nModules_h = nModules;
-    nDigis_h = nDigis;
-  }
+  void setNModules(uint32_t nModules) { nModules_h = nModules; }
 
   uint32_t nModules() const { return nModules_h; }
-  uint32_t nDigis() const { return nDigis_h; }
+  uint32_t nDigis() const { return this->view().metadata().size() - 1; }
 
 private:
   uint32_t nModules_h = 0;
-  uint32_t nDigis_h = 0;
 };
 
 #endif  // DataFormats_SiPixelDigiSoA_interface_SiPixelDigisDevice_h

--- a/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
+++ b/DataFormats/SiPixelDigiSoA/interface/SiPixelDigisHost.h
@@ -14,17 +14,13 @@ public:
   explicit SiPixelDigisHost(size_t maxFedWords, TQueue queue)
       : PortableHostCollection<SiPixelDigisSoA>(maxFedWords + 1, queue) {}
 
-  void setNModulesDigis(uint32_t nModules, uint32_t nDigis) {
-    nModules_h = nModules;
-    nDigis_h = nDigis;
-  }
+  void setNModules(uint32_t nModules) { nModules_h = nModules; }
 
   uint32_t nModules() const { return nModules_h; }
-  uint32_t nDigis() const { return nDigis_h; }
+  uint32_t nDigis() const { return view().metadata().size() - 1; }
 
 private:
   uint32_t nModules_h = 0;
-  uint32_t nDigis_h = 0;
 };
 
 #endif  // DataFormats_SiPixelDigiSoA_interface_SiPixelDigisHost_h

--- a/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h
+++ b/DataFormats/SiPixelDigiSoA/interface/alpaka/SiPixelDigisSoACollection.h
@@ -23,9 +23,9 @@ namespace cms::alpakatools {
   struct CopyToHost<SiPixelDigisDevice<TDevice>> {
     template <typename TQueue>
     static auto copyAsync(TQueue &queue, SiPixelDigisDevice<TDevice> const &srcData) {
-      SiPixelDigisHost dstData(srcData.view().metadata().size(), queue);
+      SiPixelDigisHost dstData(srcData.view().metadata().size() - 1, queue);
       alpaka::memcpy(queue, dstData.buffer(), srcData.buffer());
-      dstData.setNModulesDigis(srcData.nModules(), srcData.nDigis());
+      dstData.setNModules(srcData.nModules());
       return dstData;
     }
   };

--- a/DataFormats/SiPixelDigiSoA/src/classes_def.xml
+++ b/DataFormats/SiPixelDigiSoA/src/classes_def.xml
@@ -2,7 +2,8 @@
   <class name="SiPixelDigisSoA"/>
   <class name="SiPixelDigisSoA::View"/>
   <class name="PortableHostCollection<SiPixelDigisSoA>"/>
-  <class name="SiPixelDigisHost" ClassVersion="3">
+  <class name="SiPixelDigisHost" ClassVersion="4">
+    <version ClassVersion="4" checksum="2247404879"/>
     <version ClassVersion="3" checksum="3022474662"/>
   </class>
   <class name="edm::Wrapper<SiPixelDigisHost>" splitLevel="0"/>

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -380,8 +380,13 @@ namespace pixelTopology {
 
     static constexpr uint16_t numberOfModules = 3892;
 
-    // 1024 bins, 10 bits
-    static constexpr uint16_t clusterBinning = 1024;
+    // 1000 bins < 1024 bins (10 bits) must be:
+    // - < 32*32 (warpSize*warpSize for block prefix scan for CUDA)
+    // - > number of columns (y) in any module. This is due to the fact
+    //     that in pixel clustering we give for granted that in each
+    //     bin we only have the pixel belonging to the same column.
+    //     See RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/PixelClustering.h#L325-L347
+    static constexpr uint16_t clusterBinning = 1000;
     static constexpr uint16_t clusterBits = 10;
 
     static constexpr uint16_t numberOfModulesInBarrel = 756;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToClusterKernel.h
@@ -168,7 +168,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                                    const uint32_t numDigis);
 
       SiPixelDigisSoACollection getDigis() {
-        digis_d->setNModulesDigis(nModules_Clusters_h[0], nDigis);
+        digis_d->setNModules(nModules_Clusters_h[0]);
         return std::move(*digis_d);
       }
 


### PR DESCRIPTION
#### PR description:

Few fixes for the Alpaka chain for Phase2 Pixel reconstruction:
1. `clusterBinning` to be < than 32*32 (`warpSize*warpSize` for CUDA);
2. (minimal and applies also to Phase 1) properly size the `SiPixelDigisHost` buffer in `CopyToHost` method;
3.  removed all the errors part for Phase 2 clusterizer (not defined at the moment);
4.  fixing `ALPAKA_ASSERT_ACC(TrackerTraits::numberOfModules < 2048);`. 

#### PR validation:

Running `*.402` wfs for Phase 2 conditions (e.g. `25034` TTbar D98 with PU) 