### PR TITLE
Propagate downstream the valid state check in PATLeptonTimeLifeInfoProducer

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
@@ -162,9 +162,6 @@ void PATLeptonTimeLifeInfoProducer<T>::produceAndFillIPInfo(const T& lepton,
                                                             TrackTimeLifeInfo& info) {
   const reco::Track* track = getTrack(lepton);
   if (track != nullptr) {
-    info.setTrack(track);
-    info.setBField_z(transTrackBuilder.field()->inInverseGeV(GlobalPoint(track->vx(), track->vy(), track->vz())).z());
-
     // Extrapolate track to the point closest to PV
     reco::TransientTrack transTrack = transTrackBuilder.build(track);
     AnalyticalImpactPointExtrapolator extrapolator(transTrack.field());
@@ -187,7 +184,9 @@ void PATLeptonTimeLifeInfoProducer<T>::produceAndFillIPInfo(const T& lepton,
     if (ip_vec.dot(GlobalVector(lepton.px(), lepton.py(), lepton.pz())) < 0)
       ip_mes = Measurement1D(-1. * ip_mes.value(), ip_mes.error());
 
-    // Store PCA info
+    // Store Track and PCA info
+    info.setTrack(track);
+    info.setBField_z(transTrackBuilder.field()->inInverseGeV(GlobalPoint(track->vx(), track->vy(), track->vz())).z());
     info.setPCA(pca, pca_cov);
     info.setIP(ip_vec, ip_cov);
     info.setIPLength(ip_mes);


### PR DESCRIPTION
#### PR description:
This is an immediate follow up to #44864.
As nicely explained in https://github.com/cms-sw/cmssw/pull/44869#issuecomment-2084591790 we need a way to propagate downstream the information in case the `closestState.isValid()` check introduced in #44864 fails.

In this PR I'm simply moving:
```
info.setTrack(track);
info.setBField_z(transTrackBuilder.field()->inInverseGeV(GlobalPoint(track->vx(), track->vy(), track->vz())).z());
```
together with the other methods used to fill the `info` object and **after** the check on the track state validity.


#### PR validation:
Code compiles.
Adding a local cout for `info.hasTrack()` for the track not passing the state check I correctly get:
```
> info.hasTrack(): 0
```

#### Backport:
Not a backport. This PR will be backported in #44869 together with the backport of #44864