### PR TITLE
Remove unnecessary private include of EcalSrFlag.cc

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/plugins/DoubleCollectionMerger.cc
+++ b/TauAnalysis/MCEmbeddingTools/plugins/DoubleCollectionMerger.cc
@@ -6,7 +6,6 @@
 #include "DataFormats/EcalDigi/interface/EBSrFlag.h"
 #include "DataFormats/EcalDigi/interface/EESrFlag.h"
 #include "DataFormats/EcalDigi/interface/EcalSrFlag.h"
-#include "DataFormats/EcalDigi/src/EcalSrFlag.cc"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 
 #include "DataFormats/Common/interface/OwnVector.h"


### PR DESCRIPTION
This should fix the private header use build error
```
  ****ERROR:Private Header: File src/TauAnalysis/MCEmbeddingTools/plugins/DoubleCollectionMerger.cc directly includes src/DataFormats/EcalDigi/src/EcalSrFlag.cc
```