### PR TITLE
Move GsfTrack dicts in to GsfTrackReco from EgammaCandidates

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -239,13 +239,6 @@
    <version ClassVersion="3" checksum="3868678681"/>
   </class>
 
-  <!-- ValueMap<reco::GsfTrack> -->
-  <class name="edm::ValueMap<reco::GsfTrackRefVector>" />
-  <class name="edm::Wrapper<edm::ValueMap<reco::GsfTrackRefVector> >" />
-  <class name="std::vector<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
-  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
-
   <class name="reco::GsfElectron" ClassVersion="20">
    <version ClassVersion="20" checksum="2375747450"/>
    <version ClassVersion="19" checksum="1682285704"/>

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -52,4 +52,11 @@
   <class name="edm::reftobase::Holder<reco::Track, reco::GsfTrackRef>" />
   <class name="edm::reftobase::RefHolder<reco::GsfTrackRef>" />
 
+  <!-- ValueMap<reco::GsfTrack> -->
+  <class name="edm::ValueMap<reco::GsfTrackRefVector>" />
+  <class name="edm::Wrapper<edm::ValueMap<reco::GsfTrackRefVector> >" />
+  <class name="std::vector<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::GsfTrack>,reco::GsfTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrack>,reco::GsfTrack> > >"/>
+
   </lcgdict>


### PR DESCRIPTION
This should fix the `GsfTrack` dictionary definition (see https://github.com/cms-sw/cmssw/pull/43871#pullrequestreview-2035034342 ) in wrong package issue (https://cmssdt.cern.ch/SDT/cgi-bin/showDupDict.py/el8_amd64_gcc12/www/wed/14.1-wed-23/CMSSW_14_1_X_2024-05-01-2300/testLogs/dupDict-lostDefs.log )