### PR TITLE
Speedup GBRTree by making it non branching 

### DIFF
--- a/CondFormats/GBRForest/interface/GBRTree.h
+++ b/CondFormats/GBRForest/interface/GBRTree.h
@@ -64,7 +64,6 @@ inline double GBRTree::GetResponse(const float *vector) const {
   do {
     auto r = fRightIndices[index];
     auto l = fLeftIndices[index];
-    // index = (vector[fCutIndices[index]] > fCutVals[index]) ? r : l;
     unsigned int x = vector[fCutIndices[index]] > fCutVals[index] ? ~0 : 0;
     index = (x & r) | ((~x) & l);
   } while (index > 0);

--- a/CondFormats/GBRForest/interface/GBRTree.h
+++ b/CondFormats/GBRForest/interface/GBRTree.h
@@ -64,7 +64,9 @@ inline double GBRTree::GetResponse(const float *vector) const {
   do {
     auto r = fRightIndices[index];
     auto l = fLeftIndices[index];
-    index = vector[fCutIndices[index]] > fCutVals[index] ? r : l;
+    // index = (vector[fCutIndices[index]] > fCutVals[index]) ? r : l;
+    unsigned int x = vector[fCutIndices[index]] > fCutVals[index] ? ~0 : 0;
+    index = (x & r) | ((~x) & l);
   } while (index > 0);
   return fResponses[-index];
 }

--- a/CondFormats/GBRForest/test/BuildFile.xml
+++ b/CondFormats/GBRForest/test/BuildFile.xml
@@ -1,3 +1,8 @@
 <bin file="testSerializationGBRForest.cpp">
   <use name="CondFormats/GBRForest"/>
 </bin>
+
+<bin file="testGBRTree.cpp">
+  <use name="CondFormats/GBRForest"/>
+</bin>
+

--- a/CondFormats/GBRForest/test/testGBRTree.cpp
+++ b/CondFormats/GBRForest/test/testGBRTree.cpp
@@ -1,0 +1,71 @@
+#include "CondFormats/GBRForest/interface/GBRTree.h"
+
+namespace {
+
+  struct MyTree : public GBRTree {
+    MyTree() {
+      fCutIndices.resize(1, 0);
+      fCutVals.resize(1, 0);
+      fLeftIndices.resize(1, 0);
+      fRightIndices.resize(1, -1);
+      fResponses.resize(2);
+      fResponses[0] = 1;
+      fResponses[1] = 2;
+    }
+
+    double GetResponseNew(const float *vector) const {
+      int index = 0;
+      do {
+        auto r = fRightIndices[index];
+        auto l = fLeftIndices[index];
+        // the code below is equivalent to the original
+        // index = (vector[fCutIndices[index]] > fCutVals[index]) ? r : l;
+        // gnenerates non branching code  and it's at least 30% faster
+        // see https://godbolt.org/z/czK436hea
+        unsigned int x = vector[fCutIndices[index]] > fCutVals[index] ? ~0 : 0;
+        index = (x & r) | ((~x) & l);
+      } while (index > 0);
+      return fResponses[-index];
+    }
+
+    double GetResponseOld(const float *vector) const {
+      int index = 0;
+      do {
+        auto r = fRightIndices[index];
+        auto l = fLeftIndices[index];
+        index = (vector[fCutIndices[index]] > fCutVals[index]) ? r : l;
+      } while (index > 0);
+      return fResponses[-index];
+    }
+  };
+
+}  // namespace
+
+#include <iostream>
+
+int main() {
+  MyTree aTree;
+
+  float val[1];
+  double ret;
+
+  val[0] = -1;
+  std::cout << "val " << val[0] << std::endl;
+  ret = aTree.GetResponse(val);
+  std::cout << "def " << ret << std::endl;
+  ret = aTree.GetResponseOld(val);
+  std::cout << "old " << ret << std::endl;
+  ret = aTree.GetResponseOld(val);
+  std::cout << "new " << ret << std::endl;
+
+  val[0] = 1;
+  std::cout << "val " << val[0] << std::endl;
+  ret = aTree.GetResponse(val);
+  std::cout << "def " << ret << std::endl;
+  ret = aTree.GetResponseOld(val);
+  std::cout << "old " << ret << std::endl;
+  ret = aTree.GetResponseOld(val);
+  std::cout << "new " << ret << std::endl;
+
+  return 0;
+}

--- a/CondFormats/GBRForest/test/testGBRTree.cpp
+++ b/CondFormats/GBRForest/test/testGBRTree.cpp
@@ -21,7 +21,7 @@ namespace {
         // the code below is equivalent to the original
         // index = (vector[fCutIndices[index]] > fCutVals[index]) ? r : l;
         // gnenerates non branching code  and it's at least 30% faster
-        // see https://godbolt.org/z/czK436hea
+        // see https://godbolt.org/z/xT5dY9Th1   (yes in gcc13 is changed... but in the trunk is back as it was in gcc12)
         unsigned int x = vector[fCutIndices[index]] > fCutVals[index] ? ~0 : 0;
         index = (x & r) | ((~x) & l);
       } while (index > 0);

--- a/RecoMuon/TrackerSeedGenerator/BuildFile.xml
+++ b/RecoMuon/TrackerSeedGenerator/BuildFile.xml
@@ -55,6 +55,7 @@
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="TrackingTools/TrackAssociator"/>
 <use name="TrackPropagation/SteppingHelixPropagator"/>
+<use name="ofast-flag"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoMuon/TrackerSeedGenerator/interface/SeedMvaEstimator.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/SeedMvaEstimator.h
@@ -36,8 +36,8 @@ public:
 
 private:
   std::unique_ptr<const GBRForest> gbrForest_;
-  const std::vector<double> scale_mean_;
-  const std::vector<double> scale_std_;
+  const std::vector<float> scale_mean_;
+  std::vector<float> scale_istd_;
   const bool isFromL1_;
   const int minL1Qual_;
 


### PR DESCRIPTION
The code navigating a GBR Tree has been made explicitly not branching as the compiler (actually gcc) stubbornly produces branching code.

see
https://godbolt.org/z/aGz4eTad3
(yes it seems that gcc13 produces a different assembler closer to the bare C++. Apparently it has been fixed in the trunk)
(and yes, clang generates the same code for the old and new source)

code tested in HLT where SeedMVAEstimator is a non negligible contributor
SeedMVAEstimator speedups by itself of 40%.
The caller module hltIter0IterL3FromL1MuonPixelSeedsFromPixelTracksFiltered by a similar amount.

regression may appear due to the changes in SeedMVAEstimator itself (double ->float, div -> prod)