### PR TITLE
L1TP2: Bug Fix: Adding a setting of TTTrack word to allow Track Quality MVA to read variables

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -739,6 +739,9 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     aTrack.setStubPtConsistency(
         StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
+    // set TTTrack word first to allow Track Quality MVA to read variables:
+    aTrack.setTrackWordBits();
+
     if (trackQuality_) {
       trackQualityModel_->setL1TrackQuality(aTrack);
     }


### PR DESCRIPTION
#### PR description:

This is a bug fix to allow the Track Quality MVA to read variables which are in the TTrack word, before the Track Quality MVA is then set and saved back in the TTrack word.

#### PR validation:

This PR passes the following checks: 
 scram b
scram b code-format 
scram b code-checks
Ran the L1TrackObjectNtupleMaker over a sample before and after the fix: the output of the MVA as seen when plotting trk_MVA1 now appears as desired 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This will have to be back ported to the L1T OffSW Integration Branch too: Currently there is a [PR](https://github.com/cms-l1t-offline/cmssw/pull/1254) by @cgsavard which performs the same fix
This needs to be backported to 14_0 to be used in the Phase2 MC production