### PR TITLE
Use singularity for gridpack generation

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -69,8 +69,20 @@ tar -xaf ${path}
 # and fallback to /tmp
 export TMPDIR=${TMPDIR:-${_CONDOR_SCRATCH_DIR:-/tmp}}
 
+# define singularity
+if [ "$use_gridpack_env" != false ]; then
+    if [ -n "$scram_arch_version" ]; then
+        sing=$(echo ${scram_arch_version} | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    elif egrep -q "scram_arch_version=[^$]" runcmsgrid.sh; then
+        sing=$(grep "scram_arch_version=[^$]" runcmsgrid.sh | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    fi
+    if [ -n "${sing}" ]; then
+        sing="cmssw-el"${sing}" --"
+    fi
+fi
+
 #generate events
-./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
+${sing} ./runcmsgrid.sh $nevt $rnum $ncpu ${@:5}
 
 mv cmsgrid_final.lhe $LHEWORKDIR/
 


### PR DESCRIPTION
#### PR description:

This PR implements the use of singularity to run over the gridpacks that have been produced in different architectures.
It attempts to solve the issue raised in https://github.com/cms-sw/cmssw/issues/44863

@bbilin @menglu21

#### PR validation:

Tested it by running the gridpack from relval 180.1 and 181.1 (produced in EL8) on lxplus7 (SLC7)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
