### PR TITLE
Speedup fullJacobian

### DIFF
--- a/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
+++ b/DataFormats/GeometryVector/interface/private/extBasic3DVector.h
@@ -7,6 +7,7 @@
 #include "DataFormats/GeometryVector/interface/PreciseFloatType.h"
 #include "DataFormats/GeometryVector/interface/CoordinateSets.h"
 #include "DataFormats/Math/interface/ExtVec.h"
+#include "FWCore/Utilities/interface/Likely.h"
 #include <iosfwd>
 #include <cmath>
 
@@ -153,7 +154,7 @@ public:
    */
   Basic3DVector unit() const {
     T my_mag = mag2();
-    return (0 != my_mag) ? (*this) * (T(1) / std::sqrt(my_mag)) : *this;
+    return LIKELY(0 != my_mag) ? (*this) * (T(1) / std::sqrt(my_mag)) : *this;
   }
 
   /** Operator += with a Basic3DVector of possibly different precision.

--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -61,6 +61,19 @@ using Vec4 = ExtVec<T, 4>;
 template <typename T>
 using Vec2 = ExtVec<T, 2>;
 
+// convert V in W
+template <typename W, typename V>
+inline W convert(V v) {
+  // see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114943
+  //  return __builtin_convertvector(v,W);  // nope inefficient in gcc
+  typedef typename std::remove_reference<decltype(v[0])>::type T;
+  constexpr int N = sizeof(V) / sizeof(T);
+  W w;
+  for (int i = 0; i != N; ++i)
+    w[i] = v[i];
+  return w;
+}
+
 template <typename V>
 inline auto xy(V v) -> Vec2<typename std::remove_reference<decltype(v[0])>::type> {
   typedef typename std::remove_reference<decltype(v[0])>::type T;

--- a/DataFormats/Math/test/ExtVec_t.cpp
+++ b/DataFormats/Math/test/ExtVec_t.cpp
@@ -148,11 +148,15 @@ void go(bool dovec = true) {
   constexpr Vec x{2.0f, 4.0f, 5.0f};
   constexpr Vec y{-3.0f, 2.0f, -5.0f};
   Vec x0 = x[0] + zero;
+  Vec4<float> f = convert<Vec4<float>>(x);
+  Vec4<double> d = convert<Vec4<double>>(x);
   //constexpr Vec xx = T(3.3) + zero;  // clang 3.8 does not like it
   const Vec xx = T(3.3) + zero;
   std::cout << x << std::endl;
   std::cout << (Vec4<float>){float(x[0]), float(x[1]), float(x[2]), float(x[3])} << std::endl;
   std::cout << (Vec4<double>){x[0], x[1], x[2], x[3]} << std::endl;
+  std::cout << f << std::endl;
+  std::cout << d << std::endl;
   std::cout << -x << std::endl;
   std::cout << Vec{x[2]} << std::endl;
   //std::cout <<  Vec(x[2]) << std::endl;

--- a/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianEXT.icc
+++ b/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobianEXT.icc
@@ -33,18 +33,11 @@ void AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryPa
   double sint, cost;
   vdt::fast_sincos(theta, sint, cost);
 
-  Vec3D t1;
-  Vec3D t2;
+  Vec3D t1 = convert<Vec3D>(p1.basicVector().v);
+  Vec3D t2 = convert<Vec3D>(p2.basicVector().v);
 
-  Vec3D hn;
-  Vec3D dx;
-
-  for (int i = 0; i != 4; ++i) {
-    t1[i] = p1.basicVector().v[i];
-    t2[i] = p2.basicVector().v[i];
-    hn[i] = hnf.basicVector().v[i];
-    dx[i] = dxf.basicVector().v[i];
-  }
+  Vec3D hn = convert<Vec3D>(hnf.basicVector().v);
+  Vec3D dx = convert<Vec3D>(dxf.basicVector().v);
 
   double gamma = dot(hn, t2);
   Vec3D an = cross3(hn, t2);
@@ -58,9 +51,16 @@ void AnalyticalCurvilinearJacobian::computeFullJacobian(const GlobalTrajectoryPa
 #endif
   Vec4D tt = t * t;
 
+  Vec4D au{tt[1], tt[0], tt[3], tt[2]};
+  au += tt;
+  Vec4D neg{-1., 1., -1., 1.};
+  for (int i = 0; i < 4; ++i)
+    au[i] = neg[i] * std::sqrt(au[i]);
+  /* above equivalent to this 
   double au1 = std::sqrt(tt[0] + tt[1]);
   double au2 = std::sqrt(tt[2] + tt[3]);
   Vec4D au{-au1, au1, -au2, au2};
+  */
   Vec4D uu = t / au;
 
   Vec2D u1{uu[0], uu[1]};


### PR DESCRIPTION
Workaround some compiler (gcc) inefficiency
(see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114943  and https://godbolt.org/z/fMqEbTfe6 )
and improve some code to make it vectorize.
This makes the the ExtVec version even faster than the SSE one.

Purely technical, no regression expected.