### PR TITLE
Speedup (grouped)limitedCandidates by changing the implementation of the candidates' number limitation.

### DIFF
--- a/DataFormats/TrackCandidate/interface/TrajectoryStopReasons.h
+++ b/DataFormats/TrackCandidate/interface/TrajectoryStopReasons.h
@@ -1,9 +1,10 @@
 #ifndef TRAJECTORYSTOPREASONS_H
 #define TRAJECTORYSTOPREASONS_H
 
+#include <cstdint>
 #include <string>
 
-enum class StopReason {
+enum class StopReason : uint8_t {
   UNINITIALIZED = 0,
   MAX_HITS = 1,
   MAX_LOST_HITS = 2,

--- a/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilder.h
@@ -77,20 +77,14 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
 
-  // new interface returning the start Trajectory...
-  virtual TempTrajectory buildTrajectories(const TrajectorySeed& seed,
-                                           TrajectoryContainer& ret,
-                                           unsigned int& nCandPerSeed,
-                                           const TrajectoryFilter*) const {
+  virtual void buildTrajectories(const TrajectorySeed& seed,
+                                 TrajectoryContainer& ret,
+                                 unsigned int& nCandPerSeed,
+                                 const TrajectoryFilter*) const {
     assert(0 == 1);
-    return TempTrajectory();
   }
 
-  virtual void rebuildTrajectories(TempTrajectory const& startingTraj,
-                                   const TrajectorySeed& seed,
-                                   TrajectoryContainer& result) const {
-    assert(0 == 1);
-  }
+  virtual void rebuildTrajectories(const TrajectorySeed& seed, TrajectoryContainer& result) const { assert(0 == 1); }
 
   void setNavigationSchool(NavigationSchool const* nv) { theNavigationSchool = nv; }
 

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryBuilder.h
@@ -49,15 +49,12 @@ public:
   /// trajectories building starting from a seed
   void trajectories(const TrajectorySeed& seed, TrajectoryContainer& ret) const override;
 
-  // new interface returning the start Trajectory...
-  TempTrajectory buildTrajectories(const TrajectorySeed&,
-                                   TrajectoryContainer& ret,
-                                   unsigned int& nCandPerSeed,
-                                   const TrajectoryFilter*) const override;
+  void buildTrajectories(const TrajectorySeed&,
+                         TrajectoryContainer& ret,
+                         unsigned int& nCandPerSeed,
+                         const TrajectoryFilter*) const override;
 
-  void rebuildTrajectories(TempTrajectory const& startingTraj,
-                           const TrajectorySeed&,
-                           TrajectoryContainer& result) const override {}
+  void rebuildTrajectories(const TrajectorySeed&, TrajectoryContainer& result) const override {}
 
   /// set Event for the internal MeasurementTracker data member
   //  virtual void setEvent(const edm::Event& event) const;

--- a/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
+++ b/RecoTracker/CkfPattern/plugins/GroupedCkfTrajectoryBuilder.h
@@ -45,11 +45,10 @@ public:
   void trajectories(const TrajectorySeed&, TrajectoryContainer& ret, const TrackingRegion&) const;
 
   /// common part of both public trajectory building methods
-  // also new interface returning the start Trajectory...
-  TempTrajectory buildTrajectories(const TrajectorySeed& seed,
-                                   TrajectoryContainer& ret,
-                                   unsigned int& nCandPerSeed,
-                                   const TrajectoryFilter*) const override;
+  void buildTrajectories(const TrajectorySeed& seed,
+                         TrajectoryContainer& ret,
+                         unsigned int& nCandPerSeed,
+                         const TrajectoryFilter*) const override;
 
   /** trajectories re-building in the seeding region.
       It looks for additional measurements in the seeding region of the 
@@ -58,11 +57,8 @@ public:
       collection.
   **/
   void rebuildSeedingRegion(const TrajectorySeed&, TrajectoryContainer& result) const override;
-
-  // same as above using the precomputed startingTraj..
-  void rebuildTrajectories(TempTrajectory const& startingTraj,
-                           const TrajectorySeed&,
-                           TrajectoryContainer& result) const override;
+  // same as above FIXME
+  void rebuildTrajectories(const TrajectorySeed&, TrajectoryContainer& result) const override;
 
   // Access to lower level components
   const TrajectoryStateUpdator& updator() const { return *theUpdator; }
@@ -122,12 +118,10 @@ private:
                                         TempTrajectoryContainer& result) const dso_internal;
 
   /// try to find additional hits in seeding region
-  void rebuildSeedingRegion(const TrajectorySeed& seed,
-                            TempTrajectory const& startingTraj,
-                            TempTrajectoryContainer& result) const dso_internal;
+  void rebuildSeedingRegion(const TrajectorySeed& seed, TempTrajectoryContainer& result) const dso_internal;
 
-  //** try to find additional hits in seeding region for a candidate
-  //* (returns number of trajectories added) *
+  // ** try to find additional hits in seeding region for a candidate
+  // * (returns number of trajectories added) *
   int rebuildSeedingRegion(const TrajectorySeed& seed,
                            const std::vector<const TrackingRecHit*>& seedHits,
                            TempTrajectory& candidate,

--- a/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
+++ b/RecoTracker/CkfPattern/plugins/TrajectorySegmentBuilder.cc
@@ -527,6 +527,7 @@ void TrajectorySegmentBuilder::cleanCandidates(vector<TempTrajectory>& candidate
       if (allFound) {
         candidates[*i1].invalidate();
         statCount.invalid();
+        break;
       }
     }
   }

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -281,8 +281,7 @@ namespace cms {
         // Build trajectory from seed outwards
         theTmpTrajectories.clear();
         unsigned int nCandPerSeed = 0;
-        auto const& startTraj =
-            theTrajectoryBuilder->buildTrajectories((*collseed)[j], theTmpTrajectories, nCandPerSeed, nullptr);
+        theTrajectoryBuilder->buildTrajectories((*collseed)[j], theTmpTrajectories, nCandPerSeed, nullptr);
         {
           Lock lock(theMutex);
           (*outputSeedStopInfos)[j].setCandidatesPerSeed(nCandPerSeed);
@@ -309,7 +308,7 @@ namespace cms {
         // seed and if possible further inwards.
 
         if (doSeedingRegionRebuilding) {
-          theTrajectoryBuilder->rebuildTrajectories(startTraj, (*collseed)[j], theTmpTrajectories);
+          theTrajectoryBuilder->rebuildTrajectories((*collseed)[j], theTmpTrajectories);
 
           LogDebug("CkfPattern") << "======== Out-in trajectory building found " << theTmpTrajectories.size()
                                  << " valid/invalid trajectories from seed " << j << " ========\n"

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -157,10 +157,10 @@ void CkfTrajectoryBuilder::trajectories(const TrajectorySeed& seed,
   buildTrajectories(seed, result, tmp, nullptr);
 }
 
-TempTrajectory CkfTrajectoryBuilder::buildTrajectories(const TrajectorySeed& seed,
-                                                       TrajectoryContainer& result,
-                                                       unsigned int& nCandPerSeed,
-                                                       const TrajectoryFilter*) const {
+void CkfTrajectoryBuilder::buildTrajectories(const TrajectorySeed& seed,
+                                             TrajectoryContainer& result,
+                                             unsigned int& nCandPerSeed,
+                                             const TrajectoryFilter*) const {
   if (theMeasurementTracker == nullptr) {
     throw cms::Exception("LogicError")
         << "Asking to create trajectories to an un-initialized CkfTrajectoryBuilder.\nYou have to call clone(const "
@@ -172,8 +172,6 @@ TempTrajectory CkfTrajectoryBuilder::buildTrajectories(const TrajectorySeed& see
   /// limitedCandidates( startingTraj, regionalCondition, result);
   /// FIXME: restore regionalCondition
   nCandPerSeed = limitedCandidates(seed, startingTraj, result);
-
-  return startingTraj;
 
   /*
   //and remember what you just did

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -149,8 +149,9 @@ unsigned int CkfTrajectoryBuilder::limitedCandidates(const std::shared_ptr<const
               }  // else? no need to add it just to remove it later!
             } else {
               newCand.push_back(std::move(newTraj));
-              std::push_heap(newCand.begin(), newCand.end(), trajCandLess);
               full = (int)newCand.size() == theMaxCand;
+              if (full)
+                std::make_heap(newCand.begin(), newCand.end(), trajCandLess);
             }
           } else {
             addToResult(sharedSeed, newTraj, result);
@@ -170,7 +171,7 @@ unsigned int CkfTrajectoryBuilder::limitedCandidates(const std::shared_ptr<const
         assert((int)newCand.size() == theMaxCand);
     }  // end loop on candidates
 
-    std::sort_heap(newCand.begin(), newCand.end(), trajCandLess);
+    // no reason to sort  (no sorting in Grouped version!)
     if (theIntermediateCleaning)
       IntermediateTrajectoryCleaner::clean(newCand);
 

--- a/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrajectoryBuilder.cc
@@ -42,13 +42,6 @@ CkfTrajectoryBuilder::CkfTrajectoryBuilder(const edm::ParameterSet& conf,
   theLostHitPenalty = conf.getParameter<double>("lostHitPenalty");
   theIntermediateCleaning = conf.getParameter<bool>("intermediateCleaning");
   theAlwaysUseInvalidHits = conf.getParameter<bool>("alwaysUseInvalidHits");
-  /*
-    theSharedSeedCheck = conf.getParameter<bool>("SharedSeedCheck");
-    std::stringstream ss;
-    ss<<"CkfTrajectoryBuilder_"<<conf.getParameter<std::string>("ComponentName")<<"_"<<this;
-    theUniqueName = ss.str();
-    LogDebug("CkfPattern")<<"my unique name is: "<<theUniqueName;
-  */
 }
 
 void CkfTrajectoryBuilder::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
@@ -63,13 +56,6 @@ void CkfTrajectoryBuilder::fillPSetDescription(edm::ParameterSetDescription& iDe
   iDesc.add<edm::ParameterSetDescription>("trajectoryFilter", psdTF);
 }
 
-/*
-  void CkfTrajectoryBuilder::setEvent(const edm::Event& event) const
-  {
-  theMeasurementTracker->update(event);
-  }
-*/
-
 void CkfTrajectoryBuilder::setEvent_(const edm::Event& event, const edm::EventSetup& iSetup) {}
 
 CkfTrajectoryBuilder::TrajectoryContainer CkfTrajectoryBuilder::trajectories(const TrajectorySeed& seed) const {
@@ -79,80 +65,8 @@ CkfTrajectoryBuilder::TrajectoryContainer CkfTrajectoryBuilder::trajectories(con
   return result;
 }
 
-/*
-  void CkfTrajectoryBuilder::rememberSeedAndTrajectories(const TrajectorySeed& seed,
-  CkfTrajectoryBuilder::TrajectoryContainer &result) const
-  {
-  
-  //result ----> theCachedTrajectories
-  //every first iteration on event. forget about everything that happened before
-  if (edm::Service<UpdaterService>()->checkOnce(theUniqueName)) 
-  theCachedTrajectories.clear();
-  
-  if (seed.nHits()==0) return;
-  
-  //then remember those trajectories
-  for (TrajectoryContainer::iterator traj=result.begin();
-  traj!=result.end(); ++traj) {
-  theCachedTrajectories.insert(std::make_pair(seed.recHits().first->geographicalId(),*traj));
-  }  
-  }
-  
-  bool CkfTrajectoryBuilder::sharedSeed(const TrajectorySeed& s1,const TrajectorySeed& s2) const{
-  //quit right away on nH=0
-  if (s1.nHits()==0 || s2.nHits()==0) return false;
-  //quit right away if not the same number of hits
-  if (s1.nHits()!=s2.nHits()) return false;
-  TrajectorySeed::range r1=s1.recHits();
-  TrajectorySeed::range r2=s2.recHits();
-  TrajectorySeed::const_iterator i1,i2;
-  TrajectorySeed::const_iterator & i1_e=r1.second,&i2_e=r2.second;
-  TrajectorySeed::const_iterator & i1_b=r1.first,&i2_b=r2.first;
-  //quit right away if first detId does not match. front exist because of ==0 ->quit test
-  if(i1_b->geographicalId() != i2_b->geographicalId()) return false;
-  //then check hit by hit if they are the same
-  for (i1=i1_b,i2=i2_b;i1!=i1_e,i2!=i2_e;++i1,++i2){
-  if (!i1->sharesInput(&(*i2),TrackingRecHit::all)) return false;
-  }
-  return true;
-  }
-  bool CkfTrajectoryBuilder::seedAlreadyUsed(const TrajectorySeed& seed,
-  CkfTrajectoryBuilder::TempTrajectoryContainer &candidates) const
-  {
-  //theCachedTrajectories ---> candidates
-  if (seed.nHits()==0) return false;
-  bool answer=false;
-  pair<SharedTrajectory::const_iterator, SharedTrajectory::const_iterator> range = 
-  theCachedTrajectories.equal_range(seed.recHits().first->geographicalId());
-  SharedTrajectory::const_iterator trajP;
-  for (trajP = range.first; trajP!=range.second;++trajP){
-  //check whether seeds are identical     
-  if (sharedSeed(trajP->second.seed(),seed)){
-  candidates.push_back(trajP->second);
-  answer=true;
-  }//already existing trajectory shares the seed.   
-  }//loop already made trajectories      
-  
-  return answer;
-  }
-*/
-
 void CkfTrajectoryBuilder::trajectories(const TrajectorySeed& seed,
                                         CkfTrajectoryBuilder::TrajectoryContainer& result) const {
-  // analyseSeed( seed);
-  /*
-    if (theSharedSeedCheck){
-    TempTrajectoryContainer candidates;
-    if (seedAlreadyUsed(seed,candidates))
-    {
-    //start with those candidates already made before
-    limitedCandidates(candidates,result);
-    //and quit
-    return;
-    }
-    }
-  */
-
   unsigned int tmp;
   buildTrajectories(seed, result, tmp, nullptr);
 }
@@ -169,16 +83,7 @@ void CkfTrajectoryBuilder::buildTrajectories(const TrajectorySeed& seed,
 
   TempTrajectory startingTraj = createStartingTrajectory(seed);
 
-  /// limitedCandidates( startingTraj, regionalCondition, result);
-  /// FIXME: restore regionalCondition
   nCandPerSeed = limitedCandidates(seed, startingTraj, result);
-
-  /*
-  //and remember what you just did
-  if (theSharedSeedCheck)  rememberSeedAndTrajectories(seed,result);
-  */
-
-  // analyseResult(result);
 }
 
 unsigned int CkfTrajectoryBuilder::limitedCandidates(const TrajectorySeed& seed,
@@ -358,6 +263,4 @@ void CkfTrajectoryBuilder::findCompatibleMeasurements(const TrajectorySeed& seed
     }
   }
 #endif
-
-  //analyseMeasurements( result, traj);
 }

--- a/TrackingTools/PatternTools/interface/TempTrajectory.h
+++ b/TrackingTools/PatternTools/interface/TempTrajectory.h
@@ -56,10 +56,8 @@ public:
 
     // PropagationDirection
     int8_t theDirection = anyDirection;
-    bool theValid = false;
 
     uint8_t theNHseed = 0;
-
     uint8_t theNLoops = 0;
     StopReason stopReason_ = StopReason::UNINITIALIZED;
   };
@@ -77,16 +75,15 @@ public:
    */
   TempTrajectory(PropagationDirection dir, unsigned char nhseed) : thePayload(std::make_unique<Payload>()) {
     thePayload->theDirection = dir;
-    thePayload->theValid = true;
     thePayload->theNHseed = nhseed;
   }
 
   TempTrajectory(TempTrajectory const& rh)
-      : theData(rh.theData), thePayload(std::make_unique<Payload>(*rh.thePayload)) {}
+      : theData(rh.theData), thePayload(rh.thePayload ? std::make_unique<Payload>(*rh.thePayload) : nullptr) {}
 
   TempTrajectory& operator=(TempTrajectory const& rh) {
     theData = rh.theData;
-    thePayload = std::make_unique<Payload>(*rh.thePayload);
+    thePayload = rh.thePayload ? std::make_unique<Payload>(*rh.thePayload) : nullptr;
     return *this;
   }
 
@@ -225,10 +222,10 @@ public:
   /** Returns true if the Trajectory is valid.
    *  Trajectories are invalidated e.g. during ambiguity resolution.
    */
-  bool isValid() const { return thePayload->theValid; }
+  bool isValid() const { return bool(thePayload); }
 
   /// Method to invalidate a trajectory. Useful during ambiguity resolution.
-  void invalidate() { thePayload->theValid = false; }
+  void invalidate() { thePayload.reset(); }
 
   /** Definition of inactive Det from the Trajectory point of view.
    */

--- a/TrackingTools/PatternTools/interface/TempTrajectory.h
+++ b/TrackingTools/PatternTools/interface/TempTrajectory.h
@@ -43,6 +43,27 @@ public:
   typedef TrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
   typedef ConstRecHitContainer RecHitContainer;
 
+  struct Payload {
+    float theChiSquared = 0;
+    float theDPhiCache = 0;
+    float theCCCThreshold_ = std::numeric_limits<float>::max();
+
+    uint8_t theNumberOfFoundHits = 0;
+    uint8_t theNumberOfFoundPixelHits = 0;
+    uint8_t theNumberOfLostHits = 0;
+    uint8_t theNumberOfTrailingFoundHits = 0;
+    uint8_t theNumberOfCCCBadHits_ = 0;
+
+    // PropagationDirection
+    int8_t theDirection = anyDirection;
+    bool theValid = false;
+
+    uint8_t theNHseed = 0;
+
+    uint8_t theNLoops = 0;
+    StopReason stopReason_ = StopReason::UNINITIALIZED;
+  };
+
   /** Default constructor of an empty trajectory with undefined seed and 
    * undefined direction. This constructor is necessary in order to transiently
    * copy vector<Trajectory> in the edm::Event
@@ -54,44 +75,27 @@ public:
    *  No check is made in the push method that measurements are
    *  added in the correct direction.
    */
-  TempTrajectory(PropagationDirection dir, unsigned char nhseed)
-      : theDirection(dir), theValid(true), theNHseed(nhseed) {}
+  TempTrajectory(PropagationDirection dir, unsigned char nhseed) : thePayload(std::make_unique<Payload>()) {
+    thePayload->theDirection = dir;
+    thePayload->theValid = true;
+    thePayload->theNHseed = nhseed;
+  }
 
-  TempTrajectory(TempTrajectory const& rh) = default;
-  TempTrajectory& operator=(TempTrajectory const& rh) = default;
+  TempTrajectory(TempTrajectory const& rh)
+      : theData(rh.theData), thePayload(std::make_unique<Payload>(*rh.thePayload)) {}
 
-  TempTrajectory(TempTrajectory&& rh) noexcept
-      : theData(std::move(rh.theData)),
-        theChiSquared(rh.theChiSquared),
-        theNumberOfFoundHits(rh.theNumberOfFoundHits),
-        theNumberOfFoundPixelHits(rh.theNumberOfFoundPixelHits),
-        theNumberOfLostHits(rh.theNumberOfLostHits),
-        theNumberOfTrailingFoundHits(rh.theNumberOfTrailingFoundHits),
-        theNumberOfCCCBadHits_(rh.theNumberOfCCCBadHits_),
-        theDirection(rh.theDirection),
-        theValid(rh.theValid),
-        theNHseed(rh.theNHseed),
-        theNLoops(rh.theNLoops),
-        theDPhiCache(rh.theDPhiCache),
-        theCCCThreshold_(rh.theCCCThreshold_),
-        stopReason_(rh.stopReason_) {}
+  TempTrajectory& operator=(TempTrajectory const& rh) {
+    theData = rh.theData;
+    thePayload = std::make_unique<Payload>(*rh.thePayload);
+    return *this;
+  }
+
+  TempTrajectory(TempTrajectory&& rh) noexcept : theData(std::move(rh.theData)), thePayload(std::move(rh.thePayload)) {}
 
   TempTrajectory& operator=(TempTrajectory&& rh) noexcept {
     using std::swap;
     swap(theData, rh.theData);
-    theChiSquared = rh.theChiSquared;
-    theNumberOfFoundHits = rh.theNumberOfFoundHits;
-    theNumberOfFoundPixelHits = rh.theNumberOfFoundPixelHits;
-    theNumberOfLostHits = rh.theNumberOfLostHits;
-    theNumberOfTrailingFoundHits = rh.theNumberOfTrailingFoundHits;
-    theNumberOfCCCBadHits_ = rh.theNumberOfCCCBadHits_;
-    theDirection = rh.theDirection;
-    theValid = rh.theValid;
-    theNHseed = rh.theNHseed;
-    theNLoops = rh.theNLoops;
-    theDPhiCache = rh.theDPhiCache;
-    theCCCThreshold_ = rh.theCCCThreshold_;
-    stopReason_ = rh.stopReason_;
+    swap(thePayload, rh.thePayload);
     return *this;
   }
 
@@ -99,7 +103,7 @@ public:
   explicit TempTrajectory(Trajectory&& traj);
 
   /// destruct a TempTrajectory
-  ~TempTrajectory() {}
+  ~TempTrajectory() = default;
 
   /** Add a new measurement to a Trajectory.
    *  The Chi2 of the trajectory is incremented by the value
@@ -181,36 +185,36 @@ public:
    *  detector layers crossed without using RecHits from them are also 
    *  stored as measurements.
    */
-  int foundHits() const { return theNumberOfFoundHits; }
+  int foundHits() const { return thePayload->theNumberOfFoundHits; }
 
   /** Number of valid pixel RecHits used to determine the trajectory.
    */
-  int foundPixelHits() const { return theNumberOfFoundPixelHits; }
+  int foundPixelHits() const { return thePayload->theNumberOfFoundPixelHits; }
 
   /** Number of detector layers crossed without valid RecHits.
    *  Used mainly as a criteria for abandoning a trajectory candidate
    *  during trajectory building.
    */
-  int lostHits() const { return theNumberOfLostHits; }
+  int lostHits() const { return thePayload->theNumberOfLostHits; }
 
   /** Number of valid RecHits at the end of the trajectory after last lost hit.
    */
-  int trailingFoundHits() const { return theNumberOfTrailingFoundHits; }
+  int trailingFoundHits() const { return thePayload->theNumberOfTrailingFoundHits; }
 
   /** Number of hits that are not compatible with the CCC used during
    *  patter recognition. Used mainly as a criteria for abandoning a
    *  trajectory candidate during trajectory building.
    */
-  int cccBadHits() const { return theNumberOfCCCBadHits_; }
+  int cccBadHits() const { return thePayload->theNumberOfCCCBadHits_; }
 
   //number of hits in seed
-  unsigned int seedNHits() const { return theNHseed; }
+  unsigned int seedNHits() const { return thePayload->theNHseed; }
 
   /// True if trajectory has no measurements.
   bool empty() const { return theData.empty(); }
 
   /// Value of the raw Chi2 of the trajectory, not normalised to the N.D.F.
-  float chiSquared() const { return theChiSquared; }
+  float chiSquared() const { return thePayload->theChiSquared; }
 
   /** Direction of "growing" of the trajectory. 
    *  Possible values are alongMomentum (outwards) and 
@@ -221,10 +225,10 @@ public:
   /** Returns true if the Trajectory is valid.
    *  Trajectories are invalidated e.g. during ambiguity resolution.
    */
-  bool isValid() const { return theValid; }
+  bool isValid() const { return thePayload->theValid; }
 
   /// Method to invalidate a trajectory. Useful during ambiguity resolution.
-  void invalidate() { theValid = false; }
+  void invalidate() { thePayload->theValid = false; }
 
   /** Definition of inactive Det from the Trajectory point of view.
    */
@@ -247,20 +251,20 @@ public:
 
   /// accessor to the delta phi angle betweem the directions of the two measurements on the last
   /// two layers crossed by the trajectory
-  float dPhiCacheForLoopersReconstruction() const { return theDPhiCache; }
+  float dPhiCacheForLoopersReconstruction() const { return thePayload->theDPhiCache; }
 
   /// method to set the delta phi angle betweem the directions of the two measurements on the last
   /// two layers crossed by the trajectory
-  void setDPhiCacheForLoopersReconstruction(float dphi) { theDPhiCache = dphi; }
+  void setDPhiCacheForLoopersReconstruction(float dphi) { thePayload->theDPhiCache = dphi; }
 
-  bool isLooper() const { return (theNLoops > 0); }
-  signed char nLoops() const { return theNLoops; }
+  bool isLooper() const { return (thePayload->theNLoops > 0); }
+  signed char nLoops() const { return thePayload->theNLoops; }
 
-  void setNLoops(signed char value) { theNLoops = value; }
-  void incrementLoops() { theNLoops++; }
+  void setNLoops(int8_t value) { thePayload->theNLoops = value; }
+  void incrementLoops() { thePayload->theNLoops++; }
 
-  StopReason stopReason() const { return stopReason_; }
-  void setStopReason(StopReason s) { stopReason_ = s; }
+  StopReason stopReason() const { return thePayload->stopReason_; }
+  void setStopReason(StopReason s) { thePayload->stopReason_ = s; }
 
   int numberOfCCCBadHits(float ccc_threshold);
 
@@ -277,25 +281,7 @@ private:
 
 private:
   DataContainer theData;
-
-  float theChiSquared = 0;
-
-  signed short theNumberOfFoundHits = 0;
-  signed short theNumberOfFoundPixelHits = 0;
-  signed short theNumberOfLostHits = 0;
-  signed short theNumberOfTrailingFoundHits = 0;
-  signed short theNumberOfCCCBadHits_ = 0;
-
-  // PropagationDirection
-  signed char theDirection = anyDirection;
-  bool theValid = false;
-
-  unsigned char theNHseed = 0;
-
-  signed char theNLoops = 0;
-  float theDPhiCache = 0;
-  float theCCCThreshold_ = std::numeric_limits<float>::max();
-  StopReason stopReason_ = StopReason::UNINITIALIZED;
+  std::unique_ptr<Payload> thePayload;
 
   void check() const;
 };

--- a/TrackingTools/PatternTools/interface/TempTrajectory.h
+++ b/TrackingTools/PatternTools/interface/TempTrajectory.h
@@ -96,6 +96,12 @@ public:
     return *this;
   }
 
+  void swap(TempTrajectory& rh) noexcept {
+    using std::swap;
+    swap(theData, rh.theData);
+    swap(thePayload, rh.thePayload);
+  }
+
   /// construct TempTrajectory from standard Trajectory
   explicit TempTrajectory(Trajectory&& traj);
 

--- a/TrackingTools/PatternTools/interface/Trajectory.h
+++ b/TrackingTools/PatternTools/interface/Trajectory.h
@@ -46,7 +46,7 @@ public:
    * copy vector<Trajectory> in the edm::Event
    */
 
-  Trajectory() {}
+  Trajectory() = default;
 
   /** Constructor of an empty trajectory with undefined direction.
    *  The direction will be defined at the moment of the push of a second
@@ -83,29 +83,29 @@ public:
       : theSeed(std::move(rh.theSeed)),
         seedRef_(std::move(rh.seedRef_)),
         theData(std::move(rh.theData)),
+        theDPhiCache(rh.theDPhiCache),
+        theCCCThreshold_(rh.theCCCThreshold_),
         theChiSquared(rh.theChiSquared),
         theChiSquaredBad(rh.theChiSquaredBad),
+        theDirection(rh.theDirection),
+        theDirectionValidity(rh.theDirectionValidity),
+        theValid(rh.theValid),
         theNumberOfFoundHits(rh.theNumberOfFoundHits),
         theNumberOfFoundPixelHits(rh.theNumberOfFoundPixelHits),
         theNumberOfLostHits(rh.theNumberOfLostHits),
         theNumberOfTrailingFoundHits(rh.theNumberOfTrailingFoundHits),
         theNumberOfCCCBadHits_(rh.theNumberOfCCCBadHits_),
-        theDirection(rh.theDirection),
-        theDirectionValidity(rh.theDirectionValidity),
-        theValid(rh.theValid),
-        theDPhiCache(rh.theDPhiCache),
-        theCCCThreshold_(rh.theCCCThreshold_),
         theNLoops(rh.theNLoops),
         stopReason_(rh.stopReason_) {}
 
   Trajectory& operator=(Trajectory&& rh) {
     using std::swap;
     swap(theData, rh.theData);
+    theDPhiCache = rh.theDPhiCache;
+    theCCCThreshold_ = rh.theCCCThreshold_;
     theChiSquared = rh.theChiSquared;
     theChiSquaredBad = rh.theChiSquaredBad;
     theValid = rh.theValid;
-    theDPhiCache = rh.theDPhiCache;
-    theCCCThreshold_ = rh.theCCCThreshold_;
     theNLoops = rh.theNLoops;
     theNumberOfFoundHits = rh.theNumberOfFoundHits;
     theNumberOfFoundPixelHits = rh.theNumberOfFoundPixelHits;
@@ -326,9 +326,9 @@ public:
   void setDPhiCacheForLoopersReconstruction(float dphi) { theDPhiCache = dphi; }
 
   bool isLooper() const { return (theNLoops > 0); }
-  signed char nLoops() const { return theNLoops; }
+  int8_t nLoops() const { return theNLoops; }
 
-  void setNLoops(signed char value) { theNLoops = value; }
+  void setNLoops(int8_t value) { theNLoops = value; }
   void incrementLoops() { theNLoops++; }
 
   void setStopReason(StopReason s) { stopReason_ = s; }
@@ -345,22 +345,23 @@ private:
   edm::RefToBase<TrajectorySeed> seedRef_;
 
   DataContainer theData;
+
+  float theDPhiCache = 0;
+  float theCCCThreshold_ = std::numeric_limits<float>::max();
+
   float theChiSquared = 0;
   float theChiSquaredBad = 0;
-
-  signed short theNumberOfFoundHits = 0;
-  signed short theNumberOfFoundPixelHits = 0;
-  signed short theNumberOfLostHits = 0;
-  signed short theNumberOfTrailingFoundHits = 0;
-  signed short theNumberOfCCCBadHits_ = 0;
 
   PropagationDirection theDirection = anyDirection;
   bool theDirectionValidity = false;
   bool theValid = false;
 
-  float theDPhiCache = 0;
-  float theCCCThreshold_ = std::numeric_limits<float>::max();
-  signed char theNLoops = 0;
+  uint8_t theNumberOfFoundHits = 0;
+  uint8_t theNumberOfFoundPixelHits = 0;
+  uint8_t theNumberOfLostHits = 0;
+  uint8_t theNumberOfTrailingFoundHits = 0;
+  uint8_t theNumberOfCCCBadHits_ = 0;
+  int8_t theNLoops = 0;
   StopReason stopReason_ = StopReason::UNINITIALIZED;
 
   void check() const;

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -23,19 +23,14 @@ namespace {
   }
 }  // namespace
 
-TempTrajectory::TempTrajectory(Trajectory&& traj)
-    : theChiSquared(0),
-      theNumberOfFoundHits(0),
-      theNumberOfFoundPixelHits(0),
-      theNumberOfLostHits(0),
-      theNumberOfCCCBadHits_(0),
-      theDirection(traj.direction()),
-      theValid(traj.isValid()),
-      theNHseed(traj.seedNHits()),
-      theNLoops(traj.nLoops()),
-      theDPhiCache(traj.dPhiCacheForLoopersReconstruction()),
-      theCCCThreshold_(traj.cccThreshold()),
-      stopReason_(traj.stopReason()) {
+TempTrajectory::TempTrajectory(Trajectory&& traj) : thePayload(std::make_unique<Payload>()) {
+  thePayload->theDirection = traj.direction();
+  thePayload->theValid = traj.isValid();
+  thePayload->theNHseed = traj.seedNHits();
+  thePayload->theNLoops = traj.nLoops();
+  thePayload->theDPhiCache = traj.dPhiCacheForLoopersReconstruction();
+  thePayload->theCCCThreshold_ = traj.cccThreshold();
+  thePayload->stopReason_ = traj.stopReason();
   for (auto& it : traj.measurements()) {
     push(it);
   }
@@ -45,41 +40,41 @@ TempTrajectory::TempTrajectory(Trajectory&& traj)
 void TempTrajectory::pop() {
   if (!empty()) {
     if (theData.back().recHit()->isValid()) {
-      theNumberOfFoundHits--;
+      thePayload->theNumberOfFoundHits--;
       if (badForCCC(theData.back()))
-        theNumberOfCCCBadHits_--;
+        thePayload->theNumberOfCCCBadHits_--;
       if (Trajectory::pixel(*(theData.back().recHit())))
-        theNumberOfFoundPixelHits--;
+        thePayload->theNumberOfFoundPixelHits--;
     } else if (lost(*(theData.back().recHit()))) {
-      theNumberOfLostHits--;
+      thePayload->theNumberOfLostHits--;
     }
     theData.pop_back();
-    theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
+    thePayload->theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
   }
 }
 
 void TempTrajectory::pushAux(double chi2Increment) {
   const TrajectoryMeasurement& tm = theData.back();
   if (tm.recHit()->isValid()) {
-    theNumberOfFoundHits++;
-    theNumberOfTrailingFoundHits++;
+    thePayload->theNumberOfFoundHits++;
+    thePayload->theNumberOfTrailingFoundHits++;
     if (badForCCC(tm))
-      theNumberOfCCCBadHits_++;
+      thePayload->theNumberOfCCCBadHits_++;
     if (Trajectory::pixel(*(tm.recHit())))
-      theNumberOfFoundPixelHits++;
+      thePayload->theNumberOfFoundPixelHits++;
   }
   //else if (lost( tm.recHit()) && !inactive(tm.recHit().det())) theNumberOfLostHits++;
   else if (lost(*(tm.recHit()))) {
-    theNumberOfLostHits++;
-    theNumberOfTrailingFoundHits = 0;
+    thePayload->theNumberOfLostHits++;
+    thePayload->theNumberOfTrailingFoundHits = 0;
   }
 
-  theChiSquared += chi2Increment;
+  thePayload->theChiSquared += chi2Increment;
 }
 
 void TempTrajectory::push(const TempTrajectory& segment) {
-  assert(segment.theDirection == theDirection);
-  assert(segment.theCCCThreshold_ == theCCCThreshold_);
+  assert(segment.thePayload->theDirection == thePayload->theDirection);
+  assert(segment.thePayload->theCCCThreshold_ == thePayload->theCCCThreshold_);
 
   const int N = segment.measurements().size();
   TrajectoryMeasurement const* tmp[N];
@@ -89,34 +84,34 @@ void TempTrajectory::push(const TempTrajectory& segment) {
     tmp[i++] = &tm;
   while (i != 0)
     theData.push_back(*tmp[--i]);
-  theNumberOfFoundHits += segment.theNumberOfFoundHits;
-  theNumberOfFoundPixelHits += segment.theNumberOfFoundPixelHits;
-  theNumberOfLostHits += segment.theNumberOfLostHits;
-  theNumberOfCCCBadHits_ += segment.theNumberOfCCCBadHits_;
-  theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
-  theChiSquared += segment.theChiSquared;
+  thePayload->theNumberOfFoundHits += segment.thePayload->theNumberOfFoundHits;
+  thePayload->theNumberOfFoundPixelHits += segment.thePayload->theNumberOfFoundPixelHits;
+  thePayload->theNumberOfLostHits += segment.thePayload->theNumberOfLostHits;
+  thePayload->theNumberOfCCCBadHits_ += segment.thePayload->theNumberOfCCCBadHits_;
+  thePayload->theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
+  thePayload->theChiSquared += segment.thePayload->theChiSquared;
 }
 
 void TempTrajectory::join(TempTrajectory& segment) {
-  assert(segment.theDirection == theDirection);
+  assert(segment.thePayload->theDirection == thePayload->theDirection);
 
-  if (theCCCThreshold_ != segment.theCCCThreshold_)
-    segment.updateBadForCCC(theCCCThreshold_);
+  if (thePayload->theCCCThreshold_ != segment.thePayload->theCCCThreshold_)
+    segment.updateBadForCCC(thePayload->theCCCThreshold_);
   if (segment.theData.shared()) {
     push(segment);
     segment.theData.clear();  // obey the contract, and increase the chances it will be not shared one day
   } else {
     theData.join(segment.theData);
-    theNumberOfFoundHits += segment.theNumberOfFoundHits;
-    theNumberOfFoundPixelHits += segment.theNumberOfFoundPixelHits;
-    theNumberOfLostHits += segment.theNumberOfLostHits;
-    theNumberOfCCCBadHits_ += segment.theNumberOfCCCBadHits_;
-    theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
-    theChiSquared += segment.theChiSquared;
+    thePayload->theNumberOfFoundHits += segment.thePayload->theNumberOfFoundHits;
+    thePayload->theNumberOfFoundPixelHits += segment.thePayload->theNumberOfFoundPixelHits;
+    thePayload->theNumberOfLostHits += segment.thePayload->theNumberOfLostHits;
+    thePayload->theNumberOfCCCBadHits_ += segment.thePayload->theNumberOfCCCBadHits_;
+    thePayload->theNumberOfTrailingFoundHits = countTrailingValidHits(theData);
+    thePayload->theChiSquared += segment.thePayload->theChiSquared;
   }
 }
 
-PropagationDirection TempTrajectory::direction() const { return PropagationDirection(theDirection); }
+PropagationDirection TempTrajectory::direction() const { return PropagationDirection(thePayload->theDirection); }
 
 void TempTrajectory::check() const {
   if (theData.empty())
@@ -151,35 +146,35 @@ bool TempTrajectory::badForCCC(const TrajectoryMeasurement& tm) {
     return false;
   return siStripClusterTools::chargePerCM(thit->rawId(),
                                           thit->firstClusterRef().stripCluster(),
-                                          tm.updatedState().localParameters()) < theCCCThreshold_;
+                                          tm.updatedState().localParameters()) < thePayload->theCCCThreshold_;
 }
 
 void TempTrajectory::updateBadForCCC(float ccc_threshold) {
   // If the supplied threshold is the same as the currently cached
   // one, then return the current number of bad hits for CCC,
   // otherwise do a new full rescan.
-  if (ccc_threshold == theCCCThreshold_)
+  if (ccc_threshold == thePayload->theCCCThreshold_)
     return;
 
-  theCCCThreshold_ = ccc_threshold;
-  theNumberOfCCCBadHits_ = 0;
+  thePayload->theCCCThreshold_ = ccc_threshold;
+  thePayload->theNumberOfCCCBadHits_ = 0;
   for (auto const& h : theData) {
     if (badForCCC(h))
-      theNumberOfCCCBadHits_++;
+      thePayload->theNumberOfCCCBadHits_++;
   }
 }
 
 int TempTrajectory::numberOfCCCBadHits(float ccc_threshold) {
   updateBadForCCC(ccc_threshold);
-  return theNumberOfCCCBadHits_;
+  return thePayload->theNumberOfCCCBadHits_;
 }
 
 Trajectory TempTrajectory::toTrajectory() const {
-  PropagationDirection p = PropagationDirection(theDirection);
+  PropagationDirection p = PropagationDirection(thePayload->theDirection);
   Trajectory traj(p);
-  traj.setNLoops(theNLoops);
-  traj.setStopReason(stopReason_);
-  traj.numberOfCCCBadHits(theCCCThreshold_);
+  traj.setNLoops(thePayload->theNLoops);
+  traj.setStopReason(thePayload->stopReason_);
+  traj.numberOfCCCBadHits(thePayload->theCCCThreshold_);
 
   traj.reserve(theData.size());
   const TrajectoryMeasurement* tmp[theData.size()];

--- a/TrackingTools/PatternTools/src/TempTrajectory.cc
+++ b/TrackingTools/PatternTools/src/TempTrajectory.cc
@@ -24,8 +24,8 @@ namespace {
 }  // namespace
 
 TempTrajectory::TempTrajectory(Trajectory&& traj) : thePayload(std::make_unique<Payload>()) {
+  assert(traj.isValid());
   thePayload->theDirection = traj.direction();
-  thePayload->theValid = traj.isValid();
   thePayload->theNHseed = traj.seedNHits();
   thePayload->theNLoops = traj.nLoops();
   thePayload->theDPhiCache = traj.dPhiCacheForLoopersReconstruction();
@@ -170,6 +170,7 @@ int TempTrajectory::numberOfCCCBadHits(float ccc_threshold) {
 }
 
 Trajectory TempTrajectory::toTrajectory() const {
+  assert(isValid());
   PropagationDirection p = PropagationDirection(thePayload->theDirection);
   Trajectory traj(p);
   traj.setNLoops(thePayload->theNLoops);

--- a/TrackingTools/PatternTools/test/TrajSizes_t.cpp
+++ b/TrackingTools/PatternTools/test/TrajSizes_t.cpp
@@ -13,6 +13,7 @@ int main() {
   PSIZE(TransientTrackingRecHit);
   PSIZE(Trajectory);
   PSIZE(TempTrajectory);
+  PSIZE(TempTrajectory::Payload);
 
   return 0;
 }


### PR DESCRIPTION
Currenlty, in both (grouped)limitedCandidates, for each "step" candidates are first all collected and then the size is reduced based on some score.
This is equivalent to not "pushing" a new candidate if worse than the current worst once the collection has reached the max allowed size. (but for candidates with equal score). 
The implementation has been therefore modified to this latter mechanism that is more performant.

It should also be noticed that the final sorting is not required and indeed in groupedLimitedCandidates there is NO final sort.

The Size of TempTrajectory has also been reduced to speed up move and swap.
Took the opportunity to reduce the size of Trajectory as well
and to cleanup  in general CkfTrajectoryBuilder code.

In a HLT menu
time of limitedCandidates improves of 20%
while the one of groupedLimitedCandidates improves of a bit more than 10%

HLT throughput improves of a solid 1.5% at least.

Purely technical.  Negligible regressions may appear in case of "candidates" with identical score.