### PR TITLE
Add L1 filters early on for Muon paths

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoubleTkMuon157L1TkMuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltDoubleTkMuon157L1TkMuonFilter_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+hltDoubleTkMuon157L1TkMuonFilter = cms.EDFilter("PathStatusFilter",
+    logicalExpression = cms.string('pDoubleTkMuon15_7')
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSingleTkMuon22L1TkMuonFilter_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSingleTkMuon22L1TkMuonFilter_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+hltSingleTkMuon22L1TkMuonFilter = cms.EDFilter("PathStatusFilter",
+    logicalExpression = cms.string('pSingleTkMuon22')
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_IsoMu24_FromL1TkMuon_cfi.py
@@ -18,6 +18,7 @@ from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
 from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..modules.hltSingleTkMuon22L1TkMuonFilter_cfi import *
 from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
 from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltL3crIsoL1TkSingleMu22L3f24QL3pfecalIsoFiltered0p41_cfi import *
@@ -33,6 +34,7 @@ from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20Chis
 
 
 HLT_IsoMu24_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +hltSingleTkMuon22L1TkMuonFilter
     +RawToDigiSequence
     +itLocalRecoSequence
     +otLocalRecoSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon_cfi.py
@@ -18,6 +18,7 @@ from ..sequences.HLTPhase2L3MuonsSequence_cfi import *
 from ..sequences.HLTL2MuonsFromL1TkSequence_cfi import *
 from ..sequences.HLTPFClusteringForEgammaUnseededSequence_cfi import *
 from ..sequences.HLTPhase2L3MuonGeneralTracksSequence_cfi import *
+from ..modules.hltDoubleTkMuon157L1TkMuonFilter_cfi import *
 from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
 from ..modules.hltPhase2PixelTrackFilterByKinematics_cfi import *
 from ..modules.hltDiMuon178RelTrkIsoFiltered0p4_cfi import *
@@ -30,8 +31,7 @@ from ..modules.hltL3fL1DoubleMu155fPreFiltered8_cfi import *
 from ..modules.hltPhase2L3MuonsTrkIsoRegionalNewdR0p3dRVeto0p005dz0p25dr0p20ChisqInfPtMin0p0Cut0p4_cfi import *
 
 HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_FromL1TkMuon = cms.Path(HLTBeginSequence
-    +hltL1TkDoubleMuFiltered7
-    +hltL1TkSingleMuFiltered15
+    +hltDoubleTkMuon157L1TkMuonFilter
     +hltDoubleMuon7DZ1p0
     +RawToDigiSequence
     +itLocalRecoSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/paths/HLT_Mu50_FromL1TkMuon_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from ..modules.hltSingleTkMuon22L1TkMuonFilter_cfi import *
 from ..modules.hltL3fL1TkSingleMu22L3Filtered50Q_cfi import *
 from ..modules.hltPhase2L3MuonCandidates_cfi import *
 from ..modules.hltPhase2PixelFitterByHelixProjections_cfi import *
@@ -13,6 +14,7 @@ from ..sequences.muonlocalrecoSequence_cfi import *
 from ..sequences.otLocalRecoSequence_cfi import *
 
 HLT_Mu50_FromL1TkMuon = cms.Path(HLTBeginSequence
+    +hltSingleTkMuon22L1TkMuonFilter
     +muonlocalrecoSequence
     +itLocalRecoSequence
     +otLocalRecoSequence

--- a/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/runHLTTiming.sh
@@ -36,7 +36,7 @@ done
 ALL_FILES="${ALL_FILES%?}"
 echo "Discovered files: $ALL_FILES"
 
-cmsDriver.py Phase2 -s HLT:75e33_timing --processName=HLTX \
+cmsDriver.py Phase2 -s L1P2GT,HLT:75e33_timing --processName=HLTX \
   --conditions auto:phase2_realistic_T25 --geometry Extended2026D98 \
   --era Phase2C17I13M9 \
   --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000 \
@@ -45,11 +45,11 @@ cmsDriver.py Phase2 -s HLT:75e33_timing --processName=HLTX \
   --mc --nThreads 4 --inputCommands='keep *, drop *_hlt*_*_HLT, drop triggerTriggerFilterObjectWithRefs_l1t*_*_HLT' \
   -n 1000 --no_exec --output={}
 
-if [ -e 'Phase2_HLT.py' ]; then
+if [ -e 'Phase2_L1P2GT_HLT.py' ]; then
   if [ ! -d 'patatrack-scripts' ]; then
     git clone https://github.com/cms-patatrack/patatrack-scripts --depth 1
   fi
-  patatrack-scripts/benchmark -j 4 -t 8 -s 8 -e 1000 --no-run-io-benchmark -k Phase2Timing_resources.json -- Phase2_HLT.py
+  patatrack-scripts/benchmark -j 4 -t 16 -s 16 -e 1000 --no-run-io-benchmark -k Phase2Timing_resources.json -- Phase2_L1P2GT_HLT.py
   if [ ! -d 'circles' ]; then
     git clone https://github.com/fwyzard/circles.git --depth 1
   fi


### PR DESCRIPTION
#### PR description:

This PR reintroduces L1 filters for HLT Phase2 Muon paths based only on L1 objects. Purely technical.
The timing script has been updated to include the now mandatory `L1P2GT` step.


#### PR validation:

Ttested locally.