### PR TITLE
Phase 2 GTT L1TrackObjectNtupleMaker fixes

### DIFF
--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -1678,14 +1678,14 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trkjetemExt_ntracks->clear();
       m_trkjetemExt_nxtracks->clear();
     }
-
-    m_pv_L1reco->clear();
-    m_pv_L1reco_sum->clear();
-    m_pv_L1reco_emu->clear();
-    m_pv_L1reco_sum_emu->clear();
-    m_pv_MC->clear();
-    m_MC_lep->clear();
   }
+
+  m_pv_L1reco->clear();
+  m_pv_L1reco_sum->clear();
+  m_pv_L1reco_emu->clear();
+  m_pv_L1reco_sum_emu->clear();
+  m_pv_MC->clear();
+  m_MC_lep->clear();
 
   // -----------------------------------------------------------------------------------------------
   // retrieve various containers

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker.cc
@@ -2194,7 +2194,6 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
     for (iterL1Track = TTTrackExtendedHandle->begin(); iterL1Track != TTTrackExtendedHandle->end(); iterL1Track++) {
       L1TrackPtr l1track_ptr(TTTrackExtendedHandle, this_l1track);
       L1TrackRef l1track_ref(TTTrackExtendedGTTHandle, this_l1track);
-      this_l1track++;
 
       float tmp_trk_pt = iterL1Track->momentum().perp();
       float tmp_trk_eta = iterL1Track->momentum().eta();
@@ -2370,28 +2369,29 @@ void L1TrackObjectNtupleMaker::analyze(const edm::Event& iEvent, const edm::Even
       m_trkExt_gtt_eta->push_back(l1track_ref->momentum().eta());
       m_trkExt_gtt_phi->push_back(l1track_ref->momentum().phi());
       m_trkExt_selected_index->push_back(getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedHandle));
-      m_trkExt_selected_emulation_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationHandle));
-      m_trkExt_selected_associated_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedHandle));
-      m_trkExt_selected_associated_emulation_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationHandle));
-      m_trkExt_selected_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedForJetsHandle));
-      m_trkExt_selected_emulation_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationForJetsHandle));
-      m_trkExt_selected_associated_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedForJetsHandle));
-      m_trkExt_selected_associated_emulation_forjets_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationForJetsHandle));
-      m_trkExt_selected_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedForEtMissHandle));
-      m_trkExt_selected_emulation_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationForEtMissHandle));
-      m_trkExt_selected_associated_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedForEtMissHandle));
-      m_trkExt_selected_associated_emulation_foretmiss_index->push_back(
-          getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationForEtMissHandle));
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationHandle) >= 0)
+        m_trkExt_selected_emulation_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedHandle) >= 0)
+        m_trkExt_selected_associated_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationHandle) >= 0)
+        m_trkExt_selected_associated_emulation_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedForJetsHandle) >= 0)
+        m_trkExt_selected_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationForJetsHandle) >= 0)
+        m_trkExt_selected_emulation_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedForJetsHandle) >= 0)
+        m_trkExt_selected_associated_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationForJetsHandle) >= 0)
+        m_trkExt_selected_associated_emulation_forjets_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedForEtMissHandle) >= 0)
+        m_trkExt_selected_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedEmulationForEtMissHandle) >= 0)
+        m_trkExt_selected_emulation_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedForEtMissHandle) >= 0)
+        m_trkExt_selected_associated_foretmiss_index->push_back(this_l1track);
+      if (getSelectedTrackIndex(l1track_ref, TTTrackExtendedSelectedAssociatedEmulationForEtMissHandle) >= 0)
+        m_trkExt_selected_associated_emulation_foretmiss_index->push_back(this_l1track);
+      this_l1track++;
     }  //end track loop
   }    //end if SaveAllTracks (displaced)
 

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -126,7 +126,6 @@ if runVtxNN:
     VertexAssociator = process.l1tTrackVertexNNAssociationProducer
     AssociationName = "l1tTrackVertexNNAssociationProducer"
 else:
-    process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
     VertexAssociator = process.l1tTrackVertexAssociationProducer
     AssociationName = "l1tTrackVertexAssociationProducer"
     

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -128,7 +128,6 @@ if runVtxNN:
     AssociationName = "l1tTrackVertexNNAssociationProducer"
 else:
     process.l1tVertexFinderEmulator = process.l1tVertexProducer.clone()
-    process.l1tVertexFinderEmulator.VertexReconstruction.Algorithm = "FHEmulation"
     VertexAssociator = process.l1tTrackVertexAssociationProducer
     AssociationName = "l1tTrackVertexAssociationProducer"
     

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -13,7 +13,7 @@ L1TRK_INST ="MyL1TrackJets" ### if not in input DIGRAW then we make them in the 
 process = cms.Process(L1TRK_INST)
 
 #L1TRKALGO = 'HYBRID'  #baseline, 4par fit
-# L1TRKALGO = 'HYBRID_DISPLACED'  #extended, 5par fit
+#L1TRKALGO = 'HYBRID_DISPLACED'  #extended, 5par fit
 L1TRKALGO = 'HYBRID_PROMPTANDDISP'
 
 DISPLACED = ''
@@ -150,6 +150,7 @@ if (L1TRKALGO == 'HYBRID'):
     process.pTkMETEmu = cms.Path(process.l1tTrackerEmuEtMiss)
     process.pTkMHT = cms.Path(process.l1tTrackerHTMiss)
     process.pTkMHTEmulator = cms.Path(process.l1tTrackerEmuHTMiss)
+    process.pL1TrackTripletEmulator = cms.Path(process.l1tTrackTripletEmulation)
     DISPLACED = 'Prompt'
 
 # HYBRID: extended tracking

--- a/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
+++ b/L1Trigger/L1TTrackMatch/test/L1TrackObjectNtupleMaker_cfg.py
@@ -45,8 +45,7 @@ process.MessageLogger.cerr.INFO.limit = cms.untracked.int32(0) # default: 0
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(20))
 
 readFiles = cms.untracked.vstring(
-                              'file:/eos/cms/store/cmst3/group/l1tr/gpetrucc/prod125X/WTo3Pion_pythia8_PU200/WTo3Pion_pythia8_PU200.batch3.job99.root'
-#                                  '/store/relval/CMSSW_13_0_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/130X_mcRun4_realistic_v2_2026D95noPU-v1/00000/16f6615d-f98c-475f-ad33-0e89934b6c7f.root'
+    '/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/1cc5c14c-5bae-4e68-a369-04e230788660.root'
 )
 secFiles = cms.untracked.vstring()
 


### PR DESCRIPTION
#### PR description:

This PR aggregates various fixes for the GTT L1TrackObjectNtupleMaker, from https://github.com/cms-l1t-offline/cmssw/pull/1253 and https://github.com/cms-l1t-offline/cmssw/pull/1255

#### PR validation:

This PR passes:
scram b
scram b code-checks
scram b code-format
cmsRun L1TrackObjectNtupleMaker_cfg.py
(L1TrackObjectNtupleMaker is not called in any central workflows)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This is a forward port of https://github.com/cms-l1t-offline/cmssw/pull/1253 and https://github.com/cms-l1t-offline/cmssw/pull/1255