### PR TITLE
Phase2 Fast CPE Template Error Fix

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFast.cc
@@ -445,13 +445,6 @@ void PixelCPEFast<TrackerTraits>::errorFromTemplates(DetParam const& theDetParam
   theClusterParam.sy2 = theClusterParam.sy2 * micronsToCm;
 }
 
-template <>
-void PixelCPEFast<pixelTopology::Phase2>::errorFromTemplates(DetParam const& theDetParam,
-                                                             ClusterParamGeneric& theClusterParam,
-                                                             float qclus) const {
-  theClusterParam.qBin_ = 0.0f;
-}
-
 //-----------------------------------------------------------------------------
 //! Hit position in the local frame (in cm).  Unlike other CPE's, this
 //! one converts everything from the measurement frame (in channel numbers)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEFastParamsHost.cc
@@ -397,13 +397,6 @@ void PixelCPEFastParamsHost<TrackerTraits>::errorFromTemplates(DetParam const& t
   theClusterParam.sy2 = theClusterParam.sy2 * pixelCPEforDevice::micronsToCm;
 }
 
-template <>
-void PixelCPEFastParamsHost<pixelTopology::Phase2>::errorFromTemplates(DetParam const& theDetParam,
-                                                                       ClusterParamGeneric& theClusterParam,
-                                                                       float qclus) const {
-  theClusterParam.qBin_ = 0.0f;
-}
-
 //-----------------------------------------------------------------------------
 //! Hit position in the local frame (in cm).  Unlike other CPE's, this
 //! one converts everything from the measurement frame (in channel numbers)


### PR DESCRIPTION
This PR proposes a trivial fix for the Fast CPE error calculations. As is now only `qBin==0` is taken into account and should not be like this. Additionally with https://github.com/cms-sw/cmssw/pull/44813 this ends up in an infinite loop (that is also how I spotted it). 

Being the original author I honestly don't remember why this was like this in the first place. One of the hypotheses is that the template for Phase 2 pixels was not available at the time of the CUDA port. But I haven't done all the proper archeology. 

Fixes for both for Alpaka and CUDA.

Will produce the pixel local reco validation plots and append them here. 