### PR TITLE
[14.0.X] Add track-to-track monitoring of HLT GSF electron tracks with respect to offline

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -257,6 +257,7 @@ RECOEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 
 from Configuration.Eras.Modifier_ctpps_cff import ctpps
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
@@ -675,6 +676,12 @@ phase2_tracker.toModify(FEVTDEBUGHLTEventContent,
                             'keep *_hltPhase2PixelTracks_*_*',
                             'keep *_hltPhase2PixelVertices_*_*'
                         ])
+
+phase2_common.toModify(FEVTDEBUGHLTEventContent,
+                       outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+                           'keep *_hltEgammaGsfTracksL1Seeded_*_*',
+                       ])
+
 phase2_muon.toModify(FEVTDEBUGHLTEventContent, 
     outputCommands = FEVTDEBUGHLTEventContent.outputCommands + ['keep recoMuons_muons1stStep_*_*'])
 

--- a/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
+++ b/DQM/TrackingMonitorSource/interface/TrackToTrackComparisonHists.h
@@ -52,7 +52,7 @@ public:
     MonitorElement *h_dPt, *h_dEta, *h_dPhi, *h_dDxy, *h_dDz, *h_dDxyWRTpv, *h_dDzWRTpv, *h_dCharge, *h_dHits;
   };
 
-  typedef std::vector<std::pair<int, std::map<double, int> > > idx2idxByDoubleColl;
+  typedef std::vector<std::pair<int, std::map<double, int>>> idx2idxByDoubleColl;
 
   explicit TrackToTrackComparisonHists(const edm::ParameterSet&);
   ~TrackToTrackComparisonHists() override;
@@ -65,7 +65,10 @@ protected:
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void bookHistograms(DQMStore::IBooker& iBooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
 
-  void fillMap(reco::TrackCollection tracks1, reco::TrackCollection tracks2, idx2idxByDoubleColl& map, float dRMin);
+  void fillMap(const edm::View<reco::Track>& tracks1,
+               const edm::View<reco::Track>& tracks2,
+               idx2idxByDoubleColl& map,
+               float dRMin);
 
   void initialize_parameter(const edm::ParameterSet& iConfig);
   void bookHistos(DQMStore::IBooker& ibooker, generalME& mes, TString label, std::string& dir);
@@ -89,8 +92,8 @@ protected:
   edm::InputTag referenceTrackInputTag_;
 
   //these are used by MTVGenPs
-  edm::EDGetTokenT<reco::TrackCollection> monitoredTrackToken_;
-  edm::EDGetTokenT<reco::TrackCollection> referenceTrackToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> monitoredTrackToken_;
+  edm::EDGetTokenT<edm::View<reco::Track>> referenceTrackToken_;
   edm::EDGetTokenT<reco::BeamSpot> monitoredBSToken_;
   edm::EDGetTokenT<reco::BeamSpot> referenceBSToken_;
   edm::EDGetTokenT<reco::VertexCollection> monitoredPVToken_;

--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -30,8 +30,8 @@ TrackToTrackComparisonHists::TrackToTrackComparisonHists(const edm::ParameterSet
   initialize_parameter(iConfig);
 
   //now do what ever initialization is needed
-  monitoredTrackToken_ = consumes<reco::TrackCollection>(monitoredTrackInputTag_);
-  referenceTrackToken_ = consumes<reco::TrackCollection>(referenceTrackInputTag_);
+  monitoredTrackToken_ = consumes<edm::View<reco::Track>>(monitoredTrackInputTag_);
+  referenceTrackToken_ = consumes<edm::View<reco::Track>>(referenceTrackInputTag_);
   monitoredBSToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("monitoredBeamSpot"));
   referenceBSToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("referenceBeamSpot"));
   monitoredPVToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("monitoredPrimaryVertices"));
@@ -100,13 +100,14 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
   //
   //  Get Reference Track Info
   //
-  edm::Handle<reco::TrackCollection> referenceTracksHandle;
+  edm::Handle<edm::View<reco::Track>> referenceTracksHandle;
   iEvent.getByToken(referenceTrackToken_, referenceTracksHandle);
   if (!referenceTracksHandle.isValid()) {
-    edm::LogError("TrackToTrackComparisonHists") << "referenceTracksHandle not found, skipping event";
+    edm::LogError("TrackToTrackComparisonHists")
+        << "referenceTracksHandle with input tag " << referenceTrackInputTag_.encode() << " not found, skipping event";
     return;
   }
-  reco::TrackCollection referenceTracks = *referenceTracksHandle;
+  const edm::View<reco::Track>& referenceTracks = *referenceTracksHandle;
 
   edm::Handle<reco::BeamSpot> referenceBSHandle;
   iEvent.getByToken(referenceBSToken_, referenceBSHandle);
@@ -131,13 +132,14 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
   //
   //  Get Monitored Track Info
   //
-  edm::Handle<reco::TrackCollection> monitoredTracksHandle;
+  edm::Handle<edm::View<reco::Track>> monitoredTracksHandle;
   iEvent.getByToken(monitoredTrackToken_, monitoredTracksHandle);
   if (!monitoredTracksHandle.isValid()) {
-    edm::LogError("TrackToTrackComparisonHists") << "monitoredTracksHandle not found, skipping event";
+    edm::LogError("TrackToTrackComparisonHists")
+        << "monitoredTracksHandle with input tag " << monitoredTrackInputTag_.encode() << " not found, skipping event";
     return;
   }
-  reco::TrackCollection monitoredTracks = *monitoredTracksHandle;
+  const edm::View<reco::Track>& monitoredTracks = *monitoredTracksHandle;
 
   edm::Handle<reco::BeamSpot> monitoredBSHandle;
   iEvent.getByToken(monitoredBSToken_, monitoredBSHandle);
@@ -333,8 +335,8 @@ void TrackToTrackComparisonHists::fillDescriptions(edm::ConfigurationDescription
   descriptions.add("trackToTrackComparisonHists", desc);
 }
 
-void TrackToTrackComparisonHists::fillMap(reco::TrackCollection tracks1,
-                                          reco::TrackCollection tracks2,
+void TrackToTrackComparisonHists::fillMap(const edm::View<reco::Track>& tracks1,
+                                          const edm::View<reco::Track>& tracks2,
                                           idx2idxByDoubleColl& map,
                                           float dRMin) {
   //

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -210,6 +210,7 @@ _offlineHLTSource4HLTMonitorPDPh2 = cms.Sequence(
     dqmInfoHLTMon *
     HLTtrackerphase2DQMSource *           # phase-2 IT and OT clusters
     trackingMonitorHLT *                  # tracking
+    egmTrackingMonitorHLT *               # EGM tracking
     hltToOfflineTrackValidatorSequence *  # Relative Online to Offline performace
     vertexingMonitorHLT                   # vertexing
 )

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
@@ -79,6 +79,15 @@ hltEgammaGsfTracksVsOfflinePV = TrackToTrackComparisonHists.clone(
     monitoredPrimaryVertices = "hltVerticesPFSelector"
 )
 
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(hltEgammaGsfTracksVsOffline,
+                       monitoredTrack           = cms.InputTag("hltEgammaGsfTracksL1Seeded"),
+                       monitoredPrimaryVertices = cms.InputTag("offlinePrimaryVertices","","HLT"))
+
+phase2_common.toModify(hltEgammaGsfTracksVsOfflinePV,
+                       monitoredTrack           = cms.InputTag("hltEgammaGsfTracksL1Seeded"),
+                       monitoredPrimaryVertices = cms.InputTag("offlinePrimaryVertices","","HLT"))
+
 hltToOfflineTrackValidatorSequence = cms.Sequence(
     cms.ignore(highPurityTracks)
     + hltMerged2highPurity

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
@@ -54,8 +54,35 @@ phase2_tracker.toModify(hltMerged2highPurityPV,
                         monitoredTrack           = cms.InputTag("generalTracks","","HLT"),
                         monitoredPrimaryVertices = cms.InputTag("offlinePrimaryVertices","","HLT"))
 
+#
+# E/gamma monitoring
+#
+
+hltEgammaGsfTracksVsOffline = TrackToTrackComparisonHists.clone(
+    monitoredTrack           = "hltEgammaGsfTracks",
+    referenceTrack           = "electronGsfTracks",
+    monitoredBeamSpot        = "hltOnlineBeamSpot",
+    referenceBeamSpot        = "offlineBeamSpot",
+    topDirName               = "HLT/EGM/Tracking/ValidationWRTOffline/hltEgammaGsfTracks",
+    referencePrimaryVertices = "offlinePrimaryVertices",
+    monitoredPrimaryVertices = "hltVerticesPFSelector"
+)
+
+hltEgammaGsfTracksVsOfflinePV = TrackToTrackComparisonHists.clone(
+    dzWRTPvCut               = 0.1,
+    monitoredTrack           = "hltEgammaGsfTracks",
+    referenceTrack           = "electronGsfTracks",
+    monitoredBeamSpot        = "hltOnlineBeamSpot",
+    referenceBeamSpot        = "offlineBeamSpot",
+    topDirName               = "HLT/EGM/Tracking/ValidationWRTOffline/hltEgammaGsfTracksPV",
+    referencePrimaryVertices = "offlinePrimaryVertices",
+    monitoredPrimaryVertices = "hltVerticesPFSelector"
+)
+
 hltToOfflineTrackValidatorSequence = cms.Sequence(
     cms.ignore(highPurityTracks)
     + hltMerged2highPurity
     + hltMerged2highPurityPV
+    + hltEgammaGsfTracksVsOffline
+    + hltEgammaGsfTracksVsOfflinePV
 )

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -69,8 +69,16 @@ pp_on_PbPb_run3.toModify(TrackToTrackEfficiencies,
                              "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurity",
                              "HLT/Tracking/ValidationWRTOffline/hltMergedPPonAAWrtHighPurityPV"])
 
+EGMTrackToTrackEfficiencies = TrackToTrackEfficiencies.clone(
+    subDirs        = cms.untracked.vstring(
+        "HLT/EGM/Tracking/ValidationWRTOffline/hltEgammaGsfTracks",
+        "HLT/EGM/Tracking/ValidationWRTOffline/hltEgammaGsfTracksPV",
+    )
+)
+
 trackEfficiencyMonitoringClientHLT = cms.Sequence(
-    TrackToTrackEfficiencies
+    TrackToTrackEfficiencies+
+    EGMTrackToTrackEfficiencies
 )
 
 def _modifyForRun3Default(efffromhitpattern):

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -172,7 +172,7 @@ pp_on_PbPb_run3.toModify(doubletRecoveryHPTracksMonitoringHLT,
 # Iter1HP: hltIter1MergedForElectrons
 # Iter2HP: hltIter2MergedForElectrons
 egmTrackingMonHLT = trackingMonHLT.clone(
-    primaryVertex = "hltElectronsVertex",
+    primaryVertex = "hltPixelVertices",
     doEffFromHitPatternVsPU   = False,
     doEffFromHitPatternVsBX   = False,
     doEffFromHitPatternVsLUMI = False 

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -182,6 +182,13 @@ gsfTracksMonitoringHLT = egmTrackingMonHLT.clone(
     TrackProducer    = 'hltEgammaGsfTracks',
     allTrackProducer = 'hltEgammaGsfTracks'
 )
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(gsfTracksMonitoringHLT,
+                       primaryVertex    = 'hltPhase2PixelVertices',
+                       TrackProducer    = 'hltEgammaGsfTracksL1Seeded',
+                       allTrackProducer = 'hltEgammaGsfTracksL1Seeded')
+
 pixelTracksForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
     FolderName       = 'HLT/EGM/Tracking/pixelTracks',
     TrackProducer    = 'hltPixelTracksElectrons',


### PR DESCRIPTION
backport of #44868 

#### PR description:

Title says it all, supports track-to-track monitoring of HLT GSF electron tracks with respect to offline for both Run 3 (`hltEgammaGsfTracks`) and Phase 2 (`hltEgammaGsfTracksL1Seeded`).
In addition:
   * add  regular GSF tracking monitoring at HLT also in Phase-2;
   * fix a bug in the vertex collection used for `egmTrackingMonHLT`

#### PR validation:

Run successfully both  `runTheMatrix.py -l 13034.0 -t 4 -j 8` (Run 3) and `runTheMatrix.py -l 24834.0 -t 4 -j 8 ` (Phase 2) and observed the corresponding monitoring elements filled.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of #44868 in CMSSW_14_0_X for data-taking purposes.