### PR TITLE
[DT] Position fix and new filter to TPs from Phase2 L1T emulator

### DIFF
--- a/L1Trigger/DTTriggerPhase2/interface/GlobalCoordsObtainer.h
+++ b/L1Trigger/DTTriggerPhase2/interface/GlobalCoordsObtainer.h
@@ -29,9 +29,7 @@ struct lut_value {
 };
 
 struct lut_group {
-  std::map<int, lut_value> phic;
-  std::map<int, lut_value> phi1;
-  std::map<int, lut_value> phi3;
+  std::map<int, lut_value> phi;
   std::map<int, lut_value> phib;
 };
 
@@ -57,6 +55,10 @@ public:
 
   void generate_luts();
   std::vector<double> get_global_coordinates(uint32_t, int, int, int);
+
+  edm::FileInPath maxdrift_filename_;
+  int maxdriftinfo_[5][4][14];
+  int max_drift_tdc = -1;
 
 private:
   std::map<int, lut_value> calc_atan_lut(int, int, double, double, double, int, int, int, int, int);

--- a/L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h
@@ -1,0 +1,69 @@
+#ifndef Phase2L1Trigger_DTTrigger_MPCoincidenceFilter_h
+#define Phase2L1Trigger_DTTrigger_MPCoincidenceFilter_h
+
+#include "L1Trigger/DTTriggerPhase2/interface/MPFilter.h"
+
+#include <iostream>
+#include <fstream>
+
+// ===============================================================================
+// Previous definitions and declarations
+// ===============================================================================
+
+// ===============================================================================
+// Class declarations
+// ===============================================================================
+
+
+class MPCoincidenceFilter : public MPFilter {
+public:
+  // Constructors and destructor
+  MPCoincidenceFilter(const edm::ParameterSet &pset);
+  ~MPCoincidenceFilter() override = default;
+
+  // Main methods
+  void initialise(const edm::EventSetup &iEventSetup) override;
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &iEventSetup,
+           std::vector<cmsdt::metaPrimitive> &inMPath,
+           std::vector<cmsdt::metaPrimitive> &outMPath) override{};
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &iEventSetup,
+           std::vector<cmsdt::metaPrimitive> &allMPaths,
+           std::vector<cmsdt::metaPrimitive> &inMPaths,
+	   std::vector<cmsdt::metaPrimitive> &outMPaths) override;
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &iEventSetup,
+           MuonPathPtrs &inMPath,
+           MuonPathPtrs &outMPath) override{};
+
+  void finish() override;
+
+  // Other public methods
+
+  // Public attributes
+
+  std::map<std::string, float> mphi_mean {{"wh-2ch1",1.0},{"wh-1ch1",0.9},{"wh0ch1",-0.3},{"wh1ch1",0.9},{"wh2ch1",1.0},{"wh-2ch2",1.4},{"wh-1ch2",-0.4},{"wh0ch2",-0.3},{"wh1ch2",-0.4},{"wh2ch2",1.5},{"wh-2ch3",-0.1},{"wh-1ch3",-0.2},{"wh0ch3",-0.1},{"wh1ch3",-0.3},{"wh2ch3",-0.4},{"wh-2ch4",-1.0},{"wh-1ch4",-1.1},{"wh0ch4",-1.0},{"wh1ch4",-1.1},{"wh2ch4",-0.8}};
+  
+  std::map<std::string, float> mphi_width {{"wh-2ch1",7.2},{"wh-1ch1",7.0},{"wh0ch1",11.2},{"wh1ch1",7.4},{"wh2ch1",7.1},{"wh-2ch2",6.6},{"wh-1ch2",8.5},{"wh0ch2",11.1},{"wh1ch2",8.5},{"wh2ch2",6.5},{"wh-2ch3",8.0},{"wh-1ch3",9.2},{"wh0ch3",11.2},{"wh1ch3",9.1},{"wh2ch3",7.8},{"wh-2ch4",8.0},{"wh-1ch4",9.6},{"wh0ch4",11.8},{"wh1ch4",9.3},{"wh2ch4",7.7}};
+
+  std::map<std::string, float> mth_mean {{"wh-2ch1",-17.4},{"wh-1ch1",-9.5},{"wh0ch1",-0.8},{"wh1ch1",-9.8},{"wh2ch1",-17.1},{"wh-2ch2",-18.9},{"wh-1ch2",-6.6},{"wh0ch2",0.5},{"wh1ch2",-6.8},{"wh2ch2",-19.2},{"wh-2ch3",-16.3},{"wh-1ch3",-3.2},{"wh0ch3",1.9},{"wh1ch3",-3.6},{"wh2ch3",-17.5},{"wh-2ch4",0.0},{"wh-1ch4",0.0},{"wh0ch4",0.0},{"wh1ch4",0.0},{"wh2ch4",0.0}};
+
+  std::map<std::string, float> mth_width {{"wh-2ch1",33.5},{"wh-1ch1",12.6},{"wh0ch1",10.1},{"wh1ch1",14.4},{"wh2ch1",44.8},{"wh-2ch2",23.0},{"wh-1ch2",13.2},{"wh0ch2",11.6},{"wh1ch2",14.0},{"wh2ch2",25.6},{"wh-2ch3",22.5},{"wh-1ch3",13.8},{"wh0ch3",13.9},{"wh1ch3",14.2},{"wh2ch3",24.2},{"wh-2ch4",9.4},{"wh-1ch4",9.4},{"wh0ch4",9.4},{"wh1ch4",9.4},{"wh2ch4",9.4}};
+
+private:
+  // Private methods
+  std::vector<cmsdt::metaPrimitive> filter(std::vector<cmsdt::metaPrimitive> inMPs,
+					   std::vector<cmsdt::metaPrimitive> allMPs,
+                                           int co_option, int co_quality, double shift_back);
+
+  // Private attributes
+  const bool debug_;
+  int co_option_;                                                                                                       
+  int co_quality_;
+  int scenario_;
+ 
+
+};
+
+#endif

--- a/L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h
@@ -14,7 +14,6 @@
 // Class declarations
 // ===============================================================================
 
-
 class MPCoincidenceFilter : public MPFilter {
 public:
   // Constructors and destructor
@@ -31,7 +30,7 @@ public:
            const edm::EventSetup &iEventSetup,
            std::vector<cmsdt::metaPrimitive> &allMPaths,
            std::vector<cmsdt::metaPrimitive> &inMPaths,
-	   std::vector<cmsdt::metaPrimitive> &outMPaths) override;
+           std::vector<cmsdt::metaPrimitive> &outMPaths) override;
   void run(edm::Event &iEvent,
            const edm::EventSetup &iEventSetup,
            MuonPathPtrs &inMPath,
@@ -43,27 +42,43 @@ public:
 
   // Public attributes
 
-  std::map<std::string, float> mphi_mean {{"wh-2ch1",1.0},{"wh-1ch1",0.9},{"wh0ch1",-0.3},{"wh1ch1",0.9},{"wh2ch1",1.0},{"wh-2ch2",1.4},{"wh-1ch2",-0.4},{"wh0ch2",-0.3},{"wh1ch2",-0.4},{"wh2ch2",1.5},{"wh-2ch3",-0.1},{"wh-1ch3",-0.2},{"wh0ch3",-0.1},{"wh1ch3",-0.3},{"wh2ch3",-0.4},{"wh-2ch4",-1.0},{"wh-1ch4",-1.1},{"wh0ch4",-1.0},{"wh1ch4",-1.1},{"wh2ch4",-0.8}};
-  
-  std::map<std::string, float> mphi_width {{"wh-2ch1",7.2},{"wh-1ch1",7.0},{"wh0ch1",11.2},{"wh1ch1",7.4},{"wh2ch1",7.1},{"wh-2ch2",6.6},{"wh-1ch2",8.5},{"wh0ch2",11.1},{"wh1ch2",8.5},{"wh2ch2",6.5},{"wh-2ch3",8.0},{"wh-1ch3",9.2},{"wh0ch3",11.2},{"wh1ch3",9.1},{"wh2ch3",7.8},{"wh-2ch4",8.0},{"wh-1ch4",9.6},{"wh0ch4",11.8},{"wh1ch4",9.3},{"wh2ch4",7.7}};
+  std::map<std::string, float> mphi_mean{{"wh-2ch1", 1.0},  {"wh-1ch1", 0.9}, {"wh0ch1", -0.3},  {"wh1ch1", 0.9},
+                                         {"wh2ch1", 1.0},   {"wh-2ch2", 1.4}, {"wh-1ch2", -0.4}, {"wh0ch2", -0.3},
+                                         {"wh1ch2", -0.4},  {"wh2ch2", 1.5},  {"wh-2ch3", -0.1}, {"wh-1ch3", -0.2},
+                                         {"wh0ch3", -0.1},  {"wh1ch3", -0.3}, {"wh2ch3", -0.4},  {"wh-2ch4", -1.0},
+                                         {"wh-1ch4", -1.1}, {"wh0ch4", -1.0}, {"wh1ch4", -1.1},  {"wh2ch4", -0.8}};
 
-  std::map<std::string, float> mth_mean {{"wh-2ch1",-17.4},{"wh-1ch1",-9.5},{"wh0ch1",-0.8},{"wh1ch1",-9.8},{"wh2ch1",-17.1},{"wh-2ch2",-18.9},{"wh-1ch2",-6.6},{"wh0ch2",0.5},{"wh1ch2",-6.8},{"wh2ch2",-19.2},{"wh-2ch3",-16.3},{"wh-1ch3",-3.2},{"wh0ch3",1.9},{"wh1ch3",-3.6},{"wh2ch3",-17.5},{"wh-2ch4",0.0},{"wh-1ch4",0.0},{"wh0ch4",0.0},{"wh1ch4",0.0},{"wh2ch4",0.0}};
+  std::map<std::string, float> mphi_width{{"wh-2ch1", 7.2}, {"wh-1ch1", 7.0}, {"wh0ch1", 11.2}, {"wh1ch1", 7.4},
+                                          {"wh2ch1", 7.1},  {"wh-2ch2", 6.6}, {"wh-1ch2", 8.5}, {"wh0ch2", 11.1},
+                                          {"wh1ch2", 8.5},  {"wh2ch2", 6.5},  {"wh-2ch3", 8.0}, {"wh-1ch3", 9.2},
+                                          {"wh0ch3", 11.2}, {"wh1ch3", 9.1},  {"wh2ch3", 7.8},  {"wh-2ch4", 8.0},
+                                          {"wh-1ch4", 9.6}, {"wh0ch4", 11.8}, {"wh1ch4", 9.3},  {"wh2ch4", 7.7}};
 
-  std::map<std::string, float> mth_width {{"wh-2ch1",33.5},{"wh-1ch1",12.6},{"wh0ch1",10.1},{"wh1ch1",14.4},{"wh2ch1",44.8},{"wh-2ch2",23.0},{"wh-1ch2",13.2},{"wh0ch2",11.6},{"wh1ch2",14.0},{"wh2ch2",25.6},{"wh-2ch3",22.5},{"wh-1ch3",13.8},{"wh0ch3",13.9},{"wh1ch3",14.2},{"wh2ch3",24.2},{"wh-2ch4",9.4},{"wh-1ch4",9.4},{"wh0ch4",9.4},{"wh1ch4",9.4},{"wh2ch4",9.4}};
+  std::map<std::string, float> mth_mean{{"wh-2ch1", -17.4}, {"wh-1ch1", -9.5},  {"wh0ch1", -0.8},   {"wh1ch1", -9.8},
+                                        {"wh2ch1", -17.1},  {"wh-2ch2", -18.9}, {"wh-1ch2", -6.6},  {"wh0ch2", 0.5},
+                                        {"wh1ch2", -6.8},   {"wh2ch2", -19.2},  {"wh-2ch3", -16.3}, {"wh-1ch3", -3.2},
+                                        {"wh0ch3", 1.9},    {"wh1ch3", -3.6},   {"wh2ch3", -17.5},  {"wh-2ch4", 0.0},
+                                        {"wh-1ch4", 0.0},   {"wh0ch4", 0.0},    {"wh1ch4", 0.0},    {"wh2ch4", 0.0}};
+
+  std::map<std::string, float> mth_width{{"wh-2ch1", 33.5}, {"wh-1ch1", 12.6}, {"wh0ch1", 10.1},  {"wh1ch1", 14.4},
+                                         {"wh2ch1", 44.8},  {"wh-2ch2", 23.0}, {"wh-1ch2", 13.2}, {"wh0ch2", 11.6},
+                                         {"wh1ch2", 14.0},  {"wh2ch2", 25.6},  {"wh-2ch3", 22.5}, {"wh-1ch3", 13.8},
+                                         {"wh0ch3", 13.9},  {"wh1ch3", 14.2},  {"wh2ch3", 24.2},  {"wh-2ch4", 9.4},
+                                         {"wh-1ch4", 9.4},  {"wh0ch4", 9.4},   {"wh1ch4", 9.4},   {"wh2ch4", 9.4}};
 
 private:
   // Private methods
   std::vector<cmsdt::metaPrimitive> filter(std::vector<cmsdt::metaPrimitive> inMPs,
-					   std::vector<cmsdt::metaPrimitive> allMPs,
-                                           int co_option, int co_quality, double shift_back);
+                                           std::vector<cmsdt::metaPrimitive> allMPs,
+                                           int co_option,
+                                           int co_quality,
+                                           double shift_back);
 
   // Private attributes
   const bool debug_;
-  int co_option_;                                                                                                       
+  int co_option_;
   int co_quality_;
   int scenario_;
- 
-
 };
 
 #endif

--- a/L1Trigger/DTTriggerPhase2/interface/constants.h
+++ b/L1Trigger/DTTriggerPhase2/interface/constants.h
@@ -426,8 +426,8 @@ namespace cmsdt {
 
   constexpr int X_SIZE = 17;
   constexpr int TANPSI_SIZE = 14;
-  constexpr double PHI_SIZE = 1. / 131072; //pow(2,17)   //1 rad range, 17 bits
-  constexpr double PHIB_SIZE = 4. / 8192; //pow(2,13)  //4 rad range, 13 bits
+  constexpr double PHI_SIZE = 1. / 131072;  //pow(2,17)   //1 rad range, 17 bits
+  constexpr double PHIB_SIZE = 4. / 8192;   //pow(2,13)  //4 rad range, 13 bits
 
   constexpr int PHI_LUT_ADDR_WIDTH = 11;
   constexpr int PHI_B_SHL_BITS = 5;

--- a/L1Trigger/DTTriggerPhase2/interface/constants.h
+++ b/L1Trigger/DTTriggerPhase2/interface/constants.h
@@ -426,8 +426,8 @@ namespace cmsdt {
 
   constexpr int X_SIZE = 17;
   constexpr int TANPSI_SIZE = 14;
-  constexpr double PHI_SIZE = 1. / pow(2, 17);   //1 rad range, 17 bits
-  constexpr double PHIB_SIZE = 4. / pow(2, 13);  //4 rad range, 13 bits
+  constexpr double PHI_SIZE = 1. / 131072; //pow(2,17)   //1 rad range, 17 bits
+  constexpr double PHIB_SIZE = 4. / 8192; //pow(2,13)  //4 rad range, 13 bits
 
   constexpr int PHI_LUT_ADDR_WIDTH = 11;
   constexpr int PHI_B_SHL_BITS = 5;

--- a/L1Trigger/DTTriggerPhase2/interface/constants.h
+++ b/L1Trigger/DTTriggerPhase2/interface/constants.h
@@ -424,20 +424,20 @@ namespace cmsdt {
    * Local to global coordinates transformation
    */
 
-  constexpr int X_SIZE = 18;
-  constexpr int TANPSI_SIZE = 15;
-  constexpr int PHI_SIZE = 17;   // (1 / 2 ** 17)
-  constexpr int PHIB_SIZE = 11;  // (2 ** 2) / (2 ** 13)
+  constexpr int X_SIZE = 17;
+  constexpr int TANPSI_SIZE = 14;
+  constexpr double PHI_SIZE = 1. / pow(2, 17);   //1 rad range, 17 bits
+  constexpr double PHIB_SIZE = 4. / pow(2, 13);  //4 rad range, 13 bits
 
-  constexpr int PHI_LUT_ADDR_WIDTH = 12;
-  constexpr int PHI_B_SHL_BITS = 7;
-  constexpr int PHI_MULT_SHR_BITS = 10;
-  constexpr int PHI_LUT_A_BITS = 12;
-  constexpr int PHI_LUT_B_BITS = 20;
+  constexpr int PHI_LUT_ADDR_WIDTH = 11;
+  constexpr int PHI_B_SHL_BITS = 5;
+  constexpr int PHI_MULT_SHR_BITS = 9;
+  constexpr int PHI_LUT_A_BITS = 11;
+  constexpr int PHI_LUT_B_BITS = 21;
 
   constexpr int PHIB_LUT_ADDR_WIDTH = 9;
-  constexpr int PHIB_B_SHL_BITS = 7;
-  constexpr int PHIB_MULT_SHR_BITS = 10;
+  constexpr int PHIB_B_SHL_BITS = 6;
+  constexpr int PHIB_MULT_SHR_BITS = 9;
   constexpr int PHIB_LUT_A_BITS = 10;
   constexpr int PHIB_LUT_B_BITS = 16;
 

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -39,6 +39,7 @@
 #include "L1Trigger/DTTriggerPhase2/interface/MPFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPSLFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPCorFilter.h"
+#include "L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPRedundantFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPCleanHitsFilter.h"
@@ -135,6 +136,8 @@ private:
   double dT0_correlate_TP_;
   int scenario_;
   int df_extended_;
+  int co_option_;  //coincidence
+  int co_quality_;
   int max_index_;
 
   bool output_mixer_;
@@ -162,6 +165,7 @@ private:
   std::unique_ptr<MuonPathAnalyzer> mpathassociator_;
   std::unique_ptr<MuonPathConfirmator> mpathconfirmator_;
   std::unique_ptr<MPFilter> mpathcorfilter_;
+  std::unique_ptr<MPFilter> mpathcofilter_;
   std::shared_ptr<GlobalCoordsObtainer> globalcoordsobtainer_;
 
   // Buffering
@@ -204,6 +208,8 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
   scenario_ = pset.getParameter<int>("scenario");
 
   df_extended_ = pset.getParameter<int>("df_extended");
+  co_option_ = pset.getParameter<int>("co_option");
+  co_quality_ = pset.getParameter<int>("co_quality");
   max_index_ = pset.getParameter<int>("max_primitives") - 1;
 
   dtDigisToken_ = consumes<DTDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
@@ -261,6 +267,7 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
   mpathconfirmator_ = std::make_unique<MuonPathConfirmator>(pset, consumesColl);
   mpathassociator_ = std::make_unique<MuonPathCorFitter>(pset, consumesColl, globalcoordsobtainer_);
   mpathcorfilter_ = std::make_unique<MPCorFilter>(pset);
+  mpathcofilter_ = std::make_unique<MPCoincidenceFilter>(pset);
   rpc_integrator_ = std::make_unique<RPCIntegrator>(pset, consumesColl);
 
   dtGeomH = esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
@@ -285,6 +292,7 @@ void DTTrigPhase2Prod::beginRun(edm::Run const& iRun, const edm::EventSetup& iEv
   mpathhitsfilter_->initialise(iEventSetup);
   mpathassociator_->initialise(iEventSetup);  // Associator object initialisation
   mpathcorfilter_->initialise(iEventSetup);
+  mpathcofilter_->initialise(iEventSetup);
 
   if (auto geom = iEventSetup.getHandle(dtGeomH)) {
     dtGeo_ = &(*geom);
@@ -818,6 +826,36 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
   correlatedMetaPrimitives.clear();
   filteredMetaPrimitives.clear();
 
+  // Coincidence (co) filter
+
+  std::vector<metaPrimitive> allMetaPrimitives;
+  for (auto& ch_filtcorrelatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
+    for (const auto& metaPrimitiveIt : ch_filtcorrelatedMetaPrimitives.second) {
+      allMetaPrimitives.push_back(metaPrimitiveIt);
+    }
+  }
+
+  std::map<int, std::vector<metaPrimitive>> coMetaPrimitives;
+  if (algo_ == Standard) {
+    for (auto& ch_filtcorrelatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
+      if (!skip_processing_)
+        mpathcofilter_->run(iEvent,
+                            iEventSetup,
+                            allMetaPrimitives,
+                            filtCorrelatedMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first],
+                            coMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first]);
+      else {
+        for (auto& mp : ch_filtcorrelatedMetaPrimitives.second) {
+          coMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first].push_back(mp);
+        }
+      }
+    }
+  }
+
+  allMetaPrimitives.clear();
+
+  /////////////
+
   double shift_back = 0;
   if (scenario_ == MC)  //scope for MC
     shift_back = 400;
@@ -830,7 +868,7 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
   if (useRPC_) {
     rpc_integrator_->initialise(iEventSetup, shift_back);
     rpc_integrator_->prepareMetaPrimitives(rpcRecHits);
-    for (auto& ch_correlatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
+    for (auto& ch_correlatedMetaPrimitives : coMetaPrimitives) {
       rpc_integrator_->matchWithDTAndUseRPCTime(ch_correlatedMetaPrimitives.second);  // Probably this is a FIXME
     }
     rpc_integrator_->makeRPCOnlySegments();
@@ -846,11 +884,11 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
 
   // Assigning index value
   if (!skip_processing_)
-    for (auto& ch_correlatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
+    for (auto& ch_correlatedMetaPrimitives : coMetaPrimitives) {
       assignIndex(ch_correlatedMetaPrimitives.second);
     }
 
-  for (auto& ch_correlatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
+  for (auto& ch_correlatedMetaPrimitives : coMetaPrimitives) {
     for (const auto& metaPrimitiveIt : ch_correlatedMetaPrimitives.second) {
       DTChamberId chId(metaPrimitiveIt.rawId);
       DTSuperLayerId slId(metaPrimitiveIt.rawId);
@@ -963,19 +1001,19 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
           // thTP (extended DF)
           outExtP2Th.emplace_back(
               L1Phase2MuDTExtThDigi((int)round(metaPrimitiveIt.t0 / (float)LHC_CLK_FREQ) - shift_back,
-                                    chId.wheel(),                                        // uwh   (m_wheel)
-                                    sectorTP,                                            // usc   (m_sector)
-                                    chId.station(),                                      // ust   (m_station)
-                                    (int)round(metaPrimitiveIt.phi * ZRES_CONV),         // uz    (m_zGlobal)
-                                    (int)round(metaPrimitiveIt.phiB * KRES_CONV),        // uk    (m_kSlope)
-                                    metaPrimitiveIt.quality,                             // uqua  (m_qualityCode)
-                                    metaPrimitiveIt.index,                               // uind  (m_segmentIndex)
-                                    tp_t0,                                               // ut0   (m_t0Segment)
-                                    (int)round(metaPrimitiveIt.chi2 * CHI2RES_CONV),     // uchi2 (m_chi2Segment)
-                                    (int)round(metaPrimitiveIt.x * 1000),                // ux    (m_yLocal)
-                                    (int)round(metaPrimitiveIt.phi_cmssw * ZRES_CONV),   // uphi  (m_zCMSSW)
-                                    (int)round(metaPrimitiveIt.phiB_cmssw * KRES_CONV),  // uphib (m_kCMSSW)
-                                    metaPrimitiveIt.rpcFlag,                             // urpc  (m_rpcFlag)
+                                    chId.wheel(),                                           // uwh   (m_wheel)
+                                    sectorTP,                                               // usc   (m_sector)
+                                    chId.station(),                                         // ust   (m_station)
+                                    (int)round(metaPrimitiveIt.phi * ZRES_CONV),            // uz    (m_zGlobal)
+                                    (int)round(metaPrimitiveIt.phiB * KRES_CONV),           // uk    (m_kSlope)
+                                    metaPrimitiveIt.quality,                                // uqua  (m_qualityCode)
+                                    metaPrimitiveIt.index,                                  // uind  (m_segmentIndex)
+                                    tp_t0,                                                  // ut0   (m_t0Segment)
+                                    (int)round(metaPrimitiveIt.chi2 * CHI2RES_CONV),        // uchi2 (m_chi2Segment)
+                                    (int)round(metaPrimitiveIt.x * 1000),                   // ux    (m_yLocal)
+                                    (int)round(metaPrimitiveIt.phi_cmssw * PHIRES_CONV),    // uphi  (m_zCMSSW)
+                                    (int)round(metaPrimitiveIt.phiB_cmssw * PHIBRES_CONV),  // uphib (m_kCMSSW)
+                                    metaPrimitiveIt.rpcFlag,                                // urpc  (m_rpcFlag)
                                     pathWireId,
                                     pathTDC,
                                     pathLat));
@@ -1253,6 +1291,8 @@ void DTTrigPhase2Prod::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("minx_match_2digis", 1.0);
   desc.add<int>("scenario", 0);
   desc.add<int>("df_extended", 0);
+  desc.add<int>("co_option", 0);
+  desc.add<int>("co_quality", 0);
   desc.add<int>("max_primitives", 999);
   desc.add<bool>("output_mixer", false);
   desc.add<bool>("output_latpredictor", false);
@@ -1274,6 +1314,7 @@ void DTTrigPhase2Prod::fillDescriptions(edm::ConfigurationDescriptions& descript
                             edm::FileInPath("L1Trigger/DTTriggerPhase2/data/global_coord_perp_x_phi0.txt"));
   desc.add<edm::FileInPath>("laterality_filename",
                             edm::FileInPath("L1Trigger/DTTriggerPhase2/data/lat_predictions.dat"));
+
   desc.add<int>("algo", 0);
   desc.add<int>("minHits4Fit", 3);
   desc.add<bool>("splitPathPerSL", true);

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -840,10 +840,10 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
     for (auto& ch_filtcorrelatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
       if (!skip_processing_)
         mpathcoifilter_->run(iEvent,
-                            iEventSetup,
-                            allMetaPrimitives,
-                            filtCorrelatedMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first],
-                            coMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first]);
+                             iEventSetup,
+                             allMetaPrimitives,
+                             filtCorrelatedMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first],
+                             coMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first]);
       else {
         for (auto& mp : ch_filtcorrelatedMetaPrimitives.second) {
           coMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first].push_back(mp);
@@ -1001,19 +1001,19 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
           // thTP (extended DF)
           outExtP2Th.emplace_back(
               L1Phase2MuDTExtThDigi((int)round(metaPrimitiveIt.t0 / (float)LHC_CLK_FREQ) - shift_back,
-                                    chId.wheel(),                                           // uwh   (m_wheel)
-                                    sectorTP,                                               // usc   (m_sector)
-                                    chId.station(),                                         // ust   (m_station)
-                                    (int)round(metaPrimitiveIt.phi * ZRES_CONV),            // uz    (m_zGlobal)
-                                    (int)round(metaPrimitiveIt.phiB * KRES_CONV),           // uk    (m_kSlope)
-                                    metaPrimitiveIt.quality,                                // uqua  (m_qualityCode)
-                                    metaPrimitiveIt.index,                                  // uind  (m_segmentIndex)
-                                    tp_t0,                                                  // ut0   (m_t0Segment)
-                                    (int)round(metaPrimitiveIt.chi2 * CHI2RES_CONV),        // uchi2 (m_chi2Segment)
-                                    (int)round(metaPrimitiveIt.x * 1000),                   // ux    (m_yLocal)
-                                    (int)round(metaPrimitiveIt.phi_cmssw * ZRES_CONV),    // uphi  (m_zCMSSW)
+                                    chId.wheel(),                                        // uwh   (m_wheel)
+                                    sectorTP,                                            // usc   (m_sector)
+                                    chId.station(),                                      // ust   (m_station)
+                                    (int)round(metaPrimitiveIt.phi * ZRES_CONV),         // uz    (m_zGlobal)
+                                    (int)round(metaPrimitiveIt.phiB * KRES_CONV),        // uk    (m_kSlope)
+                                    metaPrimitiveIt.quality,                             // uqua  (m_qualityCode)
+                                    metaPrimitiveIt.index,                               // uind  (m_segmentIndex)
+                                    tp_t0,                                               // ut0   (m_t0Segment)
+                                    (int)round(metaPrimitiveIt.chi2 * CHI2RES_CONV),     // uchi2 (m_chi2Segment)
+                                    (int)round(metaPrimitiveIt.x * 1000),                // ux    (m_yLocal)
+                                    (int)round(metaPrimitiveIt.phi_cmssw * ZRES_CONV),   // uphi  (m_zCMSSW)
                                     (int)round(metaPrimitiveIt.phiB_cmssw * KRES_CONV),  // uphib (m_kCMSSW)
-                                    metaPrimitiveIt.rpcFlag,                                // urpc  (m_rpcFlag)
+                                    metaPrimitiveIt.rpcFlag,                             // urpc  (m_rpcFlag)
                                     pathWireId,
                                     pathTDC,
                                     pathLat));

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -165,7 +165,7 @@ private:
   std::unique_ptr<MuonPathAnalyzer> mpathassociator_;
   std::unique_ptr<MuonPathConfirmator> mpathconfirmator_;
   std::unique_ptr<MPFilter> mpathcorfilter_;
-  std::unique_ptr<MPFilter> mpathcofilter_;
+  std::unique_ptr<MPFilter> mpathcoifilter_;
   std::shared_ptr<GlobalCoordsObtainer> globalcoordsobtainer_;
 
   // Buffering
@@ -267,7 +267,7 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
   mpathconfirmator_ = std::make_unique<MuonPathConfirmator>(pset, consumesColl);
   mpathassociator_ = std::make_unique<MuonPathCorFitter>(pset, consumesColl, globalcoordsobtainer_);
   mpathcorfilter_ = std::make_unique<MPCorFilter>(pset);
-  mpathcofilter_ = std::make_unique<MPCoincidenceFilter>(pset);
+  mpathcoifilter_ = std::make_unique<MPCoincidenceFilter>(pset);
   rpc_integrator_ = std::make_unique<RPCIntegrator>(pset, consumesColl);
 
   dtGeomH = esConsumes<DTGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
@@ -292,7 +292,7 @@ void DTTrigPhase2Prod::beginRun(edm::Run const& iRun, const edm::EventSetup& iEv
   mpathhitsfilter_->initialise(iEventSetup);
   mpathassociator_->initialise(iEventSetup);  // Associator object initialisation
   mpathcorfilter_->initialise(iEventSetup);
-  mpathcofilter_->initialise(iEventSetup);
+  mpathcoifilter_->initialise(iEventSetup);
 
   if (auto geom = iEventSetup.getHandle(dtGeomH)) {
     dtGeo_ = &(*geom);
@@ -839,7 +839,7 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
   if (algo_ == Standard) {
     for (auto& ch_filtcorrelatedMetaPrimitives : filtCorrelatedMetaPrimitives) {
       if (!skip_processing_)
-        mpathcofilter_->run(iEvent,
+        mpathcoifilter_->run(iEvent,
                             iEventSetup,
                             allMetaPrimitives,
                             filtCorrelatedMetaPrimitives[ch_filtcorrelatedMetaPrimitives.first],

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -1011,8 +1011,8 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
                                     tp_t0,                                                  // ut0   (m_t0Segment)
                                     (int)round(metaPrimitiveIt.chi2 * CHI2RES_CONV),        // uchi2 (m_chi2Segment)
                                     (int)round(metaPrimitiveIt.x * 1000),                   // ux    (m_yLocal)
-                                    (int)round(metaPrimitiveIt.phi_cmssw * PHIRES_CONV),    // uphi  (m_zCMSSW)
-                                    (int)round(metaPrimitiveIt.phiB_cmssw * PHIBRES_CONV),  // uphib (m_kCMSSW)
+                                    (int)round(metaPrimitiveIt.phi_cmssw * ZRES_CONV),    // uphi  (m_zCMSSW)
+                                    (int)round(metaPrimitiveIt.phiB_cmssw * KRES_CONV),  // uphib (m_kCMSSW)
                                     metaPrimitiveIt.rpcFlag,                                // urpc  (m_rpcFlag)
                                     pathWireId,
                                     pathTDC,
@@ -1314,7 +1314,6 @@ void DTTrigPhase2Prod::fillDescriptions(edm::ConfigurationDescriptions& descript
                             edm::FileInPath("L1Trigger/DTTriggerPhase2/data/global_coord_perp_x_phi0.txt"));
   desc.add<edm::FileInPath>("laterality_filename",
                             edm::FileInPath("L1Trigger/DTTriggerPhase2/data/lat_predictions.dat"));
-
   desc.add<int>("algo", 0);
   desc.add<int>("minHits4Fit", 3);
   desc.add<bool>("splitPathPerSL", true);

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -23,8 +23,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                minx_match_2digis = cms.double(1.),
                                                scenario = cms.int32(0), #0 for mc, 1 for data, 2 for slice test
                                                df_extended = cms.int32(0), # DF: 0 for standard, 1 for extended, 2 for both 
-                                               co_option = cms.int32(0), # coincidence : -1 = off, 0 = co all, 1 = co phi, 2 = co theta
-                                               co_quality = cms.int32(0), # min quality of coincidence TP 
+                                               co_option = cms.int32(1), # coincidence w.r.t. : -1 = off, 0 = co all, 1 = co phi, 2 = co theta
+                                               co_quality = cms.int32(1), # quality cut (>X) for coincidence TP 
                                                max_primitives = cms.int32(999),
 
                                                output_mixer = cms.bool(False),

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -23,6 +23,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                minx_match_2digis = cms.double(1.),
                                                scenario = cms.int32(0), #0 for mc, 1 for data, 2 for slice test
                                                df_extended = cms.int32(0), # DF: 0 for standard, 1 for extended, 2 for both 
+                                               co_option = cms.int32(0), # coincidence : -1 = off, 0 = co all, 1 = co phi, 2 = co theta
+                                               co_quality = cms.int32(0), # min quality of coincidence TP 
                                                max_primitives = cms.int32(999),
 
                                                output_mixer = cms.bool(False),
@@ -40,9 +42,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                lut_2sl = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/fitterlut_2sl.dat'),
                                                shift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/wire_rawId_x.txt'),
                                                shift_theta_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/theta_shift.txt'),
-                                               maxdrift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/simple_vdrift.txt'), #JAVI
+                                               maxdrift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/simple_vdrift.txt'),
                                                global_coords_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/global_coord_perp_x_phi0.txt'),
-                                               laterality_filename  = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/lat_predictions.dat'),
                                                algo = cms.int32(0), # 0 = STD gr., 2 = Hough transform, 1 = PseudoBayes Approach
 
                                                minHits4Fit = cms.int32(3),

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -40,7 +40,7 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                lut_2sl = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/fitterlut_2sl.dat'),
                                                shift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/wire_rawId_x.txt'),
                                                shift_theta_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/theta_shift.txt'),
-                                               maxdrift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/drift_time_per_chamber.txt'),
+                                               maxdrift_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/simple_vdrift.txt'), #JAVI
                                                global_coords_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/global_coord_perp_x_phi0.txt'),
                                                laterality_filename  = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/lat_predictions.dat'),
                                                algo = cms.int32(0), # 0 = STD gr., 2 = Hough transform, 1 = PseudoBayes Approach

--- a/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc
+++ b/L1Trigger/DTTriggerPhase2/src/GlobalCoordsObtainer.cc
@@ -84,51 +84,6 @@ void GlobalCoordsObtainer::generate_luts() {
         calc_atan_lut(9, 5, 21. / SEMICELL_IN_TDC_COUNTS / (6.5 * 16), 0., 4. / std::pow(2, 13), 9, 3, 10, 16, sgn);
 
     luts[global_constant.chid] = {phi, phib};
-
-    /*
-    //4-PARAMETER CALCULATION, FROM ANCIENT TIMES
-    auto phi1 = calc_atan_lut(12,
-                              6,
-                              (1. / 16) / (global_constant.sl1.perp * 10),
-                              global_constant.sl1.x_phi0 / global_constant.sl1.perp,
-                              1. / std::pow(2, 17),
-                              10,
-                              3,
-                              12,
-                              20,
-                              sgn);
-
-    auto phi3 = calc_atan_lut(12,
-                              6,
-                              (1. / 16) / (global_constant.sl3.perp * 10),
-                              global_constant.sl3.x_phi0 / global_constant.sl3.perp,
-                              1. / std::pow(2, 17),
-                              10,
-                              3,
-                              12,
-                              20,
-                              sgn);
-
-    double max_x_phi0 = global_constant.sl1.x_phi0;
-    if (global_constant.sl3.x_phi0 > max_x_phi0) {
-      max_x_phi0 = global_constant.sl3.x_phi0;
-    }
-
-    auto phic = calc_atan_lut(12,
-                              6,
-                              (1. / 16) / ((global_constant.sl1.perp + global_constant.sl3.perp) / .2),
-                              max_x_phi0 / ((global_constant.sl1.perp + global_constant.sl3.perp) / 2),
-                              1. / std::pow(2, 17),
-                              10,
-                              3,
-                              12,
-                              20,
-                              sgn);
-
-    auto phib = calc_atan_lut(9, 6, 1. / 4096, 0., 4. / std::pow(2, 13), 10, 3, 10, 16, sgn);
-
-    luts[global_constant.chid] = {phic, phi1, phi3, phib};
-    */
   }
 }
 
@@ -238,16 +193,6 @@ std::vector<double> GlobalCoordsObtainer::get_global_coordinates(uint32_t chid, 
   // appropriate input data (x, tanpsi) from the input primitive data structure
   // and the corresponding phi-lut from the 3 available options
 
-  /*
-  //4-PARAMETER CALCULATION, FROM ANCIENT TIMES
-  auto phi_lut = &luts[chid].phic;
-  if (sl == 1) {
-    phi_lut = &luts[chid].phi1;
-  } else if (sl == 3) {
-    phi_lut = &luts[chid].phi3;
-  }
-  */
-
   auto phi_lut = &luts[chid].phi;  //One parameter to rule them all
   auto phib_lut = &luts[chid].phib;
 
@@ -299,47 +244,4 @@ std::vector<double> GlobalCoordsObtainer::get_global_coordinates(uint32_t chid, 
   double phib_f = (double)phib * PHIB_SIZE;
 
   return std::vector({phi_f, phib_f});
-
-  /*
-  //-----------------------------------//
-  // Use an analytic function atan(x)  //
-  //-----------------------------------//
-
-  int sgn = 1;
-  DTChamberId ChId(chid);
-  if (ChId.wheel() > 0 || (ChId.wheel() == 0 && ChId.sector() % 4 > 1)) {
-    sgn = -1;
-  }
-  
-  max_drift_tdc = maxdriftinfo_[ChId.wheel() + 2][ChId.station() - 1][ChId.sector() - 1];
-  int SEMICELL_IN_TDC_COUNTS = max_drift_tdc;
-  int SL1_SEMICELL_OFFSET = 96;
-
-  int pos_int = x0;
-  int slope_int = tanpsi0;
-  
-  double in_res_phi = 0.0;
-  double in_res_psi = 0.0;
-  double abscissa_0 = 0.0;
-  
-  for (auto& global_constant : global_constants) {
-    if (global_constant.chid == chid){
-      in_res_phi = 21./SEMICELL_IN_TDC_COUNTS/((global_constant.sl1.perp+global_constant.sl3.perp)/.2);
-      in_res_psi = 21./SEMICELL_IN_TDC_COUNTS/(6.5*16);
-      abscissa_0 = (global_constant.sl1.x_phi0-2.1*SL1_SEMICELL_OFFSET)/((global_constant.sl1.perp+global_constant.sl3.perp)/2);
-    }
-  }
-  
-  double phi_rad = sgn * atan( pos_int * in_res_phi - abscissa_0 );
-  double psi_rad = sgn * atan( slope_int * in_res_psi  );
-  double phib_rad = psi_rad - phi_rad;
-
-  cout << "---------------------------------------------" << endl;
-  cout << "Wheel = " << ChId.wheel() << "; Sector = " << ChId.sector() << "; Station = " << ChId.station() << endl;
-  cout << "Position = " << pos_int << "; Slope = " << slope_int << endl;
-  cout << "Phi Analytic = " << phi_rad << "; Phi LUT = " << phi_f << endl;
-  cout << "PhiB Analytic = " << phib_rad << "; PhiB LUT = " << phib_f << endl;
-  
-  return std::vector({phi_f, phib_f});  
-  */
 }

--- a/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
@@ -10,10 +10,11 @@ using namespace cmsdt;
 // Constructors and destructor
 // ============================================================================
 MPCoincidenceFilter::MPCoincidenceFilter(const ParameterSet &pset)
-  : MPFilter(pset), debug_(pset.getUntrackedParameter<bool>("debug")), 
-                    co_option_(pset.getParameter<int>("co_option")),
-                    co_quality_(pset.getParameter<int>("co_quality")),
-                    scenario_(pset.getParameter<int>("scenario")) {}
+    : MPFilter(pset),
+      debug_(pset.getUntrackedParameter<bool>("debug")),
+      co_option_(pset.getParameter<int>("co_option")),
+      co_quality_(pset.getParameter<int>("co_quality")),
+      scenario_(pset.getParameter<int>("scenario")) {}
 
 // ============================================================================
 // Main methods (initialise, run, finish)
@@ -21,23 +22,24 @@ MPCoincidenceFilter::MPCoincidenceFilter(const ParameterSet &pset)
 void MPCoincidenceFilter::initialise(const edm::EventSetup &iEventSetup) {}
 
 void MPCoincidenceFilter::run(edm::Event &iEvent,
-                      const edm::EventSetup &iEventSetup,
-		      std::vector<metaPrimitive> &allMPaths,
-                      std::vector<metaPrimitive> &inMPaths,
-		      std::vector<metaPrimitive> &outMPaths) {
-
+                              const edm::EventSetup &iEventSetup,
+                              std::vector<metaPrimitive> &allMPaths,
+                              std::vector<metaPrimitive> &inMPaths,
+                              std::vector<metaPrimitive> &outMPaths) {
   if (debug_)
     LogDebug("MPCoincidenceFilter") << "MPCoincidenceFilter: run";
- 
-  double shift_back = 0; // Needed for t0 (TDC) calculation, taken from main algo
-  if (scenario_ == MC) shift_back = 400;
-  else if (scenario_ == DATA) shift_back = 0;
-  else if (scenario_ == SLICE_TEST) shift_back = 400;
+
+  double shift_back = 0;  // Needed for t0 (TDC) calculation, taken from main algo
+  if (scenario_ == MC)
+    shift_back = 400;
+  else if (scenario_ == DATA)
+    shift_back = 0;
+  else if (scenario_ == SLICE_TEST)
+    shift_back = 400;
 
   auto filteredMPs = filter(inMPaths, allMPaths, co_option_, co_quality_, shift_back);
   for (auto &mp : filteredMPs)
     outMPaths.push_back(mp);
-  
 }
 
 void MPCoincidenceFilter::finish(){};
@@ -46,102 +48,117 @@ void MPCoincidenceFilter::finish(){};
 ///  OTHER METHODS
 
 std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive> inMPs,
-						       std::vector<metaPrimitive> allMPs,
-                                                       int co_option, int co_quality, double shift_back) {
+                                                       std::vector<metaPrimitive> allMPs,
+                                                       int co_option,
+                                                       int co_quality,
+                                                       double shift_back) {
   std::vector<metaPrimitive> outMPs;
 
-  for (auto & mp: inMPs) {
+  for (auto &mp : inMPs) {
+    DTChamberId chId(mp.rawId);
+    DTSuperLayerId slId(mp.rawId);
 
-   DTChamberId chId(mp.rawId);
-   DTSuperLayerId slId(mp.rawId);
+    bool PhiMP = 0;
+    if (slId.superLayer() != 2)
+      PhiMP = 1;
 
-   bool PhiMP = 0;
-   if(slId.superLayer() != 2)PhiMP = 1;
+    int sector = chId.sector();
+    int wheel = chId.wheel();
+    int station = chId.station();
+    if (sector == 13)
+      sector = 4;
+    if (sector == 14)
+      sector = 10;
 
-   int sector  = chId.sector(); 
-   int wheel   = chId.wheel();
-   int station = chId.station();
-   if (sector == 13) sector = 4;
-   if (sector == 14) sector = 10;
+    if ((abs(wheel) == 2 && station == 1) || mp.quality > 5 || co_option == -1)
+      outMPs.push_back(mp);  //DM
+    else {
+      int sector_p1 = sector + 1;
+      int sector_m1 = sector - 1;
+      if (sector_p1 == 13)
+        sector_p1 = 1;
+      if (sector_m1 == 0)
+        sector_m1 = 12;
 
-   if ((abs(wheel)==2 && station==1) || mp.quality > 5 || co_option==-1) outMPs.push_back(mp); //DM
-   else{ 
+      string whch = "wh" + std::to_string(wheel) + "ch" + std::to_string(station) + "";
+      float t0_mean, t0_width;
+      if (PhiMP == 1) {
+        t0_mean = mphi_mean.find("" + whch + "")->second;
+        t0_width = mphi_width.find("" + whch + "")->second;
+      } else {
+        t0_mean = mth_mean.find("" + whch + "")->second;
+        t0_width = mth_width.find("" + whch + "")->second;
+      }
 
-    int sector_p1 = sector + 1;
-    int sector_m1 = sector - 1;
-    if (sector_p1 == 13) sector_p1 = 1;
-    if (sector_m1 == 0) sector_m1 = 12;
+      float t0 = (mp.t0 - shift_back * LHC_CLK_FREQ) * ((float)TIME_TO_TDC_COUNTS / (float)LHC_CLK_FREQ);
+      t0 = t0 - t0_mean;
 
-    string whch = "wh"+std::to_string(wheel)+"ch"+std::to_string(station)+"";
-    float t0_mean, t0_width;
-    if(PhiMP == 1){ 
-     t0_mean  = mphi_mean.find(""+whch+"")->second; 
-     t0_width = mphi_width.find(""+whch+"")->second;
-    }else{ 
-     t0_mean  = mth_mean.find(""+whch+"")->second;
-     t0_width = mth_width.find(""+whch+"")->second;
-    }
+      bool co_found = 0;
 
-    float t0 = (mp.t0 - shift_back * LHC_CLK_FREQ) * ((float) TIME_TO_TDC_COUNTS / (float) LHC_CLK_FREQ); 
-    t0 = t0 - t0_mean;
+      for (auto &mp2 : allMPs) {
+        DTChamberId chId2(mp2.rawId);
+        DTSuperLayerId slId2(mp2.rawId);
 
-    bool co_found = 0;
-    
-    for (auto & mp2: allMPs) {
+        bool PhiMP2 = 0;
+        if (slId2.superLayer() != 2)
+          PhiMP2 = 1;
 
-     DTChamberId chId2(mp2.rawId);
-     DTSuperLayerId slId2(mp2.rawId);
+        if (co_option == 1 && PhiMP2 == 0)
+          continue;  // Phi Only
+        else if (co_option == 2 && PhiMP2 == 1)
+          continue;  // Theta Only
 
-     bool PhiMP2 = 0;
-     if(slId2.superLayer() != 2)PhiMP2 = 1;
+        if (!(mp2.quality > co_quality))
+          continue;  // MP Quality with Q 0, 1, 5
 
-     if      (co_option==1 && PhiMP2==0) continue; // Phi Only
-     else if (co_option==2 && PhiMP2==1) continue; // Theta Only
+        int sector2 = chId2.sector();
+        int wheel2 = chId2.wheel();
+        int station2 = chId2.station();
+        if (sector2 == 13)
+          sector2 = 4;
+        if (sector2 == 14)
+          sector2 = 10;
 
-     if (!(mp2.quality > co_quality)) continue; // MP Quality with Q 0, 1, 5	 
+        if (station2 == station)
+          continue;
 
-     int sector2  = chId2.sector();
-     int wheel2   = chId2.wheel();
-     int station2 = chId2.station();
-     if (sector2 == 13) sector2 = 4;
-     if (sector2 == 14) sector2 = 10;
+        bool SectorSearch = 0;
+        if (sector2 == sector || sector2 == sector_p1 || sector2 == sector_m1)
+          SectorSearch = 1;
+        if (SectorSearch != 1)
+          continue;
 
-     if(station2 == station) continue; 
+        bool WheelSearch = 0;
+        if (wheel2 == wheel || wheel2 == wheel - 1 || wheel2 == wheel + 1)
+          WheelSearch = 1;
+        if (WheelSearch != 1)
+          continue;
 
-     bool SectorSearch = 0;
-     if (sector2 == sector || sector2 == sector_p1 || sector2 == sector_m1) SectorSearch = 1;
-     if (SectorSearch!=1) continue;  
+        string whch2 = "wh" + std::to_string(wheel2) + "ch" + std::to_string(station2) + "";
+        float t0_mean2, t0_width2;
+        if (PhiMP2 == 1) {
+          t0_mean2 = mphi_mean.find("" + whch2 + "")->second;
+          t0_width2 = mphi_width.find("" + whch2 + "")->second;
+        } else {
+          t0_mean2 = mth_mean.find("" + whch2 + "")->second;
+          t0_width2 = mth_width.find("" + whch2 + "")->second;
+        }
 
-     bool WheelSearch = 0;
-     if (wheel2 == wheel || wheel2 == wheel-1 || wheel2 == wheel+1) WheelSearch = 1;	
-     if (WheelSearch!=1) continue;  
+        float t02 = (mp2.t0 - shift_back * LHC_CLK_FREQ) * ((float)TIME_TO_TDC_COUNTS / (float)LHC_CLK_FREQ);
+        t02 = t02 - t0_mean2;
 
-     string whch2 = "wh"+std::to_string(wheel2)+"ch"+std::to_string(station2)+"";
-     float t0_mean2, t0_width2;
-     if(PhiMP2 == 1){ 
-      t0_mean2  = mphi_mean.find(""+whch2+"")->second;
-      t0_width2 = mphi_width.find(""+whch2+"")->second;
-     }else{
-      t0_mean2  = mth_mean.find(""+whch2+"")->second; 
-      t0_width2 = mth_width.find(""+whch2+"")->second;
-     }
-    
-     float t02 = (mp2.t0 - shift_back * LHC_CLK_FREQ) * ((float) TIME_TO_TDC_COUNTS / (float) LHC_CLK_FREQ);
-     t02 = t02 - t0_mean2;
+        float thres = t0_width + t0_width2;
+        if (abs(t02 - t0) < thres) {
+          co_found = 1;
+          break;
+        }
+      }  // loop over all MPs and look for co
 
-     float thres = t0_width + t0_width2;
-     if (abs(t02 - t0) < thres){
-      co_found = 1; 
-      break;
-     }    
-    } // loop over all MPs and look for co
+      if (co_found == 1)
+        outMPs.push_back(mp);
 
-    if (co_found==1) outMPs.push_back(mp); 
-
-   }// co check decision
-  }// input MP iterator
+    }  // co check decision
+  }    // input MP iterator
 
   return outMPs;
 }
-
-

--- a/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
@@ -60,7 +60,7 @@ std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive
 
     bool PhiMP = 0;
     if (slId.superLayer() != 2)
-     PhiMP = 1;
+      PhiMP = 1;
 
     int sector = chId.sector();
     int wheel = chId.wheel();
@@ -70,8 +70,8 @@ std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive
     if (sector == 14)
       sector = 10;
 
-    if (co_option == -1 || mp.quality>5) 
-     outMPs.push_back(mp);  
+    if (co_option == -1 || mp.quality > 5)
+      outMPs.push_back(mp);
     else {
       int sector_p1 = sector + 1;
       int sector_m1 = sector - 1;
@@ -101,14 +101,16 @@ std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive
 
         bool PhiMP2 = 0;
         if (slId2.superLayer() != 2)
-         PhiMP2 = 1;
+          PhiMP2 = 1;
 
-        int qcut = co_quality; // Tested for 0,1,5
-        if(mp.quality > qcut) qcut = 0; // Filter High Quality WRT any Quality  
-        if(PhiMP2==0 && qcut > 2) qcut = 2; // For Th TP max quality is 3 (4-hit)
-      
+        int qcut = co_quality;  // Tested for 0,1,5
+        if (mp.quality > qcut)
+          qcut = 0;  // Filter High Quality WRT any Quality
+        if (PhiMP2 == 0 && qcut > 2)
+          qcut = 2;  // For Th TP max quality is 3 (4-hit)
+
         if (!(mp2.quality > qcut))
-         continue;  
+          continue;
 
         int sector2 = chId2.sector();
         int wheel2 = chId2.wheel();
@@ -143,39 +145,40 @@ std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive
         float t02 = (mp2.t0 - shift_back * LHC_CLK_FREQ) * ((float)TIME_TO_TDC_COUNTS / (float)LHC_CLK_FREQ);
         t02 = t02 - t0_mean2;
 
-        float thres = t0_width + t0_width2;   
+        float thres = t0_width + t0_width2;
 
-        bool SameCh = 0; 
-        if(station2 == station && sector2 == sector && wheel2 == wheel)
-         SameCh = 1; 
+        bool SameCh = 0;
+        if (station2 == station && sector2 == sector && wheel2 == wheel)
+          SameCh = 1;
 
-        bool Wh2Exc = 0; 
-        if(abs(wheel)==2 && station<3 && SameCh==1)
-	 Wh2Exc = 1; // exception for WH2 MB1/2
-                  
-        if(Wh2Exc==1 && PhiMP!=PhiMP2){// pass if Phi-Th(large k) pair in same chamber         
-	 float k = 0;
-         if(PhiMP==0) 
-          k = mp.phiB;
-         else         
-          k = mp2.phiB;
+        bool Wh2Exc = 0;
+        if (abs(wheel) == 2 && station < 3 && SameCh == 1)
+          Wh2Exc = 1;  // exception for WH2 MB1/2
 
-         if(wheel==2 && k>0.9){
-          co_found = 1;
-          break;
-         }else if(wheel==-2 && k<-0.9){
-          co_found = 1;
-          break;
-	 } 
+        if (Wh2Exc == 1 && PhiMP != PhiMP2) {  // pass if Phi-Th(large k) pair in same chamber
+          float k = 0;
+          if (PhiMP == 0)
+            k = mp.phiB;
+          else
+            k = mp2.phiB;
+
+          if (wheel == 2 && k > 0.9) {
+            co_found = 1;
+            break;
+          } else if (wheel == -2 && k < -0.9) {
+            co_found = 1;
+            break;
+          }
         }
 
         if (co_option == 1 && PhiMP2 == 0)
           continue;  // Phi Only
         else if (co_option == 2 && PhiMP2 == 1)
-          continue;  // Theta Only 
+          continue;  // Theta Only
 
-        if(station2 == station)continue; // Different chambers + not adjacent chambers (standard)   
-        
+        if (station2 == station)
+          continue;  // Different chambers + not adjacent chambers (standard)
+
         if (abs(t02 - t0) < thres) {
           co_found = 1;
           break;

--- a/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPCoincidenceFilter.cc
@@ -1,0 +1,147 @@
+#include "L1Trigger/DTTriggerPhase2/interface/MPCoincidenceFilter.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "L1Trigger/DTTriggerPhase2/interface/constants.h"
+
+using namespace edm;
+using namespace std;
+using namespace cmsdt;
+
+// ============================================================================
+// Constructors and destructor
+// ============================================================================
+MPCoincidenceFilter::MPCoincidenceFilter(const ParameterSet &pset)
+  : MPFilter(pset), debug_(pset.getUntrackedParameter<bool>("debug")), 
+                    co_option_(pset.getParameter<int>("co_option")),
+                    co_quality_(pset.getParameter<int>("co_quality")),
+                    scenario_(pset.getParameter<int>("scenario")) {}
+
+// ============================================================================
+// Main methods (initialise, run, finish)
+// ============================================================================
+void MPCoincidenceFilter::initialise(const edm::EventSetup &iEventSetup) {}
+
+void MPCoincidenceFilter::run(edm::Event &iEvent,
+                      const edm::EventSetup &iEventSetup,
+		      std::vector<metaPrimitive> &allMPaths,
+                      std::vector<metaPrimitive> &inMPaths,
+		      std::vector<metaPrimitive> &outMPaths) {
+
+  if (debug_)
+    LogDebug("MPCoincidenceFilter") << "MPCoincidenceFilter: run";
+ 
+  double shift_back = 0; // Needed for t0 (TDC) calculation, taken from main algo
+  if (scenario_ == MC) shift_back = 400;
+  else if (scenario_ == DATA) shift_back = 0;
+  else if (scenario_ == SLICE_TEST) shift_back = 400;
+
+  auto filteredMPs = filter(inMPaths, allMPaths, co_option_, co_quality_, shift_back);
+  for (auto &mp : filteredMPs)
+    outMPaths.push_back(mp);
+  
+}
+
+void MPCoincidenceFilter::finish(){};
+
+///////////////////////////
+///  OTHER METHODS
+
+std::vector<metaPrimitive> MPCoincidenceFilter::filter(std::vector<metaPrimitive> inMPs,
+						       std::vector<metaPrimitive> allMPs,
+                                                       int co_option, int co_quality, double shift_back) {
+  std::vector<metaPrimitive> outMPs;
+
+  for (auto & mp: inMPs) {
+
+   DTChamberId chId(mp.rawId);
+   DTSuperLayerId slId(mp.rawId);
+
+   bool PhiMP = 0;
+   if(slId.superLayer() != 2)PhiMP = 1;
+
+   int sector  = chId.sector(); 
+   int wheel   = chId.wheel();
+   int station = chId.station();
+   if (sector == 13) sector = 4;
+   if (sector == 14) sector = 10;
+
+   if ((abs(wheel)==2 && station==1) || mp.quality > 5 || co_option==-1) outMPs.push_back(mp); //DM
+   else{ 
+
+    int sector_p1 = sector + 1;
+    int sector_m1 = sector - 1;
+    if (sector_p1 == 13) sector_p1 = 1;
+    if (sector_m1 == 0) sector_m1 = 12;
+
+    string whch = "wh"+std::to_string(wheel)+"ch"+std::to_string(station)+"";
+    float t0_mean, t0_width;
+    if(PhiMP == 1){ 
+     t0_mean  = mphi_mean.find(""+whch+"")->second; 
+     t0_width = mphi_width.find(""+whch+"")->second;
+    }else{ 
+     t0_mean  = mth_mean.find(""+whch+"")->second;
+     t0_width = mth_width.find(""+whch+"")->second;
+    }
+
+    float t0 = (mp.t0 - shift_back * LHC_CLK_FREQ) * ((float) TIME_TO_TDC_COUNTS / (float) LHC_CLK_FREQ); 
+    t0 = t0 - t0_mean;
+
+    bool co_found = 0;
+    
+    for (auto & mp2: allMPs) {
+
+     DTChamberId chId2(mp2.rawId);
+     DTSuperLayerId slId2(mp2.rawId);
+
+     bool PhiMP2 = 0;
+     if(slId2.superLayer() != 2)PhiMP2 = 1;
+
+     if      (co_option==1 && PhiMP2==0) continue; // Phi Only
+     else if (co_option==2 && PhiMP2==1) continue; // Theta Only
+
+     if (!(mp2.quality > co_quality)) continue; // MP Quality with Q 0, 1, 5	 
+
+     int sector2  = chId2.sector();
+     int wheel2   = chId2.wheel();
+     int station2 = chId2.station();
+     if (sector2 == 13) sector2 = 4;
+     if (sector2 == 14) sector2 = 10;
+
+     if(station2 == station) continue; 
+
+     bool SectorSearch = 0;
+     if (sector2 == sector || sector2 == sector_p1 || sector2 == sector_m1) SectorSearch = 1;
+     if (SectorSearch!=1) continue;  
+
+     bool WheelSearch = 0;
+     if (wheel2 == wheel || wheel2 == wheel-1 || wheel2 == wheel+1) WheelSearch = 1;	
+     if (WheelSearch!=1) continue;  
+
+     string whch2 = "wh"+std::to_string(wheel2)+"ch"+std::to_string(station2)+"";
+     float t0_mean2, t0_width2;
+     if(PhiMP2 == 1){ 
+      t0_mean2  = mphi_mean.find(""+whch2+"")->second;
+      t0_width2 = mphi_width.find(""+whch2+"")->second;
+     }else{
+      t0_mean2  = mth_mean.find(""+whch2+"")->second; 
+      t0_width2 = mth_width.find(""+whch2+"")->second;
+     }
+    
+     float t02 = (mp2.t0 - shift_back * LHC_CLK_FREQ) * ((float) TIME_TO_TDC_COUNTS / (float) LHC_CLK_FREQ);
+     t02 = t02 - t0_mean2;
+
+     float thres = t0_width + t0_width2;
+     if (abs(t02 - t0) < thres){
+      co_found = 1; 
+      break;
+     }    
+    } // loop over all MPs and look for co
+
+    if (co_found==1) outMPs.push_back(mp); 
+
+   }// co check decision
+  }// input MP iterator
+
+  return outMPs;
+}
+
+

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -335,7 +335,19 @@ void MuonPathCorFitter::analyze(mp_group mp, std::vector<cmsdt::metaPrimitive>& 
     // obtention of global coordinates using luts
     int pos = (int)(10 * (pos_ch_f - shiftinfo_[wireId.rawId()]) * INCREASED_RES_POS_POW);
     int slope = (int)(-slope_f * INCREASED_RES_SLOPE_POW);
-    auto global_coords = globalcoordsobtainer_->get_global_coordinates(ChId.rawId(), 0, pos, slope);
+
+    /*
+    cout << "==================== CORRELATED PRIMITIVE =================================" << endl;
+    cout << "WHEEL = " << ChId.wheel() << endl;
+    cout << "SECTOR = " << ChId.sector() << endl;
+    cout << "STATION = " << ChId.station() << endl;
+    cout << "QUALITY = " << quality << endl;
+    cout << "POSITION = " << (double) fit_common_out.position << endl;
+    cout << "SLOPE = " << (double) fit_common_out.slope << endl;
+    */
+
+    auto global_coords =
+        globalcoordsobtainer_->get_global_coordinates(ChId.rawId(), 0, fit_common_out.position, fit_common_out.slope);
     float phi = global_coords[0];
     float phiB = global_coords[1];
 

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -170,7 +170,7 @@ void MuonPathCorFitter::finish() {
 };
 
 //------------------------------------------------------------------
-//--- Metodos privados
+//--- Private Methods
 //------------------------------------------------------------------
 
 void MuonPathCorFitter::analyze(mp_group mp, std::vector<cmsdt::metaPrimitive>& metaPrimitives) {
@@ -333,18 +333,15 @@ void MuonPathCorFitter::analyze(mp_group mp, std::vector<cmsdt::metaPrimitive>& 
     float chi2_f = fit_common_out.chi2 * std::pow(((float)CELL_SEMILENGTH / (float)max_drift_tdc), 2) / 100;
 
     // obtention of global coordinates using luts
-    int pos = (int)(10 * (pos_ch_f - shiftinfo_[wireId.rawId()]) * INCREASED_RES_POS_POW);
-    int slope = (int)(-slope_f * INCREASED_RES_SLOPE_POW);
 
-    /*
-    cout << "==================== CORRELATED PRIMITIVE =================================" << endl;
-    cout << "WHEEL = " << ChId.wheel() << endl;
-    cout << "SECTOR = " << ChId.sector() << endl;
-    cout << "STATION = " << ChId.station() << endl;
-    cout << "QUALITY = " << quality << endl;
-    cout << "POSITION = " << (double) fit_common_out.position << endl;
-    cout << "SLOPE = " << (double) fit_common_out.slope << endl;
-    */
+    
+    LogDebug("MuonPathCorFitter") << "==================== CORRELATED PRIMITIVE =================================";
+    LogDebug("MuonPathCorFitter") << "WHEEL = " << ChId.wheel();
+    LogDebug("MuonPathCorFitter") << "SECTOR = " << ChId.sector();
+    LogDebug("MuonPathCorFitter") << "STATION = " << ChId.station();
+    LogDebug("MuonPathCorFitter") << "QUALITY = " << quality ;
+    LogDebug("MuonPathCorFitter") << "POSITION = " << (double) fit_common_out.position ;
+    LogDebug("MuonPathCorFitter") << "SLOPE = " << (double) fit_common_out.slope ;
 
     auto global_coords =
         globalcoordsobtainer_->get_global_coordinates(ChId.rawId(), 0, fit_common_out.position, fit_common_out.slope);

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathCorFitter.cc
@@ -334,14 +334,13 @@ void MuonPathCorFitter::analyze(mp_group mp, std::vector<cmsdt::metaPrimitive>& 
 
     // obtention of global coordinates using luts
 
-    
     LogDebug("MuonPathCorFitter") << "==================== CORRELATED PRIMITIVE =================================";
     LogDebug("MuonPathCorFitter") << "WHEEL = " << ChId.wheel();
     LogDebug("MuonPathCorFitter") << "SECTOR = " << ChId.sector();
     LogDebug("MuonPathCorFitter") << "STATION = " << ChId.station();
-    LogDebug("MuonPathCorFitter") << "QUALITY = " << quality ;
-    LogDebug("MuonPathCorFitter") << "POSITION = " << (double) fit_common_out.position ;
-    LogDebug("MuonPathCorFitter") << "SLOPE = " << (double) fit_common_out.slope ;
+    LogDebug("MuonPathCorFitter") << "QUALITY = " << quality;
+    LogDebug("MuonPathCorFitter") << "POSITION = " << (double)fit_common_out.position;
+    LogDebug("MuonPathCorFitter") << "SLOPE = " << (double)fit_common_out.slope;
 
     auto global_coords =
         globalcoordsobtainer_->get_global_coordinates(ChId.rawId(), 0, fit_common_out.position, fit_common_out.slope);

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -265,14 +265,15 @@ void MuonPathSLFitter::analyze(MuonPathPtr &inMPath,
       // obtention of global coordinates using luts
       int pos = (int)(10 * (pos_sl_f - shiftinfo_[wireId.rawId()]) * INCREASED_RES_POS_POW);
 
-      LogDebug("MuonPathSLFitter") << "========================= SUPERLAYER PRIMITIVE =================================";
+      LogDebug("MuonPathSLFitter")
+          << "========================= SUPERLAYER PRIMITIVE =================================";
       LogDebug("MuonPathSLFitter") << "WHEEL = " << ChId.wheel();
       LogDebug("MuonPathSLFitter") << "SECTOR = " << ChId.sector();
       LogDebug("MuonPathSLFitter") << "STATION = " << ChId.station();
       LogDebug("MuonPathSLFitter") << "SUPERLAYER = " << sl;
       LogDebug("MuonPathSLFitter") << "QUALITY = " << quality;
-      LogDebug("MuonPathSLFitter") << "POSITION = " << (double) fit_common_out.position;
-      LogDebug("MuonPathSLFitter") << "SLOPE = " << (double) fit_common_out.slope;
+      LogDebug("MuonPathSLFitter") << "POSITION = " << (double)fit_common_out.position;
+      LogDebug("MuonPathSLFitter") << "SLOPE = " << (double)fit_common_out.slope;
 
       auto global_coords = globalcoordsobtainer_->get_global_coordinates(
           ChId.rawId(), sl + 1, fit_common_out.position, fit_common_out.slope);

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -266,7 +266,19 @@ void MuonPathSLFitter::analyze(MuonPathPtr &inMPath,
       int pos = (int)(10 * (pos_sl_f - shiftinfo_[wireId.rawId()]) * INCREASED_RES_POS_POW);
       int slope = (int)(-slope_f * INCREASED_RES_SLOPE_POW);
 
-      auto global_coords = globalcoordsobtainer_->get_global_coordinates(ChId.rawId(), sl + 1, pos, slope);
+      /*
+      cout << "========================= SUPERLAYER PRIMITIVE =================================" << endl;
+      cout << "WHEEL = " << ChId.wheel() << endl;
+      cout << "SECTOR = " << ChId.sector() << endl;
+      cout << "STATION = " << ChId.station() << endl;
+      cout << "SUPERLAYER = " << sl << endl;
+      cout << "QUALITY = " << quality << endl;
+      cout << "POSITION = " << (double) fit_common_out.position << endl;
+      cout << "SLOPE = " << (double) fit_common_out.slope << endl;
+      */
+
+      auto global_coords = globalcoordsobtainer_->get_global_coordinates(
+          ChId.rawId(), sl + 1, fit_common_out.position, fit_common_out.slope);
       float phi = global_coords[0];
       float phiB = global_coords[1];
 

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathSLFitter.cc
@@ -264,18 +264,15 @@ void MuonPathSLFitter::analyze(MuonPathPtr &inMPath,
 
       // obtention of global coordinates using luts
       int pos = (int)(10 * (pos_sl_f - shiftinfo_[wireId.rawId()]) * INCREASED_RES_POS_POW);
-      int slope = (int)(-slope_f * INCREASED_RES_SLOPE_POW);
 
-      /*
-      cout << "========================= SUPERLAYER PRIMITIVE =================================" << endl;
-      cout << "WHEEL = " << ChId.wheel() << endl;
-      cout << "SECTOR = " << ChId.sector() << endl;
-      cout << "STATION = " << ChId.station() << endl;
-      cout << "SUPERLAYER = " << sl << endl;
-      cout << "QUALITY = " << quality << endl;
-      cout << "POSITION = " << (double) fit_common_out.position << endl;
-      cout << "SLOPE = " << (double) fit_common_out.slope << endl;
-      */
+      LogDebug("MuonPathSLFitter") << "========================= SUPERLAYER PRIMITIVE =================================";
+      LogDebug("MuonPathSLFitter") << "WHEEL = " << ChId.wheel();
+      LogDebug("MuonPathSLFitter") << "SECTOR = " << ChId.sector();
+      LogDebug("MuonPathSLFitter") << "STATION = " << ChId.station();
+      LogDebug("MuonPathSLFitter") << "SUPERLAYER = " << sl;
+      LogDebug("MuonPathSLFitter") << "QUALITY = " << quality;
+      LogDebug("MuonPathSLFitter") << "POSITION = " << (double) fit_common_out.position;
+      LogDebug("MuonPathSLFitter") << "SLOPE = " << (double) fit_common_out.slope;
 
       auto global_coords = globalcoordsobtainer_->get_global_coordinates(
           ChId.rawId(), sl + 1, fit_common_out.position, fit_common_out.slope);


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the positions retrieved by the DT L1T Phase2 emulator (credits to @javi-llorente ) and applies a coincidence filter to the resulting Trigger Primitives  (credits to @dermotmoran ).

It constitutes the v2.1 of the AM algorithm, fixing v2.0 and recovering efficiency losses to the levels of the original v1.0

#### PR validation:

Talks explaining the problem and supporting this change:

Report from J. F de Troconiz: AM v2 Emulator Global Phi / Phi_B Assignment
https://indico.cern.ch/event/1416436/contributions/5953406/attachments/2857442/4999143/DT_TS_Ph2_24_may.pdf

Coincidence filter by D. Moran:
https://indico.cern.ch/event/1425784/contributions/5998104/attachments/2876917/5038456/dt_co.pdf

Talk by J. Llorente explaining the fix in the DT Upgrade meeting:
https://indico.cern.ch/event/1435604/contributions/6040623/attachments/2894593/5074862/llorenteDT.pdf
