### PR TITLE
fix process name for `TIER0RAWSIPIXELCAL` step

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2393,7 +2393,7 @@ steps['TIER0EXPHPBS']={'-s':'RAW2DIGI,L1Reco,RECO:reconstruction_trackingOnly,AL
                           }
 
 steps['TIER0RAWSIPIXELCAL']={'-s':'RAW2DIGI,L1Reco,RECO,ALCAPRODUCER:SiPixelCalZeroBias,DQM:@express,ENDJOB',
-                          '--process':'RECO',
+                          '--process':'ALCARECO',
                           '--scenario': 'pp',
                           '--era':'Run2_2017',
                           '--conditions':'auto:run2_data',


### PR DESCRIPTION
#### PR description:

This is a follow-up to https://github.com/cms-sw/cmssw/pull/44914 where, when changing the `triggerResultsProcess` parameter of `ALCASPLITSIPIXELCAL` to match the `process` name of `TIER0EXPSIPIXELCAL`, I accidentally put it out of synch with the process name in `TIER0RAWSIPIXELCAL`, resulting in IB relval failures, see e.g. [this log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-05-07-2300/pyRelValMatrixLogs/run/1040.0_RunZeroBias2017F/step3_RunZeroBias2017F.log#/22)

#### PR validation:

`runTheMatrix.py -l 1040,1040.1 -t 4 -j 8 --ibeos` runs OK

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to CMSSW_14_0_X in https://github.com/cms-sw/cmssw/pull/44918