### PR TITLE
BTV HLT monitoring: exclude paths requiring `pfMassDecorrelatedParticleNetDiscriminatorsJetTags` when `pp_on_PbPb_run3` is active

### DIFF
--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -283,6 +283,10 @@ btagMonitorHLT = cms.Sequence(
   + BTagMu_AK8Jet300_Mu5
 )
 
+# in the case of PbPb remove the following paths as that requires pfMassDecorrelatedParticleNetDiscriminatorsJetTags
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+pp_on_PbPb_run3.toReplaceWith(btagMonitorHLT,btagMonitorHLT.copyAndExclude([BTagMu_AK8DiJet170_Mu5,BTagMu_AK8Jet300_Mu5,BTagMu_AK8Jet170_DoubleMu5,BTagMonitor_AK8PFJet40]))
+
 btvHLTDQMSourceExtra = cms.Sequence(
     BTagMonitor_PFJet40
   + BTagMonitor_PFJet40_DeepJet


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/44899

#### PR description:

Title says it all, for description see https://github.com/cms-sw/cmssw/issues/44899.

#### PR validation:

```
runTheMatrix.py -l 142.0 -t 4 -j 8 --ibeos
```

now runs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A