### PR TITLE
Change parameters for ECAL MLDQM [14_0_X]

### DIFF
--- a/DQM/EcalMonitorClient/interface/MLClient.h
+++ b/DQM/EcalMonitorClient/interface/MLClient.h
@@ -40,7 +40,7 @@ namespace ecaldqm {
     float EEp_PUcorr_intercept_;
     float EEm_PUcorr_intercept_;
 
-    size_t nLS = 4;      //No.of lumisections to add the occupancy over
+    size_t nLS = 3;      //No.of lumisections to add the occupancy over
     size_t nLSloss = 6;  //No.of lumisections to multiply the loss over
     int nbadtowerEB;     //count the no.of bad towers flagged by the ML model.
     int nbadtowerEE;

--- a/DQM/EcalMonitorClient/python/MLClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/MLClient_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 
 #parameters derived from training
-EBThreshold = 0.1761
+EBThreshold = 0.00017
 EEpThreshold =  0.0003009
 EEmThreshold =  0.0004360
 


### PR DESCRIPTION
#### PR description:

This PR changes certain parameters and thresholds for the ML based DQM quality plot in ECAL to better accommodate the high luminosity runs in 2024. 

#### PR validation:

The PR was validated by running the online Ecal DQM configuration and the resultant plots were examined by uploading the output file to a DQM test gui. The new plots look reasonable.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 14_0_X which is currently used in production.  Master PR is https://github.com/cms-sw/cmssw/pull/44929