### PR TITLE
Pixel GPU client: fix `siPixelPhase1RawDataErrorComparator` collections post-alpaka migration

### DIFF
--- a/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py
@@ -95,8 +95,8 @@ if process.runType.getRunType() == process.runType.hi_run:
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoAPPOnAA'
     process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacyPPOnAA'
 else:
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigisFromSoA'
-    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigisLegacy'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcGPU = 'hltSiPixelDigiErrors'
+    process.siPixelPhase1RawDataErrorComparator.pixelErrorSrcCPU = 'hltSiPixelDigiErrorsSerialSync'
 #-------------------------------------
 #       Some Debug
 #-------------------------------------


### PR DESCRIPTION
#### PR description:

Title says it all, provide right collections to be monitored by the `DQM/Integration/python/clients/pixelgpu_dqm_sourceclient-live_cfg.py` after the pixel local reconstruction at HLT migration to alpaka (cf https://its.cern.ch/jira/browse/CMSHLT-3125 and https://its.cern.ch/jira/browse/CMSHLT-3132).
Noticed that in recent runs all plots are empty (see e.g. [link](https://cmsweb.cern.ch/dqm/online/start?runnr=380385;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU;focus=;zoom=no;)) and confirmed by looking at the [dqm-square logs](https://cmsweb.cern.ch/dqm/dqm-square/api?what=get_logs&id=dqm-source-state-run380508-hostdqmfu-c2b04-45-01-pid1947416&db=production) e.g.:

```
%MSG-e SiPixelPhase1RawDataErrorComparator:   SiPixelPhase1RawDataErrorComparator:siPixelPhase1RawDataErrorComparator  08-May-2024 18:58:22 CEST Run: 380509 Event: 5010
reference (cpu) SiPixelRawDataErrors collection (hltSiPixelDigisLegacy) not found; 
the comparison will not run.
%MSG
```

#### PR validation:

None, the streamer files used for input tests need to be updated. 
Validation will rely on a DQM replay.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, to be backported to 14.0.X for data-taking purposes
