### PR TITLE
[14_0_X] Removed variable-length arrays

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -184,19 +184,11 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
           }
         }
 
-        // Initialize all-false 2D array of tracks being duplicates to other tracks
-        bool dupMap[numStublists][numStublists];  // Ends up symmetric
-        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-          for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-            dupMap[itrk][jtrk] = false;
-          }
-        }
+        // Initialize all-false 2D vector of tracks being duplicates to other tracks
+        vector<vector<bool>> dupMap(numStublists, vector<bool>(numStublists, false));
 
         // Used to check if a track is in two bins, is not a duplicate in either bin, so is sent out twice
-        bool noMerge[numStublists];
-        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-          noMerge[itrk] = false;
-        }
+        vector<bool> noMerge(numStublists, false);
 
         // Find duplicates; Fill dupMap by looping over all pairs of "tracks"
         // numStublists-1 since last track has no other to compare to
@@ -286,8 +278,8 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
 
             // Fill duplicate map
             if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
-              dupMap[itrk][jtrk] = true;
-              dupMap[jtrk][itrk] = true;
+              dupMap.at(itrk).at(jtrk) = true;
+              dupMap.at(jtrk).at(itrk) = true;
             }
           }
         }
@@ -295,15 +287,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
         // Check to see if the track is a duplicate
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
           for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-            if (dupMap[itrk][jtrk]) {
-              noMerge[itrk] = true;
+            if (dupMap.at(itrk).at(jtrk)) {
+              noMerge.at(itrk) = true;
             }
           }
         }
 
         // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper rinv or phi bin, then mark it so it won't be sent to output
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-          if (noMerge[itrk] == false) {
+          if (!noMerge.at(itrk)) {
             if (((findOverlapRinvBins(inputtracklets_[itrk]).size() > 1) &&
                  (findRinvBin(inputtracklets_[itrk]) != bin)) ||
                 ((findOverlapPhiBins(inputtracklets_[itrk]).size() > 1) &&
@@ -316,7 +308,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
         for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
           for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
             // Merge a track with its first duplicate found.
-            if (dupMap[itrk][jtrk]) {
+            if (dupMap.at(itrk).at(jtrk)) {
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;


### PR DESCRIPTION
#### PR description:

This PR removes all variable-length arrays in the L1Trigger/TrackFinding* packages, which turns out to just be in L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc. This led to stack overflows, and ultimately segfaults, in CMSSW_14_1_0_pre3 on certain events, as reported in https://github.com/cms-sw/cmssw/issues/44306#issuecomment-2096830674.

#### PR validation:

With the fixes in this PR, the specific job that was reported to segfault is now able to run to completion.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Although the crash reported in https://github.com/cms-sw/cmssw/issues/44306#issuecomment-2096830674 is only seen in 14_1, we include this backport for safety.

Original PR: #44935 