### PR TITLE
[DAQ] range check for microstate (140X) [backport]

### DIFF
--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -651,14 +651,20 @@ namespace evf {
     microstate_[getSID(sid)] = getmInput();
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = getmInput();
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = getmInput();
   }
 
   void FastMonitoringService::postSourceEvent(edm::StreamID sid) {
     microstate_[getSID(sid)] = getmFwkOvhSrc();
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = getmIdle();
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = getmIdle();
   }
 
   void FastMonitoringService::preModuleEventAcquire(edm::StreamContext const& sc,
@@ -667,8 +673,11 @@ namespace evf {
     microstateAcqFlag_[getSID(sc)] = 1;
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = (void*)(mcc.moduleDescription());
-    tmicrostateAcqFlag_[getTID()] = 1;
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = (void*)(mcc.moduleDescription());
+    tmicrostateAcqFlag_[tid] = 1;
   }
 
   void FastMonitoringService::postModuleEventAcquire(edm::StreamContext const& sc,
@@ -677,22 +686,31 @@ namespace evf {
     microstateAcqFlag_[getSID(sc)] = 0;
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = getmIdle();
-    tmicrostateAcqFlag_[getTID()] = 0;
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = getmIdle();
+    tmicrostateAcqFlag_[tid] = 0;
   }
 
   void FastMonitoringService::preModuleEvent(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
     microstate_[getSID(sc)] = (void*)(mcc.moduleDescription());
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = (void*)(mcc.moduleDescription());
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = (void*)(mcc.moduleDescription());
   }
 
   void FastMonitoringService::postModuleEvent(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
     microstate_[getSID(sc)] = getmFwkOvhMod();
     if (!tbbMonitoringMode_)
       return;
-    tmicrostate_[getTID()] = getmIdle();
+    auto tid = getTID();
+    if (tid >= nThreads_)
+      return;
+    tmicrostate_[tid] = getmIdle();
   }
 
   //from source


### PR DESCRIPTION
### PR description:
Bugfix:
with `numberOfThreads = 1` it seems that there are multiple TBB threads used by the framework. In  this case, using out of bounds write is possible to vectors in `FastMonitoringService`. This patch adds check against vector size, which fixes the issue.

#### PR validation:

Tested with HLT menu (instructions from @mmusich):
```
https_proxy=http://cmsproxy.cms:3128 hltConfigFromDB --runNumber 380466 > hlt_run380466.py
cat <<@EOF >> hlt_run380466.py
from EventFilter.Utilities.EvFDaqDirector_cfi import EvFDaqDirector as _EvFDaqDirector
process.EvFDaqDirector = _EvFDaqDirector.clone(
    buBaseDir = '/eos/cms/store/group/tsg/FOG/error_stream/',
    runNumber = 380466
)
from EventFilter.Utilities.FedRawDataInputSource_cfi import source as _source
process.source = _source.clone(
    fileListMode = True,
    fileNames = (
    '/eos/cms/store/group/tsg/FOG/error_stream/run380466/run380466_ls0276_index000212_fu-c2b03-09-01_pid672001.raw',
    #'/eos/cms/store/group/tsg/FOG/error_stream/run380466/run380466_ls0276_index000232_fu-c2b03-09-01_pid672001.raw',
    #'/eos/cms/store/group/tsg/FOG/error_stream/run380466/run380466_ls0276_index000246_fu-c2b03-09-01_pid672001.raw'
    )
)
process.options.wantSummary = True

process.options.numberOfThreads = 1
process.options.numberOfStreams = 0
@EOF

mkdir run380466
cmsRun hlt_run380466.py &> crash_run380466.log
```
#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #44938
Reason for backport: bugfix of HLT workflow (affecting at least 1-thread jobs used for testing).