### PR TITLE
Use standard edm::exceptionContext() in Worker::prePrefetchSelectionAsync()

### DIFF
--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -182,15 +182,7 @@ namespace edm {
             }
 
           } catch (cms::Exception& e) {
-            e.addContext("Calling OutputModule prePrefetchSelection()");
-            if (moduleCallingContext_.type() == ModuleCallingContext::Type::kPlaceInPath) {
-              auto pathContext = moduleCallingContext_.placeInPathContext()->pathContext();
-              e.addContext("Running path '" + pathContext->pathName() + "'");
-              auto streamContext = moduleCallingContext_.getStreamContext();
-              std::ostringstream ost;
-              exceptionContext(ost, *streamContext);
-              e.addContext(ost.str());
-            }
+            edm::exceptionContext(e, moduleCallingContext_);
             setException<true>(std::current_exception());
             waitingTasks_.doneWaiting(std::current_exception());
             //TBB requires that destroyed tasks have count 0


### PR DESCRIPTION
#### PR description:

This PR improves the exception message added in https://github.com/cms-sw/cmssw/pull/44767 in response to https://github.com/cms-sw/cmssw/pull/44891#issuecomment-2092937097 . It turned out the standard `edm::exceptionContext()` was appropriate here.

An example of the present message
```
----- Begin Fatal Exception 02-May-2024 21:13:44 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Processing  Event run: 355769 lumi: 35 event: 22311221 stream: 0
   [1] Running path 'ALCARECOStreamTkAlV0sOutPath'
   [2] Calling OutputModule prePrefetchSelection()
Exception Message:
EventSelector::init, An OutputModule is using SelectEvents
to request a trigger name that does not exist
The unknown trigger name is: pathALCARECOTkAlK0s
----- End Fatal Exception -------------------------------------------------
```

An example of the message with this PR
```
----- Begin Fatal Exception 03-May-2024 15:57:21 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Processing  Event run: 355769 lumi: 35 event: 22311221 stream: 0
   [1] Running path 'ALCARECOStreamTkAlV0sOutPath'
   [2] Prefetching for module PoolOutputModule/'ALCARECOStreamTkAlV0s'
Exception Message:
EventSelector::init, An OutputModule is using SelectEvents
to request a trigger name that does not exist
The unknown trigger name is: pathALCARECOTkAlK0s
----- End Fatal Exception -------------------------------------------------
```

Resolves https://github.com/cms-sw/framework-team/issues/920

#### PR validation:

Tested locally the exception message change