### PR TITLE
Simulation: update the test for the definition of back-scattering from CALO

### DIFF
--- a/SimG4Core/Application/src/Phase2SteppingAction.cc
+++ b/SimG4Core/Application/src/Phase2SteppingAction.cc
@@ -201,28 +201,15 @@ void Phase2SteppingAction::UserSteppingAction(const G4Step* aStep) {
       if (!trkinfo->crossedBoundary()) {
         trkinfo->setCrossedBoundary(theTrack);
       }
-    } else if (preStep->GetPhysicalVolume() == calo && postStep->GetPhysicalVolume() != calo) {
-      bool backscattering(false);
-      if (postStep->GetPhysicalVolume() == tracker) {
-        backscattering = true;
-      } else if (postStep->GetPhysicalVolume() == cmse) {
-        // simple protection to avoid possible steps from calo towards the outer part of the detector, if allowed by geometry
-        // to be removed as soon as tracker-calo boundary becomes again the default
-        if (preStep->GetPosition().mag2() > postStep->GetPosition().mag2()) {
-          backscattering = true;
-        }
-      }
-      // store transition calo -> cmse to tag backscattering
-      if (backscattering) {
-        TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
-        if (!trkinfo->isInTrkFromBackscattering()) {
-          trkinfo->setInTrkFromBackscattering();
+    } else if ((preStep->GetPhysicalVolume() == calo && postStep->GetPhysicalVolume() == tracker) ||
+               (preStep->GetPhysicalVolume() == cmse && postStep->GetPhysicalVolume() == tracker)) {
+      // accounting for both geometries with direct CALO -> Tracker transitions or older versions with CMSE in the middle
+      TrackInformation* trkinfo = static_cast<TrackInformation*>(theTrack->GetUserInformation());
+      trkinfo->setInTrkFromBackscattering();
 #ifdef EDM_ML_DEBUG
-          LogDebug("SimG4CoreApplication")
-              << "Setting flag for backscattering from CALO " << trkinfo->isInTrkFromBackscattering();
+      LogDebug("SimG4CoreApplication") << "Setting flag for backscattering from CALO "
+                                       << trkinfo->isInTrkFromBackscattering();
 #endif
-        }
-      }
     }
   } else {
     theTrack->SetTrackStatus(fStopAndKill);


### PR DESCRIPTION
#### PR description:

The transition from CALO to Tracker is monitored in the ```Phase2SteppingAction``` of ```SimG4Core/Application``` to define the back-scattering condition of a particle, used to define the corresponding category for BTL ```PSimHit```. This condition was updated in #43142 to cope with the fact that the the transition changed in Phase2 geometries, removing at some point (Tracker version T34) the intermediate step into CSME volume. At that time a check on the distance from the origin was introduced, requiring that the post-step has a smaller distance from the origin than the pre-step. This condition is anyway not always fulfilled, driving to an incorrect classification of hits from back-scattering as secondary. 

This PR updates the test so as to fix this issue. Either a direct CALO -> Tracker transition is found, or a CSME -> Tracker transition is tested, with the understanding based on navigation checks that it is possible for particles coming from CALO only. As soon as older geometries will be abandoned, this test will not be any more necessary.

#### PR validation:

Tested with the debugging verbosity of ```Phase2SteppingAction``` and of the ```CMSSteppingVerbose```