### PR TITLE
HBHE stuck ADC filter

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
@@ -13,7 +13,7 @@
 <library file="HcalCalibFEDSelector.cc,HcalCalibTypeFilter.cc,HcalDigiToRaw.cc,HcalEmptyEventFilter.cc,HcalHistogramRawToDigi.cc,HcalRawToDigi.cc,modules.cc,HcalDigiToRawuHTR.cc,HcalRawToDigiFake.cc" name="EventFilterHcalRawToDigiPlugins">
 </library>
 
-<library file="HcalLaserEventFiltProducer2012.cc, HcalLaserEventFilter2012.cc,HcalLaserHFFilter2012.cc,HcalLaserHBHEFilter2012.cc,HcalLaserHBHEHFFilter2012.cc" name="EventFilterHcalRawToDigiFiltersPlugins">
+<library file="HcalLaserEventFiltProducer2012.cc, HcalLaserEventFilter2012.cc,HcalLaserHFFilter2012.cc,HcalLaserHBHEFilter2012.cc,HcalLaserHBHEHFFilter2012.cc, HBHEstuckADCfilter.cc" name="EventFilterHcalRawToDigiFiltersPlugins">
 </library>
 
 <iftool name="cuda-gcc-support">

--- a/EventFilter/HcalRawToDigi/plugins/HBHEstuckADCfilter.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HBHEstuckADCfilter.cc
@@ -1,0 +1,94 @@
+// simple filter slecting events with all-equal 8 ADC counts > threshold
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <fstream>
+
+class HBHEstuckADCfilter : public edm::one::EDFilter<> {
+public:
+  explicit HBHEstuckADCfilter(const edm::ParameterSet&);
+  ~HBHEstuckADCfilter() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  edm::EDGetTokenT<QIE11DigiCollection> tok_qie11_;
+  int thresholdADC_;
+  bool writeList_;
+  std::ofstream outfile_;
+};
+
+HBHEstuckADCfilter::HBHEstuckADCfilter(const edm::ParameterSet& conf)
+    : tok_qie11_(consumes<QIE11DigiCollection>(conf.getParameter<edm::InputTag>("digiLabel"))),
+      thresholdADC_(conf.getParameter<int>("thresholdADC")),
+      writeList_(conf.getParameter<bool>("writeList")) {
+  if (writeList_)
+    outfile_.open("events_list_stuckADC.txt");
+}
+
+HBHEstuckADCfilter::~HBHEstuckADCfilter() {}
+
+bool HBHEstuckADCfilter::filter(edm::Event& ev, const edm::EventSetup& set) {
+  edm::Handle<QIE11DigiCollection> theDigis;
+  ev.getByToken(tok_qie11_, theDigis);
+
+  bool result = true;
+  for (QIE11DigiCollection::const_iterator itr = theDigis->begin(); itr != theDigis->end(); itr++) {
+    int tsize = (*itr).size();
+    const QIE11DataFrame frame = *itr;
+
+    bool flag = true;
+    int adc0 = (frame[0]).adc();
+    if (adc0 < thresholdADC_)
+      flag = false;
+    else {
+      for (int i = 1; i < tsize; i++) {
+        if ((frame[i]).adc() != adc0) {
+          flag = false;
+          break;
+        }
+      }
+    }
+
+    //  report explicitly
+    if (flag) {
+      const HcalDetId cell(itr->id());
+      edm::LogWarning("HBHEstuckADCfilter") << "stuck ADC = " << adc0 << " in  " << cell << std::endl;
+      result = false;
+    }
+  }
+  if (!result && writeList_)
+    outfile_ << ev.id().run() << ":" << ev.luminosityBlock() << ":" << ev.id().event() << std::endl;
+
+  return result;
+}
+
+void HBHEstuckADCfilter::endJob() {
+  if (writeList_)
+    outfile_.close();
+}
+
+void HBHEstuckADCfilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("digiLabel", edm::InputTag("hcalDigis"));
+  desc.add<int>("thresholdADC", 100);
+  desc.add<bool>("writeList", true);
+  descriptions.add("hbhestuckADCfilter", desc);
+}
+
+//define as a plug-in
+DEFINE_FWK_MODULE(HBHEstuckADCfilter);

--- a/EventFilter/HcalRawToDigi/python/HBHEstuckADCfilter_cfi.py
+++ b/EventFilter/HcalRawToDigi/python/HBHEstuckADCfilter_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+import EventFilter.HcalRawToDigi.hbhestuckADCfilter_cfi
+stuckADCfilter =  EventFilter.HcalRawToDigi.hbhestuckADCfilter_cfi.hbhestuckADCfilter.clone()
+stuckADCfilter.thresholdADC = 100


### PR DESCRIPTION
#### PR description:

A rare issue may happen to HCAL RAW data:  non-rotating capacitors (capId) of FE chips, which symptom is "stuck" (all the same, high-level) ADC counts in all 8 TS. _
_Most of such cases are filtered out (per affected readout) by the unpacker,_ 
if there is a corresponding error flag set by BE.  
But it was found in Run3 data that there were _very rare_ occurrences of the issue _without the error flag set._
This filter is intended for selecting/scanning already taken data for further studies.   

In parallel, (a development of) the relevant filtering at the entrance of the HCAL reconstruction is being considered.  

#### PR validation:

NB:  this is a standalone filter not included in any wf.  
Tested by simple injection of manually altered Digi (to exactly mimic stuck ADC data):   

%MSG-w HBHEstuckADCfilter:  HBHEstuckADCfilter:stuckADCfilter  12-May-2024 07:49:34 CEST Run: 1 Event: 1
stuck ADC = 111 in  (HE 22,39,4)

Output file (events_list_stuckADC.txt) contains a simple list of affected events in the from **run:lumi:event** 
