### PR TITLE
[L1T Phase-2] Correlator Layer 1 pattern file producer updates for multi-board tests

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1TCorrelatorLayer1PatternFileWriter.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1TCorrelatorLayer1PatternFileWriter.h
@@ -30,10 +30,11 @@ private:
   const unsigned int tfTmuxFactor_ = 18, tfLinksFactor_ = 1;  // numbers not really configurable in current architecture
   const unsigned int hgcTmuxFactor_ = 18, hgcLinksFactor_ = 4;  // not really configurable in current architecture
   const unsigned int gctTmuxFactor_ = 1, gctSectors_ = 3;       // not really configurable in current architecture
-  const unsigned int gctLinksEcal_ = 1, gctLinksHad_ = 2;       // could be made configurable later
   const unsigned int gmtTmuxFactor_ = 18, gmtLinksFactor_ = 1;  // not really configurable in current architecture
   const unsigned int gttTmuxFactor_ = 6, gttLinksFactor_ = 1;   // not really configurable in current architecture
   const unsigned int tfTimeslices_, hgcTimeslices_, gctTimeslices_, gmtTimeslices_, gttTimeslices_;
+  uint32_t gctLinksEcal_, gctLinksHad_;
+  bool gctSingleLink_;
   uint32_t gmtNumberOfMuons_;
   uint32_t gttNumberOfPVs_;
   uint32_t gttLatency_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/regionizer/middle_buffer_multififo_regionizer_ref.h
@@ -85,6 +85,10 @@ namespace l1ct {
 
     void reset();
 
+    static void encode(const l1ct::EmCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
+    static void encode(const l1ct::HadCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
+    static void decode(l1ct::HadCaloObjEmu& had, l1ct::EmCaloObjEmu& em);
+
   protected:
     const unsigned int NTK_SECTORS, NCALO_SECTORS;
     const unsigned int NTK_LINKS, HCAL_LINKS, ECAL_LINKS, NMU_LINKS;
@@ -115,10 +119,6 @@ namespace l1ct {
                              const std::vector<DetectorSector<l1ct::HadCaloObjEmu>>& had_in,
                              std::vector<l1ct::HadCaloObjEmu>& links,
                              std::vector<bool>& valid);
-
-    void encode(const l1ct::EmCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
-    void encode(const l1ct::HadCaloObjEmu& from, l1ct::HadCaloObjEmu& to);
-    void decode(l1ct::HadCaloObjEmu& had, l1ct::EmCaloObjEmu& em);
   };
 }  // namespace l1ct
 

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_patternWriters_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_patternWriters_cff.py
@@ -222,9 +222,13 @@ hgcalWriterVU9PTM18WriterConfig = _hgcalWriterTM18.clone(
    inputFileName = cms.string("l1HGCalTM18-inputs-vu9p"),
    gttLatency = cms.uint32(167), # shorter, to fit 6 events in 1024 lines
    maxLinesPerInputFile = cms.uint32(1024+167), # anything beyond 986 will be nulls
+   gmtLink = 4*27+0,
+   gttLink = 4*27+3,
 )
 hgcalWriterVU13PTM18WriterConfig = hgcalWriterVU9PTM18WriterConfig.clone(
    inputFileName = cms.string("l1HGCalTM18-inputs-vu13p"),
+   gmtLink = 4*28+0,
+   gttLink = 4*28+3,
 )
 for ie in range(2):
     for iphi in range(9):
@@ -234,7 +238,10 @@ for ie in range(2):
     for iphi in range(3):
         isec, ilink = 3*ie+iphi, 2*iphi+ie
         hgcalWriterVU9PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(12+ilink),4*(12+ilink)+4)
-        hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(13+ilink),4*(13+ilink)+4)
+        if ilink < 3:
+            hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(12+ilink),4*(12+ilink)+4)
+        else:
+            hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(14+ilink),4*(14+ilink)+4)
 
 hgcalTM18WriterConfigs = [
     hgcalWriterOutputTM18WriterConfig,

--- a/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_patternWriters_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/l1ctLayer1_patternWriters_cff.py
@@ -21,6 +21,8 @@ _barrelWriterOutputOnly = cms.PSet(
     maxLinesPerOutputFile = cms.uint32(1024),
     eventsPerFile = cms.uint32(_eventsPerFile),
     tfTimeSlices = cms.VPSet(),
+    gctNLinksEcal = cms.uint32(1),
+    gctNLinksHad = cms.uint32(2),
     gctSectors = cms.VPSet(),
     gmtTimeSlices = cms.VPSet(),
     gmtNumberOfMuons = cms.uint32(12),
@@ -51,7 +53,8 @@ barrelSerenityVU9PPhi1Config = barrelSerenityPhi1Config.clone(
     outputFileName = cms.string("l1BarrelPhi1Serenity-outputs")
 )
 barrelSerenityVU13PPhi1Config = barrelSerenityPhi1Config.clone(
-    gttLink = cms.int32(4*31+3),
+    gttLink = cms.int32(4*25+3),
+    gmtTimeSlices = cms.VPSet(*[cms.PSet(gmtLink = cms.int32(4*18+t)) for t in range(3)]),
     inputFileName = cms.string("l1BarrelPhi1Serenity-inputs-vu13p"),
 )
 for t in range(3):
@@ -65,8 +68,9 @@ for t in range(3):
 for i,s in enumerate([0,1]):
    barrelSerenityVU9PPhi1Config.gctSectors[s].gctLinksHad  = [3*i+4*18, 3*i+4*18+1]
    barrelSerenityVU9PPhi1Config.gctSectors[s].gctLinksEcal = [3*i+4*18+2]
-   barrelSerenityVU13PPhi1Config.gctSectors[s].gctLinksHad  = [3*i+4*18, 3*i+4*18+1]
-   barrelSerenityVU13PPhi1Config.gctSectors[s].gctLinksEcal = [3*i+4*18+2]
+   gctLinks = list(range(4*17,4*17+4)) + list(range(4*19,4*19+2))
+   barrelSerenityVU13PPhi1Config.gctSectors[s].gctLinksHad  = [gctLinks[3*i], gctLinks[3*i+1]]
+   barrelSerenityVU13PPhi1Config.gctSectors[s].gctLinksEcal = [gctLinks[3*i+2]]
 
 barrelWriterConfigs =  barrelWriterOutputOnlyPhiConfigs
 
@@ -115,19 +119,22 @@ hgcalPosVU9PWriterConfig = _hgcalPosWriterConfig.clone()
 hgcalNegVU9PWriterConfig = _hgcalNegWriterConfig.clone()
 for t in range(3):
     hgcalPosVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(-1))         for i in range(9) ] # neg
-    hgcalPosVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*2))  for i in range(4) ] # pos, left quads
-    hgcalPosVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*25)) for i in range(5) ] # pos, right quads
-    hgcalNegVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*2))  for i in range(4) ] # neg, left quads
-    hgcalNegVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*25)) for i in range(5) ] # neg, right quads
+    hgcalPosVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*1))  for i in range(4) ] # pos, left quads
+    hgcalPosVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*26)) for i in range(5) ] # pos, right quads
+    hgcalNegVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*1))  for i in range(4) ] # neg, left quads
+    hgcalNegVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*26)) for i in range(5) ] # neg, right quads
     hgcalNegVU9PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(-1))         for i in range(9) ] # pos
-    hgcalPosVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1))                          for i in range(3) ] # neg
-    hgcalPosVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*11+12*i+4*t+j for j in range(4)])) for i in range(3) ] # pos
-    hgcalNegVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*11+12*i+4*t+j for j in range(4)])) for i in range(3) ] # neg
-    hgcalNegVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1))                          for i in range(3) ] # pos
-    hgcalPosVU9PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4+t)
-    hgcalNegVU9PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4+t)
-hgcalPosVU9PWriterConfig.gttLink = 4+3
-hgcalNegVU9PWriterConfig.gttLink = 4+3
+    hgcQuads =  [list(range(4*i,4*i+4)) for i in [10,11,12,13]]
+    hgcQuads += [[4*14+1,4*14+2,4*14+3,4*15+3]] # mixed quad
+    hgcQuads += [list(range(4*i,4*i+4)) for i in [16,17,18,19]]
+    hgcalPosVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1))      for i in range(3) ] # neg
+    hgcalPosVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*hgcQuads[3*i+t])) for i in range(3) ] # pos
+    hgcalNegVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*hgcQuads[3*i+t])) for i in range(3) ] # neg
+    hgcalNegVU9PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1))      for i in range(3) ] # pos
+    hgcalPosVU9PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*15+((t+2)%3))
+    hgcalNegVU9PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*15+((t+2)%3))
+hgcalPosVU9PWriterConfig.gttLink = 4*14+0
+hgcalNegVU9PWriterConfig.gttLink = 4*14+0
 hgcalPosVU9PWriterConfig.inputFileName = cms.string("l1HGCalPos-inputs-vu9p") 
 hgcalNegVU9PWriterConfig.inputFileName = cms.string("l1HGCalNeg-inputs-vu9p") 
 ## Current configurations for VU13P 
@@ -140,15 +147,15 @@ for t in range(3):
     hgcalNegVU13PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*0))  for i in range(5) ] # neg, left quads
     hgcalNegVU13PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(3*i+t+4*28)) for i in range(4) ] # neg, right quads
     hgcalNegVU13PWriterConfig.tfTimeSlices[t].tfSectors += [ cms.PSet(tfLink = cms.int32(-1))         for i in range(9) ] # pos
+    hgcQuads =  [list(range(4*i,4*i+4)) for i in [12,13,14,  16,17,  19,20,21,22]]
     hgcalPosVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1)) for i in range(3) ] # neg
-    for isec,q0 in (0,12),(1,17),(2,20):
-        hgcalPosVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*q0+4*t+j for j in range(4)])) ] # pos
-        hgcalNegVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*q0+4*t+j for j in range(4)])) ] # neg
+    hgcalPosVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*hgcQuads[3*i+t])) for i in range(3) ] # pos
+    hgcalNegVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*hgcQuads[3*i+t])) for i in range(3) ] # neg
     hgcalNegVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(-1,-1,-1,-1)) for i in range(3) ] # pos
-    hgcalPosVU13PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*27+t)
-    hgcalNegVU13PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*27+t)
-hgcalPosVU13PWriterConfig.gttLink = 4*27+3
-hgcalNegVU13PWriterConfig.gttLink = 4*27+3
+    hgcalPosVU13PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*18+t)
+    hgcalNegVU13PWriterConfig.gmtTimeSlices[t].gmtLink = cms.int32(4*18+t)
+hgcalPosVU13PWriterConfig.gttLink = 4*25+3
+hgcalNegVU13PWriterConfig.gttLink = 4*25+3
 hgcalPosVU13PWriterConfig.inputFileName = cms.string("l1HGCalPos-inputs-vu13p") 
 hgcalNegVU13PWriterConfig.inputFileName = cms.string("l1HGCalNeg-inputs-vu13p") 
 
@@ -190,8 +197,8 @@ hgcalNoTKOutputWriterConfig = _hgcalNoTKWriterConfig.clone(
 hgcalNoTKVU13PWriterConfig = _hgcalNoTKWriterConfig.clone()
 for t in range(3):
     for isec in range(6):
-        q0 = 3*isec + 6
-        hgcalNoTKVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*q0+4*t+j for j in range(4)])) ] # pos
+        q0 = 3*isec + (6 if isec < 3 else 8)
+        hgcalNoTKVU13PWriterConfig.hgcTimeSlices[t].hgcSectors += [ cms.PSet(hgcLinks = cms.vint32(*[4*q0+4*t+j for j in range(4)])) ]
 hgcalNoTKVU13PWriterConfig.inputFileName = cms.string("l1HGCalNoTK-inputs-vu13p") # vu9p uses the same cabling for now
 
 hgcalNoTKWriterConfigs = [ 
@@ -200,7 +207,42 @@ hgcalNoTKWriterConfigs = [
 ]
 
 #####################################################################################################################
-## HGCal TM18 configuration
+## TM18 configuration
+_barrelSerenityTM18 = _barrelWriterOutputOnly.clone(
+    tmuxFactor = cms.uint32(18),
+    tfTimeSlices = None,
+    tfSectors = cms.VPSet(*[cms.PSet(tfLink = cms.int32(-1)) for i in range(18)]),
+    gmtTimeSlices = None,
+    gmtLink = cms.int32(4*18+0),
+    gttLink = 4*28+3,
+    eventsPerFile = 4,
+)
+barrelSerenityOutputTM18WriterConfig = _barrelSerenityTM18.clone(
+    outputRegions = cms.vuint32(*range(54)),
+    outputBoard = cms.int32(0),
+    outputFileName = cms.string("l1BarrelSerenityTM18-outputs")
+)
+barrelSerenityVU13PTM18WriterConfig = _barrelSerenityTM18.clone(
+    inputFileName = cms.string("l1BarrelSerenityTM18-inputs-vu13p"),
+    gttLatency = cms.uint32(167), # shorter, to fit 6 events in 1024 lines
+    maxLinesPerInputFile = cms.uint32(1024+167), # anything beyond 986 will be nulls
+    gctNLinksEcal = 1,
+    gctNLinksHad = 1,
+    gctSectors = cms.VPSet(*[cms.PSet(
+        gctLinksHad = cms.vint32(4*18+1+s),
+        gctLinksEcal = cms.vint32(4*18+1+s),
+    ) for s in range(3)]),
+)
+for ie in range(2):
+    for iphi in range(9):
+        isec = 9*ie+iphi 
+        barrelSerenityVU13PTM18WriterConfig.tfSectors[isec].tfLink = (isec if isec < 12 else (4*30+(isec-12)))
+
+barrelSerenityTM18WriterConfigs = [
+    barrelSerenityOutputTM18WriterConfig,
+    barrelSerenityVU13PTM18WriterConfig
+]
+
 _hgcalWriterTM18 = _hgcalWriterConfig.clone(
     tmuxFactor = cms.uint32(18),
     tfTimeSlices = None,
@@ -210,7 +252,7 @@ _hgcalWriterTM18 = _hgcalWriterConfig.clone(
     gmtTimeSlices = None,
     gmtLink = cms.int32(4*27+0),
     gttLink = 4*27+3,
-    eventsPerFile = 6,
+    eventsPerFile = 4,
 )
 hgcalWriterOutputTM18WriterConfig = _hgcalWriterTM18.clone(
    outputFileName = cms.string("l1HGCalTM18-outputs"),
@@ -222,24 +264,29 @@ hgcalWriterVU9PTM18WriterConfig = _hgcalWriterTM18.clone(
    inputFileName = cms.string("l1HGCalTM18-inputs-vu9p"),
    gttLatency = cms.uint32(167), # shorter, to fit 6 events in 1024 lines
    maxLinesPerInputFile = cms.uint32(1024+167), # anything beyond 986 will be nulls
-   gmtLink = 4*27+0,
-   gttLink = 4*27+3,
+   gmtLink = 4*15+2,
+   gttLink = 0,
 )
 hgcalWriterVU13PTM18WriterConfig = hgcalWriterVU9PTM18WriterConfig.clone(
    inputFileName = cms.string("l1HGCalTM18-inputs-vu13p"),
-   gmtLink = 4*28+0,
+   gmtLink = 4*18+0,
    gttLink = 4*28+3,
 )
 for ie in range(2):
     for iphi in range(9):
         isec, ilink = 9*ie+iphi, 2*iphi+ie
-        hgcalWriterVU9PTM18WriterConfig.tfSectors[isec].tfLink = (ilink if ilink < 12 else (4*28+(ilink-12)))
+        hgcalWriterVU9PTM18WriterConfig.tfSectors[isec].tfLink = (ilink+2 if ilink < 10 else (4*28+(ilink-10)))
         hgcalWriterVU13PTM18WriterConfig.tfSectors[isec].tfLink = (ilink if ilink < 12 else (4*30+(ilink-12)))
     for iphi in range(3):
         isec, ilink = 3*ie+iphi, 2*iphi+ie
-        hgcalWriterVU9PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(12+ilink),4*(12+ilink)+4)
+        if ilink < 2:
+            hgcalWriterVU9PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(12+ilink),4*(12+ilink)+4)
+        else:
+            hgcalWriterVU9PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(14+ilink),4*(14+ilink)+4)
         if ilink < 3:
             hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(12+ilink),4*(12+ilink)+4)
+        elif ilink < 5:
+            hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(13+ilink),4*(13+ilink)+4)
         else:
             hgcalWriterVU13PTM18WriterConfig.hgcSectors[isec].hgcLinks += range(4*(14+ilink),4*(14+ilink)+4)
 

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -29,7 +29,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True), allowUnscheduled = cms.untracked.bool(False) )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000))
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1008))
 process.MessageLogger.cerr.FwkReport.reportEvery = 1
 
 process.source = cms.Source("PoolSource",

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -9,7 +9,8 @@ parser = argparse.ArgumentParser(prog=sys.argv[0], description='Optional paramet
 parser.add_argument("--dumpFilesOFF", help="switch on dump file production", action="store_true", default=False)
 parser.add_argument("--patternFilesOFF", help="switch on Layer-1 pattern file production", action="store_true", default=False)
 parser.add_argument("--serenity", help="use Serenity settigns as default everwhere, i.e. also for barrel", action="store_true", default=False)
-parser.add_argument("--tm18", help="Add TM18 emulators for the endcaps", action="store_true", default=False)
+parser.add_argument("--tm18", help="Add TM18 emulators", action="store_true", default=False)
+parser.add_argument("--split18", help="Make 3 TM18 layer 1 pattern files", action="store_true", default=False)
 
 args = parser.parse_args()
 
@@ -205,12 +206,32 @@ if args.tm18:
     if not args.patternFilesOFF:
         process.l1tLayer1HGCalTM18.patternWriters = cms.untracked.VPSet(*hgcalTM18WriterConfigs)
         process.l1tLayer1HGCalNoTKTM18.patternWriters = cms.untracked.VPSet(hgcalNoTKOutputTM18WriterConfig)
-        process.l1tLayer1BarrelSerenityTM18.patternWriters = cms.untracked.VPSet()
+        process.l1tLayer1BarrelSerenityTM18.patternWriters = cms.untracked.VPSet(*barrelSerenityTM18WriterConfigs)
         process.l1tLayer2EGTM18.writeInPattern = True
         process.l1tLayer2EGTM18.writeOutPattern = True
-
     if not args.dumpFilesOFF:
         for det in "HGCalTM18", "HGCalNoTKTM18", "BarrelSerenityTM18":
                 getattr(process, 'l1tLayer1'+det).dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
+    if args.split18 and not args.patternFilesOFF:
+        from FWCore.Modules.preScaler_cfi import preScaler
+        for tmSlice, psOffset in (0,1), (6,2), (12,0):
+            setattr(process, f"preTM{tmSlice}", preScaler.clone(prescaleFactor = 3, prescaleOffset = psOffset))
+            for det in "HGCalTM18", "HGCalNoTKTM18", "BarrelSerenityTM18":
+                tsmod = getattr(process, 'l1tLayer1'+det).clone()
+                tsmod.dumpFileName = cms.untracked.string("")
+                setattr(process, f"l1tLayer1{det}TS{tmSlice}", tsmod)
+                setattr(process, f"Write_{det}TS{tmSlice}", cms.Path(getattr(process, f"preTM{tmSlice}")+tsmod))
+            getattr(process, f'l1tLayer1HGCalTM18TS{tmSlice}').patternWriters = cms.untracked.VPSet(
+                hgcalWriterOutputTM18WriterConfig.clone(outputFileName = f"l1HGCalTM18-outputs-ts{tmSlice}"),
+                hgcalWriterVU9PTM18WriterConfig.clone(inputFileName = f"l1HGCalTM18-inputs-vu9p-ts{tmSlice}"),
+                hgcalWriterVU13PTM18WriterConfig.clone(inputFileName = f"l1HGCalTM18-inputs-vu13p-ts{tmSlice}")
+            )
+            getattr(process, f'l1tLayer1HGCalNoTKTM18TS{tmSlice}').patternWriters = cms.untracked.VPSet(
+                hgcalNoTKOutputTM18WriterConfig.clone(outputFileName = f"l1HGCalTM18-outputs-ts{tmSlice}"),
+            )
+            getattr(process, f'l1tLayer1BarrelSerenityTM18TS{tmSlice}').patternWriters = cms.untracked.VPSet(
+                barrelSerenityOutputTM18WriterConfig.clone(outputFileName = f"l1BarrelSerenityTM18-outputs-ts{tmSlice}"),
+                barrelSerenityVU13PTM18WriterConfig.clone(inputFileName = f"l1BarrelSerenityTM18-inputs-vu13p-ts{tmSlice}")
+            )        
 
 process.source.fileNames  = [ '/store/cmst3/group/l1tr/cerminar/14_0_X/fpinputs_131X/v3/TTbar_PU200/inputs131X_1.root' ]

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -38,7 +38,8 @@ process.source = cms.Source("PoolSource",
             "drop l1tPFClusters_*_*_*",
             "drop l1tPFTracks_*_*_*",
             "drop l1tPFCandidates_*_*_*",
-            "drop l1tTkPrimaryVertexs_*_*_*"),
+            "drop l1tTkPrimaryVertexs_*_*_*",
+            "drop l1tKMTFTracks_*_*_*"),
     skipEvents = cms.untracked.uint32(0),
 )
 


### PR DESCRIPTION
#### PR description:

This PR changes the pattern file produces used to prepare inputs for single and multiboard tests for the correlator layer 1, updating the cabling map to what is used at B904 and supporting production of TM18 pattern files also in the barrel.

It doesn't change anything in the physics performance, but it's useful to have it integrated so that other subsystems can have the latest configuration when synchronizing pattern files for multi-board tests.

The corresponding PR to cms-l1t-offline is https://github.com/cms-l1t-offline/cmssw/pull/1256

#### PR validation:

Usual stuff:
 * code-checks, code-format, ...
 * `runTheMatrix.py -l 24834.0` (TTbar_14TeV+2026D98)
 * `L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py` with options `--tm18 --split18 --serenity` to run all the updated pattern file producers
