### PR TITLE
Introducing `DIGInoHLT` + `HLTOnly` Steps

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4180,6 +4180,7 @@ defaultDataSets['2021FS']='CMSSW_12_4_13-124X_mcRun3_2022_realistic_v12_2021_Fas
 defaultDataSets['2023']='CMSSW_13_0_10-130X_mcRun3_2023_realistic_withEarly2023BS_v1_2023-v'
 defaultDataSets['2023FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v'
 defaultDataSets['2024']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
+defaultDataSets['2024HLTOnDigi']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
@@ -4296,7 +4297,22 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'FEVTDEBUGHLT',
                                       '--geometry' : geom
                                       }
-
+    
+    upgradeStepDict['DigiNoHLT'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW',
+                                      '--conditions':gt,
+                                      '--datatier':'GEN-SIM-DIGI-RAW',
+                                      '-n':'10',
+                                      '--eventcontent':'FEVTDEBUGHLT',
+                                      '--geometry' : geom
+                                      }
+    
+    upgradeStepDict['HLTOnly'][k] = {'-s':'HLT:%s'%(hltversion),
+                                 '--conditions':gt,
+                                 '--datatier':'GEN-SIM-DIGI-RAW',
+                                 '-n':'10',
+                                 '--eventcontent':'FEVTDEBUGHLT',
+                                 '--geometry' : geom,
+                                 }
     # Adding Track trigger step in step2
     upgradeStepDict['DigiTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1TrackTrigger,L1,L1P2GT,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,


### PR DESCRIPTION
#### PR description:

This PR proposes the introduction of a set of workflows where HLT is run separately from the DIGI step.  This expands the `*.601` wf approach allowing to have any 2024 wf, also the special ones. For the moment it's limited to 2024 (with `2024HLTOnDigi` and `2024HLTOnDigiPU`) but could be expanded further. From our (PdmV) point of view it would ease the submission of reHLT wfs with the RelVal machine. 

An example here for `15834.0`.

```
# in: /lustre/home/adrianodif/random_devs/PR_ReHLT/cmssw/src dryRun for 'cd 15834.0_TTbar_14TeV+2024HLTOnDigiPU
 cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2024_realistic --beamspot DBrealistic --datatier GEN-SIM --eventcontent FEVTDEBUG --geometry DB:Extended --era Run3 --relval 9000,100 --fileout file:step1.root  > step1_TTbar_14TeV+2024DigiAndHLTPU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_ReHLT/cmssw/src dryRun for 'cd 15834.0_TTbar_14TeV+ 2024HLTOnDigiPU
 cmsDriver.py step2  -s DIGI:pdigi_valid,L1,DIGI2RAW --conditions auto:phase1_2024_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --pileup Run3_Flat55To75_PoissonOOTPU --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein  file:step1.root  --fileout file:step2.root  > step2_TTbar_14TeV+2024DigiAndHLTPU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_ReHLT/cmssw/src dryRun for 'cd 15834.0_TTbar_14TeV+ 2024HLTOnDigiPU
 cmsDriver.py step3  -s HLT:@relval2024 --conditions auto:phase1_2024_realistic --datatier GEN-SIM-DIGI-RAW -n 10 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --filein  file:step2.root  --fileout file:step3.root  > step3_TTbar_14TeV+2024DigiAndHLTPU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_ReHLT/cmssw/src dryRun for 'cd 15834.0_TTbar_14TeV+ 2024HLTOnDigiPU
 cmsDriver.py step4  -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,NANO,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2024_realistic --datatier GEN-SIM-RECO,MINIAODSIM,NANOAODSIM,DQMIO -n 10 --eventcontent RECOSIM,MINIAODSIM,NANOEDMAODSIM,DQM --geometry DB:Extended --era Run3 --pileup Run3_Flat55To75_PoissonOOTPU --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein  file:step3.root  --fileout file:step4.root  > step4_TTbar_14TeV+2024DigiAndHLTPU.log  2>&1
 

# in: /lustre/home/adrianodif/random_devs/PR_ReHLT/cmssw/src dryRun for 'cd 15834.0_TTbar_14TeV+ 2024HLTOnDigiPU
 cmsDriver.py step5  -s HARVESTING:@standardValidation+@standardDQM+@ExtraHLT+@miniAODValidation+@miniAODDQM+@nanoAODDQM --conditions auto:phase1_2024_realistic --mc  --geometry DB:Extended --scenario pp --filetype DQM --era Run3 -n 10 --pileup Run3_Flat55To75_PoissonOOTPU --pileup_input das:/RelValMinBias_14TeV/1/GEN-SIM --filein file:step4_inDQM.root --fileout file:step5.root  > step5_TTbar_14TeV+2024DigiAndHLTPU.log  2>&1
```

#### PR validation:

Running, e.g., `15624.701` `15834.0` and `15834.402` wfs.