### PR TITLE
Run3-alca247X Add possibility to uncorrect the RecHit energies for AlCaReco tests

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -5,6 +5,13 @@
 // Root objects
 #include "TTree.h"
 
+#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+
+#include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
+#include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
+
 #include "DataFormats/HcalCalibObjects/interface/HcalIsoTrkCalibVariables.h"
 #include "DataFormats/HcalCalibObjects/interface/HcalIsoTrkEventVariables.h"
 
@@ -16,6 +23,9 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "Geometry/Records/interface/HcalRecNumberingRecord.h"
 
 //#define EDM_ML_DEBUG
 
@@ -29,15 +39,23 @@ public:
 private:
   void analyze(edm::Event const&, edm::EventSetup const&) override;
   void beginJob() override;
-  void beginRun(edm::Run const&, edm::EventSetup const&) override {}
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override;
+  double respCorr(const DetId& id);
+  double gainFactor(const HcalDbService* dbserv, const HcalDetId& id);
 
   const double pTrackLow_, pTrackHigh_;
-  const int useRaw_, dataType_;
+  const int useRaw_, dataType_, unCorrect_;
   const edm::InputTag labelIsoTkVar_, labelIsoTkEvt_;
   const std::vector<int> debEvents_;
+  const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
+  const edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_respcorr_;
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> tok_dbservice_;
   edm::EDGetTokenT<HcalIsoTrkCalibVariablesCollection> tokIsoTrkVar_;
   edm::EDGetTokenT<HcalIsoTrkEventVariablesCollection> tokIsoTrkEvt_;
+  const HcalTopology* theHBHETopology_;
+  HcalRespCorrs* respCorrs_;
+
   unsigned int nRun_, nRange_, nLow_, nHigh_;
 
   TTree *tree, *tree2;
@@ -69,11 +87,17 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
       pTrackHigh_(iConfig.getParameter<double>("momentumHigh")),
       useRaw_(iConfig.getUntrackedParameter<int>("useRaw", 0)),
       dataType_(iConfig.getUntrackedParameter<int>("dataType", 0)),
+      unCorrect_(iConfig.getUntrackedParameter<int>("unCorrect", 0)),
       labelIsoTkVar_(iConfig.getParameter<edm::InputTag>("isoTrackVarLabel")),
       labelIsoTkEvt_(iConfig.getParameter<edm::InputTag>("isoTrackEvtLabel")),
       debEvents_(iConfig.getParameter<std::vector<int>>("debugEvents")),
+      tok_htopo_(esConsumes<HcalTopology, HcalRecNumberingRecord, edm::Transition::BeginRun>()),
+      tok_respcorr_(esConsumes<HcalRespCorrs, HcalRespCorrsRcd, edm::Transition::BeginRun>()),
+      tok_dbservice_(esConsumes<HcalDbService, HcalDbRecord>()),
       tokIsoTrkVar_(consumes<HcalIsoTrkCalibVariablesCollection>(labelIsoTkVar_)),
       tokIsoTrkEvt_(consumes<HcalIsoTrkEventVariablesCollection>(labelIsoTkEvt_)),
+      theHBHETopology_(nullptr),
+      respCorrs_(nullptr),
       nRun_(0),
       nRange_(0),
       nLow_(0),
@@ -85,11 +109,12 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n\t momentumLow_ " << pTrackLow_
                                    << "\t momentumHigh_ " << pTrackHigh_ << "\t useRaw_ " << useRaw_
-                                   << "\t dataType_      " << dataType_ << " and " << debEvents_.size()
-                                   << " events to be debugged";
+                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_
+				   << " and " << debEvents_.size() << " events to be debugged";
 }
 
 void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  const HcalDbService* conditions = &iSetup.getData(tok_dbservice_);
   t_Run = iEvent.id().run();
   t_Event = iEvent.id().event();
   t_DataType = dataType_;
@@ -200,6 +225,27 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
         t_HitEnergies = itr.hitEnergies_;
         t_HitEnergies1 = itr.hitEnergies1_;
         t_HitEnergies3 = itr.hitEnergies3_;
+	if (unCorrect_ > 0) {
+	  t_eHcal = t_eHcal10 = t_eHcal30 = 0;
+	  for (unsigned int k = 0; k < t_DetIds.size(); ++k) {
+	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds[k])) : respCorr(t_DetIds[k]);
+	    if (corr != 0) 
+	      t_HitEnergies[k] /= corr;
+	    t_eHcal += t_HitEnergies[k];
+	  }
+	  for (unsigned int k = 0; k < t_DetIds1.size(); ++k) {
+	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds1[k])) : respCorr(t_DetIds1[k]);
+	    if (corr != 0) 
+	      t_HitEnergies1[k] /= corr;
+	    t_eHcal10 += t_HitEnergies1[k];
+	  }
+	  for (unsigned int k = 0; k < t_DetIds3.size(); ++k) {
+	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds3[k])) : respCorr(t_DetIds3[k]);
+	    if (corr != 0) 
+	      t_HitEnergies3[k] /= corr;
+	    t_eHcal30 += t_HitEnergies3[k];
+	  }
+	}
       }
 #ifdef EDM_ML_DEBUG
       if (debug)
@@ -324,6 +370,13 @@ void HcalIsoTrackAnalyzer::beginJob() {
 }
 
 // ------------ method called when starting to processes a run  ------------
+void HcalIsoTrackAnalyzer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  theHBHETopology_ = &iSetup.getData(tok_htopo_);
+  const HcalRespCorrs* resp = &iSetup.getData(tok_respcorr_);
+  respCorrs_ = new HcalRespCorrs(*resp);
+  respCorrs_->setTopo(theHBHETopology_);
+  edm::LogVerbatim("HcalIsoTrack") << "beginRun " << iRun.run() << " get responseCoorection " << respCorrs_;
+}
 
 // ------------ method called when ending the processing of a run  ------------
 void HcalIsoTrackAnalyzer::endRun(edm::Run const& iRun, edm::EventSetup const&) {
@@ -339,11 +392,27 @@ void HcalIsoTrackAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("momentumHigh", 60.0);
   desc.addUntracked<int>("useRaw", 0);
   desc.addUntracked<int>("dataType", 0);
+  desc.addUntracked<int>("unCorrect", 0);
   desc.add<edm::InputTag>("isoTrackVarLabel", edm::InputTag("alcaHcalIsotrkProducer", "HcalIsoTrack"));
   desc.add<edm::InputTag>("isoTrackEvtLabel", edm::InputTag("alcaHcalIsotrkProducer", "HcalIsoTrackEvent"));
   std::vector<int> events;
   desc.add<std::vector<int>>("debugEvents", events);
   descriptions.add("hcalIsoTrackAnalyzer", desc);
+}
+
+double HcalIsoTrackAnalyzer::respCorr(const DetId& id) {
+  double cfac(1.0);
+  if (respCorrs_ != nullptr)
+    cfac = (respCorrs_->getValues(id))->getValue();
+  return cfac;
+}
+
+double HcalIsoTrackAnalyzer::gainFactor(const HcalDbService* conditions, const HcalDetId& id) {
+  double gain(0.0);
+  const HcalCalibrations& calibs = conditions->getHcalCalibrations(id);
+  for (int capid = 0; capid < 4; ++capid)
+    gain += (0.25 * calibs.respcorrgain(capid));
+  return gain;
 }
 
 //define this as a plug-in

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -109,8 +109,8 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n\t momentumLow_ " << pTrackLow_
                                    << "\t momentumHigh_ " << pTrackHigh_ << "\t useRaw_ " << useRaw_
-                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_
-				   << " and " << debEvents_.size() << " events to be debugged";
+                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_ << " and "
+                                   << debEvents_.size() << " events to be debugged";
 }
 
 void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
@@ -225,27 +225,27 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
         t_HitEnergies = itr.hitEnergies_;
         t_HitEnergies1 = itr.hitEnergies1_;
         t_HitEnergies3 = itr.hitEnergies3_;
-	if (unCorrect_ > 0) {
-	  t_eHcal = t_eHcal10 = t_eHcal30 = 0;
-	  for (unsigned int k = 0; k < t_DetIds.size(); ++k) {
-	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds[k])) : respCorr(t_DetIds[k]);
-	    if (corr != 0) 
-	      t_HitEnergies[k] /= corr;
-	    t_eHcal += t_HitEnergies[k];
-	  }
-	  for (unsigned int k = 0; k < t_DetIds1.size(); ++k) {
-	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds1[k])) : respCorr(t_DetIds1[k]);
-	    if (corr != 0) 
-	      t_HitEnergies1[k] /= corr;
-	    t_eHcal10 += t_HitEnergies1[k];
-	  }
-	  for (unsigned int k = 0; k < t_DetIds3.size(); ++k) {
-	    double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds3[k])) : respCorr(t_DetIds3[k]);
-	    if (corr != 0) 
-	      t_HitEnergies3[k] /= corr;
-	    t_eHcal30 += t_HitEnergies3[k];
-	  }
-	}
+        if (unCorrect_ > 0) {
+          t_eHcal = t_eHcal10 = t_eHcal30 = 0;
+          for (unsigned int k = 0; k < t_DetIds.size(); ++k) {
+            double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds[k])) : respCorr(t_DetIds[k]);
+            if (corr != 0)
+              t_HitEnergies[k] /= corr;
+            t_eHcal += t_HitEnergies[k];
+          }
+          for (unsigned int k = 0; k < t_DetIds1.size(); ++k) {
+            double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds1[k])) : respCorr(t_DetIds1[k]);
+            if (corr != 0)
+              t_HitEnergies1[k] /= corr;
+            t_eHcal10 += t_HitEnergies1[k];
+          }
+          for (unsigned int k = 0; k < t_DetIds3.size(); ++k) {
+            double corr = (unCorrect_ == 2) ? gainFactor(conditions, HcalDetId(t_DetIds3[k])) : respCorr(t_DetIds3[k]);
+            if (corr != 0)
+              t_HitEnergies3[k] /= corr;
+            t_eHcal30 += t_HitEnergies3[k];
+          }
+        }
       }
 #ifdef EDM_ML_DEBUG
       if (debug)

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -384,6 +384,10 @@ void HcalIsoTrackAnalyzer::endRun(edm::Run const& iRun, edm::EventSetup const&) 
   edm::LogVerbatim("HcalIsoTrack") << "endRun[" << nRun_ << "] " << iRun.run() << " with " << nLow_
                                    << " events with p < " << pTrackLow_ << ", " << nHigh_ << " events with p > "
                                    << pTrackHigh_ << ", and " << nRange_ << " events in the right momentum range";
+  if (respCorrs_) {
+    delete respCorrs_;
+    respCorrs_ = nullptr;
+  }
 }
 
 void HcalIsoTrackAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -7,8 +7,15 @@
 #include "TLorentzVector.h"
 #include "TTree.h"
 
-#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+
 #include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
+#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
@@ -40,10 +47,6 @@
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-
-#include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
-#include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
-#include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
 
 //Generator information
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
@@ -112,6 +115,7 @@ private:
                               edm::Handle<CaloTowerCollection>& towerHandle,
                               edm::Handle<reco::GenParticleCollection>& genParticles,
                               const HcalRespCorrs* respCorrs,
+			      const HcalDbService* conditions,
                               const edm::Handle<reco::MuonCollection>& muonh);
   double dR(math::XYZTLorentzVector&, math::XYZTLorentzVector&);
   double trackP(const reco::Track*, const edm::Handle<reco::GenParticleCollection>&);
@@ -120,12 +124,14 @@ private:
   DetId newId(const DetId&);
   void storeEnergy(int indx,
                    const HcalRespCorrs* respCorrs,
+		   const HcalDbService* conditions,
                    const std::vector<DetId>& ids,
                    std::vector<double>& edet,
                    double& eHcal,
                    std::vector<unsigned int>* detIds,
                    std::vector<double>* hitEnergies);
   bool notaMuon(const reco::Track* pTrack0, const edm::Handle<reco::MuonCollection>& muonh);
+  double gainFactor(const HcalDbService* dbserv, const HcalDetId& id);
 
   l1t::L1TGlobalUtil* l1GtUtils_;
   HLTConfigProvider hltConfig_;
@@ -142,7 +148,7 @@ private:
   const int prescaleLow_, prescaleHigh_;
   const int useRaw_, dataType_, mode_;
   const bool ignoreTrigger_, useL1Trigger_;
-  const bool unCorrect_, collapseDepth_;
+  const bool unCorrect_, getCharge_, collapseDepth_;
   const double hitEthrEB_, hitEthrEE0_, hitEthrEE1_;
   const double hitEthrEE2_, hitEthrEE3_;
   const double hitEthrEELo_, hitEthrEEHi_;
@@ -178,10 +184,12 @@ private:
   const edm::ESGetToken<CaloTopology, CaloTopologyRecord> tok_caloTopology_;
   const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
   const edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_resp_;
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> tok_dbservice_;
   const edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> tok_ecalPFRecHitThresholds_;
 
   unsigned int nRun_, nLow_, nHigh_;
   double a_charIsoR_, a_coneR1_, a_coneR2_;
+  const HcalTopology* theHBHETopology_;
   const HcalDDDRecConstants* hdc_;
   const EcalPFRecHitThresholds* eThresholds_;
 
@@ -244,6 +252,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       ignoreTrigger_(iConfig.getUntrackedParameter<bool>("ignoreTriggers", false)),
       useL1Trigger_(iConfig.getUntrackedParameter<bool>("useL1Trigger", false)),
       unCorrect_(iConfig.getUntrackedParameter<bool>("unCorrect", false)),
+      getCharge_(iConfig.getUntrackedParameter<bool>("getCharge")),
       collapseDepth_(iConfig.getUntrackedParameter<bool>("collapseDepth", false)),
       hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
       hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
@@ -297,10 +306,12 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       tok_caloTopology_(esConsumes<CaloTopology, CaloTopologyRecord>()),
       tok_htopo_(esConsumes<HcalTopology, HcalRecNumberingRecord>()),
       tok_resp_(esConsumes<HcalRespCorrs, HcalRespCorrsRcd>()),
+      tok_dbservice_(esConsumes<HcalDbService, HcalDbRecord>()),
       tok_ecalPFRecHitThresholds_(esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>()),
       nRun_(0),
       nLow_(0),
       nHigh_(0),
+      theHBHETopology_(nullptr),
       hdc_(nullptr) {
   usesResource(TFileService::kSharedResource);
 
@@ -368,7 +379,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
+      << collapseDepth_ << "\t GetCharge " << getCharge_ <<"\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
       << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
       << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_ << " and " << debEvents_.size()
       << " events to be debugged";
@@ -428,6 +439,7 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
   const HcalTopology* theHBHETopology = &iSetup.getData(tok_htopo_);
 
   // get Hcal response corrections
+  const HcalDbService* conditions = &iSetup.getData(tok_dbservice_);
   const HcalRespCorrs* respCorrs = &iSetup.getData(tok_resp_);
 
   //=== genParticle information
@@ -590,6 +602,7 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
                          caloTower,
                          genParticles,
                          respCorrs,
+			 conditions,
                          muonh);
     t_TracksSaved = ntksave[0];
     t_TracksLoose = ntksave[1];
@@ -704,6 +717,7 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
                                  caloTower,
                                  genParticles,
                                  respCorrs,
+				 conditions,
                                  muonh);
               t_TracksSaved += ntksave[0];
               t_TracksLoose += ntksave[1];
@@ -920,6 +934,7 @@ void HcalIsoTrkAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<double>("hcalScale", 1.0);
   desc.addUntracked<int>("dataType", 0);
   desc.addUntracked<bool>("unCorrect", false);
+  desc.addUntracked<bool>("getCharge", false);
   desc.addUntracked<bool>("collapseDepth", false);
   desc.addUntracked<std::string>("l1TrigName", "L1_SingleJet60");
   desc.addUntracked<int>("outMode", 11);
@@ -949,6 +964,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
                                                 edm::Handle<CaloTowerCollection>& tower,
                                                 edm::Handle<reco::GenParticleCollection>& genParticles,
                                                 const HcalRespCorrs* respCorrs,
+						const HcalDbService* conditions,
                                                 const edm::Handle<reco::MuonCollection>& muonh) {
   int nSave(0), nLoose(0), nTight(0);
   //Loop over tracks
@@ -1205,7 +1221,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
           for (unsigned k = 0; k < ids.size(); ++k)
             ids[k] = newId(ids[k]);
         }
-        storeEnergy(0, respCorrs, ids, edet0, t_eHcal, t_DetIds, t_HitEnergies);
+        storeEnergy(0, respCorrs, conditions, ids, edet0, t_eHcal, t_DetIds, t_HitEnergies);
 
         //----- hcal energy in the extended cone 1 (a_coneR+10) --------------
         t_eHcal10 = spr::eCone_hcal(geo,
@@ -1222,7 +1238,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
           for (unsigned k = 0; k < ids1.size(); ++k)
             ids1[k] = newId(ids1[k]);
         }
-        storeEnergy(1, respCorrs, ids1, edet1, t_eHcal10, t_DetIds1, t_HitEnergies1);
+        storeEnergy(1, respCorrs, conditions, ids1, edet1, t_eHcal10, t_DetIds1, t_HitEnergies1);
 
         //----- hcal energy in the extended cone 3 (a_coneR+30) --------------
         t_eHcal30 = spr::eCone_hcal(geo,
@@ -1239,7 +1255,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
           for (unsigned k = 0; k < ids3.size(); ++k)
             ids3[k] = newId(ids3[k]);
         }
-        storeEnergy(3, respCorrs, ids3, edet3, t_eHcal30, t_DetIds3, t_HitEnergies3);
+        storeEnergy(3, respCorrs, conditions, ids3, edet3, t_eHcal30, t_DetIds3, t_HitEnergies3);
 
 #ifdef EDM_ML_DEBUG
         if (debug_) {
@@ -1401,6 +1417,7 @@ DetId HcalIsoTrkAnalyzer::newId(const DetId& id) {
 
 void HcalIsoTrkAnalyzer::storeEnergy(int indx,
                                      const HcalRespCorrs* respCorrs,
+				     const HcalDbService* conditions,
                                      const std::vector<DetId>& ids,
                                      std::vector<double>& edet,
                                      double& eHcal,
@@ -1414,11 +1431,18 @@ void HcalIsoTrkAnalyzer::storeEnergy(int indx,
         edet[k] /= corr;
       ehcal += edet[k];
     }
+  } else if (getCharge_) {
+    for (unsigned int k = 0; k < ids.size(); ++k) {
+      double gain = gainFactor(conditions, HcalDetId(ids[k]));
+      if (gain != 0)
+        edet[k] /= gain;
+      ehcal += edet[k];
+    }
   } else {
     for (const auto& en : edet)
       ehcal += en;
   }
-  if ((std::abs(ehcal - eHcal) > 0.001) && (!unCorrect_))
+  if ((std::abs(ehcal - eHcal) > 0.001) && (!unCorrect_) && (!getCharge_))
     edm::LogWarning("HcalIsoTrack") << "Check inconsistent energies: " << indx << " " << eHcal << ":" << ehcal
                                     << " from " << ids.size() << " cells";
   eHcal = hcalScale_ * ehcal;
@@ -1483,6 +1507,14 @@ bool HcalIsoTrkAnalyzer::notaMuon(const reco::Track* pTrack0, const edm::Handle<
     }
   }
   return flag;
+}
+
+double HcalIsoTrkAnalyzer::gainFactor(const HcalDbService* conditions, const HcalDetId& id) {
+  double gain(0.0);
+  const HcalCalibrations& calibs = conditions->getHcalCalibrations(id);
+  for (int capid = 0; capid < 4; ++capid)
+    gain += (0.25 * calibs.respcorrgain(capid));
+  return gain;
 }
 
 //define this as a plug-in

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -115,7 +115,7 @@ private:
                               edm::Handle<CaloTowerCollection>& towerHandle,
                               edm::Handle<reco::GenParticleCollection>& genParticles,
                               const HcalRespCorrs* respCorrs,
-			      const HcalDbService* conditions,
+                              const HcalDbService* conditions,
                               const edm::Handle<reco::MuonCollection>& muonh);
   double dR(math::XYZTLorentzVector&, math::XYZTLorentzVector&);
   double trackP(const reco::Track*, const edm::Handle<reco::GenParticleCollection>&);
@@ -124,7 +124,7 @@ private:
   DetId newId(const DetId&);
   void storeEnergy(int indx,
                    const HcalRespCorrs* respCorrs,
-		   const HcalDbService* conditions,
+                   const HcalDbService* conditions,
                    const std::vector<DetId>& ids,
                    std::vector<double>& edet,
                    double& eHcal,
@@ -379,10 +379,10 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t GetCharge " << getCharge_ <<"\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
-      << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
-      << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_ << " and " << debEvents_.size()
-      << " events to be debugged";
+      << collapseDepth_ << "\t GetCharge " << getCharge_ << "\t L1TrigName_    " << l1TrigName_
+      << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":"
+      << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_
+      << " and " << debEvents_.size() << " events to be debugged";
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_;
   for (unsigned int k = 0; k < trigNames_.size(); ++k) {
@@ -602,7 +602,7 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
                          caloTower,
                          genParticles,
                          respCorrs,
-			 conditions,
+                         conditions,
                          muonh);
     t_TracksSaved = ntksave[0];
     t_TracksLoose = ntksave[1];
@@ -717,7 +717,7 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
                                  caloTower,
                                  genParticles,
                                  respCorrs,
-				 conditions,
+                                 conditions,
                                  muonh);
               t_TracksSaved += ntksave[0];
               t_TracksLoose += ntksave[1];
@@ -964,7 +964,7 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
                                                 edm::Handle<CaloTowerCollection>& tower,
                                                 edm::Handle<reco::GenParticleCollection>& genParticles,
                                                 const HcalRespCorrs* respCorrs,
-						const HcalDbService* conditions,
+                                                const HcalDbService* conditions,
                                                 const edm::Handle<reco::MuonCollection>& muonh) {
   int nSave(0), nLoose(0), nTight(0);
   //Loop over tracks
@@ -1417,7 +1417,7 @@ DetId HcalIsoTrkAnalyzer::newId(const DetId& id) {
 
 void HcalIsoTrkAnalyzer::storeEnergy(int indx,
                                      const HcalRespCorrs* respCorrs,
-				     const HcalDbService* conditions,
+                                     const HcalDbService* conditions,
                                      const std::vector<DetId>& ids,
                                      std::vector<double>& edet,
                                      double& eHcal,


### PR DESCRIPTION
#### PR description:

Add possibility to uncorrect the RecHit energies for AlCaReco tests

#### PR validation:

Tested by creating the flat trees with uncorrected energies

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special