### PR TITLE
Add ScoutingMuonNoVtx and ScoutingMuonVtx in Run3Scouting Nano starting from 2024 data taking

### DIFF
--- a/Configuration/DataProcessing/python/Impl/hltScouting.py
+++ b/Configuration/DataProcessing/python/Impl/hltScouting.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+_hltScouting_
+
+Scenario supporting proton collisions with input HLT scouting data
+
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+
+from Configuration.DataProcessing.Scenario import *
+from Configuration.DataProcessing.Utils import stepSKIMPRODUCER, addMonitoring, dictIO, nanoFlavours, gtNameAndConnect
+import FWCore.ParameterSet.Config as cms
+
+class hltScouting(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
+        self.recoSeq = ''
+        self.cbSc = 'pp'
+        self.isRepacked = False
+        self.promptCustoms = ['Configuration/DataProcessing/RecoTLR.customisePrompt']
+        self.promptModifiers = cms.ModifierChain()
+    """
+    _hltScouting_
+
+    Implement configuration building for data processing for proton
+    collision data taking with input HLT scouting data
+    """
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Proton collision data taking prompt reco with input HLT scouting data
+
+        """
+
+        options = Options()
+        options.__dict__.update(defaultOptions.__dict__)
+        options.scenario = self.cbSc
+        if 'nThreads' in args:
+            options.nThreads = args['nThreads']
+
+        PhysicsSkimStep = ''
+        if 'PhysicsSkims' in args:
+            PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
+
+        miniAODStep = ''
+        nanoAODStep = ''
+        
+        if 'outputs' in args:
+            print(args['outputs'])
+            for a in args['outputs']:
+                if a['dataTier'] == 'MINIAOD':
+                    miniAODStep = ',PAT'
+                if a['dataTier'] in ['NANOAOD', 'NANOEDMAOD']:
+                    if "nanoFlavours" in args:
+                        nanoAODStep = ',NANO' + nanoFlavours(args['nanoFlavours'])
+                    else:
+                        nanoAODStep = ',NANO:@PHYS+@L1'        
+
+        if not 'customs' in args:
+            args['customs'] = []
+
+        for c in self.promptCustoms:
+            args['customs'].append(c)
+        options.customisation_file = args['customs']
+        
+        options.isRepacked = args.get('repacked', self.isRepacked)
+        
+        options.step = ''
+        options.step += self.recoSeq + PhysicsSkimStep
+        options.step += miniAODStep + nanoAODStep
+        options.step += ',ENDJOB'
+
+        dictIO(options, args)
+        options.conditions = gtNameAndConnect(globalTag, args)
+        
+        process = cms.Process('RECO', cms.ModifierChain(self.eras, self.promptModifiers) )
+        cb = ConfigBuilder(options, process = process, with_output = True)
+
+        # Input source
+        process.source = cms.Source("PoolSource",
+            fileNames = cms.untracked.vstring()
+        )
+
+        cb.prepare()
+
+        addMonitoring(process)
+        
+        return process

--- a/Configuration/DataProcessing/python/Impl/hltScoutingEra_Run3_2024.py
+++ b/Configuration/DataProcessing/python/Impl/hltScoutingEra_Run3_2024.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+_hltScoutingEra_Run3_2024_
+
+Scenario supporting proton collisions with input HLT scouting data for 2024
+
+"""
+
+import os
+import sys
+
+from Configuration.Eras.Era_Run3_2024_cff import Run3_2024
+from Configuration.DataProcessing.Impl.hltScouting import hltScouting
+
+class hltScoutingEra_Run3_2024(hltScouting):
+    def __init__(self):
+        hltScouting.__init__(self)
+        self.recoSeq = ''
+        self.cbSc = 'pp'
+        self.eras = Run3_2024
+        self.promptCustoms += ['Configuration/DataProcessing/RecoTLR.customisePostEra_Run3_2024']
+    """
+    _hltScoutingEra_Run3_2024_
+    Implement configuration building for data processing for proton
+    collision data taking with input HLT scouting data for Era_Run3_2024
+    """

--- a/Configuration/DataProcessing/test/BuildFile.xml
+++ b/Configuration/DataProcessing/test/BuildFile.xml
@@ -9,3 +9,4 @@
 <test name="TestConfigDP_10" command="run_CfgTest_10.sh"/>
 <test name="TestConfigDP_11" command="run_CfgTest_11.sh"/>
 <test name="TestConfigDP_12" command="run_CfgTest_12.sh"/>
+<test name="TestConfigDP_13" command="run_CfgTest_13.sh"/> 

--- a/Configuration/DataProcessing/test/run_CfgTest_13.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_13.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Test suite for various ConfigDP scenarios
+# run using: scram build runtests
+# feel free to contribute with your favourite configuration
+
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
+
+declare -a arr=("hltScoutingEra_Run3_2024")
+for scenario in "${arr[@]}"
+do
+     runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --nanoaod --global-tag GLOBALTAG --lfn=/store/whatever --nanoFlavours=@Scout"
+done

--- a/Configuration/DataProcessing/test/run_CfgTest_8.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest_8.sh
@@ -10,7 +10,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 function runTest { echo $1 ; python3 $1 || die "Failure for configuration: $1" $?; }
 
-declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked" "ppEra_Run3_2024")
+declare -a arr=("ppEra_Run3" "ppEra_Run3_2023" "ppEra_Run3_2023_repacked" "ppEra_Run3_2024" "hltScoutingEra_Run3_2024")
 for scenario in "${arr[@]}"
 do
      runTest "${SCRAM_TEST_PATH}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -2,5 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
 
-Run3_2024 = cms.ModifierChain(Run3, run3_2024_L1T)
+Run3_2024 = cms.ModifierChain(Run3, run3_2024_L1T, run3_scouting_nanoAOD_post2023)

--- a/Configuration/Eras/python/Era_Run3_post2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_post2023_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
+
+Run3_post2023 = cms.ModifierChain(Run3,run3_scouting_nanoAOD_post2023) 

--- a/Configuration/Eras/python/Era_Run3_post2023_cff.py
+++ b/Configuration/Eras/python/Era_Run3_post2023_cff.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from Configuration.Eras.Era_Run3_cff import Run3
-from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
-
-Run3_post2023 = cms.ModifierChain(Run3,run3_scouting_nanoAOD_post2023) 

--- a/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_post2023_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_scouting_nanoAOD_post2023_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_scouting_nanoAOD_post2023 = cms.Modifier()

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -345,7 +345,7 @@ workflows[_wfn()] = ['BTVNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'BTVNANO_d
 workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_data14.0']]
 workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
-# workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
+workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
 
 # DPG custom NANOs, data
 _wfn.subnext()

--- a/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_run3scouting_cff.py
@@ -14,6 +14,14 @@ particleTableTask = cms.Task(particleScoutingTable)
 ak4JetTableTask = cms.Task(ak4ScoutingJets,ak4ScoutingJetParticleNetJetTagInfos,ak4ScoutingJetParticleNetJetTags,ak4ScoutingJetTable)
 ak8JetTableTask = cms.Task(ak8ScoutingJets,ak8ScoutingJetsSoftDrop,ak8ScoutingJetsSoftDropMass,ak8ScoutingJetEcfNbeta1,ak8ScoutingJetNjettiness,ak8ScoutingJetParticleNetJetTagInfos,ak8ScoutingJetParticleNetJetTags,ak8ScoutingJetParticleNetMassRegressionJetTags,ak8ScoutingJetTable)
 
+muonScoutingTableTask = cms.Task(muonScoutingTable)
+displacedvertexScoutingTableTask = cms.Task(displacedvertexScoutingTable)
+
+# from 2024, there are two scouting muon collections
+from Configuration.Eras.Modifier_run3_scouting_nanoAOD_post2023_cff import run3_scouting_nanoAOD_post2023
+run3_scouting_nanoAOD_post2023.toReplaceWith(muonScoutingTableTask, cms.Task(muonVtxScoutingTable, muonNoVtxScoutingTable))\
+    .toReplaceWith(displacedvertexScoutingTableTask, cms.Task(displacedvertexVtxScoutingTable, displacedvertexNoVtxScoutingTable))
+
 ## L1 decisions
 gtStage2DigisScouting = gtStage2Digis.clone(InputLabel="hltFEDSelectorL1")
 l1bitsScouting = l1bits.clone(src="gtStage2DigisScouting")
@@ -49,7 +57,7 @@ triggerSequence = cms.Sequence(L1TRawToDigi+patTriggerScouting+selectedPatTrigge
 genJetTask = cms.Task(ak4ScoutingJetMatchGen,ak4ScoutingJetExtTable,ak8ScoutingJetMatchGen,ak8ScoutingJetExtTable)
 puTask = cms.Task(puTable)
 
-nanoTableTaskCommon = cms.Task(photonScoutingTable,muonScoutingTable,electronScoutingTable,trackScoutingTable,primaryvertexScoutingTable,displacedvertexScoutingTable,rhoScoutingTable,metScoutingTable,particleTask,particleTableTask,ak4JetTableTask,ak8JetTableTask)
+nanoTableTaskCommon = cms.Task(photonScoutingTable,muonScoutingTableTask,electronScoutingTable,trackScoutingTable,primaryvertexScoutingTable,displacedvertexScoutingTableTask,rhoScoutingTable,metScoutingTable,particleTask,particleTableTask,ak4JetTableTask,ak8JetTableTask)
 
 nanoSequenceCommon = cms.Sequence(triggerSequence,nanoTableTaskCommon)
 

--- a/PhysicsTools/NanoAOD/python/run3scouting_cff.py
+++ b/PhysicsTools/NanoAOD/python/run3scouting_cff.py
@@ -223,6 +223,32 @@ metScoutingTable = cms.EDProducer("GlobalVariablesTableProducer",
     )
 )
 
+# from 2024, there are two scouting muon collections
+
+# muonVtx
+muonVtxScoutingTable = muonScoutingTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerVtx"),
+    name = cms.string("ScoutingMuonVtx"),
+    doc  = cms.string("Scouting Muon Vtx information"),
+)
+displacedvertexVtxScoutingTable = displacedvertexScoutingTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerVtx", "displacedVtx"),
+    name = cms.string("ScoutingMuonVtxDisplacedVertex"),
+    doc  = cms.string("Scouting Muon Vtx DisplacedVertex information"),
+)
+
+# muonNoVtx
+muonNoVtxScoutingTable = muonScoutingTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerNoVtx"),
+    name = cms.string("ScoutingMuonNoVtx"),
+    doc  = cms.string("Scouting Muon NoVtx information"),
+)
+displacedvertexNoVtxScoutingTable = displacedvertexScoutingTable.clone(
+    src = cms.InputTag("hltScoutingMuonPackerNoVtx", "displacedVtx"),
+    name = cms.string("ScoutingMuonNoVtxDisplacedVertex"),
+    doc  = cms.string("Scouting Muon NoVtx DisplacedVertex information"),
+)
+
 ################
 # Scouting particles
 


### PR DESCRIPTION
#### PR description:

This PR adds two versions of scouting muon collections, ScoutingMuonNoVtx and ScoutingMuonVtx, following this change [CMSHLT-3089:Add hltScoutingMuonPackerVtx to Scouting EventContent](https://its.cern.ch/jira/browse/CMSHLT-3089). 

This fixes issue [Missing "hltScoutingMuonPacker" in ScoutingNANO using recent Run-3 data#44817](https://github.com/cms-sw/cmssw/issues/44817).

This PR also introduces ```run3_scouting_nanoAOD_post2023``` Modifier used to modify configuration and top level ```Run3_post2023``` ModifierChain based on ```Run3``` with ```run3_scouting_nanoAOD_post2023``` Modifier.

#### PR validation:

Tested by producing scouting NanoAOD from a 2024 scouting HLTSCOUT datatier file using the following ```cmsDriver.py``` command:

```
cmsDriver.py step2 -s NANO:@Scout --process NANO \
--data --eventcontent NANOAOD --datatier NANOAOD -n 10000 \
--era Run3_post2023 --conditions auto:run3_data --filein fileIN.root
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, but backport to 140X will follow.

cc: @elfontan @karim @silviodonato @vlimant 