### PR TITLE
update data used for the Pixel,ECal,HCal GPU online DQM clients for post-alpaka migration in the HLT menu

### DIFF
--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -25,9 +25,9 @@
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 373710"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 373710"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 373710"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 380649"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 380649"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 380649"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->


### PR DESCRIPTION
#### PR description:

This PR (joint with the corresponding `cms-data` update https://github.com/cms-data/DQM-Integration/pull/7), is meant to supply to the Pixel, ECal and HCal GPU clients fresher streamer input files for the unit tests.
This is needed because starting from online `GRun` menus `V1.1.x` in 2024, the naming of the collections in output to the `DQMGPUvsCPU` stream has been updated (see TSG ticket [CMSHLT-3132](https://its.cern.ch/jira/browse/CMSHLT-3132)).
This has prompted `cmssw` PRs in order to comply with the changes:
   * https://github.com/cms-sw/cmssw/pull/44934 (for Pixel)
   * https://github.com/cms-sw/cmssw/pull/44675 (for ECAL, see also related TSG ticket [CMSHLT-3139](https://its.cern.ch/jira/browse/CMSHLT-3139))
   
Due to that, the data used in unit tests currently running in IB and PR tests is out-of-synch with the collection names requested by the clients, see e.g. these [logs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-05-14-2300/unitTestLogs/DQM/Integration#/27150).
The purpose of this PR (joint to the companion `cms-data` update https://github.com/cms-data/DQM-Integration/pull/7) is to update the data used for the tests to a fresher set coming from  run380649 (from Run2024D pp run [OMS link](https://cmsoms.cern.ch/cms/runs/report?cms_run=380649&cms_run_sequence=GLOBAL-RUN)), which features the new collection names.   

#### PR validation:

Unit tests:

```
scram b runtests_TestDQMOnlineClient-ecalgpu_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-hcalgpu_dqm_sourceclient
scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient
```

now run fine, and without missing collection warnings.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be useful to backport to 14.0.X if accepted.
