### PR TITLE
[JMENano] Backport of #44972 (Add customize functions to recompute Puppi and PuppiMET) to 14_0_X

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1263,6 +1263,32 @@ def RemoveAllJetPtCuts(proc):
 
   return proc
 
+def RecomputePuppiWeights(proc):
+  """
+  Setup packedpuppi and packedpuppiNoLep to recompute puppi weights
+  """
+  if hasattr(proc,"packedpuppi"):
+    proc.packedpuppi.useExistingWeights = False
+  if hasattr(proc,"packedpuppiNoLep"):
+    proc.packedpuppiNoLep.useExistingWeights = False
+  return proc
+
+def RecomputePuppiMET(proc):
+  """
+  Recompute PuppiMET. This is useful when puppi weights are recomputed.
+  """
+  runOnMC=True
+  if hasattr(proc,"NANOEDMAODoutput") or hasattr(proc,"NANOAODoutput"):
+    runOnMC = False
+
+  from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+  runMetCorAndUncFromMiniAOD(proc, isData=runOnMC,
+    jetCollUnskimmed='updatedJetsPuppi',metType='Puppi',postfix='Puppi',jetFlavor='AK4PFPuppi',
+    puppiProducerLabel='packedpuppi',puppiProducerForMETLabel='packedpuppiNoLep',
+    recoMetFromPFCs=True
+  )
+  return proc
+
 #===========================================================================
 #
 # CUSTOMIZATION function
@@ -1382,3 +1408,4 @@ def PrepJMECustomNanoAOD(process):
     process.genWeightsTable.keepAllPSWeights = True
 
   return process
+


### PR DESCRIPTION
Backport of #44972 

#### Original PR description:

This PR adds two wrapper functions which 

- set the PuppiProducer instances (`packedpuppi` & `packedpuppiNoLep`) to recompute puppi weights.
- setup the recalculation of PuppiMET.

The two functions can be setup in cmsRun config files  using `--customise` or `-customize_commands` arguments of cmsDriver.py. This would be useful if a (official or private) JMENano production needs updated puppi weights.

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`

No changes are expected to any workflow because the two functions are not being called anywhere.