### PR TITLE
Enable SoA range checking by default [14.0.x]

### DIFF
--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -72,13 +72,13 @@ namespace cms::soa {
   namespace RestrictQualify {
     constexpr bool enabled = true;
     constexpr bool disabled = false;
-    constexpr bool Default = disabled;
+    constexpr bool Default = enabled;
   }  // namespace RestrictQualify
 
   namespace RangeChecking {
     constexpr bool enabled = true;
     constexpr bool disabled = false;
-    constexpr bool Default = disabled;
+    constexpr bool Default = enabled;
   }  // namespace RangeChecking
 
   template <typename T, bool RESTRICT_QUALIFY>

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -456,8 +456,8 @@
                                                                                                                        \
     template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                            \
             bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,                                 \
-            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,                                                \
-            bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>                                                   \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
     struct ViewTemplateFreeParams;                                                                                     \
                                                                                                                        \
     /* dump the SoA internal structure */                                                                              \
@@ -539,7 +539,7 @@
     using ConstViewTemplate = ConstViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY,          \
       RANGE_CHECKING>;                                                                                                 \
                                                                                                                        \
-    using ConstView = ConstViewTemplate<cms::soa::RestrictQualify::enabled, cms::soa::RangeChecking::disabled>;        \
+    using ConstView = ConstViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::Default>;         \
                                                                                                                        \
     /* Generate the mutable View template */                                                                           \
     _GENERATE_SOA_TRIVIAL_VIEW(CLASS,                                                                                  \
@@ -552,7 +552,7 @@
     template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
     using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \
                                                                                                                        \
-    using View = ViewTemplate<cms::soa::RestrictQualify::enabled, cms::soa::RangeChecking::disabled>;                  \
+    using View = ViewTemplate<cms::soa::RestrictQualify::Default, cms::soa::RangeChecking::Default>;                   \
                                                                                                                        \
     /* Trivial constuctor */                                                                                           \
     CLASS()                                                                                                            \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -492,8 +492,8 @@ namespace cms::soa {
 #define _GENERATE_SOA_VIEW_PART_0(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                          \
   template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                              \
             bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,                                 \
-            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,                                                \
-            bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>                                                   \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
   struct VIEW : public CONST_VIEW<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING> {      \
     /* Declare the parametrized layouts as the default */                                                              \
     /*BOOST_PP_SEQ_CAT(_ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE, ~, LAYOUTS_LIST))   */              \
@@ -671,8 +671,8 @@ namespace cms::soa {
 #define _GENERATE_SOA_CONST_VIEW_PART_0(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                    \
   template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                              \
             bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,                                 \
-            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,                                                \
-            bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>                                                   \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
   struct CONST_VIEW {                                                                                                  \
     /* these could be moved to an external type trait to free up the symbol names */                                   \
     using self_type = CONST_VIEW;


### PR DESCRIPTION
#### PR description:

Enable SoA range checking by default.

#### PR validation:

None.

#### Backport status:

Backport of #44988 for data taking.