### PR TITLE
(DAQ) remove dummy MicroStateService

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -74,7 +74,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
   std::string openHistoFilePathName;
   std::string histoFilePathName;
 
-  evf::FastMonitoringService * fms = nullptr;
+  evf::FastMonitoringService* fms = nullptr;
   edm::Service<DQMStore> store;
 
   // create the files names

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -74,7 +74,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
   std::string openHistoFilePathName;
   std::string histoFilePathName;
 
-  evf::FastMonitoringService* fms = nullptr;
+  evf::FastMonitoringService * fms = nullptr;
   edm::Service<DQMStore> store;
 
   // create the files names
@@ -104,7 +104,7 @@ void DQMFileSaverPB::saveLumi(const FileParameters& fp) const {
         edm::Service<evf::EvFDaqDirector>()->getOpenProtocolBufferHistogramFilePath(fp.lumi_, streamLabel_);
     histoFilePathName = edm::Service<evf::EvFDaqDirector>()->getProtocolBufferHistogramFilePath(fp.lumi_, streamLabel_);
 
-    fms = (evf::FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+    fms = edm::Service<evf::FastMonitoringService>().operator->();
   }
 
   bool abortFlag = false;

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -13,7 +13,7 @@
 
 #include <filesystem>
 
-#include "EventFilter/Utilities/interface/MicroStateService.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
 
 #include <string>
 #include <vector>
@@ -33,9 +33,6 @@
   At snapshot time only (every few seconds) we do the map lookup to produce snapshot.
   The general counters and status variables (event number, number of processed events, number of passed and stored 
   events, luminosity section etc.) are also monitored here.
-
-  N.B. MicroStateService is referenced by a common base class which is now trivial.
-  It's complete removal will be completed in the future commit.
 */
 
 class FedRawDataInputSource;
@@ -164,7 +161,7 @@ namespace evf {
   //reserve output module space
   constexpr int nReservedModules = 128;
 
-  class FastMonitoringService : public MicroStateService {
+  class FastMonitoringService {
   public:
     // the names of the states - some of them are never reached in an online app
     static const edm::ModuleDescription specialMicroStateNames[FastMonState::mCOUNT];
@@ -172,7 +169,7 @@ namespace evf {
     static const std::string inputStateNames[FastMonState::inCOUNT];
     // Reserved names for microstates
     FastMonitoringService(const edm::ParameterSet&, edm::ActivityRegistry&);
-    ~FastMonitoringService() override;
+    ~FastMonitoringService();
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     std::string makeModuleLegendaJson();

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -326,7 +326,7 @@ namespace evf {
     //create JSD
     GlobalEvFOutputJSONDef(streamLabel_, true);
 
-    fms_ = (evf::FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+    fms_ = (evf::FastMonitoringService*)(edm::Service<evf::FastMonitoringService>().operator->());
   }
 
   GlobalEvFOutputModule::~GlobalEvFOutputModule() {}

--- a/EventFilter/Utilities/plugins/modules.cc
+++ b/EventFilter/Utilities/plugins/modules.cc
@@ -17,14 +17,12 @@
 using namespace edm::serviceregistry;
 using namespace evf;
 
-typedef edm::serviceregistry::AllArgsMaker<MicroStateService, FastMonitoringService> FastMonitoringServiceMaker;
-DEFINE_FWK_SERVICE_MAKER(FastMonitoringService, FastMonitoringServiceMaker);
-
 typedef RawEventOutputModuleForBU<RawEventFileWriterForBU> RawStreamFileWriterForBU;
 DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
 DEFINE_FWK_MODULE(FRDOutputModule);
 DEFINE_FWK_SERVICE(EvFBuildingThrottle);
 DEFINE_FWK_SERVICE(EvFDaqDirector);
+DEFINE_FWK_SERVICE(FastMonitoringService);
 DEFINE_FWK_MODULE(ExceptionGenerator);
 DEFINE_FWK_MODULE(EvFFEDSelector);
 DEFINE_FWK_MODULE(EvFFEDExcluder);

--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -132,12 +132,12 @@ DAQSource::DAQSource(edm::ParameterSet const& pset, edm::InputSourceDescription 
   //get handles to DaqDirector and FastMonitoringService because getting them isn't possible in readSupervisor thread
   if (fileListMode_) {
     try {
-      fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+      fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::FastMonitoringService>().operator->());
     } catch (cms::Exception const&) {
       edm::LogInfo("DAQSource") << "No FastMonitoringService found in the configuration";
     }
   } else {
-    fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+    fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::FastMonitoringService>().operator->());
     if (!fms_) {
       throw cms::Exception("DAQSource") << "FastMonitoringService not found";
     }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -836,7 +836,7 @@ namespace evf {
                                 bool& setExceptionState) {
     if (previousFileSize_ != 0) {
       if (!fms_) {
-        fms_ = (FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+        fms_ = (FastMonitoringService*)(edm::Service<evf::FastMonitoringService>().operator->());
       }
       if (fms_)
         fms_->accumulateFileSize(ls, previousFileSize_);

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -195,8 +195,7 @@ namespace evf {
   };
 
   FastMonitoringService::FastMonitoringService(const edm::ParameterSet& iPS, edm::ActivityRegistry& reg)
-      : MicroStateService(iPS, reg),
-        fmt_(new FastMonitoringThread()),
+      : fmt_(new FastMonitoringThread()),
         tbbMonitoringMode_(iPS.getUntrackedParameter<bool>("tbbMonitoringMode", true)),
         tbbConcurrencyTracker_(iPS.getUntrackedParameter<bool>("tbbConcurrencyTracker", true) && tbbMonitoringMode_),
         sleepTime_(iPS.getUntrackedParameter<int>("sleepTime", 1)),
@@ -1046,10 +1045,5 @@ namespace evf {
     } else
       fmt_->jsonMonitor_->snap(ls);
   }
-
-  //compatibility
-  MicroStateService::MicroStateService(const edm::ParameterSet& iPS, edm::ActivityRegistry& reg) {}
-
-  MicroStateService::~MicroStateService() {}
 
 }  //end namespace evf

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -122,12 +122,12 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset, edm:
   //get handles to DaqDirector and FastMonitoringService because getting them isn't possible in readSupervisor thread
   if (fileListMode_) {
     try {
-      fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+      fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::FastMonitoringService>().operator->());
     } catch (cms::Exception const&) {
       edm::LogInfo("FedRawDataInputSource") << "No FastMonitoringService found in the configuration";
     }
   } else {
-    fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::MicroStateService>().operator->());
+    fms_ = static_cast<evf::FastMonitoringService*>(edm::Service<evf::FastMonitoringService>().operator->());
     if (!fms_) {
       throw cms::Exception("FedRawDataInputSource") << "FastMonitoringService not found";
     }

--- a/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/HLTriggerJSONMonitoring.cc
@@ -428,9 +428,9 @@ void HLTriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   unsigned int run = lumi.run();
 
   bool writeFiles = true;
-  if (edm::Service<evf::MicroStateService>().isAvailable()) {
+  if (edm::Service<evf::FastMonitoringService*>().isAvailable()) {
     evf::FastMonitoringService* fms =
-        (evf::FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+        (evf::FastMonitoringService*)(edm::Service<evf::FastMonitoringService*>().operator->());
     if (fms)
       writeFiles = fms->shouldWriteFiles(ls);
   }

--- a/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/L1TriggerJSONMonitoring.cc
@@ -364,9 +364,9 @@ void L1TriggerJSONMonitoring::globalEndLuminosityBlockSummary(edm::LuminosityBlo
   unsigned int run = lumi.run();
 
   bool writeFiles = true;
-  if (edm::Service<evf::MicroStateService>().isAvailable()) {
+  if (edm::Service<evf::FastMonitoringService>().isAvailable()) {
     evf::FastMonitoringService* fms =
-        (evf::FastMonitoringService*)(edm::Service<evf::MicroStateService>().operator->());
+        (evf::FastMonitoringService*)(edm::Service<evf::FastMonitoringService>().operator->());
     if (fms)
       writeFiles = fms->shouldWriteFiles(ls);
   }


### PR DESCRIPTION
#### PR description:
Removes dummy MicroStateService class and changes to using FastMonitoringService directly

#### PR validation:

Tested in DAQ test setup (online HLT emulation) with no issues seen.