### PR TITLE
[14.0.X] Adding PPS and ECALTiming Runs to HLT Menu veto of PCL alignment

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
+++ b/Alignment/CommonAlignmentProducer/python/LSNumberFilter_cfi.py
@@ -1,5 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 from Alignment.CommonAlignmentProducer.lsNumberFilter_cfi import lsNumberFilter
-LSNumberFilter = lsNumberFilter.clone(minLS = 21,
-                                      veto_HLT_Menu = ["LumiScan"])
+LSNumberFilter = lsNumberFilter.clone(
+    minLS = 21,
+    veto_HLT_Menu = [
+        "LumiScan",
+        "PPS",
+        "ECALTiming"]
+    )


### PR DESCRIPTION
Backport of PR https://github.com/cms-sw/cmssw/pull/44983 to CMSSW 14_0_X

### PR description:

Added the "special" HLT menus PPS and ECALTiming to the veto_HLT_Menu for the PCL alignment, so that such runs are not used in the PCL alignment.

### PR validation:

PR was validated by testing the MilleStep for a PPS run (Run [379060](https://cmsoms.cern.ch/cms/runs/report?cms_run=379060)) and a ECALTiming run (Run [379354](https://cmsoms.cern.ch/cms/runs/report?cms_run=379354)), using the following command:

```
cmsDriver.py milleStep -s ALCA:PromptCalibProdSiPixelAli --conditions 140X_dataRun3_Express_v2 --scenario pp --data --era Run3 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100 --dasquery='file dataset=/StreamExpress/Run2024B-TkAlMinBias-Express-v1/ALCARECO run=<379060, 379354>'
```

@mmusich @dmeuser @henriettepetersen @TomasKello