### PR TITLE
Introducing `SimOnGen` and `GenOnly` wfs for 2024 and 2026D110

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -159,10 +159,11 @@ class WorkFlowRunner(Thread):
                     # Disable input for premix stage2 in FastSim to allow combined stage1+stage2 workflow (in FS, stage2 does also GEN)
                     # Ugly hack but works
                     if istep!=1 and not '--filein' in cmd and not 'premix_stage1' in cmd and not ("--fast" in cmd and "premix_stage2" in cmd):
-                        if "ALCA" not in cmd:
+                        steps = cmd.split("-s ")[1].split(" ")[0] ## relying on the syntax: cmsDriver -s STEPS --otherFlags
+                        if "ALCA" not in steps:
                             cmd+=' --filein  file:step%s.root '%(istep-1,)
-                        elif "ALCA" in cmd and "RECO" in cmd:
-                             cmd+=' --filein  file:step%s.root '%(istep-1,)
+                        elif "ALCA" in steps and "RECO" in steps:
+                            cmd+=' --filein  file:step%s.root '%(istep-1,)
                         else:
                             cmd+=' --filein %s'%(self.recoOutput)
                     if not '--fileout' in com:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -25,6 +25,7 @@ class WorkFlowRunner(Thread):
         self.nStreams=nStreams
         self.maxSteps=maxSteps
         self.nEvents=nEvents
+        self.recoOutput=''
         
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
         return
@@ -158,9 +159,16 @@ class WorkFlowRunner(Thread):
                     # Disable input for premix stage2 in FastSim to allow combined stage1+stage2 workflow (in FS, stage2 does also GEN)
                     # Ugly hack but works
                     if istep!=1 and not '--filein' in cmd and not 'premix_stage1' in cmd and not ("--fast" in cmd and "premix_stage2" in cmd):
-                        cmd+=' --filein  file:step%s.root '%(istep-1,)
+                        if "ALCA" not in cmd:
+                            cmd+=' --filein  file:step%s.root '%(istep-1,)
+                        elif "ALCA" in cmd and "RECO" in cmd:
+                             cmd+=' --filein  file:step%s.root '%(istep-1,)
+                        else:
+                            cmd+=' --filein %s'%(self.recoOutput)
                     if not '--fileout' in com:
                         cmd+=' --fileout file:step%s.root '%(istep,)
+                        if "RECO" in cmd:
+                            self.recoOutput = "file:step%d.root"%(istep)
                 if self.jobReport:
                   cmd += ' --suffix "-j JobReport%s.xml " ' % istep
                 if (self.nThreads > 1) and ('HARVESTING' not in cmd) and ('ALCAHARVEST' not in cmd):

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4222,6 +4222,7 @@ defaultDataSets['2023']='CMSSW_13_0_10-130X_mcRun3_2023_realistic_withEarly2023B
 defaultDataSets['2023FS']='CMSSW_13_0_11-130X_mcRun3_2023_realistic_withEarly2023BS_v1_FastSim-v'
 defaultDataSets['2024']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
 defaultDataSets['2024HLTOnDigi']='CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
+defaultDataSets["2024SimOnGen"] = 'CMSSW_14_0_0_pre3-140X_mcRun3_2024_realistic_v1_STD_2024_noPU-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
@@ -4302,6 +4303,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
                                        }
+    
     if beamspot is not None: upgradeStepDict['GenSim'][k]['--beamspot']=beamspot
 
     upgradeStepDict['GenSimHLBeamSpot'][k]= {'-s' : 'GEN,SIM',
@@ -4330,6 +4332,18 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
                                        }
+
+    upgradeStepDict['Sim'][k]= {'-s' : 'SIM',
+                                       '-n' : 10,
+                                       '--conditions' : gt,
+                                       '--beamspot' : 'Realistic25ns13TeVEarly2017Collision',
+                                       '--datatier' : 'SIM',
+                                       '--eventcontent': 'FEVTDEBUG',
+                                       '--geometry' : geom
+                                       }
+    
+    if beamspot is not None: upgradeStepDict['Sim'][k]['--beamspot']=beamspot
+    
 
     upgradeStepDict['Digi'][k] = {'-s':'DIGI:pdigi_valid,L1,DIGI2RAW,HLT:%s'%(hltversion),
                                       '--conditions':gt,
@@ -4461,7 +4475,6 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '-n':'10',
                                       '--eventcontent':'ALCARECO',
                                       '--geometry' : geom,
-                                      '--filein':'file:step3.root'
                                       }
 
     upgradeStepDict['ALCAPhase2'][k] = merge([{'-s':'ALCA:SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+TkAlMinBias+MuAlOverlaps+EcalESAlign+TkAlZMuMu+TkAlDiMuonAndVertex+HcalCalHBHEMuonProducerFilter+TkAlUpsilonMuMu+TkAlJpsiMuMu'},upgradeStepDict['ALCA'][k]])
@@ -4545,7 +4558,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
 for step in upgradeStepDict.keys():
     # we need to do this for each fragment
-    if ('Sim' in step and 'Fast' not in step) or ('Premix' in step) or ('Sim' not in step and 'Gen' in step):
+    if ('Sim' in step and ('Fast' not in step and step != 'Sim')) or ('Premix' in step) or ('Sim' not in step and 'Gen' in step):
         for frag,info in upgradeFragments.items():
             howMuch=info.howMuch
             for key in [key for year in upgradeKeys for key in upgradeKeys[year]]:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -16,6 +16,10 @@ def makeStepName(key,frag,step,suffix):
 
 #just define all of them
 
+## ... but we don't need all the flavors for the GenOnly
+def notForGenOnly(key,specialType):
+    return "GenOnly" in key and specialType != 'baseline'
+
 for year in upgradeKeys:
     for i,key in enumerate(upgradeKeys[year]):
         numWF=numWFAll[year][i]
@@ -26,6 +30,8 @@ for year in upgradeKeys:
                 continue
             stepList={}
             for specialType in upgradeWFs.keys():
+                if notForGenOnly(key,specialType):
+                    continue
                 stepList[specialType] = []
             hasHarvest = False
             for step in upgradeProperties[year][key]['ScenToRun']:
@@ -43,6 +49,10 @@ for year in upgradeKeys:
                 if 'HARVEST' in step: hasHarvest = True
 
                 for specialType,specialWF in upgradeWFs.items():
+
+                    if notForGenOnly(key,specialType): ## we don't need all the flavors for the GEN
+                        continue 
+
                     if (specialType != 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
@@ -71,6 +81,8 @@ for year in upgradeKeys:
 
             for specialType,specialWF in upgradeWFs.items():
                 # remove other steps for premixS1
+                if notForGenOnly(key,specialType):
+                    continue
                 if specialType=="PMXS1":
                     stepList[specialType] = stepList[specialType][:1]
                 specialWF.workflow(workflows, numWF, info.dataset, stepList[specialType], key, hasHarvest)

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -30,7 +30,7 @@ for year in upgradeKeys:
             hasHarvest = False
             for step in upgradeProperties[year][key]['ScenToRun']:
                 stepMaker = makeStepName
-                if 'Sim' in step and 'Fast' not in step:
+                if 'Sim' in step and 'Fast' not in step and step != "Sim":
                     if 'HLBeamSpot' in step:
                         if '14TeV' in frag:
                             step = 'GenSimHLBeamSpot14'

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2624,7 +2624,7 @@ upgradeWFs['Run3FStrackingOnly'] = UpgradeWorkflow_Run3FStrackingOnly(
 
 class UpgradeWorkflow_Run3FSMBMixing(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        if 'Gen' in step:
+        if 'Gen' in step and 'GenOnly' not in step:
             stepDict[stepName][k] = merge([{'-s':'GEN,SIM,RECOBEFMIX',
                                             '--fast':'',
                                             '--era':'Run3_FastSim',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -37,8 +37,9 @@ upgradeKeys[2017] = [
     '2023HI',
     '2023HIRP', #RawPrime
     '2024HLTOnDigi',
-    '2024HLTOnDigiPU'
-
+    '2024HLTOnDigiPU',
+    '2024GenOnly',
+    '2024SimOnGen',
 ]
 
 upgradeKeys[2026] = [
@@ -93,7 +94,9 @@ upgradeKeys[2026] = [
     '2026D113',
     '2026D113PU',
     '2026D114',
-    '2026D114PU'
+    '2026D114PU',
+    '2026D110GenOnly',
+    '2026D110SimOnGen',
 ]
 
 # pre-generation of WF numbers
@@ -178,7 +181,7 @@ class UpgradeWorkflow(object):
     def condition(self, fragment, stepList, key, hasHarvest):
         return False
     def preventReuse(self, stepName, stepDict, k):
-        if "Sim" in stepName:
+        if "Sim" in stepName and stepName != "Sim":
             stepDict[stepName][k] = None
         if "Gen" in stepName:
             stepDict[stepName][k] = None
@@ -198,6 +201,7 @@ class UpgradeWorkflow_baseline(UpgradeWorkflow):
 upgradeWFs['baseline'] = UpgradeWorkflow_baseline(
     steps =  [
         'Gen',
+        'Sim',
         'GenSim',
         'GenSimHLBeamSpot',
         'GenSimHLBeamSpot14',
@@ -2933,7 +2937,22 @@ upgradeProperties[2017] = {
         'Era':'Run3_pp_on_PbPb_approxSiStripClusters',
         'BeamSpot': 'DBrealistic',
         'ScenToRun' : ['GenSim','Digi','RecoNano','HARVESTNano','ALCA'],
-    }
+    },
+    '2024GenOnly' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2024_realistic',
+        'Era' : 'Run3',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen'],
+    },
+    '2024SimOnGen' : {
+        'Geom' : 'DB:Extended',
+        'GT' : 'auto:phase1_2024_realistic',
+        'HLTmenu': '@relval2024',
+        'Era' : 'Run3',
+        'BeamSpot': 'DBrealistic',
+        'ScenToRun' : ['Gen','Sim','Digi','RecoNano','HARVESTNano','ALCA'],
+    },
 }
 
 # standard PU sequences
@@ -3132,6 +3151,21 @@ upgradeProperties[2026] = {
         'GT' : 'auto:phase2_realistic_T33',
         'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
+    },
+    '2026D110GenOnly' : {
+        'Geom' : 'Extended2026D110',
+        'Beamspot' : 'HLLHC',
+        'GT' : 'auto:phase2_realistic_T33',
+        'Era' : 'Phase2C17I13M9',
+        'ScenToRun' : ['Gen'],
+    },
+    '2026D110SimOnGen' : {
+        'Geom' : 'Extended2026D110',
+        'HLTmenu': '@relval2026',
+        'Beamspot' : 'HLLHC',
+        'GT' : 'auto:phase2_realistic_T33',
+        'Era' : 'Phase2C17I13M9',
+        'ScenToRun' : ['Gen','Sim','DigiTrigger','RecoGlobal', 'HARVESTGlobal', 'ALCAPhase2'],
     },
 }
 


### PR DESCRIPTION
This PR proposes the addition of:
- `Sim` only step running only the SIM step (to be run on top of GEN);
- `SimOnGen`  wfs running the SIM step separated from `GEN` for 2024 and 2026D110 conditions;
- `GenOnly` wfs running only the GEN step for 2024 and 2026D110 conditions.

As a bonus the `ALCA` input for "upgrade" workflows is updated in order to be more general and to take the output of the `RECO` step rather than being hardcoded to be `step3.root`.

These are useful for us (PdmV) e.g.:

1. to run RelVal jobs recycling only the GEN rerunning the SIM. This will help when we have changes in simulation (e.g. changes in Phase2 geometries) than needs to be validated allowing us to reduce the statistical fluctuations recycling the underlying GEN.
2. to run GEN only wfs (for MinBias, or default samples) without having to act manually on each workflow.

#### PR Validation

Running, e.g., `15824.0` and `15634.0`.
