### PR TITLE
fix `testTkHistoMap_cfg.py` to include `TrackerAdditionalParametersPerDet` ESSource

### DIFF
--- a/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
+++ b/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("test")
 
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+process.load("Geometry.TrackerGeometryBuilder.TrackerAdditionalParametersPerDet_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")


### PR DESCRIPTION
#### PR description:

Title says it all, needed because of https://github.com/cms-sw/cmssw/pull/44576, fixes https://github.com/cms-sw/cmssw/pull/44576#issuecomment-2124015651 (failed unit test, see e.g. [here](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-05-21-2300/unitTestLogs/DQM/SiStripCommon#/37) ).

#### PR validation:

`scram b runtests`  runs fine in the corresponding package.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A