### PR TITLE
Improve behavior after exception in begin/end run transitions

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -212,10 +212,7 @@ namespace edm {
 
     InputSource::ItemType processRuns();
     void beginRunAsync(IOVSyncValue const&, WaitingTaskHolder);
-    void streamBeginRunAsync(unsigned int iStream,
-                             std::shared_ptr<RunProcessingStatus>,
-                             bool precedingTasksSucceeded,
-                             WaitingTaskHolder);
+    void streamBeginRunAsync(unsigned int iStream, std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder) noexcept;
     void releaseBeginRunResources(unsigned int iStream);
     void endRunAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
     void handleEndRunExceptions(std::exception_ptr, WaitingTaskHolder const&);

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -1,9 +1,6 @@
 #ifndef FWCore_Framework_GlobalSchedule_h
 #define FWCore_Framework_GlobalSchedule_h
 
-/*
-*/
-
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Common/interface/FWCoreCommonFwd.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -103,6 +100,9 @@ namespace edm {
     AllWorkers const& allWorkers() const { return workerManagers_[0].allWorkers(); }
 
   private:
+    /// returns the action table
+    ExceptionToActionTable const& actionTable() const { return workerManagers_[0].actionTable(); }
+
     template <typename T>
     void preScheduleSignal(GlobalContext const*, ServiceToken const&);
 
@@ -113,9 +113,6 @@ namespace edm {
                          ServiceWeakToken const&,
                          bool cleaningUpAfterException,
                          std::exception_ptr&);
-
-    /// returns the action table
-    ExceptionToActionTable const& actionTable() const { return workerManagers_[0].actionTable(); }
 
     std::vector<WorkerManager> workerManagers_;
     std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -59,14 +59,7 @@ namespace edm {
 
     Path& operator=(Path const&) = delete;
 
-    template <typename T>
-    void runAllModulesAsync(WaitingTaskHolder,
-                            typename T::TransitionInfoType const&,
-                            ServiceToken const&,
-                            StreamID const&,
-                            typename T::Context const*);
-
-    void processOneOccurrenceAsync(
+    void processEventUsingPathAsync(
         WaitingTaskHolder, EventTransitionInfo const&, ServiceToken const&, StreamID const&, StreamContext const*);
 
     int bitPosition() const { return bitpos_; }
@@ -177,17 +170,6 @@ namespace edm {
       PathContext const* pathContext_;
     };
   }  // namespace
-
-  template <typename T>
-  void Path::runAllModulesAsync(WaitingTaskHolder task,
-                                typename T::TransitionInfoType const& info,
-                                ServiceToken const& token,
-                                StreamID const& streamID,
-                                typename T::Context const* context) {
-    for (auto& worker : workers_) {
-      worker.runWorkerAsync<T>(task, info, token, streamID, context);
-    }
-  }
 
 }  // namespace edm
 

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -15,25 +15,22 @@
 
  */
 
-#include "FWCore/Framework/interface/BranchActionType.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/OccurrenceTraits.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Framework/interface/maker/Worker.h"
 #include "FWCore/Framework/interface/UnscheduledAuxiliary.h"
-#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
-#include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
+#include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
-#include <vector>
-#include <unordered_map>
-#include <string>
-#include <sstream>
+#include <algorithm>
 #include <cassert>
+#include <functional>
+#include <vector>
 
 namespace edm {
 
   class EventTransitionInfo;
-  class ModuleCallingContext;
 
   class UnscheduledCallProducer {
   public:
@@ -67,28 +64,6 @@ namespace edm {
     const_iterator end() const { return unscheduledWorkers_.end(); }
     worker_container const& workers() const { return unscheduledWorkers_; }
 
-    template <typename T, typename U>
-    void runNowAsync(WaitingTaskHolder task,
-                     typename T::TransitionInfoType const& info,
-                     ServiceToken const& token,
-                     StreamID streamID,
-                     typename T::Context const* topContext,
-                     U const* context) const noexcept {
-      //do nothing for event since we will run when requested
-      if (!T::isEvent_) {
-        for (auto worker : unscheduledWorkers_) {
-          ParentContext parentContext(context);
-
-          // We do not need to run prefetching here because this only handles
-          // stream transitions for runs and lumis. There are no products put
-          // into the runs or lumis in stream transitions, so there can be
-          // no data dependencies which require prefetching. Prefetching is
-          // needed for global transitions, but they are run elsewhere.
-          worker->doWorkNoPrefetchingAsync<T>(task, info, token, streamID, parentContext, topContext);
-        }
-      }
-    }
-
     template <typename T>
     void runAccumulatorsAsync(WaitingTaskHolder task,
                               typename T::TransitionInfoType const& info,
@@ -102,12 +77,6 @@ namespace edm {
     }
 
   private:
-    template <typename T, typename ID>
-    void addContextToException(cms::Exception& ex, Worker const* worker, ID const& id) const {
-      std::ostringstream ost;
-      ost << "Processing " << T::transitionName() << " " << id;
-      ex.addContext(ost.str());
-    }
     worker_container unscheduledWorkers_;
     worker_container accumulatorWorkers_;
     UnscheduledAuxiliary aux_;

--- a/FWCore/Framework/interface/WorkerInPath.h
+++ b/FWCore/Framework/interface/WorkerInPath.h
@@ -112,23 +112,11 @@ namespace edm {
                                     ServiceToken const& token,
                                     StreamID streamID,
                                     typename T::Context const* context) noexcept {
-    if constexpr (T::isEvent_) {
-      ++timesVisited_;
-    }
+    static_assert(T::isEvent_);
 
-    if constexpr (T::isEvent_) {
-      ParentContext parentContext(&placeInPathContext_);
-      worker_->doWorkAsync<T>(std::move(iTask), info, token, streamID, parentContext, context);
-    } else {
-      ParentContext parentContext(context);
-
-      // We do not need to run prefetching here because this only handles
-      // stream transitions for runs and lumis. There are no products put
-      // into the runs or lumis in stream transitions, so there can be
-      // no data dependencies which require prefetching. Prefetching is
-      // needed for global transitions, but they are run elsewhere.
-      worker_->doWorkNoPrefetchingAsync<T>(std::move(iTask), info, token, streamID, parentContext, context);
-    }
+    ++timesVisited_;
+    ParentContext parentContext(&placeInPathContext_);
+    worker_->doWorkAsync<T>(std::move(iTask), info, token, streamID, parentContext, context);
   }
 }  // namespace edm
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1305,11 +1305,6 @@ namespace edm {
                           using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
                           beginGlobalTransitionAsync<Traits>(
                               nextTask, *schedule_, transitionInfo, serviceToken_, subProcesses_);
-                        }) | then([status](auto nextTask) mutable {
-                          if (status->stopBeforeProcessingRun()) {
-                            return;
-                          }
-                          status->globalBeginDidSucceed();
                         }) | ifThen(looper_, [this, status, &es](auto nextTask) {
                           if (status->stopBeforeProcessingRun()) {
                             return;
@@ -1323,11 +1318,11 @@ namespace edm {
                           ServiceRegistry::Operate operateLooper(serviceToken_);
                           looper_->doBeginRun(*status->runPrincipal(), es, &processContext_);
                         }) | then([this, status](std::exception_ptr const* iException, auto holder) mutable {
-                          bool precedingTasksSucceeded = true;
                           if (iException) {
-                            precedingTasksSucceeded = false;
                             WaitingTaskHolder copyHolder(holder);
                             copyHolder.doneWaiting(*iException);
+                          } else {
+                            status->globalBeginDidSucceed();
                           }
 
                           if (status->stopBeforeProcessingRun()) {
@@ -1365,27 +1360,23 @@ namespace edm {
                           PauseQueueSentry pauseQueueSentry(streamQueuesInserter_);
 
                           CMS_SA_ALLOW try {
-                            streamQueuesInserter_.push(
-                                *holder.group(), [this, status, precedingTasksSucceeded, holder]() mutable {
-                                  for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
-                                    CMS_SA_ALLOW try {
-                                      streamQueues_[i].push(
-                                          *holder.group(),
-                                          [this, i, status, precedingTasksSucceeded, holder]() mutable {
-                                            streamBeginRunAsync(
-                                                i, std::move(status), precedingTasksSucceeded, std::move(holder));
-                                          });
-                                    } catch (...) {
-                                      if (status->streamFinishedBeginRun()) {
-                                        WaitingTaskHolder copyHolder(holder);
-                                        copyHolder.doneWaiting(std::current_exception());
-                                        status->resetBeginResources();
-                                        queueWhichWaitsForIOVsToFinish_.resume();
-                                        exceptionRunStatus_ = status;
-                                      }
-                                    }
+                            streamQueuesInserter_.push(*holder.group(), [this, status, holder]() mutable {
+                              for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+                                CMS_SA_ALLOW try {
+                                  streamQueues_[i].push(*holder.group(), [this, i, status, holder]() mutable {
+                                    streamBeginRunAsync(i, std::move(status), std::move(holder));
+                                  });
+                                } catch (...) {
+                                  if (status->streamFinishedBeginRun()) {
+                                    WaitingTaskHolder copyHolder(holder);
+                                    copyHolder.doneWaiting(std::current_exception());
+                                    status->resetBeginResources();
+                                    queueWhichWaitsForIOVsToFinish_.resume();
+                                    exceptionRunStatus_ = status;
                                   }
-                                });
+                                }
+                              }
+                            });
                           } catch (...) {
                             WaitingTaskHolder copyHolder(holder);
                             copyHolder.doneWaiting(std::current_exception());
@@ -1419,8 +1410,7 @@ namespace edm {
 
   void EventProcessor::streamBeginRunAsync(unsigned int iStream,
                                            std::shared_ptr<RunProcessingStatus> status,
-                                           bool precedingTasksSucceeded,
-                                           WaitingTaskHolder iHolder) {
+                                           WaitingTaskHolder iHolder) noexcept {
     // These shouldn't throw
     streamQueues_[iStream].pause();
     ++streamRunActive_;
@@ -1428,9 +1418,9 @@ namespace edm {
 
     CMS_SA_ALLOW try {
       using namespace edm::waiting_task::chain;
-      chain::first([this, iStream, precedingTasksSucceeded](auto nextTask) {
-        if (precedingTasksSucceeded) {
-          RunProcessingStatus& rs = *streamRunStatus_[iStream];
+      chain::first([this, iStream](auto nextTask) {
+        RunProcessingStatus& rs = *streamRunStatus_[iStream];
+        if (rs.didGlobalBeginSucceed()) {
           RunTransitionInfo transitionInfo(
               *rs.runPrincipal(), rs.eventSetupImpl(esp_->subProcessIndex()), &rs.eventSetupImpls());
           using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -200,11 +200,11 @@ namespace edm {
     pathStatusInserterWorker_ = pathStatusInserterWorker;
   }
 
-  void Path::processOneOccurrenceAsync(WaitingTaskHolder iTask,
-                                       EventTransitionInfo const& iInfo,
-                                       ServiceToken const& iToken,
-                                       StreamID const& iStreamID,
-                                       StreamContext const* iStreamContext) {
+  void Path::processEventUsingPathAsync(WaitingTaskHolder iTask,
+                                        EventTransitionInfo const& iInfo,
+                                        ServiceToken const& iToken,
+                                        StreamID const& iStreamID,
+                                        StreamContext const* iStreamContext) {
     waitingTasks_.reset();
     modulesToRun_ = workers_.size();
     ++timesRun_;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -543,8 +543,8 @@ namespace edm {
     // unknown to the ModuleRegistry
     const std::string kTriggerResults("TriggerResults");
     std::vector<std::string> modulesToUse;
-    modulesToUse.reserve(streamSchedules_[0]->allWorkers().size());
-    for (auto const& worker : streamSchedules_[0]->allWorkers()) {
+    modulesToUse.reserve(streamSchedules_[0]->allWorkersLumisAndEvents().size());
+    for (auto const& worker : streamSchedules_[0]->allWorkersLumisAndEvents()) {
       if (worker->description()->moduleLabel() != kTriggerResults) {
         modulesToUse.push_back(worker->description()->moduleLabel());
       }
@@ -608,7 +608,7 @@ namespace edm {
     // At this point all BranchDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.
     {
-      auto const& unsched = streamSchedules_[0]->unscheduledWorkers();
+      auto const& unsched = streamSchedules_[0]->unscheduledWorkersLumisAndEvents();
       if (not unsched.empty()) {
         std::set<std::string> unscheduledModules;
         std::transform(unsched.begin(),
@@ -643,7 +643,7 @@ namespace edm {
 
     branchIDListHelper.updateFromRegistry(preg);
 
-    for (auto const& worker : streamSchedules_[0]->allWorkers()) {
+    for (auto const& worker : streamSchedules_[0]->allWorkersLumisAndEvents()) {
       worker->registerThinnedAssociations(preg, thinnedAssociationsHelper);
     }
 

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -244,7 +244,7 @@ namespace edm {
                           ProductRegistry& preg,
                           PreallocationConfiguration const* prealloc,
                           std::shared_ptr<ProcessConfiguration const> processConfiguration,
-                          WorkerManager& workerManager,
+                          WorkerManager& workerManagerLumisAndEvents,
                           std::vector<std::string> const& trigPathNames) {
       std::unordered_set<std::string> allConditionalMods;
       for (auto const& pathName : trigPathNames) {
@@ -261,7 +261,7 @@ namespace edm {
 
       for (auto const& cond : allConditionalMods) {
         //force the creation of the conditional modules so alias check can work
-        (void)getWorker(cond, proc_pset, workerManager, preg, prealloc, processConfiguration);
+        (void)getWorker(cond, proc_pset, workerManagerLumisAndEvents, preg, prealloc, processConfiguration);
       }
 
       fillAliasMap(proc_pset, allConditionalMods);
@@ -360,7 +360,9 @@ namespace edm {
       std::shared_ptr<ProcessConfiguration const> processConfiguration,
       StreamID streamID,
       ProcessContext const* processContext)
-      : workerManager_(modReg, areg, actions),
+      : workerManagerBeginEnd_(modReg, areg, actions),
+        workerManagerRuns_(modReg, areg, actions),
+        workerManagerLumisAndEvents_(modReg, areg, actions),
         actReg_(areg),
         results_(new HLTGlobalStatus(tns.getTrigPaths().size())),
         results_inserter_(),
@@ -376,7 +378,7 @@ namespace edm {
     std::vector<std::string> const& endPathNames = tns.getEndPaths();
 
     ConditionalTaskHelper conditionalTaskHelper(
-        proc_pset, preg, &prealloc, processConfiguration, workerManager_, pathNames);
+        proc_pset, preg, &prealloc, processConfiguration, workerManagerLumisAndEvents_, pathNames);
     std::unordered_set<std::string> conditionalModules;
 
     int trig_bitpos = 0;
@@ -424,7 +426,7 @@ namespace edm {
 
     //See if all modules were used
     std::set<std::string> usedWorkerLabels;
-    for (auto const& worker : allWorkers()) {
+    for (auto const& worker : allWorkersLumisAndEvents()) {
       usedWorkerLabels.insert(worker->description()->moduleLabel());
     }
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
@@ -447,7 +449,7 @@ namespace edm {
         ParameterSet* modulePSet(proc_pset.getPSetForUpdate(label, isTracked));
         assert(isTracked);
         assert(modulePSet != nullptr);
-        workerManager_.addToUnscheduledWorkers(
+        workerManagerLumisAndEvents_.addToUnscheduledWorkers(
             *modulePSet, preg, &prealloc, processConfiguration, label, unscheduledLabels, shouldBeUsedLabels);
       }
       if (!shouldBeUsedLabels.empty()) {
@@ -488,6 +490,27 @@ namespace edm {
         }
       }
     }
+
+    for (auto const& worker : allWorkersLumisAndEvents()) {
+      std::string const& moduleLabel = worker->description()->moduleLabel();
+
+      // The new worker pointers will be null for the TriggerResultsInserter, PathStatusInserter, and
+      // EndPathStatusInserter because there are no ParameterSets for those in the configuration.
+      // We could add special code to create workers for those, but instead we skip them because they
+      // do not have beginStream, endStream, or run/lumi begin/end stream transition functions.
+
+      Worker* workerBeginEnd =
+          getWorker(moduleLabel, proc_pset, workerManagerBeginEnd_, preg, &prealloc, processConfiguration);
+      if (workerBeginEnd) {
+        workerManagerBeginEnd_.addToAllWorkers(workerBeginEnd);
+      }
+
+      Worker* workerRuns = getWorker(moduleLabel, proc_pset, workerManagerRuns_, preg, &prealloc, processConfiguration);
+      if (workerRuns) {
+        workerManagerRuns_.addToAllWorkers(workerRuns);
+      }
+    }
+
   }  // StreamSchedule::StreamSchedule
 
   void StreamSchedule::initializeEarlyDelete(ModuleRegistry& modReg,
@@ -530,7 +553,7 @@ namespace edm {
     }
 
     std::unordered_set<std::string> modulesToExclude(modulesToSkip.begin(), modulesToSkip.end());
-    for (auto w : allWorkers()) {
+    for (auto w : allWorkersLumisAndEvents()) {
       if (modulesToExclude.end() != modulesToExclude.find(w->description()->moduleLabel())) {
         continue;
       }
@@ -757,8 +780,8 @@ namespace edm {
           }
         }
         if (productFromConditionalModule) {
-          auto condWorker =
-              getWorker(productModuleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+          auto condWorker = getWorker(
+              productModuleLabel, proc_pset, workerManagerLumisAndEvents_, preg, prealloc, processConfiguration);
           assert(condWorker);
 
           conditionalModules.erase(itFound);
@@ -835,7 +858,8 @@ namespace edm {
         moduleLabel.erase(0, 1);
       }
 
-      Worker* worker = getWorker(moduleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+      Worker* worker =
+          getWorker(moduleLabel, proc_pset, workerManagerLumisAndEvents_, preg, prealloc, processConfiguration);
       if (worker == nullptr) {
         std::string pathType("endpath");
         if (!search_all(endPathNames, pathName)) {
@@ -958,33 +982,45 @@ namespace edm {
     }
   }
 
-  void StreamSchedule::beginStream() { workerManager_.beginStream(streamID_, streamContext_); }
+  void StreamSchedule::beginStream() { workerManagerBeginEnd_.beginStream(streamID_, streamContext_); }
 
-  void StreamSchedule::endStream() { workerManager_.endStream(streamID_, streamContext_); }
+  void StreamSchedule::endStream() { workerManagerBeginEnd_.endStream(streamID_, streamContext_); }
 
   void StreamSchedule::replaceModule(maker::ModuleHolder* iMod, std::string const& iLabel) {
-    Worker* found = nullptr;
-    for (auto const& worker : allWorkers()) {
+    for (auto const& worker : allWorkersBeginEnd()) {
       if (worker->description()->moduleLabel() == iLabel) {
-        found = worker;
+        iMod->replaceModuleFor(worker);
+        worker->beginStream(streamID_, streamContext_);
         break;
       }
     }
-    if (nullptr == found) {
-      return;
+
+    for (auto const& worker : allWorkersRuns()) {
+      if (worker->description()->moduleLabel() == iLabel) {
+        iMod->replaceModuleFor(worker);
+        break;
+      }
     }
 
-    iMod->replaceModuleFor(found);
-    found->beginStream(streamID_, streamContext_);
+    for (auto const& worker : allWorkersLumisAndEvents()) {
+      if (worker->description()->moduleLabel() == iLabel) {
+        iMod->replaceModuleFor(worker);
+        break;
+      }
+    }
   }
 
-  void StreamSchedule::deleteModule(std::string const& iLabel) { workerManager_.deleteModuleIfExists(iLabel); }
+  void StreamSchedule::deleteModule(std::string const& iLabel) {
+    workerManagerBeginEnd_.deleteModuleIfExists(iLabel);
+    workerManagerRuns_.deleteModuleIfExists(iLabel);
+    workerManagerLumisAndEvents_.deleteModuleIfExists(iLabel);
+  }
 
   std::vector<ModuleDescription const*> StreamSchedule::getAllModuleDescriptions() const {
     std::vector<ModuleDescription const*> result;
-    result.reserve(allWorkers().size());
+    result.reserve(allWorkersLumisAndEvents().size());
 
-    for (auto const& worker : allWorkers()) {
+    for (auto const& worker : allWorkersLumisAndEvents()) {
       ModuleDescription const* p = worker->description();
       result.push_back(p);
     }
@@ -1012,8 +1048,8 @@ namespace edm {
       // Data dependencies need to be set up before marking empty
       // (End)Paths complete in case something consumes the status of
       // the empty (EndPath)
-      workerManager_.setupResolvers(ep);
-      workerManager_.setupOnDemandSystem(info);
+      workerManagerLumisAndEvents_.setupResolvers(ep);
+      workerManagerLumisAndEvents_.setupOnDemandSystem(info);
 
       HLTPathStatus hltPathStatus(hlt::Pass, 0);
       for (int empty_trig_path : empty_trig_paths_) {
@@ -1085,15 +1121,15 @@ namespace edm {
       //start end paths first so on single threaded the paths will run first
       WaitingTaskHolder hAllPathsDone(*iTask.group(), allPathsDone);
       for (auto it = end_paths_.rbegin(), itEnd = end_paths_.rend(); it != itEnd; ++it) {
-        it->processOneOccurrenceAsync(hAllPathsDone, info, serviceToken, streamID_, &streamContext_);
+        it->processEventUsingPathAsync(hAllPathsDone, info, serviceToken, streamID_, &streamContext_);
       }
 
       for (auto it = trig_paths_.rbegin(), itEnd = trig_paths_.rend(); it != itEnd; ++it) {
-        it->processOneOccurrenceAsync(taskHolder, info, serviceToken, streamID_, &streamContext_);
+        it->processEventUsingPathAsync(taskHolder, info, serviceToken, streamID_, &streamContext_);
       }
 
       ParentContext parentContext(&streamContext_);
-      workerManager_.processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
+      workerManagerLumisAndEvents_.processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
           hAllPathsDone, info, serviceToken, streamID_, parentContext, &streamContext_);
     } catch (...) {
       iTask.doneWaiting(std::current_exception());
@@ -1318,7 +1354,7 @@ namespace edm {
 
     fill_summary(trig_paths_, rep.trigPathSummaries, &fillPathSummary);
     fill_summary(end_paths_, rep.endPathSummaries, &fillPathSummary);
-    fill_summary(allWorkers(), rep.workerSummaries, &fillWorkerSummary);
+    fill_summary(allWorkersLumisAndEvents(), rep.workerSummaries, &fillWorkerSummary);
   }
 
   void StreamSchedule::clearCounters() {
@@ -1326,12 +1362,12 @@ namespace edm {
     total_events_ = total_passed_ = 0;
     for_all(trig_paths_, std::bind(&Path::clearCounters, _1));
     for_all(end_paths_, std::bind(&Path::clearCounters, _1));
-    for_all(allWorkers(), std::bind(&Worker::clearCounters, _1));
+    for_all(allWorkersLumisAndEvents(), std::bind(&Worker::clearCounters, _1));
   }
 
   void StreamSchedule::resetAll() { results_->reset(); }
 
-  void StreamSchedule::addToAllWorkers(Worker* w) { workerManager_.addToAllWorkers(w); }
+  void StreamSchedule::addToAllWorkers(Worker* w) { workerManagerLumisAndEvents_.addToAllWorkers(w); }
 
   void StreamSchedule::resetEarlyDelete() {
     //must be sure we have cleared the count first
@@ -1395,6 +1431,33 @@ namespace edm {
         ++indexOfPath;
       }
       ++bitpos;
+    }
+  }
+
+  void StreamSchedule::handleException(StreamContext const& streamContext,
+                                       ServiceWeakToken const& weakToken,
+                                       bool cleaningUpAfterException,
+                                       std::exception_ptr& excpt) const noexcept {
+    //add context information to the exception and print message
+    try {
+      convertException::wrap([&excpt]() { std::rethrow_exception(excpt); });
+    } catch (cms::Exception& ex) {
+      std::ostringstream ost;
+      // In most cases the exception will already have context at this point,
+      // but add some context here in those rare cases where it does not.
+      if (ex.context().empty()) {
+        exceptionContext(ost, streamContext);
+      }
+      ServiceRegistry::Operate op(weakToken.lock());
+      addContextAndPrintException(ost.str().c_str(), ex, cleaningUpAfterException);
+      excpt = std::current_exception();
+    }
+    // We are already handling an earlier exception, so ignore it
+    // if this signal results in another exception being thrown.
+    CMS_SA_ALLOW try {
+      ServiceRegistry::Operate op(weakToken.lock());
+      actReg_->preStreamEarlyTerminationSignal_(streamContext, TerminationOrigin::ExceptionFromThisContext);
+    } catch (...) {
     }
   }
 }  // namespace edm

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -2,11 +2,15 @@
 #include "UnscheduledConfigurator.h"
 
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
-#include "FWCore/Utilities/interface/Algorithms.h"
-#include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+#include "FWCore/Framework/interface/maker/Worker.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/ConvertException.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ExceptionCollector.h"
+
+#include <functional>
 
 static const std::string kFilterType("EDFilter");
 static const std::string kProducerType("EDProducer");

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -543,6 +543,8 @@ void testGlobalFilter::testTransitions(std::shared_ptr<T> iMod, Expectations con
     edm::WorkerT<edm::global::EDFilterBase> wOther{iMod, m_desc, nullptr};
     edm::WorkerT<edm::global::EDFilterBase> wGlobalLumi{iMod, m_desc, nullptr};
     edm::WorkerT<edm::global::EDFilterBase> wStreamLumi{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDFilterBase> wGlobalRun{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDFilterBase> wStreamRun{iMod, m_desc, nullptr};
     for (auto& keyVal : m_transToFunc) {
       edm::Worker* worker = &wOther;
       if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
@@ -550,7 +552,12 @@ void testGlobalFilter::testTransitions(std::shared_ptr<T> iMod, Expectations con
       } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock ||
                  keyVal.first == Trans::kGlobalEndLuminosityBlock) {
         worker = &wGlobalLumi;
+      } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+        worker = &wStreamRun;
+      } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+        worker = &wGlobalRun;
       }
+
       testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
     }
   });

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -509,6 +509,8 @@ void testGlobalProducer::testTransitions(std::shared_ptr<T> iMod, Expectations c
     edm::WorkerT<edm::global::EDProducerBase> wOther{iMod, m_desc, nullptr};
     edm::WorkerT<edm::global::EDProducerBase> wGlobalLumi{iMod, m_desc, nullptr};
     edm::WorkerT<edm::global::EDProducerBase> wStreamLumi{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDProducerBase> wGlobalRun{iMod, m_desc, nullptr};
+    edm::WorkerT<edm::global::EDProducerBase> wStreamRun{iMod, m_desc, nullptr};
     for (auto& keyVal : m_transToFunc) {
       edm::Worker* worker = &wOther;
       if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
@@ -516,6 +518,10 @@ void testGlobalProducer::testTransitions(std::shared_ptr<T> iMod, Expectations c
       } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock ||
                  keyVal.first == Trans::kGlobalEndLuminosityBlock) {
         worker = &wGlobalLumi;
+      } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+        worker = &wStreamRun;
+      } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+        worker = &wGlobalRun;
       }
       testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
     }

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -550,12 +550,18 @@ void testLimitedFilter::testTransitions(std::shared_ptr<T> iMod, Expectations co
   edm::WorkerT<edm::limited::EDFilterBase> wOther{iMod, m_desc, nullptr};
   edm::WorkerT<edm::limited::EDFilterBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::limited::EDFilterBase> wStreamLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDFilterBase> wGlobalRun{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDFilterBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
     edm::Worker* worker = &wOther;
     if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;
+    } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+      worker = &wStreamRun;
+    } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+      worker = &wGlobalRun;
     }
     testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
   }

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -515,12 +515,18 @@ void testLimitedProducer::testTransitions(std::shared_ptr<T> iMod, Expectations 
   edm::WorkerT<edm::limited::EDProducerBase> wOther{iMod, m_desc, nullptr};
   edm::WorkerT<edm::limited::EDProducerBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::limited::EDProducerBase> wStreamLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDProducerBase> wGlobalRun{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::limited::EDProducerBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
     edm::Worker* worker = &wOther;
     if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;
+    } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+      worker = &wStreamRun;
+    } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+      worker = &wGlobalRun;
     }
     testTransition(iMod, worker, keyVal.first, iExpect, keyVal.second);
   }

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -590,12 +590,18 @@ void testStreamFilter::testTransitions(std::shared_ptr<U> iMod, Expectations con
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wOther{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wStreamLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wGlobalRun{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
     edm::Worker* worker = &wOther;
     if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;
+    } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+      worker = &wStreamRun;
+    } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+      worker = &wGlobalRun;
     }
     testTransition<T>(worker, keyVal.first, iExpect, keyVal.second);
   }

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -551,12 +551,18 @@ void testStreamProducer::testTransitions(std::shared_ptr<U> iMod, Expectations c
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wOther{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wStreamLumi{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDProducerAdaptorBase> wGlobalRun{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDProducerAdaptorBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
     edm::Worker* worker = &wOther;
     if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;
+    } else if (keyVal.first == Trans::kStreamBeginRun || keyVal.first == Trans::kStreamEndRun) {
+      worker = &wStreamRun;
+    } else if (keyVal.first == Trans::kGlobalBeginRun || keyVal.first == Trans::kGlobalEndRun) {
+      worker = &wGlobalRun;
     }
     testTransition<T>(worker, keyVal.first, iExpect, keyVal.second);
   }

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -37,10 +37,6 @@ Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c
 ++ finished: begin job
 ++++ starting: begin stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin stream for module: stream = 0 label = 'get' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: begin stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
@@ -550,10 +546,6 @@ ModuleCallingContext state = Running
 ++++ finished: write process block
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'get' id = 3
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'p' id = 2
-++++ finished: end stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -35,10 +35,6 @@
 ++++ finished: begin stream for module: stream = 0 label = 'two' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ finished: begin stream for module: stream = 0 label = 'getTwo' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
@@ -49,10 +45,10 @@
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
@@ -62,10 +58,10 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 5
 ++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'two' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
@@ -149,20 +145,20 @@
 ++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
 ++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'two' id = 5
-++++++ finished: end run for module: stream = 0 label = 'two' id = 5
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: end run for module: stream = 0 label = 'one' id = 3
+++++++ starting: end run for module: stream = 0 label = 'two' id = 5
+++++++ finished: end run for module: stream = 0 label = 'two' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
 ++++ finished: global end run 1 : time = 1000030
@@ -180,10 +176,6 @@
 ++++ finished: end stream for module: stream = 0 label = 'two' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ finished: end stream for module: stream = 0 label = 'getTwo' id = 6
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'p' id = 2
-++++ finished: end stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: end job for module with label 'one' id = 3
 ++++ finished: end job for module with label 'one' id = 3
 ++++ starting: end job for module with label 'getOne' id = 4

--- a/FWCore/Integration/plugins/TestServiceOne.cc
+++ b/FWCore/Integration/plugins/TestServiceOne.cc
@@ -60,9 +60,6 @@ namespace edmtest {
     iRegistry.watchPreBeginProcessBlock(this, &TestServiceOne::preBeginProcessBlock);
     iRegistry.watchPreEndProcessBlock(this, &TestServiceOne::preEndProcessBlock);
 
-    iRegistry.watchPreGlobalBeginRun(this, &TestServiceOne::preGlobalBeginRun);
-    iRegistry.watchPreGlobalEndRun(this, &TestServiceOne::preGlobalEndRun);
-
     iRegistry.watchPreStreamBeginLumi(this, &TestServiceOne::preStreamBeginLumi);
     iRegistry.watchPostStreamBeginLumi(this, &TestServiceOne::postStreamBeginLumi);
     iRegistry.watchPreStreamEndLumi(this, &TestServiceOne::preStreamEndLumi);
@@ -85,6 +82,29 @@ namespace edmtest {
 
     iRegistry.watchPreGlobalWriteLumi(this, &TestServiceOne::preGlobalWriteLumi);
     iRegistry.watchPostGlobalWriteLumi(this, &TestServiceOne::postGlobalWriteLumi);
+
+    iRegistry.watchPreStreamBeginRun(this, &TestServiceOne::preStreamBeginRun);
+    iRegistry.watchPostStreamBeginRun(this, &TestServiceOne::postStreamBeginRun);
+    iRegistry.watchPreStreamEndRun(this, &TestServiceOne::preStreamEndRun);
+    iRegistry.watchPostStreamEndRun(this, &TestServiceOne::postStreamEndRun);
+
+    iRegistry.watchPreModuleStreamBeginRun(this, &TestServiceOne::preModuleStreamBeginRun);
+    iRegistry.watchPostModuleStreamBeginRun(this, &TestServiceOne::postModuleStreamBeginRun);
+    iRegistry.watchPreModuleStreamEndRun(this, &TestServiceOne::preModuleStreamEndRun);
+    iRegistry.watchPostModuleStreamEndRun(this, &TestServiceOne::postModuleStreamEndRun);
+
+    iRegistry.watchPreGlobalBeginRun(this, &TestServiceOne::preGlobalBeginRun);
+    iRegistry.watchPostGlobalBeginRun(this, &TestServiceOne::postGlobalBeginRun);
+    iRegistry.watchPreGlobalEndRun(this, &TestServiceOne::preGlobalEndRun);
+    iRegistry.watchPostGlobalEndRun(this, &TestServiceOne::postGlobalEndRun);
+
+    iRegistry.watchPreModuleGlobalBeginRun(this, &TestServiceOne::preModuleGlobalBeginRun);
+    iRegistry.watchPostModuleGlobalBeginRun(this, &TestServiceOne::postModuleGlobalBeginRun);
+    iRegistry.watchPreModuleGlobalEndRun(this, &TestServiceOne::preModuleGlobalEndRun);
+    iRegistry.watchPostModuleGlobalEndRun(this, &TestServiceOne::postModuleGlobalEndRun);
+
+    iRegistry.watchPreGlobalWriteRun(this, &TestServiceOne::preGlobalWriteRun);
+    iRegistry.watchPostGlobalWriteRun(this, &TestServiceOne::postGlobalWriteRun);
   }
 
   void TestServiceOne::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -104,18 +124,6 @@ namespace edmtest {
   void TestServiceOne::preEndProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preEndProcessBlock";
-    }
-  }
-
-  void TestServiceOne::preGlobalBeginRun(GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalBeginRun";
-    }
-  }
-
-  void TestServiceOne::preGlobalEndRun(GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preGlobalEndRun";
     }
   }
 
@@ -293,6 +301,172 @@ namespace edmtest {
     }
   }
 
+  void TestServiceOne::preStreamBeginRun(StreamContext const& sc) {
+    ++nPreStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::postStreamBeginRun(StreamContext const& sc) {
+    ++nPostStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::preStreamEndRun(StreamContext const& sc) {
+    ++nPreStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::postStreamEndRun(StreamContext const& sc) {
+    ++nPostStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPreModuleStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPostModuleStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPreModuleStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPostModuleStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceOne::preGlobalBeginRun(GlobalContext const& gc) {
+    ++nPreGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::postGlobalBeginRun(GlobalContext const& gc) {
+    ++nPostGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::preGlobalEndRun(GlobalContext const& gc) {
+    ++nPreGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::postGlobalEndRun(GlobalContext const& gc) {
+    ++nPostGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::preGlobalWriteRun(GlobalContext const& gc) {
+    ++nPreGlobalWriteRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preGlobalWriteRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceOne::postGlobalWriteRun(GlobalContext const& gc) {
+    ++nPostGlobalWriteRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postGlobalWriteRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
   unsigned int TestServiceOne::nPreStreamBeginLumi() const { return nPreStreamBeginLumi_.load(); }
   unsigned int TestServiceOne::nPostStreamBeginLumi() const { return nPostStreamBeginLumi_.load(); }
   unsigned int TestServiceOne::nPreStreamEndLumi() const { return nPreStreamEndLumi_.load(); }
@@ -315,6 +489,29 @@ namespace edmtest {
 
   unsigned int TestServiceOne::nPreGlobalWriteLumi() const { return nPreGlobalWriteLumi_.load(); }
   unsigned int TestServiceOne::nPostGlobalWriteLumi() const { return nPostGlobalWriteLumi_.load(); }
+
+  unsigned int TestServiceOne::nPreStreamBeginRun() const { return nPreStreamBeginRun_.load(); }
+  unsigned int TestServiceOne::nPostStreamBeginRun() const { return nPostStreamBeginRun_.load(); }
+  unsigned int TestServiceOne::nPreStreamEndRun() const { return nPreStreamEndRun_.load(); }
+  unsigned int TestServiceOne::nPostStreamEndRun() const { return nPostStreamEndRun_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleStreamBeginRun() const { return nPreModuleStreamBeginRun_.load(); }
+  unsigned int TestServiceOne::nPostModuleStreamBeginRun() const { return nPostModuleStreamBeginRun_.load(); }
+  unsigned int TestServiceOne::nPreModuleStreamEndRun() const { return nPreModuleStreamEndRun_.load(); }
+  unsigned int TestServiceOne::nPostModuleStreamEndRun() const { return nPostModuleStreamEndRun_.load(); }
+
+  unsigned int TestServiceOne::nPreGlobalBeginRun() const { return nPreGlobalBeginRun_.load(); }
+  unsigned int TestServiceOne::nPostGlobalBeginRun() const { return nPostGlobalBeginRun_.load(); }
+  unsigned int TestServiceOne::nPreGlobalEndRun() const { return nPreGlobalEndRun_.load(); }
+  unsigned int TestServiceOne::nPostGlobalEndRun() const { return nPostGlobalEndRun_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleGlobalBeginRun() const { return nPreModuleGlobalBeginRun_.load(); }
+  unsigned int TestServiceOne::nPostModuleGlobalBeginRun() const { return nPostModuleGlobalBeginRun_.load(); }
+  unsigned int TestServiceOne::nPreModuleGlobalEndRun() const { return nPreModuleGlobalEndRun_.load(); }
+  unsigned int TestServiceOne::nPostModuleGlobalEndRun() const { return nPostModuleGlobalEndRun_.load(); }
+
+  unsigned int TestServiceOne::nPreGlobalWriteRun() const { return nPreGlobalWriteRun_.load(); }
+  unsigned int TestServiceOne::nPostGlobalWriteRun() const { return nPostGlobalWriteRun_.load(); }
 }  // namespace edmtest
 
 using edmtest::TestServiceOne;

--- a/FWCore/Integration/plugins/TestServiceOne.h
+++ b/FWCore/Integration/plugins/TestServiceOne.h
@@ -31,9 +31,6 @@ namespace edmtest {
     void preBeginProcessBlock(edm::GlobalContext const&);
     void preEndProcessBlock(edm::GlobalContext const&);
 
-    void preGlobalBeginRun(edm::GlobalContext const&);
-    void preGlobalEndRun(edm::GlobalContext const&);
-
     void preStreamBeginLumi(edm::StreamContext const&);
     void postStreamBeginLumi(edm::StreamContext const&);
     void preStreamEndLumi(edm::StreamContext const&);
@@ -57,6 +54,29 @@ namespace edmtest {
     void preGlobalWriteLumi(edm::GlobalContext const&);
     void postGlobalWriteLumi(edm::GlobalContext const&);
 
+    void preStreamBeginRun(edm::StreamContext const&);
+    void postStreamBeginRun(edm::StreamContext const&);
+    void preStreamEndRun(edm::StreamContext const&);
+    void postStreamEndRun(edm::StreamContext const&);
+
+    void preModuleStreamBeginRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamBeginRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void preModuleStreamEndRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamEndRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalBeginRun(edm::GlobalContext const&);
+    void postGlobalBeginRun(edm::GlobalContext const&);
+    void preGlobalEndRun(edm::GlobalContext const&);
+    void postGlobalEndRun(edm::GlobalContext const&);
+
+    void preModuleGlobalBeginRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalBeginRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void preModuleGlobalEndRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalEndRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalWriteRun(edm::GlobalContext const&);
+    void postGlobalWriteRun(edm::GlobalContext const&);
+
     unsigned int nPreStreamBeginLumi() const;
     unsigned int nPostStreamBeginLumi() const;
     unsigned int nPreStreamEndLumi() const;
@@ -79,6 +99,29 @@ namespace edmtest {
 
     unsigned int nPreGlobalWriteLumi() const;
     unsigned int nPostGlobalWriteLumi() const;
+
+    unsigned int nPreStreamBeginRun() const;
+    unsigned int nPostStreamBeginRun() const;
+    unsigned int nPreStreamEndRun() const;
+    unsigned int nPostStreamEndRun() const;
+
+    unsigned int nPreModuleStreamBeginRun() const;
+    unsigned int nPostModuleStreamBeginRun() const;
+    unsigned int nPreModuleStreamEndRun() const;
+    unsigned int nPostModuleStreamEndRun() const;
+
+    unsigned int nPreGlobalBeginRun() const;
+    unsigned int nPostGlobalBeginRun() const;
+    unsigned int nPreGlobalEndRun() const;
+    unsigned int nPostGlobalEndRun() const;
+
+    unsigned int nPreModuleGlobalBeginRun() const;
+    unsigned int nPostModuleGlobalBeginRun() const;
+    unsigned int nPreModuleGlobalEndRun() const;
+    unsigned int nPostModuleGlobalEndRun() const;
+
+    unsigned int nPreGlobalWriteRun() const;
+    unsigned int nPostGlobalWriteRun() const;
 
   private:
     bool verbose_;
@@ -106,6 +149,29 @@ namespace edmtest {
 
     std::atomic<unsigned int> nPreGlobalWriteLumi_ = 0;
     std::atomic<unsigned int> nPostGlobalWriteLumi_ = 0;
+
+    std::atomic<unsigned int> nPreStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPostStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPreStreamEndRun_ = 0;
+    std::atomic<unsigned int> nPostStreamEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreModuleStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPreModuleStreamEndRun_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPreGlobalEndRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreModuleGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPreModuleGlobalEndRun_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalWriteRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalWriteRun_ = 0;
   };
 }  // namespace edmtest
 #endif

--- a/FWCore/Integration/plugins/TestServiceTwo.cc
+++ b/FWCore/Integration/plugins/TestServiceTwo.cc
@@ -60,9 +60,6 @@ namespace edmtest {
     iRegistry.watchPreBeginProcessBlock(this, &TestServiceTwo::preBeginProcessBlock);
     iRegistry.watchPreEndProcessBlock(this, &TestServiceTwo::preEndProcessBlock);
 
-    iRegistry.watchPreGlobalBeginRun(this, &TestServiceTwo::preGlobalBeginRun);
-    iRegistry.watchPreGlobalEndRun(this, &TestServiceTwo::preGlobalEndRun);
-
     iRegistry.watchPreStreamBeginLumi(this, &TestServiceTwo::preStreamBeginLumi);
     iRegistry.watchPostStreamBeginLumi(this, &TestServiceTwo::postStreamBeginLumi);
     iRegistry.watchPreStreamEndLumi(this, &TestServiceTwo::preStreamEndLumi);
@@ -85,6 +82,29 @@ namespace edmtest {
 
     iRegistry.watchPreGlobalWriteLumi(this, &TestServiceTwo::preGlobalWriteLumi);
     iRegistry.watchPostGlobalWriteLumi(this, &TestServiceTwo::postGlobalWriteLumi);
+
+    iRegistry.watchPreStreamBeginRun(this, &TestServiceTwo::preStreamBeginRun);
+    iRegistry.watchPostStreamBeginRun(this, &TestServiceTwo::postStreamBeginRun);
+    iRegistry.watchPreStreamEndRun(this, &TestServiceTwo::preStreamEndRun);
+    iRegistry.watchPostStreamEndRun(this, &TestServiceTwo::postStreamEndRun);
+
+    iRegistry.watchPreModuleStreamBeginRun(this, &TestServiceTwo::preModuleStreamBeginRun);
+    iRegistry.watchPostModuleStreamBeginRun(this, &TestServiceTwo::postModuleStreamBeginRun);
+    iRegistry.watchPreModuleStreamEndRun(this, &TestServiceTwo::preModuleStreamEndRun);
+    iRegistry.watchPostModuleStreamEndRun(this, &TestServiceTwo::postModuleStreamEndRun);
+
+    iRegistry.watchPreGlobalBeginRun(this, &TestServiceTwo::preGlobalBeginRun);
+    iRegistry.watchPostGlobalBeginRun(this, &TestServiceTwo::postGlobalBeginRun);
+    iRegistry.watchPreGlobalEndRun(this, &TestServiceTwo::preGlobalEndRun);
+    iRegistry.watchPostGlobalEndRun(this, &TestServiceTwo::postGlobalEndRun);
+
+    iRegistry.watchPreModuleGlobalBeginRun(this, &TestServiceTwo::preModuleGlobalBeginRun);
+    iRegistry.watchPostModuleGlobalBeginRun(this, &TestServiceTwo::postModuleGlobalBeginRun);
+    iRegistry.watchPreModuleGlobalEndRun(this, &TestServiceTwo::preModuleGlobalEndRun);
+    iRegistry.watchPostModuleGlobalEndRun(this, &TestServiceTwo::postModuleGlobalEndRun);
+
+    iRegistry.watchPreGlobalWriteRun(this, &TestServiceTwo::preGlobalWriteRun);
+    iRegistry.watchPostGlobalWriteRun(this, &TestServiceTwo::postGlobalWriteRun);
   }
 
   void TestServiceTwo::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -104,18 +124,6 @@ namespace edmtest {
   void TestServiceTwo::preEndProcessBlock(GlobalContext const&) {
     if (verbose_) {
       edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preEndProcessBlock";
-    }
-  }
-
-  void TestServiceTwo::preGlobalBeginRun(GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalBeginRun";
-    }
-  }
-
-  void TestServiceTwo::preGlobalEndRun(GlobalContext const&) {
-    if (verbose_) {
-      edm::LogAbsolute("TestServiceTwo") << "test message from TestServiceTwo::preGlobalEndRun";
     }
   }
 
@@ -293,6 +301,172 @@ namespace edmtest {
     }
   }
 
+  void TestServiceTwo::preStreamBeginRun(StreamContext const& sc) {
+    ++nPreStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::preStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::postStreamBeginRun(StreamContext const& sc) {
+    ++nPostStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::postStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::preStreamEndRun(StreamContext const& sc) {
+    ++nPreStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::preStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::postStreamEndRun(StreamContext const& sc) {
+    ++nPostStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamIndent << "TestServiceTwo::postStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPreModuleStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::preModuleStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPostModuleStreamBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::postModuleStreamBeginRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPreModuleStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::preModuleStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
+    ++nPostModuleStreamEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << streamModuleIndent << "TestServiceTwo::postModuleStreamEndRun " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel()
+          << " run = " << sc.eventID().run();
+    }
+  }
+
+  void TestServiceTwo::preGlobalBeginRun(GlobalContext const& gc) {
+    ++nPreGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::postGlobalBeginRun(GlobalContext const& gc) {
+    ++nPostGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::preGlobalEndRun(GlobalContext const& gc) {
+    ++nPreGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::postGlobalEndRun(GlobalContext const& gc) {
+    ++nPostGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::preModuleGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalBeginRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::postModuleGlobalBeginRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPreModuleGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::preModuleGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
+    ++nPostModuleGlobalEndRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalModuleIndent << "TestServiceTwo::postModuleGlobalEndRun " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel() << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::preGlobalWriteRun(GlobalContext const& gc) {
+    ++nPreGlobalWriteRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::preGlobalWriteRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
+  void TestServiceTwo::postGlobalWriteRun(GlobalContext const& gc) {
+    ++nPostGlobalWriteRun_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceTwo");
+      out << globalIndent << "TestServiceTwo::postGlobalWriteRun " << TimeStamper(printTimestamps_)
+          << " run = " << gc.luminosityBlockID().run();
+    }
+  }
+
   unsigned int TestServiceTwo::nPreStreamBeginLumi() const { return nPreStreamBeginLumi_.load(); }
   unsigned int TestServiceTwo::nPostStreamBeginLumi() const { return nPostStreamBeginLumi_.load(); }
   unsigned int TestServiceTwo::nPreStreamEndLumi() const { return nPreStreamEndLumi_.load(); }
@@ -315,6 +489,29 @@ namespace edmtest {
 
   unsigned int TestServiceTwo::nPreGlobalWriteLumi() const { return nPreGlobalWriteLumi_.load(); }
   unsigned int TestServiceTwo::nPostGlobalWriteLumi() const { return nPostGlobalWriteLumi_.load(); }
+
+  unsigned int TestServiceTwo::nPreStreamBeginRun() const { return nPreStreamBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPostStreamBeginRun() const { return nPostStreamBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPreStreamEndRun() const { return nPreStreamEndRun_.load(); }
+  unsigned int TestServiceTwo::nPostStreamEndRun() const { return nPostStreamEndRun_.load(); }
+
+  unsigned int TestServiceTwo::nPreModuleStreamBeginRun() const { return nPreModuleStreamBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPostModuleStreamBeginRun() const { return nPostModuleStreamBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPreModuleStreamEndRun() const { return nPreModuleStreamEndRun_.load(); }
+  unsigned int TestServiceTwo::nPostModuleStreamEndRun() const { return nPostModuleStreamEndRun_.load(); }
+
+  unsigned int TestServiceTwo::nPreGlobalBeginRun() const { return nPreGlobalBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalBeginRun() const { return nPostGlobalBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPreGlobalEndRun() const { return nPreGlobalEndRun_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalEndRun() const { return nPostGlobalEndRun_.load(); }
+
+  unsigned int TestServiceTwo::nPreModuleGlobalBeginRun() const { return nPreModuleGlobalBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPostModuleGlobalBeginRun() const { return nPostModuleGlobalBeginRun_.load(); }
+  unsigned int TestServiceTwo::nPreModuleGlobalEndRun() const { return nPreModuleGlobalEndRun_.load(); }
+  unsigned int TestServiceTwo::nPostModuleGlobalEndRun() const { return nPostModuleGlobalEndRun_.load(); }
+
+  unsigned int TestServiceTwo::nPreGlobalWriteRun() const { return nPreGlobalWriteRun_.load(); }
+  unsigned int TestServiceTwo::nPostGlobalWriteRun() const { return nPostGlobalWriteRun_.load(); }
 }  // namespace edmtest
 
 using edmtest::TestServiceTwo;

--- a/FWCore/Integration/plugins/TestServiceTwo.h
+++ b/FWCore/Integration/plugins/TestServiceTwo.h
@@ -36,9 +36,6 @@ namespace edmtest {
     void preBeginProcessBlock(edm::GlobalContext const&);
     void preEndProcessBlock(edm::GlobalContext const&);
 
-    void preGlobalBeginRun(edm::GlobalContext const&);
-    void preGlobalEndRun(edm::GlobalContext const&);
-
     void preStreamBeginLumi(edm::StreamContext const&);
     void postStreamBeginLumi(edm::StreamContext const&);
     void preStreamEndLumi(edm::StreamContext const&);
@@ -62,6 +59,29 @@ namespace edmtest {
     void preGlobalWriteLumi(edm::GlobalContext const&);
     void postGlobalWriteLumi(edm::GlobalContext const&);
 
+    void preStreamBeginRun(edm::StreamContext const&);
+    void postStreamBeginRun(edm::StreamContext const&);
+    void preStreamEndRun(edm::StreamContext const&);
+    void postStreamEndRun(edm::StreamContext const&);
+
+    void preModuleStreamBeginRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamBeginRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void preModuleStreamEndRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleStreamEndRun(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalBeginRun(edm::GlobalContext const&);
+    void postGlobalBeginRun(edm::GlobalContext const&);
+    void preGlobalEndRun(edm::GlobalContext const&);
+    void postGlobalEndRun(edm::GlobalContext const&);
+
+    void preModuleGlobalBeginRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalBeginRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void preModuleGlobalEndRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleGlobalEndRun(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+
+    void preGlobalWriteRun(edm::GlobalContext const&);
+    void postGlobalWriteRun(edm::GlobalContext const&);
+
     unsigned int nPreStreamBeginLumi() const;
     unsigned int nPostStreamBeginLumi() const;
     unsigned int nPreStreamEndLumi() const;
@@ -84,6 +104,29 @@ namespace edmtest {
 
     unsigned int nPreGlobalWriteLumi() const;
     unsigned int nPostGlobalWriteLumi() const;
+
+    unsigned int nPreStreamBeginRun() const;
+    unsigned int nPostStreamBeginRun() const;
+    unsigned int nPreStreamEndRun() const;
+    unsigned int nPostStreamEndRun() const;
+
+    unsigned int nPreModuleStreamBeginRun() const;
+    unsigned int nPostModuleStreamBeginRun() const;
+    unsigned int nPreModuleStreamEndRun() const;
+    unsigned int nPostModuleStreamEndRun() const;
+
+    unsigned int nPreGlobalBeginRun() const;
+    unsigned int nPostGlobalBeginRun() const;
+    unsigned int nPreGlobalEndRun() const;
+    unsigned int nPostGlobalEndRun() const;
+
+    unsigned int nPreModuleGlobalBeginRun() const;
+    unsigned int nPostModuleGlobalBeginRun() const;
+    unsigned int nPreModuleGlobalEndRun() const;
+    unsigned int nPostModuleGlobalEndRun() const;
+
+    unsigned int nPreGlobalWriteRun() const;
+    unsigned int nPostGlobalWriteRun() const;
 
   private:
     bool verbose_;
@@ -111,6 +154,29 @@ namespace edmtest {
 
     std::atomic<unsigned int> nPreGlobalWriteLumi_ = 0;
     std::atomic<unsigned int> nPostGlobalWriteLumi_ = 0;
+
+    std::atomic<unsigned int> nPreStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPostStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPreStreamEndRun_ = 0;
+    std::atomic<unsigned int> nPostStreamEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreModuleStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamBeginRun_ = 0;
+    std::atomic<unsigned int> nPreModuleStreamEndRun_ = 0;
+    std::atomic<unsigned int> nPostModuleStreamEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPreGlobalEndRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreModuleGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalBeginRun_ = 0;
+    std::atomic<unsigned int> nPreModuleGlobalEndRun_ = 0;
+    std::atomic<unsigned int> nPostModuleGlobalEndRun_ = 0;
+
+    std::atomic<unsigned int> nPreGlobalWriteRun_ = 0;
+    std::atomic<unsigned int> nPostGlobalWriteRun_ = 0;
   };
 }  // namespace edmtest
 #endif

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -8,12 +8,11 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 
   echo "testGetBy1"
   cmsRun ${LOCAL_TEST_DIR}/${test}1_cfg.py > testGetBy1.log 2>/dev/null || die "cmsRun ${test}1_cfg.py" $?
-  grep -v "LegacyModules" testGetBy1.log > testGetBy1_1.log
-  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log testGetBy1_1.log || die "comparing testGetBy1.log" $?
+  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log testGetBy1.log || die "comparing testGetBy1.log" $?
 
   echo "testGetBy2"
   cmsRun ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log 2>/dev/null || die "cmsRun ${test}2_cfg.py" $?
-  grep -v 'Initiating request to open file\|Successfully opened file\|Closed file\|LegacyModules' testGetBy2.log > testGetBy2_1.log
+  grep -v 'Initiating request to open file\|Successfully opened file\|Closed file' testGetBy2.log > testGetBy2_1.log
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log testGetBy2_1.log || die "comparing testGetBy2.log" $?
 
   echo "testGetBy3"

--- a/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
+++ b/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
@@ -75,6 +75,11 @@ if options.testNumber == 1:
     process.throwException.eventIDThrowOnEvent = cms.untracked.EventID(3, 1, 5)
 elif options.testNumber == 2:
     process.throwException.eventIDThrowOnGlobalBeginRun = cms.untracked.EventID(4, 0, 0)
+    process.throwException.expectedGlobalBeginRun = cms.untracked.uint32(4)
+    process.throwException.expectedOffsetNoGlobalEndRun = cms.untracked.uint32(1)
+    process.throwException.expectedOffsetNoWriteRun = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoGlobalEndRun = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoWriteRun = cms.untracked.uint32(1)
 elif options.testNumber == 3:
     process.throwException.eventIDThrowOnGlobalBeginLumi = cms.untracked.EventID(4, 1, 0)
     process.throwException.expectedGlobalBeginLumi = cms.untracked.uint32(4)
@@ -84,6 +89,9 @@ elif options.testNumber == 3:
     process.doNotThrowException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
 elif options.testNumber == 4:
     process.throwException.eventIDThrowOnGlobalEndRun = cms.untracked.EventID(3, 0, 0)
+    process.throwException.expectedGlobalBeginRun = cms.untracked.uint32(3)
+    process.throwException.expectedOffsetNoWriteRun = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedOffsetNoWriteRun = cms.untracked.uint32(1)
 elif options.testNumber == 5:
     process.throwException.eventIDThrowOnGlobalEndLumi = cms.untracked.EventID(3, 1, 0)
     process.throwException.expectedGlobalBeginLumi = cms.untracked.uint32(3)
@@ -91,6 +99,10 @@ elif options.testNumber == 5:
     process.doNotThrowException.expectedOffsetNoWriteLumi = cms.untracked.uint32(1)
 elif options.testNumber == 6:
     process.throwException.eventIDThrowOnStreamBeginRun = cms.untracked.EventID(4, 0, 0)
+    process.throwException.expectedStreamBeginRun = cms.untracked.uint32(4)
+    process.throwException.expectedOffsetNoStreamEndRun = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedStreamBeginRun = cms.untracked.uint32(4)
+    process.doNotThrowException.expectedOffsetNoStreamEndRun = cms.untracked.uint32(1)
 elif options.testNumber == 7:
     process.throwException.eventIDThrowOnStreamBeginLumi = cms.untracked.EventID(4, 1, 0)
     process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(4)
@@ -99,10 +111,12 @@ elif options.testNumber == 7:
     process.doNotThrowException.expectedOffsetNoStreamEndLumi = cms.untracked.uint32(1)
 elif options.testNumber == 8:
     process.throwException.eventIDThrowOnStreamEndRun = cms.untracked.EventID(3, 0, 0)
+    process.throwException.expectedStreamBeginRun = cms.untracked.uint32(3)
+    process.doNotThrowException.expectedStreamBeginRun = cms.untracked.uint32(3)
 elif options.testNumber == 9:
     process.throwException.eventIDThrowOnStreamEndLumi = cms.untracked.EventID(3, 1, 0)
-    process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(4)
-    process.doNotThrowException.expectedStreamBeginLumi = cms.untracked.uint32(4)
+    process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(3)
+    process.doNotThrowException.expectedStreamBeginLumi = cms.untracked.uint32(3)
 else:
     print("The parameter named testNumber is out of range. An exception will not be thrown. Supported values range from 1 to 9.")
     print("The proper syntax for setting the parameter is:")

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -96,12 +96,8 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'a2' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'a3' id = 6
 ++++ finished: begin stream for module: stream = 0 label = 'a3' id = 6
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 7
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 7
-++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
@@ -319,10 +315,8 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
 ++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -347,8 +341,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -462,10 +458,8 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -490,8 +484,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1193,10 +1189,8 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 12
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1221,8 +1215,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1359,10 +1355,8 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 12
-++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 9
-++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
 ++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -1387,8 +1381,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
-++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
-++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 3
+++++++ starting: end run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ finished: end run for module: stream = 0 label = 'intProducerB' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 12
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 12
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -1695,12 +1691,8 @@ ModuleCallingContext state = Running
 ++++ finished: end stream for module: stream = 0 label = 'a2' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'a3' id = 6
 ++++ finished: end stream for module: stream = 0 label = 'a3' id = 6
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 7
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 7
-++++ starting: end stream for module: stream = 0 label = 'p' id = 2
-++++ finished: end stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 8
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -59,12 +59,8 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 4
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 4
-++++ starting: begin stream for module: stream = 0 label = 'p' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 6
@@ -132,8 +128,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -158,6 +152,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -187,8 +183,6 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -213,6 +207,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -666,8 +662,6 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -692,6 +686,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -730,8 +726,6 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 5
-++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 5
 ++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -756,6 +750,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 5
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -840,12 +836,8 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 4
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 4
-++++ starting: end stream for module: stream = 0 label = 'p' id = 2
-++++ finished: end stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 6

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -162,14 +162,6 @@
 ++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 10
 ++++ starting: begin stream for module: stream = 0 label = 'noPut' id = 11
 ++++ finished: begin stream for module: stream = 0 label = 'noPut' id = 11
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: begin stream for module: stream = 0 label = 'p1' id = 2
-++++ finished: begin stream for module: stream = 0 label = 'p1' id = 2
-++++ starting: begin stream for module: stream = 0 label = 'path1' id = 3
-++++ finished: begin stream for module: stream = 0 label = 'path1' id = 3
-++++ starting: begin stream for module: stream = 0 label = 'path2' id = 4
-++++ finished: begin stream for module: stream = 0 label = 'path2' id = 4
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ starting: begin stream for module: stream = 0 label = 'test' id = 18
@@ -182,18 +174,8 @@
 ++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 21
 ++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 23
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 23
-++++ starting: begin stream for module: stream = 0 label = 'path1' id = 13
-++++ finished: begin stream for module: stream = 0 label = 'path1' id = 13
-++++ starting: begin stream for module: stream = 0 label = 'path2' id = 14
-++++ finished: begin stream for module: stream = 0 label = 'path2' id = 14
-++++ starting: begin stream for module: stream = 0 label = 'path3' id = 15
-++++ finished: begin stream for module: stream = 0 label = 'path3' id = 15
-++++ starting: begin stream for module: stream = 0 label = 'path4' id = 16
-++++ finished: begin stream for module: stream = 0 label = 'path4' id = 16
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: begin stream for module: stream = 0 label = 'test' id = 30
@@ -206,18 +188,8 @@
 ++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 33
 ++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 24
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 24
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 35
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 35
-++++ starting: begin stream for module: stream = 0 label = 'path1' id = 25
-++++ finished: begin stream for module: stream = 0 label = 'path1' id = 25
-++++ starting: begin stream for module: stream = 0 label = 'path2' id = 26
-++++ finished: begin stream for module: stream = 0 label = 'path2' id = 26
-++++ starting: begin stream for module: stream = 0 label = 'path3' id = 27
-++++ finished: begin stream for module: stream = 0 label = 'path3' id = 27
-++++ starting: begin stream for module: stream = 0 label = 'path4' id = 28
-++++ finished: begin stream for module: stream = 0 label = 'path4' id = 28
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ starting: begin process block
@@ -336,12 +308,12 @@
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
@@ -435,12 +407,12 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
@@ -1064,12 +1036,12 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
@@ -1252,12 +1224,12 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
@@ -1881,12 +1853,12 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
@@ -2069,12 +2041,12 @@
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
@@ -2394,12 +2366,12 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
@@ -2507,12 +2479,12 @@
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
@@ -2695,12 +2667,12 @@
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
@@ -2794,12 +2766,12 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
@@ -3423,12 +3395,12 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
@@ -3611,12 +3583,12 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
@@ -4240,12 +4212,12 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
@@ -4428,12 +4400,12 @@
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
@@ -4753,12 +4725,12 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
@@ -4866,12 +4838,12 @@
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
@@ -5054,12 +5026,12 @@
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
@@ -5153,12 +5125,12 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
@@ -5782,12 +5754,12 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
@@ -5970,12 +5942,12 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
@@ -6599,12 +6571,12 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
@@ -6787,12 +6759,12 @@
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
@@ -7112,12 +7084,12 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
@@ -7222,12 +7194,12 @@
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
-++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
-++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 9
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 9
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
@@ -7381,14 +7353,6 @@
 ++++ finished: end stream for module: stream = 0 label = 'getInt' id = 10
 ++++ starting: end stream for module: stream = 0 label = 'noPut' id = 11
 ++++ finished: end stream for module: stream = 0 label = 'noPut' id = 11
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
-++++ starting: end stream for module: stream = 0 label = 'p1' id = 2
-++++ finished: end stream for module: stream = 0 label = 'p1' id = 2
-++++ starting: end stream for module: stream = 0 label = 'path1' id = 3
-++++ finished: end stream for module: stream = 0 label = 'path1' id = 3
-++++ starting: end stream for module: stream = 0 label = 'path2' id = 4
-++++ finished: end stream for module: stream = 0 label = 'path2' id = 4
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ starting: end stream for module: stream = 0 label = 'test' id = 18
@@ -7401,18 +7365,8 @@
 ++++ finished: end stream for module: stream = 0 label = 'getInt' id = 21
 ++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 12
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 12
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 23
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 23
-++++ starting: end stream for module: stream = 0 label = 'path1' id = 13
-++++ finished: end stream for module: stream = 0 label = 'path1' id = 13
-++++ starting: end stream for module: stream = 0 label = 'path2' id = 14
-++++ finished: end stream for module: stream = 0 label = 'path2' id = 14
-++++ starting: end stream for module: stream = 0 label = 'path3' id = 15
-++++ finished: end stream for module: stream = 0 label = 'path3' id = 15
-++++ starting: end stream for module: stream = 0 label = 'path4' id = 16
-++++ finished: end stream for module: stream = 0 label = 'path4' id = 16
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: end stream for module: stream = 0 label = 'test' id = 30
@@ -7425,18 +7379,8 @@
 ++++ finished: end stream for module: stream = 0 label = 'getInt' id = 33
 ++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 24
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 24
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 35
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 35
-++++ starting: end stream for module: stream = 0 label = 'path1' id = 25
-++++ finished: end stream for module: stream = 0 label = 'path1' id = 25
-++++ starting: end stream for module: stream = 0 label = 'path2' id = 26
-++++ finished: end stream for module: stream = 0 label = 'path2' id = 26
-++++ starting: end stream for module: stream = 0 label = 'path3' id = 27
-++++ finished: end stream for module: stream = 0 label = 'path3' id = 27
-++++ starting: end stream for module: stream = 0 label = 'path4' id = 28
-++++ finished: end stream for module: stream = 0 label = 'path4' id = 28
 ++++ starting: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ finished: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ starting: end job for module with label 'get' id = 6

--- a/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
@@ -5,6 +5,9 @@ namespace edm {
   class ActivityRegistry;
   class GlobalContext;
   class ModuleCallingContext;
+  class ParentContext;
+  class ProcessContext;
+  class ServiceToken;
   class StreamContext;
 }  // namespace edm
 #endif

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -2,6 +2,7 @@
 #include "Mixing/Base/src/SecondaryEventProvider.h"
 #include "FWCore/Common/interface/ProcessBlockHelper.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
+#include "FWCore/Framework/interface/ExceptionHelpers.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Improve the behavior of the Framework after exceptions in Run begin/end stream/global transitions. This is the third in a series of PRs where we plan to make the behavior after exceptions more consistent in all the begin/end transitions. The first PR handled stream begin/end lumi exceptions (PR #44624). The second PR handled global begin/end lumi exceptions (PR #44840). The comments at the head of the first PR state the design for this behavior we are implementing.

The intent is that nothing in the output will change if there are not any exceptions. The order of modules in begin/end stream transitions may change, although in existing releases these functions are run asynchronously and the order can vary if an identical configuration is repeated in multi-threaded jobs. It is a problem already if something depends on that order.

Another minor change in behavior is that signals pre/post for beginStream and endStream will no longer be issued for trigger results inserter, path status inserters, and end path status inserters. These modules don't do anything in those transitions. I examined the services watching those signals and cannot see any reason for those signals to be emitted.

This work was motivated by discussions related to Issues #43831 and #42501.

The most complicated detail in this PR is that instead of each StreamSchedule having one WorkerManager, each StreamSchedule will have 3, one for lumis/events, one for runs, and one for beginStream/endStream. Although I intend
to address the beginStream/endStream transitions in the next PR, I went ahead and converted them to use a different WorkerManager because I didn't want to have to modify that complex part of the code twice.

#### PR validation:

An existing unit test covering exceptions in different transitions is extended to cover the most salient cases. Additional manual testing of many various cases was also done. Existing unit tests pass.
