### PR TITLE
VertexFinder: Fix unused variable warnings

### DIFF
--- a/L1Trigger/VertexFinder/src/VertexFinder.cc
+++ b/L1Trigger/VertexFinder/src/VertexFinder.cc
@@ -762,7 +762,6 @@ namespace l1tVertexFinder {
   void VertexFinder::fastHistoEmulation() {
     // Relevant constants for the track word
     static constexpr int kZ0Size = 12,  // Width of z-position (40cm / 0.1)
-        kZ0MagSize = 5,                 // Width of z-position magnitude (signed)
         kPtSize = 14,                   // Width of pt
         kPtMagSize = 9,                 // Width of pt magnitude (unsigned)
         kReducedPrecisionPt = 7         // Width of the reduced precision, integer only, pt


### PR DESCRIPTION
Remove unused variable https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_X_2024-05-21-2300/L1Trigger/VertexFinder
```
  src/L1Trigger/VertexFinder/src/VertexFinder.cc:765:9: warning: unused variable 'kZ0MagSize' [-Wunused-variable]
   765 |         kZ0MagSize = 5,                 // Width of z-position magnitude (signed)

```