### PR TITLE
AMPTInterface: Fix used uninitialized warnings

### DIFF
--- a/GeneratorInterface/AMPTInterface/src/hipyset1.35.f
+++ b/GeneratorInterface/AMPTInterface/src/hipyset1.35.f
@@ -500,6 +500,8 @@ C...to collapse into one or two particles and to check flavours.
     
 C...Rearrange parton shower product listing along strings: begin loop.  
       I1=N  
+      DO 101 J=1,5
+  101 DPC(J)=0
       DO 130 MQGST=1,2  
       DO 120 I=MAX(1,IP),N  
       IF(K(I,1).NE.3) GOTO 120  
@@ -3459,6 +3461,11 @@ C...Initialization of cutoff masses etc.
       PT2MIN=MAX(0.5*PARJ(82),1.1*PARJ(81))**2  
       ALAMS=PARJ(81)**2 
       ALFM=LOG(PT2MIN/ALAMS)    
+      DO 101 I=1,4
+      ISI(I)=0
+      IPA(I)=0
+      KFLD(I)=0
+  101 CONTINUE
     
 C...Store positions of shower initiating partons.   
       M3JC=0    
@@ -9582,6 +9589,8 @@ C...Start iteration to find k factor.
         XI=0.   
         YI=0.   
         XK=0.5  
+        XF=1.
+        YF=1.
         IIT=0   
   130   IF(IIT.EQ.0) THEN   
           XK=2.*XK  
@@ -9877,6 +9886,9 @@ C...Add second parton to event record.
     
         IF(RFLAV.LT.PARP(85).AND.NSTR.GE.1) THEN    
 C....Choose relevant string pieces to place gluons on.  
+          IST1=0
+          IST2=0
+          ISTM=0
           DO 210 I=N+1,N+2  
           DMIN=1E8  
           DO 200 ISTR=1,NSTR    
@@ -11248,6 +11260,7 @@ C...H0 -> g + g; quark loop contribution only
 C...H0 -> gamma + gamma; quark, charged lepton and W loop contributions 
           ETARE=0.  
           ETAIM=0.  
+          EJ=0.
           DO 150 J=1,3*MSTP(1)+1    
           IF(J.LE.2*MSTP(1)) THEN   
             EJ=KCHG(J,1)/3. 
@@ -11289,7 +11302,9 @@ C...H0 -> gamma + gamma; quark, charged lepton and W loop contributions
         ELSEIF(I.EQ.15) THEN    
 C...H0 -> gamma + Z0; quark, charged lepton and W loop contributions    
           ETARE=0.  
-          ETAIM=0.  
+          ETAIM=0.
+          VJ=0.
+          EJ=0.  
           DO 160 J=1,3*MSTP(1)+1    
           IF(J.LE.2*MSTP(1)) THEN   
             EJ=KCHG(J,1)/3. 
@@ -11304,7 +11319,7 @@ C...H0 -> gamma + Z0; quark, charged lepton and W loop contributions
             VJ=AJ-4.*EJ*XW  
             EPS=(2.*PMAS(10+JL,1)/RMAS)**2  
             EPSP=(2.*PMAS(10+JL,1)/PMAS(23,1))**2   
-          ELSE  
+          ELSE
             EPS=(2.*PMAS(24,1)/RMAS)**2 
             EPSP=(2.*PMAS(24,1)/PMAS(23,1))**2  
           ENDIF 


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/44913
Fixes `used uninitialized variable` warnings reported by enabling `-O3` [GEANT4 IBs](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_GEANT4_X_2024-05-22-1100/GeneratorInterface/AMPTInterface) and GCC13 #44913)
```
src/GeneratorInterface/AMPTInterface/src/hipyset1.35.f:11352:72:

11352 |             ETARE=ETARE-3.*EJ*VJ*(FXYRE-0.25*F1RE)
      |                                                                        ^
  Warning: 'vj' may be used uninitialized [-Wmaybe-uninitialized]
 src/GeneratorInterface/AMPTInterface/src/hipyset1.35.f:11297:14:

11297 |             VJ=AJ-4.*EJ*XW
      |              ^
note: 'vj' was declared here
src/GeneratorInterface/AMPTInterface/src/hipyset1.35.f:11276:72:

11276 |             ETARE=ETARE+0.5*3.*EJ**2*EPS*(1.+(EPS-1.)*PHIRE)
      |                                                                        ^
  Warning: 'ej' may be used uninitialized [-Wmaybe-uninitialized]
 src/GeneratorInterface/AMPTInterface/src/hipyset1.35.f:11253:14:

11253 |             EJ=KCHG(J,1)/3.
      |              ^
note: 'ej' was declared here

```