### PR TITLE
Add new dEdx calibration condition format

### DIFF
--- a/CondCore/PhysicsToolsPlugins/src/plugin.cc
+++ b/CondCore/PhysicsToolsPlugins/src/plugin.cc
@@ -17,6 +17,8 @@
 #include "CondFormats/DataRecord/interface/SiStripDeDxKaon_3D_Rcd.h"
 #include "CondFormats/DataRecord/interface/SiStripDeDxElectron_3D_Rcd.h"
 
+#include "CondFormats/DataRecord/interface/DeDxCalibrationRcd.h"
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
 #include "CondFormats/DataRecord/interface/PhysicsTFormulaPayloadRcd.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
 #include "CondFormats/DataRecord/interface/PhysicsTGraphPayloadRcd.h"
@@ -29,6 +31,7 @@
 
 REGISTER_PLUGIN(DropBoxMetadataRcd, DropBoxMetadata);
 
+REGISTER_PLUGIN(DeDxCalibrationRcd, DeDxCalibration);
 REGISTER_PLUGIN(SiStripDeDxMipRcd, PhysicsTools::Calibration::HistogramD2D);
 REGISTER_PLUGIN(SiStripDeDxMip_3D_Rcd, PhysicsTools::Calibration::HistogramD3D);
 REGISTER_PLUGIN_NO_SERIAL(SiStripDeDxProton_3D_Rcd, PhysicsTools::Calibration::HistogramD3D);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -46,6 +46,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   PAYLOAD_2XML_CLASS(CastorRecoParams);
   PAYLOAD_2XML_CLASS(CastorSaturationCorrs);
   PAYLOAD_2XML_CLASS(CentralityTable);
+  PAYLOAD_2XML_CLASS(DeDxCalibration);
   PAYLOAD_2XML_CLASS(DTCCBConfig);
   PAYLOAD_2XML_CLASS(DTDeadFlag);
   PAYLOAD_2XML_CLASS(DTHVStatus);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -70,6 +70,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(CastorRecoParams)
       FETCH_PAYLOAD_CASE(CastorSaturationCorrs)
       FETCH_PAYLOAD_CASE(CentralityTable)
+      FETCH_PAYLOAD_CASE(DeDxCalibration)
       FETCH_PAYLOAD_CASE(DTCCBConfig)
       FETCH_PAYLOAD_CASE(DTDeadFlag)
       FETCH_PAYLOAD_CASE(DTHVStatus)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -90,6 +90,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(CastorRecoParams)
         IMPORT_PAYLOAD_CASE(CastorSaturationCorrs)
         IMPORT_PAYLOAD_CASE(CentralityTable)
+        IMPORT_PAYLOAD_CASE(DeDxCalibration)
         IMPORT_PAYLOAD_CASE(DTCCBConfig)
         IMPORT_PAYLOAD_CASE(DTDeadFlag)
         IMPORT_PAYLOAD_CASE(DTHVStatus)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -282,6 +282,7 @@
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyList.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayload.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"

--- a/CondFormats/DataRecord/interface/DeDxCalibrationRcd.h
+++ b/CondFormats/DataRecord/interface/DeDxCalibrationRcd.h
@@ -1,0 +1,6 @@
+#ifndef CondFormats_DataRecord_DeDxCalibrationRcd_h
+#define CondFormats_DataRecord_DeDxCalibrationRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+class DeDxCalibrationRcd : public edm::eventsetup::EventSetupRecordImplementation<DeDxCalibrationRcd> {};
+#endif

--- a/CondFormats/DataRecord/src/DeDxCalibrationRcd.cc
+++ b/CondFormats/DataRecord/src/DeDxCalibrationRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/DeDxCalibrationRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DeDxCalibrationRcd);

--- a/CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h
+++ b/CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h
@@ -1,0 +1,36 @@
+#ifndef CondFormats_PhysicsToolsObjects_DeDxCalibration_h
+#define CondFormats_PhysicsToolsObjects_DeDxCalibration_h
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <vector>
+class DeDxCalibration {
+public:
+  DeDxCalibration();
+  virtual ~DeDxCalibration() {}
+
+  typedef std::pair<uint32_t, unsigned char> ChipId;
+  DeDxCalibration(const std::vector<double>& thr,
+                  const std::vector<double>& alpha,
+                  const std::vector<double>& sigma,
+                  const std::map<ChipId, float>& gain)
+      : thr_(thr), alpha_(alpha), sigma_(sigma), gain_(gain){};
+
+  const std::vector<double>& thr() const { return thr_; }
+  const std::vector<double>& alpha() const { return alpha_; }
+  const std::vector<double>& sigma() const { return sigma_; }
+  const std::map<ChipId, float>& gain() const { return gain_; }
+
+  void setThr(const std::vector<double>& v) { thr_ = v; }
+  void setAlpha(const std::vector<double>& v) { alpha_ = v; }
+  void setSigma(const std::vector<double>& v) { sigma_ = v; }
+  void setGain(const std::map<ChipId, float>& v) { gain_ = v; }
+
+private:
+  std::vector<double> thr_;
+  std::vector<double> alpha_;
+  std::vector<double> sigma_;
+  std::map<ChipId, float> gain_;
+
+  COND_SERIALIZABLE;
+};
+#endif

--- a/CondFormats/PhysicsToolsObjects/src/DeDxCalibration.cc
+++ b/CondFormats/PhysicsToolsObjects/src/DeDxCalibration.cc
@@ -1,0 +1,6 @@
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
+DeDxCalibration::DeDxCalibration() {
+  thr_.reserve(5);
+  alpha_.reserve(5);
+  sigma_.reserve(5);
+}

--- a/CondFormats/PhysicsToolsObjects/src/T_EventSetup_DeDx.cc
+++ b/CondFormats/PhysicsToolsObjects/src/T_EventSetup_DeDx.cc
@@ -1,0 +1,4 @@
+#include "FWCore/Utilities/interface/typelookup.h"
+
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
+TYPELOOKUP_DATA_REG(DeDxCalibration);

--- a/CondFormats/PhysicsToolsObjects/src/headers.h
+++ b/CondFormats/PhysicsToolsObjects/src/headers.h
@@ -1,3 +1,4 @@
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram2D.h"
 #include "CondFormats/PhysicsToolsObjects/interface/Histogram3D.h"

--- a/CondTools/DeDx/plugins/BuildFile.xml
+++ b/CondTools/DeDx/plugins/BuildFile.xml
@@ -1,0 +1,8 @@
+<export>
+</export>
+<library name="CondToolsDeDxplugins" file="*.cc">
+  <use name="CondFormats/PhysicsToolsObjects"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="CondCore/DBOutputService"/>
+</library>

--- a/CondTools/DeDx/plugins/DeDxCalibrationDbCreator.cc
+++ b/CondTools/DeDx/plugins/DeDxCalibrationDbCreator.cc
@@ -1,0 +1,122 @@
+// system include files
+#include <iostream>
+#include <fstream>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CondFormats/DataRecord/interface/DeDxCalibrationRcd.h"
+#include "CondFormats/PhysicsToolsObjects/interface/DeDxCalibration.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+
+class DeDxCalibrationDbCreator : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  typedef std::pair<uint32_t, unsigned char> ChipId;
+  enum AllDetector { PXB = 0, PXF = 1, TIB = 2, TID = 3, TOB = 4, TECThin = 5, TECThick = 6, nDets };
+
+  explicit DeDxCalibrationDbCreator(const edm::ParameterSet&);
+  ~DeDxCalibrationDbCreator() override{};
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override{};
+
+  void readStripProps(std::vector<double>&, std::vector<double>&, std::vector<double>&);
+  void readGainCorrection(std::map<ChipId, float>&);
+
+  const std::string propFile_, gainFile_;
+};
+
+DeDxCalibrationDbCreator::DeDxCalibrationDbCreator(const edm::ParameterSet& iConfig)
+    : propFile_(iConfig.getParameter<std::string>("propFile")),
+      gainFile_(iConfig.getParameter<std::string>("gainFile")) {}
+
+void DeDxCalibrationDbCreator::beginJob() {
+  std::map<ChipId, float> gain;
+  std::vector<double> thr, alpha, sigma;
+  readStripProps(thr, alpha, sigma);
+  readGainCorrection(gain);
+  DeDxCalibration TD(thr, alpha, sigma, gain);
+
+  edm::Service<cond::service::PoolDBOutputService> pool;
+  if (pool.isAvailable())
+    pool->writeOneIOV(TD, pool->beginOfTime(), "DeDxCalibrationRcd");
+}
+
+/*****************************************************************************/
+void DeDxCalibrationDbCreator::readStripProps(std::vector<double>& thr,
+                                              std::vector<double>& alpha,
+                                              std::vector<double>& sigma) {
+  std::cout << " reading strip properties from " << propFile_;
+  std::ifstream file(edm::FileInPath(propFile_).fullPath());
+
+  int det;
+  for (det = PXB; det <= PXF; det++) {
+    thr.emplace_back(0.);
+    alpha.emplace_back(0.);
+    sigma.emplace_back(0.);
+  }
+
+  while (!file.eof()) {
+    std::string detName;
+    float f;
+
+    file >> detName;
+    file >> f;
+    thr.emplace_back(f);
+    file >> f;
+    alpha.emplace_back(f);
+    file >> f;
+    sigma.emplace_back(f);
+
+    det++;
+  }
+
+  file.close();
+  std::cout << " [done]" << std::endl;
+}
+
+/*****************************************************************************/
+void DeDxCalibrationDbCreator::readGainCorrection(std::map<ChipId, float>& gain) {
+  std::cout << " reading gain from " << gainFile_;
+  std::ifstream fileGain(edm::FileInPath(gainFile_).fullPath());
+
+  int i = 0;
+  while (!fileGain.eof()) {
+    uint32_t det;
+    int chip;
+
+    int d;
+    float g, f;
+    std::string s;
+
+    fileGain >> std::hex >> det;
+    fileGain >> std::dec >> chip;
+
+    ChipId detId(det, (unsigned char)chip);
+
+    fileGain >> std::dec >> d;
+    fileGain >> g;
+    fileGain >> f;
+    fileGain >> s;
+
+    if (!fileGain.eof()) {
+      if (g > 0.5 && g < 2.0)
+        gain[detId] = g;
+      else
+        gain[detId] = -1.;
+    }
+
+    if (i++ % 5000 == 0)
+      std::cout << ".";
+  }
+
+  fileGain.close();
+  std::cout << " [done]" << std::endl;
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(DeDxCalibrationDbCreator);

--- a/CondTools/DeDx/test/dedxCalibrationDbCreation.py
+++ b/CondTools/DeDx/test/dedxCalibrationDbCreation.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+tagger = "dedxCalibration"
+db_file = f'{tagger}.db'
+
+process = cms.Process("DeDxCalibCreator")
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = 'sqlite_file:' + db_file
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(1),
+)
+
+process.source = cms.Source("EmptySource")
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    process.CondDB,
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string("DeDxCalibrationRcd"),
+            tag = cms.string(tagger),
+            label = cms.string(""),
+        ),
+    )
+)
+
+process.dbCreator = cms.EDAnalyzer("DeDxCalibrationDbCreator",
+    propFile = cms.string("stripProps.par"),
+    gainFile = cms.string("gain.dat")
+)
+
+process.p = cms.Path(
+    process.dbCreator
+)


### PR DESCRIPTION
#### PR description:

This PR adds a new dEdx condition format for dEdx gain calibrations meant for the 2024 PbPb UPC reco. It includes a new condition format DeDxCalibration to store the pixel/strip chip-level gain calibrations and strip detector properties (threshold t, coupling α and standard deviation σ of the Gaussian noise derived from data) and a producer DeDxCalibrationDbCreator to derive the calibration database files.

The details of the dEdx calibration for 2023 PbPb UPC are documented in [results](https://mattermost.web.cern.ch/files/4nmdmxc9t78rzegzauypsmtrqa/public?h=18Plo_V7jlY5LjDWvJYhTAMOw482S3AFI-BZChE_NEo) and in the CADI [HIN-12-016](https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=HIN-12-016&tp=an&id=1021&ancode=HIN-12-016).

This PR is needed for https://github.com/cms-sw/cmssw/pull/45016

@mandrenguyen @sikler

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
