### PR TITLE
Disabled ROCs for Online DQM Pixel Summary (BP)

### DIFF
--- a/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
+++ b/DQM/SiPixelPhase1Summary/src/SiPixelPhase1Summary.cc
@@ -272,6 +272,7 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
   //Fill the dead ROC summary
   std::vector<trendPlots> trendOrder = {layer1, layer2, layer3, layer4, ring1, ring2};
   std::vector<int> nRocsPerTrend = {1536, 3584, 5632, 8192, 4224, 6528};
+  std::vector<int> nDisabledRocs = {12, 128, 240, 320, 96, 120};
   for (unsigned int i = 0; i < trendOrder.size(); i++) {
     int xBin = i < 4 ? 1 : 2;
     int yBin = i % 4 + 1;
@@ -321,7 +322,9 @@ void SiPixelPhase1Summary::fillSummaries(DQMStore::IBooker& iBooker, DQMStore::I
     // Filled ROCs = Total number - dead ROCs
     numFilledROCs = nRocsPerTrend[i] - numDeadROCs;
     //Fill with fraction of filled ROCs (with digis)
-    fracFilledROCs = numFilledROCs / nRocsPerTrend[i];
+    fracFilledROCs = numFilledROCs / (nRocsPerTrend[i] - nDisabledRocs[i]);
+    if (fracFilledROCs > 1)
+      fracFilledROCs = 1;
     deadROCSummary->setBinContent(xBin, yBin, fracFilledROCs);
     deadROCSummary->setBinContent(2, 3, -1);
     deadROCSummary->setBinContent(2, 4, -1);


### PR DESCRIPTION
Exclude disabled ROCs when calculating the fraction of "good" ROCs for the Online DQM Pixel Summary map.

#### PR validation:

Data produced with cmsRun on [recent 2024 pp run 380400](https://cmsoms.cern.ch/cms/runs/report?cms_run=380400):

cmsRun DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py dataset=/ZeroBias/Run2024D-v1/RAW runNumber=380400

Results available in [private GUI](http://provola.cern.ch:8070/dqm/online-dev/start?runnr=380400;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=PixelPhase1;size=M;root=PixelPhase1/Layouts;focus=PixelPhase1/EventInfo/reportSummaryMap;zoom=yes;)

#### About backport
This is a backport to 14_0_X of https://github.com/cms-sw/cmssw/pull/45026