### PR TITLE
RPCDigis validaiton module update

### DIFF
--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -27,15 +27,22 @@ protected:
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
 
 private:
-  MonitorElement *xyview;
-  MonitorElement *rzview;
+  // RZ and XY views
+  MonitorElement *hRZ_;
+
+  MonitorElement *hXY_Barrel_;
+  std::map<int, MonitorElement *> hXY_Endcap_;
+
+  // Strip profile
+  MonitorElement *hStripProf;
+  MonitorElement *hStripProf_RB12_, *hStripProf_RB34_;
+  MonitorElement *hStripProf_Endcap_, *hStripProf_IRPC_;
+
+  // Bunch crossing distributions
   MonitorElement *BxDist;
-  MonitorElement *StripProf;
 
   MonitorElement *BxDisc_4Plus;
   MonitorElement *BxDisc_4Min;
-  MonitorElement *xyvDplu4;
-  MonitorElement *xyvDmin4;
 
   // Timing information
   MonitorElement *hDigiTimeAll, *hDigiTime, *hDigiTimeIRPC, *hDigiTimeNoIRPC;

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -32,7 +32,7 @@ private:
 
   MonitorElement *hXY_Barrel_;
   std::map<int, MonitorElement *> hXY_Endcap_;  // X-Y plots for Endcap, by station
-  std::map<int, MonitorElement *> hRPhi_;       // R-phi plots for Barrel, by layers
+  std::map<int, MonitorElement *> hZPhi_;       // R-phi plots for Barrel, by layers
 
   // Strip profile
   MonitorElement *hStripProf_;

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -47,6 +47,16 @@ private:
   // Timing information
   MonitorElement *hDigiTimeAll_, *hDigiTime_, *hDigiTimeIRPC_, *hDigiTimeNoIRPC_;
 
+  // Multiplicity plots
+  MonitorElement *hNSimHitPerRoll_, *hNDigiPerRoll_;
+
+  // Residual plots
+  MonitorElement *hRes_;
+  std::map<int, MonitorElement *> hResBarrelLayers_;
+  std::map<int, MonitorElement *> hResBarrelWheels_;
+  std::map<int, MonitorElement *> hResEndcapDisks_;
+  std::map<int, MonitorElement *> hResEndcapRings_;
+
   // Tokens for accessing run data. Used for passing to edm::Event. - stanislav
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
   edm::EDGetTokenT<RPCDigiCollection> rpcDigiToken_;

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -34,18 +34,17 @@ private:
   std::map<int, MonitorElement *> hXY_Endcap_;
 
   // Strip profile
-  MonitorElement *hStripProf;
+  MonitorElement *hStripProf_;
   MonitorElement *hStripProf_RB12_, *hStripProf_RB34_;
   MonitorElement *hStripProf_Endcap_, *hStripProf_IRPC_;
 
   // Bunch crossing distributions
-  MonitorElement *BxDist;
-
-  MonitorElement *BxDisc_4Plus;
-  MonitorElement *BxDisc_4Min;
+  MonitorElement *hBxDist_;
+  MonitorElement *hBxDisc_4Plus_;
+  MonitorElement *hBxDisc_4Min_;
 
   // Timing information
-  MonitorElement *hDigiTimeAll, *hDigiTime, *hDigiTimeIRPC, *hDigiTimeNoIRPC;
+  MonitorElement *hDigiTimeAll_, *hDigiTime_, *hDigiTimeIRPC_, *hDigiTimeNoIRPC_;
 
   // Tokens for accessing run data. Used for passing to edm::Event. - stanislav
   edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -20,7 +20,7 @@
 class RPCDigiValid : public DQMEDAnalyzer {
 public:
   RPCDigiValid(const edm::ParameterSet &ps);
-  ~RPCDigiValid() override;
+  ~RPCDigiValid() override = default;
 
 protected:
   void analyze(const edm::Event &e, const edm::EventSetup &c) override;
@@ -29,47 +29,9 @@ protected:
 private:
   MonitorElement *xyview;
   MonitorElement *rzview;
-  MonitorElement *Res;
-  MonitorElement *ResWmin2;
-  MonitorElement *ResWmin1;
-  MonitorElement *ResWzer0;
-  MonitorElement *ResWplu1;
-  MonitorElement *ResWplu2;
   MonitorElement *BxDist;
   MonitorElement *StripProf;
 
-  // barrel layers residuals
-  MonitorElement *ResLayer1_barrel;
-  MonitorElement *ResLayer2_barrel;
-  MonitorElement *ResLayer3_barrel;
-  MonitorElement *ResLayer4_barrel;
-  MonitorElement *ResLayer5_barrel;
-  MonitorElement *ResLayer6_barrel;
-
-  // members for EndCap's disks:
-  MonitorElement *ResDmin1;
-  MonitorElement *ResDmin2;
-  MonitorElement *ResDmin3;
-  MonitorElement *ResDplu1;
-  MonitorElement *ResDplu2;
-  MonitorElement *ResDplu3;
-
-  // endcap layters residuals
-  MonitorElement *Res_Endcap1_Ring2_A;
-  MonitorElement *Res_Endcap1_Ring2_B;
-  MonitorElement *Res_Endcap1_Ring2_C;
-
-  MonitorElement *Res_Endcap23_Ring2_A;
-  MonitorElement *Res_Endcap23_Ring2_B;
-  MonitorElement *Res_Endcap23_Ring2_C;
-
-  MonitorElement *Res_Endcap123_Ring3_A;
-  MonitorElement *Res_Endcap123_Ring3_B;
-  MonitorElement *Res_Endcap123_Ring3_C;
-
-  // 4 endcap
-  MonitorElement *ResDmin4;
-  MonitorElement *ResDplu4;
   MonitorElement *BxDisc_4Plus;
   MonitorElement *BxDisc_4Min;
   MonitorElement *xyvDplu4;
@@ -78,12 +40,9 @@ private:
   // Timing information
   MonitorElement *hDigiTimeAll, *hDigiTime, *hDigiTimeIRPC, *hDigiTimeNoIRPC;
 
-  std::string outputFile_;
-  std::string digiLabel;
-
   // Tokens for accessing run data. Used for passing to edm::Event. - stanislav
-  edm::EDGetTokenT<edm::PSimHitContainer> simHitToken;
-  edm::EDGetTokenT<RPCDigiCollection> rpcDigiToken;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitToken_;
+  edm::EDGetTokenT<RPCDigiCollection> rpcDigiToken_;
 
   edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 };

--- a/Validation/MuonRPCDigis/interface/RPCDigiValid.h
+++ b/Validation/MuonRPCDigis/interface/RPCDigiValid.h
@@ -31,7 +31,8 @@ private:
   MonitorElement *hRZ_;
 
   MonitorElement *hXY_Barrel_;
-  std::map<int, MonitorElement *> hXY_Endcap_;
+  std::map<int, MonitorElement *> hXY_Endcap_;  // X-Y plots for Endcap, by station
+  std::map<int, MonitorElement *> hRPhi_;       // R-phi plots for Barrel, by layers
 
   // Strip profile
   MonitorElement *hStripProf_;

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -59,7 +59,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
 
       auto match = hZPhi_.find(stla);
       if (match != hZPhi_.end()) {
-        const double phiInDeg = gp.phi() / TMath::Pi() * 180;
+        const double phiInDeg = 180. * gp.barePhi() / TMath::Pi();
         match->second->Fill(gp.z(), phiInDeg);
       }
     } else {

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -38,38 +38,22 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   event.getByToken(rpcDigiToken_, rpcDigisHandle);
 
   // loop over Simhit
-  std::map<RPCDetId, std::vector<double>> allsims;
-
   for (auto simIt = simHitHandle->begin(); simIt != simHitHandle->end(); ++simIt) {
-    RPCDetId Rsid = simIt->detUnitId();
-    const RPCRoll *soll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
-    if (!soll) continue;
-    const int ptype = simIt->particleType();
+    const RPCDetId Rsid = simIt->detUnitId();
+    const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
+    if (!roll)
+      continue;
 
-    if (ptype == 13 || ptype == -13) {
-      std::vector<double> buff;
-      if (allsims.find(Rsid) != allsims.end()) {
-        buff = allsims[Rsid];
-      }
-
-      buff.push_back(simIt->localPosition().x());
-
-      allsims[Rsid] = buff;
-    }
-    const GlobalPoint p = soll->toGlobal(simIt->localPosition());
-
-    const double sim_x = p.x();
-    const double sim_y = p.y();
-
-    xyview->Fill(sim_x, sim_y);
+    const GlobalPoint p = roll->toGlobal(simIt->localPosition());
+    xyview->Fill(p.x(), p.y());
 
     if (Rsid.region() == (+1)) {
       if (Rsid.station() == 4) {
-        xyvDplu4->Fill(sim_x, sim_y);
+        xyvDplu4->Fill(p.x(), p.y());
       }
     } else if (Rsid.region() == (-1)) {
       if (Rsid.station() == 4) {
-        xyvDmin4->Fill(sim_x, sim_y);
+        xyvDmin4->Fill(p.x(), p.y());
       }
     }
     rzview->Fill(p.z(), p.perp());
@@ -78,12 +62,10 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   for (auto detUnitIt = rpcDigisHandle->begin(); detUnitIt != rpcDigisHandle->end(); ++detUnitIt) {
     const RPCDetId Rsid = (*detUnitIt).first;
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
+    if (!roll)
+      continue;
 
     const RPCDigiCollection::Range &range = (*detUnitIt).second;
-    std::vector<double> sims;
-    if (allsims.find(Rsid) != allsims.end()) {
-      sims = allsims[Rsid];
-    }
 
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
       StripProf->Fill(digiIt->strip());

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -139,15 +139,15 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   const int nbinsBarrelZ = 140;  // bin width: 10cm
 
   // RZ plot
-  hRZ_ = booker.book2D("RZ", "RZ;Z (cm);R (cm)", nbinsZ, -maxZ, maxZ, nbinsR, minR, maxR);
+  hRZ_ = booker.book2D("RZ", "R-Z view;Z (cm);R (cm)", nbinsZ, -maxZ, maxZ, nbinsR, minR, maxR);
 
   // XY plots
-  hXY_Barrel_ = booker.book2D("XY_Barrel", "XY_Barrel", nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
+  hXY_Barrel_ = booker.book2D("XY_Barrel", "X-Y view of Barrel", nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
   for (int disk = 1; disk <= 4; ++disk) {
     const std::string meNameP = fmt::format("XY_EndcapP{:1d}", disk);
     const std::string meNameN = fmt::format("XY_EndcapN{:1d}", disk);
-    const std::string meTitleP = fmt::format("XY view of Endcap{:+1d};X (cm);Y (cm)", disk);
-    const std::string meTitleN = fmt::format("XY view of Endcap{:+1d};X (cm);Y (cm)", -disk);
+    const std::string meTitleP = fmt::format("X-Y view of Endcap{:+1d};X (cm);Y (cm)", disk);
+    const std::string meTitleN = fmt::format("X-Y view of Endcap{:+1d};X (cm);Y (cm)", -disk);
     hXY_Endcap_[disk] = booker.book2D(meNameP, meTitleP, nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
     hXY_Endcap_[-disk] = booker.book2D(meNameN, meTitleN, nbinsXY, -maxXY, maxXY, nbinsXY, -maxXY, maxXY);
   }
@@ -156,7 +156,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   for (int layer = 1; layer <= 6; ++layer) {
     const std::string meName = fmt::format("ZPhi_Layer{:1d}", layer);
     const std::string meTitle = fmt::format("Z-#phi view of Layer{:1d};Z (cm);#phi (degree)", layer);
-    hZPhi_[layer] = booker.book2D(meName, meName, nbinsBarrelZ, -maxBarrelZ, maxBarrelZ, nbinsPhi, -180, 180);
+    hZPhi_[layer] = booker.book2D(meName, meTitle, nbinsBarrelZ, -maxBarrelZ, maxBarrelZ, nbinsPhi, -180, 180);
   }
 
   // Strip profile

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -76,39 +76,39 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       hStripProf->Fill(strip);
 
       if (region == 0) {
-        // Barrel
         const int station = rsid.station();
         if (station == 1 or station == 2)
           hStripProf_RB12_->Fill(strip);
         else if (station == 3 or station == 4)
           hStripProf_RB34_->Fill(strip);
       } else {
-        const int ring = rsid.ring();
-        if (ring == 1)
+        if (roll->isIRPC())
           hStripProf_IRPC_->Fill(strip);
         else
           hStripProf_Endcap_->Fill(strip);
       }
 
-      BxDist->Fill(digiIt->bx());
+      // Bunch crossing
+      const int bx = digiIt->bx();
+      hBxDist_->Fill(bx);
       // bx for 4 endcaps
-      if (rsid.region() == (+1)) {
-        if (rsid.station() == 4)
-          BxDisc_4Plus->Fill(digiIt->bx());
-      } else if (rsid.region() == (-1)) {
-        if (rsid.station() == 4)
-          BxDisc_4Min->Fill(digiIt->bx());
+      if (rsid.station() == 4) {
+        if (region == 1) {
+          hBxDisc_4Plus_->Fill(bx);
+        } else if (region == -1) {
+          hBxDisc_4Min_->Fill(bx);
+        }
       }
 
       // Fill timing information
       const double digiTime = digiIt->hasTime() ? digiIt->time() : digiIt->bx() * 25;
-      hDigiTimeAll->Fill(digiTime);
+      hDigiTimeAll_->Fill(digiTime);
       if (digiIt->hasTime()) {
-        hDigiTime->Fill(digiTime);
+        hDigiTime_->Fill(digiTime);
         if (roll->isIRPC())
-          hDigiTimeIRPC->Fill(digiTime);
+          hDigiTimeIRPC_->Fill(digiTime);
         else
-          hDigiTimeNoIRPC->Fill(digiTime);
+          hDigiTimeNoIRPC_->Fill(digiTime);
       }
     }
   }
@@ -139,14 +139,14 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   hStripProf_IRPC_ = booker.book1D("Strip_Profile_IRPC", "Strip Profile IRPC", 100, 0, 100);
 
   // Bunch crossing
-  BxDist = booker.book1D("Bunch_Crossing", "Bunch_Crossing", 20, -10., 10.);
-  BxDisc_4Plus = booker.book1D("BxDisc_4Plus", "BxDisc_4Plus", 20, -10., 10.);
-  BxDisc_4Min = booker.book1D("BxDisc_4Min", "BxDisc_4Min", 20, -10., 10.);
+  hBxDist_ = booker.book1D("Bunch_Crossing", "Bunch_Crossing", 20, -10., 10.);
+  hBxDisc_4Plus_ = booker.book1D("BxDisc_4Plus", "BxDisc_4Plus", 20, -10., 10.);
+  hBxDisc_4Min_ = booker.book1D("BxDisc_4Min", "BxDisc_4Min", 20, -10., 10.);
 
   // Timing informations
-  hDigiTimeAll =
+  hDigiTimeAll_ =
       booker.book1D("DigiTimeAll", "Digi time including present electronics;Digi time (ns)", 100, -12.5, 12.5);
-  hDigiTime = booker.book1D("DigiTime", "Digi time only with timing information;Digi time (ns)", 100, -12.5, 12.5);
-  hDigiTimeIRPC = booker.book1D("DigiTimeIRPC", "IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
-  hDigiTimeNoIRPC = booker.book1D("DigiTimeNoIRPC", "non-IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTime_ = booker.book1D("DigiTime", "Digi time only with timing information;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTimeIRPC_ = booker.book1D("DigiTimeIRPC", "IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
+  hDigiTimeNoIRPC_ = booker.book1D("DigiTimeNoIRPC", "non-IRPC Digi time;Digi time (ns)", 100, -12.5, 12.5);
 }

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -134,7 +134,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   const int nbinsXY = 160;  // bin width: 10cm
   const double minR = 100, maxR = 800;
   const int nbinsR = 70;    // bin width: 10cm
-  const int nbinsPhi = 90;  // bin width: 4 degree
+  const int nbinsPhi = 72;  // bin width: 5 degree
   const double maxBarrelZ = 700;
   const int nbinsBarrelZ = 140;  // bin width: 10cm
 

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -1,6 +1,7 @@
+#include "Validation/MuonRPCDigis/interface/RPCDigiValid.h"
+
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-#include "Validation/MuonRPCDigis/interface/RPCDigiValid.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
@@ -19,37 +20,31 @@ RPCDigiValid::RPCDigiValid(const ParameterSet &ps) {
   //  configuration. The second param is default value module, instance and
   //  process labels may be passed in a single string if separated by colon ':'
   //  (@see the edm::InputTag constructor documentation)
-  simHitToken = consumes<PSimHitContainer>(
+  simHitToken_ = consumes<PSimHitContainer>(
       ps.getUntrackedParameter<edm::InputTag>("simHitTag", edm::InputTag("g4SimHits:MuonRPCHits")));
-  rpcDigiToken = consumes<RPCDigiCollection>(
+  rpcDigiToken_ = consumes<RPCDigiCollection>(
       ps.getUntrackedParameter<edm::InputTag>("rpcDigiTag", edm::InputTag("simMuonRPCDigis")));
-
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "rpcDigiValidPlots.root");
 
   rpcGeomToken_ = esConsumes();
 }
-
-RPCDigiValid::~RPCDigiValid() {}
 
 void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
   // Get the RPC Geometry
   auto rpcGeom = eventSetup.getHandle(rpcGeomToken_);
 
-  edm::Handle<PSimHitContainer> simHit;
-  edm::Handle<RPCDigiCollection> rpcDigis;
-  event.getByToken(simHitToken, simHit);
-  event.getByToken(rpcDigiToken, rpcDigis);
-
-  // Loop on simhits
-  PSimHitContainer::const_iterator simIt;
+  edm::Handle<PSimHitContainer> simHitHandle;
+  edm::Handle<RPCDigiCollection> rpcDigisHandle;
+  event.getByToken(simHitToken_, simHitHandle);
+  event.getByToken(rpcDigiToken_, rpcDigisHandle);
 
   // loop over Simhit
   std::map<RPCDetId, std::vector<double>> allsims;
 
-  for (simIt = simHit->begin(); simIt != simHit->end(); simIt++) {
-    RPCDetId Rsid = (RPCDetId)(*simIt).detUnitId();
+  for (auto simIt = simHitHandle->begin(); simIt != simHitHandle->end(); ++simIt) {
+    RPCDetId Rsid = simIt->detUnitId();
     const RPCRoll *soll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
-    int ptype = simIt->particleType();
+    if (!soll) continue;
+    const int ptype = simIt->particleType();
 
     if (ptype == 13 || ptype == -13) {
       std::vector<double> buff;
@@ -61,10 +56,10 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
 
       allsims[Rsid] = buff;
     }
-    GlobalPoint p = soll->toGlobal(simIt->localPosition());
+    const GlobalPoint p = soll->toGlobal(simIt->localPosition());
 
-    double sim_x = p.x();
-    double sim_y = p.y();
+    const double sim_x = p.x();
+    const double sim_y = p.y();
 
     xyview->Fill(sim_x, sim_y);
 
@@ -80,8 +75,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
     rzview->Fill(p.z(), p.perp());
   }
   // loop over Digis
-  RPCDigiCollection::DigiRangeIterator detUnitIt;
-  for (detUnitIt = rpcDigis->begin(); detUnitIt != rpcDigis->end(); ++detUnitIt) {
+  for (auto detUnitIt = rpcDigisHandle->begin(); detUnitIt != rpcDigisHandle->end(); ++detUnitIt) {
     const RPCDetId Rsid = (*detUnitIt).first;
     const RPCRoll *roll = dynamic_cast<const RPCRoll *>(rpcGeom->roll(Rsid));
 
@@ -91,8 +85,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
       sims = allsims[Rsid];
     }
 
-    int ndigi = 0;
-    for (RPCDigiCollection::const_iterator digiIt = range.first; digiIt != range.second; ++digiIt) {
+    for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
       StripProf->Fill(digiIt->strip());
       BxDist->Fill(digiIt->bx());
       // bx for 4 endcaps
@@ -115,87 +108,6 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
           hDigiTimeNoIRPC->Fill(digiTime);
       }
     }
-
-    if (sims.size() == 1 && ndigi == 1) {
-      double dis = roll->centreOfStrip(range.first->strip()).x() - sims[0];
-      Res->Fill(dis);
-
-      if (Rsid.region() == 0) {
-        if (Rsid.ring() == -2)
-          ResWmin2->Fill(dis);
-        else if (Rsid.ring() == -1)
-          ResWmin1->Fill(dis);
-        else if (Rsid.ring() == 0)
-          ResWzer0->Fill(dis);
-        else if (Rsid.ring() == 1)
-          ResWplu1->Fill(dis);
-        else if (Rsid.ring() == 2)
-          ResWplu2->Fill(dis);
-        // barrel layers
-        if (Rsid.station() == 1 && Rsid.layer() == 1)
-          ResLayer1_barrel->Fill(dis);
-        if (Rsid.station() == 1 && Rsid.layer() == 2)
-          ResLayer2_barrel->Fill(dis);
-        if (Rsid.station() == 2 && Rsid.layer() == 1)
-          ResLayer3_barrel->Fill(dis);
-        if (Rsid.station() == 2 && Rsid.layer() == 2)
-          ResLayer4_barrel->Fill(dis);
-        if (Rsid.station() == 3)
-          ResLayer5_barrel->Fill(dis);
-        if (Rsid.station() == 4)
-          ResLayer6_barrel->Fill(dis);
-      }
-      // endcap layers residuals
-      if (Rsid.region() != 0) {
-        if (Rsid.ring() == 2) {
-          if (abs(Rsid.station()) == 1) {
-            if (Rsid.roll() == 1)
-              Res_Endcap1_Ring2_A->Fill(dis);
-            if (Rsid.roll() == 2)
-              Res_Endcap1_Ring2_B->Fill(dis);
-            if (Rsid.roll() == 3)
-              Res_Endcap1_Ring2_C->Fill(dis);
-          }
-          if (abs(Rsid.station()) == 2 || abs(Rsid.station()) == 3) {
-            if (Rsid.roll() == 1)
-              Res_Endcap23_Ring2_A->Fill(dis);
-            if (Rsid.roll() == 2)
-              Res_Endcap23_Ring2_B->Fill(dis);
-            if (Rsid.roll() == 3)
-              Res_Endcap23_Ring2_C->Fill(dis);
-          }
-        }
-        if (Rsid.ring() == 3) {
-          if (Rsid.roll() == 1)
-            Res_Endcap123_Ring3_A->Fill(dis);
-          if (Rsid.roll() == 2)
-            Res_Endcap123_Ring3_B->Fill(dis);
-          if (Rsid.roll() == 3)
-            Res_Endcap123_Ring3_C->Fill(dis);
-        }
-      }
-
-      if (Rsid.region() == (+1)) {
-        if (Rsid.station() == 1)
-          ResDplu1->Fill(dis);
-        else if (Rsid.station() == 2)
-          ResDplu2->Fill(dis);
-        else if (Rsid.station() == 3)
-          ResDplu3->Fill(dis);
-        else if (Rsid.station() == 4)
-          ResDplu4->Fill(dis);
-      }
-      if (Rsid.region() == (-1)) {
-        if (Rsid.station() == 1)
-          ResDmin1->Fill(dis);
-        else if (Rsid.station() == 2)
-          ResDmin2->Fill(dis);
-        else if (Rsid.station() == 3)
-          ResDmin3->Fill(dis);
-        else if (Rsid.station() == 4)
-          ResDmin4->Fill(dis);
-      }
-    }
   }
 }
 
@@ -208,48 +120,12 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   xyvDmin4 = booker.book2D("Dmin4_XvsY", "Dmin4_XvsY", 155, -775., 775., 155, -775., 775.);
 
   rzview = booker.book2D("R_Vs_Z_View", "R_Vs_Z_View", 216, -1080., 1080., 52, 260., 780.);
-  Res = booker.book1D("Digi_SimHit_difference", "Digi_SimHit_difference", 300, -8, 8);
-  ResWmin2 = booker.book1D("W_Min2_Residuals", "W_Min2_Residuals", 400, -8, 8);
-  ResWmin1 = booker.book1D("W_Min1_Residuals", "W_Min1_Residuals", 400, -8, 8);
-  ResWzer0 = booker.book1D("W_Zer0_Residuals", "W_Zer0_Residuals", 400, -8, 8);
-  ResWplu1 = booker.book1D("W_Plu1_Residuals", "W_Plu1_Residuals", 400, -8, 8);
-  ResWplu2 = booker.book1D("W_Plu2_Residuals", "W_Plu2_Residuals", 400, -8, 8);
-
-  ResLayer1_barrel = booker.book1D("ResLayer1_barrel", "ResLayer1_barrel", 400, -8, 8);
-  ResLayer2_barrel = booker.book1D("ResLayer2_barrel", "ResLayer2_barrel", 400, -8, 8);
-  ResLayer3_barrel = booker.book1D("ResLayer3_barrel", "ResLayer3_barrel", 400, -8, 8);
-  ResLayer4_barrel = booker.book1D("ResLayer4_barrel", "ResLayer4_barrel", 400, -8, 8);
-  ResLayer5_barrel = booker.book1D("ResLayer5_barrel", "ResLayer5_barrel", 400, -8, 8);
-  ResLayer6_barrel = booker.book1D("ResLayer6_barrel", "ResLayer6_barrel", 400, -8, 8);
 
   BxDist = booker.book1D("Bunch_Crossing", "Bunch_Crossing", 20, -10., 10.);
   StripProf = booker.book1D("Strip_Profile", "Strip_Profile", 100, 0, 100);
 
   BxDisc_4Plus = booker.book1D("BxDisc_4Plus", "BxDisc_4Plus", 20, -10., 10.);
   BxDisc_4Min = booker.book1D("BxDisc_4Min", "BxDisc_4Min", 20, -10., 10.);
-
-  // endcap residuals
-  ResDmin1 = booker.book1D("Disk_Min1_Residuals", "Disk_Min1_Residuals", 400, -8, 8);
-  ResDmin2 = booker.book1D("Disk_Min2_Residuals", "Disk_Min2_Residuals", 400, -8, 8);
-  ResDmin3 = booker.book1D("Disk_Min3_Residuals", "Disk_Min3_Residuals", 400, -8, 8);
-  ResDplu1 = booker.book1D("Disk_Plu1_Residuals", "Disk_Plu1_Residuals", 400, -8, 8);
-  ResDplu2 = booker.book1D("Disk_Plu2_Residuals", "Disk_Plu2_Residuals", 400, -8, 8);
-  ResDplu3 = booker.book1D("Disk_Plu3_Residuals", "Disk_Plu3_Residuals", 400, -8, 8);
-
-  ResDmin4 = booker.book1D("Disk_Min4_Residuals", "Disk_Min4_Residuals", 400, -8, 8);
-  ResDplu4 = booker.book1D("Disk_Plu4_Residuals", "Disk_Plu4_Residuals", 400, -8, 8);
-
-  Res_Endcap1_Ring2_A = booker.book1D("Res_Endcap1_Ring2_A", "Res_Endcap1_Ring2_A", 400, -8, 8);
-  Res_Endcap1_Ring2_B = booker.book1D("Res_Endcap1_Ring2_B", "Res_Endcap1_Ring2_B", 400, -8, 8);
-  Res_Endcap1_Ring2_C = booker.book1D("Res_Endcap1_Ring2_C", "Res_Endcap1_Ring2_C", 400, -8, 8);
-
-  Res_Endcap23_Ring2_A = booker.book1D("Res_Endcap23_Ring2_A", "Res_Endcap23_Ring2_A", 400, -8, 8);
-  Res_Endcap23_Ring2_B = booker.book1D("Res_Endcap23_Ring2_B", "Res_Endcap23_Ring2_B", 400, -8, 8);
-  Res_Endcap23_Ring2_C = booker.book1D("Res_Endcap23_Ring2_C", "Res_Endcap23_Ring2_C", 400, -8, 8);
-
-  Res_Endcap123_Ring3_A = booker.book1D("Res_Endcap123_Ring3_A", "Res_Endcap123_Ring3_A", 400, -8, 8);
-  Res_Endcap123_Ring3_B = booker.book1D("Res_Endcap123_Ring3_B", "Res_Endcap123_Ring3_B", 400, -8, 8);
-  Res_Endcap123_Ring3_C = booker.book1D("Res_Endcap123_Ring3_C", "Res_Endcap123_Ring3_C", 400, -8, 8);
 
   // Timing informations
   hDigiTimeAll =

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -73,7 +73,7 @@ void RPCDigiValid::analyze(const Event &event, const EventSetup &eventSetup) {
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
       // Strip profile
       const int strip = digiIt->strip();
-      hStripProf->Fill(strip);
+      hStripProf_->Fill(strip);
 
       if (region == 0) {
         const int station = rsid.station();
@@ -132,7 +132,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   }
 
   // Strip profile
-  hStripProf = booker.book1D("Strip_Profile", "Strip_Profile", 100, 0, 100);
+  hStripProf_ = booker.book1D("Strip_Profile", "Strip_Profile", 100, 0, 100);
   hStripProf_RB12_ = booker.book1D("Strip_Profile_RB12", "Strip Profile RB1 and RB2", 100, 0, 100);
   hStripProf_RB34_ = booker.book1D("Strip_Profile_RB12", "Strip Profile RB1 and RB2", 50, 0, 50);
   hStripProf_Endcap_ = booker.book1D("Strip_Profile_Endcap", "Strip Profile Endcap", 40, 0, 40);

--- a/Validation/MuonRPCDigis/src/RPCDigiValid.cc
+++ b/Validation/MuonRPCDigis/src/RPCDigiValid.cc
@@ -134,7 +134,7 @@ void RPCDigiValid::bookHistograms(DQMStore::IBooker &booker, edm::Run const &run
   // Strip profile
   hStripProf_ = booker.book1D("Strip_Profile", "Strip_Profile", 100, 0, 100);
   hStripProf_RB12_ = booker.book1D("Strip_Profile_RB12", "Strip Profile RB1 and RB2", 100, 0, 100);
-  hStripProf_RB34_ = booker.book1D("Strip_Profile_RB12", "Strip Profile RB1 and RB2", 50, 0, 50);
+  hStripProf_RB34_ = booker.book1D("Strip_Profile_RB34", "Strip Profile RB3 and RB4", 50, 0, 50);
   hStripProf_Endcap_ = booker.book1D("Strip_Profile_Endcap", "Strip Profile Endcap", 40, 0, 40);
   hStripProf_IRPC_ = booker.book1D("Strip_Profile_IRPC", "Strip Profile IRPC", 100, 0, 100);
 


### PR DESCRIPTION
#### PR description:

This PR is to update the RPCDigis validation.
Main motivation of the proposed change is to cleanup unused plots, fix empty plots if any
and add more useful plots to perform the release validation.

The proposal for this update was presented in the RPC-DPG working meeting 22 May 2024: [link to the slide](https://indico.cern.ch/event/1419527/contributions/5967272/attachments/2861397/5006306/%5B2024.05.22%5D%20Update%20of%20RPCDigi%20Validation.pdf)

This PR addresses suggestions during the meeting, to keep the plots for residual distributions but fixing the (known) bug in the code.
It only modifies/adds DQM plots during the validation step.

#### PR validation:

Performed tests on `CMSSW_14_1_0_pre3` release
- `runTheMatrix.py -l 12834.0` 
- Run cmsDriver step3 and step4 with the existing GEN-SIM-DIGI-RAW samples stored in eos (no crashes, DQM plots seems to be OK)
- code-checks OK
- code-format OK

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

We want to have backport to the currently active release cycles
- 14_0_X
- 14_1_X

Possible watchers:  @mileva @mrcthiel