### PR TITLE
Set 3 instead of 4 OMTF track sub-address as expected by uGMT

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
@@ -294,7 +294,8 @@ std::vector<l1t::RegionalMuonCand> OMTFProcessor<GoldenPatternType>::getFinalcan
     //check if it matters if it needs to be here as well
     trackAddr[1] = myCand->getRefLayer();
     trackAddr[2] = myCand->getDisc();
-    trackAddr[3] = myCand->getGpResultUnconstr().getPdfSumUnconstr();
+    //TODO: uGMT expects only 3 sub-addresses, so not set 4th. This is anyway currently not used.
+    //trackAddr[3] = myCand->getGpResultUnconstr().getPdfSumUnconstr();
     if (candidate.hwPt() > 0 || candidate.hwPtUnconstrained() > 0) {
       candidate.setTrackAddress(trackAddr);
       candidate.setTFIdentifiers(iProcessor, mtfType);


### PR DESCRIPTION
#### PR description:

As title says: this PR reduces number of OMTF track sub-addresses sent to uGMT from 4 to 3 to meet expected number. It calms "OMTF muon track address map contains 4 instead of the expected 3 subaddresses. Check the data format. Setting track address to 0." warning without impact on performance as the sub-addresses are currently not used.

#### PR validation:

tested with wf 141.044

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be potentially backported to 14_0_X to calm warning in uGMT emulator.
