### PR TITLE
HcalZDCDetId fix for Run3

### DIFF
--- a/DataFormats/HcalDetId/interface/HcalZDCDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalZDCDetId.h
@@ -24,7 +24,7 @@
 class HcalZDCDetId : public DetId {
 public:
   static constexpr uint32_t kZDCChannelMask1 = 0xF;
-  static constexpr uint32_t kZDCChannelMask2 = 0x7F;
+  static constexpr uint32_t kZDCChannelMask2 = 0x3F;
   static constexpr uint32_t kZDCSectionMask = 0x3;
   static constexpr uint32_t kZDCSectionOffset = 4;
   static constexpr uint32_t kZDCZsideMask = 0x40;


### PR DESCRIPTION
#### PR description:

Fix of a bug in Run3 update of the HcalZDCDetId  https://github.com/cms-sw/cmssw/pull/43200
which prevented a proper serialization of the conditions for newly added Run3-specific ZDC readouts (RPD) 

#### PR validation:

(1) new Run3 ZDC conditions can now be parsed and dumped,  once [ZDC indexing parameter is set for Run3](https://github.com/abdoulline/cmssw/blob/2c86f7138bf114e62f72523db7bbbe02ea461364/DataFormats/HcalDetId/interface/HcalZDCDetId.h#L203)  The latter will be rearranged in the subsequent PR(s) by @bsunanda  together with some ZDC Geometry initialization updates.   
(2) runTheMatrix.py -l limited


