### PR TITLE
clang-tidy: Remove deprecated AnalyzeTemporaryDtors option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,7 +23,6 @@ Checks: -*,
   ,readability-uniqueptr-delete-release
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:    
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'


### PR DESCRIPTION
`AnalyzeTemporaryDtors` option was deprecated in llvm 16 and remove din llvm18 (https://github.com/llvm/llvm-project/issues/62020)
This PR removes it from cmssw clang-tidy configuration.