### PR TITLE
Add Unpacker for L1T Calo Layer 1 to unpack CICADA

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
@@ -1,0 +1,55 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
+
+#include "CICADAUnpacker.h"
+
+#include <cmath>
+
+using namespace edm;
+
+namespace l1t {
+  namespace stage2 {
+    bool CICADAUnpacker::unpack(const Block& block, UnpackerCollections* coll) {
+      LogDebug("L1T") << "Block Size = " << block.header().getSize();
+      LogDebug("L1T") << "Board ID = " << block.amc().getBoardID();
+
+      auto res = static_cast<CaloLayer1Collections*>(coll)->getCICADABxCollection();
+      // default BX range to trigger standard -2 to 2
+      // Even though CICADA will never have BX information
+      // And everything gets put in BX 0
+      res->setBXRange(-2, 2);
+
+      int amc_slot = block.amc().getAMCNumber();
+      if (not(amc_slot == 7)) {
+        throw cms::Exception("CICADAUnpacker")
+            << "Calo Summary (CICADA) unpacker is unpacking an unexpected AMC. Expected AMC number 7, got AMC number "
+            << amc_slot << std::endl;
+        return false;
+      } else {
+        std::vector<uint32_t> cicadaWords = {0, 0, 0, 0};
+        //the first 4 words are CICADA words
+        for (uint32_t i = 0; i < 4; ++i) {
+          cicadaWords.at(i) = ((block.payload().at(i)) >> 28);
+        }
+
+        float cicadaScore = convertCICADABitsToFloat(cicadaWords);
+        res->push_back(0, cicadaScore);
+        return true;
+      }
+    }
+
+    //convert the 4 CICADA bits/words into a proper number
+    float CICADAUnpacker::convertCICADABitsToFloat(const std::vector<uint32_t>& cicadaBits) {
+      uint32_t tempResult = 0;
+      tempResult |= cicadaBits.at(0) << 12;
+      tempResult |= cicadaBits.at(1) << 8;
+      tempResult |= cicadaBits.at(2) << 4;
+      tempResult |= cicadaBits.at(3);
+      float result = 0.0;
+      result = (float)tempResult * pow(2.0, -8);
+      return result;
+    }
+  }  // namespace stage2
+}  // namespace l1t
+
+DEFINE_L1T_UNPACKER(l1t::stage2::CICADAUnpacker);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
@@ -27,9 +27,9 @@ namespace l1t {
         return false;
       } else {
         std::vector<uint32_t> cicadaWords = {0, 0, 0, 0};
-        //the first 4 words are CICADA words
-        for (uint32_t i = 0; i < 4; ++i) {
-          cicadaWords.at(i) = ((block.payload().at(i)) >> 28);
+        //the last 4 words are CICADA words
+        for (uint32_t i = 2; i < 6; ++i) {
+          cicadaWords.at(i-2) = ((block.payload().at(i)) >> 28);
         }
 
         float cicadaScore = convertCICADABitsToFloat(cicadaWords);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.cc
@@ -29,7 +29,7 @@ namespace l1t {
         std::vector<uint32_t> cicadaWords = {0, 0, 0, 0};
         //the last 4 words are CICADA words
         for (uint32_t i = 2; i < 6; ++i) {
-          cicadaWords.at(i-2) = ((block.payload().at(i)) >> 28);
+          cicadaWords.at(i - 2) = ((block.payload().at(i)) >> 28);
         }
 
         float cicadaScore = convertCICADABitsToFloat(cicadaWords);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CICADAUnpacker.h
@@ -1,0 +1,19 @@
+#ifndef EventFilter_L1TRawToDigi_CICADAUnpacker_h
+#define EventFilter_L1TRawToDigi_CICADAUnpacker_h
+
+#include "EventFilter/L1TRawToDigi/interface/Unpacker.h"
+#include "CaloLayer1Collections.h"
+
+namespace l1t {
+  namespace stage2 {
+    class CICADAUnpacker : public Unpacker {
+    public:
+      bool unpack(const Block& block, UnpackerCollections* coll) override;
+
+    private:
+      float convertCICADABitsToFloat(const std::vector<uint32_t>&);
+    };
+  }  // namespace stage2
+}  // namespace l1t
+
+#endif

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
@@ -12,6 +12,7 @@ namespace l1t {
       for (int i = 0; i < 5; ++i) {
         event_.put(std::move(ecalDigisBx_[i]), "EcalDigisBx" + std::to_string(i + 1));
       }
+      event_.put(std::move(cicadaDigis_), "CICADAScore");
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
 #include "L1TObjectCollections.h"
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
 
 namespace l1t {
   namespace stage2 {
@@ -15,7 +16,8 @@ namespace l1t {
           : L1TObjectCollections(e),
             ecalDigis_(new EcalTrigPrimDigiCollection()),
             hcalDigis_(new HcalTrigPrimDigiCollection()),
-            caloRegions_(new L1CaloRegionCollection()) {
+            caloRegions_(new L1CaloRegionCollection()),
+            cicadaDigis_(std::make_unique<CICADABxCollection>()) {
         // Pre-allocate:
         //  72 iPhi values
         //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
@@ -37,6 +39,7 @@ namespace l1t {
       inline EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) override {
         return ecalDigisBx_[copy].get();
       };
+      inline CICADABxCollection* getCICADABxCollection() { return cicadaDigis_.get(); };
 
     private:
       std::unique_ptr<EcalTrigPrimDigiCollection> ecalDigis_;
@@ -44,6 +47,7 @@ namespace l1t {
       std::unique_ptr<L1CaloRegionCollection> caloRegions_;
 
       std::array<std::unique_ptr<EcalTrigPrimDigiCollection>, 5> ecalDigisBx_;
+      std::unique_ptr<CICADABxCollection> cicadaDigis_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -6,6 +6,8 @@
 
 #include "CaloLayer1Setup.h"
 
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
+
 namespace l1t {
   namespace stage2 {
     std::unique_ptr<PackerTokens> CaloLayer1Setup::registerConsumes(const edm::ParameterSet& cfg,
@@ -58,6 +60,7 @@ namespace l1t {
       for (int i = 0; i < 5; ++i) {
         prod.produces<EcalTrigPrimDigiCollection>("EcalDigisBx" + std::to_string(i + 1));
       }
+      prod.produces<CICADABxCollection>("CICADAScore");
     }
 
     std::unique_ptr<UnpackerCollections> CaloLayer1Setup::getCollections(edm::Event& e) {
@@ -71,6 +74,9 @@ namespace l1t {
       if (fed == 1354 || fed == 1356 || fed == 1358) {
         if (board < 18) {
           res[0] = UnpackerFactory::get()->make("stage2::CaloLayer1Unpacker");
+        }
+        if (fed == 1356 && amc == 7) {  //calo summary board
+          res[0] = UnpackerFactory::get()->make("stage2::CICADAUnpacker");
         }
       }
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSummaryCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSummaryCollections.cc
@@ -1,0 +1,9 @@
+#include "FWCore/Framework/interface/Event.h"
+
+#include "CaloSummaryCollections.h"
+
+namespace l1t {
+  namespace stage2 {
+    CaloSummaryCollections::~CaloSummaryCollections() { event_.put(std::move(cicadaDigis_)); }
+  }  // namespace stage2
+}  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSummaryCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloSummaryCollections.h
@@ -1,0 +1,23 @@
+#ifndef EventFilter_L1TRawToDigi_CaloSummaryCollections_h
+#define EventFilter_L1TRawToDigi_CaloSummaryCollections_h
+
+#include "DataFormats/L1CaloTrigger/interface/CICADA.h"
+
+#include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
+
+namespace l1t {
+  namespace stage2 {
+    class CaloSummaryCollections : public UnpackerCollections {
+    public:
+      CaloSummaryCollections(edm::Event& e)
+          : UnpackerCollections(e), cicadaDigis_(std::make_unique<CICADABxCollection>()){};
+      ~CaloSummaryCollections() override;
+      inline CICADABxCollection* getCICADABxCollection() { return cicadaDigis_.get(); };
+
+    private:
+      std::unique_ptr<CICADABxCollection> cicadaDigis_;
+    };
+  }  // namespace stage2
+}  // namespace l1t
+
+#endif


### PR DESCRIPTION
### PR description:

This PR adds an unpacker to the L1T Calo Layer 1 Unpacking Setup to explicitly unpack CICADA (found in FED 1356, AMC slot 7). This PR relies on data-types introduced in it's companion PR https://github.com/cms-sw/cmssw/pull/44222. https://github.com/cms-sw/cmssw/pull/44222 Unpacks the uGT received CICADA scores, while this PR unpacks the Calo sent CICADA scores.

### PR validation:

All code compiles and has had code formatting applied. This Unpacker has also been tested against events with the CaloSummary/CICADA cards in DAQ. A screenshot of some debugging output of the development of the unpacker is attached. On the left side you can see the unpacked data from FED 1356, which matches the dumped FED output seen on the right (CICADA/CaloSummary highlighted)

![image](https://github.com/cms-sw/cmssw/assets/28607665/c043c249-e872-464c-8dd0-a385dffebeb1)

Also shown is a demonstration that the correct CICADA bits are received in the correct order, and the resulting constructed score, matched to the expected hex number (when transformed into a 16 bit fixed-point number, with 8 integer bits, and 8 bits after the decimal point, to within machine epsilon, or display precision).

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport, and is not expected to need a backport. It is however, a feature of an upcoming data-taking tool, so it is not impossible that a backport will be requested for it.


@eyigitba @slaurila FYI, this is one of the DPG requested pieces for CICADA that we have made for our own commissioning purposes now. Packers will be made when we are satisfied with commissioning progress using these unpackers.