### PR TITLE
`PhotonXGBoostEstimator` : set `XGBoost` to use one thread to avoid spawning hundreds of OpenMP threads

### DIFF
--- a/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
@@ -3,6 +3,9 @@
 
 PhotonXGBoostEstimator::PhotonXGBoostEstimator(const edm::FileInPath& weightsFile, int best_ntree_limit) {
   XGBoosterCreate(NULL, 0, &booster_);
+  // Set number of threads to 1, to avoid spawning hundreds of OpenMP threads
+  // See https://github.com/cms-sw/cmssw/issues/44923 for details
+  XGBoosterSetParam(booster_, "nthread", "1");
   XGBoosterLoadModel(booster_, weightsFile.fullPath().c_str());
   best_ntree_limit_ = best_ntree_limit;
 


### PR DESCRIPTION
#### PR description:

Title says it all, see #44923 for details

#### PR validation:

Run the script https://github.com/cms-sw/cmssw/issues/44923#issuecomment-2128937695 and verified with `gdb` and `info threads` that the amount of threads is limited, see also https://github.com/cms-sw/cmssw/issues/44923#issuecomment-2130124566 and https://github.com/cms-sw/cmssw/issues/44923#issuecomment-2130273419

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport to be backported to 14.0.X for data-taking purposes 