### PR TITLE
guard against invalid output products from `HLTL1TSeed`

### DIFF
--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -950,6 +950,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
                                     << "\nNo muons added to filterproduct." << endl;
     } else {
       for (std::list<int>::const_iterator itObj = listMuon.begin(); itObj != listMuon.end(); ++itObj) {
+        // skip invalid indices
+        if (*itObj < 0 or unsigned(*itObj) >= muons->size(0)) {
+          edm::LogWarning("HLTL1TSeed")
+              << "Invalid index from the L1ObjectMap (L1uGT emulator), will be ignored (l1t::MuonBxCollection):"
+              << " index=" << *itObj << " (size of unpacked L1T objects in BX0 = " << muons->size(0) << ")";
+          continue;
+        }
+
         // Transform to index for Bx = 0 to begin of BxVector
         unsigned int index = muons->begin(0) - muons->begin() + *itObj;
 
@@ -970,6 +978,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
                                     << "\nNo muon showers added to filterproduct." << endl;
     } else {
       for (std::list<int>::const_iterator itObj = listMuonShower.begin(); itObj != listMuonShower.end(); ++itObj) {
+        // skip invalid indices
+        if (*itObj < 0 or unsigned(*itObj) >= muonShowers->size(0)) {
+          edm::LogWarning("HLTL1TSeed")
+              << "Invalid index from the L1ObjectMap (L1uGT emulator), will be ignored (l1t::MuonShowerBxCollection):"
+              << " index=" << *itObj << " (size of unpacked L1T objects in BX0 = " << muonShowers->size(0) << ")";
+          continue;
+        }
+
         // Transform to index for Bx = 0 to begin of BxVector
         unsigned int index = muonShowers->begin(0) - muonShowers->begin() + *itObj;
 
@@ -989,6 +1005,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
                                     << "\nNo egammas added to filterproduct." << endl;
     } else {
       for (std::list<int>::const_iterator itObj = listEG.begin(); itObj != listEG.end(); ++itObj) {
+        // skip invalid indices
+        if (*itObj < 0 or unsigned(*itObj) >= egammas->size(0)) {
+          edm::LogWarning("HLTL1TSeed")
+              << "Invalid index from the L1ObjectMap (L1uGT emulator), will be ignored (l1t::EGammaBxCollection):"
+              << " index=" << *itObj << " (size of unpacked L1T objects in BX0 = " << egammas->size(0) << ")";
+          continue;
+        }
+
         // Transform to begin of BxVector
         unsigned int index = egammas->begin(0) - egammas->begin() + *itObj;
 
@@ -1009,6 +1033,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
                                     << "\nNo jets added to filterproduct." << endl;
     } else {
       for (std::list<int>::const_iterator itObj = listJet.begin(); itObj != listJet.end(); ++itObj) {
+        // skip invalid indices
+        if (*itObj < 0 or unsigned(*itObj) >= jets->size(0)) {
+          edm::LogWarning("HLTL1TSeed")
+              << "Invalid index from the L1ObjectMap (L1uGT emulator), will be ignored (l1t::JetBxCollection):"
+              << " index=" << *itObj << " (size of unpacked L1T objects in BX0 = " << jets->size(0) << ")";
+          continue;
+        }
+
         // Transform to begin of BxVector
         unsigned int index = jets->begin(0) - jets->begin() + *itObj;
 
@@ -1029,6 +1061,14 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
                                     << "\nNo taus added to filterproduct." << endl;
     } else {
       for (std::list<int>::const_iterator itObj = listTau.begin(); itObj != listTau.end(); ++itObj) {
+        // skip invalid indices
+        if (*itObj < 0 or unsigned(*itObj) >= taus->size(0)) {
+          edm::LogWarning("HLTL1TSeed")
+              << "Invalid index from the L1ObjectMap (L1uGT emulator), will be ignored (l1t::TauBxCollection):"
+              << " index=" << *itObj << " (size of unpacked L1T objects in BX0 = " << taus->size(0) << ")";
+          continue;
+        }
+
         // Transform to begin of BxVector
         unsigned int index = taus->begin(0) - taus->begin() + *itObj;
 


### PR DESCRIPTION
#### PR description:

This PR adds a safeguard to ensure that the plugin `HLTL1TSeed` does not add to the Event invalid references to L1T objects (by means of incorrect indices). For more information, see #44940 and [CMSHLT-3216](https://its.cern.ch/jira/browse/CMSHLT-3216).

#### PR validation:

Tested on the reproducer in https://github.com/cms-sw/cmssw/issues/44940#issuecomment-2131391510.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

`CMSSW_14_0_X`

To be backported to `CMSSW_14_0_X` to avoid recurring HLT crashes (~1 every few days).
