### PR TITLE
Fix compilation warning in DDHGCalPassive.cc

### DIFF
--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
@@ -101,7 +101,7 @@ struct HGCalPassive {
       double rinB = HGCalGeomTools::radius(zo, zFrontB, rMinFront, slopeB) + shiftBot;
       zim += moduleThick;
       for (unsigned int k = 0; k < tagSector.size(); ++k) {
-        std::string parentName = parentName + tagLayer[j] + tagSector[k];
+        std::string parentName = args.parentName() + tagLayer[j] + tagSector[k];
         double phi1 = phi0 + k * dphi;
         double phi2 = phi1 + dphi;
         double phi0 = phi1 + 0.5 * dphi;


### PR DESCRIPTION
#### PR description:

Fix compilation warning in `DDHGCalPassive.cc`:

```
>> Compiling  src/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc
.../bin/clang++ <...> src/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc -o tmp/el8_amd64_gcc12/src/Geometry/HGCalCommonData/plugins/DD4hep_GeometryHGCalCommonDataPlugins/dd4hep/DDHGCalTBModule.cc.o
  src/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc:104:34: warning: variable 'parentName' is uninitialized when used within its own initialization [-Wuninitialized]
   104 |         std::string parentName = parentName + tagLayer[j] + tagSector[k];
      |                     ~~~~~~~~~~   ^~~~~~~~~~
```

@bsunanda could you please confirm that the generated solids' should be `{parentName}{tagLayer[j]}{tagSector[k]}`  and not `{parentName}{tagLayer[0]}{tagSector[0]}{tagLayer[1]}{tagSector[0]}{tagSector[1]}...{tagLayer[j]}{tagSector[k]}` (if that has any importance)?

#### PR validation:

Bot tests
