### PR TITLE
Protection for invalid TSOS in MuonTrajectoryUpdator

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -156,6 +156,12 @@ pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const Traject
 
             lastUpdatedTSOS = measurementUpdator()->update(propagatedTSOS, *((*recHit).get()));
 
+            if (!lastUpdatedTSOS.isValid()) {
+              edm::LogInfo(metname) << "Invalid last TSOS, will skip RecHit ";
+              lastUpdatedTSOS = propagatedTSOS; // Revert update
+              continue;
+            }
+
             LogTrace(metname) << "  Fit   Position : " << lastUpdatedTSOS.globalPosition()
                               << "  Fit  Direction : " << lastUpdatedTSOS.globalDirection() << "\n"
                               << "  Fit position radius : " << lastUpdatedTSOS.globalPosition().perp()

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -158,7 +158,7 @@ pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const Traject
 
             if (!lastUpdatedTSOS.isValid()) {
               edm::LogInfo(metname) << "Invalid last TSOS, will skip RecHit ";
-              lastUpdatedTSOS = propagatedTSOS; // Revert update
+              lastUpdatedTSOS = propagatedTSOS;  // Revert update
               continue;
             }
 


### PR DESCRIPTION
#### PR description:

This PR addresses https://github.com/cms-sw/cmssw/issues/45035 
Attempts to fix a crash observed when KFUpdator returns an invalid trajectory state on surface.
Whenever this happens, muon trajectory updator skips that recHit.

FYI @francescobrivio @mmusich @mandrenguyen @jfernan2 @rbhattacharya04 

#### PR validation:

Tested successfully in conditions detailed in issue https://github.com/cms-sw/cmssw/issues/45035.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR needs to be backported to 14_0_X.
