### PR TITLE
Include per ROC histograms for Pixel Cluster Counting luminosity - CMSSW_14_0_X

### DIFF
--- a/DataFormats/Luminosity/interface/PixelClusterCounts.h
+++ b/DataFormats/Luminosity/interface/PixelClusterCounts.h
@@ -31,24 +31,45 @@ namespace reco {
       m_counts.at(LumiConstants::numBX * modIndex + bxID - 1) += count;
     }
 
+    void incrementRoc(int rD, unsigned int bxID, int count) {
+      size_t rocIndex = std::distance(m_RocID.begin(), std::find(m_RocID.begin(), m_RocID.end(), rD));
+      if (rocIndex == m_RocID.size()) {
+        m_RocID.push_back(rD);
+        m_countsRoc.resize(m_countsRoc.size() + LumiConstants::numBX, 0);
+      }
+      m_countsRoc.at(LumiConstants::numBX * rocIndex + bxID - 1) += count;
+    }
+
     void eventCounter(unsigned int bxID) { m_events.at(bxID - 1)++; }
 
     void add(reco::PixelClusterCountsInEvent const& pccInEvent) {
       std::vector<int> const& countsInEvent = pccInEvent.counts();
+      std::vector<int> const& rocCountsInEvent = pccInEvent.countsRoc();
       std::vector<int> const& modIDInEvent = pccInEvent.modID();
+      std::vector<int> const& rocIDInEvent = pccInEvent.rocID();
       int bxIDInEvent = pccInEvent.bxID();
       for (unsigned int i = 0; i < modIDInEvent.size(); i++) {
         increment(modIDInEvent[i], bxIDInEvent, countsInEvent.at(i));
+      }
+      for (unsigned int i = 0; i < rocIDInEvent.size(); i++) {
+        incrementRoc(rocIDInEvent[i], bxIDInEvent, rocCountsInEvent.at(i));
       }
     }
 
     void merge(reco::PixelClusterCounts const& pcc) {
       std::vector<int> const& counts = pcc.readCounts();
+      std::vector<int> const& countsRoc = pcc.readRocCounts();
       std::vector<int> const& modIDs = pcc.readModID();
+      std::vector<int> const& rocIDs = pcc.readRocID();
       std::vector<int> const& events = pcc.readEvents();
       for (unsigned int i = 0; i < modIDs.size(); i++) {
         for (unsigned int bxID = 0; bxID < LumiConstants::numBX; ++bxID) {
           increment(modIDs[i], bxID + 1, counts.at(i * LumiConstants::numBX + bxID));
+        }
+      }
+      for (unsigned int i = 0; i < rocIDs.size(); i++) {
+        for (unsigned int bxID = 0; bxID < LumiConstants::numBX; ++bxID) {
+          incrementRoc(rocIDs[i], bxID + 1, countsRoc.at(i * LumiConstants::numBX + bxID));
         }
       }
       for (unsigned int i = 0; i < LumiConstants::numBX; ++i) {
@@ -58,19 +79,25 @@ namespace reco {
 
     void reset() {
       m_counts.clear();
+      m_countsRoc.clear();
       m_ModID.clear();
+      m_RocID.clear();
       m_events.clear();
       m_events.resize(LumiConstants::numBX, 0);
     }
 
     std::vector<int> const& readCounts() const { return (m_counts); }
+    std::vector<int> const& readRocCounts() const { return (m_countsRoc); }
     std::vector<int> const& readEvents() const { return (m_events); }
     std::vector<int> const& readModID() const { return (m_ModID); }
+    std::vector<int> const& readRocID() const { return (m_RocID); }
 
   private:
     std::vector<int> m_counts;
+    std::vector<int> m_countsRoc;
     std::vector<int> m_events;
     std::vector<int> m_ModID;
+    std::vector<int> m_RocID;
   };
 
 }  // namespace reco

--- a/DataFormats/Luminosity/interface/PixelClusterCountsInEvent.h
+++ b/DataFormats/Luminosity/interface/PixelClusterCountsInEvent.h
@@ -25,17 +25,32 @@ namespace reco {
       m_counts[modIndex] += count;
     }
 
+    void incrementRoc(int rD, int count) {
+      size_t rocIndex = std::distance(m_RocID.begin(), std::find(m_RocID.begin(), m_RocID.end(), rD));
+      if (rocIndex == m_RocID.size()) {
+        m_RocID.push_back(rD);
+        m_countsRoc.push_back(0);
+      }
+      m_countsRoc[rocIndex] += count;
+    }
+
     void setbxID(unsigned int inputbxID) { m_bxID = inputbxID; }
 
     std::vector<int> const& counts() const { return (m_counts); }
 
+    std::vector<int> const& countsRoc() const { return (m_countsRoc); }
+
     std::vector<int> const& modID() const { return (m_ModID); }
+
+    std::vector<int> const& rocID() const { return (m_RocID); }
 
     unsigned int const& bxID() const { return m_bxID; }
 
   private:
     std::vector<int> m_counts;
+    std::vector<int> m_countsRoc;
     std::vector<int> m_ModID;
+    std::vector<int> m_RocID;
     unsigned int m_bxID;
   };
 

--- a/DataFormats/Luminosity/src/classes_def.xml
+++ b/DataFormats/Luminosity/src/classes_def.xml
@@ -46,11 +46,13 @@
   </class>
   <class name="std::vector<LumiSummary::L1>"/>
   <class name="std::vector<LumiSummary::HLT>"/>
-  <class name="reco::PixelClusterCounts" ClassVersion="3">
+  <class name="reco::PixelClusterCounts" ClassVersion="4">
+   <version ClassVersion="4" checksum="63275688"/>
    <version ClassVersion="3" checksum="1474294271"/>
   </class>
   <class name="edm::Wrapper<reco::PixelClusterCounts>"/>
-  <class name="reco::PixelClusterCountsInEvent" ClassVersion="3">
+  <class name="reco::PixelClusterCountsInEvent" ClassVersion="4">
+   <version ClassVersion="4" checksum="3986679997"/>
    <version ClassVersion="3" checksum="3776858548"/>
   </class>
   <class name="edm::Wrapper<reco::PixelClusterCountsInEvent>"/>


### PR DESCRIPTION
Including extra loops to AlcaPCCEventProducer to iterate over clusters and sort them by corresponding ROC modules. Later the information is used to produce luminosity histograms (per bx) with per ROC granularity at HLT. This information could be used to identify the outliers and improve the stability and linearity of Pixel Cluster Counting luminosity (talk by B. Kronheim and C. Palmer https://indico.cern.ch/event/1358674/contributions/5725781/attachments/2775100/4836057/PCC_Active_Masking_Dec_19_2023.pdf)

#### PR validation:

Merged in master since CMSSW_14_1_0_pre4

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

backport of PR #44996

#### PLEASE NOTICE

Once this PR gets merged in CMSSW_14_0_X and deployed in Tier0 for data-taking, we will need at least a processing version change! (See also the [notes](https://docs.google.com/document/d/1_T0Rxajcz7A0RgmIA7FkkYji3v6Yoy23OywS-TwsaFE) taken during the Joint Ops meeting on May 27)
