### PR TITLE
2024 Data RelVals and `InputInfo` Events Skimming (actually) Working

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -55,7 +55,8 @@ class MatrixReader(object):
                              'relval_identity':'id-',
                              'relval_machine': 'mach-',
                              'relval_premix': 'premix-',
-                             'relval_nano':'nano-'
+                             'relval_nano':'nano-',
+                             'relval_data_highstats':'data-'
                              }
 
         self.files = ['relval_standard' ,
@@ -73,7 +74,8 @@ class MatrixReader(object):
                       'relval_identity',
                       'relval_machine',
                       'relval_premix',
-                      'relval_nano'
+                      'relval_nano',
+                      'relval_data_highstats'
                       ]
         self.filesDefault = {'relval_standard':True ,
                              'relval_highstats':True ,
@@ -90,7 +92,8 @@ class MatrixReader(object):
                              'relval_identity':False,
                              'relval_machine':True,
                              'relval_premix':True,
-                             'relval_nano':True
+                             'relval_nano':True,
+                             'relval_data_highstats':False
                              }
 
         self.relvalModule = None

--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -132,7 +132,12 @@ class InputInfo(object):
         elif not self.skimEvents:
             command = "dasgoclient %s --query '%s'" % (das_options, self.queries(dataset)[0])
         elif self.skimEvents:
-            command = "das-up-to-nevents.py -d %s -e %d"%(dataset,self.events)
+            from os import getenv
+            if getenv("CMSSW_USE_IBEOS","false")=="true": 
+                # to be assured that whatever happens the files are only those at CERN
+                command = "das-up-to-nevents.py -d %s -e %d -s T2_CH_CERN"%(dataset,self.events) 
+            else:
+                command = "das-up-to-nevents.py -d %s -e %d"%(dataset,self.events)
         # Run filter on DAS output 
         if self.ib_blacklist:
             command += " | grep -E -v "

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -1,0 +1,30 @@
+# import the definition of the steps and input files:
+from  Configuration.PyReleaseValidation.relval_steps import *
+
+# here only define the workflows as a combination of the steps defined above:
+workflows = Matrix()
+
+## Here we define higher (>50k events) stats data workflows
+## not to be run as default. 150k, 250k, 500k or 1M events each
+
+## 2024
+base_wf_number_2024 = 2024.0
+offset_era = 0.1 # less than 10 eras
+offset_pd = 0.001 # less than 100 pds
+offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
+
+for e_n,era in enumerate(eras_2024):
+    for p_n,pd in enumerate(pds_2024):
+        for e_key,evs in event_steps_dict.items():
+            if "50k" in e_key: # already defined in relval_standard
+                continue   
+            wf_number = base_wf_number_2024
+            wf_number = wf_number + offset_era * e_n
+            wf_number = wf_number + offset_pd * p_n
+            wf_number = wf_number + offset_events * evs 
+            wf_number = round(wf_number,6)
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
+
+
+

--- a/Configuration/PyReleaseValidation/python/relval_data_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_data_highstats.py
@@ -16,7 +16,7 @@ offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
 for e_n,era in enumerate(eras_2024):
     for p_n,pd in enumerate(pds_2024):
         for e_key,evs in event_steps_dict.items():
-            if "50k" in e_key: # already defined in relval_standard
+            if "50k" == e_key: # already defined in relval_standard
                 continue   
             wf_number = base_wf_number_2024
             wf_number = wf_number + offset_era * e_n

--- a/Configuration/PyReleaseValidation/python/relval_highstats.py
+++ b/Configuration/PyReleaseValidation/python/relval_highstats.py
@@ -89,3 +89,26 @@ workflows[134.99603] = ['',['RunSingleMu2015HLHS','HLTDR2_25ns','RECODR2_25nsreH
 
 
 
+## 2024 Data Higher Stats Workflows
+## with 150k, 250k, 500k or 1M events each
+
+base_wf_number_2024 = 2024.0
+offset_era = 0.1 # less than 10 eras
+offset_pd = 0.001 # less than 100 pds
+offset_events = 0.0001 # less than 10 event setups (50k,150k,250k,500k)
+
+for e_n,era in enumerate(eras_2024):
+    for p_n,pd in enumerate(pds_2024):
+        for e_key,evs in event_steps_dict.items():
+            if "50k" in e_key: # already defined in relval_standard
+                continue   
+            wf_number = base_wf_number_2024
+            wf_number = wf_number + offset_era * e_n
+            wf_number = wf_number + offset_pd * p_n
+            wf_number = wf_number + offset_events * evs 
+            wf_number = round(wf_number,6)
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
+
+
+

--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -415,6 +415,7 @@ workflows[136.902] = ['', ['RunDoubleMuon2016H', 'TauEmbedding_Selection_2016', 
 workflows[136.903] = ['', ['RunDoubleMuon2017B', 'TauEmbedding_Selection_2017', 'TauEmbedding_Cleaning_2017', 'TauEmbedding_GenPreHLT_2017', 'TauEmbedding_GenHLT_2017', 'TauEmbedding_GenPostHLT_2017', 'TauEmbedding_Merging_2017']]
 workflows[136.904] = ['', ['RunDoubleMuon2018C', 'TauEmbedding_Selection_2018', 'TauEmbedding_Cleaning_2018', 'TauEmbedding_GenPreHLT_2018', 'TauEmbedding_GenHLT_2018', 'TauEmbedding_GenPostHLT_2018', 'TauEmbedding_Merging_2018']]
 
+
 ### run 2021 collisions ###
 workflows[139.001] = ['RunMinimumBias2021',['RunMinimumBias2021','HLTDR3_2022','RECODR3_reHLT_MinBiasOffline','HARVESTD2021MB_reHLT']]
 workflows[139.002] = ['',['RunZeroBias2021','HLTDR3_2022','RECODR3_reHLT_ZBOffline','HARVESTD2021ZB_reHLT']]
@@ -557,6 +558,21 @@ workflows[142.0] = ['',['RunHIPhysicsRawPrime2023A','HLTDR3_HI2023ARawprime','RE
 ### run3-2024 (2024 HI UPC data)
 workflows[142.901] = ['',['RunUPC2023','RECODR3_2024_UPC','HARVESTDPROMPTR3']]
 workflows[142.902] = ['',['RunUPC2023','RECODR3_2024_HIN','HARVESTDPROMPTR3']]
+
+## 2024 Data Workflows
+base_wf_number_2024 = 2024.0
+offset_era = 0.1 # less than 10 eras
+offset_pd = 0.001 # less than 100 pds
+
+for e_n,era in enumerate(eras_2024):
+    for p_n,pd in enumerate(pds_2024):
+        wf_number = base_wf_number_2024
+        wf_number = wf_number + offset_era * e_n
+        wf_number = wf_number + offset_pd * p_n
+        wf_number = wf_number + 0.0001 * 0.05 
+        wf_number = round(wf_number,6)
+        step_name = "Run" + pd + era.split("Run")[1] + "_50k"
+        workflows[wf_number] = ['',[step_name,'HLTDR3_2024','AODNANORUN3_reHLT_2024','HARVESTRUN3_2024']]
 
 ### fastsim ###
 workflows[5.1] = ['TTbarFS', ['TTbarFS','HARVESTFS']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -44,6 +44,10 @@ step1Up2024HiProdDefaults = merge ([{'--conditions':'auto:phase1_2024_realistic_
 
 steps = Steps()
 
+#### Event to runs
+event_steps = [0.05,0.15,0.25,0.5,1] #in millions
+event_steps_k = ["50k","150k","250k","500k","1M"]
+event_steps_dict = dict(zip(event_steps_k,event_steps))
 #### Production test section ####
 steps['ProdMinBias']=merge([{'cfg':'MinBias_8TeV_pythia8_TuneCUETP8M1_cff','--relval':'9000,300'},step1Defaults])
 steps['ProdTTbar']=merge([{'cfg':'TTbar_8TeV_TuneCUETP8M1_cfi','--relval':'9000,100'},step1Defaults])
@@ -478,7 +482,13 @@ steps['RunRawPPSReco2024E']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2024E-v1/RA
 # UL AOD
 steps['RunJetHT2018D_reminiaodUL']={'INPUT':InputInfo(dataSet='/JetHT/Run2018D-12Nov2019_UL2018-v4/AOD',label='2018DrmaodUL',events=100000,location='STD', ls=Run2018D)}
 
-#### run3 ####
+####################################
+#### Run3 ##########################
+####################################
+
+###2022
+
+## Collisions at 900 GeV and ramp-up to 13.6 TeV
 Run2022A={353015: [[1, 100]]}
 steps['RunMinimumBias2022A']={'INPUT':InputInfo(dataSet='/MinimumBias/Run2022A-v1/RAW',label='2022A',events=100000,location='STD', ls=Run2022A)}
 steps['RunSingleMuon2022A']={'INPUT':InputInfo(dataSet='/SingleMuon/Run2022A-v1/RAW',label='2022A',events=100000,location='STD', ls=Run2022A)}
@@ -497,7 +507,7 @@ steps['RunTau2022A']={'INPUT':InputInfo(dataSet='/Tau/Run2022A-v1/RAW',label='20
 steps['RunDoubleMuon2022A']={'INPUT':InputInfo(dataSet='/DoubleMuon/Run2022A-v1/RAW',label='2022A',events=100000,location='STD', ls=Run2022A)}
 steps['RunMuonEG2022A']={'INPUT':InputInfo(dataSet='/MuonEG/Run2022A-v1/RAW',label='2022A',events=100000,location='STD', ls=Run2022A)}
 
-Run2022B={355769: [[1, 106]]}
+Run2022B={355769: [[1, 106]]} ## this could be rised to "355769": [[1, 541]]
 steps['RunMinimumBias2022B']={'INPUT':InputInfo(dataSet='/MinimumBias/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
 steps['RunSingleMuon2022B']={'INPUT':InputInfo(dataSet='/SingleMuon/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
 steps['RunZeroBias2022B']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
@@ -514,7 +524,6 @@ steps['RunEGamma2022B']={'INPUT':InputInfo(dataSet='/EGamma/Run2022B-v1/RAW',lab
 steps['RunTau2022B']={'INPUT':InputInfo(dataSet='/Tau/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
 steps['RunDoubleMuon2022B']={'INPUT':InputInfo(dataSet='/DoubleMuon/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
 steps['RunMuonEG2022B']={'INPUT':InputInfo(dataSet='/MuonEG/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
-#steps['RunParkingBPH2022B']={'INPUT':InputInfo(dataSet='/ParkingBPH/Run2022B-v1/RAW',label='2022B',events=100000,location='STD', ls=Run2022B)}
 
 Run2022C={356381: [[1, 1193]]}
 Run2022C_LS40={356381: [[1, 40]]}
@@ -576,7 +585,7 @@ steps['RunSiPixelCalCosmics2022F']={'INPUT':InputInfo(dataSet='/Cosmics/Run2022F
 # reMINIAOD for 2022
 steps['RunJetMET2022D_reMINI']={'INPUT':InputInfo(dataSet='/JetMET/Run2022D-16Jun2023-v1/AOD',label='rmaod',events=100000,location='STD', ls=Run2022D_LS25)}
 
-#### run3 ####
+###2023
 Run2023B={366727: [[1, 244]]}
 steps['RunMuon2023B']={'INPUT':InputInfo(dataSet='/Muon0/Run2023B-v1/RAW',label='2023B',events=100000,location='STD', ls=Run2023B)}
 steps['RunZeroBias2023B']={'INPUT':InputInfo(dataSet='/ZeroBias/Run2023B-v1/RAW',label='2023B',events=100000,location='STD', ls=Run2023B)}
@@ -624,6 +633,23 @@ steps['RunUPC2023']={'INPUT':InputInfo(dataSet='/HIForward1/HIRun2023A-v1/RAW',l
 
 RunHI2023={375491: [[100, 100]]}
 steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrime0/HIRun2023A-v1/RAW',label='HI2023A',events=100000,location='STD', ls=RunHI2023)}
+
+### Golden Data Wfs
+# reading good runs directly from the latest golden json 
+# in https://cms-service-dqmdc.web.cern.ch/CAF/certification/
+# or (if available) 
+
+###2024 
+# number of events limits the files used as input
+
+pds_2024 = ['BTagMu', 'DisplacedJet', 'EGamma0', 'EphemeralZeroBias0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
+eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F']
+for era in eras_2024:
+    for pd in pds_2024:
+        dataset = "/" + pd + "/" + era + "-v1/RAW"
+        for e_key,evs in event_steps_dict.items():
+            step_name = "Run" + pd + era.split("Run")[1] + "_" + e_key
+            steps[step_name] = {'INPUT':InputInfo(dataSet=dataset,label=era.split("Run")[1],events=int(evs*1e6), skimEvents=True, location='STD')}
 
 # Highstat HLTPhysics
 Run2015DHS=selectedLS([258712,258713,258714,258741,258742,258745,258749,258750,259626,259637,259683,259685,259686,259721,259809,259810,259818,259820,259821,259822,259862,259890,259891])
@@ -2166,6 +2192,8 @@ steps['HLTDR3_2023']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--con
 
 steps['HLTDR3_2023B']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3'},steps['HLTD'] ] )
 
+steps['HLTDR3_2024']=merge( [ {'-s':'L1REPACK:Full,HLT:@%s'%hltKey2024,},{'--conditions':'auto:run3_hlt_relval'},{'--era' : 'Run3_2024'},steps['HLTD'] ] )
+
 steps['HLTDR3_HI2023ARawprime']=merge([{'-s':'L1REPACK:Full,HLT:HIon'},
                                        {'--conditions':'auto:run3_hlt_HIon'},
                                        {'--era' : 'Run3_pp_on_PbPb_approxSiStripClusters_2023'},
@@ -2696,10 +2724,11 @@ steps['RECODR3']=merge([{'--scenario':'pp',
 
 steps['RECODR3_2023']=merge([{'--era':'Run3_2023'},steps['RECODR3']])
 steps['RECODR3_2024']=merge([{'--era':'Run3_2024'},steps['RECODR3']])
-                         
+
 steps['RECODR3_reHLT_2022']=merge([{'--conditions':'auto:run3_data_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 steps['RECODR3_reHLT_2023']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3_2023']])
 steps['RECODR3_reHLT_2023B']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
+steps['RECODR3_reHLT_2024']=merge([{'--conditions':'auto:run3_data_prompt_relval', '--hltProcess':'reHLT'},steps['RECODR3']])
 
 steps['RECODR3_2023_HIN']=merge([{'--conditions':'auto:run3_data_prompt', '-s':'RAW2DIGI,L1Reco,RECO,DQM:@commonFakeHLT+@standardDQMFakeHLT', '--repacked':'', '-n':1000},steps['RECODR3_2023']])
 steps['RECODR3_2023_UPC']=merge([{'--era':'Run3_2023_UPC'},steps['RECODR3_2023_HIN']])
@@ -3057,6 +3086,8 @@ steps['AODNANORUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:
 steps['AODNANORUN3_reHLT_2023B']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2023B']])
 
 steps['RECOHIRUN3_reHLT_2023']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,DQM:@standardDQM','--datatier':'RECO,MINIAOD,DQMIO','--eventcontent':'RECO,MINIAOD,DQM','--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023','--conditions':'auto:run3_data_HIon'},steps['RECODR3_reHLT_2023']])
+
+steps['AODNANORUN3_reHLT_2024']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,PAT,NANO,DQM:@standardDQM+@miniAODDQM+@nanoAODDQM','--datatier':'AOD,MINIAOD,NANOAOD,DQMIO','--eventcontent':'AOD,MINIAOD,NANOEDMAOD,DQM'},steps['RECODR3_reHLT_2024']])
 
 # patatrack validation in data
 steps['RecoData_Patatrack_AllGPU_Validation_2023'] = merge([{'-s':'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
@@ -3788,6 +3819,7 @@ steps['HARVESTRUN3_ZB_2022']=merge([{'--data':'', '-s':'HARVESTING:@rerecoZeroBi
 steps['HARVESTRUN3_COS_2022']=merge([{'--data':'', '--scenario':'cosmics', '--era':'Run3', '-s':'HARVESTING:dqmHarvesting'},steps['HARVESTDRUN3']])
 steps['HARVESTRUN3_2023']=merge([{'--era':'Run3_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
 steps['HARVESTRUN3_2023B']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTRUN3_2022']])
+steps['HARVESTRUN3_2024']=merge([{'--era':'Run3', '-s':'HARVESTING:@standardDQM+@miniAODDQM+@nanoAODDQM'},steps['HARVESTDRUN3']])
 
 steps['HARVESTRUN3_HI2023A']=merge([{'--era':'Run3_pp_on_PbPb_approxSiStripClusters_2023', '-s':'HARVESTING:@standardDQM+@miniAODDQM'},steps['HARVESTRUN3_2022']])
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -642,7 +642,7 @@ steps['RunHIPhysicsRawPrime2023A']={'INPUT':InputInfo(dataSet='/HIPhysicsRawPrim
 ###2024 
 # number of events limits the files used as input
 
-pds_2024 = ['BTagMu', 'DisplacedJet', 'EGamma0', 'EphemeralZeroBias0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
+pds_2024  = ['BTagMu', 'DisplacedJet', 'EGamma0', 'HcalNZS', 'JetMET0', 'Muon0', 'MuonEG', 'NoBPTX', 'ParkingDoubleMuonLowMass0', 'ParkingHH', 'ParkingLLP', 'ParkingSingleMuon0', 'ParkingVBF0', 'Tau', 'ZeroBias']
 eras_2024 = ['Run2024B', 'Run2024C', 'Run2024D', 'Run2024E', 'Run2024F']
 for era in eras_2024:
     for pd in pds_2024:

--- a/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
+++ b/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import pycurl
+from io import BytesIO
+import pycurl
+import ast
+import subprocess
+import pandas as pd
+import argparse
+from bs4 import BeautifulSoup
+import numpy as np
+import os
+import json
+import sys
+
+## Helpers
+base_cert_url = "https://cms-service-dqmdc.web.cern.ch/CAF/certification/"
+base_cert_path = "/eos/user/c/cmsdqm/www/CAF/certification/"
+
+def get_url_clean(url):
+    
+    buffer = BytesIO()
+    c = pycurl.Curl()
+    c.setopt(c.URL, url)
+    c.setopt(c.WRITEDATA, buffer)
+    c.perform()
+    c.close()
+    
+    return BeautifulSoup(buffer.getvalue(), "lxml").text
+
+def das_do_command(cmd):
+    out = subprocess.check_output(cmd, shell=True, executable="/bin/bash").decode('utf8')
+    return out
+
+def das_file_data(dataset,opt=""):
+    cmd = "dasgoclient --query='file dataset=%s %s| grep file.name, file.nevents'"%(dataset,opt)
+    
+    out = das_do_command(cmd).split("\n")
+    out = [np.array(r.split(" "))[[0,3]] for r in out if len(r) > 0]
+    
+    df = pd.DataFrame(out,columns=["file","events"])
+    df.events = df.events.values.astype(int)
+    
+    return df
+
+def das_lumi_data(dataset,opt=""):
+    cmd = "dasgoclient --query='file,lumi,run dataset=%s %s'"%(dataset,opt)
+    
+    out = das_do_command(cmd).split("\n")
+    out = [r.split(" ") for r in out if len(r)>0]
+    
+    df = pd.DataFrame(out,columns=["file","run","lumis"])
+    
+    return df
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset','-d', default=None, help="Dataset Name (e.g. '/DisplacedJet/Run2024C-v1/RAW' )",type=str,required=True)
+    parser.add_argument('--threshold','-t', help ="Event threshold per file",type=int,default=-1)
+    parser.add_argument('--events','-e', help ="Tot number of events targeted",type=int,default=-1)
+    parser.add_argument('--outfile','-o', help='Dump results to file', type=str, default=None)
+    parser.add_argument('--pandas', '-pd',action='store_true',help="Store the whole dataset (no event or threshold cut) in a csv") 
+    parser.add_argument('--proxy','-p', help='Allow to parse a x509 proxy if needed', type=str, default=None)
+    parser.add_argument('--site','-s', help='Only data at specific site', type=str, default=None)
+    args = parser.parse_args()
+
+    if args.proxy is not None:
+        os.environ["X509_USER_PROXY"] = args.proxy
+    elif "X509_USER_PROXY" not in os.environ:
+        print("No X509 proxy set. Exiting.")
+        sys.exit(1)
+    
+    dataset   = args.dataset
+    events    = args.events
+    threshold = args.threshold
+    outfile   = args.outfile
+    site      = "site="+args.site if args.site is not None else ""
+
+    ## get the greatest golden json
+    year = dataset.split("Run")[1][2:4] # from 20XX to XX
+    PD = dataset.split("/")[1]
+    cert_type = "Collisions" + str(year)
+    if "Cosmics" in dataset:
+        cert_type = "Cosmics" + str(year)
+    elif "Commisioning" in dataset:
+        cert_type = "Commisioning2020" 
+    elif "HI" in PD:
+        cert_type = "Collisions" + str(year) + "HI"
+    
+    cert_path = base_cert_path + cert_type + "/"
+    web_fallback = False
+
+    if os.path.isdir(cert_path):
+        json_list = os.listdir(cert_path)
+        if len(json_list) == 0:
+            web_fallback == True
+        json_list = [c for c in json_list if "Golden" in c and "era" not in c]
+        json_list = [c for c in json_list if c.startswith("Cert_C") and c.endswith("json")]
+    else:
+        web_fallback = True
+    
+    if web_fallback:
+        cert_url = base_cert_url + cert_type + "/"
+        json_list = get_url_clean(cert_url).split("\n")
+        json_list = [c for c in json_list if "Golden" in c and "era" not in c]
+        json_list = [[cc for cc in c.split(" ") if cc.startswith("Cert_C") and cc.endswith("json")][0] for c in json_list]
+
+    # the larger the better, assuming file naming schema 
+    # Cert_X_RunStart_RunFinish_Type.json
+    run_ranges = [int(c.split("_")[3]) - int(c.split("_")[2]) for c in json_list]
+    latest_json = np.array(json_list[np.argmax(run_ranges)]).reshape(1,-1)[0].astype(str)
+    best_json = str(latest_json[0])
+    if not web_fallback:
+        with open(cert_path + "/" + best_json) as js:
+            golden = json.load(js)
+    else:
+        golden = get_url_clean(cert_url + best_json)
+        golden = ast.literal_eval(golden) #converts string to dict
+
+    # golden json with all the lumisections
+    golden_flat = {}
+    for k in golden:
+        R = []
+        for r in golden[k]:
+            R = R + [f for f in range(r[0],r[1]+1)]
+        golden_flat[k] = R
+
+    # building the dataframe, cleaning for bad lumis
+    df = das_lumi_data(dataset).merge(das_file_data(dataset),on="file",how="inner") # merge file informations with run and lumis
+    df = df[df["run"].isin(list(golden.keys()))] # skim for golden runs
+    df["lumis"] = [[int(ff) for ff in f.replace("[","").replace("]","").split(",")] for f in df.lumis.values]
+    df_rs = []
+    for r in golden_flat:
+        cut = (df["run"] == r)
+        if not any(cut):
+            continue
+
+        df_r = df[cut]
+
+        # jumping low event content runs
+        if df_r["events"].sum() < threshold:
+            continue
+
+        good_lumis = np.array([len([ll for ll in l if ll in golden_flat[r]]) for l in df_r.lumis])
+        n_lumis = np.array([len(l) for l in df_r.lumis])
+        df_rs.append(df_r[good_lumis==n_lumis])
+
+    df = pd.concat(df_rs)
+    df.loc[:,"min_lumi"] = [min(f) for f in df.lumis]
+    df.loc[:,"max_lumi"] = [max(f) for f in df.lumis]
+    df = df.sort_values(["run","min_lumi","max_lumi"])
+
+    if args.pandas:
+        df.to_csv(dataset.replace("/","")+".csv")
+
+    if events > 0:
+        df.loc[:,"sum_evs"] = df.loc[:,"events"].cumsum()
+        df = df[df["sum_evs"] < events]
+            
+    files = df.file
+
+    if outfile is not None:
+        with open(outfile, 'w') as f:
+            for line in files:
+                f.write(f"{line}\n") 
+    else:
+        print("\n".join(files))
+
+    sys.exit(0)
+
+    

--- a/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
+++ b/Configuration/PyReleaseValidation/scripts/das-up-to-nevents.py
@@ -171,6 +171,7 @@ if __name__ == '__main__':
         df.to_csv(dataset.replace("/","")+".csv")
 
     if events > 0:
+        df = df[df["events"] <= events] #jump too big files
         df.loc[:,"sum_evs"] = df.loc[:,"events"].cumsum()
         df = df[df["sum_evs"] < events]
             


### PR DESCRIPTION
#### PR description:

This PR proposes few things:

1. the introduction of a new script `das-up-to-nevents.py` that, given in input a dataset name, allows to get the list of files corresponding to N events. The dataset is also automatically skimmed to include only the run and the lumis from the latest and greatest Golden data certification json;

2. a fix to the fact that  the `InputInfo` class, while accepting as input a variable `events` does not really use it to skim the result of the das query. It's only really used in a [log](https://github.com/AdrianoDee/cmssw/blob/1d62219e28a38c574b9cc9af52ec07d34ab5303e/Configuration/PyReleaseValidation/python/MatrixReader.py#L389). I find it ambiguous and a bit confusing. In practice it also means that for 2023 and 2022 RelVals we have been running on O(few millions) events per pre-release (see e.g. [CMSSW_14_1_0_pre3__Data_Run3_2023_Data-RunEGamma2023D](https://cms-pdmv-prod.web.cern.ch/relval/relvals?prepid=CMSSW_14_1_0_pre3__Data_Run3_2023_Data-RunEGamma2023D-00001&shown=1082367&page=0&limit=50)). While this is nice in terms of being able to do that (kudos on computing!) it usually slows down a lot the RelVal production. This leverages on the script introduced in (1).

3. the addition of 2024 data RelVals for Eras from B to F as `standard` wfs with `2024.*` prefix. These are run with:
   - `Run3_2024` era; 
   - `HLT:@relval2024` (currently pointing at GRun);
   - running on 50k events using the script in (1) and the script in (2)

4. a new set of RelVals under `relvals_data_highstats.py` that should include all the higher statistics data RelVals workflows with 150k,250k,500k and 1M events. For the moment it includes only the 2024 wfs. This set is not turned on by default to avoid to have an over crowded matrix.

All the needed input RAW samples have been copied via Rucio at `T2_CH_CERN`.
 
#### PR validation:

Running (e.g.) `runTheMatrix.py -w data,standard -l 12024.003015, 2024.00405, 2024.007005, 2024.0091, 2024.012005, 2024.013025, 2024.10305, 2024.108005, 2024.108015, 2024.210025, 2024.211015, 2024.2111, 2024.212025, 2024.213015, 2024.214025, 2024.21405, 2024.303015, 2024.310025, 2024.31305, 2024.3141, 2024.400005, 2024.402015`