### PR TITLE
Use std::abs instead of integer abs in HLTMCtruth.cc

### DIFF
--- a/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc
+++ b/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc
@@ -125,7 +125,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView>& mctruth,
         if (pt < 5.0)
           continue;
         double eta = j.momentum().eta();
-        if (abs(eta) > 2.5)
+        if (std::abs(eta) > 2.5)
           continue;
         if (j.noVertex())
           continue;
@@ -136,7 +136,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView>& mctruth,
         if (r > 200.)
           continue;  // I think units are cm here
         double z = simVertices->at(vertIndex).position().z();
-        if (abs(z) > 400.)
+        if (std::abs(z) > 400.)
           continue;  // I think units are cm here
         mu3 += 1;
         break;


### PR DESCRIPTION
#### PR description:

Fix compilation warnings in HLTMCtruth.cc:

```
  src/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc:128:13: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   128 |         if (abs(eta) > 2.5)
      |             ^
src/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc:128:13: note: use function 'std::abs' instead
  128 |         if (abs(eta) > 2.5)
      |             ^~~
      |             std::abs
  src/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc:139:13: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   139 |         if (abs(z) > 400.)
      |             ^
src/HLTrigger/HLTanalyzers/plugins/HLTMCtruth.cc:139:13: note: use function 'std::abs' instead
  139 |         if (abs(z) > 400.)
      |             ^~~
      |             std::abs
```

#### PR validation:

Bot tests