### PR TITLE
Fix compilation warning in Batching.cc

### DIFF
--- a/PhysicsTools/TensorFlowAOT/src/Batching.cc
+++ b/PhysicsTools/TensorFlowAOT/src/Batching.cc
@@ -95,7 +95,7 @@ namespace tfaot {
     for (size_t i = 0; i < rule.nSizes(); i++) {
       out << (i == 0 ? "" : ",") << rule.getSizes()[i];
     }
-    return out << ", lastPadding=" << rule.getLastPadding() + ")";
+    return out << ", lastPadding=" << rule.getLastPadding() << ")";
   }
 
   void BatchStrategy::setDefaultRule(size_t batchSize, const std::vector<size_t>& availableBatchSizes) {


### PR DESCRIPTION
#### PR description:

Fix compilation warning in PhysicsTools/TensorFlowAOT/src/Batching.cc:

```
  src/PhysicsTools/TensorFlowAOT/src/Batching.cc:98:61: warning: adding 'size_t' (aka 'unsigned long') to a string does not append to the string [-Wstring-plus-int]
    98 |     return out << ", lastPadding=" << rule.getLastPadding() + ")";
      |                                       ~~~~~~~~~~~~~~~~~~~~~~^~~~~
src/PhysicsTools/TensorFlowAOT/src/Batching.cc:98:61: note: use array indexing to silence this warning
```

(the fix suggested by clang is not valid in this context).

#### PR validation:

Bot tests