### PR TITLE
Use std::abs instead of abs in PixelPhase2TopologyBuilder.cc

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h
@@ -109,7 +109,7 @@ public:
   bool isItBigPixelInX(const int ixbin) const override {
     bool no_big_pixel = (m_BIG_PIX_PER_ROC_X == 0);
     if (!no_big_pixel)
-      no_big_pixel = abs((ixbin - m_nrows / 2) + 0.5) > m_BIG_PIX_PER_ROC_X;
+      no_big_pixel = std::abs((ixbin - m_nrows / 2) + 0.5) > m_BIG_PIX_PER_ROC_X;
 
     return !no_big_pixel;
   }
@@ -117,7 +117,7 @@ public:
   bool isItBigPixelInY(const int iybin) const override {
     bool no_big_pixel = (m_BIG_PIX_PER_ROC_Y == 0);
     if (!no_big_pixel)
-      no_big_pixel = abs((iybin - m_ncols / 2) + 0.5) > m_BIG_PIX_PER_ROC_Y;
+      no_big_pixel = std::abs((iybin - m_ncols / 2) + 0.5) > m_BIG_PIX_PER_ROC_Y;
 
     return !no_big_pixel;
   }


### PR DESCRIPTION
#### PR description:

Fix compilation warnings in PixelPhase2TopologyBuilder.cc:
```
In file included from src/Geometry/TrackerGeometryBuilder/src/PixelPhase2TopologyBuilder.cc:3:
  src/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h:112:22: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   112 |       no_big_pixel = abs((ixbin - m_nrows / 2) + 0.5) > m_BIG_PIX_PER_ROC_X;
      |                      ^
src/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h:112:22: note: use function 'std::abs' instead
  112 |       no_big_pixel = abs((ixbin - m_nrows / 2) + 0.5) > m_BIG_PIX_PER_ROC_X;
      |                      ^~~
      |                      std::abs
  src/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h:120:22: warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
   120 |       no_big_pixel = abs((iybin - m_ncols / 2) + 0.5) > m_BIG_PIX_PER_ROC_Y;
      |                      ^
src/Geometry/TrackerGeometryBuilder/interface/RectangularPixelPhase2Topology.h:120:22: note: use function 'std::abs' instead
  120 |       no_big_pixel = abs((iybin - m_ncols / 2) + 0.5) > m_BIG_PIX_PER_ROC_Y;
      |                      ^~~
      |                      std::abs
2 warnings generated.
```

#### PR validation:

Bot tests