### PR TITLE
[140X] Protection for invalid TSOS in MuonTrajectoryUpdator

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -156,6 +156,12 @@ pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const Traject
 
             lastUpdatedTSOS = measurementUpdator()->update(propagatedTSOS, *((*recHit).get()));
 
+            if (!lastUpdatedTSOS.isValid()) {
+              edm::LogInfo(metname) << "Invalid last TSOS, will skip RecHit ";
+              lastUpdatedTSOS = propagatedTSOS;  // Revert update
+              continue;
+            }
+
             LogTrace(metname) << "  Fit   Position : " << lastUpdatedTSOS.globalPosition()
                               << "  Fit  Direction : " << lastUpdatedTSOS.globalDirection() << "\n"
                               << "  Fit position radius : " << lastUpdatedTSOS.globalPosition().perp()


### PR DESCRIPTION
#### PR description:

This PR addresses https://github.com/cms-sw/cmssw/issues/45035
Attempts to fix a crash observed when KFUpdator returns an invalid trajectory state on surface.
Whenever this happens, muon trajectory updator skips that recHit.

#### PR validation:

Code compiles and has been tested in affected jobs

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is a plain backport of https://github.com/cms-sw/cmssw/pull/45053