### PR TITLE
`MuonHLTSeedMVAClassifier`: update to use MVA-related parameters according to `isL1` value

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -268,6 +268,53 @@ def customizeHLTfor44576(process):
         break
     return process
 
+def customizeHLTfor45063(process):
+    """Assigns value of MuonHLTSeedMVAClassifier mva input file, scales and mean values according to the value of isFromL1"""
+    for prod in producers_by_type(process, 'MuonHLTSeedMVAClassifier'):
+        if hasattr(prod, "isFromL1"):
+            if (prod.isFromL1 == True):
+                if hasattr(prod, "mvaFileBL1"):
+                    prod.mvaFileB = prod.mvaFileBL1
+                if hasattr(prod, "mvaFileEL1"):
+                    prod.mvaFileE = prod.mvaFileEL1
+                if hasattr(prod, "mvaScaleMeanBL1"):
+                    prod.mvaScaleMeanB = prod.mvaScaleMeanBL1
+                if hasattr(prod, "mvaScaleStdBL1"):
+                    prod.mvaScaleStdB = prod.mvaScaleStdBL1
+                if hasattr(prod, "mvaScaleMeanEL1"):
+                    prod.mvaScaleMeanE = prod.mvaScaleMeanEL1
+                if hasattr(prod, "mvaScaleStdEL1"):                    
+                    prod.mvaScaleStdE = prod.mvaScaleStdEL1                
+            else:
+                if hasattr(prod, "mvaFileBL2"):
+                    prod.mvaFileB = prod.mvaFileBL2
+                if hasattr(prod, "mvaFileEL2"):
+                    prod.mvaFileE = prod.mvaFileEL2
+                if hasattr(prod, "mvaScaleMeanBL2"):
+                    prod.mvaScaleMeanB = prod.mvaScaleMeanBL2
+                if hasattr(prod, "mvaScaleStdBL2"):
+                    prod.mvaScaleStdB = prod.mvaScaleStdBL2
+                if hasattr(prod, "mvaScaleMeanEL2"):
+                    prod.mvaScaleMeanE = prod.mvaScaleMeanEL2
+                if hasattr(prod, "mvaScaleStdEL2"):
+                    prod.mvaScaleStdE = prod.mvaScaleStdEL2
+                    
+    for prod in producers_by_type(process, 'MuonHLTSeedMVAClassifier'):
+        delattr(prod,"mvaFileBL1")
+        delattr(prod,"mvaFileEL1")
+        delattr(prod,"mvaScaleMeanBL1")
+        delattr(prod,"mvaScaleStdBL1")
+        delattr(prod,"mvaScaleMeanEL1")
+        delattr(prod,"mvaScaleStdEL1")
+        delattr(prod,"mvaFileBL2")
+        delattr(prod,"mvaFileEL2")
+        delattr(prod,"mvaScaleMeanBL2")
+        delattr(prod,"mvaScaleStdBL2")
+        delattr(prod,"mvaScaleMeanEL2")
+        delattr(prod,"mvaScaleStdEL2")       
+                    
+    return process
+            
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -278,5 +325,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     process = checkHLTfor43774(process)
     process = customizeHLTfor44576(process)
+    process = customizeHLTfor45063(process)
 
     return process

--- a/RecoMuon/TrackerSeedGenerator/interface/SeedMvaEstimator.h
+++ b/RecoMuon/TrackerSeedGenerator/interface/SeedMvaEstimator.h
@@ -20,6 +20,24 @@ namespace edm {
   class FileInPath;
 }
 
+namespace {
+  enum inputIndexes {
+    kTsosErr0,       // 0
+    kTsosErr2,       // 1
+    kTsosErr5,       // 2
+    kTsosDxdz,       // 3
+    kTsosDydz,       // 4
+    kTsosQbp,        // 5
+    kDRdRL1SeedP,    // 6
+    kDPhidRL1SeedP,  // 7
+    kLastL1,         // 8
+
+    kDRdRL2SeedP = 8,  // 8
+    kDPhidRL2SeedP,    // 9
+    kLastL2,           // 10
+  };
+}  // namespace
+
 class SeedMvaEstimator {
 public:
   SeedMvaEstimator(const edm::FileInPath& weightsfile,

--- a/RecoMuon/TrackerSeedGenerator/plugins/MuonHLTSeedMVAClassifier.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/MuonHLTSeedMVAClassifier.cc
@@ -92,28 +92,35 @@ MuonHLTSeedMVAClassifier::MuonHLTSeedMVAClassifier(const edm::ParameterSet& iCon
       l1MuonToken_(consumes<l1t::MuonBxCollection>(iConfig.getParameter<edm::InputTag>("L1Muon"))),
       l2MuonToken_(consumes<reco::RecoChargedCandidateCollection>(iConfig.getParameter<edm::InputTag>("L2Muon"))),
       trackerGeometryToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
-
       rejectAll_(iConfig.getParameter<bool>("rejectAll")),
       isFromL1_(iConfig.getParameter<bool>("isFromL1")),
-
-      mvaFileB_(iConfig.getParameter<edm::FileInPath>(isFromL1_ ? "mvaFileBL1" : "mvaFileBL2")),
-      mvaFileE_(iConfig.getParameter<edm::FileInPath>(isFromL1_ ? "mvaFileEL1" : "mvaFileEL2")),
-
-      mvaScaleMeanB_(iConfig.getParameter<std::vector<double>>(isFromL1_ ? "mvaScaleMeanBL1" : "mvaScaleMeanBL2")),
-      mvaScaleStdB_(iConfig.getParameter<std::vector<double>>(isFromL1_ ? "mvaScaleStdBL1" : "mvaScaleStdBL2")),
-      mvaScaleMeanE_(iConfig.getParameter<std::vector<double>>(isFromL1_ ? "mvaScaleMeanEL1" : "mvaScaleMeanEL2")),
-      mvaScaleStdE_(iConfig.getParameter<std::vector<double>>(isFromL1_ ? "mvaScaleStdEL1" : "mvaScaleStdEL2")),
-
+      mvaFileB_(iConfig.getParameter<edm::FileInPath>("mvaFileB")),
+      mvaFileE_(iConfig.getParameter<edm::FileInPath>("mvaFileE")),
+      mvaScaleMeanB_(iConfig.getParameter<std::vector<double>>("mvaScaleMeanB")),
+      mvaScaleStdB_(iConfig.getParameter<std::vector<double>>("mvaScaleStdB")),
+      mvaScaleMeanE_(iConfig.getParameter<std::vector<double>>("mvaScaleMeanE")),
+      mvaScaleStdE_(iConfig.getParameter<std::vector<double>>("mvaScaleStdE")),
       doSort_(iConfig.getParameter<bool>("doSort")),
       nSeedsMaxB_(iConfig.getParameter<int>("nSeedsMaxB")),
       nSeedsMaxE_(iConfig.getParameter<int>("nSeedsMaxE")),
-
       etaEdge_(iConfig.getParameter<double>("etaEdge")),
       mvaCutB_(iConfig.getParameter<double>("mvaCutB")),
       mvaCutE_(iConfig.getParameter<double>("mvaCutE")),
-
       minL1Qual_(iConfig.getParameter<int>("minL1Qual")),
       baseScore_(iConfig.getParameter<double>("baseScore")) {
+  const auto& mvaFileBPath = mvaFileB_.fullPath();
+  const auto& mvaFileEPath = mvaFileE_.fullPath();
+
+  if (!isFromL1_ and
+      ((mvaFileBPath.find("FromL1") != std::string::npos) or (mvaFileEPath.find("FromL1") != std::string::npos))) {
+    throw cms::Exception("ConfigurationError")
+        << " isFromL1 parameter is False, but using FromL1 MVA files.\n Please check your configuration";
+  } else if (isFromL1_ and ((mvaFileBPath.find("FromL1") == std::string::npos) or
+                            (mvaFileEPath.find("FromL1") == std::string::npos))) {
+    throw cms::Exception("ConfigurationError")
+        << " isFromL1 parameter is True, but not using FromL1 MVA files.\n Please check your configuration";
+  }
+
   if (!rejectAll_) {
     mvaEstimator_ = std::make_pair(
         std::make_unique<SeedMvaEstimator>(mvaFileB_, mvaScaleMeanB_, mvaScaleStdB_, isFromL1_, minL1Qual_),
@@ -247,22 +254,14 @@ void MuonHLTSeedMVAClassifier::fillDescriptions(edm::ConfigurationDescriptions& 
   desc.add<bool>("rejectAll", false);
   desc.add<bool>("isFromL1", false);
 
-  desc.add<edm::FileInPath>("mvaFileBL1",
+  desc.add<edm::FileInPath>("mvaFileB",
                             edm::FileInPath("RecoMuon/TrackerSeedGenerator/data/xgb_Run3_Iter2FromL1Seeds_barrel.xml"));
-  desc.add<edm::FileInPath>("mvaFileEL1",
+  desc.add<edm::FileInPath>("mvaFileE",
                             edm::FileInPath("RecoMuon/TrackerSeedGenerator/data/xgb_Run3_Iter2FromL1Seeds_endcap.xml"));
-  desc.add<edm::FileInPath>("mvaFileBL2",
-                            edm::FileInPath("RecoMuon/TrackerSeedGenerator/data/xgb_Run3_Iter2Seeds_barrel.xml"));
-  desc.add<edm::FileInPath>("mvaFileEL2",
-                            edm::FileInPath("RecoMuon/TrackerSeedGenerator/data/xgb_Run3_Iter2Seeds_endcap.xml"));
-  desc.add<std::vector<double>>("mvaScaleMeanBL1", {0., 0., 0., 0., 0., 0., 0., 0.});
-  desc.add<std::vector<double>>("mvaScaleStdBL1", {1., 1., 1., 1., 1., 1., 1., 1.});
-  desc.add<std::vector<double>>("mvaScaleMeanEL1", {0., 0., 0., 0., 0., 0., 0., 0.});
-  desc.add<std::vector<double>>("mvaScaleStdEL1", {1., 1., 1., 1., 1., 1., 1., 1.});
-  desc.add<std::vector<double>>("mvaScaleMeanBL2", {0., 0., 0., 0., 0., 0., 0., 0., 0., 0.});
-  desc.add<std::vector<double>>("mvaScaleStdBL2", {1., 1., 1., 1., 1., 1., 1., 1., 1., 1.});
-  desc.add<std::vector<double>>("mvaScaleMeanEL2", {0., 0., 0., 0., 0., 0., 0., 0., 0., 0.});
-  desc.add<std::vector<double>>("mvaScaleStdEL2", {1., 1., 1., 1., 1., 1., 1., 1., 1., 1.});
+  desc.add<std::vector<double>>("mvaScaleMeanB", {0., 0., 0., 0., 0., 0., 0., 0.});
+  desc.add<std::vector<double>>("mvaScaleStdB", {1., 1., 1., 1., 1., 1., 1., 1.});
+  desc.add<std::vector<double>>("mvaScaleMeanE", {0., 0., 0., 0., 0., 0., 0., 0.});
+  desc.add<std::vector<double>>("mvaScaleStdE", {1., 1., 1., 1., 1., 1., 1., 1.});
 
   desc.add<bool>("doSort", false);
   desc.add<int>("nSeedsMaxB", 1e6);

--- a/RecoMuon/TrackerSeedGenerator/src/SeedMvaEstimator.cc
+++ b/RecoMuon/TrackerSeedGenerator/src/SeedMvaEstimator.cc
@@ -20,24 +20,6 @@ SeedMvaEstimator::SeedMvaEstimator(const edm::FileInPath& weightsfile,
 
 SeedMvaEstimator::~SeedMvaEstimator() {}
 
-namespace {
-  enum inputIndexes {
-    kTsosErr0,       // 0
-    kTsosErr2,       // 1
-    kTsosErr5,       // 2
-    kTsosDxdz,       // 3
-    kTsosDydz,       // 4
-    kTsosQbp,        // 5
-    kDRdRL1SeedP,    // 6
-    kDPhidRL1SeedP,  // 7
-    kLastL1,         // 8
-
-    kDRdRL2SeedP = 8,  // 8
-    kDPhidRL2SeedP,    // 9
-    kLastL2,           // 10
-  };
-}  // namespace
-
 void SeedMvaEstimator::getL1MuonVariables(const GlobalVector& global_p,
                                           const l1t::MuonBxCollection& l1Muons,
                                           float& dR2dRL1SeedP,


### PR DESCRIPTION
#### PR description:

In [CMSHLT-3197](https://its.cern.ch/jira/browse/CMSHLT-3197) it was discussed to avoid loading to HLT configuration  parameters that are unneeded by looking into improving the plugin `MuonHLTSeedMVAClassifier`. 
For example, `isFromL1`  is needed, but there is no need to have separate `*L1` and `*L2` parameters, since the plugin only ever uses one set (`*L1` or `*L2`) based on the value of `isFromL1`. The following list of parameters is enough, 
- `isFromL1`
- `mvaFileB`
- `mvaFileE`
- `mvaScaleMeanB`
- `mvaScaleStdB`
- `mvaScaleMeanE`
- `mvaScaleStdE`

provided one configures every module correctly. A check is added throwing an exception in case the MVA model is not compatible with the value of `isFromL1`.

#### PR validation:

`addOnTests.py` runs fine with this PR

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported to CMSSW_14_0_X