### PR TITLE
Phase 2 Bugfix: add the TkJetWord ValidBit to match Firmware

### DIFF
--- a/DataFormats/L1Trigger/interface/TkJetWord.h
+++ b/DataFormats/L1Trigger/interface/TkJetWord.h
@@ -20,7 +20,7 @@ namespace l1t {
   public:
     // ----------constants, enums and typedefs ---------
     static constexpr double MAX_Z0 = 30.;
-    static constexpr double MAX_ETA = 8.;
+    static constexpr double MAX_ETA = 2 * M_PI;
 
     enum TkJetBitWidths {
       kValidSize = 1,
@@ -156,7 +156,7 @@ namespace l1t {
     float pt() const { return ptWord().to_float(); }
     float glbeta() const {
       return unpackSignedValue(
-          glbEtaWord(), TkJetBitWidths::kGlbEtaSize, (MAX_ETA) / (1 << TkJetBitWidths::kGlbEtaSize));
+          glbEtaWord(), TkJetBitWidths::kGlbEtaSize, (2 * MAX_ETA) / (1 << TkJetBitWidths::kGlbEtaSize));
     }
     float glbphi() const {
       return unpackSignedValue(

--- a/DataFormats/L1Trigger/src/TkJetWord.cc
+++ b/DataFormats/L1Trigger/src/TkJetWord.cc
@@ -4,7 +4,8 @@
 #include "DataFormats/L1Trigger/interface/TkJetWord.h"
 
 namespace l1t {
-  TkJetWord::TkJetWord(pt_t pt,
+  TkJetWord::TkJetWord(tkjetvalid_t valid,
+                       pt_t pt,
                        glbeta_t eta,
                        glbphi_t phi,
                        z0_t z0,
@@ -12,10 +13,11 @@ namespace l1t {
                        nx_t nx,
                        dispflag_t dispflag,
                        tkjetunassigned_t unassigned) {
-    setTkJetWord(pt, eta, phi, z0, nt, nx, dispflag, unassigned);
+    setTkJetWord(valid, pt, eta, phi, z0, nt, nx, dispflag, unassigned);
   }
 
-  void TkJetWord::setTkJetWord(pt_t pt,
+  void TkJetWord::setTkJetWord(tkjetvalid_t valid,
+                               pt_t pt,
                                glbeta_t eta,
                                glbphi_t phi,
                                z0_t z0,
@@ -25,6 +27,10 @@ namespace l1t {
                                tkjetunassigned_t unassigned) {
     // pack the TkJet word
     unsigned int offset = 0;
+    for (unsigned int b = offset; b < (offset + TkJetBitWidths::kValidSize); b++) {
+      tkJetWord_.set(b, valid[b - offset]);
+    }
+    offset += TkJetBitWidths::kValidSize;
     for (unsigned int b = offset; b < (offset + TkJetBitWidths::kPtSize); b++) {
       tkJetWord_.set(b, pt[b - offset]);
     }

--- a/DataFormats/L1Trigger/src/TkJetWord.cc
+++ b/DataFormats/L1Trigger/src/TkJetWord.cc
@@ -56,7 +56,7 @@ namespace l1t {
     }
     offset += TkJetBitWidths::kXtSize;
     for (unsigned int b = offset; b < (offset + TkJetBitWidths::kDispFlagSize); b++) {
-      tkJetWord_.set(b, nx[b - offset]);
+      tkJetWord_.set(b, dispflag[b - offset]);
     }
     offset += TkJetBitWidths::kDispFlagSize;
     for (unsigned int b = offset; b < (offset + TkJetBitWidths::kUnassignedSize); b++) {

--- a/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
+++ b/L1Trigger/DemonstratorTools/src/codecs_tkjets.cc
@@ -29,12 +29,9 @@ namespace l1t::demo::codecs {
     std::vector<l1t::TkJetWord> tkJets;
 
     for (size_t f = 0; f < frames.size(); f += 2) {
-      // There is no valid bit in the definition right now.
-      // Uncomment the next two lines when this is available.
-      //if (not x.test(TkJetWord::kValidLSB))
-      //  break;
-
       TkJetWord j(
+          TkJetWord::tkjetvalid_t(
+              frames[f](TkJetWord::TkJetBitLocations::kValidMSB, TkJetWord::TkJetBitLocations::kValidLSB)),
           TkJetWord::pt_t(frames[f](TkJetWord::TkJetBitLocations::kPtMSB, TkJetWord::TkJetBitLocations::kPtLSB)),
           TkJetWord::glbphi_t(
               frames[f](TkJetWord::TkJetBitLocations::kGlbPhiMSB, TkJetWord::TkJetBitLocations::kGlbPhiLSB)),
@@ -47,6 +44,11 @@ namespace l1t::demo::codecs {
               frames[f](TkJetWord::TkJetBitLocations::kDispFlagMSB, TkJetWord::TkJetBitLocations::kDispFlagLSB)),
           TkJetWord::tkjetunassigned_t(
               frames[f](TkJetWord::TkJetBitLocations::kUnassignedMSB, TkJetWord::TkJetBitLocations::kUnassignedLSB)));
+      // There is no valid bit in the definition right now.
+      // Uncomment the next two lines when this is available.
+      if (not j.valid())
+        break;
+
       tkJets.push_back(j);
     }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -286,9 +286,11 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
   vector<edm::Ptr<L1TTTrackType>> L1TrackAssocJet;
   for (unsigned int j = 0; j < mzb.clusters.size(); ++j) {
     l1t::TkJetWord::tkjetvalid_t valid = 1;
-    l1t::TkJetWord::glbeta_t jetEta = DoubleToBit(double(mzb.clusters[j].eta),
-                                                  TkJetWord::TkJetBitWidths::kGlbEtaSize,
-                                                  TkJetWord::MAX_ETA / (1 << TkJetWord::TkJetBitWidths::kGlbEtaSize));
+    l1t::TkJetWord::glbeta_t jetEta =
+        DoubleToBit(double(mzb.clusters[j].eta),
+                    TkJetWord::TkJetBitWidths::kGlbEtaSize,
+                    2 * TkJetWord::MAX_ETA / (1 << TkJetWord::TkJetBitWidths::kGlbEtaSize));
+    // TkJetWord::MAX_ETA / (1 << TkJetWord::TkJetBitWidths::kGlbEtaSize));
     l1t::TkJetWord::glbphi_t jetPhi = DoubleToBit(
         BitToDouble(mzb.clusters[j].phi, TTTrack_TrackWord::TrackBitWidths::kPhiSize + 4, TTTrack_TrackWord::stepPhi0),
         TkJetWord::TkJetBitWidths::kGlbPhiSize,

--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetEmulatorProducer.cc
@@ -285,6 +285,7 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
 
   vector<edm::Ptr<L1TTTrackType>> L1TrackAssocJet;
   for (unsigned int j = 0; j < mzb.clusters.size(); ++j) {
+    l1t::TkJetWord::tkjetvalid_t valid = 1;
     l1t::TkJetWord::glbeta_t jetEta = DoubleToBit(double(mzb.clusters[j].eta),
                                                   TkJetWord::TkJetBitWidths::kGlbEtaSize,
                                                   TkJetWord::MAX_ETA / (1 << TkJetWord::TkJetBitWidths::kGlbEtaSize));
@@ -305,7 +306,7 @@ void L1TrackJetEmulatorProducer::produce(Event &iEvent, const EventSetup &iSetup
     for (unsigned int itrk = 0; itrk < mzb.clusters[j].trackidx.size(); itrk++)
       L1TrackAssocJet.push_back(L1TrkPtrs_[mzb.clusters[j].trackidx[itrk]]);
 
-    l1t::TkJetWord trkJet(jetPt, jetEta, jetPhi, jetZ0, total_ntracks, total_disptracks, dispflag, unassigned);
+    l1t::TkJetWord trkJet(valid, jetPt, jetEta, jetPhi, jetZ0, total_ntracks, total_disptracks, dispflag, unassigned);
 
     L1TrackJetContainer->push_back(trkJet);
   }


### PR DESCRIPTION
#### PR description:

This PR adds a missing validBit to the TkJetWord's 128bit word, needed for Integration Tests between Global Track Trigger and Global Trigger. 

#### PR validation:
This PR passes:
scram b code-checks
scram b code-format
scram b
runTheMatrix.py -l limited -i all --ibeos [output:
exit: 0 256 0 46 3 0 0 0 0 0 0 0 0 0 tests passed, 2 42 3 0 0 0 0 0 0 0 0 failed (The number of "failed" tests looks like ones I've seen before locally... ) ]

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR may need a backport to the cms-l1t-offline Phase 2 Integration Branch (the "may": if that will still be maintained)
