### PR TITLE
Correction to cell shapes for partial wafers in v18 version of HGCal 

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalWaferMask.h
+++ b/Geometry/HGCalCommonData/interface/HGCalWaferMask.h
@@ -79,9 +79,9 @@ private:
   static constexpr double tan_60_ = sqrt3_;
   static constexpr std::array<double, 12> tan_1 = {
       {-sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0}};
-  static constexpr std::array<double, 12> cos_1 = {{0.5, -0.5, -1.0, -0.5, 0.5, 1.0, -0.5, 0.5, 1.0, 0.5, -0.5, -1.0}};
-  static constexpr std::array<double, 12> cot_1 = {
-      {sqrt3_, -sqrt3_, 0.0, sqrt3_, -sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0, -sqrt3_, sqrt3_, 0.0}};
+  static constexpr std::array<double, 12> cos_1 = {{0.5, -0.5, -1.0, -0.5, 0.5, 1.0, 0.5, -0.5, -1.0, -0.5, 0.5, 1.0}};
+  static constexpr std::array<double, 12> sign_1 = {{1.0, -1.0, -1.0, -1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0}};
+  static constexpr std::array<double, 12> sign_2 = {{1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, 1.0, 1.0}};
 };
 
 #endif

--- a/Geometry/HGCalCommonData/src/HGCalCellUV.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellUV.cc
@@ -372,13 +372,10 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY2(  // for v18
           HGCalWaferMask::maskCut(HGCalTypes::WaferLDTop, placement, waferSize_, 0.0, false);
       if ((criterion[0] * yloc) + (criterion[1] * xloc) < -criterion[2]) {
         std::pair<double, double> xy1 = hgcalcell_->cellUV2XY1(u, v, placement, 1);
-        std::pair<double, double> xy2 = hgcalcell_->cellUV2XY1(u - 2, v - 1, placement, 1);
-        if (((placement >= HGCalCell::cellPlacementExtra) &&
-             ((((xloc - xy1.first) / (xy2.first - xy1.first)) - ((yloc - xy1.second) / (xy2.second - xy1.second))) >
-              0.0)) ||
-            ((placement < HGCalCell::cellPlacementExtra) &&
-             ((((xloc - xy1.first) / (xy2.first - xy1.first)) - ((yloc - xy1.second) / (xy2.second - xy1.second))) <
-              0.0))) {
+        std::array<double, 4> criterion2 =
+            HGCalWaferMask::maskCut(HGCalTypes::WaferLDThree, placement, waferSize_, 0.0, false);
+        if (((criterion2[0] * yloc) + (criterion2[1] * xloc) - (criterion2[0] * xy1.second) -
+             (criterion2[1] * xy1.first)) < 0.0) {
           --u;
           if ((v - u) >= ncell_[1])
             --v;
@@ -411,13 +408,10 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY2(  // for v18
           HGCalWaferMask::maskCut(HGCalTypes::WaferHDBottom, placement, waferSize_, 0.0, false);
       if ((criterion[0] * yloc) + (criterion[1] * xloc) < -criterion[2]) {
         std::pair<double, double> xy1 = hgcalcell_->cellUV2XY1(u, v, placement, 0);
-        std::pair<double, double> xy2 = hgcalcell_->cellUV2XY1(u - 2, v - 1, placement, 0);
-        if (((placement >= HGCalCell::cellPlacementExtra) &&
-             ((((xloc - xy1.first) / (xy2.first - xy1.first)) - ((yloc - xy1.second) / (xy2.second - xy1.second))) >
-              0.0)) ||
-            ((placement < HGCalCell::cellPlacementExtra) &&
-             ((((xloc - xy1.first) / (xy2.first - xy1.first)) - ((yloc - xy1.second) / (xy2.second - xy1.second))) <
-              0.0))) {
+        std::array<double, 4> criterion2 =
+            HGCalWaferMask::maskCut(HGCalTypes::WaferHDRight, placement, waferSize_, 0.0, false);
+        if (((criterion2[0] * yloc) + (criterion2[1] * xloc) - (criterion2[0] * xy1.second) -
+             (criterion2[1] * xy1.first)) < 0.0) {
           ++u;
           ++v;
         } else {

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <sstream>
-
+#include <iostream>
 //#define EDM_ML_DEBUG
 
 bool HGCalWaferMask::maskCell(int u, int v, int n, int ncor, int fcor, int corners) {
@@ -2017,83 +2017,82 @@ std::array<double, 4> HGCalWaferMask::maskCut(
   std::array<double, 4> criterion;
   switch (part) {
     case (HGCalTypes::WaferLDTop): {
-      criterion[0] = tan_1[placement];
-      criterion[1] = 1.0;
+      criterion[0] = -tan_1[placement] * sign_1[placement];
+      criterion[1] = 1.0 * sign_1[placement];
       criterion[2] = 0.0;
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferLDBottom): {
-      criterion[0] = -tan_1[placement];
-      criterion[1] = -1.0;
+      criterion[0] = tan_1[placement] * sign_1[placement];
+      criterion[1] = -1.0 * sign_1[placement];
       criterion[2] = 0.0;
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferLDLeft): {
-      criterion[0] = 1.0;
-      criterion[1] = -tan_1[placement];
+      criterion[0] = 1.0 * sign_2[placement];
+      criterion[1] = tan_1[placement] * sign_2[placement];
       criterion[2] = 0.0;
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferLDRight): {
-      criterion[0] = -1.0;
-      criterion[1] = tan_1[placement];
+      criterion[0] = -1.0 * sign_2[placement];
+      criterion[1] = -tan_1[placement] * sign_2[placement];
       criterion[2] = 0.0;
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferLDFive): {
-      criterion[0] = 1;
-      criterion[1] = -tan_1[placement];
-      criterion[2] = ((HGCalTypes::c50 * delY) / cos_1[placement]);
+      criterion[0] = 1 * sign_2[placement];
+      criterion[1] = tan_1[placement] * sign_2[placement];
+      criterion[2] = -((HGCalTypes::c50 * delY) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferLDThree): {
-      criterion[0] = -1;
-      criterion[1] = tan_1[placement];
-      criterion[2] = -((HGCalTypes::c50 * delY) / cos_1[placement]);
+      criterion[0] = -1 * sign_2[placement];
+      criterion[1] = -tan_1[placement] * sign_2[placement];
+      criterion[2] = ((HGCalTypes::c50 * delY) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDTop): {
-      criterion[0] = tan_1[placement];
-      criterion[1] = 1;
-      criterion[2] = ((c22 * delX) / cos_1[placement]);
+      criterion[0] = -tan_1[placement] * sign_1[placement];
+      criterion[1] = 1 * sign_1[placement];
+      criterion[2] = ((c22 * delX) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDBottom): {
-      criterion[0] = -tan_1[placement];
-      criterion[1] = -1;
-      criterion[2] = -((c22 * delX) / cos_1[placement]);
+      criterion[0] = tan_1[placement] * sign_1[placement];
+      criterion[1] = -1 * sign_1[placement];
+      criterion[2] = -((c22 * delX) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDLeft): {
-      criterion[0] = 1.0;
-      criterion[1] = -tan_1[placement];
-      criterion[2] = ((c271 * delY) / cos_1[placement]);
+      criterion[0] = 1.0 * sign_2[placement];
+      criterion[1] = tan_1[placement] * sign_2[placement];
+      criterion[2] = ((c271 * delY) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDRight): {
-      criterion[0] = -1.0;
-      criterion[1] = tan_1[placement];
-      criterion[2] = -((c271 * delY) / cos_1[placement]);
+      criterion[0] = -1.0 * sign_2[placement];
+      criterion[1] = -tan_1[placement] * sign_2[placement];
+      criterion[2] = ((c271 * delY) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
     case (HGCalTypes::WaferHDFive): {
-      criterion[0] = -1.0;
-      criterion[1] = tan_1[placement];
-      criterion[2] = ((c271 * delY) / cos_1[placement]);
+      criterion[0] = 1.0 * sign_2[placement];
+      criterion[1] = tan_1[placement] * sign_2[placement];
+      criterion[2] = -((c271 * delY) / cos_1[placement]) * sign_2[placement];
       criterion[3] = tresh;
       break;
     }
   }
-  criterion[1] = (placement > HGCalCell::cellPlacementExtra) ? criterion[1] : -criterion[1];
   return criterion;
 }


### PR DESCRIPTION
PR description:

Corrections to cell shapes in partial wafers for all orientations or placement index of v18 version of HGCal Geometry

PR validation:

Tested with the runTheMatrix test workflows

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special
