### PR TITLE
[CPP20][DB] Replace some enums with constexpr ints in Ecal*_PayloadInspector.cc

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
@@ -18,8 +18,9 @@
 
 namespace {
   constexpr int kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255;
-  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
-  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85,
+                MAX_IPHI = 360;                                      // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;  // endcaps lower and upper bounds on x and y
 
   /*******************************************************
      2d plot of ECAL barrel DQM channel status of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalDQMChannelStatus_PayloadInspector.cc
@@ -17,9 +17,9 @@
 #include "TLatex.h"
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255;
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
 
   /*******************************************************
      2d plot of ECAL barrel DQM channel status of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
@@ -17,8 +17,9 @@
 
 namespace {
   constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 5;
-  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
-  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85,
+                MAX_IPHI = 360;                                      // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;  // endcaps lower and upper bounds on x and y
 
   /*****************************************************
      2d plot of ECAL FloatCondObjectContainer of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalFloatCondObjectContainer_PayloadInspector.cc
@@ -16,9 +16,9 @@
 #include <string>
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 5 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 5;
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
 
   /*****************************************************
      2d plot of ECAL FloatCondObjectContainer of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
@@ -17,8 +17,9 @@
 
 namespace {
   constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kValues = 3, kRMS = 5;
-  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85,
+                MAX_IPHI = 360;                                      // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;  // endcaps lower and upper bounds on x and y
 
   /*************************************************
      2d plot of ECAL LinearCorrections of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalLinearCorrections_PayloadInspector.cc
@@ -16,9 +16,9 @@
 #include <string>
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kValues = 3, kRMS = 5 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kValues = 3, kRMS = 5;
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
 
   /*************************************************
      2d plot of ECAL LinearCorrections of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -19,8 +19,9 @@
 
 namespace {
   constexpr int kEBChannels = 61200, kEEChannels = 14648, kGains = 3, kRMS = 5;
-  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
-  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85,
+                MAX_IPHI = 360;                                      // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;  // endcaps lower and upper bounds on x and y
 
   /**************************************
      1d plot of ECAL pedestal of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPedestals_PayloadInspector.cc
@@ -18,9 +18,9 @@
 #include <sstream>
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, kGains = 3, kRMS = 5 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int kEBChannels = 61200, kEEChannels = 14648, kGains = 3, kRMS = 5;
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
 
   /**************************************
      1d plot of ECAL pedestal of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
@@ -18,8 +18,9 @@
 
 namespace {
   constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 3, TEMPLATESAMPLES = 12;
-  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
-  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85,
+                MAX_IPHI = 360;                                      // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;  // endcaps lower and upper bounds on x and y
 
   /*****************************************************
      2d plot of ECAL PulseShapes of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalPulseShapes_PayloadInspector.cc
@@ -17,9 +17,9 @@
 #include <string>
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 3, TEMPLATESAMPLES = 12 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  constexpr int kEBChannels = 61200, kEEChannels = 14648, kSides = 2, kRMS = 3, TEMPLATESAMPLES = 12;
+  constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;  // barrel lower and upper bounds on eta and phi
+  constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;         // endcaps lower and upper bounds on x and y
 
   /*****************************************************
      2d plot of ECAL PulseShapes of 1 IOV


### PR DESCRIPTION
#### PR description:

Replace some enums with constexpr ints to avoid deprecated enum arithmetics.

#### PR validation:

Bot tests.