### PR TITLE
Fix deprecated arithmetics between different enum types in AlignPCLThresholdsHG

### DIFF
--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -111,7 +111,8 @@ const int AlignPCLThresholdsHG::payloadVersion() const {
       return 1;
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
-          << "Payload version with parameter size equal to " << static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE) << " is not defined.\n";
+          << "Payload version with parameter size equal to "
+          << static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE) << " is not defined.\n";
   }
 }
 

--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -106,12 +106,12 @@ const bool AlignPCLThresholdsHG::hasFloatMap(const std::string &AlignableId) con
 
 //****************************************************************************//
 const int AlignPCLThresholdsHG::payloadVersion() const {
-  switch (FSIZE + ISIZE + SSIZE) {
+  switch (static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE)) {
     case 6:
       return 1;
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
-          << "Payload version with parameter size equal to " << FSIZE + ISIZE + SSIZE << " is not defined.\n";
+          << "Payload version with parameter size equal to " << static_cast<int>(FSIZE) + static_cast<int>(ISIZE) + static_cast<int>(SSIZE) << " is not defined.\n";
   }
 }
 


### PR DESCRIPTION
#### PR description:

Fixes the following warnings in CPP20 IBs:

```
src/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc: In member function 'const int AlignPCLThresholdsHG::payloadVersion() const':
  src/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc:109:17: warning: arithmetic between different enumeration types 'AlignPCLThresholdsHG::FloatParamIndex' and 'AlignPCLThresholdsHG::IntParamIndex' is deprecated [-Wdeprecated-enum-enum-conversion]
   109 |   switch (FSIZE + ISIZE + SSIZE) {
      |           ~~~~~~^~~~~~~
  src/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc:114:71: warning: arithmetic between different enumeration types 'AlignPCLThresholdsHG::FloatParamIndex' and 'AlignPCLThresholdsHG::IntParamIndex' is deprecated [-Wdeprecated-enum-enum-conversion]
   114 |           << "Payload version with parameter size equal to " << FSIZE + ISIZE + SSIZE << " is not defined.\n";
      |          
```

#### PR validation:

Bot tests
