### PR TITLE
[CPP20][DQM] Replace enum with static constexpr int in DQWorkerClient; replace ecaldqm::Constants enum with  static constexpr ints

### DIFF
--- a/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
+++ b/DQM/EcalCommon/interface/EcalDQMCommonUtils.h
@@ -87,32 +87,18 @@ namespace ecaldqm {
     kEBpHigh = kEBp18
   };
 
-  enum Constants {
-    nDCC = 54,
-    nEBDCC = 36,
-    nEEDCC = 18,
-    nDCCMEM = 44,
-    nEEDCCMEM = 8,
+  static constexpr int nDCC = 54, nEBDCC = 36, nEEDCC = 18, nDCCMEM = 44, nEEDCCMEM = 8;
 
-    nTTOuter = 16,
-    nTTInner = 28,
-    // These lines set the number of TriggerTowers in "outer" and "inner" TCCs,
-    // where "outer" := closer to the barrel. These constants are used in
-    // setting the binning. There are 16 trigger towers per TCC for "outer" TCCs,
-    // and 24 per TCC for "inner" TCCs (but the numbering is from 0 to 27, so
-    // 28 bins are required).
+  // These lines set the number of TriggerTowers in "outer" and "inner" TCCs,
+  // where "outer" := closer to the barrel. These constants are used in
+  // setting the binning. There are 16 trigger towers per TCC for "outer" TCCs,
+  // and 24 per TCC for "inner" TCCs (but the numbering is from 0 to 27, so
+  // 28 bins are required).
+  static constexpr int nTTOuter = 16, nTTInner = 28;
 
-    nTCC = 108,
-    kEEmTCCLow = 0,
-    kEEmTCCHigh = 35,
-    kEEpTCCLow = 72,
-    kEEpTCCHigh = 107,
-    kEBTCCLow = 36,
-    kEBTCCHigh = 71,
-
-    nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
-    nTowers = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing
-  };
+  static constexpr int nTCC = 108, kEEmTCCLow = 0, kEEmTCCHigh = 35, kEEpTCCLow = 72, kEEpTCCHigh = 107, kEBTCCLow = 36,
+                       kEBTCCHigh = 71, nChannels = EBDetId::kSizeForDenseIndexing + EEDetId::kSizeForDenseIndexing,
+                       nTowers = EcalTrigTowerDetId::kEBTotalTowers + EcalScDetId::kSizeForDenseIndexing;
 
   extern std::vector<unsigned> const memDCC;
 

--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -41,7 +41,7 @@ namespace ecaldqm {
 
     void setStatusManager(StatusManager const& _manager) { statusManager_ = &_manager; }
 
-    enum Quality { kBad = 0, kGood = 1, kUnknown = 2, kMBad = 3, kMGood = 4, kMUnknown = 5 };
+    static constexpr int kBad = 0, kGood = 1, kUnknown = 2, kMBad = 3, kMGood = 4, kMUnknown = 5;
 
   protected:
     void setME(edm::ParameterSet const& _ps) final;


### PR DESCRIPTION
#### PR description:

Fixes the following compilation warnings:

```
src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc: In member function 'virtual void ecaldqm::CalibrationSummaryClient::producePlots(ecaldqm::DQWorkerClient::ProcessType)':
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:157:67: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   157 |           if (sLaser->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:169:67: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   169 |             if (sLed->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:180:71: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   180 |           if (sTestPulse->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:190:70: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   190 |           if (sPedestal->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:214:70: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   214 |         if (sPNIntegrity.getBinContent(getEcalDQMSetupObjects(), id) == kBad)
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:220:71: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   220 |             if (sLaserPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:230:69: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   230 |             if (sLedPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:240:75: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   240 |             if (sTestPulsePN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
  src/DQM/EcalMonitorClient/src/CalibrationSummaryClient.cc:251:74: warning: comparison of floating-point type 'double' with enumeration type 'ecaldqm::DQWorkerClient::Quality' is deprecated [-Wdeprecated-enum-float-conversion]
   251 |             if (sPedestalPN->getBinContent(getEcalDQMSetupObjects(), id) == kBad) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
src/DQM/EcalMonitorClient/src/CertificationClient.cc: In member function 'virtual void ecaldqm::CertificationClient::producePlots(ecaldqm::DQWorkerClient::ProcessType)':
  src/DQM/EcalMonitorClient/src/CertificationClient.cc:34:62: warning: arithmetic between floating-point type 'double' and enumeration type 'ecaldqm::Constants' is deprecated [-Wdeprecated-enum-float-conversion]
    34 |     meCertification.fill(getEcalDQMSetupObjects(), meanValue / nChannels);
      |                                                    ~~~~~~~~~~^~~~~~~~~~~
```

#### PR validation:

Bot tests