### PR TITLE
[CPP20][DQM] Fix deprecated enum arithmetics in TkAlCaRecoMonitor and SiPixelPhase1RawDataErrorComparator

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -264,8 +264,8 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                    -0.5,
                    nErrors - 0.5,
                    nFEDs,
-                   FEDNumbering::MINSiPixeluTCAFEDID - 0.5,
-                   FEDNumbering::MAXSiPixeluTCAFEDID - 0.5);
+                   static_cast<double>(FEDNumbering::MINSiPixeluTCAFEDID) - 0.5,
+                   static_cast<double>(FEDNumbering::MAXSiPixeluTCAFEDID) - 0.5);
   for (int j = 0; j < nErrors; j++) {
     const auto& errorCode = static_cast<SiPixelFEDErrorCodes>(j + k_FED25);
     h_FEDerrorVsFEDIdUnbalance_->setBinLabel(j + 1, errorCodeToTypeMap.at(errorCode));

--- a/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
+++ b/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc
@@ -72,8 +72,11 @@ void TkAlCaRecoMonitor::bookHistograms(DQMStore::IBooker &iBooker, edm::Run cons
   TrackPtNegative_->setAxisTitle("p_{T} of tracks charge < 0");
 
   histname = "TrackQuality_";
-  TrackQuality_ = iBooker.book1D(
-      histname + AlgoName, histname + AlgoName, reco::TrackBase::qualitySize, -0.5, reco::TrackBase::qualitySize - 0.5);
+  TrackQuality_ = iBooker.book1D(histname + AlgoName,
+                                 histname + AlgoName,
+                                 reco::TrackBase::qualitySize,
+                                 -0.5,
+                                 static_cast<double>(reco::TrackBase::qualitySize) - 0.5);
   TrackQuality_->setAxisTitle("quality");
   for (int i = 0; i < reco::TrackBase::qualitySize; ++i) {
     TrackQuality_->getTH1()->GetXaxis()->SetBinLabel(


### PR DESCRIPTION
#### PR description:

Fix the following compilation warnings:

```
src/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc: In member function 'virtual void TkAlCaRecoMonitor::bookHistograms(dqm::legacy::DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)':
  src/DQMOffline/Alignment/src/TkAlCaRecoMonitor.cc:76:114: warning: arithmetic between enumeration type 'reco::TrackBase::TrackQuality' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
    76 |       histname + AlgoName, histname + AlgoName, reco::TrackBase::qualitySize, -0.5, reco::TrackBase::qualitySize - 0.5);
      |             
```

```
src/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc: In member function 'virtual void SiPixelPhase1RawDataErrorComparator::bookHistograms(dqm::legacy::DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)':
  src/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc:267:54: warning: arithmetic between enumeration type 'FEDNumbering::<unnamed enum>' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
   267 |                    FEDNumbering::MINSiPixeluTCAFEDID - 0.5,
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
  src/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc:268:54: warning: arithmetic between enumeration type 'FEDNumbering::<unnamed enum>' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
   268 |                    FEDNumbering::MAXSiPixeluTCAFEDID - 0.5);
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

#### PR validation:

Bot tests

