### PR TITLE
[CPP20] Replace enum with static constexpr int in L1TriggerRates

### DIFF
--- a/DataFormats/Scalers/interface/L1TriggerRates.h
+++ b/DataFormats/Scalers/interface/L1TriggerRates.h
@@ -29,7 +29,7 @@ class L1TriggerScalers;
 
 class L1TriggerRates {
 public:
-  enum { N_BX = 3654, N_BX_ACTIVE = 2808 };
+  static constexpr int N_BX = 3654, N_BX_ACTIVE = 2808;
 
 #define BX_SPACING (double)25E-9
 


### PR DESCRIPTION
#### PR description:

Fixes compilation warnings:

```
src/DataFormats/Scalers/src/L1TriggerRates.cc: In member function 'void L1TriggerRates::computeRates(const L1TriggerScalers&, const L1TriggerScalers&)':
  src/DataFormats/Scalers/src/L1TriggerRates.cc:87:33: warning: arithmetic between floating-point type 'double' and enumeration type 'L1TriggerRates::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
    87 |     double deltaBC = deltaOrbit * N_BX;
      |                      ~~~~~~~~~~~^~~~~~
  src/DataFormats/Scalers/src/L1TriggerRates.cc:88:39: warning: arithmetic between floating-point type 'double' and enumeration type 'L1TriggerRates::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
    88 |     double deltaBCActive = deltaOrbit * N_BX_ACTIVE;
      |                            ~~~~~~~~~~~^~~~~~~~~~~~~
src/DataFormats/Scalers/src/L1TriggerRates.cc: In member function 'void L1TriggerRates::computeRunRates(const L1TriggerScalers&)':
  src/DataFormats/Scalers/src/L1TriggerRates.cc:156:33: warning: arithmetic between floating-point type 'double' and enumeration type 'L1TriggerRates::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   156 |     double deltaBC = deltaOrbit * N_BX;
      |                      ~~~~~~~~~~~^~~~~~
  src/DataFormats/Scalers/src/L1TriggerRates.cc:157:39: warning: arithmetic between floating-point type 'double' and enumeration type 'L1TriggerRates::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   157 |     double deltaBCActive = deltaOrbit * N_BX_ACTIVE;
      |                            ~~~~~~~~~~~^~~~~~~~~~~~~
```

#### PR validation:

Bot tests