### PR TITLE
[MTD] Update MTD hit pattern + add outermost hits position in the TrackExtenderWithMTD

### DIFF
--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -98,9 +98,18 @@ public:
   }
 
   /** ETL TDR Construct and fill only the det and sub-det fields. */
+  /** input disc runs from 0 to 1 */
 
   inline uint32_t encodeSector(uint32_t& disc, uint32_t& discside, uint32_t& sector) const {
     return (sector + discside * kSoff + 2 * kSoff * disc);
+  }
+
+  /** decode encoded "ring" field, disc numbered from 1 to 2, as in dedicated method */
+
+  static void decodeSector(const uint32_t rr, uint32_t& nDisc, uint32_t& discSide, uint32_t& sector) {
+    nDisc = (((rr - 1) >> kETLnDiscOffset) & kETLnDiscMask) + 1;
+    discSide = ((rr - 1) >> kETLdiscSideOffset) & kETLdiscSideMask;
+    sector = ((rr - 1) & kETLsectorMask) + 1;
   }
 
   // pre v8

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -35,8 +35,8 @@
 // | mu  = 0    |    RPC = 3    | 4*(stat-1)+2*layer+region |                 | hit type = 0-3 |
 // | mu  = 0    |    GEM = 4    | 1xxx=st0, 0yxx=st y-1 la x|                 | hit type = 0-3 |
 // | mu  = 0    |    ME0 = 5    | roll                      |                 | hit type = 0-3 |
-// | mtd = 2    |    BTL = 1    | moduleType = 1-3          |                 | hit type = 0-3 |
-// | mtd = 2    |    ETL = 2    | ring = 1-12               |                 | hit type = 0-3 |
+// | mtd = 2    |    BTL = 1    | globalReadoutUnit = 1-6   |                 | hit type = 0-3 |
+// | mtd = 2    |    ETL = 2    | encodedSector = 1-14      |                 | hit type = 0-3 |
 // +------------+---------------+---------------------------+-----------------+----------------+
 //
 //  hit type, see DataFormats/TrackingRecHit/interface/TrackingRecHit.h

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -981,9 +981,6 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         }
         npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
-
-        std::cout << "isBTL: " << mBTL.hit << "    outermost hot position: z = " << (*track).outerZ()
-                  << "   R = " << (*track).outerRadius() << std::endl;
         outermostHitPosition.push_back(
             mBTL.hit ? (float)(*track).outerRadius()
                      : (float)(*track).outerZ());  // save R of the outermost hit for BTL, z for ETL.

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -566,6 +566,7 @@ private:
   edm::EDPutToken etlMatchTimeChi2Token_;
   edm::EDPutToken npixBarrelToken_;
   edm::EDPutToken npixEndcapToken_;
+  edm::EDPutToken outermostHitPositionToken_;
   edm::EDPutToken pOrigTrkToken_;
   edm::EDPutToken betaOrigTrkToken_;
   edm::EDPutToken t0OrigTrkToken_;
@@ -657,6 +658,7 @@ TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet
   etlMatchTimeChi2Token_ = produces<edm::ValueMap<float>>("etlMatchTimeChi2");
   npixBarrelToken_ = produces<edm::ValueMap<int>>("npixBarrel");
   npixEndcapToken_ = produces<edm::ValueMap<int>>("npixEndcap");
+  outermostHitPositionToken_ = produces<edm::ValueMap<float>>("generalTrackOutermostHitPosition");
   pOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackp");
   betaOrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackBeta");
   t0OrigTrkToken_ = produces<edm::ValueMap<float>>("generalTrackt0");
@@ -774,6 +776,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   std::vector<float> etlMatchTimeChi2;
   std::vector<int> npixBarrel;
   std::vector<int> npixEndcap;
+  std::vector<float> outermostHitPosition;
   std::vector<float> pOrigTrkRaw;
   std::vector<float> betaOrigTrkRaw;
   std::vector<float> t0OrigTrkRaw;
@@ -978,6 +981,13 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         }
         npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
+
+        std::cout << "isBTL: " << mBTL.hit << "    outermost hot position: z = " << (*track).outerZ()
+                  << "   R = " << (*track).outerRadius() << std::endl;
+        outermostHitPosition.push_back(
+            mBTL.hit ? (float)(*track).outerRadius()
+                     : (float)(*track).outerZ());  // save R of the outermost hit for BTL, z for ETL.
+
         LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: tmtd " << tmtdMap << " +/- " << sigmatmtdMap
                                          << " t0 " << t0Map << " +/- " << sigmat0Map << " tof pi/K/p " << tofpiMap
                                          << "+/-" << fmt::format("{:0.2g}", sigmatofpiMap) << " ("
@@ -1013,6 +1023,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
       etlMatchTimeChi2.push_back(-1.f);
       npixBarrel.push_back(-1.f);
       npixEndcap.push_back(-1.f);
+      outermostHitPosition.push_back(0.);
     }
 
     ++itrack;
@@ -1028,6 +1039,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   fillValueMap(ev, tracksH, etlMatchTimeChi2, etlMatchTimeChi2Token_);
   fillValueMap(ev, tracksH, npixBarrel, npixBarrelToken_);
   fillValueMap(ev, tracksH, npixEndcap, npixEndcapToken_);
+  fillValueMap(ev, tracksH, outermostHitPosition, outermostHitPositionToken_);
   fillValueMap(ev, tracksH, pOrigTrkRaw, pOrigTrkToken_);
   fillValueMap(ev, tracksH, betaOrigTrkRaw, betaOrigTrkToken_);
   fillValueMap(ev, tracksH, t0OrigTrkRaw, t0OrigTrkToken_);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -906,7 +906,6 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
 #endif
     }
 
-    
     auto ordering = checkRecHitsOrdering(thits);
     if (ordering == RefitDirection::insideOut) {
       thits.insert(thits.end(), mtdthits.begin(), mtdthits.end());
@@ -995,7 +994,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
           backtrack.hitPattern().printHitPattern(reco::HitPattern::MISSING_INNER_HITS, i, std::cout);
         }
 #endif
-	npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
+        npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
         outermostHitPosition.push_back(
             mBTL.hit ? (float)(*track).outerRadius()

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -899,8 +899,14 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            mETL);
         mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
       }
+#ifdef EDM_ML_DEBUG
+      else {
+        LogTrace("TrackExtenderWithMTD") << "Failing getTrajectoryStateClosestToBeamLine, no search for hits in MTD!";
+      }
+#endif
     }
 
+    
     auto ordering = checkRecHitsOrdering(thits);
     if (ordering == RefitDirection::insideOut) {
       thits.insert(thits.end(), mtdthits.begin(), mtdthits.end());
@@ -979,7 +985,17 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         for (unsigned ihit = hitsstart; ihit < hitsend; ++ihit) {
           backtrack.appendHitPattern((*outhits)[ihit], ttopo);
         }
-        npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
+#ifdef EDM_ML_DEBUG
+        LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: hit pattern of refitted track";
+        for (int i = 0; i < backtrack.hitPattern().numberOfAllHits(reco::HitPattern::TRACK_HITS); i++) {
+          backtrack.hitPattern().printHitPattern(reco::HitPattern::TRACK_HITS, i, std::cout);
+        }
+        LogTrace("TrackExtenderWithMTD") << "TrackExtenderWithMTD: missing hit pattern of refitted track";
+        for (int i = 0; i < backtrack.hitPattern().numberOfAllHits(reco::HitPattern::MISSING_INNER_HITS); i++) {
+          backtrack.hitPattern().printHitPattern(reco::HitPattern::MISSING_INNER_HITS, i, std::cout);
+        }
+#endif
+	npixBarrel.push_back(backtrack.hitPattern().numberOfValidPixelBarrelHits());
         npixEndcap.push_back(backtrack.hitPattern().numberOfValidPixelEndcapHits());
         outermostHitPosition.push_back(
             mBTL.hit ? (float)(*track).outerRadius()

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -557,7 +557,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       if (isBTL)
         meTrackOutermostHitR_->Fill(outermostHitPosition[trackref]);
       if (isETL)
-        meTrackOutermostHitZ_->Fill(outermostHitPosition[trackref]);
+        meTrackOutermostHitZ_->Fill(std::abs(outermostHitPosition[trackref]));
 
       LogDebug("MtdTracksValidation") << "Track p/pt = " << track.p() << " " << track.pt() << " eta " << track.eta()
                                       << " BTL " << isBTL << " ETL " << isETL << " 2disks " << twoETLdiscs;
@@ -984,9 +984,8 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
 
-  meTrackOutermostHitR_ = ibook.book1D("TrackOutermostHitR", "Track outermost hit position R; R[cm]", 100, 0, 120.);
-
-  meTrackOutermostHitZ_ = ibook.book1D("TrackOutermostHitZ", "Track outermost hit position Z; z[cm]", 100, 0, 350.);
+  meTrackOutermostHitR_ = ibook.book1D("TrackOutermostHitR", "Track outermost hit position R; R[cm]", 30, 0, 120.);
+  meTrackOutermostHitZ_ = ibook.book1D("TrackOutermostHitZ", "Track outermost hit position Z; z[cm]", 60, 0, 300.);
 
   meTrackSigmaTof_[0] =
       ibook.book1D("TrackSigmaTof_Pion", "Sigma(TOF) for pion hypothesis; #sigma_{t0} [ps]", 10, 0, 5);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -984,8 +984,8 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
 
-  meTrackOutermostHitR_ = ibook.book1D("TrackOutermostHitR", "Track outermost hit position R; R[cm]", 30, 0, 120.);
-  meTrackOutermostHitZ_ = ibook.book1D("TrackOutermostHitZ", "Track outermost hit position Z; z[cm]", 60, 0, 300.);
+  meTrackOutermostHitR_ = ibook.book1D("TrackOutermostHitR", "Track outermost hit position R; R[cm]", 40, 0, 120.);
+  meTrackOutermostHitZ_ = ibook.book1D("TrackOutermostHitZ", "Track outermost hit position Z; z[cm]", 100, 0, 300.);
 
   meTrackSigmaTof_[0] =
       ibook.book1D("TrackSigmaTof_Pion", "Sigma(TOF) for pion hypothesis; #sigma_{t0} [ps]", 10, 0, 5);


### PR DESCRIPTION
#### PR description:
This PR includes 
1) an update of the hit pattern for MTD 
2) the addition of a ValueMap, filled within the TrackExtenderWithMTD, to store the track outermost hit position (R for tracks with hits in BTL, Z for tracks with hits in ETL).

#### PR validation:
The code was tested on wf 24906.0 and 24807.0.