### PR TITLE
[CPP20][Visualisation] Fix deprecated enum bitwise operation in FWCandidateHGCalLegoProxyBuilder

### DIFF
--- a/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
@@ -94,4 +94,4 @@ void FWCandidateHGCalLegoProxyBuilder::build(const reco::HGCalMultiCluster &iDat
 REGISTER_FWPROXYBUILDER(FWCandidateHGCalLegoProxyBuilder,
                         reco::HGCalMultiCluster,
                         "HGCal Multiclusters Lego",
-                        static_cast<int>(FWViewType::kLegoBit) | static_cast<int>(FWViewType::kLegoHFBit));
+                        FWViewType::kLegoBit | FWViewType::kLegoHFBit);

--- a/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
@@ -94,4 +94,4 @@ void FWCandidateHGCalLegoProxyBuilder::build(const reco::HGCalMultiCluster &iDat
 REGISTER_FWPROXYBUILDER(FWCandidateHGCalLegoProxyBuilder,
                         reco::HGCalMultiCluster,
                         "HGCal Multiclusters Lego",
-                        static_cast<int>(FWViewType::kLegoBit) | static_cast<int>(FWViewType::kLegoHF));
+                        static_cast<int>(FWViewType::kLegoBit) | static_cast<int>(FWViewType::kLegoHFBit));

--- a/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc
@@ -94,4 +94,4 @@ void FWCandidateHGCalLegoProxyBuilder::build(const reco::HGCalMultiCluster &iDat
 REGISTER_FWPROXYBUILDER(FWCandidateHGCalLegoProxyBuilder,
                         reco::HGCalMultiCluster,
                         "HGCal Multiclusters Lego",
-                        FWViewType::kLegoBit | FWViewType::kLegoHF);
+                        static_cast<int>(FWViewType::kLegoBit) | static_cast<int>(FWViewType::kLegoHF));

--- a/Fireworks/Core/interface/FWViewType.h
+++ b/Fireworks/Core/interface/FWViewType.h
@@ -46,11 +46,12 @@ public:
     kTypeSize
   };
 
-  static constexpr int k3DBit = 1 << k3D, kRhoPhiBit = 1 << kRhoPhi, kRhoZBit = 1 << kRhoZ,
-                       kRhoPhiPFBit = 1 << kRhoPhiPF, kISpyBit = 1 << kISpy, kLegoBit = 1 << kLego,
-                       kLegoHFBit = 1 << kLegoHF, kLegoPFECALBit = 1 << kLegoPFECAL, kGlimpseBit = 1 << kGlimpse,
-                       kTableBit = 1 << kTable, kTableHLTBit = 1 << kTableHLT, kTableL1Bit = 1 << kTableL1,
-                       kGeometryBit = 1 << kGeometryTable, kOverlapBit = 1 << kOverlapTable;
+  static constexpr unsigned int k3DBit = 1 << k3D, kRhoPhiBit = 1 << kRhoPhi, kRhoZBit = 1 << kRhoZ,
+                                kRhoPhiPFBit = 1 << kRhoPhiPF, kISpyBit = 1 << kISpy, kLegoBit = 1 << kLego,
+                                kLegoHFBit = 1 << kLegoHF, kLegoPFECALBit = 1 << kLegoPFECAL,
+                                kGlimpseBit = 1 << kGlimpse, kTableBit = 1 << kTable, kTableHLTBit = 1 << kTableHLT,
+                                kTableL1Bit = 1 << kTableL1, kGeometryBit = 1 << kGeometryTable,
+                                kOverlapBit = 1 << kOverlapTable;
 
   // shortcuts
   static const int kAllRPZBits;

--- a/Fireworks/Core/interface/FWViewType.h
+++ b/Fireworks/Core/interface/FWViewType.h
@@ -46,22 +46,11 @@ public:
     kTypeSize
   };
 
-  enum EBit {
-    k3DBit = 1 << k3D,
-    kRhoPhiBit = 1 << kRhoPhi,
-    kRhoZBit = 1 << kRhoZ,
-    kRhoPhiPFBit = 1 << kRhoPhiPF,
-    kISpyBit = 1 << kISpy,
-    kLegoBit = 1 << kLego,
-    kLegoHFBit = 1 << kLegoHF,
-    kLegoPFECALBit = 1 << kLegoPFECAL,
-    kGlimpseBit = 1 << kGlimpse,
-    kTableBit = 1 << kTable,
-    kTableHLTBit = 1 << kTableHLT,
-    kTableL1Bit = 1 << kTableL1,
-    kGeometryBit = 1 << kGeometryTable,
-    kOverlapBit = 1 << kOverlapTable
-  };
+  static constexpr int k3DBit = 1 << k3D, kRhoPhiBit = 1 << kRhoPhi, kRhoZBit = 1 << kRhoZ,
+                       kRhoPhiPFBit = 1 << kRhoPhiPF, kISpyBit = 1 << kISpy, kLegoBit = 1 << kLego,
+                       kLegoHFBit = 1 << kLegoHF, kLegoPFECALBit = 1 << kLegoPFECAL, kGlimpseBit = 1 << kGlimpse,
+                       kTableBit = 1 << kTable, kTableHLTBit = 1 << kTableHLT, kTableL1Bit = 1 << kTableL1,
+                       kGeometryBit = 1 << kGeometryTable, kOverlapBit = 1 << kOverlapTable;
 
   // shortcuts
   static const int kAllRPZBits;

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -77,7 +77,7 @@ FWTEveViewer::~FWTEveViewer() {
 void FWTEveViewer::spawn_image_thread() {
   std::unique_lock<std::mutex> lko(m_moo);
 
-  m_thr = new std::thread([=]() {
+  m_thr = new std::thread([this]() {
     {
       std::unique_lock<std::mutex> lk(m_moo);
       m_cnd.notify_one();

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -77,7 +77,7 @@ FWTEveViewer::~FWTEveViewer() {
 void FWTEveViewer::spawn_image_thread() {
   std::unique_lock<std::mutex> lko(m_moo);
 
-  m_thr = new std::thread([this]() {
+  m_thr = new std::thread([=]() {
     {
       std::unique_lock<std::mutex> lk(m_moo);
       m_cnd.notify_one();


### PR DESCRIPTION
#### PR description:

Fix deprecated enum bitwise operation in FWCandidateHGCalLegoProxyBuilder

```
src/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc: In static member function 'static const std::string& FWCandidateHGCalLegoProxyBuilder::classView()':
  src/Fireworks/Candidates/plugins/FWCandidateHGCalLegoProxyBuilder.cc:97:46: warning: bitwise operation between different enumeration types 'FWViewType::EBit' and 'FWViewType::EType' is deprecated [-Wdeprecated-enum-enum-conversion]
    97 |                         FWViewType::kLegoBit | FWViewType::kLegoHF);
      |                         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```

#### PR validation:

Bot tests