### PR TITLE
[CPP20][Visualization] Remove deprecated implicit capture of this in FWTEveViewer

### DIFF
--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -77,7 +77,7 @@ FWTEveViewer::~FWTEveViewer() {
 void FWTEveViewer::spawn_image_thread() {
   std::unique_lock<std::mutex> lko(m_moo);
 
-  m_thr = new std::thread([=]() {
+  m_thr = new std::thread([this]() {
     {
       std::unique_lock<std::mutex> lk(m_moo);
       m_cnd.notify_one();


### PR DESCRIPTION
#### PR description:

Remove deprecated implicit capture of this in FWTEveViewer:

```
src/Fireworks/Core/src/FWTEveViewer.cc: In lambda function:
  src/Fireworks/Core/src/FWTEveViewer.cc:80:27: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]
    80 |   m_thr = new std::thread([=]() {
      |                           ^
src/Fireworks/Core/src/FWTEveViewer.cc:80:27: note: add explicit 'this' or '*this' capture
```

#### PR validation:

Bot tests
