### PR TITLE
[14_0_X] Revert "Workaround to produce exactly same data products in Serial and CUDA backends in Alpaka modules possibly used at HLT"

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalRawToDigiPortable.cc
@@ -64,14 +64,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         fedsToUnpack_{ps.getParameter<std::vector<int>>("FEDs")} {
     config_.maxChannelsEB = ps.getParameter<uint32_t>("maxChannelsEB");
     config_.maxChannelsEE = ps.getParameter<uint32_t>("maxChannelsEE");
-
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>",
-                        ps.getParameter<std::string>("digisLabelEB"));
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalDigiDeviceCollection>",
-                        ps.getParameter<std::string>("digisLabelEE"));
-#endif
   }
 
   void EcalRawToDigiPortable::produce(device::Event& event, device::EventSetup const& setup) {

--- a/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
+++ b/HeterogeneousCore/AlpakaCore/interface/alpaka/ProducerBase.h
@@ -58,12 +58,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       return ProducerBaseAdaptor<ProducerBase, Tr>(*this, std::move(instanceName));
     }
 
-    // For a workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-    void producesTemporarily(std::string const& iTypeName, std::string instanceName = std::string()) {
-      auto td = edm::TypeWithDict::byName(iTypeName);
-      Base::template produces<edm::Transition::Event>(edm::TypeID(td.typeInfo()), std::move(instanceName));
-    }
-
     static void prevalidate(edm::ConfigurationDescriptions& descriptions) {
       Base::prevalidate(descriptions);
       cms::alpakatools::module_backend_config(descriptions);

--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitProducerPortable.cc
@@ -87,14 +87,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         multifitParametersToken_{esConsumes()},
         ebDigisSizeHostBuf_{cms::alpakatools::make_host_buffer<uint32_t>()},
         eeDigisSizeHostBuf_{cms::alpakatools::make_host_buffer<uint32_t>()} {
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>",
-                        ps.getParameter<std::string>("recHitsLabelEB"));
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::EcalUncalibratedRecHitDeviceCollection>",
-                        ps.getParameter<std::string>("recHitsLabelEE"));
-#endif
-
     std::pair<double, double> EBtimeFitLimits, EEtimeFitLimits;
     EBtimeFitLimits.first = ps.getParameter<double>("EBtimeFitLimits_Lower");
     EBtimeFitLimits.second = ps.getParameter<double>("EBtimeFitLimits_Upper");

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/alpaka/SiPixelRawToCluster.cc
@@ -94,13 +94,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronGain_L1")),
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronOffset")),
                            static_cast<float>(iConfig.getParameter<double>("VCaltoElectronOffset_L1"))} {
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelDigisSoACollection>");
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelDigiErrorsSoACollection>");
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::SiPixelClustersSoACollection>");
-#endif
-
     if (includeErrors_) {
       digiErrorPutToken_ = produces();
       fmtErrorToken_ = produces();

--- a/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/alpaka/SiPixelRecHitAlpaka.cc
@@ -60,14 +60,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         tBeamSpot(consumes(iConfig.getParameter<edm::InputTag>("beamSpot"))),
         tokenClusters_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
         tokenDigi_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
-        tokenHit_(produces()) {
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1>) {
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::TrackingRecHitSoAPhase1>");
-    }
-#endif
-  }
+        tokenHit_(produces()) {}
 
   template <typename TrackerTraits>
   void SiPixelRecHitAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/alpaka/PFClusterSoAProducer.cc
@@ -25,13 +25,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           outputPFClusterSoA_Token_{produces()},
           outputPFRHFractionSoA_Token_{produces()},
           synchronise_(config.getParameter<bool>("synchronise")),
-          pfRecHitFractionAllocation_(config.getParameter<int>("pfRecHitFractionAllocation")) {
-      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFClusterDeviceCollection>");
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFRecHitFractionDeviceCollection>");
-#endif
-    }
+          pfRecHitFractionAllocation_(config.getParameter<int>("pfRecHitFractionAllocation")) {}
 
     void produce(device::Event& event, device::EventSetup const& setup) override {
       const reco::PFClusterParamsDeviceCollection& params = setup.getData(pfClusParamsToken);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -25,12 +25,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     CaloRecHitSoAProducer(edm::ParameterSet const& config)
         : recHitsToken_(consumes(config.getParameter<edm::InputTag>("src"))),
           deviceToken_(produces()),
-          synchronise_(config.getUntrackedParameter<bool>("synchronise")) {
-      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::CaloRecHitDeviceCollection>");
-#endif
-    }
+          synchronise_(config.getUntrackedParameter<bool>("synchronise")) {}
 
     void produce(edm::StreamID sid, device::Event& event, device::EventSetup const&) const override {
       const edm::SortedCollection<typename CAL::CaloRecHitType>& recHits = event.get(recHitsToken_);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitSoAProducer.cc
@@ -24,11 +24,6 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         : topologyToken_(esConsumes(config.getParameter<edm::ESInputTag>("topology"))),
           pfRecHitsToken_(produces()),
           synchronise_(config.getUntrackedParameter<bool>("synchronise")) {
-      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::reco::PFRecHitDeviceCollection>");
-#endif
-
       const std::vector<edm::ParameterSet> producers = config.getParameter<std::vector<edm::ParameterSet>>("producers");
       recHitsToken_.reserve(producers.size());
       for (const edm::ParameterSet& producer : producers) {

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAHitNtuplet.cc
@@ -58,14 +58,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         cpeToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("CPE")))),
         tokenHit_(consumes(iConfig.getParameter<edm::InputTag>("pixelRecHitSrc"))),
         tokenTrack_(produces()),
-        deviceAlgo_(iConfig) {
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    if constexpr (std::is_same_v<TrackerTraits, pixelTopology::Phase1>) {
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::pixelTrack::TracksSoACollectionPhase1>");
-    }
-#endif
-  }
+        deviceAlgo_(iConfig) {}
 
   template <typename TrackerTraits>
   void CAHitNtupletAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoTracker/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
+++ b/RecoTracker/PixelVertexFinding/plugins/alpaka/PixelVertexProducerAlpaka.cc
@@ -64,12 +64,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         ptMin_(conf.getParameter<double>("PtMin")),  // 0.5 GeV
         ptMax_(conf.getParameter<double>("PtMax")),  // 75. Onsumes
         tokenDeviceTrack_(consumes(conf.getParameter<edm::InputTag>("pixelTrackSrc"))),
-        tokenDeviceVertex_(produces()) {
-    // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-    producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::ZVertexSoACollection>");
-#endif
-  }
+        tokenDeviceVertex_(produces()) {}
 
   template <typename TrackerTraits>
   void PixelVertexProducerAlpaka<TrackerTraits>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/alpaka/BeamSpotDeviceProducer.cc
@@ -15,12 +15,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class BeamSpotDeviceProducer : public global::EDProducer<> {
   public:
     BeamSpotDeviceProducer(edm::ParameterSet const& config)
-        : legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))}, deviceToken_{produces()} {
-      // Workaround until the ProductID problem in issue https://github.com/cms-sw/cmssw/issues/44643 is fixed
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-      producesTemporarily("edm::DeviceProduct<alpaka_cuda_async::BeamSpotDevice>");
-#endif
-    }
+        : legacyToken_{consumes(config.getParameter<edm::InputTag>("src"))}, deviceToken_{produces()} {}
 
     void produce(edm::StreamID, device::Event& event, device::EventSetup const& setup) const override {
       reco::BeamSpot const& beamspot = event.get(legacyToken_);


### PR DESCRIPTION
#### PR description:

Reverts cms-sw/cmssw#44699, to be used in conjunction with https://github.com/cms-sw/cmssw/pull/44978

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45080