### PR TITLE
avoid crashing when encounter unphysical GEM pad numbers; add logging

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMClusterProcessor.cc
@@ -149,6 +149,20 @@ void GEMClusterProcessor::addCoincidenceClusters(const GEMPadDigiClusterCollecti
           if (!match)
             continue;
 
+          auto const& p_pads = p->pads();
+          auto const& co_p_pads = co_p->pads();
+
+          int num_unphys_pads_in_p = std::count_if(p_pads.begin(), p_pads.end(), [](auto pad) { return pad >= 192; });
+          int num_unphys_pads_co_p =
+              std::count_if(co_p_pads.begin(), co_p_pads.end(), [](auto pad) { return pad >= 192; });
+
+          if (num_unphys_pads_in_p > 0 || num_unphys_pads_co_p > 0) {
+            edm::LogWarning("GEMClusterProcessor")
+                << "Encountered unphysical GEM pads when making a coincidence cluster, resetting cluster to empty.";
+            clusters_.emplace_back(
+                id, co_id, GEMPadDigiCluster(), GEMPadDigiCluster(), delayGEMinOTMB_, tmbL1aWindowSize_);
+          }
+
           // make a new coincidence
           clusters_.emplace_back(id, co_id, *p, *co_p, delayGEMinOTMB_, tmbL1aWindowSize_);
           // std::cout << clusters_.back() << std::endl;
@@ -191,6 +205,15 @@ void GEMClusterProcessor::addSingleClusters(const GEMPadDigiClusterCollection* i
             return q.has_cluster(*p);
           }) != std::end(coincidences))
         continue;
+
+      auto const& p_pads = p->pads();
+      int num_unphys_pads = std::count_if(p_pads.begin(), p_pads.end(), [](auto pad) { return pad >= 192; });
+
+      if (num_unphys_pads > 0) {
+        edm::LogWarning("GEMClusterProcessor")
+            << "Encountered unphysical GEM pads when making a single cluster, resetting cluster to empty.";
+        clusters_.emplace_back(id, id, GEMPadDigiCluster(), GEMPadDigiCluster(), delayGEMinOTMB_, tmbL1aWindowSize_);
+      }
 
       // put the single clusters into the collection
       if (id.layer() == 1) {


### PR DESCRIPTION
#### PR description:
Add checks to avoid crashing GEMClusterProcessor when it accesses lookup table values corresponding to unphysical GEM pad numbers (greater than 192). If any unphysical pad numbers are discovered for a cluster being processed, cluster is reset to empty value so that it is skipped by the function doing coordinate conversion. The issue is most likely due to unstable GEM links and is currently being investigated. 

Slides with additional information are attached.
[unphysical_gem_pads.pdf](https://github.com/cms-sw/cmssw/files/15475792/unphysical_gem_pads.pdf)

#### PR validation:
Emulator code was run locally to make sure no crashes occur. 