### PR TITLE
[17.0.X] improve `SiStripHitEffFromCalibTree` and `SiStripHitResolFromCalibTree`

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/test/testHitEffWorker.py
+++ b/CalibTracker/SiStripHitEfficiency/test/testHitEffWorker.py
@@ -19,17 +19,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')  
 
 process.source = cms.Source("PoolSource", fileNames=cms.untracked.vstring(
-    # 10 random files, will need the rest later
     "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/E3D6AECF-3F12-6540-97DC-4A6994CFEBF3.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/242566C3-0540-8C43-8D6E-BB42C1FE0BB5.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/BC8C0839-F645-B948-9040-15FCB5D50472.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/3A806401-2CBC-4345-A5CB-593AABD4BE4E.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/852C3C1E-2BD4-A843-A65B-51110A503FBD.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/B795F9A0-4681-A34A-B879-E33A0DEC8720.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/3A0884F2-A395-C541-8EFB-740C45A57CCE.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/D274E7C1-5A9D-A544-B9B3-6A30166FC16C.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/C4D243DC-2A09-CF42-A050-7678EF4A90D7.root",
-    "/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/325/172/00000/7946A89D-8AC5-6B4F-BAD2-AE3B971865C5.root",
     ))
 
 if(options.isUnitTest):

--- a/CalibTracker/SiStripHitEfficiency/test/testHitEffWorker.py
+++ b/CalibTracker/SiStripHitEfficiency/test/testHitEffWorker.py
@@ -90,9 +90,13 @@ process.eventInfo = cms.EDAnalyzer(
 ## END OLD HITEFF
 
 ## TODO double-check in main CalibTree config if hiteff also takes refitted tracks
-process.allPath = cms.Path(process.MeasurementTrackerEvent*process.offlineBeamSpot*process.refitTracks
-        *process.anEff*process.shallowEventRun*process.eventInfo
-        *process.hiteff)
+process.allPath = cms.Path(process.MeasurementTrackerEvent*
+                           process.offlineBeamSpot*
+                           process.refitTracks*
+                           process.anEff*
+                           process.shallowEventRun*
+                           process.eventInfo*
+                           process.hiteff)
 
 # save the DQM plots in the DQMIO format
 process.dqmOutput = cms.OutputModule("DQMRootOutputModule",

--- a/CalibTracker/SiStripHitEfficiency/test/test_SiStripHitEfficiency.sh
+++ b/CalibTracker/SiStripHitEfficiency/test/test_SiStripHitEfficiency.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
+#export MALLOC_CONF=junk:true
+
 if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   mkdir ${SCRAM_TEST_NAME}
   cd ${SCRAM_TEST_NAME}

--- a/CalibTracker/SiStripHitResolution/plugins/SiStripHitResolFromCalibTree.cc
+++ b/CalibTracker/SiStripHitResolution/plugins/SiStripHitResolFromCalibTree.cc
@@ -90,7 +90,11 @@ private:
   void totalStatistics();
   void makeSummary(const edm::Service<TFileService>& fs);
   void makeSummaryVsBx(const edm::Service<TFileService>& fs);
-  void ComputeEff(const edm::Service<TFileService>& fs, vector<TH1F*>& vhfound, vector<TH1F*>& vhtotal, string name);
+  void ComputeEff(const edm::Service<TFileService>& fs,
+                  vector<TH1F*>& vhfound,
+                  vector<TH1F*>& vhtotal,
+                  string name,
+                  vector<TGraphAsymmErrors*> geff);
   void makeSummaryVsLumi(const edm::Service<TFileService>& fs);
   void makeSummaryVsCM(const edm::Service<TFileService>& fs);
   TString GetLayerName(Long_t k);
@@ -142,11 +146,11 @@ private:
   vector<hit> hits[::k_END_OF_LAYERS];
   vector<TH2F*> HotColdMaps;
   map<unsigned int, pair<unsigned int, unsigned int> > modCounter[::k_END_OF_LAYERS];
-  TrackerMap* tkmap;
-  TrackerMap* tkmapbad;
-  TrackerMap* tkmapeff;
-  TrackerMap* tkmapnum;
-  TrackerMap* tkmapden;
+  TrackerMap* tkmap{nullptr};
+  TrackerMap* tkmapbad{nullptr};
+  TrackerMap* tkmapeff{nullptr};
+  TrackerMap* tkmapnum{nullptr};
+  TrackerMap* tkmapden{nullptr};
   long layerfound[::k_END_OF_LAYERS];
   long layertotal[::k_END_OF_LAYERS];
   map<unsigned int, vector<int> > layerfound_perBx;
@@ -159,6 +163,11 @@ private:
   vector<TH1F*> layertotal_vsCM;
   vector<TH1F*> layerfound_vsBX;
   vector<TH1F*> layertotal_vsBX;
+  vector<TGraphAsymmErrors*> geff_vsBX;
+  vector<TGraphAsymmErrors*> geff_avg_vsBX;
+  vector<TGraphAsymmErrors*> geff_avg_vsLumi;
+  vector<TGraphAsymmErrors*> geff_avg_vsPU;
+  vector<TGraphAsymmErrors*> geff_avg_vsCM;
   int goodlayertotal[::k_END_OF_LAYS_AND_RINGS];
   int goodlayerfound[::k_END_OF_LAYS_AND_RINGS];
   int alllayertotal[::k_END_OF_LAYS_AND_RINGS];
@@ -208,6 +217,11 @@ SiStripHitResolFromCalibTree::SiStripHitResolFromCalibTree(const edm::ParameterS
   layertotal_vsCM.reserve(::k_END_OF_LAYS_AND_RINGS);
   layerfound_vsBX.reserve(::k_END_OF_LAYS_AND_RINGS);
   layertotal_vsBX.reserve(::k_END_OF_LAYS_AND_RINGS);
+  geff_vsBX.reserve(::k_END_OF_LAYERS);
+  geff_avg_vsBX.reserve(::k_END_OF_LAYERS);
+  geff_avg_vsLumi.reserve(::k_END_OF_LAYERS);
+  geff_avg_vsPU.reserve(::k_END_OF_LAYERS);
+  geff_avg_vsCM.reserve(::k_END_OF_LAYERS);
 }
 
 SiStripHitResolFromCalibTree::~SiStripHitResolFromCalibTree() {
@@ -335,11 +349,40 @@ void SiStripHitResolFromCalibTree::algoAnalyze(const edm::Event& e, const edm::E
     layertotal_vsBX.push_back(fs->make<TH1F>(
         Form("totalVsBx_layer%i", (int)ilayer), Form("layer %i", (int)ilayer), nBxInAnOrbit, 0, nBxInAnOrbit));
 
+    geff_vsBX.push_back(fs->make<TGraphAsymmErrors>(nBxInAnOrbit - 1));
+    geff_vsBX[ilayer]->SetName(Form("effVsBx_layer%i", (int)ilayer));
+    geff_vsBX[ilayer]->SetTitle(
+        fmt::format("Hit Efficiency vs bx - {}", ::layerName(ilayer, showRings_, nTEClayers_)).c_str());
+
+    geff_avg_vsBX.push_back(fs->make<TGraphAsymmErrors>(nBxInAnOrbit - 1));
+    geff_avg_vsBX[ilayer]->SetName(Form("effVsBxAvg_layer%i", (int)ilayer));
+    geff_avg_vsBX[ilayer]->SetTitle(
+        fmt::format("Hit Efficiency vs bx - {}", ::layerName(ilayer, showRings_, nTEClayers_)).c_str());
+    geff_avg_vsBX[ilayer]->SetMarkerStyle(20);
+
+    geff_avg_vsLumi.push_back(fs->make<TGraphAsymmErrors>(99));
+    geff_avg_vsLumi[ilayer]->SetName(Form("effVsLumiAvg_layer%i", (int)ilayer));
+    geff_avg_vsLumi[ilayer]->SetTitle(
+        fmt::format("Hit Efficiency vs inst. lumi. - {}", ::layerName(ilayer, showRings_, nTEClayers_)).c_str());
+    geff_avg_vsLumi[ilayer]->SetMarkerStyle(20);
+
+    geff_avg_vsPU.push_back(fs->make<TGraphAsymmErrors>(44));
+    geff_avg_vsLumi[ilayer]->SetName(Form("effVsPUAvg_layer%i", (int)ilayer));
+    geff_avg_vsPU[ilayer]->SetTitle(
+        fmt::format("Hit Efficiency vs pileup - {}", ::layerName(ilayer, showRings_, nTEClayers_)).c_str());
+    geff_avg_vsPU[ilayer]->SetMarkerStyle(20);
+
     if (useCM_) {
       layerfound_vsCM.push_back(
           fs->make<TH1F>(Form("layerfound_vsCM_layer_%i", (int)(ilayer)), GetLayerName(ilayer), 20, 0, 400));
       layertotal_vsCM.push_back(
           fs->make<TH1F>(Form("layertotal_vsCM_layer_%i", (int)(ilayer)), GetLayerName(ilayer), 20, 0, 400));
+
+      geff_avg_vsCM.push_back(fs->make<TGraphAsymmErrors>(19));
+      geff_avg_vsCM[ilayer]->SetName(Form("effVsCMAvg_layer%i", (int)ilayer));
+      geff_avg_vsCM[ilayer]->SetTitle(
+          fmt::format("Hit Efficiency vs common Mode - {}", ::layerName(ilayer, showRings_, nTEClayers_)).c_str());
+      geff_avg_vsCM[ilayer]->SetMarkerStyle(20);
     }
     layertotal[ilayer] = 0;
     layerfound[ilayer] = 0;
@@ -1505,7 +1548,7 @@ void SiStripHitResolFromCalibTree::makeSummaryVsBx(const edm::Service<TFileServi
   if (showRings_)
     nLayers = 20;
 
-  for (unsigned int ilayer = 1; ilayer < nLayers; ilayer++) {
+  for (unsigned int ilayer = 0; ilayer <= nLayers; ilayer++) {
     for (unsigned int ibx = 0; ibx <= nBxInAnOrbit; ibx++) {
       layerfound_vsBX[ilayer]->SetBinContent(ibx, 1e-6);
       layertotal_vsBX[ilayer]->SetBinContent(ibx, 1);
@@ -1521,16 +1564,9 @@ void SiStripHitResolFromCalibTree::makeSummaryVsBx(const edm::Service<TFileServi
     layerfound_vsBX[ilayer]->Sumw2();
     layertotal_vsBX[ilayer]->Sumw2();
 
-    TGraphAsymmErrors* geff = fs->make<TGraphAsymmErrors>(nBxInAnOrbit - 1);
-    geff->SetName(Form("effVsBx_layer%i", ilayer));
-    geff->SetTitle("Hit Efficiency vs bx - " + GetLayerName(ilayer));
-    geff->BayesDivide(layerfound_vsBX[ilayer], layertotal_vsBX[ilayer]);
+    geff_vsBX[ilayer]->BayesDivide(layerfound_vsBX[ilayer], layertotal_vsBX[ilayer]);
 
     //Average over trains
-    TGraphAsymmErrors* geff_avg = fs->make<TGraphAsymmErrors>();
-    geff_avg->SetName(Form("effVsBxAvg_layer%i", ilayer));
-    geff_avg->SetTitle("Hit Efficiency vs bx - " + GetLayerName(ilayer));
-    geff_avg->SetMarkerStyle(20);
     int ibx = 0;
     int previous_bx = -80;
     int delta_bx = 0;
@@ -1548,10 +1584,11 @@ void SiStripHitResolFromCalibTree::makeSummaryVsBx(const edm::Service<TFileServi
       if (delta_bx > (int)spaceBetweenTrains_ && nbx > 0 && total > 0) {
         eff = found / (float)total;
         //edm::LogInfo("SiStripHitResolFromCalibTree")<<"new train "<<ipt<<" "<<sum_bx/nbx<<" "<<eff<<endl;
-        geff_avg->SetPoint(ipt, sum_bx / nbx, eff);
+        geff_avg_vsBX[ilayer]->SetPoint(ipt, sum_bx / nbx, eff);
         low = TEfficiency::Bayesian(total, found, .683, 1, 1, false);
         up = TEfficiency::Bayesian(total, found, .683, 1, 1, true);
-        geff_avg->SetPointError(ipt, sum_bx / nbx - firstbx, previous_bx - sum_bx / nbx, eff - low, up - eff);
+        geff_avg_vsBX[ilayer]->SetPointError(
+            ipt, sum_bx / nbx - firstbx, previous_bx - sum_bx / nbx, eff - low, up - eff);
         ipt++;
         sum_bx = 0;
         found = 0;
@@ -1569,10 +1606,10 @@ void SiStripHitResolFromCalibTree::makeSummaryVsBx(const edm::Service<TFileServi
     //last train
     eff = found / (float)total;
     //edm::LogInfo("SiStripHitResolFromCalibTree")<<"new train "<<ipt<<" "<<sum_bx/nbx<<" "<<eff<<endl;
-    geff_avg->SetPoint(ipt, sum_bx / nbx, eff);
+    geff_avg_vsBX[ilayer]->SetPoint(ipt, sum_bx / nbx, eff);
     low = TEfficiency::Bayesian(total, found, .683, 1, 1, false);
     up = TEfficiency::Bayesian(total, found, .683, 1, 1, true);
-    geff_avg->SetPointError(ipt, sum_bx / nbx - firstbx, previous_bx - sum_bx / nbx, eff - low, up - eff);
+    geff_avg_vsBX[ilayer]->SetPointError(ipt, sum_bx / nbx - firstbx, previous_bx - sum_bx / nbx, eff - low, up - eff);
   }
 }
 
@@ -1597,7 +1634,8 @@ TString SiStripHitResolFromCalibTree::GetLayerName(Long_t k) {
 void SiStripHitResolFromCalibTree::ComputeEff(const edm::Service<TFileService>& fs,
                                               vector<TH1F*>& vhfound,
                                               vector<TH1F*>& vhtotal,
-                                              string name) {
+                                              string name,
+                                              vector<TGraphAsymmErrors*> geff) {
   unsigned int nLayers = 22;
   if (showRings_)
     nLayers = 20;
@@ -1605,7 +1643,7 @@ void SiStripHitResolFromCalibTree::ComputeEff(const edm::Service<TFileService>& 
   TH1F* hfound;
   TH1F* htotal;
 
-  for (unsigned int ilayer = 1; ilayer < nLayers; ilayer++) {
+  for (unsigned int ilayer = 0; ilayer <= nLayers; ilayer++) {
     hfound = vhfound[ilayer];
     htotal = vhtotal[ilayer];
 
@@ -1620,16 +1658,7 @@ void SiStripHitResolFromCalibTree::ComputeEff(const edm::Service<TFileService>& 
         htotal->SetBinContent(i, 1);
     }
 
-    TGraphAsymmErrors* geff = fs->make<TGraphAsymmErrors>(hfound->GetNbinsX());
-    geff->SetName(Form("%s_layer%i", name.c_str(), ilayer));
-    geff->BayesDivide(hfound, htotal);
-    if (name == "effVsLumi")
-      geff->SetTitle("Hit Efficiency vs inst. lumi. - " + GetLayerName(ilayer));
-    if (name == "effVsPU")
-      geff->SetTitle("Hit Efficiency vs pileup - " + GetLayerName(ilayer));
-    if (name == "effVsCM")
-      geff->SetTitle("Hit Efficiency vs common Mode - " + GetLayerName(ilayer));
-    geff->SetMarkerStyle(20);
+    geff[ilayer]->BayesDivide(hfound, htotal);
   }
 }
 
@@ -1668,13 +1697,13 @@ void SiStripHitResolFromCalibTree::makeSummaryVsLumi(const edm::Service<TFileSer
     edm::LogInfo("SiStripHitResolFromCalibTree") << "Avg conditions:   lumi :" << avgLumi << "  pu: " << avgPU << endl;
   }
 
-  ComputeEff(fs, layerfound_vsLumi, layertotal_vsLumi, "effVsLumi");
-  ComputeEff(fs, layerfound_vsPU, layertotal_vsPU, "effVsPU");
+  ComputeEff(fs, layerfound_vsLumi, layertotal_vsLumi, "effVsLumi", geff_avg_vsLumi);
+  ComputeEff(fs, layerfound_vsPU, layertotal_vsPU, "effVsPU", geff_avg_vsPU);
 }
 
 void SiStripHitResolFromCalibTree::makeSummaryVsCM(const edm::Service<TFileService>& fs) {
   edm::LogInfo("SiStripHitResolFromCalibTree") << "Computing efficiency vs CM" << endl;
-  ComputeEff(fs, layerfound_vsCM, layertotal_vsCM, "effVsCM");
+  ComputeEff(fs, layerfound_vsCM, layertotal_vsCM, "effVsCM", geff_avg_vsPU);
 }
 
 TString SiStripHitResolFromCalibTree::GetLayerSideName(Long_t k) {

--- a/CalibTracker/SiStripHitResolution/test/test_SiStripHitResolution.sh
+++ b/CalibTracker/SiStripHitResolution/test/test_SiStripHitResolution.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
 
+#export MALLOC_CONF=junk:true
+
 if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   mkdir ${SCRAM_TEST_NAME}
   cd ${SCRAM_TEST_NAME}


### PR DESCRIPTION
#### PR description:

Somewhat inspired by https://github.com/cms-sw/cms-bot/pull/2228, trying to debug crashes reported at https://github.com/cms-sw/cms-bot/pull/2228#issuecomment-2108606810, improve the modules `SiStripHitEffFromCalibTree` and `SiStripHitResolFromCalibTree`:
   * close input calibTree files after reading them;
   * `delete` all `new`-ly allocated memory;
   * use named constants for `k_END_OF_LAYERS` and `k_END_OF_LAYS_AND_RINGS` in lieu of magic numbers

#### PR validation:

`scram b runtests_testSiStripHitEfficiency` and `scram b runtests_testSiStripHitResolution` run fine after the update.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported to 14.0.X
