### PR TITLE
Adds muon shower triggers for MC data

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
@@ -33,6 +33,7 @@
 
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
@@ -85,12 +86,14 @@ namespace l1t {
     //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
 
     TRandom3* gRandom;
+    TRandom3* mushowerRandom;
 
     // BX parameters
     int bxFirst_;
     int bxLast_;
 
     int maxNumMuCands_;
+    int maxNumMuShowerCands_;
     int maxNumJetCands_;
     int maxNumEGCands_;
     int maxNumTauCands_;
@@ -114,6 +117,11 @@ namespace l1t {
     std::vector<l1t::Muon> muonVec_bxm1;
     std::vector<l1t::Muon> muonVec_bx0;
     std::vector<l1t::Muon> muonVec_bxp1;
+
+    std::vector<l1t::MuonShower> muonShowerVec_bxm2;
+    std::vector<l1t::MuonShower> muonShowerVec_bxm1;
+    std::vector<l1t::MuonShower> muonShowerVec_bx0;
+    std::vector<l1t::MuonShower> muonShowerVec_bxp1;
 
     std::vector<l1t::EGamma> egammaVec_bxm2;
     std::vector<l1t::EGamma> egammaVec_bxm1;
@@ -148,6 +156,7 @@ namespace l1t {
     // register what you produce
     produces<BXVector<l1t::EGamma>>();
     produces<BXVector<l1t::Muon>>();
+    produces<BXVector<l1t::MuonShower>>();
     produces<BXVector<l1t::Tau>>();
     produces<BXVector<l1t::Jet>>();
     produces<BXVector<l1t::EtSum>>();
@@ -158,6 +167,7 @@ namespace l1t {
     bxLast_ = iConfig.getParameter<int>("bxLast");
 
     maxNumMuCands_ = iConfig.getParameter<int>("maxMuCand");
+    maxNumMuShowerCands_ = iConfig.getParameter<int>("maxMuShowerCand");
     maxNumJetCands_ = iConfig.getParameter<int>("maxJetCand");
     maxNumEGCands_ = iConfig.getParameter<int>("maxEGCand");
     maxNumTauCands_ = iConfig.getParameter<int>("maxTauCand");
@@ -193,6 +203,7 @@ namespace l1t {
 
     // Setup vectors
     std::vector<l1t::Muon> muonVec;
+    std::vector<l1t::MuonShower> muonShowerVec;
     std::vector<l1t::EGamma> egammaVec;
     std::vector<l1t::Tau> tauVec;
     std::vector<l1t::Jet> jetVec;
@@ -224,6 +235,7 @@ namespace l1t {
     //outputs
     std::unique_ptr<l1t::EGammaBxCollection> egammas(new l1t::EGammaBxCollection(0, bxFirst, bxLast));
     std::unique_ptr<l1t::MuonBxCollection> muons(new l1t::MuonBxCollection(0, bxFirst, bxLast));
+    std::unique_ptr<l1t::MuonShowerBxCollection> muonShowers(new l1t::MuonShowerBxCollection(0, bxFirst, bxLast));
     std::unique_ptr<l1t::TauBxCollection> taus(new l1t::TauBxCollection(0, bxFirst, bxLast));
     std::unique_ptr<l1t::JetBxCollection> jets(new l1t::JetBxCollection(0, bxFirst, bxLast));
     std::unique_ptr<l1t::EtSumBxCollection> etsums(new l1t::EtSumBxCollection(0, bxFirst, bxLast));
@@ -258,6 +270,23 @@ namespace l1t {
     } else {
       LogTrace("GtGenToInputProducer") << ">>> GenParticles collection not found!" << std::endl;
     }
+
+    // Muon Shower Collection
+
+    bool mus0 = (bool)mushowerRandom->Integer(2);  // should be [0,1] = 1 bit;
+    bool mus1 = (bool)mushowerRandom->Integer(2);
+    bool mus2 = (bool)mushowerRandom->Integer(2);
+    bool mus2Loose = (bool)mushowerRandom->Integer(2);
+    bool musoot0 = (bool)mushowerRandom->Integer(2);
+    bool musoot1 = (bool)mushowerRandom->Integer(2);
+    bool musoot2Loose = (bool)mushowerRandom->Integer(2);
+    //fill a vector of MuonShower objs with only one obj per BX, not one obj per muon obj
+    cout << "GenToInputProducer MuonShower = (MUS0, MUS1, MUS2, MUSOOT0, MUSOOT1) = (" << mus0 << "," << mus1 << ","
+         << mus2 << "," << musoot0 << "," << musoot1 << ")" << endl;
+    l1t::MuonShower muShower(mus0, musoot0, mus2Loose, musoot2Loose, mus1, musoot1, mus2);
+    muShower.setMusOutOfTime0(musoot0);
+    muShower.setMusOutOfTime1(musoot1);
+    muonShowerVec.push_back(muShower);
 
     // Muon Collection
     int numMuCands = int(mu_cands_index.size());
@@ -635,6 +664,28 @@ namespace l1t {
       muonVec.clear();
     }
 
+    // Fill MuonShowers
+    for (int iMuShower = 0; iMuShower < int(muonShowerVec_bxm2.size()); iMuShower++) {
+      muonShowers->push_back(-2, muonShowerVec_bxm2[iMuShower]);
+    }
+    for (int iMuShower = 0; iMuShower < int(muonShowerVec_bxm1.size()); iMuShower++) {
+      muonShowers->push_back(-1, muonShowerVec_bxm1[iMuShower]);
+    }
+    for (int iMuShower = 0; iMuShower < int(muonShowerVec_bx0.size()); iMuShower++) {
+      muonShowers->push_back(0, muonShowerVec_bx0[iMuShower]);
+    }
+    for (int iMuShower = 0; iMuShower < int(muonShowerVec_bxp1.size()); iMuShower++) {
+      muonShowers->push_back(1, muonShowerVec_bxp1[iMuShower]);
+    }
+    if (emptyBxTrailer_ <= (emptyBxEvt_ - eventCnt_)) {
+      for (int iMuShower = 0; iMuShower < int(muonShowerVec.size()); iMuShower++) {
+        muonShowers->push_back(2, muonShowerVec[iMuShower]);
+      }
+    } else {
+      // this event is part of empty trailer...clear out data
+      muonShowerVec.clear();
+    }
+
     // Fill Egammas
     for (int iEG = 0; iEG < int(egammaVec_bxm2.size()); iEG++) {
       egammas->push_back(-2, egammaVec_bxm2[iEG]);
@@ -737,6 +788,7 @@ namespace l1t {
 
     iEvent.put(std::move(egammas));
     iEvent.put(std::move(muons));
+    iEvent.put(std::move(muonShowers));
     iEvent.put(std::move(taus));
     iEvent.put(std::move(jets));
     iEvent.put(std::move(etsums));
@@ -744,6 +796,7 @@ namespace l1t {
 
     // Now shift the bx data by one to prepare for next event.
     muonVec_bxm2 = muonVec_bxm1;
+    muonShowerVec_bxm2 = muonShowerVec_bxm1;
     egammaVec_bxm2 = egammaVec_bxm1;
     tauVec_bxm2 = tauVec_bxm1;
     jetVec_bxm2 = jetVec_bxm1;
@@ -751,6 +804,7 @@ namespace l1t {
     extCond_bxm2 = extCond_bxm1;
 
     muonVec_bxm1 = muonVec_bx0;
+    muonShowerVec_bxm1 = muonShowerVec_bx0;
     egammaVec_bxm1 = egammaVec_bx0;
     tauVec_bxm1 = tauVec_bx0;
     jetVec_bxm1 = jetVec_bx0;
@@ -758,6 +812,7 @@ namespace l1t {
     extCond_bxm1 = extCond_bx0;
 
     muonVec_bx0 = muonVec_bxp1;
+    muonShowerVec_bx0 = muonShowerVec_bxp1;
     egammaVec_bx0 = egammaVec_bxp1;
     tauVec_bx0 = tauVec_bxp1;
     jetVec_bx0 = jetVec_bxp1;
@@ -765,6 +820,7 @@ namespace l1t {
     extCond_bx0 = extCond_bxp1;
 
     muonVec_bxp1 = muonVec;
+    muonShowerVec_bxp1 = muonShowerVec;
     egammaVec_bxp1 = egammaVec;
     tauVec_bxp1 = tauVec;
     jetVec_bxp1 = jetVec;
@@ -786,6 +842,7 @@ namespace l1t {
     srand(0);
 
     gRandom = new TRandom3();
+    mushowerRandom = new TRandom3();
   }
 
   // ------------ method called when ending the processing of a run ------------

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -3,9 +3,6 @@ from __future__ import print_function
 import sys
 
 """
-IMPORTANT NOTE: currently not working for MC-based validation after the updates of the GtRecordDump!
-                Fix needed.
- 
 Description: script used for offline validation of the Global Trigger firmware and emulator agreement                                 
 (Contacts: Richard Cavanaugh, Elisa Fontanesi)                                                                                
 -----------------------------------------------------------------------------------------------------                      
@@ -226,6 +223,7 @@ process.simGtExtFakeProd.setBptxOR    = cms.bool(True)
 # Run the Stage 2 uGT emulator
 # ----------------------------
 process.load('L1Trigger.L1TGlobal.simGtStage2Digis_cfi')
+process.simGtStage2Digis.useMuonShowers = cms.bool(True)
 process.simGtStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
 process.simGtStage2Digis.MuonInputTag = cms.InputTag("gtInput")


### PR DESCRIPTION
#### PR description:

Implements HMT triggers in test vector code with MC data files for uGT emulator in master.

No changes are expected to the output.

This PR does not depend on any other PRs or externals.

#### PR validation:

Performed runTheMatrix with -l 11634.0, passed 5 out of 5 tests. Test vector code was also validated with firmware and was shown to be equivalent.

Changes were checked against "scram build code-format" to ensure they followed CMS Naming, Coding and Style Rules.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.