### PR TITLE
Fix maybe-uninitialized warnings in Zmumumerge.cc

### DIFF
--- a/Alignment/OfflineValidation/bin/Zmumumerge.cc
+++ b/Alignment/OfflineValidation/bin/Zmumumerge.cc
@@ -298,8 +298,8 @@ void Draw_TH1D_forMultiRootFiles(const vector<TString>& file_names,
   lg->SetLineColor(0);
   lg->SetEntrySeparation(0.05);
 
-  double ymin;
-  double ymax;
+  double ymin = 0.;
+  double ymax = 0.;
 
   for (auto const& labelname : label_names | boost::adaptors::indexed(0)) {
     double temp_ymin = th1d_input[labelname.index()]->GetMinimum();


### PR DESCRIPTION
#### PR description:

Fixes the following warnings in ASAN IBs:

```
src/Alignment/OfflineValidation/bin/Zmumumerge.cc: In function 'void Draw_TH1D_forMultiRootFiles(const std::vector<TString>&, const std::vector<TString>&, const std::vector<int>&, const std::vector<int>&, const TString&, const TString&, const TString&, const TString&, const TString&)':
  src/Alignment/OfflineValidation/bin/Zmumumerge.cc:331:29: warning: 'ymax' may be used uninitialized [-Wmaybe-uninitialized]
   331 |       double yrange = (ymax - ymin) * 2;
      |                       ~~~~~~^~~~~~~
src/Alignment/OfflineValidation/bin/Zmumumerge.cc:302:10: note: 'ymax' was declared here
  302 |   double ymax;
      |          ^~~~
  src/Alignment/OfflineValidation/bin/Zmumumerge.cc:331:29: warning: 'ymin' may be used uninitialized [-Wmaybe-uninitialized]
   331 |       double yrange = (ymax - ymin) * 2;
      |                       ~~~~~~^~~~~~~
src/Alignment/OfflineValidation/bin/Zmumumerge.cc:301:10: note: 'ymin' was declared here
  301 |   double ymin;
      |          ^~~~
```

#### PR validation:

Bot tests