### PR TITLE
[CPP20] remove depracated use of volatile as for #45072

### DIFF
--- a/DataFormats/Math/test/FastMath_t.cpp
+++ b/DataFormats/Math/test/FastMath_t.cpp
@@ -43,7 +43,7 @@ namespace {
     amax = std::max(amax, std::abs(d));
   }
 
-  volatile double dummy;
+  double dummy;
   template <typename T>
   inline T eta(T x, T y, T z) {
     x = z / std::sqrt(x * x + y * y);

--- a/DataFormats/Math/test/rdtscp.h
+++ b/DataFormats/Math/test/rdtscp.h
@@ -28,13 +28,13 @@ namespace {
       return false;
   }
   unsigned int rdtscp_val = 0;
-  inline volatile unsigned long long rdtsc() { return __rdtscp(&rdtscp_val); }
+  inline unsigned long long rdtsc() { return __rdtscp(&rdtscp_val); }
 }  // namespace
 #endif
 #else   // !defined(__arm__) && !defined(__aarch64__)
 namespace {
   inline bool has_rdtscp() { return false; }
-  inline volatile unsigned long long rdtsc() { return 0; }
+  inline unsigned long long rdtsc() { return 0; }
 }  // namespace
 #endif  // !defined(__arm__) && !defined(__aarch64__)
 


### PR DESCRIPTION
in DataFormats/Math/tests
no production code affected.