### PR TITLE
Remove unused variable in VertexTimeAlgorithmLegacy4D.cc

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
@@ -26,7 +26,6 @@ bool VertexTimeAlgorithmLegacy4D::vertexTime(float& vtxTime, float& vtxTimeError
   }
 
   double sumwt = 0.;
-  double sumwt2 = 0.;
   double sumw = 0.;
 
   for (const auto& trk : vtx.originalTracks()) {
@@ -37,7 +36,6 @@ bool VertexTimeAlgorithmLegacy4D::vertexTime(float& vtxTime, float& vtxTimeError
     const double inverr = err > 0. ? 1.0 / err : 0.;
     const double w = inverr * inverr;
     sumwt += w * time;
-    sumwt2 += w * time * time;
     sumw += w;
   }
 


### PR DESCRIPTION
#### PR description:

Fixes the following compilation warning:

```
  src/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc:29:10: warning: variable 'sumwt2' set but not used [-Wunused-but-set-variable]
    29 |   double sumwt2 = 0.;
      |          ^
1 warning generated.
```

#### PR validation:

Bot tests