### PR TITLE
Removed duplicate cfi file in L1Trigger/L1CaloTrigger

### DIFF
--- a/L1Trigger/L1CaloTrigger/python/l1tS2PFJetInputPatternWriter_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/l1tS2PFJetInputPatternWriter_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from L1Trigger.L1CaloTrigger.l1tS2PFJetInputPatternWriter_cfi import *
-
-l1tS2PFJetInputPatternWriter = L1TS2PFJetInputPatternWriter.clone()


### PR DESCRIPTION
#### PR description:

The same named cfi file was generated and placed in cfipython and the package's python directory.

#### PR validation:

Code compiles.