### PR TITLE
(DAQ) fix lock contention in source

### DIFF
--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -1075,12 +1075,13 @@ void DAQSource::readWorker(unsigned int tid) {
     workerPool_.push(tid);
 
     if (init) {
-      std::unique_lock<std::mutex> lk(startupLock_);
+      std::unique_lock<std::mutex> lks(startupLock_);
       init = false;
       startupCv_.notify_one();
     }
     cvWakeup_.notify_all();
     cvReader_[tid]->wait(lk);
+    lk.unlock();
 
     if (thread_quit_signal[tid])
       return;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -1300,12 +1300,13 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
     workerPool_.push(tid);
 
     if (init) {
-      std::unique_lock<std::mutex> lk(startupLock_);
+      std::unique_lock<std::mutex> lks(startupLock_);
       init = false;
       startupCv_.notify_one();
     }
     cvWakeup_.notify_all();
     cvReader_[tid]->wait(lk);
+    lk.unlock();
 
     if (thread_quit_signal[tid])
       return;


### PR DESCRIPTION
#### PR description:
Fixes lock contention in source. Lock is used for setting up waiting on the condition variable, but it should be released after.
However, the lock is automatically reacquired at the end of `wait` as described:
https://en.cppreference.com/w/cpp/thread/condition_variable/wait

In production HLT this is seen to take significant time in the source (8-20% depending on data flow conditions and configuration) and could be the cause preventing using top ~10% of the CPU capacity in HLT.

Also, more logging (destination info) is added for the case of file broker connection issues.

#### PR validation:

Tested in daq3val system with both FedRawDataInputSource and DAQSource.