### PR TITLE
[CPP20] Remove volatile from CondCore/Utilities

### DIFF
--- a/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_perf.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <fstream>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 
@@ -325,7 +326,7 @@ cond::TestGTPerf::TestGTPerf() : Utilities("conddb_test_gt_load") {
 // thread helpers
 
 // global counter for dummy thread measurements:
-volatile int fooGlobal = 0;
+std::atomic<int> fooGlobal = 0;
 
 class FetchWorker {
 private:


### PR DESCRIPTION
#### PR description:
Addressing #45072 
This PR removes the only occurrence of a _volatile_ variable in `CondCore/Utilities`.
The cpp script containing such variable is not run in production and not even run as unitTest. 

The `[RFC]` in the title is due to the fact that I'm not 100% sure this is the correct way of handling this, at least I could not understand if there are preferred ways to address this deprecation from the link in the original issue, but I don't have much experience with this. 😄 
@iarspider @VinInn any feedback is more than welcome.

#### PR validation:
Code compiles.
Additionally, I have run the following command:
```
conddb_test_gt_perf -g 80X_dataRun2_HLT_for800Validatio_test -n 1 -c oracle://cms_orcoff_prep/CMS_CONDITIONS --n_fetch 1 --n_deser 1 2>&1 | tee run.log
```
with and without this PR and the test passes with the same result.

#### Backport:
Not a backport, no backport needed