### PR TITLE
[14_0_X] EMTF emulator support for 2024 primitive converison LUTs

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
+++ b/L1Trigger/L1TMuonEndCap/src/ConditionHelper.cc
@@ -87,8 +87,11 @@ unsigned int ConditionHelper::get_pc_lut_version() const {
   } else if (params_->firmwareVersion_ <
              1687686338) {  // Corresponds to June 25, 2023. The firmware was deployed on June 26, 2023.
     return 3;               // Starting October 6, 2022 with run 359924 (data only, not in MC)
+  } else if (params_->firmwareVersion_ <
+             1716282790) {  // Corresponds to May 21, 2024. The firmware was deployed on May 28, 2024.
+    return 4;               // Starting July 1, 2023 with run 369675 (data only, not in MC)
   } else {
-    return 4;  // Starting July 1, 2023 with run 369675 (data only, not in MC)
+    return 5;  // Starting May 28, 2024 with run 381316 (data only, not in MC)
   }
 }
 

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorLUT.cc
@@ -29,6 +29,8 @@ void SectorProcessorLUT::read(bool pc_lut_data, int pc_lut_version) {
     coord_lut_dir = "ph_lut_Run3_2022_data";  // Update in October 2022 from Run 3 2022 alignment, data only
   else if (pc_lut_version == 4 && pc_lut_data)
     coord_lut_dir = "ph_lut_Run3_2023_data";  // Update in June 2023 from Run 3 2023 alignment, data only
+  else if (pc_lut_version == 5 && pc_lut_data)
+    coord_lut_dir = "ph_lut_Run3_2024_data";  // Update in May 2024 from Run 3 2024 alignment, data only
   else if (pc_lut_version >= 2)
     coord_lut_dir = "ph_lut_v2";  // MC still uses ideal CMS aligment
   else if (pc_lut_version == -1 && pc_lut_data)


### PR DESCRIPTION
#### PR description:

This PR adds options to use the new primitive conversion LUTs in the EMTF emulator. The LUTs were deployed at P5 on May 28th, but they are not used in the emulator yet. 

This PR needs the LUTs in https://github.com/cms-data/L1Trigger-L1TMuon/pull/28 to work.

We see improvement in EMTF performance at P5 with these new LUTs, so changes to muon efficiencies etc are expected when testing the re-emulation workflows from recent runs.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by comparing unpacked and re-emulated collections from recent runs. Emulator picks the correct LUTs based on firmware version. Results are as expected.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of https://github.com/cms-sw/cmssw/pull/45105. It's not urgent, but it is needed to reduce DQM mismatches between EMTF fw and emulator.

N/A

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
