### PR TITLE
[14_0_X] Add possibility to read triggerbits for Secondary Datasets from the GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,7 +24,7 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   :    '131X_mcRun2_pA_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    :    '140X_dataRun2_v1',
+    'run2_data'                    :    '140X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_HEfail'             :    '140X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 HI data
@@ -35,12 +35,12 @@ autoCond = {
     'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v3',
     # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
     'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
-    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
-    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 but snapshot at 2024-05-31 09:09:12 (UTC)
+    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v3',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-02-07 16:38:59 (UTC)
-    'run3_data'                    :    '140X_dataRun3_v3',
+    'run3_data'                    :    '140X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
-    'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v1',
+    'run3_data_PromptAnalysis'     :    '140X_dataRun3_PromptAnalysis_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           :    '131X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
+++ b/Configuration/Skimming/python/PDWG_ReserveDMu_SD_cff.py
@@ -4,57 +4,9 @@ import FWCore.ParameterSet.Config as cms
 import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt
 ReserveDMu = hlt.hltHighLevel.clone()
 ReserveDMu.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
-ReserveDMu.HLTPaths = cms.vstring(
-    'HLT_Dimuon0_Jpsi3p5_Muon2_v*',
-    'HLT_Dimuon0_Jpsi_L1_4R_0er1p5R_v*',
-    'HLT_Dimuon0_Jpsi_L1_NoOS_v*',
-    'HLT_Dimuon0_Jpsi_NoVertexing_L1_4R_0er1p5R_v*',
-    'HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*',
-    'HLT_Dimuon0_Jpsi_NoVertexing_v*',
-    'HLT_Dimuon0_Jpsi_v*',
-    'HLT_Dimuon0_LowMass_L1_0er1p5R_v*',
-    'HLT_Dimuon0_LowMass_L1_0er1p5_v*',
-    'HLT_Dimuon0_LowMass_L1_4R_v*',
-    'HLT_Dimuon0_LowMass_L1_4_v*',
-    'HLT_Dimuon0_LowMass_L1_TM530_v*',
-    'HLT_Dimuon0_LowMass_v*',
-    'HLT_Dimuon0_Upsilon_L1_4p5_v*',
-    'HLT_Dimuon0_Upsilon_L1_4p5er2p0M_v*',
-    'HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*',
-    'HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*',
-    'HLT_Dimuon0_Upsilon_NoVertexing_v*',
-    'HLT_Dimuon12_Upsilon_y1p4_v*',
-    'HLT_Dimuon14_Phi_Barrel_Seagulls_v*',
-    'HLT_Dimuon18_PsiPrime_noCorrL1_v*',
-    'HLT_Dimuon18_PsiPrime_v*',
-    'HLT_Dimuon24_Phi_noCorrL1_v*',
-    'HLT_Dimuon24_Upsilon_noCorrL1_v*',
-    'HLT_Dimuon25_Jpsi_noCorrL1_v*',
-    'HLT_Dimuon25_Jpsi_v*',
-    'HLT_DoubleMu2_Jpsi_DoubleTrk1_Phi1p05_v*',
-    'HLT_DoubleMu3_DoubleEle7p5_CaloIdL_TrackIdL_Upsilon_v*',
-    'HLT_DoubleMu3_TkMu_DsTau3Mu_v*',
-    'HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*',
-    'HLT_DoubleMu3_Trk_Tau3mu_v*',
-    'HLT_DoubleMu4_3_Bs_v*',
-    'HLT_DoubleMu4_3_Jpsi_v*',
-    'HLT_DoubleMu4_JpsiTrkTrk_Displaced_v*',
-    'HLT_DoubleMu4_Jpsi_Displaced_v*',
-    'HLT_DoubleMu4_Jpsi_NoVertexing_v*',
-    'HLT_DoubleMu4_MuMuTrk_Displaced_v*',
-    'HLT_DoubleMu5_Upsilon_DoubleEle3_CaloIdL_TrackIdL_v*',
-    'HLT_Mu25_TkMu0_Phi_v*',
-    'HLT_Mu30_TkMu0_Psi_v*',
-    'HLT_Mu30_TkMu0_Upsilon_v*',
-    'HLT_Mu4_L1DoubleMu_v*',
-    'HLT_Mu7p5_L2Mu2_Jpsi_v*',
-    'HLT_Mu7p5_L2Mu2_Upsilon_v*',
-    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_v*',
-    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*',
-    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_v*',
-    'HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_v*',
-    'HLT_Trimuon5_3p5_2_Upsilon_Muon_v*',
-    'HLT_TrimuonOpen_5_3p5_2_Upsilon_Muon_v*')
+# Read list of paths from the SecondaryDataset Triggerbit tag in the GT
+ReserveDMu.eventSetupPathsLabel = 'SecondaryDatasetTrigger' # TriggerBits tag label
+ReserveDMu.eventSetupPathsKey = 'ReserveDMu'                # Dataset-specific key
 ReserveDMu.andOr = cms.bool( True )
 # we want to intentionally throw and exception
 # in case it does not match one of the HLT Paths

--- a/HLTrigger/HLTfilters/plugins/HLTHighLevel.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTHighLevel.cc
@@ -40,6 +40,7 @@ HLTHighLevel::HLTHighLevel(const edm::ParameterSet& iConfig)
       andOr_(iConfig.getParameter<bool>("andOr")),
       throw_(iConfig.getParameter<bool>("throw")),
       eventSetupPathsKey_(iConfig.getParameter<std::string>("eventSetupPathsKey")),
+      eventSetupPathsLabel_(iConfig.getParameter<std::string>("eventSetupPathsLabel")),
       HLTPatterns_(iConfig.getParameter<std::vector<std::string> >("HLTPaths")),
       HLTPathsByName_(),
       HLTPathsByIndex_() {
@@ -55,7 +56,8 @@ HLTHighLevel::HLTHighLevel(const edm::ParameterSet& iConfig)
           << HLTPatterns_.size() << " HLTPaths and\n"
           << " eventSetupPathsKey " << eventSetupPathsKey_ << ", choose either of them.";
     }
-    alcaRecotriggerBitsToken_ = esConsumes<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd>();
+    alcaRecotriggerBitsToken_ =
+        esConsumes<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd>(edm::ESInputTag("", eventSetupPathsLabel_));
     watchAlCaRecoTriggerBitsRcd_.emplace();
   }
 }
@@ -72,6 +74,7 @@ void HLTHighLevel::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<std::vector<std::string> >("HLTPaths", hltPaths);
   // # not empty => use read paths from AlCaRecoTriggerBitsRcd via this key
   desc.add<std::string>("eventSetupPathsKey", "");
+  desc.add<std::string>("eventSetupPathsLabel", "");
   // # how to deal with multiple triggers: True (OR) accept if ANY is true, False (AND) accept if ALL are true
   desc.add<bool>("andOr", true);
   // # throw exception on unknown path names

--- a/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
+++ b/HLTrigger/HLTfilters/plugins/HLTHighLevel.h
@@ -77,6 +77,7 @@ private:
 
   /// not empty => use read paths from AlCaRecoTriggerBitsRcd via this key
   const std::string eventSetupPathsKey_;
+  const std::string eventSetupPathsLabel_;
   /// Watcher to be created and used if 'eventSetupPathsKey_' non empty:
   std::optional<edm::ESWatcher<AlCaRecoTriggerBitsRcd>> watchAlCaRecoTriggerBitsRcd_;
   /// ESGetToken to read AlCaRecoTriggerBits


### PR DESCRIPTION
#### PR description:
Verbatim backport of #45092
See master PR for a complete description, here I'm only reporting the GT difference:

**Full GT differences:**
- `run2_data`
  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun2_v1/140X_dataRun2_v2
- `run3_data_prompt`
  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Prompt_frozen_v1/140X_dataRun3_Prompt_frozen_v3
   - Jump from version `v1` to `v3` since the `v2` GT was never propagated to the release (but it was correctly deployed in production, see comment in https://github.com/cms-sw/cmssw/pull/45092#issuecomment-2141723733), so it additionaly includes the change of the `DropBoxMetadataRcd` tag (from `DropBoxMetadata_v8.4_express` to `DropBoxMetadata_v8.5_express`)
- `run3_data`
  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_v3/140X_dataRun3_v4
- `run3_data_PromptAnalysis`
  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_PromptAnalysis_v1/140X_dataRun3_PromptAnalysis_v2


#### PR validation:
See master PR.

#### Backport:
backport of #45092