### PR TITLE
(DAQ) fix lock contention in the DAQ source [14_0_7_patchX]

### DIFF
--- a/EventFilter/Utilities/src/DAQSource.cc
+++ b/EventFilter/Utilities/src/DAQSource.cc
@@ -1075,11 +1075,12 @@ void DAQSource::readWorker(unsigned int tid) {
     workerPool_.push(tid);
 
     if (init) {
-      std::unique_lock<std::mutex> lk(startupLock_);
+      std::unique_lock<std::mutex> lks(startupLock_);
       init = false;
       startupCv_.notify_one();
     }
     cvReader_[tid]->wait(lk);
+    lk.unlock();
 
     if (thread_quit_signal[tid])
       return;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <cstdio>
 #include <boost/algorithm/string.hpp>
+#include <fmt/printf.h>
 
 //using boost::asio::ip::tcp;
 
@@ -1549,6 +1550,7 @@ namespace evf {
                                                                int maxLS) {
     EvFDaqDirector::FileStatus fileStatus = noFile;
     serverError = false;
+    std::string dest = fmt::sprintf(" on connection to %s:%s", fileBrokerHost_, fileBrokerPort_);
 
     boost::system::error_code ec;
     try {
@@ -1558,7 +1560,7 @@ namespace evf {
           boost::asio::connect(*socket_, *endpoint_iterator_, ec);
 
           if (ec) {
-            edm::LogWarning("EvFDaqDirector") << "boost::asio::connect error -:" << ec;
+            edm::LogWarning("EvFDaqDirector") << "boost::asio::connect error -:" << ec << dest;
             serverError = true;
             break;
           }
@@ -1581,17 +1583,17 @@ namespace evf {
         boost::asio::write(*socket_, request, ec);
         if (ec) {
           if (fileBrokerKeepAlive_ && ec == boost::asio::error::connection_reset) {
-            edm::LogInfo("EvFDaqDirector") << "reconnecting socket on received connection_reset";
+            edm::LogInfo("EvFDaqDirector") << "reconnecting socket on received connection_reset" << dest;
             //we got disconnected, try to reconnect to the server before writing the request
             boost::asio::connect(*socket_, *endpoint_iterator_, ec);
             if (ec) {
-              edm::LogWarning("EvFDaqDirector") << "boost::asio::connect error -:" << ec;
+              edm::LogWarning("EvFDaqDirector") << "boost::asio::connect error -:" << ec << dest;
               serverError = true;
               break;
             }
             continue;
           }
-          edm::LogWarning("EvFDaqDirector") << "boost::asio::write error -:" << ec;
+          edm::LogWarning("EvFDaqDirector") << "boost::asio::write error -:" << ec << dest;
           serverError = true;
           break;
         }
@@ -1599,7 +1601,7 @@ namespace evf {
         boost::asio::streambuf response;
         boost::asio::read_until(*socket_, response, "\r\n", ec);
         if (ec) {
-          edm::LogWarning("EvFDaqDirector") << "boost::asio::read_until error -:" << ec;
+          edm::LogWarning("EvFDaqDirector") << "boost::asio::read_until error -:" << ec << dest;
           serverError = true;
           break;
         }
@@ -1768,7 +1770,7 @@ namespace evf {
           while (boost::asio::read(*socket_, response, boost::asio::transfer_at_least(1), ec)) {
           }
           if (ec != boost::asio::error::eof) {
-            edm::LogWarning("EvFDaqDirector") << "boost::asio::read_until error -:" << ec;
+            edm::LogWarning("EvFDaqDirector") << "boost::asio::read_until error -:" << ec << dest;
             serverError = true;
           }
         }
@@ -1784,11 +1786,11 @@ namespace evf {
     if (!fileBrokerKeepAlive_ && socket_->is_open()) {
       socket_->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
       if (ec) {
-        edm::LogWarning("EvFDaqDirector") << "socket shutdown error -:" << ec;
+        edm::LogWarning("EvFDaqDirector") << "socket shutdown error -:" << ec << dest;
       }
       socket_->close(ec);
       if (ec) {
-        edm::LogWarning("EvFDaqDirector") << "socket close error -:" << ec;
+        edm::LogWarning("EvFDaqDirector") << "socket close error -:" << ec << dest;
       }
     }
 
@@ -1796,7 +1798,7 @@ namespace evf {
       if (socket_->is_open())
         socket_->close(ec);
       if (ec) {
-        edm::LogWarning("EvFDaqDirector") << "socket close error -:" << ec;
+        edm::LogWarning("EvFDaqDirector") << "socket close error -:" << ec << dest;
       }
       fileStatus = noFile;
       sleep(1);  //back-off if error detected

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -1299,11 +1299,12 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
     workerPool_.push(tid);
 
     if (init) {
-      std::unique_lock<std::mutex> lk(startupLock_);
+      std::unique_lock<std::mutex> lks(startupLock_);
       init = false;
       startupCv_.notify_one();
     }
     cvReader_[tid]->wait(lk);
+    lk.unlock();
 
     if (thread_quit_signal[tid])
       return;


### PR DESCRIPTION
#### PR description:

Fixes lock contention in source. Lock is used for setting up waiting on the condition variable, but it should be released after.
However, the lock is automatically reacquired at the end of wait as described:
https://en.cppreference.com/w/cpp/thread/condition_variable/wait

In production HLT this is seen to take significant time in the source (8-20% depending on data flow conditions and configuration) and could be the cause preventing using top ~10% of the CPU capacity in HLT.

Also, more logging (destination info) is added for the case of file broker connection issues.

#### PR validation:

Tested in daq3val system with both FedRawDataInputSource and DAQSource.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/45097 for 14_0_7_patchX release cycle.
Reason: performance bugfix in DAQ/HLT