### PR TITLE
remove leftover printout in `GlobalEvFOutputModule`

### DIFF
--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -493,7 +493,6 @@ namespace evf {
                                       edm::WaitingTaskWithArenaHolder iHolder) const {
     edm::Handle<edm::TriggerResults> const& triggerResults = getTriggerResults(trToken_, e);
 
-    std::cout << " writing Event " << moduleDescription().moduleLabel() << std::endl;
     auto buffer = streamCache(id);
     std::unique_ptr<EventMsgBuilder> msg =
         msgBuilders_->serializeEvent(*buffer, e, triggerResults, selectorConfig(), metaDataCache_->checksum_);


### PR DESCRIPTION
#### PR description:

Addresses https://github.com/cms-sw/cmssw/pull/44892#discussion_r1623371146.

Cherry-picked from @Dr15Jones.
https://github.com/cms-sw/cmssw/pull/44978/commits/f834a20e02d065f84ce4ebc1f4933bf55e17b5c2

#### PR validation:

None.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

Already backported as part of #44978.
