### PR TITLE
[14_0_X] Monopole SKIM updates for Run 3

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -18,9 +18,17 @@ hltMonopole.HLTPaths = cms.vstring(
     #"HLT_PFMET250_HBHECleaned_v*",
     #"HLT_PFMET300_HBHECleaned_v*",
     #2021: on EGamma dataset only
+    #"HLT_Photon200_v*",
+    #"HLT_DoublePhoton70_v*",
+    #"HLT_DoublePhoton85_v*",
+    #2024: on EGamma, MET and JetMET datasets
+    "HLT_Photon175_v*",
     "HLT_Photon200_v*",
-    "HLT_DoublePhoton70_v*",
-    "HLT_DoublePhoton85_v*",
+    "HLT_PFMET170_HBHECleaned_v*",
+    "HLT_PFMET300_v*",
+    "HLT_PFMET250_HBHECleaned_v*",
+    "HLT_PFMET200_HBHE_BeamHaloCleaned_v*",
+    "HLT_PFMET200_BeamHaloCleaned_v*"
 )
 hltMonopole.throw = False
 hltMonopole.andOr = True

--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -22,12 +22,7 @@ hltMonopole.HLTPaths = cms.vstring(
     #"HLT_DoublePhoton70_v*",
     #"HLT_DoublePhoton85_v*",
     #2024: on EGamma, MET and JetMET datasets
-    "HLT_Photon175_v*",
     "HLT_Photon200_v*",
-    "HLT_PFMET170_HBHECleaned_v*",
-    "HLT_PFMET300_v*",
-    "HLT_PFMET250_HBHECleaned_v*",
-    "HLT_PFMET200_HBHE_BeamHaloCleaned_v*",
     "HLT_PFMET200_BeamHaloCleaned_v*"
 )
 hltMonopole.throw = False

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -3,8 +3,8 @@ autoSkim = {
  # Skim 2023
  'BTagMu' : 'LogError+LogErrorMonitor',
  'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+EXOLLPJetHCAL+LogError+LogErrorMonitor',
- 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
- 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET0' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXOMONOPOLE+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET1' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXOMONOPOLE+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'EGamma0':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'EGamma1':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Tau' : 'EXODisappTrk+LogError+LogErrorMonitor',
@@ -28,11 +28,11 @@ autoSkim = {
 
  # These should be uncommented when 2022 data reprocessing
  # Dedicated skim for 2022
- 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+EXOMONOPOLE+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'EGamma':'EGMJME+ZElectron+WElectron+EXOMONOPOLE+EXODisappTrk+IsoPhotonEB+LogError+LogErrorMonitor',
  'Muon' : 'MUOJME+ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
  'JetHT' : 'JetHTJetPlusHOFilter+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
- 'MET' : 'EXOHighMET+EXODelayedJetMET+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
+ 'MET' : 'EXOHighMET+EXODelayedJetMET+EXOMONOPOLE+EXODisappTrk+EXOSoftDisplacedVertices+TeVJet+LogError+LogErrorMonitor',
  'SingleMuon' : 'ZMu+EXODisappTrk+EXODisappMuon+LogError+LogErrorMonitor',
  'DoubleMuon' : 'MUOJME+LogError+LogErrorMonitor',
 


### PR DESCRIPTION
PR description:


Provide an update to the trigger paths to be employed in the MONOPOLE SKIM file for the Run 3. The additional inclusion of trigger paths associated with MET can be mentioned.
Additionally, the inclusion of the EXOMONOPOLE SKIM file to be executed in the MET and JetMET datasets for the Run 3.


PR validation: The PR was validated through the the basic test procedure available in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)


This PR is a backport of https://github.com/cms-sw/cmssw/pull/45134 for the release 14_0_X.


