### PR TITLE
Fix deprecated enum arithmetics in ElectronConversionRejectionValidator and PhotonValidator

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc
@@ -131,10 +131,16 @@ void ElectronConversionRejectionValidator::bookHistograms(DQMStore::IBooker& ibo
 
   h_convLog10TrailTrackpt_ = ibooker.book1D("convLog10TrailTrackpt", "# of Electrons", ptBin, -2.0, 3.0);
 
-  h_convLeadTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
-  h_convTrailTrackAlgo_ = ibooker.book1D(
-      "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_convLeadTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                        "# of Electrons",
+                                        reco::TrackBase::algoSize,
+                                        -0.5,
+                                        static_cast<double>(reco::TrackBase::algoSize) - 0.5);
+  h_convTrailTrackAlgo_ = ibooker.book1D("convLeadTrackAlgo",
+                                         "# of Electrons",
+                                         reco::TrackBase::algoSize,
+                                         -0.5,
+                                         static_cast<double>(reco::TrackBase::algoSize) - 0.5);
 }
 
 void ElectronConversionRejectionValidator::analyze(const edm::Event& e, const edm::EventSetup&) {

--- a/Validation/RecoEgamma/plugins/PhotonValidator.cc
+++ b/Validation/RecoEgamma/plugins/PhotonValidator.cc
@@ -3126,8 +3126,11 @@ void PhotonValidator::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&
   h_trkProv_[0] = iBooker.book1D("allTrkProv", " Track pair provenance ", 4, 0., 4.);
   h_trkProv_[1] = iBooker.book1D("assTrkProv", " Track pair provenance ", 4, 0., 4.);
   //
-  h_trkAlgo_ =
-      iBooker.book1D("allTrackAlgo", " Track Algo ", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
+  h_trkAlgo_ = iBooker.book1D("allTrackAlgo",
+                              " Track Algo ",
+                              reco::TrackBase::algoSize,
+                              -0.5,
+                              static_cast<double>(reco::TrackBase::algoSize) - 0.5);
   h_convAlgo_ = iBooker.book1D("allConvAlgo", " Conv Algo ", 5, -0.5, 4.5);
   h_convQuality_ = iBooker.book1D("allConvQuality", "Conv quality ", 11, -0.5, 11.);
 


### PR DESCRIPTION
#### PR description:

Fixes the following warnings:

```
src/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc: In member function 'virtual void ElectronConversionRejectionValidator::bookHistograms(dqm::legacy::DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)':
  src/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc:135:105: warning: arithmetic between enumeration type 'reco::TrackBase::TrackAlgorithm' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
   135 |       "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
      |                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
  src/Validation/RecoEgamma/plugins/ElectronConversionRejectionValidator.cc:137:105: warning: arithmetic between enumeration type 'reco::TrackBase::TrackAlgorithm' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
   137 |       "convLeadTrackAlgo", "# of Electrons", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
      |                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
(...)
src/Validation/RecoEgamma/plugins/PhotonValidator.cc: In member function 'virtual void PhotonValidator::bookHistograms(dqm::legacy::DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&)':
  src/Validation/RecoEgamma/plugins/PhotonValidator.cc:3130:113: warning: arithmetic between enumeration type 'reco::TrackBase::TrackAlgorithm' and floating-point type 'double' is deprecated [-Wdeprecated-enum-float-conversion]
  3130 |       iBooker.book1D("allTrackAlgo", " Track Algo ", reco::TrackBase::algoSize, -0.5, reco::TrackBase::algoSize - 0.5);
      |                                           
```

#### PR validation:

Bot tests