### PR TITLE
Fix maybe-uninitialized warning in BaseCrystal

### DIFF
--- a/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
+++ b/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h
@@ -25,7 +25,7 @@ public:
   // side numbering
   //  enum CrystalSide{EAST=0,NORTH=1,WEST=2,SOUTH=3,FRONT=4,BACK=5};
   /// Empty constructor
-  BaseCrystal() { ; };
+  BaseCrystal() = default;
   /// constructor from DetId
   BaseCrystal(const DetId& cell);
 
@@ -36,7 +36,7 @@ public:
   //      computeBasicProperties();
   //      std::cout << " done " << std::endl;
   //    }
-  ~BaseCrystal() { ; }
+  ~BaseCrystal() = default;
   ///
   void setCorners(const CaloCellGeometry::CornersVec& vec, const GlobalPoint& pos);
 


### PR DESCRIPTION
#### PR description:

Fixes the following warning:

```
In member function '__ct ',
    inlined from 'construct_at' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:97:14,
    inlined from 'construct' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/alloc_traits.h:518:21,
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1830:30,
    inlined from '_M_fill_insert' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:534:25,
    inlined from 'resize' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1032:18,
    inlined from 'buildCrystalArray' at src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:393:25:
  src/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h:19:7: warning: 'MEM[(const struct BaseCrystal &)&D.11030].subdetn_' may be used uninitialized [-Wmaybe-uninitialized]
    19 | class BaseCrystal {
      |       ^
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc: In member function 'buildCrystalArray':
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:393:47: note: '<anonymous>' declared here
  393 |   barrelCrystals_.resize(nbarrel, BaseCrystal());
      |                                               ^
In member function '__ct ',
    inlined from '_Construct' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:119:7,
    inlined from '__do_uninit_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:267:21,
    inlined from '__uninit_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:284:34,
    inlined from 'uninitialized_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:327:17,
    inlined from '__uninitialized_fill_n_a' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:467:39,
    inlined from '_M_fill_insert' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:586:34,
    inlined from 'resize' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1032:18,
    inlined from 'buildCrystalArray' at src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:393:25:
  src/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h:19:7: warning: 'MEM[(const struct BaseCrystal &)&D.11030].subdetn_' may be used uninitialized [-Wmaybe-uninitialized]
    19 | class BaseCrystal {
      |       ^
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc: In member function 'buildCrystalArray':
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:393:47: note: '<anonymous>' declared here
  393 |   barrelCrystals_.resize(nbarrel, BaseCrystal());
      |                                               ^
In member function '__ct ',
    inlined from 'construct_at' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:97:14,
    inlined from 'construct' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/alloc_traits.h:518:21,
    inlined from '__ct ' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1830:30,
    inlined from '_M_fill_insert' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:534:25,
    inlined from 'resize' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1032:18,
    inlined from 'buildCrystalArray' at src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:415:25:
  src/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h:19:7: warning: 'MEM[(const struct BaseCrystal &)&D.11031].subdetn_' may be used uninitialized [-Wmaybe-uninitialized]
    19 | class BaseCrystal {
      |       ^
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc: In member function 'buildCrystalArray':
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:415:47: note: '<anonymous>' declared here
  415 |   endcapCrystals_.resize(nendcap, BaseCrystal());
      |                                               ^
In member function '__ct ',
    inlined from '_Construct' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:119:7,
    inlined from '__do_uninit_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:267:21,
    inlined from '__uninit_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:284:34,
    inlined from 'uninitialized_fill_n' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:327:17,
    inlined from '__uninitialized_fill_n_a' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_uninitialized.h:467:39,
    inlined from '_M_fill_insert' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:586:34,
    inlined from 'resize' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1032:18,
    inlined from 'buildCrystalArray' at src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:415:25:
  src/FastSimulation/CaloGeometryTools/interface/BaseCrystal.h:19:7: warning: 'MEM[(const struct BaseCrystal &)&D.11031].subdetn_' may be used uninitialized [-Wmaybe-uninitialized]
    19 | class BaseCrystal {
      |       ^
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc: In member function 'buildCrystalArray':
src/FastSimulation/CaloGeometryTools/src/CaloGeometryHelper.cc:415:47: note: '<anonymous>' declared here
  415 |   endcapCrystals_.resize(nendcap, BaseCrystal());
      |                                               ^
```

#### PR validation:

Bot tests