### PR TITLE
Fix deprecated bitwise operations between different enum types in WTableWidget

### DIFF
--- a/Fireworks/TableWidget/src/FWTableWidget.cc
+++ b/Fireworks/TableWidget/src/FWTableWidget.cc
@@ -26,8 +26,10 @@
 //
 // constants, enums and typedefs
 //
-static const UInt_t kRowOptions = kLHintsExpandX | kLHintsFillX | kLHintsShrinkX;
-static const UInt_t kColOptions = kLHintsExpandY | kLHintsFillY | kLHintsShrinkY;
+static const UInt_t kRowOptions =
+    static_cast<UInt_t>(kLHintsExpandX) | static_cast<UInt_t>(kLHintsFillX) | static_cast<UInt_t>(kLHintsShrinkX);
+static const UInt_t kColOptions =
+    static_cast<UInt_t>(kLHintsExpandY) | static_cast<UInt_t>(kLHintsFillY) | static_cast<UInt_t>(kLHintsShrinkY);
 
 //
 // static data member definitions


### PR DESCRIPTION
#### PR description:

Fixes the following warnings:

```
  src/Fireworks/TableWidget/src/FWTableWidget.cc:29:50: warning: bitwise operation between different enumeration types 'ELayoutHints' and 'ETableLayoutHints' is deprecated [-Wdeprecated-enum-enum-conversion]
    29 | static const UInt_t kRowOptions = kLHintsExpandX | kLHintsFillX | kLHintsShrinkX;
      |                                   ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
  src/Fireworks/TableWidget/src/FWTableWidget.cc:30:50: warning: bitwise operation between different enumeration types 'ELayoutHints' and 'ETableLayoutHints' is deprecated [-Wdeprecated-enum-enum-conversion]
    30 | static const UInt_t kColOptions = kLHintsExpandY | kLHintsFillY | kLHintsShrinkY;
      |                                   ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```

#### PR validation:

Bot tests