### PR TITLE
Fix deprecated enum arithmetics in CaloGeometry

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloGeometry.h
@@ -56,14 +56,8 @@ private:
 
   unsigned int makeIndex(DetId::Detector det, int subdet, bool& ok) const;
 
-  enum {
-    kMaxDet = 10,
-    kMinDet = 3,
-    kNDets = kMaxDet - kMinDet + 1,
-    kMaxSub = 6,
-    kNSubDets = kMaxSub + 1,
-    kLength = kNDets * kNSubDets
-  };
+  static constexpr int kMaxDet = 10, kMinDet = 3, kNDets = kMaxDet - kMinDet + 1, kMaxSub = 6, kNSubDets = kMaxSub + 1,
+                       kLength = kNDets * kNSubDets;
 };
 
 #endif

--- a/Geometry/CaloGeometry/src/CaloGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloGeometry.cc
@@ -16,7 +16,7 @@ unsigned int CaloGeometry::makeIndex(DetId::Detector det, int subdet, bool& ok) 
     edm::LogWarning("CaloGeometry") << "Det:Subdet " << idet << ":" << subdet << " min|max Det " << kMinDet << ":"
                                     << kMaxDet << " min|max subdet 0:" << kMaxSub;
 
-  return ((det - static_cast<int>(kMinDet)) * kNSubDets + subdet);
+  return ((det - kMinDet) * kNSubDets + subdet);
 }
 
 void CaloGeometry::setSubdetGeometry(DetId::Detector det, int subdet, const CaloSubdetectorGeometry* geom) {

--- a/Geometry/CaloGeometry/src/CaloGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloGeometry.cc
@@ -16,7 +16,7 @@ unsigned int CaloGeometry::makeIndex(DetId::Detector det, int subdet, bool& ok) 
     edm::LogWarning("CaloGeometry") << "Det:Subdet " << idet << ":" << subdet << " min|max Det " << kMinDet << ":"
                                     << kMaxDet << " min|max subdet 0:" << kMaxSub;
 
-  return ((det - kMinDet) * kNSubDets + subdet);
+  return ((det - static_cast<int>(kMinDet)) * kNSubDets + subdet);
 }
 
 void CaloGeometry::setSubdetGeometry(DetId::Detector det, int subdet, const CaloSubdetectorGeometry* geom) {


### PR DESCRIPTION
#### PR description:

Fix the following compilation warning:

```
  src/Geometry/CaloGeometry/src/CaloGeometry.cc:19:16: warning: arithmetic between different enumeration types 'DetId::Detector' and 'CaloGeometry::<unnamed enum>' is deprecated [-Wdeprecated-enum-enum-conversion]
    19 |   return ((det - kMinDet) * kNSubDets + subdet);
      |            ~~~~^~~~~~~~~
```

#### PR validation:

Bot tests