### PR TITLE
Backport of PR #44992 for sexaquark simulation code.

### DIFF
--- a/SimG4Core/CustomPhysics/data/particles_sexaq_1p5_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_1p5_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     1.5                  # sexaq
+ -1020000020     1.5                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_1p7_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_1p7_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     1.7                  # sexaq
+ -1020000020     1.7                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_1p85_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_1p85_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     1.85                  # sexaq
+ -1020000020     1.85                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_1p8_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_1p8_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     1.8                  # sexaq
+ -1020000020     1.8                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_1p9_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_1p9_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     1.9                  # sexaq
+ -1020000020     1.9                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_2_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_2_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     2.0                  # sexaq
+ -1020000020     2.0                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/data/particles_sexaq_2p1_GeV.txt
+++ b/SimG4Core/CustomPhysics/data/particles_sexaq_2p1_GeV.txt
@@ -1,0 +1,5 @@
+Block MASS   #
+#  PDG code    mass                 particle
+ 1020000020     2.1                  # sexaq
+ -1020000020     2.1                  # anti_sexaq
+Block

--- a/SimG4Core/CustomPhysics/interface/CMSAntiSQ.h
+++ b/SimG4Core/CustomPhysics/interface/CMSAntiSQ.h
@@ -1,0 +1,23 @@
+#ifndef CMSAntiSQ_h
+#define CMSAntiSQ_h 1
+
+#include "globals.hh"
+#include "G4ios.hh"
+#include "G4ParticleDefinition.hh"
+
+// ######################################################################
+// ###                      ANTI-SEXAQUARK                            ###
+// ######################################################################
+
+class CMSAntiSQ : public G4ParticleDefinition {
+private:
+  static CMSAntiSQ* theInstance;
+  CMSAntiSQ() {}
+  ~CMSAntiSQ() {}
+
+public:
+  static CMSAntiSQ* Definition(double mass);
+  static CMSAntiSQ* AntiSQ(double mass);
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSSQ.h
+++ b/SimG4Core/CustomPhysics/interface/CMSSQ.h
@@ -1,0 +1,24 @@
+
+#ifndef CMSSQ_h
+#define CMSSQ_h 1
+
+#include "globals.hh"
+#include "G4ios.hh"
+#include "G4ParticleDefinition.hh"
+
+// ######################################################################
+// ###                         SEXAQUARK                              ###
+// ######################################################################
+
+class CMSSQ : public G4ParticleDefinition {
+private:
+  static CMSSQ* theInstance;
+  CMSSQ() {}
+  ~CMSSQ() {}
+
+public:
+  static CMSSQ* Definition(double mass);
+  static CMSSQ* SQ(double mass);
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSSQInelasticCrossSection.h
+++ b/SimG4Core/CustomPhysics/interface/CMSSQInelasticCrossSection.h
@@ -1,0 +1,30 @@
+
+#ifndef CMSSQInelasticCrossSection_h
+#define CMSSQInelasticCrossSection_h
+
+#include "globals.hh"
+#include "G4VCrossSectionDataSet.hh"
+
+class G4NistManager;
+class CMSSQ;
+class CMSAntiSQ;
+
+class CMSSQInelasticCrossSection : public G4VCrossSectionDataSet {
+public:
+  CMSSQInelasticCrossSection(double mass);
+
+  ~CMSSQInelasticCrossSection();
+
+  virtual G4bool IsElementApplicable(const G4DynamicParticle* aPart, G4int Z, const G4Material*);
+
+  virtual G4double GetElementCrossSection(const G4DynamicParticle*, G4int Z, const G4Material*);
+
+  G4double GetSQCrossSection(G4double kineticEnergy, G4int Z);
+
+private:
+  G4NistManager* nist;
+  CMSSQ* theSQ;
+  CMSAntiSQ* theAntiSQ;
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSSQLoopProcess.h
+++ b/SimG4Core/CustomPhysics/interface/CMSSQLoopProcess.h
@@ -1,0 +1,43 @@
+#ifndef CMSSQLoopProcess_h
+#define CMSSQLoopProcess_h 1
+
+#include "G4VContinuousProcess.hh"
+#include "globals.hh"
+#include "G4Track.hh"
+#include "G4ParticleChange.hh"
+
+class G4Step;
+class G4ParticleDefinition;
+
+class CMSSQLoopProcess : public G4VContinuousProcess {
+public:
+  CMSSQLoopProcess(const G4String& name = "SQLooper", G4ProcessType type = fUserDefined);
+  virtual ~CMSSQLoopProcess();
+
+public:
+  virtual G4VParticleChange* AlongStepDoIt(const G4Track&, const G4Step&);
+  virtual G4double AlongStepGetPhysicalInteractionLength(const G4Track& track,
+                                                         G4double previousStepSize,
+                                                         G4double currentMinimumStep,
+                                                         G4double& proposedSafety,
+                                                         G4GPILSelection* selection);
+  virtual void StartTracking(G4Track* aTrack);
+
+protected:
+  virtual G4double GetContinuousStepLimit(const G4Track& track,
+                                          G4double previousStepSize,
+                                          G4double currentMinimumStep,
+                                          G4double& currentSafety);
+
+private:
+  CMSSQLoopProcess(CMSSQLoopProcess&);
+  CMSSQLoopProcess& operator=(const CMSSQLoopProcess& right);
+
+protected:
+  G4ParticleChange* fParticleChange;
+
+private:
+  G4ThreeVector posini;
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSSQLoopProcessDiscr.h
+++ b/SimG4Core/CustomPhysics/interface/CMSSQLoopProcessDiscr.h
@@ -1,0 +1,42 @@
+#ifndef CMSSQLoopProcessDiscr_h
+#define CMSSQLoopProcessDiscr_h 1
+
+#include "G4VDiscreteProcess.hh"
+#include "globals.hh"
+#include "G4Track.hh"
+#include "G4ParticleChange.hh"
+#include "G4ParticleChangeForTransport.hh"
+#include "CMSSQ.h"
+#include "CMSAntiSQ.h"
+
+class G4Step;
+class G4ParticleDefinition;
+
+class CMSSQLoopProcessDiscr : public G4VDiscreteProcess {
+public:
+  CMSSQLoopProcessDiscr(double mass, const G4String& name = "SQLooper", G4ProcessType type = fUserDefined);
+  virtual ~CMSSQLoopProcessDiscr();
+
+public:
+  virtual G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&);
+  virtual G4double PostStepGetPhysicalInteractionLength(const G4Track& track,
+                                                        G4double previousStepSize,
+                                                        G4ForceCondition* condition);
+  virtual G4double GetMeanFreePath(const G4Track&, G4double, G4ForceCondition*);
+  void SetTimeLimit(G4double);
+  virtual void StartTracking(G4Track* aTrack);
+
+private:
+  CMSSQLoopProcessDiscr(CMSSQLoopProcessDiscr&);
+  CMSSQLoopProcessDiscr& operator=(const CMSSQLoopProcessDiscr& right);
+
+protected:
+  G4ParticleChange* fParticleChange;
+  double GenMass;
+
+private:
+  G4ThreeVector posini;
+  G4double globaltimeini;
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/interface/CMSSQNeutronAnnih.h
+++ b/SimG4Core/CustomPhysics/interface/CMSSQNeutronAnnih.h
@@ -1,0 +1,30 @@
+
+#ifndef CMSSQNeutronAnnih_h
+#define CMSSQNeutronAnnih_h 1
+
+#include "globals.hh"
+#include "G4HadronicInteraction.hh"
+#include "G4HadProjectile.hh"
+#include "G4Nucleus.hh"
+#include "G4IonTable.hh"
+
+class G4ParticleDefinition;
+
+class CMSSQNeutronAnnih : public G4HadronicInteraction {
+public:
+  CMSSQNeutronAnnih(double mass);
+
+  ~CMSSQNeutronAnnih() override;
+
+  G4double momDistr(G4double x_in);
+
+  G4HadFinalState* ApplyYourself(const G4HadProjectile& aTrack, G4Nucleus& targetNucleus) override;
+
+private:
+  G4ParticleDefinition* theSQ;
+  G4ParticleDefinition* theK0S;
+  G4ParticleDefinition* theAntiL;
+  G4ParticleDefinition* theProton;
+};
+
+#endif

--- a/SimG4Core/CustomPhysics/src/CMSAntiSQ.cc
+++ b/SimG4Core/CustomPhysics/src/CMSAntiSQ.cc
@@ -1,0 +1,43 @@
+
+#include "SimG4Core/CustomPhysics/interface/CMSAntiSQ.h"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ParticleTable.hh"
+
+#include "G4PhaseSpaceDecayChannel.hh"
+#include "G4DecayTable.hh"
+
+// ######################################################################
+// ###                       ANTI-SEXAQUARK                           ###
+// ######################################################################
+
+CMSAntiSQ* CMSAntiSQ::theInstance = 0;
+
+CMSAntiSQ* CMSAntiSQ::Definition(double mass) {
+  if (theInstance != 0)
+    return theInstance;
+  const G4String name = "anti_sexaq";
+  // search in particle table]
+  G4ParticleTable* pTable = G4ParticleTable::GetParticleTable();
+  G4ParticleDefinition* anInstance = pTable->FindParticle(name);
+  if (anInstance == 0) {
+    // create particle
+    //
+    //    Arguments for constructor are as follows
+    //               name             mass          width         charge
+    //             2*spin           parity  C-conjugation
+    //          2*Isospin       2*Isospin3       G-parity
+    //               type    lepton number  baryon number   PDG encoding
+    //             stable         lifetime    decay table
+    //             shortlived      subType    anti_encoding
+
+    anInstance = new G4ParticleDefinition(
+        name, mass, 0, 0.0, 0, +1, 0, 0, 0, 0, "baryon", 0, -2, -1020000020, true, -1.0, nullptr, false, "sexaq");
+  }
+  theInstance = reinterpret_cast<CMSAntiSQ*>(anInstance);
+  return theInstance;
+}
+
+CMSAntiSQ* CMSAntiSQ::AntiSQ(double mass) {
+  return Definition(mass * GeV);  // will use correct mass if instance exists
+}

--- a/SimG4Core/CustomPhysics/src/CMSSQ.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQ.cc
@@ -1,0 +1,43 @@
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQ.h"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ParticleTable.hh"
+
+#include "G4PhaseSpaceDecayChannel.hh"
+#include "G4DecayTable.hh"
+
+// ######################################################################
+// ###                          SEXAQUARK                             ###
+// ######################################################################
+
+CMSSQ* CMSSQ::theInstance = 0;
+
+CMSSQ* CMSSQ::Definition(double mass) {
+  if (theInstance != 0)
+    return theInstance;
+  const G4String name = "sexaq";
+  // search in particle table]
+  G4ParticleTable* pTable = G4ParticleTable::GetParticleTable();
+  G4ParticleDefinition* anInstance = pTable->FindParticle(name);
+  if (anInstance == 0) {
+    // create particle
+    //
+    //    Arguments for constructor are as follows
+    //               name             mass          width         charge
+    //             2*spin           parity  C-conjugation
+    //          2*Isospin       2*Isospin3       G-parity
+    //               type    lepton number  baryon number   PDG encoding
+    //             stable         lifetime    decay table
+    //             shortlived      subType    anti_encoding
+
+    anInstance = new G4ParticleDefinition(
+        name, mass, 0, 0.0, 0, +1, 0, 0, 0, 0, "baryon", 0, +2, 1020000020, true, -1.0, nullptr, false, "sexaq");
+  }
+  theInstance = reinterpret_cast<CMSSQ*>(anInstance);
+  return theInstance;
+}
+
+CMSSQ* CMSSQ::SQ(double mass) {
+  return Definition(mass * GeV);  // will use correct mass if instance exists
+}

--- a/SimG4Core/CustomPhysics/src/CMSSQInelasticCrossSection.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQInelasticCrossSection.cc
@@ -1,0 +1,42 @@
+
+#include "G4SystemOfUnits.hh"
+#include "G4DynamicParticle.hh"
+#include "G4NistManager.hh"
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQ.h"
+#include "SimG4Core/CustomPhysics/interface/CMSAntiSQ.h"
+#include "SimG4Core/CustomPhysics/interface/CMSSQInelasticCrossSection.h"
+
+CMSSQInelasticCrossSection::CMSSQInelasticCrossSection(double mass) : G4VCrossSectionDataSet("SQ-neutron") {
+  nist = G4NistManager::Instance();
+  theSQ = CMSSQ::SQ(mass);
+  theAntiSQ = CMSAntiSQ::AntiSQ(mass);
+}
+
+CMSSQInelasticCrossSection::~CMSSQInelasticCrossSection() {}
+
+G4bool CMSSQInelasticCrossSection::IsElementApplicable(const G4DynamicParticle* aPart, G4int Z, const G4Material*) {
+  return true;
+}
+
+G4double CMSSQInelasticCrossSection::GetElementCrossSection(const G4DynamicParticle* aPart,
+                                                            G4int Z,
+                                                            const G4Material*) {
+  // return zero for particle instead of antiparticle
+  // sexaquark interaction with matter expected really tiny
+  if (aPart->GetDefinition() != theAntiSQ)
+    return 0;
+
+  //I don't want to interact on hydrogen
+  if (Z <= 1) {
+    return 0.0;
+  }
+
+  // get the atomic weight (to estimate nr neutrons)
+  G4double A = nist->GetAtomicMassAmu(Z);
+
+  // put the X section low for the antiS to get a flat interaction rate,
+  // but also make it scale with the number of neutrons in the material
+  // because we are going to interact on neutrons, not on protons
+  return (100. * (A - (G4double)Z) / (G4double)Z) * millibarn;
+}

--- a/SimG4Core/CustomPhysics/src/CMSSQLoopProcess.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQLoopProcess.cc
@@ -1,0 +1,49 @@
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQLoopProcess.h"
+#include "G4SystemOfUnits.hh"
+#include "G4Step.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4VParticleChange.hh"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+CMSSQLoopProcess::CMSSQLoopProcess(const G4String& name, G4ProcessType type) : G4VContinuousProcess(name, type) {
+  fParticleChange = new G4ParticleChange();
+}
+
+CMSSQLoopProcess::~CMSSQLoopProcess() { delete fParticleChange; }
+
+G4VParticleChange* CMSSQLoopProcess::AlongStepDoIt(const G4Track& track, const G4Step& step) {
+  if (track.GetPosition() == posini)
+    edm::LogInfo("CMSSQLoopProcess::AlongStepDoIt")
+        << "CMSSQLoopProcess::AlongStepDoIt: CMSSQLoopProcess::AlongStepDoIt  MomentumDirection "
+        << track.GetMomentumDirection().eta() << " track GetPostion  " << track.GetPosition() / cm << " trackId "
+        << track.GetTrackID() << " parentId: " << track.GetParentID() << " GlobalTime " << track.GetGlobalTime() / ns
+        << " TotalEnergy: " << track.GetTotalEnergy() / GeV << " Velocity " << track.GetVelocity() / m / ns
+        << std::endl;
+
+  fParticleChange->Clear();
+  fParticleChange->Initialize(track);
+  fParticleChange->ProposeWeight(track.GetWeight());
+  //Sbar not passing the following criteria are not of interest. They will not be reconstructable. A cut like this is required otherwise you will get Sbar infinitely looping.
+  if (fabs(track.GetMomentumDirection().eta()) > 999. || fabs(track.GetPosition().z()) > 160 * centimeter) {
+    edm::LogInfo("CMSSQLoopProcess::AlongStepDoIt") << "Particle getting killed because too large z" << std::endl;
+    fParticleChange->ProposeTrackStatus(fStopAndKill);
+  }
+
+  return fParticleChange;
+}
+
+G4double CMSSQLoopProcess::AlongStepGetPhysicalInteractionLength(const G4Track& track,
+                                                                 G4double previousStepSize,
+                                                                 G4double currentMinimumStep,
+                                                                 G4double& proposedSafety,
+                                                                 G4GPILSelection* selection) {
+  return 1. * centimeter;
+}
+
+G4double CMSSQLoopProcess::GetContinuousStepLimit(const G4Track& track, G4double, G4double, G4double&) {
+  return 1. * centimeter;  // seems irrelevant
+}
+
+void CMSSQLoopProcess::StartTracking(G4Track* aTrack) { posini = aTrack->GetPosition(); }

--- a/SimG4Core/CustomPhysics/src/CMSSQLoopProcessDiscr.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQLoopProcessDiscr.cc
@@ -1,0 +1,70 @@
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQLoopProcessDiscr.h"
+#include "G4SystemOfUnits.hh"
+#include "G4Step.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4VParticleChange.hh"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+CMSSQLoopProcessDiscr::CMSSQLoopProcessDiscr(double mass, const G4String& name, G4ProcessType type)
+    : G4VDiscreteProcess(name, type) {
+  fParticleChange = new G4ParticleChange();
+  fParticleChange->ClearDebugFlag();
+  GenMass = mass;
+}
+
+CMSSQLoopProcessDiscr::~CMSSQLoopProcessDiscr() { delete fParticleChange; }
+
+G4VParticleChange* CMSSQLoopProcessDiscr::PostStepDoIt(const G4Track& track, const G4Step& step) {
+  G4Track* mytr = const_cast<G4Track*>(&track);
+  mytr->SetPosition(posini);
+  if (mytr->GetGlobalTime() / ns > 4990)
+    edm::LogWarning("CMSSQLoopProcess::AlongStepDoIt")
+        << "going to loose the particle because the GlobalTime is getting close to 5000" << std::endl;
+
+  fParticleChange->Clear();
+  fParticleChange->Initialize(track);
+
+  //adding secondary antiS
+  fParticleChange->SetNumberOfSecondaries(1);
+  G4DynamicParticle* replacementParticle =
+      new G4DynamicParticle(CMSAntiSQ::AntiSQ(GenMass), track.GetMomentumDirection(), track.GetKineticEnergy());
+  fParticleChange->AddSecondary(replacementParticle, globaltimeini);
+
+  //killing original AntiS
+  fParticleChange->ProposeTrackStatus(fStopAndKill);
+
+  // note SL: this way of working makes a very long history of the track,
+  // which all get saved recursively in SimTracks. If the cross section
+  // is too low such that 10's of thousands of iterations are needed, then
+  // this becomes too heavy to swallow writing out this history.
+  // So if we ever need very small cross sections, then we really need
+  // to change this way of working such that we can throw away all original
+  // tracks and only save the one that interacted.
+
+  return fParticleChange;
+}
+
+G4double CMSSQLoopProcessDiscr::PostStepGetPhysicalInteractionLength(const G4Track& track,
+                                                                     G4double previousStepSize,
+                                                                     G4ForceCondition* condition) {
+  *condition = NotForced;
+  G4double intLength =
+      DBL_MAX;  //by default the interaction length is super large, only when outside tracker make it 0 to be sure it will do the reset to the original position
+  G4Track* mytr = const_cast<G4Track*>(&track);
+  if (sqrt(pow(mytr->GetPosition().rho(), 2)) >
+      2.45 *
+          centimeter) {  //this is an important cut for the looping: if the radius of the particle is largher than 2.45cm its interaction length becomes 0 which means it will get killed
+    // updated from 2.5 to 2.45 so that the Sbar does not start to hit the support of the new inner tracker which was added in 2018
+    intLength = 0.0;  //0 interaction length means particle will directly interact.
+  }
+  return intLength;
+}
+
+G4double CMSSQLoopProcessDiscr::GetMeanFreePath(const G4Track&, G4double, G4ForceCondition*) { return DBL_MAX; }
+
+void CMSSQLoopProcessDiscr::StartTracking(G4Track* aTrack) {
+  posini = aTrack->GetPosition();
+  globaltimeini = aTrack->GetGlobalTime();
+}

--- a/SimG4Core/CustomPhysics/src/CMSSQNeutronAnnih.cc
+++ b/SimG4Core/CustomPhysics/src/CMSSQNeutronAnnih.cc
@@ -1,0 +1,218 @@
+
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ParticleTable.hh"
+#include "G4ParticleDefinition.hh"
+#include "Randomize.hh"
+#include "G4NucleiProperties.hh"
+#include <math.h>
+#include "TMath.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQNeutronAnnih.h"
+#include "SimG4Core/CustomPhysics/interface/CMSSQ.h"
+
+CMSSQNeutronAnnih::CMSSQNeutronAnnih(double mass) : G4HadronicInteraction("SexaQuark-neutron annihilation") {
+  SetMinEnergy(0.0 * GeV);
+  SetMaxEnergy(100. * TeV);
+
+  theSQ = CMSSQ::SQ(mass);
+  theK0S = G4KaonZeroShort::KaonZeroShort();
+  theAntiL = G4AntiLambda::AntiLambda();
+  theProton = G4Proton::
+      Proton();  //proton only used when the particle which the sexaquark hits is a deutereon and the neutron dissapears, so what stays behind is a proton
+}
+
+CMSSQNeutronAnnih::~CMSSQNeutronAnnih() {}
+
+//9Be momentum distribution from Jan Ryckebusch
+G4double CMSSQNeutronAnnih::momDistr(G4double x_in) {
+  const int n_entries = 50;
+
+  G4double CDF_k[n_entries] = {0,   0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1,   1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
+                               1.7, 1.8, 1.9, 2,   2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3,   3.1, 3.2, 3.3,
+                               3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.,  4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9};
+
+  G4double x[n_entries] = {0,
+                           0.0038033182,
+                           0.0187291764,
+                           0.0510409777,
+                           0.1048223609,
+                           0.1807862863,
+                           0.2756514534,
+                           0.3825832103,
+                           0.4926859745,
+                           0.5970673837,
+                           0.6887542272,
+                           0.7637748784,
+                           0.8212490273,
+                           0.8627259608,
+                           0.8911605331,
+                           0.9099115186,
+                           0.9220525854,
+                           0.9300190818,
+                           0.9355376091,
+                           0.9397242185,
+                           0.9432387722,
+                           0.946438928,
+                           0.9495023924,
+                           0.9525032995,
+                           0.9554669848,
+                           0.9583936672,
+                           0.9612770117,
+                           0.9641067202,
+                           0.9668727859,
+                           0.9695676121,
+                           0.9721815799,
+                           0.9747092981,
+                           0.9771426396,
+                           0.9794740235,
+                           0.9816956807,
+                           0.9838003583,
+                           0.9857816165,
+                           0.9876331761,
+                           0.9893513365,
+                           0.9909333198,
+                           0.992378513,
+                           0.9936885054,
+                           0.9948665964,
+                           0.9959179448,
+                           0.9968491104,
+                           0.9976680755,
+                           0.9983832508,
+                           0.9990041784,
+                           0.9995400073,
+                           1};
+
+  //now interpolate the above points for x_in
+  G4double result = 9999;
+  for (int i = 0; i < n_entries; i++) {
+    if (x[i] > x_in) {
+      result = (CDF_k[i] - CDF_k[i - 1]) / (x[i] - x[i - 1]) * (x_in - x[i - 1]) + CDF_k[i - 1];
+      break;
+    }
+  }
+  //ROOT::Math::Interpolator inter(n_entries, ROOT::Math::Interpolation::kAKIMA);
+  //inter.SetData(n_entries,x,CDF_k);
+  //result = inter.Eval(x_in);
+
+  return result;
+  //return 1;
+}
+
+G4HadFinalState* CMSSQNeutronAnnih::ApplyYourself(const G4HadProjectile& aTrack, G4Nucleus& targetNucleus) {
+  theParticleChange.Clear();
+  const G4HadProjectile* aParticle = &aTrack;
+  G4double ekin = aParticle->GetKineticEnergy();
+
+  G4int A = targetNucleus.GetA_asInt();
+  G4int Z = targetNucleus.GetZ_asInt();
+
+  G4double m_K0S = G4KaonZeroShort::KaonZeroShort()->GetPDGMass();
+  G4double m_L = G4AntiLambda::AntiLambda()->GetPDGMass();
+
+  //G4double plab = aParticle->GetTotalMomentum();
+
+  //    edm::LogVerbatim("CMSSWNeutronAnnih") << "CMSSQNeutronAnnih: Incident particle p (GeV), total Energy (GeV), particle name, eta ="
+  //       << plab/GeV << "  "
+  //       << aParticle->GetTotalEnergy()/GeV << "  "
+  //       << aParticle->GetDefinition()->GetParticleName() << " "
+  //	   << aParticle->Get4Momentum();
+
+  // Scattered particle referred to axis of incident particle
+  //const G4ParticleDefinition* theParticle = aParticle->GetDefinition();
+
+  //G4int projPDG = theParticle->GetPDGEncoding();
+  //    edm::LogVerbatim("CMSSWNeutronAnnih") << "CMSSQNeutronAnnih: for " << theParticle->GetParticleName()
+  //           << " PDGcode= " << projPDG << " on nucleus Z= " << Z
+  //           << " A= " << A << " N= " << N;
+
+  G4LorentzVector lv1 = aParticle->Get4Momentum();
+  edm::LogVerbatim("CMSSWNeutronAnnih") << "The neutron Fermi momentum (mag, x, y, z) "
+                                        << targetNucleus.GetFermiMomentum().mag() / MeV << " "
+                                        << targetNucleus.GetFermiMomentum().x() / MeV << " "
+                                        << targetNucleus.GetFermiMomentum().y() / MeV << " "
+                                        << targetNucleus.GetFermiMomentum().z() / MeV;
+
+  //calculate fermi momentum
+
+  G4double k_neutron = momDistr(G4UniformRand());
+  G4double momentum_neutron = 0.1973 * GeV * k_neutron;
+
+  G4double theta_neutron = TMath::ACos(2 * G4UniformRand() - 1);
+  G4double phi_neutron = 2. * TMath::Pi() * G4UniformRand();
+
+  G4double p_neutron_x = momentum_neutron * TMath::Sin(theta_neutron) * TMath::Cos(phi_neutron);
+  G4double p_neutron_y = momentum_neutron * TMath::Sin(theta_neutron) * TMath::Sin(phi_neutron);
+  G4double p_neutron_z = momentum_neutron * TMath::Cos(theta_neutron);
+
+  //G4LorentzVector lv0(targetNucleus.GetFermiMomentum(), sqrt( pow(G4Neutron::Neutron()->GetPDGMass(),2) + targetNucleus.GetFermiMomentum().mag2()  ) );
+  G4LorentzVector lv0(p_neutron_x,
+                      p_neutron_y,
+                      p_neutron_z,
+                      sqrt(pow(G4Neutron::Neutron()->GetPDGMass(), 2) + momentum_neutron * momentum_neutron));
+
+  //const G4Nucleus* aNucleus = &targetNucleus;
+  G4double BENeutronInNucleus = 0;
+  if (A != 0)
+    BENeutronInNucleus = G4NucleiProperties::GetBindingEnergy(A, Z) / (A);
+
+  edm::LogVerbatim("CMSSWNeutronAnnih") << "BE of nucleon in the nucleus (GeV): " << BENeutronInNucleus / GeV;
+
+  G4LorentzVector lvBE(0, 0, 0, BENeutronInNucleus / GeV);
+  G4LorentzVector lv = lv0 + lv1 - lvBE;
+
+  // kinematiacally impossible ?
+  G4double etot = lv0.e() + lv1.e() - lvBE.e();
+  if (etot < theK0S->GetPDGMass() + theAntiL->GetPDGMass()) {
+    theParticleChange.SetEnergyChange(ekin);
+    theParticleChange.SetMomentumChange(aTrack.Get4Momentum().vect().unit());
+    return &theParticleChange;
+  }
+
+  float newIonMass = targetNucleus.AtomicMass(A - 1, Z) * 931.5 * MeV;
+  ;
+  G4LorentzVector nlvIon(0, 0, 0, newIonMass);
+
+  G4double theta_KS0_star = TMath::ACos(2 * G4UniformRand() - 1);
+  G4double phi_KS0_star = 2. * TMath::Pi() * G4UniformRand();
+
+  G4double p_K0S_star_x = TMath::Sin(theta_KS0_star) * TMath::Cos(phi_KS0_star);
+  G4double p_K0S_star_y = TMath::Sin(theta_KS0_star) * TMath::Sin(phi_KS0_star);
+  G4double p_K0S_star_z = TMath::Cos(theta_KS0_star);
+
+  G4ThreeVector p(p_K0S_star_x, p_K0S_star_y, p_K0S_star_z);
+  double m0 = lv.m();
+  double m0_2 = m0 * m0;
+  double m1_2 = m_K0S * m_K0S;
+  double m2_2 = m_L * m_L;
+
+  p *= 0.5 / m0 * sqrt(m0_2 * m0_2 + m1_2 * m1_2 + m2_2 * m2_2 - 2 * m0_2 * m1_2 - 2 * m0_2 * m2_2 - 2 * m1_2 * m2_2);
+  double p2 = p.mag2();
+
+  G4LorentzVector nlvK0S(p, sqrt(p2 + m1_2));
+  G4LorentzVector nlvAntiL(-p, sqrt(p2 + m2_2));
+
+  // Boost out of the rest frame.
+  nlvK0S.boost(lv.boostVector());
+  nlvAntiL.boost(lv.boostVector());
+
+  // now move to implement the interaction
+  theParticleChange.SetStatusChange(stopAndKill);
+  //theParticleChange.SetEnergyChange(ekin); // was 0.0
+
+  G4DynamicParticle* aSec1 = new G4DynamicParticle(theK0S, nlvK0S);
+  theParticleChange.AddSecondary(aSec1);
+  G4DynamicParticle* aSec2 = new G4DynamicParticle(theAntiL, nlvAntiL);
+  theParticleChange.AddSecondary(aSec2);
+
+  const G4ParticleDefinition* theRemainingNucleusDef = theProton;
+  if (A != 1)
+    theRemainingNucleusDef = G4IonTable::GetIonTable()->GetIon(Z, A - 1);
+  G4DynamicParticle* aSec3 = new G4DynamicParticle(theRemainingNucleusDef, nlvIon);
+  theParticleChange.AddSecondary(aSec3);
+
+  // return as is; we don't care about what happens to the nucleus
+  return &theParticleChange;
+}

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -12,9 +12,16 @@
 #include "G4hMultipleScattering.hh"
 #include "G4hIonisation.hh"
 #include "G4ProcessManager.hh"
+#include "G4HadronicProcess.hh"
 
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.h"
 #include "SimG4Core/CustomPhysics/interface/CMSDarkPairProductionProcess.h"
+
+#include "SimG4Core/CustomPhysics/interface/CMSSQLoopProcess.h"
+#include "SimG4Core/CustomPhysics/interface/CMSSQLoopProcessDiscr.h"
+#include "SimG4Core/CustomPhysics/interface/CMSSQNeutronAnnih.h"
+#include "SimG4Core/CustomPhysics/interface/CMSSQInelasticCrossSection.h"
+
 
 using namespace CLHEP;
 
@@ -83,6 +90,22 @@ void CustomPhysicsList::ConstructProcess() {
         if (particle->GetParticleType() == "darkpho") {
           CMSDarkPairProductionProcess* darkGamma = new CMSDarkPairProductionProcess(dfactor);
           pmanager->AddDiscreteProcess(darkGamma);
+        }
+        if (particle->GetParticleName() == "anti_sexaq") {
+          // here the different sexaquark interactions get defined
+          G4HadronicProcess* sqInelPr = new G4HadronicProcess();
+          CMSSQNeutronAnnih* sqModel = new CMSSQNeutronAnnih(particle->GetPDGMass() / GeV);
+          sqInelPr->RegisterMe(sqModel);
+          CMSSQInelasticCrossSection* sqInelXS = new CMSSQInelasticCrossSection(particle->GetPDGMass() / GeV);
+          sqInelPr->AddDataSet(sqInelXS);
+          pmanager->AddDiscreteProcess(sqInelPr);
+          // add also the looping needed to simulate flat interaction probability
+          CMSSQLoopProcess* sqLoopPr = new CMSSQLoopProcess();
+          pmanager->AddContinuousProcess(sqLoopPr);
+          CMSSQLoopProcessDiscr* sqLoopPrDiscr = new CMSSQLoopProcessDiscr(particle->GetPDGMass() / GeV);
+          pmanager->AddDiscreteProcess(sqLoopPrDiscr);
+        } else if (particle->GetParticleName() == "sexaq") {
+          edm::LogVerbatim("CustomPhysics") << "   No pmanager implemented for sexaq, only for anti_sexaq";
         }
       }
     }

--- a/SimG4Core/CustomPhysics/test/Sexaquark_RunIIFall18GenSim_cfg.py
+++ b/SimG4Core/CustomPhysics/test/Sexaquark_RunIIFall18GenSim_cfg.py
@@ -1,0 +1,148 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: Configuration/GenProduction/python/BPH-RunIIFall18GS-00369-fragment.py --python_filename BPH-RunIIFall18GS-00369_1_cfg.py --eventcontent RAWSIM --datatier GEN-SIM --fileout file:BPH-RunIIFall18GS-00369.root --conditions 102X_upgrade2018_realistic_v11 --beamspot Realistic25ns13TeVEarly2018Collision --step GEN,SIM --geometry DB:Extended --era Run2_2018 --no_exec --mc -n 1000
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+process = cms.Process('SIM',eras.Run2_2018)
+options = VarParsing ('analysis')
+options.outputFile = 'file:sexaq_sim.root'
+#options.inputFiles = 'root://cmsxrootd.hep.wisc.edu//store/user/wvetens/crmc_Sexaq/crmc/Sexaquark_13TeV_trial_4_1p8GeV/0/crmc_Sexaq_1.root'
+options.inputFiles = 'file:crmc_Sexaq_1.root'
+options.maxEvents= 100
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+#process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.GeometrySimDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+# Vtx Smearing done in hepmc 2 gen step
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13TeVEarly2018Collision_cfi')
+#process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('RecoVertex.BeamSpotProducer.BeamSpot_cfi')
+
+# Lengthy message logs - uncomment to debug
+process.MessageLogger = cms.Service("MessageLogger",
+  destinations = cms.untracked.vstring('cout'),
+  cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('INFO')
+  )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+    #input = cms.untracked.int32(-1)
+)
+
+# Input source
+
+#process.source = cms.Source("EmptySource")
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(options.inputFiles),
+    skipEvents = cms.untracked.uint32(0),
+    duplicateCheckMode = cms.untracked.string ("noDuplicateCheck")
+)
+
+
+process.options = cms.untracked.PSet(
+  wantSummary = cms.untracked.bool(True)
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string(options.outputFile),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+process.RAWSIMoutput.outputCommands += ("keep *_genParticlesPlusGEANT_*_*",)
+
+# Other statements
+#process.XMLFromDBSource.label = cms.string("Extended")
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '102X_upgrade2018_realistic_v11', '')
+
+
+
+process.genParticlesPlusGEANT = cms.EDProducer("GenPlusSimParticleProducer",
+  src           = cms.InputTag("g4SimHits"),
+  setStatus     = cms.int32(8),                 # set status = 8 for GEANT GPs
+  particleTypes = cms.vstring(),
+  filter = cms.vstring(),
+  genParticles  = cms.InputTag("genParticles") # original genParticle list
+)
+
+from SimG4Core.CustomPhysics.CustomPhysics_cfi import customPhysicsSetup
+process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
+process.g4SimHits.Physics.RHadronDummyFlip = cms.bool(False)
+process.g4SimHits.Physics.Verbosity = 1
+process.g4SimHits.Physics = cms.PSet(
+  process.g4SimHits.Physics, #keep all default value and add others
+  customPhysicsSetup
+  )
+process.g4SimHits.Physics.particlesDef = cms.FileInPath('SimG4Core/CustomPhysics/data/particles_sexaq_1p8_GeV.txt')
+
+
+## Vtx Smearing done in hepmc 2 gen step
+process.VtxSmeared.src = cms.InputTag("source", "generator")
+process.genParticles.src = cms.InputTag("generatorSmeared")
+process.g4SimHits.HepMCProductLabel = cms.InputTag("generatorSmeared")
+process.g4SimHits.Generator.HepMCProductLabel = cms.InputTag("generatorSmeared")
+
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+#moved beamspot and vtx smearing to hepmc2gen step
+#process.simulation_step = cms.Path(process.offlineBeamSpot*process.generatorSmeared*process.psim*process.genParticlesPlusGEANT)
+process.simulation_step = cms.Path(process.psim*process.genParticlesPlusGEANT)
+#process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+#process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step)
+process.schedule = cms.Schedule(process.generation_step,process.simulation_step,process.endjob_step,process.RAWSIMoutput_step)
+
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+## filter all path with the production filter sequence
+#for path in process.paths:
+#	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+
+from Configuration.DataProcessing.Utils import addMonitoring
+process = addMonitoring(process)
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+
+# End adding early deletion
+# For debug:
+#print process.dumpPython()


### PR DESCRIPTION
Backport of pull request https://github.com/cms-sw/cmssw/pull/44992
for the integration of the sexaquark simulation code to CMSSW_10_6_X.

Backport needed to run sexaquark simulation under 2018 UL B-parking conditions to validate private simulation from the 10_6 cycle. Such validation was requested by EXO MC&I conveners @tvami @DickyChant

+CC @vetens
