### PR TITLE
Skip evaluation of TensorFlow model if inputs are empty

### DIFF
--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -106,6 +106,8 @@ namespace tensorflow {
   // version of the function above that accepts a const session
   bool closeSession(const Session*& session);
 
+  bool checkEmptyInputs(const NamedTensorList& inputs);
+
   // run the session with inputs and outputNames, store output tensors, and control the underlying
   // thread pool using threadPoolOptions
   // used for thread scheduling with custom thread pool options

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -256,6 +256,19 @@ namespace tensorflow {
     return state;
   }
 
+  bool checkEmptyInputs(const NamedTensorList& inputs) {
+    // check for empty tensors in the inputs
+    bool isEmpty = false;
+    for (const auto& input : inputs) {
+      // Checking using the shape
+      if (input.second.shape().num_elements() == 0) {
+        isEmpty = true;
+        break;
+      }
+    }
+    return isEmpty;
+  }
+
   void run(Session* session,
            const NamedTensorList& inputs,
            const std::vector<std::string>& outputNames,
@@ -267,6 +280,10 @@ namespace tensorflow {
 
     // create empty run options
     RunOptions runOptions;
+
+    // Check if the inputs are empty
+    if (checkEmptyInputs(inputs))
+      return;
 
     // run and check the status
     Status status = session->Run(runOptions, inputs, outputNames, {}, outputs, nullptr, threadPoolOptions);

--- a/PhysicsTools/TensorFlow/test/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/test/BuildFile.xml
@@ -144,6 +144,13 @@
   <use name="PhysicsTools/TensorFlow"/>
 </bin>
 
+<bin name="testTFEmptyInputs" file="testRunner.cpp,testEmptyInputs.cc">
+  <use name="boost_filesystem"/>
+  <use name="cppunit"/>
+  <use name="PhysicsTools/TensorFlow"/>
+</bin>
+
+
 
 <iftool name="cuda">
   <bin name="testTFVisibleDevicesCUDA" file="testRunner.cpp,testVisibleDevicesCUDA.cc">

--- a/PhysicsTools/TensorFlow/test/testEmptyInputs.cc
+++ b/PhysicsTools/TensorFlow/test/testEmptyInputs.cc
@@ -1,0 +1,57 @@
+/*
+ * Tests for working with empty inputs
+ *
+ */
+
+#include <stdexcept>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+
+#include "testBase.h"
+
+class testEmptyInputs : public testBase {
+  CPPUNIT_TEST_SUITE(testEmptyInputs);
+  CPPUNIT_TEST(test);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  std::string pyScript() const override;
+  void test() override;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testEmptyInputs);
+
+std::string testEmptyInputs::pyScript() const { return "createconstantgraph.py"; }
+
+void testEmptyInputs::test() {
+  std::string pbFile = dataPath_ + "/constantgraph.pb";
+
+  std::cout << "Testing CPU backend" << std::endl;
+  tensorflow::Backend backend = tensorflow::Backend::cpu;
+
+  // load the graph
+  tensorflow::Options options{backend};
+  tensorflow::GraphDef* graphDef = tensorflow::loadGraphDef(pbFile);
+  CPPUNIT_ASSERT(graphDef != nullptr);
+
+  // create a new session and add the graphDef
+  const tensorflow::Session* session = tensorflow::createSession(graphDef, options);
+  CPPUNIT_ASSERT(session != nullptr);
+
+  // example evaluation with empty tensor
+  tensorflow::Tensor input(tensorflow::DT_FLOAT, {1, 0});
+  tensorflow::Tensor scale(tensorflow::DT_FLOAT, {});
+  scale.scalar<float>()() = 1.0;
+  std::vector<tensorflow::Tensor> outputs;
+
+  // run using the convenience helper
+  outputs.clear();
+  tensorflow::run(session, {{"input", input}, {"scale", scale}}, {"output"}, &outputs);
+  CPPUNIT_ASSERT(outputs.size() == 0);
+
+  // cleanup
+  CPPUNIT_ASSERT(tensorflow::closeSession(session));
+  CPPUNIT_ASSERT(session == nullptr);
+  delete graphDef;
+}


### PR DESCRIPTION
#### PR description:

Solves: https://github.com/cms-sw/cmssw/issues/44481

Evaluating TensorFlow models with empty tensors is problematic. We observed different behavior on different architectures. It  crashes on machines with AVX512 registers available, whereas it works fine and returns empty tensors. 
In some cases incompatible shapes for operators are reported by the TF engine.

Related issues: https://github.com/cms-sw/cmssw/issues/45136, https://github.com/cms-sw/cmssw/issues/44333

This PR introduces a simple check for empty inputs in the central TensorFlow interface to avoid evaluation of the model for empty tensors. 

#### PR validation:
A new test has been added calling the TF inference with empty tensors.