### PR TITLE
Add Run 3 HLT timing for CI tests

### DIFF
--- a/HLTrigger/Configuration/timing/measure_Timing_HLT_GRun.sh
+++ b/HLTrigger/Configuration/timing/measure_Timing_HLT_GRun.sh
@@ -1,0 +1,43 @@
+#! /bin/bash -e
+
+SOURCE=/data/store/data/Run2024E/EphemeralHLTPhysics/FED/run381065_cff.py
+
+# check for the source configuration
+if ! [ -f $SOURCE ]; then
+  echo "The necessary input data cannot be found, the test will be skipped"
+  exit 0
+fi
+
+# link the source configuration locally
+ln -sf $SOURCE source_cff.py
+
+# check for the HLT configuration
+if ! [ -f Timing_HLT_GRun.py ]; then
+  echo "Cannot find the HLT configuration, the test will be skipped"
+  exit 1
+fi
+
+# check out the timing scripts, if needed
+if ! [ -d "patatrack-scripts" ]; then
+  git clone https://github.com/cms-patatrack/patatrack-scripts.git
+  if ! [ -x "patatrack-scripts/benchmark" ]; then
+    echo "Cannot find the timing scripts, the test will be skipped"
+    exit 0
+  fi
+  echo
+fi
+
+# start a local instance of the NVIDIA MPS server
+CUDA_MPS_PATH=$(mktemp -d)
+mkdir -p $CUDA_MPS_PATH/{control,log}
+export CUDA_MPS_PIPE_DIRECTORY=$CUDA_MPS_PATH/control
+export CUDA_MPS_LOG_DIRECTORY=$CUDA_MPS_PATH/log
+nvidia-cuda-mps-control -d
+
+# benchmark the HLT execution time
+patatrack-scripts/benchmark -r 4 -e 20300 -j 8 -t 32 -s 24 -g 1 --numa-affinity --no-cpu-affinity -l logs -k resources.json -- Timing_HLT_GRun.py
+mergeResourcesJson.py logs/step*/pid*/resources.json > resources.json
+
+# stop the local instance of the NVIDIA MPS server
+echo quit | nvidia-cuda-mps-control
+rm -rf $CUDA_MPS_PATH

--- a/HLTrigger/Configuration/timing/update_Timing_HLT_GRun.sh
+++ b/HLTrigger/Configuration/timing/update_Timing_HLT_GRun.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+CONFIG=/dev/CMSSW_14_0_0/GRun/V124
+
+# extract the configuration from the database
+hltConfigFromDB --configName $CONFIG > Timing_HLT_GRun.py
+
+# customise the configuration for the timing measurements
+cat >> Timing_HLT_GRun.py << @EOF
+# run over recent data
+process.load('source_cff')
+
+# use the date global tag
+process.GlobalTag.globaltag = '140X_dataRun3_HLT_v3'
+
+# update the HLT menu for re-running offline using a recent release
+from HLTrigger.Configuration.customizeHLTforCMSSW import customizeHLTforCMSSW
+process = customizeHLTforCMSSW(process)
+
+# run with 32 threads, 24 concurrent events, 2 concurrent lumisections, over 20k events
+process.options.numberOfThreads = 32
+process.options.numberOfStreams = 24
+process.options.numberOfConcurrentLuminosityBlocks = 2
+process.maxEvents.input = 20300
+
+# force the '2e34' prescale column
+process.PrescaleService.lvl1DefaultLabel = '2p0E34'
+process.PrescaleService.forceDefault = True
+
+# do not run the HLTAnalyzerEndpath
+if 'HLTAnalyzerEndpath' in process.endpaths:
+  del process.HLTAnalyzerEndpath
+
+# do not print a final summary
+process.options.wantSummary = False
+process.MessageLogger.cerr.enableStatistics = cms.untracked.bool(False)
+
+# write a JSON file with the timing information
+process.FastTimerService.writeJSONSummary = True
+@EOF


### PR DESCRIPTION
#### PR description:

`update_Timing_HLT_GRun.sh` dumps the HLT menu in a format close to what is used online, and applied minimal changes for running offline over recent data.

`Timing_HLT_GRun.py` is the HLT menu extracted and customised.

`measure_Timing_HLT_GRun.sh` sets up and run the HLT throughput measurements in a way that is close to how the HLT is run online.
Note that currently this script will only work on the CI node used by Jenkins.

#### PR validation:

Tested in CMSSW_14_0_7_patch2_MULTIARCHS:
```
Cloning into 'patatrack-scripts'...
remote: Enumerating objects: 325, done.
remote: Counting objects: 100% (62/62), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 325 (delta 58), reused 56 (delta 55), pack-reused 263
Receiving objects: 100% (325/325), 127.35 KiB | 5.31 MiB/s, done.
Resolving deltas: 100% (207/207), done.
2 CPUs:
  0: AMD EPYC 7763 64-Core Processor (64 cores, 128 threads)
  1: AMD EPYC 7763 64-Core Processor (64 cores, 128 threads)

2 visible NVIDIA GPUs:
  0: Tesla T4
  1: Tesla T4

Benchmarking only I/O
Warming up

Running 4 times over 20300 events with 8 jobs, each with 32 threads, 24 streams and 1 GPUs
 15373.6 ±  11.5 ev/s (20000 events, 95.0% overlap)
 15445.9 ±   8.6 ev/s (20000 events, 95.3% overlap)
 15463.4 ±   9.9 ev/s (20000 events, 87.1% overlap)
 15574.9 ±   9.5 ev/s (20000 events, 91.6% overlap)
 --------------------
 15464.8 ± 102.0 ev/s (based on 3 measurements)


Benchmarking Timing_HLT_GRun.py
Warming up
     
Running 4 times over 20300 events with 8 jobs, each with 32 threads, 24 streams and 1 GPUs
   285.5 ±   0.0 ev/s (20000 events, 99.4% overlap)
   284.9 ±   0.0 ev/s (20000 events, 99.0% overlap)
...
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to CMSSW_14_0_X.