### PR TITLE
[14.0.X] `L2TauTagNNProducerAlpaka`: do not call TF inference with empty grid

### DIFF
--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducerAlpaka.cc
@@ -731,15 +731,19 @@ void L2TauNNProducerAlpaka::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
 }
 
 std::vector<float> L2TauNNProducerAlpaka::getTauScore(const tensorflow::Tensor& cellGridMatrix) {
-  std::vector<tensorflow::Tensor> pred_tensor;
-  tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
   const int nTau = cellGridMatrix.shape().dim_size(0);
-  std::vector<float> pred_vector(nTau);
-  for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {
-    pred_vector[tau_idx] = pred_tensor[0].matrix<float>()(tau_idx, 0);
-  }
+  if (nTau == 0) {
+    return std::vector<float>();
+  } else {
+    std::vector<tensorflow::Tensor> pred_tensor;
+    tensorflow::run(L2cacheData_->session, {{inputTensorName_, cellGridMatrix}}, {outputTensorName_}, &pred_tensor);
+    std::vector<float> pred_vector(nTau);
+    for (int tau_idx = 0; tau_idx < nTau; ++tau_idx) {
+      pred_vector[tau_idx] = pred_tensor[0].matrix<float>()(tau_idx, 0);
+    }
 
-  return pred_vector;
+    return pred_vector;
+  }
 }
 
 void L2TauNNProducerAlpaka::produce(edm::Event& event, const edm::EventSetup& eventsetup) {


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45147

#### PR description:

Fix for https://github.com/cms-sw/cmssw/issues/45136.
Implemented in the same style as https://github.com/cms-sw/cmssw/pull/44456 (originally from @valsdav).
When this input is passed to a TF model executed on a CPU without `AVX512F AVX512_VNNI`, the model is executed and returns an empty output without complaining. When `AVX512F AVX512_VNNI` instructions are present, the TF executor complains.

#### PR validation:

Run the HLT over all the error stream files from run-381543 and run-381544 following https://github.com/cms-sw/cmssw/issues/45136#issuecomment-2150786504.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/45147 to  CMSSW_14_0_X for data-taking purposes