### PR TITLE
Fix thread local use in AllocMonitor

### DIFF
--- a/PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h
+++ b/PerfTools/AllocMonitor/interface/AllocMonitorRegistry.h
@@ -65,8 +65,8 @@ namespace cms::perftools {
     friend void* ::operator new[](std::size_t size);
     friend void* ::operator new(std::size_t count, std::align_val_t al);
     friend void* ::operator new[](std::size_t count, std::align_val_t al);
-    friend void* ::operator new(std::size_t count, const std::nothrow_t& tag) noexcept;
-    friend void* ::operator new[](std::size_t count, const std::nothrow_t& tag) noexcept;
+    friend void* ::operator new(std::size_t count, const std::nothrow_t & tag) noexcept;
+    friend void* ::operator new[](std::size_t count, const std::nothrow_t & tag) noexcept;
     friend void* ::operator new(std::size_t count, std::align_val_t al, const std::nothrow_t&) noexcept;
     friend void* ::operator new[](std::size_t count, std::align_val_t al, const std::nothrow_t&) noexcept;
 
@@ -78,22 +78,27 @@ namespace cms::perftools {
     friend void ::operator delete[](void* ptr, std::size_t sz) noexcept;
     friend void ::operator delete(void* ptr, std::size_t sz, std::align_val_t al) noexcept;
     friend void ::operator delete[](void* ptr, std::size_t sz, std::align_val_t al) noexcept;
-    friend void ::operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
-    friend void ::operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
-    friend void ::operator delete(void* ptr, std::align_val_t al, const std::nothrow_t& tag) noexcept;
-    friend void ::operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t& tag) noexcept;
+    friend void ::operator delete(void* ptr, const std::nothrow_t & tag) noexcept;
+    friend void ::operator delete[](void* ptr, const std::nothrow_t & tag) noexcept;
+    friend void ::operator delete(void* ptr, std::align_val_t al, const std::nothrow_t & tag) noexcept;
+    friend void ::operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t & tag) noexcept;
 
     friend class AllocTester;
 
     // ---------- member data --------------------------------
     void start();
-    bool& isRunning();
+    bool stopReporting();
+    void startReporting();
 
     struct Guard {
-      explicit Guard(bool& iOriginal) noexcept : address_(&iOriginal), original_(iOriginal) { *address_ = false; }
-      ~Guard() { *address_ = original_; }
+      explicit Guard(AllocMonitorRegistry& iReg) noexcept : reg_(iReg), original_(iReg.stopReporting()) {}
+      ~Guard() {
+        if (original_) {
+          reg_.startReporting();
+        }
+      }
 
-      bool running() const noexcept { return original_; }
+      bool shouldReport() const noexcept { return original_; }
 
       Guard(Guard const&) = delete;
       Guard(Guard&&) = delete;
@@ -101,11 +106,11 @@ namespace cms::perftools {
       Guard& operator=(Guard&&) = delete;
 
     private:
-      bool* address_;
+      AllocMonitorRegistry& reg_;
       bool original_;
     };
 
-    Guard makeGuard() { return Guard(isRunning()); }
+    Guard makeGuard() { return Guard(*this); }
 
     void allocCalled_(size_t, size_t);
     void deallocCalled_(size_t);
@@ -114,7 +119,7 @@ namespace cms::perftools {
     auto allocCalled(size_t iRequested, ALLOC iAlloc, ACT iGetActual) {
       [[maybe_unused]] Guard g = makeGuard();
       auto a = iAlloc();
-      if (g.running()) {
+      if (g.shouldReport()) {
         allocCalled_(iRequested, iGetActual(a));
       }
       return a;
@@ -122,7 +127,7 @@ namespace cms::perftools {
     template <typename DEALLOC, typename ACT>
     void deallocCalled(void* iPtr, DEALLOC iDealloc, ACT iGetActual) {
       [[maybe_unused]] Guard g = makeGuard();
-      if (g.running() and iPtr != nullptr) {
+      if (g.shouldReport() and iPtr != nullptr) {
         deallocCalled_(iGetActual(iPtr));
       }
       iDealloc(iPtr);

--- a/PerfTools/AllocMonitor/src/AllocMonitorRegistry.cc
+++ b/PerfTools/AllocMonitor/src/AllocMonitorRegistry.cc
@@ -24,12 +24,47 @@
 extern "C" {
 void alloc_monitor_start();
 void alloc_monitor_stop();
+bool alloc_monitor_stop_thread_reporting();
+void alloc_monitor_start_thread_reporting();
 }
 
 namespace {
-  bool& threadRunning() {
+  bool& dummyThreadReportingFcn() {
     static thread_local bool s_running = true;
     return s_running;
+  }
+
+  bool dummyStopThreadReportingFcn() {
+    auto& t = dummyThreadReportingFcn();
+    auto last = t;
+    t = false;
+    return last;
+  }
+
+  void dummyStartThreadReportingFcn() { dummyThreadReportingFcn() = true; }
+
+  bool stopThreadReporting() {
+    static decltype(&::alloc_monitor_stop_thread_reporting) s_fcn = []() {
+      void* fcn = dlsym(RTLD_DEFAULT, "alloc_monitor_stop_thread_reporting");
+      if (fcn != nullptr) {
+        return reinterpret_cast<decltype(&::alloc_monitor_stop_thread_reporting)>(fcn);
+      }
+      //this should only be called for testing;
+      return &::dummyStopThreadReportingFcn;
+    }();
+    return s_fcn();
+  }
+
+  void startThreadReporting() {
+    static decltype(&::alloc_monitor_start_thread_reporting) s_fcn = []() {
+      void* fcn = dlsym(RTLD_DEFAULT, "alloc_monitor_start_thread_reporting");
+      if (fcn != nullptr) {
+        return reinterpret_cast<decltype(&::alloc_monitor_start_thread_reporting)>(fcn);
+      }
+      //this should only be called for testing;
+      return &::dummyStartThreadReportingFcn;
+    }();
+    s_fcn();
   }
 }  // namespace
 
@@ -43,10 +78,10 @@ using namespace cms::perftools;
 // constructors and destructor
 //
 AllocMonitorRegistry::AllocMonitorRegistry() {
-  threadRunning() = true;
   //Cannot start here because statics can cause memory to be allocated in the atexit registration
   // done behind the scenes. If the allocation happens, AllocMonitorRegistry::instance will be called
   // recursively before the static has finished and we well deadlock
+  startReporting();
 }
 
 AllocMonitorRegistry::~AllocMonitorRegistry() {
@@ -55,7 +90,7 @@ AllocMonitorRegistry::~AllocMonitorRegistry() {
     auto s = reinterpret_cast<decltype(&::alloc_monitor_stop)>(stop);
     s();
   }
-  threadRunning() = false;
+  stopReporting();
   monitors_.clear();
 }
 
@@ -78,7 +113,8 @@ void AllocMonitorRegistry::start() {
   }
 }
 
-bool& AllocMonitorRegistry::isRunning() { return threadRunning(); }
+bool AllocMonitorRegistry::stopReporting() { return stopThreadReporting(); }
+void AllocMonitorRegistry::startReporting() { startThreadReporting(); }
 
 void AllocMonitorRegistry::deregisterMonitor(AllocMonitorBase* iMonitor) {
   for (auto it = monitors_.begin(); monitors_.end() != it; ++it) {


### PR DESCRIPTION

#### PR description:

OS change in alma 8 now trigger calls to memory allocation during usage of a thread_local during dynamic loads. This update removes the use of thread_local and uses a hash based pre-set container to keep track of which threads have calls into the alloc routines.

#### PR validation:

Cod compilers and related unit test pass. Ran the MaxMemoryPreload tool using the first step of RelVal 8.0 which was failing without this change and runs file with this change.