### PR TITLE
Fix maybe-uninitialized warning in SeedingTrackFeatures

### DIFF
--- a/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc
+++ b/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc
@@ -213,7 +213,7 @@ namespace btagbtvdeep {
     if (sortedSeedsMap.size() < 10) {
       for (unsigned int i = sortedSeedsMap.size(); i < 10; i++) {
         std::vector<btagbtvdeep::TrackPairFeatures> tp_features_zeropad(20);
-        btagbtvdeep::SeedingTrackFeatures seed_features_zeropad;
+        btagbtvdeep::SeedingTrackFeatures seed_features_zeropad{};
         seed_features_zeropad.nearTracks = tp_features_zeropad;
         seedingT_features_vector.push_back(seed_features_zeropad);
       }


### PR DESCRIPTION
#### PR description:

(proper version of #45135)

Fixes the following warnings:

```
src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc: In function 'seedingTracksToFeatures':
  src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].pt' may be used uninitialized [-Wmaybe-uninitialized]
   216 |         btagbtvdeep::SeedingTrackFeatures seed_features_zeropad;
      |                                           ^
  src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].eta' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].phi' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].mass' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].dz' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].dxy' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].ip3D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].sip3D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].ip2D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].sip2D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].signedIp3D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].signedSip3D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].signedIp2D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].signedSip2D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].trackProbability3D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].trackProbability2D' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].chi2reduced' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].nPixelHits' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].nHits' may be used uninitialized [-Wmaybe-uninitialized]
   src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].jetAxisDistance' may be used uninitialized [-Wmaybe-uninitialized]
 In member function '__ct ',
    inlined from 'construct_at' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_construct.h:97:14,
    inlined from 'construct' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/alloc_traits.h:518:21,
    inlined from 'push_back' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_vector.h:1281:30,
    inlined from 'seedingTracksToFeatures' at src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:218:43:
  src/DataFormats/BTauReco/interface/SeedingTrackFeatures.h:9:9: warning: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].jetAxisDlength' may be used uninitialized [-Wmaybe-uninitialized]
     9 |   class SeedingTrackFeatures {
      |         ^
src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc: In function 'seedingTracksToFeatures':
src/RecoBTag/FeatureTools/src/SeedingTracksConverter.cc:216:43: note: 'MEM[(const struct SeedingTrackFeatures &)&seed_features_zeropad].jetAxisDlength' was declared here
  216 |         btagbtvdeep::SeedingTrackFeatures seed_features_zeropad;
      |                                           ^
```

#### PR validation:

Bot tests