### PR TITLE
ECAL - Roll back to ECAL ratio timing for Run 3

### DIFF
--- a/Configuration/ProcessModifiers/python/ecal_cctiming_cff.py
+++ b/Configuration/ProcessModifiers/python/ecal_cctiming_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for the ECAL Cross-Correlation timing algorithm
+
+ecal_cctiming =  cms.Modifier()
+

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -5,8 +5,8 @@ ecalMultiFitUncalibRecHit = _mod.ecalMultiFitUncalibRecHitProducer.clone()
 
 # use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
-run3_ecal.toModify(ecalMultiFitUncalibRecHit,
+from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
+ecal_cctiming.toModify(ecalMultiFitUncalibRecHit,
     algoPSet = dict(timealgo = 'crossCorrelationMethod',
         EBtimeNconst = 25.5,
         EBtimeConstantTerm = 0.85,
@@ -19,7 +19,7 @@ run3_ecal.toModify(ecalMultiFitUncalibRecHit,
     )
 )
 
-# this overrides the modifications made by run3_ecal if both modifiers are active
+# this overrides the modifications made by the ecal_cctiming modifier if both modifiers are active
 from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 gpuValidationEcal.toModify(ecalMultiFitUncalibRecHit,
     algoPSet = dict(timealgo = 'RatioMethod',

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -100,13 +100,13 @@ fastSim.toModify(ecalRecHit,
                 )
 
 # use CC timing method for Run3 and Phase 2 (carried over from Run3 era)
-from Configuration.Eras.Modifier_run3_ecal_cff import run3_ecal
-run3_ecal.toModify(ecalRecHit,
+from Configuration.ProcessModifiers.ecal_cctiming_cff import ecal_cctiming
+ecal_cctiming.toModify(ecalRecHit,
     timeCalibTag = ':CC',
     timeOffsetTag = ':CC'
 )
 
-# this overrides the modifications made by run3_ecal if both modifiers are active
+# this overrides the modifications made by ecal_cctiming if both modifiers are active
 from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 gpuValidationEcal.toModify(ecalRecHit,
     timeCalibTag = ':',


### PR DESCRIPTION
#### PR description:

Due to issues observed with the ECAL ratio timing at high pT [1] we are rolling back to the ratio timing algorithm.
To achieve this the `run3_ecal` modifier which used to activate the CC timing algorithm in Run 3 was replaced with a new modifier`ecal_cctiming` that explicitly activates the algorithm. The new modifier is not used in the `run 3` era though and so the default ratio timing algorithm is used in Run 3 reconstruction.

The change can run out of the box with the current prompt and express GTs but for better handling a new prompt tag with the calibrations and a new express tag with the offsets for ratio timing will be prepared to replace the HLT tags in the GTs.

[1] https://indico.cern.ch/event/1424192/contributions/5990405/attachments/2872238/5028943/ecal_cctiming_ppd_20240606.pdf

#### PR validation:

No syntax errors in python configuration. Code compiles.
