### PR TITLE
[Core] Remove unused lambda captures in test_catch2_WaitingThreadPool.cc and StreamSchedule.h

### DIFF
--- a/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
@@ -126,7 +126,7 @@ TEST_CASE("Test WaitingThreadPool", "[edm::WaitingThreadPool") {
         auto h = first([&pool, &count](edm::WaitingTaskHolder h) {
                    edm::WaitingTaskWithArenaHolder h2(std::move(h));
                    pool.runAsync(
-                       std::move(h2), [&count]() { throw std::runtime_error("error"); }, errorContext);
+                       std::move(h2), []() { throw std::runtime_error("error"); }, errorContext);
                  }) |
                  lastTask(edm::WaitingTaskHolder(group, &waitTask));
         h.doneWaiting(std::exception_ptr());

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -368,7 +368,7 @@ namespace edm {
 
     auto id = principal.id();
     ServiceWeakToken weakToken = token;
-    auto doneTask = make_waiting_task([this, iHolder = std::move(iHolder), id, cleaningUpAfterException, weakToken](
+    auto doneTask = make_waiting_task([this, iHolder = std::move(iHolder), cleaningUpAfterException, weakToken](
                                           std::exception_ptr const* iPtr) mutable {
       std::exception_ptr excpt;
       if (iPtr) {


### PR DESCRIPTION
#### PR description:

Fixes the following warnings:

```
  src/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc:129:41: warning: lambda capture 'count' is not used [-Wunused-lambda-capture]
   129 |                        std::move(h2), [&count]() { throw std::runtime_error("error"); }, errorContext);
      |                                        ~^~~~~
1 warning generated.
```

```
  src/FWCore/Framework/interface/StreamSchedule.h:371:76: warning: lambda capture 'id' is not used [-Wunused-lambda-capture]
   371 |     auto doneTask = make_waiting_task([this, iHolder = std::move(iHolder), id, cleaningUpAfterException, weakToken](
      |                                                                            ^
```

#### PR validation:

Bot tests