### PR TITLE
Miscellaneous fixes for TRK POG Data/MC validation tool

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -1836,17 +1836,18 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
             theMainVtx = *theClosestVertex;
           }
           if (theMainVtx.isValid()) {
-            const math::XYZPoint theMainVtxPos(
-                theMainVtx.position().x(), theMainVtx.position().y(), theMainVtx.position().z());
-            const math::XYZPoint myVertex(
-                mumuTransientVtx.position().x(), mumuTransientVtx.position().y(), mumuTransientVtx.position().z());
-            const math::XYZPoint deltaVtx(
-                theMainVtxPos.x() - myVertex.x(), theMainVtxPos.y() - myVertex.y(), theMainVtxPos.z() - myVertex.z());
-            double cosphi3D =
-                (Zp.Px() * deltaVtx.x() + Zp.Py() * deltaVtx.y() + Zp.Pz() * deltaVtx.z()) /
-                (sqrt(Zp.Px() * Zp.Px() + Zp.Py() * Zp.Py() + Zp.Pz() * Zp.Pz()) *
-                 sqrt(deltaVtx.x() * deltaVtx.x() + deltaVtx.y() * deltaVtx.y() + deltaVtx.z() * deltaVtx.z()));
-            cosPhi3DdileptonH_->Fill(cosphi3D, wfac);
+            const auto& mainVertexPos = theMainVtx.position();
+            const auto& myVertexPos = mumuTransientVtx.position();
+
+            const double deltaX = myVertexPos.x() - mainVertexPos.x();
+            const double deltaY = myVertexPos.y() - mainVertexPos.y();
+            const double deltaZ = myVertexPos.z() - mainVertexPos.z();
+
+            const double deltaNorm = sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
+            const double zpNorm = sqrt(Zp.Px() * Zp.Px() + Zp.Py() * Zp.Py() + Zp.Pz() * Zp.Pz());
+
+            const double cosPhi3D = (Zp.Px() * deltaX + Zp.Py() * deltaY + Zp.Pz() * deltaZ) / (zpNorm * deltaNorm);
+            cosPhi3DdileptonH_->Fill(cosPhi3D, wfac);
           }
         }
       }

--- a/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
@@ -24,6 +24,6 @@ standaloneTrackMonitor = standaloneTrackMonitorDefault.clone(
     verbose           = False,
     trackEtaH         = dict(Xbins = 60,  Xmin = -3.0, Xmax = 3.0),
     trackPtH          = dict(Xbins = 100, Xmin =  0.0 ,Xmax = 100.0),
-    trackPhiH         = dict(Xbins = 100, Xmin = 3.15, Xmax = 3.15),
+    trackPhiH         = dict(Xbins = 100, Xmin = -3.15, Xmax = 3.15),
     #trackMVAH        = dict(Xbins = 100 ,Xmin = -1.0, Xmax = 1.0)
 )

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -178,7 +178,7 @@ standaloneValidationK0sMC = cms.Sequence(
     * selectedPrimaryVertices
     * KShortEventSelector
     * KshortTracks
-    * standaloneTrackMonitorK0
+    * standaloneTrackMonitorK0MC
     * KshortMonitor)
 
 standaloneValidationLambdas = cms.Sequence(


### PR DESCRIPTION
#### PR description:

Few miscellaneous fixes for the TRK POG data/MC validation tool:
   * 6ca6c2605f222246f45ae425622a24c221a8dedf: fix MC KShort analysis sequence
   * 5e9ff21cc6ab88c52ef3d37bd3f8cf95c65035c1: fix sign of 3D pointing angle variable, make code slightly more readable 
   * e5a0fb2ecf740ec3635f13e1991930914640d5a1: fix axis limits for the `trackPhiH` ME to avoid using dynamic range which causes histogram merging issues

These were spotted by operating the data/MC validation tool on 2024 data.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_14_0_X for 2024 data-taking purposes.

Cc: @dbruschi 