### PR TITLE
[14.0.X] Miscellaneous fixes for TRK POG Data/MC validation tool

### DIFF
--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -1836,17 +1836,18 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
             theMainVtx = *theClosestVertex;
           }
           if (theMainVtx.isValid()) {
-            const math::XYZPoint theMainVtxPos(
-                theMainVtx.position().x(), theMainVtx.position().y(), theMainVtx.position().z());
-            const math::XYZPoint myVertex(
-                mumuTransientVtx.position().x(), mumuTransientVtx.position().y(), mumuTransientVtx.position().z());
-            const math::XYZPoint deltaVtx(
-                theMainVtxPos.x() - myVertex.x(), theMainVtxPos.y() - myVertex.y(), theMainVtxPos.z() - myVertex.z());
-            double cosphi3D =
-                (Zp.Px() * deltaVtx.x() + Zp.Py() * deltaVtx.y() + Zp.Pz() * deltaVtx.z()) /
-                (sqrt(Zp.Px() * Zp.Px() + Zp.Py() * Zp.Py() + Zp.Pz() * Zp.Pz()) *
-                 sqrt(deltaVtx.x() * deltaVtx.x() + deltaVtx.y() * deltaVtx.y() + deltaVtx.z() * deltaVtx.z()));
-            cosPhi3DdileptonH_->Fill(cosphi3D, wfac);
+            const auto& mainVertexPos = theMainVtx.position();
+            const auto& myVertexPos = mumuTransientVtx.position();
+
+            const double deltaX = myVertexPos.x() - mainVertexPos.x();
+            const double deltaY = myVertexPos.y() - mainVertexPos.y();
+            const double deltaZ = myVertexPos.z() - mainVertexPos.z();
+
+            const double deltaNorm = sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
+            const double zpNorm = sqrt(Zp.Px() * Zp.Px() + Zp.Py() * Zp.Py() + Zp.Pz() * Zp.Pz());
+
+            const double cosPhi3D = (Zp.Px() * deltaX + Zp.Py() * deltaY + Zp.Pz() * deltaZ) / (zpNorm * deltaNorm);
+            cosPhi3DdileptonH_->Fill(cosPhi3D, wfac);
           }
         }
       }

--- a/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/StandaloneTrackMonitor_cfi.py
@@ -24,6 +24,6 @@ standaloneTrackMonitor = standaloneTrackMonitorDefault.clone(
     verbose           = False,
     trackEtaH         = dict(Xbins = 60,  Xmin = -3.0, Xmax = 3.0),
     trackPtH          = dict(Xbins = 100, Xmin =  0.0 ,Xmax = 100.0),
-    trackPhiH         = dict(Xbins = 100, Xmin = 3.15, Xmax = 3.15),
+    trackPhiH         = dict(Xbins = 100, Xmin = -3.15, Xmax = 3.15),
     #trackMVAH        = dict(Xbins = 100 ,Xmin = -1.0, Xmax = 1.0)
 )

--- a/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingDataMCValidation_Standalone_cff.py
@@ -178,7 +178,7 @@ standaloneValidationK0sMC = cms.Sequence(
     * selectedPrimaryVertices
     * KShortEventSelector
     * KshortTracks
-    * standaloneTrackMonitorK0
+    * standaloneTrackMonitorK0MC
     * KshortMonitor)
 
 standaloneValidationLambdas = cms.Sequence(


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45173

#### PR description:

Few miscellaneous fixes for the TRK POG data/MC validation tool:
   *  a97f0120689fd86c2951142894c1c08b2a633671: fix MC KShort analysis sequence
   *  69a5846a1461b14c9259a2ddd21fa619964a5890: fix sign of 3D pointing angle variable, make code slightly more readable 
   * 0f4aa342c1961724ea18f727d5b20ae7b25478ea: fix axis limits for the `trackPhiH` ME to avoid using dynamic range which causes histogram merging issues

These were spotted by operating the data/MC validation tool on 2024 data.

#### PR validation:

`cmssw` compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/45173 for 2024 data-taking purposes.

Cc: @dbruschi 