### PR TITLE
Update default Phase-2 geometry to D110 and restructure relvals_2026

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -11,6 +11,7 @@ workflows = Matrix()
 from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgrade_workflows
 
 #just define all of them
+prefixDet = 29600 #update this line when change the default version
 
 #2026 WFs to run in IB (TTbar)
 numWFIB = []
@@ -23,15 +24,8 @@ numWFIB.extend([23234.0]) #2026D94
 numWFIB.extend([23634.0]) #2026D95
 numWFIB.extend([24034.0]) #2026D96
 numWFIB.extend([24434.0]) #2026D97
-numWFIB.extend([24834.0,24834.911,24834.103]) #2026D98 DDD XML, DD4hep XML, aging
-numWFIB.extend([25061.97]) #2026D98 premixing stage1 (NuGun+PU)
-numWFIB.extend([24834.702]) #2026D98 mkFit tracking (initialStep)
-numWFIB.extend([24834.5,24834.9]) #2026D98 pixelTrackingOnly, vector hits
-numWFIB.extend([24834.501,24834.502]) #2026D98 Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
-numWFIB.extend([25034.99,25034.999]) #2026D98 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
-numWFIB.extend([24834.21,25034.21,25034.9921]) #2026D98 prodlike, prodlike PU, prodlike premix stage1+stage2
-numWFIB.extend([25034.114]) #2026D98 PU, with 10% OT ineffiency 
-numWFIB.extend([25234.0,25234.911]) #2026D99 DDD XML, DD4hep XML
+numWFIB.extend([24834.0]) #2026D98
+numWFIB.extend([25234.0]) #2026D99
 numWFIB.extend([25634.0]) #2026D100
 numWFIB.extend([26034.0]) #2026D101
 numWFIB.extend([26434.0]) #2026D102
@@ -49,11 +43,24 @@ numWFIB.extend([30834.0]) #2026D113
 numWFIB.extend([31234.0]) #2026D114
 
 #Additional sample for short matrix and IB
-#CloseByPGun for HGCAL
-numWFIB.extend([24896.0]) #CE_E_Front_120um D98
-numWFIB.extend([24900.0]) #CE_H_Coarse_Scint D98
-# NuGun 
-numWFIB.extend([24861.0]) #Nu Gun 2026D98
+#Default Phase-2 Det NoPU
+numWFIB.extend([prefixDet+34.911]) #DD4hep XML
+numWFIB.extend([prefixDet+34.702]) #mkFit tracking (initialStep)
+numWFIB.extend([prefixDet+34.5])   #pixelTrackingOnly
+numWFIB.extend([prefixDet+34.9])   #vector hits
+numWFIB.extend([prefixDet+34.501]) #Patatrack local reconstruction on CPU
+numWFIB.extend([prefixDet+34.502]) #Patatrack local reconstruction on GPU
+numWFIB.extend([prefixDet+34.21])  #prodlike
+numWFIB.extend([prefixDet+96.0])   #CloseByPGun CE_E_Front_120um
+numWFIB.extend([prefixDet+100.0])  #CloseByPGun CE_H_Coarse_Scint
+numWFIB.extend([prefixDet+61.0])   #Nu Gun
+#Default Phase-2 Det PU
+numWFIB.extend([prefixDet+261.97])   #premixing stage1 (NuGun+PU)
+numWFIB.extend([prefixDet+234.99])   #premixing combined stage1+stage2 ttbar+PU200
+numWFIB.extend([prefixDet+234.999])  #premixing combined stage1+stage2 ttbar+PU50 for PR test
+numWFIB.extend([prefixDet+234.21])   #prodlike PU
+numWFIB.extend([prefixDet+234.9921]) #prodlike premix stage1+stage2
+numWFIB.extend([prefixDet+234.114])  #PU, with 10% OT inefficiency
 
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -90,11 +90,11 @@ if __name__ == '__main__':
                     2500.4,     # RelValTTbar_14TeV             NanoAOD from existing MINI
 
                     # Phase2
-                    24834.0,    # RelValTTbar_14TeV                     phase2_realistic_T25        Extended2026D98         (Phase-2 baseline)   
-                    24834.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T25        DD4hepExtended2026D98   DD4Hep (HLLHC14TeV BeamSpot) 
-                    25034.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T25        Extended2026D98         AVE_50_BX_25ns_m3p3     
-                    24896.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T25        Extended2026D98
-                    24900.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T25        Extended2026D98  
+                    29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T25        Extended2026D110         (Phase-2 baseline)   
+                    29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T25        DD4hepExtended2026D110   DD4Hep (HLLHC14TeV BeamSpot) 
+                    29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T25        Extended2026D110         AVE_50_BX_25ns_m3p3     
+                    29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T25        Extended2026D110
+                    29700.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T25        Extended2026D110  
                     23234.0,    # TTbar_14TeV_TuneCP5                   phase2_realistic_T21        Extended2026D94         (exercise with HFNose) 
                     
 

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -90,11 +90,11 @@ if __name__ == '__main__':
                     2500.4,     # RelValTTbar_14TeV             NanoAOD from existing MINI
 
                     # Phase2
-                    29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T25        Extended2026D110         (Phase-2 baseline)   
-                    29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T25        DD4hepExtended2026D110   DD4Hep (HLLHC14TeV BeamSpot) 
-                    29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T25        Extended2026D110         AVE_50_BX_25ns_m3p3     
-                    29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T25        Extended2026D110
-                    29700.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T25        Extended2026D110  
+                    29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline)   
+                    29634.911,  # TTbar_14TeV_TuneCP5                   phase2_realistic_T33        DD4hepExtended2026D110   DD4Hep (HLLHC14TeV BeamSpot) 
+                    29834.999,  # RelValTTbar_14TeV (PREMIX)            phase2_realistic_T33        Extended2026D110         AVE_50_BX_25ns_m3p3     
+                    29696.0,    # RelValCloseByPGun_CE_E_Front_120um    phase2_realistic_T33        Extended2026D110
+                    29700.0,    # RelValCloseByPGun_CE_H_Coarse_Scint   phase2_realistic_T33        Extended2026D110  
                     23234.0,    # TTbar_14TeV_TuneCP5                   phase2_realistic_T21        Extended2026D94         (exercise with HFNose) 
                     
 


### PR DESCRIPTION
#### PR description:
Update short and long matrix to D110. I use this chance to restructure relvals_2026, to make it more easy when update the base line.

#### PR validation:
Test PR config.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
No need o f backport. However, we may backport to 14_0 as we also move to D110 in 14_0.
