### PR TITLE
[JMENano] Backport of #45167 (Add customize functions to recompute Puppi weights and PuppiMET, add new autoNano option) to 14_0_X

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -186,8 +186,8 @@ steps['lepTrackInfoNANO_data13.0']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoA
                                           '-n' : '1000'},
                                          steps['NANO_data13.0']])
 
-steps['jmeNANO_rePuppi_data13.0']=merge([steps['jmeNANO_data13.0']])
-steps['jmeNANO_rePuppi_data13.0']['--customise'] += ',"PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET"'
+steps['jmeNANO_rePuppi_data13.0']= merge([{'-s':'NANO:@JMErePuppi', '-n' : '1000'},
+                                  steps['NANO_data13.0']])
 
 ###current release cycle workflows : 13.2
 steps['TTBarMINIAOD13.2'] = {'INPUT':InputInfo(location='STD',
@@ -214,8 +214,9 @@ steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAOD
                                         '-n' : '1000'},
                                        steps['NANO_mc13.2']])
 
-steps['jmeNANO_rePuppi_mc13.2']=merge([steps['jmeNANO_mc13.2']])
-steps['jmeNANO_rePuppi_mc13.2']['--customise'] += ',"PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET"'
+steps['jmeNANO_rePuppi_mc13.2']merge([{'-s' : 'NANO:@JMErePuppi ', '-n' : '1000'},
+                                     steps['NANO_mc13.2']])
+
 
 ##13.X INPUT
 steps['ScoutingPFRun32022DRAW13.X']={'INPUT':InputInfo(dataSet='/ScoutingPFRun3/Run2022D-v1/RAW',label='2022D',events=100000,location='STD', ls=Run2022D)}

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -214,7 +214,7 @@ steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAOD
                                         '-n' : '1000'},
                                        steps['NANO_mc13.2']])
 
-steps['jmeNANO_rePuppi_mc13.2']merge([{'-s' : 'NANO:@JMErePuppi ', '-n' : '1000'},
+steps['jmeNANO_rePuppi_mc13.2']=merge([{'-s' : 'NANO:@JMErePuppi ', '-n' : '1000'},
                                      steps['NANO_mc13.2']])
 
 

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -179,12 +179,15 @@ steps['BTVNANO_data13.0']=merge([{'-s' : 'NANO:@BTV',
                                     '-n' : '1000'},
                                     steps['NANO_data13.0']])
 
-steps['jmeNano_data13.0'] = merge([{'-s':'NANO:@JME', '-n' : '1000'},
+steps['jmeNANO_data13.0'] = merge([{'-s':'NANO:@JME', '-n' : '1000'},
                                   steps['NANO_data13.0']])
 
 steps['lepTrackInfoNANO_data13.0']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
                                           '-n' : '1000'},
                                          steps['NANO_data13.0']])
+
+steps['jmeNANO_rePuppi_data13.0']=merge([steps['jmeNANO_data13.0']])
+steps['jmeNANO_rePuppi_data13.0']['--customise'] += ',"PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET"'
 
 ###current release cycle workflows : 13.2
 steps['TTBarMINIAOD13.2'] = {'INPUT':InputInfo(location='STD',
@@ -210,6 +213,9 @@ steps['jmeNANO_mc13.2']=merge([{'-s' : 'NANO:@JME ', '-n' : '1000'},
 steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
                                         '-n' : '1000'},
                                        steps['NANO_mc13.2']])
+
+steps['jmeNANO_rePuppi_mc13.2']=merge([steps['jmeNANO_mc13.2']])
+steps['jmeNANO_rePuppi_mc13.2']['--customise'] += ',"PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET"'
 
 ##13.X INPUT
 steps['ScoutingPFRun32022DRAW13.X']={'INPUT':InputInfo(dataSet='/ScoutingPFRun3/Run2022D-v1/RAW',label='2022D',events=100000,location='STD', ls=Run2022D)}
@@ -263,9 +269,10 @@ workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGNANO
 workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGNANOBkg_data13.0']]
 workflows[_wfn()] = ['muPOGNANO130Xrun3', ['MuonEG2023MINIAOD13.0', 'muPOGNANO_data13.0']]
 workflows[_wfn()] = ['EGMNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'EGMNano_data13.0']]
-workflows[_wfn()] = ['jmeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNano_data13.0']]
+workflows[_wfn()] = ['jmeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNANO_data13.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTrackInfoNANO_data13.0']]
 workflows[_wfn()] = ['BTVNANO_data130Xrun3', ['MuonEG2023MINIAOD13.0', 'BTVNANO_data13.0']]
+workflows[_wfn()] = ['jmeNANOrePuppidata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNANO_rePuppi_data13.0']]
 
 _wfn.next()
 ################
@@ -276,6 +283,7 @@ workflows[_wfn()] = ['EGMNANOmc132X', ['TTBarMINIAOD13.2', 'EGMNano_mc13.2']]
 workflows[_wfn()] = ['jmeNANOmc132X', ['TTBarMINIAOD13.2', 'jmeNANO_mc13.2']]
 workflows[_wfn()] = ['lepTrackInfoNANOmc132X', ['TTBarMINIAOD13.2', 'lepTrackInfoNANO_mc13.2']]
 workflows[_wfn()] = ['BTVNANO_mc132X', ['TTBarMINIAOD13.2', 'BTVNANO_mc13.2']]
+workflows[_wfn()] = ['jmeNANOrePuppimc132X', ['TTBarMINIAOD13.2', 'jmeNANO_rePuppi_mc13.2']]
 
 _wfn.next()
 ################

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -36,6 +36,8 @@ autoNANO = {
     # JME custom NANO
     'JME' : { 'sequence': '@PHYS',
                'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},
+    'JMErePuppi' : { 'sequence': '@PHYS',
+                     'customize': '@PHYS+@JME+PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET'},
     # Muon POG flavours : add tables through customize, supposed to be combined with PHYS
     'MUPOG' : { 'sequence': '@PHYS',
                 'customize' : '@PHYS+PhysicsTools/NanoAOD/custom_muon_cff.PrepMuonCustomNanoAOD'},

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1282,7 +1282,7 @@ def RecomputePuppiMET(proc):
     runOnMC = False
 
   from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-  runMetCorAndUncFromMiniAOD(proc, isData=runOnMC,
+  runMetCorAndUncFromMiniAOD(proc, isData=not(runOnMC),
     jetCollUnskimmed='updatedJetsPuppi',metType='Puppi',postfix='Puppi',jetFlavor='AK4PFPuppi',
     puppiProducerLabel='packedpuppi',puppiProducerForMETLabel='packedpuppiNoLep',
     recoMetFromPFCs=True

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1263,6 +1263,33 @@ def RemoveAllJetPtCuts(proc):
 
   return proc
 
+def RecomputePuppiWeights(proc):
+  """
+  Setup packedpuppi and packedpuppiNoLep to recompute puppi weights
+  """
+  if hasattr(proc,"packedpuppi"):
+    proc.packedpuppi.useExistingWeights = False
+  if hasattr(proc,"packedpuppiNoLep"):
+    proc.packedpuppiNoLep.useExistingWeights = False
+  return proc
+
+def RecomputePuppiMET(proc):
+  """
+  Recompute PuppiMET. This is useful when puppi weights are recomputed.
+  """
+  runOnMC=True
+  if hasattr(proc,"NANOEDMAODoutput") or hasattr(proc,"NANOAODoutput"):
+    runOnMC = False
+
+  from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+  runMetCorAndUncFromMiniAOD(proc, isData=runOnMC,
+    jetCollUnskimmed='updatedJetsPuppi',metType='Puppi',postfix='Puppi',jetFlavor='AK4PFPuppi',
+    puppiProducerLabel='packedpuppi',puppiProducerForMETLabel='packedpuppiNoLep',
+    recoMetFromPFCs=True
+  )
+  return proc
+
+
 #===========================================================================
 #
 # CUSTOMIZATION function

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -1289,6 +1289,13 @@ def RecomputePuppiMET(proc):
   )
   return proc
 
+def RecomputePuppiWeightsAndMET(proc):
+  """
+  Recompute Puppi weights PuppiMET.
+  """
+  proc = RecomputePuppiWeights(proc)
+  proc = RecomputePuppiMET(proc)
+  return proc
 
 #===========================================================================
 #


### PR DESCRIPTION
Backport of #45167

#### Original PR description:

This PR adds three wrapper functions which 

- set the PuppiProducer instances (`packedpuppi` & `packedpuppiNoLep`) to recompute puppi weights.
- setup the recalculation of PuppiMET.
- wraps over the two functions above.

The three functions can be set up in cmsRun config files  using `--customise` or `-customize_commands` arguments of cmsDriver.py. This would be useful if a (official or private) JMENano production needs updated Puppi weights. An `autoNano` option called `jmeNANOrePuppi` is added which sets up JMENano production with recomputation of Puppi weights and Puppi MET. Added two new test workflows (`2500.319,2500.406`) using the new `autoNano` option.

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`
passes the new JMENano wokflows runTheMatrix: `runTheMatrix.py -i all --ibeos -l 2500.319,2500.406`