### PR TITLE
Set uGMT version used for 2024 in the packers

### DIFF
--- a/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
@@ -15,7 +15,7 @@ gmtStage2Raw = cms.EDProducer(
     EMTFShowerInputLabel = cms.InputTag("simEmtfShowers", "EMTF"),
     ShowerInputLabel = cms.InputTag("simGmtShowerDigis"),
     FedId = cms.int32(1402),
-    FWId = cms.uint32(0x8000000), # Firmware with support for 2loose showers
+    FWId = cms.uint32(0x8010000), # Firmware for 2024
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -34,4 +34,5 @@ stage2L1Trigger_2018.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simBm
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x8000000))
+stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x8010000))
+


### PR DESCRIPTION
The unpacking of quantities in the uGMT unpacker is switched by the firmware version that is written in the raw data. In this PR I updated the firmware version written by the packers so that the repack workflows work as expected.

This might be needed for the central MC production (depending on whether the workflow uses repack), could you let me know if this will require a backport?