### PR TITLE
SONIC updates for site support

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -132,7 +132,7 @@ The script has three operations (`start`, `stop`, `check`) and the following opt
 * `-c`: don't cleanup temporary dir (for debugging)
 * `-C [dir]`: directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)
 * `-D`: dry run: print container commands rather than executing them
-* `-d`: use Docker instead of Apptainer
+* `-d [exe]`: container choice: Apptainer, Docker, Podman (default: apptainer)
 * `-E [path]`: include extra path(s) for executables (default: /cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin)
 * `-f`: force reuse of (possibly) existing container instance
 * `-g [device]`: device choice: auto (try to detect GPU), CPU, GPU (default: auto)
@@ -200,8 +200,8 @@ The fallback server has a separate set of options, mostly related to the invocat
 * `enable`: enable the fallback server
 * `debug`: enable debugging (equivalent to `-c` in `cmsTriton`)
 * `verbose`: enable verbose output in logs (equivalent to `-v` in `cmsTriton`)
-* `useDocker`: use Docker instead of Apptainer (equivalent to `-d` in `cmsTriton`)
-* `useGPU`: run on local GPU (equivalent to `-g` in `cmsTriton`)
+* `container`: container choice (equivalent to `-d` in `cmsTriton`)
+* `device`: device choice (equivalent to `-g` in `cmsTriton`)
 * `retries`: number of retries when starting container (passed to `-r [num]` in `cmsTriton` if >= 0; default: -1)
 * `wait`: maximum time to wait for server to start (passed to `-w time` in `cmsTriton` if >= 0; default: -1)
 * `instanceBaseName`: base name for server instance if random names are enabled (default: triton_server_instance)

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -135,8 +135,8 @@ The script has three operations (`start`, `stop`, `check`) and the following opt
 * `-d`: use Docker instead of Apptainer
 * `-E [path]`: include extra path(s) for executables (default: /cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin)
 * `-f`: force reuse of (possibly) existing container instance
-* `-g`: use GPU instead of CPU
-* `-i` [name]`: server image name (default: fastml/triton-torchgeo:22.07-py3-geometric)
+* `-g [device]`: device choice: auto (try to detect GPU), CPU, GPU (default: auto)
+* `-i [name]`: server image name (default: fastml/triton-torchgeo:22.07-py3-geometric)
 * `-I [num]`: number of model instances (default: 0 -> means no local editing of config files)
 * `-M [dir]`: model repository (can be given more than once)
 * `-m [dir]`: specific model directory (can be given more than one)

--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -132,7 +132,7 @@ The script has three operations (`start`, `stop`, `check`) and the following opt
 * `-c`: don't cleanup temporary dir (for debugging)
 * `-C [dir]`: directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)
 * `-D`: dry run: print container commands rather than executing them
-* `-d [exe]`: container choice: Apptainer, Docker, Podman (default: apptainer)
+* `-d [exe]`: container choice: apptainer, docker, podman, podman-hpc (default: apptainer)
 * `-E [path]`: include extra path(s) for executables (default: /cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin)
 * `-f`: force reuse of (possibly) existing container instance
 * `-g [device]`: device choice: auto (try to detect GPU), CPU, GPU (default: auto)
@@ -144,7 +144,7 @@ The script has three operations (`start`, `stop`, `check`) and the following opt
 * `-P [port]`: base port number for services (-1: automatically find an unused port range) (default: 8000)
 * `-p [pid]`: automatically shut down server when process w/ specified PID ends (-1: use parent process PID)
 * `-r [num]`: number of retries when starting container (default: 3)
-* `-s [dir]`: Apptainer sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:22.07-py3-geometric)
+* `-s [dir]`: apptainer sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:22.07-py3-geometric)
 * `-t [dir]`: non-default hidden temporary dir
 * `-v`: (verbose) start: activate server debugging info; stop: keep server logs
 * `-w [time]`: maximum time to wait for server to start (default: 300 seconds)

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -89,6 +89,7 @@ public:
     std::unordered_set<std::string> models;
     static const std::string fallbackName;
     static const std::string fallbackAddress;
+    static const std::string siteconfName;
   };
   struct Model {
     Model(const std::string& path_ = "") : path(path_) {}

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -36,7 +36,7 @@ public:
         : enable(pset.getUntrackedParameter<bool>("enable")),
           debug(pset.getUntrackedParameter<bool>("debug")),
           verbose(pset.getUntrackedParameter<bool>("verbose")),
-          useDocker(pset.getUntrackedParameter<bool>("useDocker")),
+          container(pset.getUntrackedParameter<std::string>("container")),
           device(pset.getUntrackedParameter<std::string>("device")),
           retries(pset.getUntrackedParameter<int>("retries")),
           wait(pset.getUntrackedParameter<int>("wait")),
@@ -54,7 +54,7 @@ public:
     bool enable;
     bool debug;
     bool verbose;
-    bool useDocker;
+    std::string container;
     std::string device;
     int retries;
     int wait;

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -37,7 +37,7 @@ public:
           debug(pset.getUntrackedParameter<bool>("debug")),
           verbose(pset.getUntrackedParameter<bool>("verbose")),
           useDocker(pset.getUntrackedParameter<bool>("useDocker")),
-          useGPU(pset.getUntrackedParameter<bool>("useGPU")),
+          device(pset.getUntrackedParameter<std::string>("device")),
           retries(pset.getUntrackedParameter<int>("retries")),
           wait(pset.getUntrackedParameter<int>("wait")),
           instanceName(pset.getUntrackedParameter<std::string>("instanceName")),
@@ -55,7 +55,7 @@ public:
     bool debug;
     bool verbose;
     bool useDocker;
-    bool useGPU;
+    std::string device;
     int retries;
     int wait;
     std::string instanceName;

--- a/HeterogeneousCore/SonicTriton/python/TritonService_cff.py
+++ b/HeterogeneousCore/SonicTriton/python/TritonService_cff.py
@@ -2,18 +2,8 @@ from HeterogeneousCore.SonicTriton.TritonService_cfi import *
 
 from Configuration.ProcessModifiers.enableSonicTriton_cff import enableSonicTriton
 
-_gpu_available_cached = None
-
-def _gpu_available():
-    global _gpu_available_cached
-    if _gpu_available_cached is None:
-        import os
-        _gpu_available_cached = (os.system("nvidia-smi -L") == 0)
-    return _gpu_available_cached
-
 enableSonicTriton.toModify(TritonService,
     fallback = dict(
         enable = True,
-        useGPU = _gpu_available(),
     ),
 )

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # defaults
-USEDOCKER=""
+CONTAINER=apptainer
 VERBOSE=""
 VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-warning=1 --log-info=1"
 WTIME=600
@@ -42,7 +42,7 @@ usage() {
 	$ECHO "-c          \t don't cleanup temporary dir (for debugging)"
 	$ECHO "-C [dir]    \t directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)"
 	$ECHO "-D          \t dry run: print container commands rather than executing them"
-	$ECHO "-d          \t use Docker instead of Apptainer"
+	$ECHO "-d [exe]    \t container choice: Apptainer, Docker, Podman (default: ${CONTAINER})"
 	$ECHO "-E [path]   \t include extra path(s) for executables (default: ${EXTRAPATH})"
 	$ECHO "-f          \t force reuse of (possibly) existing container instance"
 	$ECHO "-g [device] \t device choice: auto (try to detect GPU), CPU, GPU (default: ${DEVICE})"
@@ -73,7 +73,7 @@ if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "cC:Ddfg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
+while getopts "cC:Dd:fg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
 	case "$opt" in
 		c) CLEANUP=""
 		;;
@@ -81,7 +81,7 @@ while getopts "cC:Ddfg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
 		;;
 		D) DRYRUN=echo
 		;;
-		d) USEDOCKER=true
+		d) CONTAINER="$OPTARG"
 		;;
 		f) FORCE=true
 		;;
@@ -130,6 +130,13 @@ if [[ ! " auto cpu gpu " =~ " $DEVICE " ]]; then
 	exit 1
 fi
 
+# check acceptable values for container choice
+CONTAINER="${CONTAINER,,}"
+if [[ ! " apptainer docker podman " =~ " $CONTAINER " ]]; then
+	echo "Unsupported container value: $CONTAINER"
+	exit 1
+fi
+
 if [ "$RETRIES" -le 0 ]; then
 	RETRIES=1
 fi
@@ -147,9 +154,13 @@ if [ -n "$EXTRAPATH" ]; then
 fi
 
 # find executables
-if [ -n "$USEDOCKER" ]; then
+if [ "$CONTAINER" == "docker" ]; then
 	if [ -z "$DOCKER" ]; then
-		DOCKER="sudo docker"
+		DOCKER="docker"
+	fi
+elif [ "$CONTAINER" == "podman" ]; then
+	if [ -z "$PODMAN" ]; then
+		PODMAN="podman"
 	fi
 else
 	if [ -z "$APPTAINER" ]; then
@@ -246,6 +257,29 @@ start_docker(){
 		${IMAGE} tritonserver $PORTARGS $REPOARGS $VERBOSE
 }
 
+start_podman(){
+	# mount all model repositories
+	MOUNTARGS=""
+	REPOARGS=""
+	for REPO in ${REPOS[@]}; do
+		MOUNTARGS="$MOUNTARGS --volume $REPO:$REPO"
+		REPOARGS="$REPOARGS --model-repository=${REPO}"
+	done
+
+	# compatibility driver environment
+	if [ -n "$COMPAT" ]; then
+		MOUNTARGS="$MOUNTARGS --volume $COMPAT"
+		if [ -n "$COMPAT_SCRIPT_MOUNT" ]; then
+			MOUNTARGS="$MOUNTARGS --volume $COMPAT_SCRIPT_MOUNT"
+		fi
+	fi
+
+	$DRYRUN $PODMAN run -d --name ${SERVER} \
+		--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
+		-p${HTTPPORT}:${HTTPPORT} -p${GRPCPORT}:${GRPCPORT} -p${METRPORT}:${METRPORT} $EXTRA $MOUNTARGS \
+		${IMAGE} tritonserver $PORTARGS $REPOARGS $VERBOSE
+}
+
 start_apptainer(){
 	# triton server image may need to modify contents of opt/tritonserver/lib/
 	# but cvmfs is read-only
@@ -305,6 +339,16 @@ stop_docker(){
 	$DRYRUN $DOCKER rm ${SERVER}
 }
 
+stop_podman(){
+	# keep log
+	if [ -z "$DRYRUN" ]; then
+		if [ -n "$VERBOSE" ]; then $PODMAN logs ${SERVER} >& "$LOG"; fi
+	fi
+
+	$DRYRUN $PODMAN stop ${SERVER}
+	$DRYRUN $PODMAN rm ${SERVER}
+}
+
 stop_apptainer(){
 	$DRYRUN $APPTAINER instance stop ${SERVER}
 }
@@ -312,6 +356,11 @@ stop_apptainer(){
 test_docker(){
 	# docker logs print to stderr
 	${DOCKER} logs ${SERVER} |& grep "$1"
+}
+
+test_podman(){
+	# podman logs print to stdout
+	${PODMAN} logs ${SERVER} | grep "$1"
 }
 
 test_apptainer(){
@@ -462,6 +511,10 @@ driver_docker(){
 	$DOCKER run --rm --entrypoint env ${IMAGE} | grep "CUDA_DRIVER_VERSION="
 }
 
+driver_podman(){
+	$PODMAN run --rm --entrypoint env ${IMAGE} | grep "CUDA_DRIVER_VERSION="
+}
+
 driver_apptainer(){
 	D2S=${SANDBOX}/.singularity.d/env/10-docker2singularity.sh
 	if [ -f "$D2S" ]; then
@@ -536,13 +589,18 @@ extra_docker(){
 		EXTRA="--gpus all"
 	fi
 }
+extra_podman(){
+	if [ "$DEVICE" == gpu ]; then
+		EXTRA="--device nvidia.com/gpu=all"
+	fi
+}
 extra_apptainer(){
 	if [ "$DEVICE" == gpu ]; then
 		EXTRA="--nv"
 	fi
 }
 
-if [ -n "$USEDOCKER" ]; then
+if [ "$CONTAINER" == "docker" ]; then
 	START_FN=start_docker
 	EXTRA_FN=extra_docker
 	TEST_FN=test_docker
@@ -550,6 +608,14 @@ if [ -n "$USEDOCKER" ]; then
 	DRIVER_FN=driver_docker
 	COMPAT_FN=compat_docker
 	PROG_NAME=Docker
+elif [ "$CONTAINER" == "podman" ]; then
+	START_FN=start_podman
+	EXTRA_FN=extra_podman
+	TEST_FN=test_podman
+	STOP_FN=stop_podman
+	DRIVER_FN=driver_podman
+	COMPAT_FN=compat_podman
+	PROG_NAME=Podman
 else
 	START_FN=start_apptainer
 	EXTRA_FN=extra_apptainer

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -265,7 +265,9 @@ start_apptainer(){
 
 	# start instance
 	# need to bind /cvmfs for above symlinks to work inside container
+	# --underlay: workaround for https://github.com/apptainer/apptainer/issues/2167
 	$DRYRUN $APPTAINER instance start \
+		--underlay \
 		-B ${SHM}:/run/shm -B ${LIB}:/opt/tritonserver/lib -B ${SANDBOX} $MOUNTARGS $EXTRA \
 		${SANDBOX} ${SERVER}
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -263,17 +263,6 @@ start_apptainer(){
 		fi
 	fi
 
-	# workaround for nvidia libs w/ singularity-in-singularity
-	# from https://github.com/hpcng/singularity/issues/5759#issuecomment-919523970
-	if [ -d /.singularity.d/libs ]; then
-		TMPD=`mktemp -d`
-		(echo '#!/bin/bash'; echo 'exec /usr/sbin/ldconfig -C '"$TMPD"'/ld.so.cache "$@"') > $TMPD/ldconfig
-		chmod +x $TMPD/ldconfig
-		PATH=$TMPD:$PATH
-		# this does not work with LD_LIBRARY_PATH from cmsenv
-		ldconfig /.singularity.d/libs
-	fi
-
 	# start instance
 	# need to bind /cvmfs for above symlinks to work inside container
 	$DRYRUN $APPTAINER instance start \

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -2,7 +2,6 @@
 
 # defaults
 USEDOCKER=""
-GPU=""
 VERBOSE=""
 VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-warning=1 --log-info=1"
 WTIME=600
@@ -24,6 +23,8 @@ IMAGE=fastml/triton-torchgeo:22.07-py3-geometric
 SANDBOX=""
 COMPAT_USR=""
 EXTRAPATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin
+DEVICE=auto
+THREADCONTROL=""
 
 get_sandbox(){
 	if [ -z "$SANDBOX" ]; then
@@ -44,7 +45,7 @@ usage() {
 	$ECHO "-d          \t use Docker instead of Apptainer"
 	$ECHO "-E [path]   \t include extra path(s) for executables (default: ${EXTRAPATH})"
 	$ECHO "-f          \t force reuse of (possibly) existing container instance"
-	$ECHO "-g          \t use GPU instead of CPU"
+	$ECHO "-g [device] \t device choice: auto (try to detect GPU), CPU, GPU (default: ${DEVICE})"
 	$ECHO "-i [name]   \t server image name (default: ${IMAGE})"
 	$ECHO "-I [num]    \t number of model instances (default: ${INSTANCES} -> means no local editing of config files)"
 	$ECHO "-M [dir]    \t model repository (can be given more than once)"
@@ -72,7 +73,7 @@ if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "cC:Ddfgi:I:M:m:n:P:p:r:s:t:vw:h" opt; do
+while getopts "cC:Ddfg:i:I:M:m:n:P:p:r:s:t:vw:h" opt; do
 	case "$opt" in
 		c) CLEANUP=""
 		;;
@@ -84,7 +85,7 @@ while getopts "cC:Ddfgi:I:M:m:n:P:p:r:s:t:vw:h" opt; do
 		;;
 		f) FORCE=true
 		;;
-		g) GPU=true
+		g) DEVICE="$OPTARG"
 		;;
 		i) IMAGE="$OPTARG"
 		;;
@@ -120,6 +121,13 @@ OP=$1
 
 if [ "$OP" != start ] && [ "$OP" != stop ] && [ "$OP" != check ]; then
 	usage 1
+fi
+
+# check acceptable values for device choice
+DEVICE="${DEVICE,,}"
+if [[ ! " auto cpu gpu " =~ " $DEVICE " ]]; then
+	echo "Unsupported device value: $DEVICE"
+	exit 1
 fi
 
 if [ "$RETRIES" -le 0 ]; then
@@ -166,9 +174,8 @@ SEGFAULT_INDICATOR="Address already in use"
 EXTRA=""
 COMPAT_SCRIPT=/etc/shinit_v2
 
-THREADCONTROL=""
-# do not apply thread control settings if GPU use is requested
-if [ "$INSTANCES" -gt 0 ] && [ -z "$GPU" ]; then
+# this will be reset later if chosen device is gpu
+if [ "$INSTANCES" -gt 0 ]; then
 	THREADCONTROL=true
 fi
 
@@ -524,21 +531,28 @@ check_drivers(){
 	fi
 }
 
-if [ -n "$USEDOCKER" ]; then
-	if [ -n "$GPU" ]; then
+extra_docker(){
+	if [ "$DEVICE" == gpu ]; then
 		EXTRA="--gpus all"
 	fi
+}
+extra_apptainer(){
+	if [ "$DEVICE" == gpu ]; then
+		EXTRA="--nv"
+	fi
+}
+
+if [ -n "$USEDOCKER" ]; then
 	START_FN=start_docker
+	EXTRA_FN=extra_docker
 	TEST_FN=test_docker
 	STOP_FN=stop_docker
 	DRIVER_FN=driver_docker
 	COMPAT_FN=compat_docker
 	PROG_NAME=Docker
 else
-	if [ -n "$GPU" ]; then
-		EXTRA="--nv"
-	fi
 	START_FN=start_apptainer
+	EXTRA_FN=extra_apptainer
 	TEST_FN=test_apptainer
 	STOP_FN=stop_apptainer
 	DRIVER_FN=driver_apptainer
@@ -556,6 +570,22 @@ elif [ "$OP" == start ]; then
 	elif [ -d "$TMPDIR" ]; then
 		echo "Error: this container may already exist (override with -f)"
 		exit 1
+	fi
+
+	# auto GPU check
+	if [ "$DEVICE" == auto ]; then
+		if nvidia-smi -L >& /dev/null; then
+			DEVICE=gpu
+		else
+			DEVICE=cpu
+		fi
+	fi
+	echo "CMS_TRITON_CHOSEN_DEVICE: $DEVICE"
+	$EXTRA_FN
+
+	# do not apply thread control settings if GPU use is requested
+	if [ "$DEVICE" == gpu ]; then
+		THREADCONTROL=""
 	fi
 
 	handle_ports
@@ -576,7 +606,7 @@ elif [ "$OP" == start ]; then
 		if [ "$counter" -eq 0 ] || [ -n "$THREADCONTROL" ]; then list_models; fi
 
 		# only need to check drivers if using GPU
-		if [ -n "$GPU" ]; then
+		if [ "$DEVICE" == gpu ]; then
 			check_drivers
 			DRIVER_EXIT=$?
 			if [ "$DRIVER_EXIT" -ne 0 ]; then exit $DRIVER_EXIT; fi

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -23,6 +23,11 @@ IMAGE=fastml/triton-torchgeo:22.07-py3-geometric
 SANDBOX=""
 COMPAT_USR=""
 EXTRAPATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin
+OSVERSION=$(sed -nr 's/[^0-9]*([0-9]+).*/\1/p' /etc/redhat-release)
+if [ "$OSVERSION" -eq 7 ]; then
+	# this is the latest version with guaranteed sl7 support
+	EXTRAPATH=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/1.2.5/bin
+fi
 DEVICE=auto
 THREADCONTROL=""
 

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -364,7 +364,7 @@ test_docker(){
 
 test_podman(){
 	# podman logs print to stdout
-	${PODMAN} logs ${SERVER} | grep "$1"
+	${PODMAN} logs ${SERVER} |& grep "$1"
 }
 
 test_apptainer(){
@@ -522,7 +522,7 @@ driver_podman(){
 driver_apptainer(){
 	D2S=${SANDBOX}/.singularity.d/env/10-docker2singularity.sh
 	if [ -f "$D2S" ]; then
-		source $D2S && echo $CUDA_DRIVER_VERSION
+		source $D2S && echo "CUDA_DRIVER_VERSION=$CUDA_DRIVER_VERSION"
 	fi
 }
 
@@ -536,9 +536,10 @@ compat_apptainer(){
 
 check_drivers(){
 	# get sandbox env vars in subshell
-	CUDA_DRIVER_VERSION=$($DRIVER_FN)
+	eval "$($DRIVER_FN)"
 	# copied from https://github.com/triton-inference-server/server/blob/v2.11.0/nvidia_entrypoint.sh
-	DRIVER_VERSION=$(sed -n 's/^NVRM.*Kernel Module *\([0-9.]*\).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)
+	# regex generalized to handle SUSE
+	DRIVER_VERSION=$(sed -nr 's/^NVRM.*Kernel Module[^.]* ([0-9.]*).*$/\1/p' /proc/driver/nvidia/version 2>/dev/null || true)
 	if [[ "${DRIVER_VERSION%%.*}" -ge "${CUDA_DRIVER_VERSION%%.*}" ]]; then
 		return 0
 	fi
@@ -602,6 +603,7 @@ extra_podman_hpc(){
 	if [ "$DEVICE" == gpu ]; then
 		EXTRA="--gpu"
 	fi
+	EXTRA="$EXTRA --cvmfs --log-driver=json-file"
 }
 extra_apptainer(){
 	if [ "$DEVICE" == gpu ]; then

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -42,7 +42,7 @@ usage() {
 	$ECHO "-c          \t don't cleanup temporary dir (for debugging)"
 	$ECHO "-C [dir]    \t directory containing Nvidia compatibility drivers (checks CMSSW_BASE by default if available)"
 	$ECHO "-D          \t dry run: print container commands rather than executing them"
-	$ECHO "-d [exe]    \t container choice: Apptainer, Docker, Podman (default: ${CONTAINER})"
+	$ECHO "-d [exe]    \t container choice: apptainer, docker, podman, podman-hpc (default: ${CONTAINER})"
 	$ECHO "-E [path]   \t include extra path(s) for executables (default: ${EXTRAPATH})"
 	$ECHO "-f          \t force reuse of (possibly) existing container instance"
 	$ECHO "-g [device] \t device choice: auto (try to detect GPU), CPU, GPU (default: ${DEVICE})"
@@ -54,7 +54,7 @@ usage() {
 	$ECHO "-P [port]   \t base port number for services (-1: automatically find an unused port range) (default: ${BASEPORT})"
 	$ECHO "-p [pid]    \t automatically shut down server when process w/ specified PID ends (-1: use parent process PID)"
 	$ECHO "-r [num]    \t number of retries when starting container (default: ${RETRIES})"
-	$ECHO "-s [dir]    \t Apptainer sandbox directory (default: $(get_sandbox))"
+	$ECHO "-s [dir]    \t apptainer sandbox directory (default: $(get_sandbox))"
 	$ECHO "-t [dir]    \t non-default hidden temporary dir"
 	$ECHO "-v          \t (verbose) start: activate server debugging info; stop: keep server logs"
 	$ECHO "-w [time]   \t maximum time to wait for server to start (default: ${WTIME} seconds)"
@@ -132,7 +132,7 @@ fi
 
 # check acceptable values for container choice
 CONTAINER="${CONTAINER,,}"
-if [[ ! " apptainer docker podman " =~ " $CONTAINER " ]]; then
+if [[ ! " apptainer docker podman podman-hpc " =~ " $CONTAINER " ]]; then
 	echo "Unsupported container value: $CONTAINER"
 	exit 1
 fi
@@ -161,6 +161,10 @@ if [ "$CONTAINER" == "docker" ]; then
 elif [ "$CONTAINER" == "podman" ]; then
 	if [ -z "$PODMAN" ]; then
 		PODMAN="podman"
+	fi
+elif [ "$CONTAINER" == "podman-hpc" ]; then
+	if [ -z "$PODMAN" ]; then
+		PODMAN="podman-hpc"
 	fi
 else
 	if [ -z "$APPTAINER" ]; then
@@ -594,6 +598,11 @@ extra_podman(){
 		EXTRA="--device nvidia.com/gpu=all"
 	fi
 }
+extra_podman_hpc(){
+	if [ "$DEVICE" == gpu ]; then
+		EXTRA="--gpu"
+	fi
+}
 extra_apptainer(){
 	if [ "$DEVICE" == gpu ]; then
 		EXTRA="--nv"
@@ -607,7 +616,7 @@ if [ "$CONTAINER" == "docker" ]; then
 	STOP_FN=stop_docker
 	DRIVER_FN=driver_docker
 	COMPAT_FN=compat_docker
-	PROG_NAME=Docker
+	PROG_NAME=docker
 elif [ "$CONTAINER" == "podman" ]; then
 	START_FN=start_podman
 	EXTRA_FN=extra_podman
@@ -615,7 +624,15 @@ elif [ "$CONTAINER" == "podman" ]; then
 	STOP_FN=stop_podman
 	DRIVER_FN=driver_podman
 	COMPAT_FN=compat_podman
-	PROG_NAME=Podman
+	PROG_NAME=podman
+elif [ "$CONTAINER" == "podman-hpc" ]; then
+	START_FN=start_podman
+	EXTRA_FN=extra_podman_hpc
+	TEST_FN=test_podman
+	STOP_FN=stop_podman
+	DRIVER_FN=driver_podman
+	COMPAT_FN=compat_podman
+	PROG_NAME=podman-hpc
 else
 	START_FN=start_apptainer
 	EXTRA_FN=extra_apptainer
@@ -623,7 +640,7 @@ else
 	STOP_FN=stop_apptainer
 	DRIVER_FN=driver_apptainer
 	COMPAT_FN=compat_apptainer
-	PROG_NAME=Apptainer
+	PROG_NAME=apptainer
 fi
 
 if [ "$OP" == check ]; then

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTritonConfigTool
@@ -381,7 +381,7 @@ def cfg_threadcontrol(args):
     for key,val in thread_control_parameters.items():
         if key in platform: # partial matching
             for param in val:
-                item = args.model.parameters.get_or_create(key)
+                item = args.model.parameters.get_or_create(param)
                 item.string_value = "1"
             found_params = True
             break

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -263,8 +263,8 @@ unsigned TritonClient::batchSize() const { return batchMode_ == TritonBatchMode:
 bool TritonClient::setBatchSize(unsigned bsize) {
   if (batchMode_ == TritonBatchMode::Rectangular) {
     if (bsize > maxOuterDim_) {
-      edm::LogWarning(fullDebugName_) << "Requested batch size " << bsize << " exceeds server-specified max batch size "
-                                      << maxOuterDim_ << ". Batch size will remain as " << outerDim_;
+      throw TritonException("LocalFailure")
+          << "Requested batch size " << bsize << " exceeds server-specified max batch size " << maxOuterDim_ << ".";
       return false;
     } else {
       outerDim_ = bsize;

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -66,8 +66,7 @@ TritonClient::TritonClient(const edm::ParameterSet& params, const std::string& d
   const auto& server =
       ts->serverInfo(options_[0].model_name_, params.getUntrackedParameter<std::string>("preferredServer"));
   serverType_ = server.type;
-  if (verbose_)
-    edm::LogInfo(fullDebugName_) << "Using server: " << server.url;
+  edm::LogInfo("TritonDiscovery") << debugName_ << " assigned server: " << server.url;
   //enforce sync mode for fallback CPU server to avoid contention
   //todo: could enforce async mode otherwise (unless mode was specified by user?)
   if (serverType_ == TritonServerType::LocalCPU)

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -100,13 +100,14 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
         std::forward_as_tuple(Server::siteconfName),
         std::forward_as_tuple(Server::siteconfName, siteconf_address + ":" + siteconf_port, TritonServerType::Remote));
     if (verbose_)
-      edm::LogInfo("TritonService") << "Obtained server from SITECONF: "
-                                    << servers_.find(Server::siteconfName)->second.url;
+      edm::LogInfo("TritonDiscovery") << "Obtained server from SITECONF: "
+                                      << servers_.find(Server::siteconfName)->second.url;
   } else if (siteconf_address.empty() != siteconf_port.empty()) {  //xor
-    edm::LogWarning("TritonService") << "Incomplete server information from SITECONF: HOST = " << siteconf_address
+    edm::LogWarning("TritonDiscovery") << "Incomplete server information from SITECONF: HOST = " << siteconf_address
                                      << ", PORT = " << siteconf_port;
   }
-  //if nothing provided, assume there's no SITECONF server
+  else
+    edm::LogWarning("TritonDiscovery") << "No server information from SITECONF";
 
   //finally, populate list of servers from config input
   for (const auto& serverPset : pset.getUntrackedParameterSetVector("servers")) {
@@ -173,7 +174,7 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
       msg += "\n";
   }
   if (verbose_)
-    edm::LogInfo("TritonService") << msg;
+    edm::LogInfo("TritonDiscovery") << msg;
 }
 
 void TritonService::preallocate(edm::service::SystemBounds const& bounds) {
@@ -263,7 +264,7 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
       msg += modelName + ", ";
   }
   if (verbose_)
-    edm::LogInfo("TritonService") << msg;
+    edm::LogInfo("TritonDiscovery") << msg;
 
   //assemble server start command
   fallbackOpts_.command = "cmsTriton -P -1 -p " + pid_;

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -273,12 +273,11 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
   //assemble server start command
   fallbackOpts_.command = "cmsTriton -P -1 -p " + pid_;
   fallbackOpts_.command += " -g " + fallbackOpts_.device;
+  fallbackOpts_.command += " -d " + fallbackOpts_.container;
   if (fallbackOpts_.debug)
     fallbackOpts_.command += " -c";
   if (fallbackOpts_.verbose)
     fallbackOpts_.command += " -v";
-  if (fallbackOpts_.useDocker)
-    fallbackOpts_.command += " -d";
   if (!fallbackOpts_.instanceName.empty())
     fallbackOpts_.command += " -n " + fallbackOpts_.instanceName;
   if (fallbackOpts_.retries >= 0)
@@ -434,7 +433,8 @@ void TritonService::fillDescriptions(edm::ConfigurationDescriptions& description
   fallbackDesc.addUntracked<bool>("enable", false);
   fallbackDesc.addUntracked<bool>("debug", false);
   fallbackDesc.addUntracked<bool>("verbose", false);
-  fallbackDesc.addUntracked<bool>("useDocker", false);
+  fallbackDesc.ifValue(edm::ParameterDescription<std::string>("container", "apptainer", false),
+                       edm::allowedValues<std::string>("apptainer", "docker", "podman"));
   fallbackDesc.ifValue(edm::ParameterDescription<std::string>("device", "auto", false),
                        edm::allowedValues<std::string>("auto", "cpu", "gpu"));
   fallbackDesc.addUntracked<int>("retries", -1);

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -92,6 +92,7 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
   areg.watchPostEndJob(this, &TritonService::postEndJob);
 
   //check for server specified in SITECONF
+  //(temporary solution, to be replaced with entry in site-local-config.xml or similar)
   std::string siteconf_address(edm::getEnvironmentVariable(Server::siteconfName + "_HOST"));
   std::string siteconf_port(edm::getEnvironmentVariable(Server::siteconfName + "_PORT"));
   if (!siteconf_address.empty() and !siteconf_port.empty()) {
@@ -318,7 +319,7 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
   if (rv != 0) {
     edm::LogError("TritonService") << output;
     printFallbackServerLog<edm::LogError>();
-    throw cms::Exception("FallbackFailed")
+    throw edm::Exception(edm::errors::ExternalFailure)
         << "TritonService: Starting the fallback server failed with exit code " << rv;
   } else if (verbose_)
     edm::LogInfo("TritonService") << output;
@@ -333,11 +334,11 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
       else if (chosenDevice == "gpu")
         server.type = TritonServerType::LocalGPU;
       else
-        throw cms::Exception("FallbackFailed")
+        throw edm::Exception(edm::errors::ExternalFailure)
             << "TritonService: unsupported device choice " << chosenDevice << " for fallback server, log follows:\n"
             << output;
     } else
-      throw cms::Exception("FallbackFailed")
+      throw edm::Exception(edm::errors::ExternalFailure)
           << "TritonService: unknown device choice for fallback server, log follows:\n"
           << output;
   }
@@ -351,8 +352,9 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
   if (!portNum.empty())
     server.url += ":" + portNum;
   else
-    throw cms::Exception("FallbackFailed") << "TritonService: Unknown port for fallback server, log follows:\n"
-                                           << output;
+    throw edm::Exception(edm::errors::ExternalFailure)
+        << "TritonService: Unknown port for fallback server, log follows:\n"
+        << output;
 }
 
 void TritonService::notifyCallStatus(bool status) const {

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -131,11 +131,12 @@ TritonService::TritonService(const edm::ParameterSet& pset, edm::ActivityRegistr
 
     if (verbose_) {
       inference::ServerMetadataResponse serverMetaResponse;
-      TRITON_THROW_IF_ERROR(client->ServerMetadata(&serverMetaResponse),
-                            "TritonService(): unable to get metadata for " + serverName + " (" + server.url + ")",
-                            false);
-      edm::LogInfo("TritonService") << "Server " << serverName << ": url = " << server.url
-                                    << ", version = " << serverMetaResponse.version();
+      auto err = client->ServerMetadata(&serverMetaResponse);
+      if (err.IsOk())
+        edm::LogInfo("TritonService") << "Server " << serverName << ": url = " << server.url
+                                      << ", version = " << serverMetaResponse.version();
+      else
+        edm::LogInfo("TritonService") << "unable to get metadata for " + serverName + " (" + server.url + ")";
     }
 
     //if this query fails, it indicates that the server is nonresponsive or saturated

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -101,7 +101,13 @@ modules = {
     "Analyzer": cms.EDAnalyzer,
 }
 
-keepMsgs = ['TritonClient','TritonService','TritonDiscovery']
+keepMsgs = []
+if options.verbose or options.verboseDiscovery:
+    keepMsgs.append('TritonDiscovery')
+if options.verbose or options.verboseClient:
+    keepMsgs.append('TritonClient')
+if options.verbose or options.verboseService:
+    keepMsgs.append('TritonService')
 
 for im,module in enumerate(options.modules):
     model = options.models[im]
@@ -142,7 +148,8 @@ for im,module in enumerate(options.modules):
             processModule.edgeMax = cms.uint32(15000)
         processModule.brief = cms.bool(options.brief)
     process.p += processModule
-    keepMsgs.extend([module,module+':TritonClient'])
+    if options.verbose or options.verboseClient:
+        keepMsgs.extend([module,module+':TritonClient'])
     if options.testother:
         # clone modules to test both gRPC and shared memory
         _module2 = module+"GRPC" if processModule.Client.useSharedMemory else "SHM"
@@ -153,10 +160,9 @@ for im,module in enumerate(options.modules):
         )
         processModule2 = getattr(process, _module2)
         process.p += processModule2
-        keepMsgs.extend([_module2,_module2+':TritonClient'])
+        if options.verbose or options.verboseClient:
+            keepMsgs.extend([_module2,_module2+':TritonClient'])
 
-if options.verboseDiscovery:
-    keepMsgs = ['TritonDiscovery']
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 500
 for msg in keepMsgs:

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -15,7 +15,7 @@ models = {
 allowed_modes = ["Async","PseudoAsync","Sync"]
 allowed_compression = ["none","deflate","gzip"]
 allowed_devices = ["auto","cpu","gpu"]
-allowed_containers = ["apptainer","docker","podman"]
+allowed_containers = ["apptainer","docker","podman","podman-hpc"]
 
 parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument("--maxEvents", default=-1, type=int, help="Number of events to process (-1 for all)")

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -75,10 +75,9 @@ process.source = cms.Source("EmptySource")
 process.TritonService.verbose = options.verbose or options.verboseService or options.verboseDiscovery
 process.TritonService.fallback.verbose = options.verbose or options.verboseServer
 process.TritonService.fallback.useDocker = options.docker
+process.TritonService.fallback.device = options.device
 if len(options.fallbackName)>0:
     process.TritonService.fallback.instanceBaseName = options.fallbackName
-if options.device != "auto":
-    process.TritonService.fallback.useGPU = options.device=="gpu"
 if len(options.address)>0:
     process.TritonService.servers.append(
         cms.PSet(

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -33,6 +33,7 @@ parser.add_argument("--verbose", default=False, action="store_true", help="enabl
 parser.add_argument("--verboseClient", default=False, action="store_true", help="enable verbose output for clients")
 parser.add_argument("--verboseServer", default=False, action="store_true", help="enable verbose output for server")
 parser.add_argument("--verboseService", default=False, action="store_true", help="enable verbose output for TritonService")
+parser.add_argument("--verboseDiscovery", default=False, action="store_true", help="enable verbose output just for server discovery in TritonService")
 parser.add_argument("--brief", default=False, action="store_true", help="briefer output for graph modules")
 parser.add_argument("--fallbackName", default="", type=str, help="name for fallback server")
 parser.add_argument("--unittest", default=False, action="store_true", help="unit test mode: reduce input sizes")
@@ -71,7 +72,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxE
 
 process.source = cms.Source("EmptySource")
 
-process.TritonService.verbose = options.verbose or options.verboseService
+process.TritonService.verbose = options.verbose or options.verboseService or options.verboseDiscovery
 process.TritonService.fallback.verbose = options.verbose or options.verboseServer
 process.TritonService.fallback.useDocker = options.docker
 if len(options.fallbackName)>0:
@@ -100,7 +101,7 @@ modules = {
     "Analyzer": cms.EDAnalyzer,
 }
 
-keepMsgs = ['TritonClient','TritonService']
+keepMsgs = ['TritonClient','TritonService','TritonDiscovery']
 
 for im,module in enumerate(options.modules):
     model = options.models[im]
@@ -154,6 +155,8 @@ for im,module in enumerate(options.modules):
         process.p += processModule2
         keepMsgs.extend([_module2,_module2+':TritonClient'])
 
+if options.verboseDiscovery:
+    keepMsgs = ['TritonDiscovery']
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 500
 for msg in keepMsgs:

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -15,6 +15,7 @@ models = {
 allowed_modes = ["Async","PseudoAsync","Sync"]
 allowed_compression = ["none","deflate","gzip"]
 allowed_devices = ["auto","cpu","gpu"]
+allowed_containers = ["apptainer","docker","podman"]
 
 parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
 parser.add_argument("--maxEvents", default=-1, type=int, help="Number of events to process (-1 for all)")
@@ -42,7 +43,7 @@ parser.add_argument("--noShm", default=False, action="store_true", help="disable
 parser.add_argument("--compression", default="", type=str, choices=allowed_compression, help="enable I/O compression")
 parser.add_argument("--ssl", default=False, action="store_true", help="enable SSL authentication for server communication")
 parser.add_argument("--device", default="auto", type=str.lower, choices=allowed_devices, help="specify device for fallback server")
-parser.add_argument("--docker", default=False, action="store_true", help="use Docker for fallback server")
+parser.add_argument("--container", default="apptainer", type=str.lower, choices=allowed_containers, help="specify container for fallback server")
 parser.add_argument("--tries", default=0, type=int, help="number of retries for failed request")
 options = parser.parse_args()
 
@@ -74,7 +75,7 @@ process.source = cms.Source("EmptySource")
 
 process.TritonService.verbose = options.verbose or options.verboseService or options.verboseDiscovery
 process.TritonService.fallback.verbose = options.verbose or options.verboseServer
-process.TritonService.fallback.useDocker = options.docker
+process.TritonService.fallback.container = options.container
 process.TritonService.fallback.device = options.device
 if len(options.fallbackName)>0:
     process.TritonService.fallback.instanceBaseName = options.fallbackName

--- a/RecoEcal/EgammaClusterProducers/test/DRNTest_cfg.py
+++ b/RecoEcal/EgammaClusterProducers/test/DRNTest_cfg.py
@@ -15,8 +15,8 @@ process.options.TryToContinue = cms.untracked.vstring('ProductNotFound')
 
 process.TritonService.verbose = False
 process.TritonService.fallback.verbose = False
-process.TritonService.fallback.useDocker = False
-process.TritonService.fallback.useGPU = False
+process.TritonService.fallback.container = "apptainer"
+process.TritonService.fallback.device = "cpu"
 
 process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
 #process.MessageLogger.suppressWarning = cms.untracked.vstring('DRNProducerEB', 'DRNProducerEE')


### PR DESCRIPTION
#### PR description:

This PR includes several updates to support production-style tests at several sites, including T2_US_Purdue, other T2s, and NERSC. There are also some important fixes for bugs that were found during the course of testing.

New features/changes:
* A failed response to a repository index query is now interpreted to indicate that the server should be skipped. (The new load balancer developed at Purdue will intercept the repository index query and return an error if it detects that a GPU is saturated.)
* A site can provide a local GPU server using environment variables `$SONIC_LOCAL_BALANCER_HOST` and `$SONIC_LOCAL_BALANCER_PORT`, set via `cmsset_local.sh` in `SITECONF`. (This is a temporary solution that is eventually expected to migrate to something more standardized, similar to `storage.json`. It is introduced here to facilitate tests at other T2 sites to gain operational experience before determining the final form of this configuration.)
* Separate message category called `TritonDiscovery` to enable tracking/debugging of production-style jobs without requiring full verbosity. (This can be seen as an interim step toward full provenance tracking.)
    * Along these lines, improve handling of verbose output options in test script.
* Support is added for `podman` and `podman-hpc` to launch Triton containers (useful at NERSC).
* Failures of optional server requests are no longer treated as exceptions, to avoid unnecessary job failures.

Bug fixes:
* Modify some apptainer workarounds (remove an old one, add a new one...)
* Check for the presence of a GPU in the `cmsTriton` server launching script, rather than in Python. (Production-style jobs can dump the Python config on a local node and then reuse it on a worker node, so any system calls happen on the local node and may not give the right answer for the worker node as to the presence of a GPU.)
* Fix a bug in the implementation of thread controls for models on the CPU fallback server.

There are some interface changes (related to supporting more container engines and checking for local GPUs), which are documented.

#### PR validation:

Unit tests succeed. Site-specific options have been tested successfully at the appropriate sites.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and not intended to be backported.
