### PR TITLE
[PPS] Run the T2 test with ROOT Raw instead of streamer files [backport of 45144]

### DIFF
--- a/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
+++ b/RecoPPS/Local/test/totemT2NewDigi_reco_cfg.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.pfnInPath import *
 
 process = cms.Process('RECO')
 
@@ -14,13 +15,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
 
-#dummy = cms.untracked.FileInPath('RecoPPS/Local/data/run364983_ls0001_streamA_StorageManager.dat'),
-
-# raw data source
-process.source = cms.Source("NewEventStreamFileReader",
-fileNames = cms.untracked.vstring('http://cmsrep.cern.ch/cmssw/download/data/RecoPPS/Local/V1/run364983_ls0001_streamA_StorageManager.dat'
-#        '/store/group/dpg_ctpps/comm_ctpps/TotemT2/RecoTest/run364983_ls0001_streamA_StorageManager.dat',
-    )
+process.source = cms.Source('PoolSource',
+    fileNames =  cms.untracked.pfnInPaths('RecoPPS/Local/data/run364983_ls0001_raw.root')
 )
 
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

This PR fixes issue https://github.com/cms-sw/cmssw/issues/45101
The original streamer file used for test of T2 unpacker were replaced with ROOT RAW files.
The ROOT Raw files were generated using https://github.com/CTPPS/data2022test/blob/main/streamer-test.py script in rel CMSSW_14_1_0_pre3

#### PR validation:

I checked the unit test with local file, it runs as expected. This PR should run the test on top of https://github.com/cms-data/RecoPPS-Local/pull/2 , as suggested in https://github.com/cms-sw/cmssw/issues/45101#issuecomment-2150096421

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45144