### PR TITLE
Replace enums with static constexpr int in EcalChannelStatus_PayloadInspector.cc

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
@@ -18,9 +18,11 @@
 #include "TLatex.h"
 
 namespace {
-  enum { kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255 };
-  enum { MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360 };  // barrel lower and upper bounds on eta and phi
-  enum { IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100 };         // endcaps lower and upper bounds on x and y
+  static constexpr int kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255;
+  // barrel lower and upper bounds on eta and phi  
+  static constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;
+  // endcaps lower and upper bounds on x and y
+  static constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;
 
   /*******************************************************
         2d plot of ECAL barrel channel status of 1 IOV

--- a/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
@@ -19,7 +19,7 @@
 
 namespace {
   static constexpr int kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255;
-  // barrel lower and upper bounds on eta and phi  
+  // barrel lower and upper bounds on eta and phi
   static constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;
   // endcaps lower and upper bounds on x and y
   static constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;


### PR DESCRIPTION
#### PR description:

Fixes the following warnings:

```
src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc: In member function 'virtual bool {anonymous}::EcalChannelStatusEBMap::fill(const std::vector<std::tuple<long long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)':
  src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc:120:41: warning: arithmetic between floating-point type 'Double_t' {aka 'double'} and enumeration type '{anonymous}::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   120 |       Double_t prop = (Double_t)ebcount / kEBChannels * 100.;
      |                       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc: In member function 'virtual bool {anonymous}::EcalChannelStatusEEMap::fill(const std::vector<std::tuple<long long unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)':
  src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc:255:41: warning: arithmetic between floating-point type 'Double_t' {aka 'double'} and enumeration type '{anonymous}::<unnamed enum>' is deprecated [-Wdeprecated-enum-float-conversion]
   255 |       Double_t prop = (Double_t)eecount / kEEChannels * 100.;
      |                       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```

#### PR validation:

Bot tests