### PR TITLE
Added local web server for Tracer log viewer

### DIFF
--- a/FWCore/Services/web/README.md
+++ b/FWCore/Services/web/README.md
@@ -5,21 +5,16 @@
 ### standard web server
 If the output of `edmTracerCompactLogViewer.py` and the files from `FWCore/Services/web` have been placed in a directory accessible to a web server, you may just point your browser to the correct URL to run the viewer.
 
-### local file
-By default, web browsers are not allowed to read files from the local disk. Many browsers give options to override that default. After overriding the default, make sure the output of `edmTracerCompactLogViewer.py` and the files from `FWCore/Services/web` have been placed in a directory on your local machine. Then tell  your web browser to open the `index.html` file in that directory to start the viewer.
+# My HTTP Server
 
-#### Local files in Chrome
-In order to open a local file using Chrome, you need to
-1. Exit from Chrome
-1. Start Chrome from the terminal using the `--allow-file-access-from-files` argument.
+This is a simple HTTP server implemented in Python using the `http.server` module.
 
-On macOS, within Terminal the command would be
-```
-open -a Google\ Chrome --args --allow-file-access-from-files file://<where ever the directory is>/index.html
-```
+## Usage
 
-#### Local file in Safari
-Local file support in Safari requires access the the Developer menu options. You can turn on those options by going to `Safari/Settings...`, choose the `Advanced` tab and then toggle `Show features for web developers`. Then in the newly added `Developer` tag, toggle `Disable local file restrictions`. Once you've done that, you can use `file://<where ever the directory is>/index.html` to start the application.
+1. Run the server script (`server.py`) using Python.
+2. Access the server in your web browser by navigating to `http://localhost:65432`.
+
+
 
 ## Viewer layout
 The viewer is composed to two main areas, the top is the timing viewer and at the bottom shows information about a selected time block. The top time viewer is further divided into three parts. On the left is the macro scoping grouping of framework activity types into Global and Stream activities. If the _module centric_ option was chosen then this area is also divided by each module activity which is sorted based on most time used to least time used. At the bottom is the measurement of time since the start of the job. The main area shows the blocks of time spend doing various work within the Framework.

--- a/FWCore/Services/web/server.py
+++ b/FWCore/Services/web/server.py
@@ -1,0 +1,39 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import os
+import mimetypes
+
+class Serv(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            self.path = '/index.html'
+        
+        try:
+            file_path = self.path[1:]
+
+            with open(file_path, 'rb') as file:
+                file_to_open = file.read()
+
+            mime_type, _ = mimetypes.guess_type(file_path)
+
+            self.send_response(200)
+            if mime_type:
+                self.send_header("Content-type", mime_type)
+            self.end_headers()
+
+            self.wfile.write(file_to_open)
+        
+        except FileNotFoundError:
+            self.send_response(404)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(bytes("File not found", 'utf-8'))
+        
+        except Exception as e:
+            self.send_response(500)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(bytes(f"Internal server error: {str(e)}", 'utf-8'))
+
+httpd = HTTPServer(('localhost', 65432), Serv)
+print("Server started at http://localhost:65432")
+httpd.serve_forever()


### PR DESCRIPTION
#### PR description:
- Introduced a python based web server that users can use to avoid the web browsers from needing to access the files locally

#### PR validation:

-ran the server locally on a windows machine