### PR TITLE
add GEM pad numbers check before doing coordinate conversion to avoid…

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -84,9 +84,9 @@ process.maxEvents = cms.untracked.PSet(
       input = cms.untracked.int32(options.maxEvents)
 )
 
-process.options = cms.untracked.PSet(
-      SkipEvent = cms.untracked.vstring('ProductNotFound')
-)
+#process.options = cms.untracked.PSet(
+#      SkipEvent = cms.untracked.vstring('ProductNotFound')
+#)
 
 process.source = cms.Source(
       "PoolSource",
@@ -110,7 +110,7 @@ if options.mc:
 else:
       process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')
       if options.run3:
-            process.GlobalTag = GlobalTag(process.GlobalTag, '112X_dataRun3_Prompt_v5', '')
+            process.GlobalTag = GlobalTag(process.GlobalTag, '140X_dataRun3_v3', '')
 
 ## running on unpacked data, or after running the unpacker
 if not options.mc or options.unpack:


### PR DESCRIPTION
… crashing when computing coordinates corresponding to unphysical (>= 192) pads

#### PR description:

Add checks to avoid crashing GEMClusterProcessor when it accesses lookup table values corresponding to unphysical GEM pad numbers (greater than 192). If any unphysical pad numbers are discovered for a cluster being processed, cluster is reset to empty value so that it is skipped by the function doing coordinate conversion.
[unphysical_gem_pads.pdf](https://github.com/user-attachments/files/15789435/unphysical_gem_pads.pdf)


#### PR validation:
Have run local test on /eos/cms/store/group/upgrade/GEMCSC_Trigger_PhaseII/run2024E_381365_test.root vitth the following command line options:

cmsRun L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py run3=True unpack=True l1=True l1GEM=True unpackGEM=True dqm=False dqmGEM=False useB904ME11=False  runCCLUTOTMB=True runME11ILT=True  maxEvents=700 inputFiles="file:/eos/cms/store/group/upgrade/GEMCSC_Trigger_PhaseII/run2024E_381365_test.root"

During the test run program did not crash.

