### PR TITLE
HcalRecHit SoA dataFormat

### DIFF
--- a/DataFormats/HcalRecHit/BuildFile.xml
+++ b/DataFormats/HcalRecHit/BuildFile.xml
@@ -2,6 +2,10 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/HcalDigi"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="!serial"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h
@@ -1,0 +1,13 @@
+#ifndef DataFormats_HcalRecHit_HcalRecHitHostCollection_h
+#define DataFormats_HcalRecHit_HcalRecHitHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitSoA.h"
+
+namespace hcal {
+
+  // HcalRecHitSoA in host memory
+  using RecHitHostCollection = PortableHostCollection<HcalRecHitSoA>;
+}  // namespace hcal
+
+#endif

--- a/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
+++ b/DataFormats/HcalRecHit/interface/HcalRecHitSoA.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_HcalRecHit_HcalRecHitSoA_h
+#define DataFormats_HcalRecHit_HcalRecHitSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+namespace hcal {
+
+  GENERATE_SOA_LAYOUT(HcalRecHitSoALayout,
+                      SOA_SCALAR(uint32_t, size),
+                      SOA_COLUMN(uint32_t, detId),
+                      SOA_COLUMN(float, energy),
+                      SOA_COLUMN(float, chi2),
+                      SOA_COLUMN(float, energyM0),
+                      SOA_COLUMN(float, timeM0))
+
+  using HcalRecHitSoA = HcalRecHitSoALayout<>;
+}  // namespace hcal
+
+#endif

--- a/DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h
+++ b/DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h
@@ -1,0 +1,22 @@
+#ifndef DataFormats_HcalRecHit_alpaka_HcalRecHitDeviceCollection_h
+#define DataFormats_HcalRecHit_alpaka_HcalRecHitDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hcal {
+
+    // make the names from the top-level hcal namespace visible for unqualified lookup
+    // inside the ALPAKA_ACCELERATOR_NAMESPACE::hcal namespace
+    using namespace ::hcal;
+
+    // HcalRecHitSoA in device global memory
+    using RecHitDeviceCollection = PortableCollection<HcalRecHitSoA>;
+  }  // namespace hcal
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif

--- a/DataFormats/HcalRecHit/src/alpaka/classes_cuda.h
+++ b/DataFormats/HcalRecHit/src/alpaka/classes_cuda.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitSoA.h"
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"

--- a/DataFormats/HcalRecHit/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/HcalRecHit/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::hcal::RecHitDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_cuda_async::hcal::RecHitDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_cuda_async::hcal::RecHitDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/HcalRecHit/src/alpaka/classes_rocm.h
+++ b/DataFormats/HcalRecHit/src/alpaka/classes_rocm.h
@@ -1,0 +1,4 @@
+#include "DataFormats/Common/interface/DeviceProduct.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitSoA.h"
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"

--- a/DataFormats/HcalRecHit/src/alpaka/classes_rocm_def.xml
+++ b/DataFormats/HcalRecHit/src/alpaka/classes_rocm_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="alpaka_rocm_async::hcal::RecHitDeviceCollection" persistent="false"/>
+  <class name="edm::DeviceProduct<alpaka_rocm_async::hcal::RecHitDeviceCollection>" persistent="false"/>
+  <class name="edm::Wrapper<edm::DeviceProduct<alpaka_rocm_async::hcal::RecHitDeviceCollection>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/HcalRecHit/src/classes.cc
+++ b/DataFormats/HcalRecHit/src/classes.cc
@@ -1,0 +1,4 @@
+#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollectionReadRules.h"
+
+SET_PORTABLEHOSTCOLLECTION_READ_RULES(hcal::RecHitHostCollection);

--- a/DataFormats/HcalRecHit/src/classes.h
+++ b/DataFormats/HcalRecHit/src/classes.h
@@ -10,6 +10,8 @@
 #include "DataFormats/HcalRecHit/interface/HcalSourcePositionData.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitSoA.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/HcalRecHit/src/classes_def.xml
+++ b/DataFormats/HcalRecHit/src/classes_def.xml
@@ -118,4 +118,9 @@
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit> >,HFRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HFRecHit,edm::StrictWeakOrdering<HFRecHit> >,HFRecHit> > >" />
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HORecHit,edm::StrictWeakOrdering<HORecHit> >,HORecHit> > >" />
   <class name="edm::reftobase::Holder<CaloRecHit,edm::Ref<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HBHERecHit,edm::StrictWeakOrdering<HBHERecHit> >,HBHERecHit> > >" />
-</lcgdict>
+
+  <class name="hcal::HcalRecHitSoA"/>
+  <class name="hcal::HcalRecHitSoA::View"/>
+  <class name="hcal::RecHitHostCollection" />
+  <class name="edm::Wrapper<hcal::RecHitHostCollection>" splitLevel="0"/>
+  </lcgdict>


### PR DESCRIPTION
#### PR description:

A subset of changes from #44910, including only the data format changes for HcalRecHit SoA output.
Since the output data format is stable, this PR allows @jsamudio in parallel to develop for the changes on the PF cluster side to use HcalRecHit SoA as input. 
 
#### PR validation:

See #44910.

