### PR TITLE
Update `edm::bit_cast` [14.0.x]

### DIFF
--- a/FWCore/Utilities/interface/bit_cast.h
+++ b/FWCore/Utilities/interface/bit_cast.h
@@ -18,19 +18,43 @@
 //         Created:  Wed, 01 Sep 2021 19:11:41 GMT
 //
 
+// for compilers that do not support __has_builtin
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 // system include files
 #include <cstring>
+#include <type_traits>
 
-// user include files
+#if __cplusplus >= 202002L
+
+// in C++20 we can use std::bit_cast
+
+#include <bit>
 
 namespace edm {
-  //in C++20 we can use std::bit_cast which is constexpr
-  template <class To, class From>
-  inline To bit_cast(const From &src) noexcept {
+  using std::bit_cast;
+}  // namespace edm
+
+#elif __has_builtin(__builtin_bit_cast)
+
+// before C++20 we can use __builtin_bit_cast, if supported
+
+namespace edm {
+  template <typename To, typename From>
+  constexpr inline To bit_cast(const From &src) noexcept {
+    static_assert(std::is_trivially_copyable_v<From>);
+    static_assert(std::is_trivially_copyable_v<To>);
     static_assert(sizeof(To) == sizeof(From), "incompatible types");
-    To dst;
-    std::memcpy(&dst, &src, sizeof(To));
-    return dst;
+    return __builtin_bit_cast(To, src);
   }
 }  // namespace edm
-#endif
+
+#else
+
+#error constexpr edm::bit_cast is not supported by the compiler
+
+#endif  // __cplusplus >= 202002L
+
+#endif  // FWCore_Utilities_bit_cast_h


### PR DESCRIPTION
#### PR description:

Update `edm::bit_cast` to use `std::bit_cast` in C++20 mode, otherwise fall back to `__builtin_bit_cast` if available.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45166 to 14.0.x for data taking, using the same branch.