### PR TITLE
Explicitly build with O2 to avoid build errors

### DIFF
--- a/Geometry/HGCalCommonData/plugins/BuildFile.xml
+++ b/Geometry/HGCalCommonData/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <library name="GeometryHGCalCommonDataPlugin" file="DD*.cc">
+  <flags CXXFLAGS="-O2" file="DDHGCalPassive.cc"/>
   <use name="DetectorDescription/Core"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
@@ -23,6 +24,7 @@
 </library>
 
 <library name="DD4hep_GeometryHGCalCommonDataPlugins" file="dd4hep/*.cc">
+  <flags CXXFLAGS="-O2" file="DDHGCalPassive.cc"/>
   <use name="DetectorDescription/DDCMS"/>
   <use name="Geometry/HGCalCommonData"/>
   <use name="dd4hep"/>


### PR DESCRIPTION
This should fix the build errors for NONLTO IBs which were first shown when we enabled `-O3`.  This might be relatged to https://rkoucha.fr/tech_corner/nonnull_gcc_attribute.html ( as mentioned [here](https://github.com/pytorch/pytorch/issues/99278#issuecomment-1512027064) ). This change explicitly use `-O2` for the source files which failed to compile using `-O3`. Otherwise option is that we use `-Wno-error=nonnull` which will turn the build error in to warning.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_NONLTO_X_2024-06-11-1100/Geometry/HGCalCommonData
```
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/specfun.h:45,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/cmath:1935,
                 from src/DataFormats/Math/interface/angle_units.h:4,
                 from src/Geometry/HGCalCommonData/plugins/DDHGCalPassive.cc:6:
In static member function 'static _Tp* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(const _Tp*, const _Tp*, _Tp*) [with _Tp = double; bool _IsMove = false]',
    inlined from '_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = const double*; _OI = double*]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_algobase.h:495:30,
    inlined from '_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = const double*; _OI = double*]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_algobase.h:522:42,
    inlined from '_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = const double*; _OI = double*]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_algobase.h:529:31,
    inlined from '_OI std::copy(_II, _II, _OI) [with _II = const double*; _OI = double*]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_algobase.h:620:7,
    inlined from 'void std::vector<_Tp, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const double*; _Tp = double; _Alloc = std::allocator<double>]' at /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/vector.tcc:330:19:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/include/c++/12.3.1/bits/stl_algobase.h:431:30: error: argument 1 null where non-null expected [-Werror=nonnull]
   431 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```