### PR TITLE
StreamSchedule.h: remove unused variable

### DIFF
--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -366,7 +366,6 @@ namespace edm {
     auto const& principal = transitionInfo.principal();
     T::setStreamContext(streamContext_, principal);
 
-    auto id = principal.id();
     ServiceWeakToken weakToken = token;
     auto doneTask = make_waiting_task([this, iHolder = std::move(iHolder), cleaningUpAfterException, weakToken](
                                           std::exception_ptr const* iPtr) mutable {


### PR DESCRIPTION
#### PR description:

Fix error in PR tests:

```
src/FWCore/Framework/interface/StreamSchedule.h:369:10: error: variable 'id' set but not used [-Werror=unused-but-set-variable]
  369 |     auto id = principal.id();
      |          ^~
```

#### PR validation:

Bot tests