### PR TITLE
Including more general DQM compare modules for pixel tracks objects

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHits.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareRecHits.cc
@@ -1,0 +1,263 @@
+// TODO: change file name to SiPixelCompareRecHitsSoA.cc when CUDA code is removed
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsHost.h"
+#include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+// TODO: change class name to SiPixelCompareRecHitsSoA when CUDA code is removed
+template <typename T>
+class SiPixelCompareRecHits : public DQMEDAnalyzer {
+public:
+  using HitsSoA = TrackingRecHitHost<T>;
+
+  explicit SiPixelCompareRecHits(const edm::ParameterSet&);
+  ~SiPixelCompareRecHits() override = default;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  // analyzeSeparate is templated to accept distinct types of SoAs
+  // The default use case is to use rechits from Alpaka reconstructed on CPU and GPU;
+  template <typename U, typename V>
+  void analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  // these two are both on Host but originally they have been produced on Host or on Device
+  const edm::EDGetTokenT<HitsSoA> tokenSoAHitsReference_;
+  const edm::EDGetTokenT<HitsSoA> tokenSoAHitsTarget_;
+  const std::string topFolderName_;
+  const float mind2cut_;
+  static constexpr uint32_t invalidHit_ = std::numeric_limits<uint32_t>::max();
+  static constexpr float micron_ = 10000.;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+  MonitorElement* hnHits_;
+  MonitorElement* hBchargeL_[4];  // max 4 barrel hits
+  MonitorElement* hBsizexL_[4];
+  MonitorElement* hBsizeyL_[4];
+  MonitorElement* hBposxL_[4];
+  MonitorElement* hBposyL_[4];
+  MonitorElement* hFchargeD_[2][12];  // max 12 endcap disks
+  MonitorElement* hFsizexD_[2][12];
+  MonitorElement* hFsizeyD_[2][12];
+  MonitorElement* hFposxD_[2][12];
+  MonitorElement* hFposyD_[2][12];
+  //differences
+  MonitorElement* hBchargeDiff_;
+  MonitorElement* hFchargeDiff_;
+  MonitorElement* hBsizeXDiff_;
+  MonitorElement* hFsizeXDiff_;
+  MonitorElement* hBsizeYDiff_;
+  MonitorElement* hFsizeYDiff_;
+  MonitorElement* hBposXDiff_;
+  MonitorElement* hFposXDiff_;
+  MonitorElement* hBposYDiff_;
+  MonitorElement* hFposYDiff_;
+};
+
+//
+// constructors
+//
+template <typename T>
+SiPixelCompareRecHits<T>::SiPixelCompareRecHits(const edm::ParameterSet& iConfig)
+    : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      tokenSoAHitsReference_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsReferenceSoA"))),
+      tokenSoAHitsTarget_(consumes(iConfig.getParameter<edm::InputTag>("pixelHitsTargetSoA"))),
+      topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
+      mind2cut_(iConfig.getParameter<double>("minD2cut")) {}
+
+//
+// Begin Run
+//
+template <typename T>
+void SiPixelCompareRecHits<T>::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
+}
+
+template <typename T>
+template <typename U, typename V>
+void SiPixelCompareRecHits<T>::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+  const auto& rhsoaHandleRef = iEvent.getHandle(tokenRef);
+  const auto& rhsoaHandleTar = iEvent.getHandle(tokenTar);
+
+  if (not rhsoaHandleRef or not rhsoaHandleTar) {
+    edm::LogWarning out("SiPixelCompareRecHits");
+    if (not rhsoaHandleRef) {
+      out << "reference rechits not found; ";
+    }
+    if (not rhsoaHandleTar) {
+      out << "target rechits not found; ";
+    }
+    out << "the comparison will not run.";
+    return;
+  }
+
+  auto const& rhsoaRef = *rhsoaHandleRef;
+  auto const& rhsoaTar = *rhsoaHandleTar;
+
+  auto const& soa2dRef = rhsoaRef.const_view();
+  auto const& soa2dTar = rhsoaTar.const_view();
+
+  uint32_t nHitsRef = soa2dRef.metadata().size();
+  uint32_t nHitsTar = soa2dTar.metadata().size();
+
+  hnHits_->Fill(nHitsRef, nHitsTar);
+  auto detIds = tkGeom_->detUnitIds();
+  for (uint32_t i = 0; i < nHitsRef; i++) {
+    float minD = mind2cut_;
+    uint32_t matchedHit = invalidHit_;
+    uint16_t indRef = soa2dRef[i].detectorIndex();
+    float xLocalRef = soa2dRef[i].xLocal();
+    float yLocalRef = soa2dRef[i].yLocal();
+    for (uint32_t j = 0; j < nHitsTar; j++) {
+      if (soa2dTar.detectorIndex(j) == indRef) {
+        float dx = xLocalRef - soa2dTar[j].xLocal();
+        float dy = yLocalRef - soa2dTar[j].yLocal();
+        float distance = dx * dx + dy * dy;
+        if (distance < minD) {
+          minD = distance;
+          matchedHit = j;
+        }
+      }
+    }
+    DetId id = detIds[indRef];
+    uint32_t chargeRef = soa2dRef[i].chargeAndStatus().charge;
+    int16_t sizeXRef = std::ceil(float(std::abs(soa2dRef[i].clusterSizeX()) / 8.));
+    int16_t sizeYRef = std::ceil(float(std::abs(soa2dRef[i].clusterSizeY()) / 8.));
+    uint32_t chargeTar = 0;
+    int16_t sizeXTar = -99;
+    int16_t sizeYTar = -99;
+    float xLocalTar = -999.;
+    float yLocalTar = -999.;
+    if (matchedHit != invalidHit_) {
+      chargeTar = soa2dTar[matchedHit].chargeAndStatus().charge;
+      sizeXTar = std::ceil(float(std::abs(soa2dTar[matchedHit].clusterSizeX()) / 8.));
+      sizeYTar = std::ceil(float(std::abs(soa2dTar[matchedHit].clusterSizeY()) / 8.));
+      xLocalTar = soa2dTar[matchedHit].xLocal();
+      yLocalTar = soa2dTar[matchedHit].yLocal();
+    }
+    switch (id.subdetId()) {
+      case PixelSubdetector::PixelBarrel:
+        hBchargeL_[tTopo_->pxbLayer(id) - 1]->Fill(chargeRef, chargeTar);
+        hBsizexL_[tTopo_->pxbLayer(id) - 1]->Fill(sizeXRef, sizeXTar);
+        hBsizeyL_[tTopo_->pxbLayer(id) - 1]->Fill(sizeYRef, sizeYTar);
+        hBposxL_[tTopo_->pxbLayer(id) - 1]->Fill(xLocalRef, xLocalTar);
+        hBposyL_[tTopo_->pxbLayer(id) - 1]->Fill(yLocalRef, yLocalTar);
+        hBchargeDiff_->Fill(chargeRef - chargeTar);
+        hBsizeXDiff_->Fill(sizeXRef - sizeXTar);
+        hBsizeYDiff_->Fill(sizeYRef - sizeYTar);
+        hBposXDiff_->Fill(micron_ * (xLocalRef - xLocalTar));
+        hBposYDiff_->Fill(micron_ * (yLocalRef - yLocalTar));
+        break;
+      case PixelSubdetector::PixelEndcap:
+        hFchargeD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(chargeRef, chargeTar);
+        hFsizexD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeXRef, sizeXTar);
+        hFsizeyD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeYRef, sizeYTar);
+        hFposxD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(xLocalRef, xLocalTar);
+        hFposyD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(yLocalRef, yLocalTar);
+        hFchargeDiff_->Fill(chargeRef - chargeTar);
+        hFsizeXDiff_->Fill(sizeXRef - sizeXTar);
+        hFsizeYDiff_->Fill(sizeYRef - sizeYTar);
+        hFposXDiff_->Fill(micron_ * (xLocalRef - xLocalTar));
+        hFposYDiff_->Fill(micron_ * (yLocalRef - yLocalTar));
+        break;
+    }
+  }
+}
+
+//
+// -- Analyze
+//
+template <typename T>
+void SiPixelCompareRecHits<T>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
+  // The function is left templated if any other cases need to be added
+  analyzeSeparate(tokenSoAHitsReference_, tokenSoAHitsTarget_, iEvent);
+}
+
+//
+// -- Book Histograms
+//
+template <typename T>
+void SiPixelCompareRecHits<T>::bookHistograms(DQMStore::IBooker& iBook,
+                                              edm::Run const& iRun,
+                                              edm::EventSetup const& iSetup) {
+  iBook.cd();
+  iBook.setCurrentFolder(topFolderName_);
+
+  // clang-format off
+  //Global
+  hnHits_ = iBook.book2I("nHits", "ReferencevsTarget RecHits per event;#Reference RecHits;#Target RecHits", 200, 0, 5000,200, 0, 5000);
+  //Barrel Layer
+  for(unsigned int il=0;il<tkGeom_->numberOfLayers(PixelSubdetector::PixelBarrel);il++){
+    hBchargeL_[il] = iBook.book2I(Form("recHitsBLay%dCharge",il+1), Form("ReferencevsTarget RecHits Charge Barrel Layer%d;Reference Charge;Target Charge",il+1), 250, 0, 100000, 250, 0, 100000);
+    hBsizexL_[il] = iBook.book2I(Form("recHitsBLay%dSizex",il+1), Form("ReferencevsTarget RecHits SizeX Barrel Layer%d;Reference SizeX;Target SizeX",il+1), 30, 0, 30, 30, 0, 30);
+    hBsizeyL_[il] = iBook.book2I(Form("recHitsBLay%dSizey",il+1), Form("ReferencevsTarget RecHits SizeY Barrel Layer%d;Reference SizeY;Target SizeY",il+1), 30, 0, 30, 30, 0, 30);
+    hBposxL_[il] = iBook.book2D(Form("recHitsBLay%dPosx",il+1), Form("ReferencevsTarget RecHits x-pos in Barrel Layer%d;Reference pos x;Target pos x",il+1), 200, -5, 5, 200,-5,5);
+    hBposyL_[il] = iBook.book2D(Form("recHitsBLay%dPosy",il+1), Form("ReferencevsTarget RecHits y-pos in Barrel Layer%d;Reference pos y;Target pos y",il+1), 200, -5, 5, 200,-5,5);
+  }
+  //Endcaps
+  //Endcaps Disk
+  for(int is=0;is<2;is++){
+    int sign=is==0? -1:1;
+    for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
+      hFchargeD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("ReferencevsTarget RecHits Charge Endcaps Disk%+d;Reference Charge;Target Charge",id*sign+sign), 250, 0, 100000, 250, 0, 100000);
+      hFsizexD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("ReferencevsTarget RecHits SizeX Endcaps Disk%+d;Reference SizeX;Target SizeX",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFsizeyD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("ReferencevsTarget RecHits SizeY Endcaps Disk%+d;Reference SizeY;Target SizeY",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFposxD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosx",id*sign+sign), Form("ReferencevsTarget RecHits x-pos Endcaps Disk%+d;Reference pos x;Target pos x",id*sign+sign), 200, -5, 5, 200, -5, 5);
+      hFposyD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosy",id*sign+sign), Form("ReferencevsTarget RecHits y-pos Endcaps Disk%+d;Reference pos y;Target pos y",id*sign+sign), 200, -5, 5, 200, -5, 5);
+    }
+  }
+  //1D differences
+  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
+  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (Reference - Target)", 101, -50.5, 50.5);
+  hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (Reference - Target)", 21, -10.5, 10.5);
+  hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (Reference - Target)", 21, -10.5, 10.5);
+  hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (Reference - Target)", 21, -10.5, 10.5);
+  hFsizeYDiff_ = iBook.book1D("rechitsizeYDiffFpix","SizeY difference of rechits in FPix; rechit sizey difference (Reference - Target)", 21, -10.5, 10.5);
+  hBposXDiff_ = iBook.book1D("rechitsposXDiffBpix","x-position difference of rechits in BPix; rechit x-pos difference (Reference - Target)", 1000, -10, 10);
+  hFposXDiff_ = iBook.book1D("rechitsposXDiffFpix","x-position difference of rechits in FPix; rechit x-pos difference (Reference - Target)", 1000, -10, 10);
+  hBposYDiff_ = iBook.book1D("rechitsposYDiffBpix","y-position difference of rechits in BPix; rechit y-pos difference (Reference - Target)", 1000, -10, 10);
+  hFposYDiff_ = iBook.book1D("rechitsposYDiffFpix","y-position difference of rechits in FPix; rechit y-pos difference (Reference - Target)", 1000, -10, 10);
+}
+
+template<typename T>
+void SiPixelCompareRecHits<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // monitorpixelRecHitsSoAAlpaka
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pixelHitsReferenceSoA", edm::InputTag("siPixelRecHitsPreSplittingAlpakaSerial"));
+  desc.add<edm::InputTag>("pixelHitsTargetSoA", edm::InputTag("siPixelRecHitsPreSplittingAlpaka"));
+  desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelRecHitsCompareDeviceVSHost");
+  desc.add<double>("minD2cut", 0.0001);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+using SiPixelPhase1CompareRecHits = SiPixelCompareRecHits<pixelTopology::Phase1>;
+using SiPixelPhase2CompareRecHits = SiPixelCompareRecHits<pixelTopology::Phase2>;
+using SiPixelHIonPhase1CompareRecHits = SiPixelCompareRecHits<pixelTopology::HIonPhase1>;
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+// TODO: change module names to SiPixel*CompareRecHitsSoA when CUDA code is removed
+DEFINE_FWK_MODULE(SiPixelPhase1CompareRecHits);
+DEFINE_FWK_MODULE(SiPixelPhase2CompareRecHits);
+DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareRecHits);
+

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareTracks.cc
@@ -1,0 +1,342 @@
+// TODO: change file name to SiPixelCompareTracksSoA.cc when CUDA code is removed
+
+// -*- C++ -*-
+// Package:    SiPixelCompareTracks
+// Class:      SiPixelCompareTracks
+//
+/**\class SiPixelCompareTracks SiPixelCompareTracks.cc
+*/
+//
+// Author: Suvankar Roy Chowdhury
+//
+
+// for string manipulations
+#include <fmt/printf.h>
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+// DQM Histograming
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+// DataFormats
+#include "DataFormats/TrackSoA/interface/TracksHost.h"
+#include "DataFormats/TrackSoA/interface/alpaka/TrackUtilities.h"
+
+namespace {
+  // same logic used for the MTV:
+  // cf https://github.com/cms-sw/cmssw/blob/master/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+  typedef dqm::reco::DQMStore DQMStore;
+
+  void setBinLog(TAxis* axis) {
+    int bins = axis->GetNbins();
+    float from = axis->GetXmin();
+    float to = axis->GetXmax();
+    float width = (to - from) / bins;
+    std::vector<float> new_bins(bins + 1, 0);
+    for (int i = 0; i <= bins; i++) {
+      new_bins[i] = TMath::Power(10, from + i * width);
+    }
+    axis->Set(bins, new_bins.data());
+  }
+
+  void setBinLogX(TH1* h) {
+    TAxis* axis = h->GetXaxis();
+    setBinLog(axis);
+  }
+  void setBinLogY(TH1* h) {
+    TAxis* axis = h->GetYaxis();
+    setBinLog(axis);
+  }
+
+  template <typename... Args>
+  dqm::reco::MonitorElement* make2DIfLog(DQMStore::IBooker& ibook, bool logx, bool logy, Args&&... args) {
+    auto h = std::make_unique<TH2I>(std::forward<Args>(args)...);
+    if (logx)
+      setBinLogX(h.get());
+    if (logy)
+      setBinLogY(h.get());
+    const auto& name = h->GetName();
+    return ibook.book2I(name, h.release());
+  }
+}  // namespace
+
+// TODO: change class name to SiPixelCompareTracksSoA when CUDA code is removed
+template <typename T>
+class SiPixelCompareTracks : public DQMEDAnalyzer {
+public:
+  using PixelTrackSoA = TracksHost<T>;
+
+  explicit SiPixelCompareTracks(const edm::ParameterSet&);
+  ~SiPixelCompareTracks() override = default;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  // analyzeSeparate is templated to accept distinct types of SoAs
+  // The default use case is to use tracks from Alpaka reconstructed on CPU and GPU;
+  template <typename U, typename V>
+  void analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // these two are both on Host but originally they have been produced on Host or on Device
+  const edm::EDGetTokenT<PixelTrackSoA> tokenSoATrackReference_;
+  const edm::EDGetTokenT<PixelTrackSoA> tokenSoATrackTarget_;
+  const std::string topFolderName_;
+  const bool useQualityCut_;
+  const pixelTrack::Quality minQuality_;
+  const float dr2cut_;
+  MonitorElement* hnTracks_;
+  MonitorElement* hnLooseAndAboveTracks_;
+  MonitorElement* hnLooseAndAboveTracks_matched_;
+  MonitorElement* hnHits_;
+  MonitorElement* hnHitsVsPhi_;
+  MonitorElement* hnHitsVsEta_;
+  MonitorElement* hnLayers_;
+  MonitorElement* hnLayersVsPhi_;
+  MonitorElement* hnLayersVsEta_;
+  MonitorElement* hCharge_;
+  MonitorElement* hchi2_;
+  MonitorElement* hChi2VsPhi_;
+  MonitorElement* hChi2VsEta_;
+  MonitorElement* hpt_;
+  MonitorElement* hptLogLog_;
+  MonitorElement* heta_;
+  MonitorElement* hphi_;
+  MonitorElement* hz_;
+  MonitorElement* htip_;
+  MonitorElement* hquality_;
+  //1D differences
+  MonitorElement* hptdiffMatched_;
+  MonitorElement* hCurvdiffMatched_;
+  MonitorElement* hetadiffMatched_;
+  MonitorElement* hphidiffMatched_;
+  MonitorElement* hzdiffMatched_;
+  MonitorElement* htipdiffMatched_;
+
+  //for matching eff vs region: derive the ratio at harvesting
+  MonitorElement* hpt_eta_tkAllRef_;
+  MonitorElement* hpt_eta_tkAllRefMatched_;
+  MonitorElement* hphi_z_tkAllRef_;
+  MonitorElement* hphi_z_tkAllRefMatched_;
+};
+
+//
+// constructors
+//
+
+template <typename T>
+SiPixelCompareTracks<T>::SiPixelCompareTracks(const edm::ParameterSet& iConfig)
+    : tokenSoATrackReference_(consumes<PixelTrackSoA>(iConfig.getParameter<edm::InputTag>("pixelTrackReferenceSoA"))),
+      tokenSoATrackTarget_(consumes<PixelTrackSoA>(iConfig.getParameter<edm::InputTag>("pixelTrackTargetSoA"))),
+      topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
+      useQualityCut_(iConfig.getParameter<bool>("useQualityCut")),
+      minQuality_(pixelTrack::qualityByName(iConfig.getParameter<std::string>("minQuality"))),
+      dr2cut_(iConfig.getParameter<double>("deltaR2cut")) {}
+
+template <typename T>
+template <typename U, typename V>
+void SiPixelCompareTracks<T>::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+  using helper = TracksUtilities<T>;
+
+  const auto& tsoaHandleRef = iEvent.getHandle(tokenRef);
+  const auto& tsoaHandleTar = iEvent.getHandle(tokenTar);
+
+  if (not tsoaHandleRef or not tsoaHandleTar) {
+    edm::LogWarning out("SiPixelCompareTracks");
+    if (not tsoaHandleRef) {
+      out << "reference tracks not found; ";
+    }
+    if (not tsoaHandleTar) {
+      out << "target tracks not found; ";
+    }
+    out << "the comparison will not run.";
+    return;
+  }
+
+  auto const& tsoaRef = *tsoaHandleRef;
+  auto const& tsoaTar = *tsoaHandleTar;
+
+  auto maxTracksRef = tsoaRef.view().metadata().size();  //this should be same for both?
+  auto maxTracksTar = tsoaTar.view().metadata().size();  //this should be same for both?
+
+  auto const* qualityRef = tsoaRef.view().quality();
+  auto const* qualityTar = tsoaTar.view().quality();
+
+  int32_t nTracksRef = 0;
+  int32_t nTracksTar = 0;
+  int32_t nLooseAndAboveTracksRef = 0;
+  int32_t nLooseAndAboveTracksRef_matchedTar = 0;
+  int32_t nLooseAndAboveTracksTar = 0;
+
+  //Loop over Tar tracks and store the indices of the loose tracks. Whats happens if useQualityCut_ is false?
+  std::vector<int32_t> looseTrkidxTar;
+  for (int32_t jt = 0; jt < maxTracksTar; ++jt) {
+    if (helper::nHits(tsoaTar.view(), jt) == 0)
+      break;  // this is a guard
+    if (!(tsoaTar.view()[jt].pt() > 0.))
+      continue;
+    nTracksTar++;
+    if (useQualityCut_ && qualityTar[jt] < minQuality_)
+      continue;
+    nLooseAndAboveTracksTar++;
+    looseTrkidxTar.emplace_back(jt);
+  }
+
+  //Now loop over Ref tracks//nested loop for loose gPU tracks
+  for (int32_t it = 0; it < maxTracksRef; ++it) {
+    int nHitsRef = helper::nHits(tsoaRef.view(), it);
+
+    if (nHitsRef == 0)
+      break;  // this is a guard
+
+    float ptRef = tsoaRef.view()[it].pt();
+    float etaRef = tsoaRef.view()[it].eta();
+    float phiRef = reco::phi(tsoaRef.view(), it);
+    float zipRef = reco::zip(tsoaRef.view(), it);
+    float tipRef = reco::tip(tsoaRef.view(), it);
+
+    if (!(ptRef > 0.))
+      continue;
+    nTracksRef++;
+    if (useQualityCut_ && qualityRef[it] < minQuality_)
+      continue;
+    nLooseAndAboveTracksRef++;
+    //Now loop over loose Tar trk and find the closest in DeltaR//do we need pt cut?
+    const int32_t notFound = -1;
+    int32_t closestTkidx = notFound;
+    float mindr2 = dr2cut_;
+
+    for (auto gid : looseTrkidxTar) {
+      float etaTar = tsoaTar.view()[gid].eta();
+      float phiTar = reco::phi(tsoaTar.view(), gid);
+      float dr2 = reco::deltaR2(etaRef, phiRef, etaTar, phiTar);
+      if (dr2 > dr2cut_)
+        continue;  // this is arbitrary
+      if (mindr2 > dr2) {
+        mindr2 = dr2;
+        closestTkidx = gid;
+      }
+    }
+
+    hpt_eta_tkAllRef_->Fill(etaRef, ptRef);  //all Ref tk
+    hphi_z_tkAllRef_->Fill(phiRef, zipRef);
+    if (closestTkidx == notFound)
+      continue;
+    nLooseAndAboveTracksRef_matchedTar++;
+
+    hchi2_->Fill(tsoaRef.view()[it].chi2(), tsoaTar.view()[closestTkidx].chi2());
+    hCharge_->Fill(reco::charge(tsoaRef.view(), it), reco::charge(tsoaTar.view(), closestTkidx));
+    hnHits_->Fill(helper::nHits(tsoaRef.view(), it), helper::nHits(tsoaTar.view(), closestTkidx));
+    hnLayers_->Fill(tsoaRef.view()[it].nLayers(), tsoaTar.view()[closestTkidx].nLayers());
+    hpt_->Fill(ptRef, tsoaTar.view()[closestTkidx].pt());
+    hptLogLog_->Fill(ptRef, tsoaTar.view()[closestTkidx].pt());
+    heta_->Fill(etaRef, tsoaTar.view()[closestTkidx].eta());
+    hphi_->Fill(phiRef, reco::phi(tsoaTar.view(), closestTkidx));
+    hz_->Fill(zipRef, reco::zip(tsoaTar.view(), closestTkidx));
+    htip_->Fill(tipRef, reco::tip(tsoaTar.view(), closestTkidx));
+    hptdiffMatched_->Fill(ptRef - tsoaTar.view()[closestTkidx].pt());
+    hCurvdiffMatched_->Fill((reco::charge(tsoaRef.view(), it) / tsoaRef.view()[it].pt()) -
+                            (reco::charge(tsoaTar.view(), closestTkidx) / tsoaTar.view()[closestTkidx].pt()));
+    hetadiffMatched_->Fill(etaRef - tsoaTar.view()[closestTkidx].eta());
+    hphidiffMatched_->Fill(reco::deltaPhi(phiRef, reco::phi(tsoaTar.view(), closestTkidx)));
+    hzdiffMatched_->Fill(zipRef - reco::zip(tsoaTar.view(), closestTkidx));
+    htipdiffMatched_->Fill(tipRef - reco::tip(tsoaTar.view(), closestTkidx));
+    hpt_eta_tkAllRefMatched_->Fill(etaRef, tsoaRef.view()[it].pt());  //matched to gpu
+    hphi_z_tkAllRefMatched_->Fill(etaRef, zipRef);
+  }
+  hnTracks_->Fill(nTracksRef, nTracksTar);
+  hnLooseAndAboveTracks_->Fill(nLooseAndAboveTracksRef, nLooseAndAboveTracksTar);
+  hnLooseAndAboveTracks_matched_->Fill(nLooseAndAboveTracksRef, nLooseAndAboveTracksRef_matchedTar);
+}
+
+//
+// -- Analyze
+//
+template <typename T>
+void SiPixelCompareTracks<T>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
+  // The function is left templated if any other cases need to be added
+  analyzeSeparate(tokenSoATrackReference_, tokenSoATrackTarget_, iEvent);
+}
+
+//
+// -- Book Histograms
+//
+template <typename T>
+void SiPixelCompareTracks<T>::bookHistograms(DQMStore::IBooker& iBook,
+                                             edm::Run const& iRun,
+                                             edm::EventSetup const& iSetup) {
+  iBook.cd();
+  iBook.setCurrentFolder(topFolderName_);
+
+  // clang-format off
+  std::string toRep = "Number of tracks";
+  // FIXME: all the 2D correlation plots are quite heavy in terms of memory consumption, so a as soon as DQM supports THnSparse
+  // these should be moved to a less resource consuming format
+  hnTracks_ = iBook.book2I("nTracks", fmt::sprintf("%s per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
+  hnLooseAndAboveTracks_ = iBook.book2I("nLooseAndAboveTracks", fmt::sprintf("%s (quality #geq loose) per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
+  hnLooseAndAboveTracks_matched_ = iBook.book2I("nLooseAndAboveTracks_matched", fmt::sprintf("%s (quality #geq loose) per event; Reference; Target",toRep), 501, -0.5, 500.5, 501, -0.5, 500.5);
+
+  toRep = "Number of all RecHits per track (quality #geq loose)";
+  hnHits_ = iBook.book2I("nRecHits", fmt::sprintf("%s;Reference;Target",toRep), 15, -0.5, 14.5, 15, -0.5, 14.5);
+
+  toRep = "Number of all layers per track (quality #geq loose)";
+  hnLayers_ = iBook.book2I("nLayers", fmt::sprintf("%s;Reference;Target",toRep), 15, -0.5, 14.5, 15, -0.5, 14.5);
+
+  toRep = "Track (quality #geq loose) #chi^{2}/ndof";
+  hchi2_ = iBook.book2I("nChi2ndof", fmt::sprintf("%s;Reference;Target",toRep), 40, 0., 20., 40, 0., 20.);
+
+  toRep = "Track (quality #geq loose) charge";
+  hCharge_ = iBook.book2I("charge",fmt::sprintf("%s;Reference;Target",toRep),3, -1.5, 1.5, 3, -1.5, 1.5);
+
+  hpt_ = iBook.book2I("pt", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, 0., 200., 200, 0., 200.);
+  hptLogLog_ = make2DIfLog(iBook, true, true, "ptLogLog", "Track (quality #geq loose) p_{T} [GeV];Reference;Target", 200, log10(0.5), log10(200.), 200, log10(0.5), log10(200.));
+  heta_ = iBook.book2I("eta", "Track (quality #geq loose) #eta;Reference;Target", 30, -3., 3., 30, -3., 3.);
+  hphi_ = iBook.book2I("phi", "Track (quality #geq loose) #phi;Reference;Target", 30, -M_PI, M_PI, 30, -M_PI, M_PI);
+  hz_ = iBook.book2I("z", "Track (quality #geq loose) z [cm];Reference;Target", 30, -30., 30., 30, -30., 30.);
+  htip_ = iBook.book2I("tip", "Track (quality #geq loose) TIP [cm];Reference;Target", 100, -0.5, 0.5, 100, -0.5, 0.5);
+  //1D difference plots
+  hptdiffMatched_ = iBook.book1D("ptdiffmatched", " p_{T} diff [GeV] between matched tracks; #Delta p_{T} [GeV]", 60, -30., 30.);
+  hCurvdiffMatched_ = iBook.book1D("curvdiffmatched", "q/p_{T} diff [GeV] between matched tracks; #Delta q/p_{T} [GeV]", 60, -30., 30.);
+  hetadiffMatched_ = iBook.book1D("etadiffmatched", " #eta diff between matched tracks; #Delta #eta", 160, -0.04 ,0.04);
+  hphidiffMatched_ = iBook.book1D("phidiffmatched", " #phi diff between matched tracks; #Delta #phi",  160, -0.04 ,0.04);
+  hzdiffMatched_ = iBook.book1D("zdiffmatched", " z diff between matched tracks; #Delta z [cm]", 300, -1.5, 1.5);
+  htipdiffMatched_ = iBook.book1D("tipdiffmatched", " TIP diff between matched tracks; #Delta TIP [cm]", 300, -1.5, 1.5);
+  //2D plots for eff
+  hpt_eta_tkAllRef_ = iBook.book2I("ptetatrkAllReference", "Track (quality #geq loose) on Reference; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
+  hpt_eta_tkAllRefMatched_ = iBook.book2I("ptetatrkAllReferencematched", "Track (quality #geq loose) on Reference matched to Target track; #eta; p_{T} [GeV];", 30, -M_PI, M_PI, 200, 0., 200.);
+
+  hphi_z_tkAllRef_ = iBook.book2I("phiztrkAllReference", "Track (quality #geq loose) on Reference; #phi; z [cm];",  30, -M_PI, M_PI, 30, -30., 30.);
+  hphi_z_tkAllRefMatched_ = iBook.book2I("phiztrkAllReferencematched", "Track (quality #geq loose) on Reference; #phi; z [cm];", 30, -M_PI, M_PI, 30, -30., 30.);
+
+}
+
+template<typename T>
+void SiPixelCompareTracks<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // monitorpixelTrackSoA
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pixelTrackReferenceSoA", edm::InputTag("pixelTracksAlpakaSerial"));
+  desc.add<edm::InputTag>("pixelTrackTargetSoA", edm::InputTag("pixelTracksAlpaka"));
+  desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelTrackCompareDeviceVSHost");
+  desc.add<bool>("useQualityCut", true);
+  desc.add<std::string>("minQuality", "loose");
+  desc.add<double>("deltaR2cut", 0.04);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// TODO: change module names to SiPixel*CompareTracksSoA when CUDA code is removed
+
+using SiPixelPhase1CompareTracks = SiPixelCompareTracks<pixelTopology::Phase1>;
+using SiPixelPhase2CompareTracks = SiPixelCompareTracks<pixelTopology::Phase2>;
+using SiPixelHIonPhase1CompareTracks = SiPixelCompareTracks<pixelTopology::HIonPhase1>;
+
+DEFINE_FWK_MODULE(SiPixelPhase1CompareTracks);
+DEFINE_FWK_MODULE(SiPixelPhase2CompareTracks);
+DEFINE_FWK_MODULE(SiPixelHIonPhase1CompareTracks);
+

--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVertices.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelCompareVertices.cc
@@ -1,0 +1,204 @@
+// TODO: change file name to SiPixelCompareVerticesSoA.cc when CUDA code is removed
+
+// -*- C++ -*-
+// Package:    SiPixelCompareVertices
+// Class:      SiPixelCompareVertices
+//
+/**\class SiPixelCompareVertices SiPixelCompareVertices.cc
+*/
+//
+// Author: Suvankar Roy Chowdhury
+//
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+// DQM Histograming
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/VertexSoA/interface/ZVertexHost.h"
+#include "CUDADataFormats/Vertex/interface/ZVertexSoAHeterogeneousHost.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+// TODO: change class name to SiPixelCompareVerticesSoA when CUDA code is removed
+class SiPixelCompareVertices : public DQMEDAnalyzer {
+public:
+  using IndToEdm = std::vector<uint16_t>;
+  explicit SiPixelCompareVertices(const edm::ParameterSet&);
+  ~SiPixelCompareVertices() override = default;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  // analyzeSeparate is templated to accept distinct types of SoAs
+  // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
+  template <typename U, typename V>
+  void analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  // these two are both on Host but originally they have been produced on Host or on Device
+  const edm::EDGetTokenT<ZVertexHost> tokenSoAVertexReferenceSoA_;
+  const edm::EDGetTokenT<ZVertexHost> tokenSoAVertexTargetSoA_;
+  const edm::EDGetTokenT<reco::BeamSpot> tokenBeamSpot_;
+  const std::string topFolderName_;
+  const float dzCut_;
+  MonitorElement* hnVertex_;
+  MonitorElement* hx_;
+  MonitorElement* hy_;
+  MonitorElement* hz_;
+  MonitorElement* hchi2_;
+  MonitorElement* hchi2oNdof_;
+  MonitorElement* hptv2_;
+  MonitorElement* hntrks_;
+  MonitorElement* hxdiff_;
+  MonitorElement* hydiff_;
+  MonitorElement* hzdiff_;
+};
+
+//
+// constructors
+//
+
+SiPixelCompareVertices::SiPixelCompareVertices(const edm::ParameterSet& iConfig)
+    : tokenSoAVertexReferenceSoA_(
+          consumes<ZVertexHost>(iConfig.getParameter<edm::InputTag>("pixelVertexReferenceSoA"))),
+      tokenSoAVertexTargetSoA_(consumes<ZVertexHost>(iConfig.getParameter<edm::InputTag>("pixelVertexTargetSoA"))),
+      tokenBeamSpot_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
+      topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
+      dzCut_(iConfig.getParameter<double>("dzCut")) {}
+
+template <typename U, typename V>
+void SiPixelCompareVertices::analyzeSeparate(U tokenRef, V tokenTar, const edm::Event& iEvent) {
+  const auto& vsoaHandleRef = iEvent.getHandle(tokenRef);
+  const auto& vsoaHandleTar = iEvent.getHandle(tokenTar);
+
+  if (not vsoaHandleRef or not vsoaHandleTar) {
+    edm::LogWarning out("SiPixelCompareVertices");
+    if (not vsoaHandleRef) {
+      out << "reference vertices not found; ";
+    }
+    if (not vsoaHandleTar) {
+      out << "Refget vertices not found; ";
+    }
+    out << "the comparison will not run.";
+    return;
+  }
+
+  auto const& vsoaRef = *vsoaHandleRef;
+  int nVerticesRef = vsoaRef.view().nvFinal();
+  auto const& vsoaTar = *vsoaHandleTar;
+  int nVerticesTar = vsoaTar.view().nvFinal();
+
+  auto bsHandle = iEvent.getHandle(tokenBeamSpot_);
+  float x0 = 0., y0 = 0., z0 = 0., dxdz = 0., dydz = 0.;
+  if (!bsHandle.isValid()) {
+    edm::LogWarning("SiPixelCompareVertices") << "No beamspot found. returning vertexes with (0,0,Z) ";
+  } else {
+    const reco::BeamSpot& bs = *bsHandle;
+    x0 = bs.x0();
+    y0 = bs.y0();
+    z0 = bs.z0();
+    dxdz = bs.dxdz();
+    dydz = bs.dydz();
+  }
+
+  for (int ivc = 0; ivc < nVerticesRef; ivc++) {
+    auto sic = vsoaRef.view()[ivc].sortInd();
+    auto zc = vsoaRef.view()[sic].zv();
+    auto xc = x0 + dxdz * zc;
+    auto yc = y0 + dydz * zc;
+    zc += z0;
+
+    auto ndofRef = vsoaRef.view()[sic].ndof();
+    auto chi2Ref = vsoaRef.view()[sic].chi2();
+
+    const int32_t notFound = -1;
+    int32_t closestVtxidx = notFound;
+    float mindz = dzCut_;
+
+    for (int ivg = 0; ivg < nVerticesTar; ivg++) {
+      auto sig = vsoaTar.view()[ivg].sortInd();
+      auto zgc = vsoaTar.view()[sig].zv() + z0;
+      auto zDist = std::abs(zc - zgc);
+      //insert some matching condition
+      if (zDist > dzCut_)
+        continue;
+      if (mindz > zDist) {
+        mindz = zDist;
+        closestVtxidx = sig;
+      }
+    }
+    if (closestVtxidx == notFound)
+      continue;
+
+    auto zg = vsoaTar.view()[closestVtxidx].zv();
+    auto xg = x0 + dxdz * zg;
+    auto yg = y0 + dydz * zg;
+    zg += z0;
+    auto ndofTar = vsoaTar.view()[closestVtxidx].ndof();
+    auto chi2Tar = vsoaTar.view()[closestVtxidx].chi2();
+
+    hx_->Fill(xc - x0, xg - x0);
+    hy_->Fill(yc - y0, yg - y0);
+    hz_->Fill(zc, zg);
+    hxdiff_->Fill(xc - xg);
+    hydiff_->Fill(yc - yg);
+    hzdiff_->Fill(zc - zg);
+    hchi2_->Fill(chi2Ref, chi2Tar);
+    hchi2oNdof_->Fill(chi2Ref / ndofRef, chi2Tar / ndofTar);
+    hptv2_->Fill(vsoaRef.view()[sic].ptv2(), vsoaTar.view()[closestVtxidx].ptv2());
+    hntrks_->Fill(ndofRef + 1, ndofTar + 1);
+  }
+  hnVertex_->Fill(nVerticesRef, nVerticesTar);
+}
+
+//
+// -- Analyze
+//
+void SiPixelCompareVertices::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // The default use case is to use vertices from Alpaka reconstructed on CPU and GPU;
+  // The function is left templated if any other cases need to be added
+  analyzeSeparate(tokenSoAVertexReferenceSoA_, tokenSoAVertexTargetSoA_, iEvent);
+}
+
+//
+// -- Book Histograms
+//
+void SiPixelCompareVertices::bookHistograms(DQMStore::IBooker& ibooker,
+                                            edm::Run const& iRun,
+                                            edm::EventSetup const& iSetup) {
+  ibooker.cd();
+  ibooker.setCurrentFolder(topFolderName_);
+
+  // FIXME: all the 2D correlation plots are quite heavy in terms of memory consumption, so a as soon as DQM supports either TH2I or THnSparse
+  // these should be moved to a less resource consuming format
+  hnVertex_ = ibooker.book2I("nVertex", "# of Vertices;Reference;Target", 101, -0.5, 100.5, 101, -0.5, 100.5);
+  hx_ = ibooker.book2I("vx", "Vertez x - Beamspot x;Reference;Target", 50, -0.1, 0.1, 50, -0.1, 0.1);
+  hy_ = ibooker.book2I("vy", "Vertez y - Beamspot y;Reference;Target", 50, -0.1, 0.1, 50, -0.1, 0.1);
+  hz_ = ibooker.book2I("vz", "Vertez z;Reference;Target", 30, -30., 30., 30, -30., 30.);
+  hchi2_ = ibooker.book2I("chi2", "Vertex chi-squared;Reference;Target", 40, 0., 20., 40, 0., 20.);
+  hchi2oNdof_ = ibooker.book2I("chi2oNdof", "Vertex chi-squared/Ndof;Reference;Target", 40, 0., 20., 40, 0., 20.);
+  hptv2_ = ibooker.book2I("ptsq", "Vertex #sum (p_{T})^{2};Reference;Target", 200, 0., 200., 200, 0., 200.);
+  hntrks_ = ibooker.book2I("ntrk", "#tracks associated;Reference;Target", 100, -0.5, 99.5, 100, -0.5, 99.5);
+  hntrks_ = ibooker.book2I("ntrk", "#tracks associated;Reference;Target", 100, -0.5, 99.5, 100, -0.5, 99.5);
+  hxdiff_ = ibooker.book1D("vxdiff", ";Vertex x difference (Reference - Target);#entries", 100, -0.001, 0.001);
+  hydiff_ = ibooker.book1D("vydiff", ";Vertex y difference (Reference - Target);#entries", 100, -0.001, 0.001);
+  hzdiff_ = ibooker.book1D("vzdiff", ";Vertex z difference (Reference - Target);#entries", 100, -2.5, 2.5);
+}
+
+void SiPixelCompareVertices::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // monitorpixelVertexSoA
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pixelVertexReferenceSoA", edm::InputTag("pixelVerticesAlpakaSerial"));
+  desc.add<edm::InputTag>("pixelVertexTargetSoA", edm::InputTag("pixelVerticesAlpaka"));
+  desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
+  desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelVertexCompareSoADeviceVSHost");
+  desc.add<double>("dzCut", 1.);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// TODO: change module name to SiPixelCompareVerticesSoA when CUDA code is removed
+DEFINE_FWK_MODULE(SiPixelCompareVertices);

--- a/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelHeterogeneous/python/SiPixelHeterogenousDQM_FirstStep_cff.py
@@ -49,13 +49,13 @@ from DQM.SiPixelHeterogeneous.siPixelCompareVertexSoA_cfi import *
 from DQM.SiPixelHeterogeneous.siPixelPhase1RawDataErrorComparator_cfi import *
 from DQM.SiPixelPhase1Common.SiPixelPhase1RawData_cfi import *
 #Alpaka
-from DQM.SiPixelHeterogeneous.siPixelPhase1CompareRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2CompareRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareRecHitsSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase1CompareTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelPhase2CompareTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareTrackSoAAlpaka_cfi import *
-from DQM.SiPixelHeterogeneous.siPixelCompareVertexSoAAlpaka_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase1CompareRecHits_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase2CompareRecHits_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareRecHits_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase1CompareTracks_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelPhase2CompareTracks_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelHIonPhase1CompareTracks_cfi import *
+from DQM.SiPixelHeterogeneous.siPixelCompareVertices_cfi import *
 
 # digi errors
 SiPixelPhase1RawDataConfForCPU = copy.deepcopy(SiPixelPhase1RawDataConf)
@@ -151,6 +151,31 @@ siPixelMonitorVertexSoAGPU = siPixelMonitorVertexSoA.clone(
 
 ### Alpaka
 
+# digi errors
+SiPixelPhase1RawDataConfForSerial = copy.deepcopy(SiPixelPhase1RawDataConf)
+for pset in SiPixelPhase1RawDataConfForSerial:
+    pset.topFolderName =  "SiPixelHeterogeneous/PixelErrorsCPU"
+
+siPixelPhase1MonitorRawDataASerial = SiPixelPhase1RawDataAnalyzer.clone(
+    src = "siPixelDigiErrorsAlpakaSerial",
+    histograms = SiPixelPhase1RawDataConfForSerial
+)
+
+SiPixelPhase1RawDataConfForDevice = copy.deepcopy(SiPixelPhase1RawDataConf)
+for pset in SiPixelPhase1RawDataConfForDevice:
+    pset.topFolderName =  "SiPixelHeterogeneous/PixelErrorsGPU"
+
+siPixelPhase1MonitorRawDataADevice = SiPixelPhase1RawDataAnalyzer.clone(
+    src = "siPixelDigiErrorsAlpaka",
+    histograms = SiPixelPhase1RawDataConfForDevice
+)
+
+siPixelPhase1CompareDigiErrorsSoAAlpaka = siPixelPhase1RawDataErrorComparator.clone(
+    pixelErrorSrcGPU = cms.InputTag("siPixelDigiErrorsAlpaka"),
+    pixelErrorSrcCPU = cms.InputTag("siPixelDigiErrorsAlpakaSerial"),
+    topFolderName = cms.string('SiPixelHeterogeneous/PixelErrorCompareGPUvsCPU')
+)
+
 # PixelRecHits: monitor of CPUSerial product (Alpaka backend: 'serial_sync')
 siPixelRecHitsSoAMonitorSerial = siPixelPhase1MonitorRecHitsSoAAlpaka.clone(
     pixelHitsSrc = cms.InputTag( 'siPixelRecHitsPreSplittingAlpakaSerial' ),
@@ -201,15 +226,18 @@ monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRawDataACPU *
                                             siPixelPhase1RawDataErrorComparator)
 # and the Alpaka version
 monitorpixelSoACompareSourceAlpaka = cms.Sequence(
+                                            siPixelPhase1MonitorRawDataASerial *
+                                            siPixelPhase1MonitorRawDataADevice *
+                                            siPixelPhase1CompareDigiErrorsSoAAlpaka *
                                             siPixelRecHitsSoAMonitorSerial *
                                             siPixelRecHitsSoAMonitorDevice *
-                                            siPixelPhase1CompareRecHitsSoAAlpaka *
+                                            siPixelPhase1CompareRecHits *
                                             siPixelTrackSoAMonitorSerial *
                                             siPixelTrackSoAMonitorDevice *
-                                            siPixelPhase1CompareTrackSoAAlpaka *
+                                            siPixelPhase1CompareTracks *
                                             siPixelVertexSoAMonitorSerial *
                                             siPixelVertexSoAMonitorDevice *
-                                            siPixelCompareVertexSoAAlpaka )
+                                            siPixelCompareVertices )
 
 # Phase-2 sequence
 _monitorpixelSoACompareSource =  cms.Sequence(siPixelPhase2MonitorRecHitsSoACPU *

--- a/DataFormats/TrackSoA/src/classes_def.xml
+++ b/DataFormats/TrackSoA/src/classes_def.xml
@@ -5,9 +5,7 @@
   <class name="reco::TrackSoAView<pixelTopology::Phase1>"/>
 
   <class name="PortableHostCollection<reco::TrackLayout<pixelTopology::Phase1>>"/>
-  <class name="pixelTrack::TracksHostPhase1" ClassVersion="3">
-    <version ClassVersion="3" checksum="794224446"/>
-  </class>
+  <class name="pixelTrack::TracksHostPhase1"/>
   <class name="edm::Wrapper<pixelTrack::TracksHostPhase1>" splitLevel="0"/>
 
   <class name="reco::TrackSoA<pixelTopology::Phase2>"/>
@@ -16,9 +14,7 @@
   <class name="reco::TrackSoAView<pixelTopology::Phase2>"/>
 
   <class name="PortableHostCollection<reco::TrackLayout<pixelTopology::Phase2>>"/>
-  <class name="pixelTrack::TracksHostPhase2" ClassVersion="3">
-    <version ClassVersion="3" checksum="3813159454"/>
-  </class>
+  <class name="pixelTrack::TracksHostPhase2"/>
   <class name="edm::Wrapper<pixelTrack::TracksHostPhase2>" splitLevel="0"/>
 
   <class name="reco::TrackSoA<pixelTopology::HIonPhase1>"/>
@@ -27,8 +23,6 @@
   <class name="reco::TrackSoAView<pixelTopology::HIonPhase1>"/>
 
   <class name="PortableHostCollection<reco::TrackLayout<pixelTopology::HIonPhase1>>"/>
-  <class name="pixelTrack::TracksHostHIonPhase1" ClassVersion="3">
-    <version ClassVersion="3" checksum="3935456462"/>
-  </class>
+  <class name="pixelTrack::TracksHostHIonPhase1"/>
   <class name="edm::Wrapper<pixelTrack::TracksHostHIonPhase1>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/TrackingRecHitSoA/src/classes_def.xml
+++ b/DataFormats/TrackingRecHitSoA/src/classes_def.xml
@@ -5,9 +5,7 @@
   <class name="TrackingRecHitSoAView<pixelTopology::Phase1>"/>
 
   <class name="PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase1>>"/>
-  <class name="TrackingRecHitHostPhase1" ClassVersion="3">
-    <version ClassVersion="3" checksum="3242244550"/>
-  </class>
+  <class name="TrackingRecHitHostPhase1"/>
   <class name="edm::Wrapper<TrackingRecHitHostPhase1>" splitLevel="0"/>
 
   <class name="TrackingRecHitSoA<pixelTopology::Phase2>"/>
@@ -16,9 +14,7 @@
   <class name="TrackingRecHitSoAView<pixelTopology::Phase2>"/>
 
   <class name="PortableHostCollection<TrackingRecHitLayout<pixelTopology::Phase2>>"/>
-  <class name="TrackingRecHitHostPhase2" ClassVersion="3">
-    <version ClassVersion="3" checksum="3095739150"/>
-  </class>
+  <class name="TrackingRecHitHostPhase2"/>
   <class name="edm::Wrapper<TrackingRecHitHostPhase2>" splitLevel="0"/>
 
   <class name="TrackingRecHitSoA<pixelTopology::HIonPhase1>"/>
@@ -27,8 +23,6 @@
   <class name="TrackingRecHitSoAView<pixelTopology::HIonPhase1>"/>
 
   <class name="PortableHostCollection<TrackingRecHitLayout<pixelTopology::HIonPhase1>>"/>
-  <class name="TrackingRecHitHostHIonPhase1" ClassVersion="3">
-    <version ClassVersion="3" checksum="1544316214"/>
-  </class>
+  <class name="TrackingRecHitHostHIonPhase1"/>
   <class name="edm::Wrapper<TrackingRecHitHostHIonPhase1>" splitLevel="0"/>
 </lcgdict>

--- a/EventFilter/SiPixelRawToDigi/python/siPixelDigis_cff.py
+++ b/EventFilter/SiPixelRawToDigi/python/siPixelDigis_cff.py
@@ -23,12 +23,6 @@ siPixelDigiErrorsSoA = _siPixelDigiErrorsSoAFromCUDA.clone(
 from EventFilter.SiPixelRawToDigi.siPixelDigiErrorsFromSoA_cfi import siPixelDigiErrorsFromSoA as _siPixelDigiErrorsFromSoA
 siPixelDigiErrors = _siPixelDigiErrorsFromSoA.clone()
 
-# Alpaka modifier
-from Configuration.ProcessModifiers.alpaka_cff import alpaka
-from EventFilter.SiPixelRawToDigi.siPixelDigiErrorsFromSoAAlpaka_cfi import siPixelDigiErrorsFromSoAAlpaka as _siPixelDigiErrorsFromSoAAlpaka
-
-alpaka.toReplaceWith(siPixelDigiErrors, _siPixelDigiErrorsFromSoAAlpaka.clone())
-
 # use the Phase 1 settings
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(siPixelDigiErrors,

--- a/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/siPixelClustersPreSplitting_cff.py
@@ -159,12 +159,29 @@ alpaka.toModify(siPixelClustersPreSplitting,
     )
 )
 
+# These produce pixelDigiErrors in Alpaka; they are constructed here because they need
+# siPixelClustersPreSplittingAlpaka* as input
+from EventFilter.SiPixelRawToDigi.siPixelDigiErrorsFromSoAAlpaka_cfi import siPixelDigiErrorsFromSoAAlpaka as _siPixelDigiErrorsFromSoAAlpaka
+siPixelDigiErrorsAlpaka = _siPixelDigiErrorsFromSoAAlpaka.clone(
+    digiErrorSoASrc = cms.InputTag('siPixelClustersPreSplittingAlpaka'),
+    fmtErrorsSoASrc = cms.InputTag('siPixelClustersPreSplittingAlpaka'),
+    UsePhase1 = cms.bool(True)
+)
+
+siPixelDigiErrorsAlpakaSerial = siPixelDigiErrorsAlpaka.clone(
+    digiErrorSoASrc = cms.InputTag('siPixelClustersPreSplittingAlpakaSerial'),
+    fmtErrorsSoASrc = cms.InputTag('siPixelClustersPreSplittingAlpakaSerial')
+)
+
 # Run 3
 alpaka.toReplaceWith(siPixelClustersPreSplittingTask, cms.Task(
     # reconstruct the pixel clusters with alpaka
     siPixelClustersPreSplittingAlpaka,
     # reconstruct the pixel clusters with alpaka on the cpu (if requested by the validation)
     siPixelClustersPreSplittingAlpakaSerial,
+    # reconstruct pixel digis errors legacy with alpaka on serial and device
+    siPixelDigiErrorsAlpaka,
+    siPixelDigiErrorsAlpakaSerial,
     # convert from host SoA to legacy formats (digis and clusters)
     siPixelDigisClustersPreSplitting,
     # EDAlias for the clusters
@@ -177,6 +194,9 @@ alpaka.toReplaceWith(siPixelClustersPreSplittingTask, cms.Task(
     siPixelClustersPreSplittingAlpaka,
     # reconstruct the pixel clusters with alpaka from copied digis on the cpu (if requested by the validation)
     siPixelClustersPreSplittingAlpakaSerial,
+    # reconstruct pixel digis errors legacy with alpaka on serial and device
+    siPixelDigiErrorsAlpaka,
+    siPixelDigiErrorsAlpakaSerial,
     # convert the pixel digis (except errors) and clusters to the legacy format
     siPixelDigisClustersPreSplitting,
     # SwitchProducer wrapping the legacy pixel cluster producer or an alias for the pixel clusters information converted from SoA


### PR DESCRIPTION
#### PR description:

This PR is the replacement of https://github.com/cms-sw/cmssw/pull/43964 with essentially the same changes, **except** for the Alpaka vs CUDA compare modules that are not needed anymore. It still includes generalized DQM compare modules for pixel rechits, tracks and vertices, which are templated if needed for other SoA types, an HLT customize function to include the module changes and pixel digi errors monitoring (that is also included in the DQM step), and the changes requested in https://github.com/cms-sw/cmssw/pull/43964#discussion_r1491530401.

#### PR validation:

Executed the code with wf `12834.403` to check DQM plots and everything works as expected.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport. These changes will be backported to 14_0_X in a following PR.

Pinging @mmusich @makortel @fwyzard @AdrianoDee 