### PR TITLE
Initialise the `EcalElectronicsMappingHost` with null detids

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/alpaka/EcalElectronicsMappingHostESProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/EcalElectronicsMappingHostESProducer.cc
@@ -1,3 +1,5 @@
+#include <alpaka/alpaka.hpp>
+
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/DataRecord/interface/EcalMappingElectronicsRcd.h"
@@ -31,6 +33,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // tmp solution for linear mapping of eid -> did
       int const size = 0x3FFFFF;
       auto product = std::make_unique<EcalElectronicsMappingHost>(size, cms::alpakatools::host());
+
+      // fill the whole collection with null detids
+      alpaka::QueueCpuBlocking queue{cms::alpakatools::host()};
+      alpaka::memset(queue, product->buffer(), 0x00);
 
       // fill in eb
       auto const& barrelValues = mapping.barrelItems();

--- a/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
+++ b/EventFilter/EcalRawToDigi/plugins/alpaka/UnpackPortable.dev.cc
@@ -202,7 +202,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::raw {
 
           ElectronicsIdGPU eid{fed2dcc(fed), ttid, stripid, xtalid};
           auto const didraw = isBarrel ? compute_ebdetid(eid) : eid2did[eid.linearIndex()].rawid();
-          // FIXME: what kind of channels are these guys
+          // skip channels with an invalid detid
           if (didraw == 0)
             continue;
 


### PR DESCRIPTION
#### PR description:

Initialise the `EcalElectronicsMappingHost` with null detids explicitly, instead of relying on uninitialised memory.

#### PR validation:

Fixes #44956.
Running the HLT with `export MALLOC_CONF=junk:true` now works.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14.0.x for data taking.