### PR TITLE
MTD geometry: fix BTL numbering scheme for scenario v3, input by Geant4, move unit tests to D110 scenario

### DIFF
--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -117,7 +117,11 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
         modCopy = negModCopy[modCopy - 1];
       }
 
-      bool isV2(baseNumber.getLevelName(0).back() != 'l');
+      bool isV2(bareBaseName(baseNumber.getLevelName(0)).back() != 'l');
+
+#ifdef EDM_ML_DEBUG
+      LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isV2 " << isV2;
+#endif
 
       if (isV2) {
         // V2: the type is embedded in crystal name

--- a/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/BTLNumberingScheme.cc
@@ -26,6 +26,10 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
     }
   }
 
+#ifdef EDM_ML_DEBUG
+  LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isDD4hep " << isDD4hepOK;
+#endif
+
   auto bareBaseName = [&](std::string_view name) {
     size_t ipos = name.rfind('_');
     return (isDD4hepOK) ? name.substr(0, ipos) : name;
@@ -208,7 +212,11 @@ uint32_t BTLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
       modCopy = negModCopy[modCopy - 1];
     }
 
-    bool isV2(baseNumber.getLevelName(0).back() != 'e');
+    bool isV2(bareBaseName(baseNumber.getLevelName(0)).back() != 'e');
+
+#ifdef EDM_ML_DEBUG
+    LogDebug("MTDGeom") << "BTLNumberingScheme::getUnitID(): isV2 " << isV2;
+#endif
 
     if (isV2) {
       // V2: the type is embedded in crystal name

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -54,7 +54,7 @@ process.MessageLogger.files.mtdCommonDataDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryDD4hepExtended2026D98_cff')
+process.load('Configuration.Geometry.GeometryDD4hepExtended2026D110_cff')
 
 process.testBTL = cms.EDAnalyzer("DD4hep_TestMTDIdealGeometry",
                                  DDDetector = cms.ESInputTag('',''),

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -53,7 +53,7 @@ process.MessageLogger.files.mtdCommonDataDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryExtended2026D98_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D110_cff')
 
 process.testBTL = cms.EDAnalyzer("TestMTDIdealGeometry",
                                ddTopNodeName = cms.untracked.string('BarrelTimingLayer')

--- a/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
@@ -50,7 +50,7 @@ process.MessageLogger.files.mtdGeometryDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryDD4hepExtended2026D110Reco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdGeometryDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D98_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D110_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -47,7 +47,7 @@ process.MessageLogger.files.mtdNumberingDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryDD4hepExtended2026D110Reco_cff")
 
 process.prod = cms.EDAnalyzer("GeometricTimingDetAnalyzer")
 

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdNumberingDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
 
 process.Timing = cms.Service("Timing")
 

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -48,7 +48,7 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
 process.load("MagneticField.Engine.volumeBasedMagneticField_160812_cfi")
 
 process.Timing = cms.Service("Timing")

--- a/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_DD4hep_cfg.py
@@ -4,7 +4,7 @@ from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 process = cms.Process('G4PrintGeometry',Phase2C17I13M9,dd4hep)
 
-process.load('Configuration.Geometry.GeometryDD4hepExtended2026D98Reco_cff')
+process.load('Configuration.Geometry.GeometryDD4hepExtended2026D110Reco_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
@@ -85,6 +85,6 @@ process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmea
 process.g4SimHits.UseMagneticField        = False
 process.g4SimHits.Physics.DefaultCutValue = 10. 
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
-	Name           = cms.untracked.vstring('BTLCrystal1','BTLCrystal2','BTLCrystal3','EModule_Timingactive'),
+	Name           = cms.untracked.vstring('BTLCrystal','LGAD_active'),
 	type           = cms.string('PrintMTDSens')
 ))

--- a/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
+++ b/SimG4CMS/Forward/test/python/runMTDSens_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 process = cms.Process('G4PrintGeometry',Phase2C17I13M9)
 
-process.load('Configuration.Geometry.GeometryExtended2026D98Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D110Reco_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
@@ -84,6 +84,6 @@ process.p1 = cms.Path(process.generator*process.VtxSmeared*process.generatorSmea
 process.g4SimHits.UseMagneticField        = False
 process.g4SimHits.Physics.DefaultCutValue = 10. 
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
-	Name           = cms.untracked.vstring('BTLCrystal1','BTLCrystal2','BTLCrystal3','EModule_Timingactive'),
+	Name           = cms.untracked.vstring('BTLCrystal','LGAD_active'),
 	type           = cms.string('PrintMTDSens')
 ))


### PR DESCRIPTION
#### PR description:

Fix of BTL numbering scheme for the latest geometry scenario v3, when DD4hep input is passed by Geant4. Addresses the failure reported in https://github.com/cms-sw/cmssw/pull/45175#issuecomment-2155832315 .

The whole set of unit tests for MTD geometry is updated to scenario I17 / D110, a corresponding update of the cms-data reference https://github.com/cms-data/Geometry-TestReference/pull/14 is required.

#### PR validation:

Code checked both with standalone test code (not failing anyway even before) and test workflows 24834.0, 24834.911, 29634.0, 29634.911 .