### PR TITLE
workflow runner: use previous step output as next step input

### DIFF
--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -164,8 +164,10 @@ class WorkFlowRunner(Thread):
                             cmd+=' --filein  file:step%s.root '%(istep-1,)
                         elif "ALCA" in steps and "RECO" in steps:
                             cmd+=' --filein  file:step%s.root '%(istep-1,)
-                        else:
+                        elif self.recoOutput:
                             cmd+=' --filein %s'%(self.recoOutput)
+                        else:
+                            cmd+=' --filein  file:step%s.root '%(istep-1,)
                     if not '--fileout' in com:
                         cmd+=' --fileout file:step%s.root '%(istep,)
                         if "RECO" in cmd:


### PR DESCRIPTION
Looks like change in https://github.com/cms-sw/cmssw/pull/45005/files has broken workflow [105.0] (https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-12-1900/pyRelValMatrixLogs/run/105.0_MinBiasHcalNZS/step3_MinBiasHcalNZS.log#/) . This happens when `recoOutput` is not set. This proposes to use the previous setup output as input if `recoOutput` is not set (which was what we were doing before #45005 change)

FYI @AdrianoDee , I do not know if this is the correct fix, may be for 105.0 the  `recoOutput` should be set? Feel free to provide a correct fix

[a]
```
usage: cmsDriver.py <TYPE> [options].
Example:

cmsDriver.py reco -s RAW2DIGI,RECO --conditions STARTUP_V4::All --eventcontent RECOSIM
cmsDriver.py: error: argument --filein: expected one argument
```