### PR TITLE
TICLv5 - Fix TracksterLinkingbySkeletons Logic

### DIFF
--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -178,7 +178,7 @@ void SimTrackstersProducer::makePUTrackster(const std::vector<float>& inputClust
   Trackster tmpTrackster;
   for (size_t i = 0; i < output_mask.size(); i++) {
     const float remaining_fraction = output_mask[i];
-    if (remaining_fraction > 0.) {
+    if (remaining_fraction > std::numeric_limits<float>::epsilon()) {
       tmpTrackster.vertices().push_back(i);
       tmpTrackster.vertex_multiplicity().push_back(1. / remaining_fraction);
     }


### PR DESCRIPTION
This PR introduces a fix in the logic of the Skeletons algorithm for the Linking step in TICLv5. 
It also introduces a small fix for comparing two floating points in the SimTrackster Producer.


This PR should be tested enabling some TICLv5 workflows: 
 - `29688.203 SinglePiPt25Eta1p7_2p7_2026D110_GenSimHLBeamSpot+DigiTrigger_2026D110+RecoGlobal_ticl_v5_2026D110+HARVESTGlobal_ticl_v5_2026D110+ALCAPhase2_2026D110 `
 - `29888.203 SinglePiPt25Eta1p7_2p7_2026D110PU_GenSimHLBeamSpot+DigiTriggerPU_2026D110PU+RecoGlobalPU_ticl_v5_2026D110PU+HARVESTGlobalPU_ticl_v5_2026D110PU `

