### PR TITLE
workaround for -O3 compilation issues in Geometry/HGCalCommonData

### DIFF
--- a/Geometry/HGCalCommonData/plugins/BuildFile.xml
+++ b/Geometry/HGCalCommonData/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <library name="GeometryHGCalCommonDataPlugin" file="DD*.cc">
-  <flags CXXFLAGS="-O2" file="DDHGCalPassive.cc"/>
   <use name="DetectorDescription/Core"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
@@ -24,7 +23,6 @@
 </library>
 
 <library name="DD4hep_GeometryHGCalCommonDataPlugins" file="dd4hep/*.cc">
-  <flags CXXFLAGS="-O2" file="DDHGCalPassive.cc"/>
   <use name="DetectorDescription/DDCMS"/>
   <use name="Geometry/HGCalCommonData"/>
   <use name="dd4hep"/>

--- a/Geometry/HGCalCommonData/plugins/DDHGCalPassive.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalPassive.cc
@@ -135,7 +135,6 @@ void DDHGCalPassive::execute(DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HGCalGeom") << "==>> Executing DDHGCalPassive...";
 #endif
-
   static constexpr double tol = 0.00001;
 
   // Loop over Layers
@@ -157,18 +156,21 @@ void DDHGCalPassive::execute(DDCompactView& cpv) {
         xM = {rinB * cos(phi1), routF * cos(phi1), routF * cos(phi2), rinB * cos(phi2)};
         yM = {rinB * sin(phi1), routF * sin(phi1), routF * sin(phi2), rinB * sin(phi2)};
       } else {
-        xM = {rinB * cos(phi1),
-              routF * cos(phi1),
-              routF * cos(phi0),
-              routF * cos(phi2),
-              rinB * cos(phi2),
-              rinB * cos(phi0)};
-        yM = {rinB * sin(phi1),
-              routF * sin(phi1),
-              routF * sin(phi0),
-              routF * sin(phi2),
-              rinB * sin(phi2),
-              rinB * sin(phi0)};
+        // workaround for https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2134850535
+        std::vector<double> xTmp = {rinB * cos(phi1),
+                                    routF * cos(phi1),
+                                    routF * cos(phi0),
+                                    routF * cos(phi2),
+                                    rinB * cos(phi2),
+                                    rinB * cos(phi0)};
+        std::vector<double> yTmp = {rinB * sin(phi1),
+                                    routF * sin(phi1),
+                                    routF * sin(phi0),
+                                    routF * sin(phi2),
+                                    rinB * sin(phi2),
+                                    rinB * sin(phi0)};
+        xM = std::move(xTmp);
+        yM = std::move(yTmp);
       }
       std::vector<double> zw = {-0.5 * thick_, 0.5 * thick_};
       std::vector<double> zx(2, 0), zy(2, 0), scale(2, 1.0);

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalPassive.cc
@@ -111,18 +111,21 @@ struct HGCalPassive {
           xM = {rinB * cos(phi1), routF * cos(phi1), routF * cos(phi2), rinB * cos(phi2)};
           yM = {rinB * sin(phi1), routF * sin(phi1), routF * sin(phi2), rinB * sin(phi2)};
         } else {
-          xM = {rinB * cos(phi1),
-                routF * cos(phi1),
-                routF * cos(phi0),
-                routF * cos(phi2),
-                rinB * cos(phi2),
-                rinB * cos(phi0)};
-          yM = {rinB * sin(phi1),
-                routF * sin(phi1),
-                routF * sin(phi0),
-                routF * sin(phi2),
-                rinB * sin(phi2),
-                rinB * sin(phi0)};
+          // workaround for https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2134850535
+          std::vector<double> xTmp = {rinB * cos(phi1),
+                                      routF * cos(phi1),
+                                      routF * cos(phi0),
+                                      routF * cos(phi2),
+                                      rinB * cos(phi2),
+                                      rinB * cos(phi0)};
+          std::vector<double> yTmp = {rinB * sin(phi1),
+                                      routF * sin(phi1),
+                                      routF * sin(phi0),
+                                      routF * sin(phi2),
+                                      rinB * sin(phi2),
+                                      rinB * sin(phi0)};
+          xM = std::move(xTmp);
+          yM = std::move(yTmp);
         }
         std::vector<double> zw = {-0.5 * thick, 0.5 * thick};
         std::vector<double> zx(2, 0), zy(2, 0), scale(2, 1.0);


### PR DESCRIPTION
#### PR description:

This PR has a workaround for the compiler errors seen with '-O3' optimization covered in https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2134850535.  This is likely a compiler bug, but I'm not optimistic about getting a simple replication for a gcc bug report.

#### PR validation:

Compiles, purely technical fix.