### PR TITLE
Move online (frozen) GTs to 141X and add the dedxCalibration record for HI

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -31,12 +31,12 @@ autoCond = {
     'run2_data_promptlike_hi'      :    '140X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              :    '140X_dataRun2_HLT_relval_v1',
-    # GlobalTag for Run3 HLT: identical to the online GT - 140X_dataRun3_HLT_v3 with snapshot at 2024-02-29 18:52:29 (UTC)
-    'run3_hlt'                     :    '140X_dataRun3_HLT_frozen_v3',
-    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v1 but snapshot at 2024-01-20 12:00:00 (UTC)
-    'run3_data_express'            :    '140X_dataRun3_Express_frozen_v1',
-    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 but snapshot at 2024-05-31 09:09:12 (UTC)
-    'run3_data_prompt'             :    '140X_dataRun3_Prompt_frozen_v3',
+    # GlobalTag for Run3 HLT: identical the online GT - 140X_dataRun3_HLT_v1 with snapshot at 2024-06-13 14:22:43 (UTC)
+    'run3_hlt'                     :    '141X_dataRun3_HLT_frozen_v1',
+    # GlobalTag for Run3 data relvals (express GT) - 140X_dataRun3_Express_v2 (+ the new LHCInfoPer*_duringFill tags) but snapshot at 2024-06-13 15:13:03 (UTC)
+    'run3_data_express'            :    '141X_dataRun3_Express_frozen_v2',
+    # GlobalTag for Run3 data relvals (prompt GT) - 140X_dataRun3_Prompt_v3 (+ the the SecondaryDataset TriggerBits tag and the DeDxCalibrationRcd for HI) but snapshot at 2024_06_12 13:47:20 (UTC)
+    'run3_data_prompt'             :    '141X_dataRun3_Prompt_frozen_v1',
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2024-02-07 16:38:59 (UTC)
     'run3_data'                    :    '140X_dataRun3_v4',
     # GlobalTag for Run3 offline data reprocessing with Prompt GT, currenlty for 2022FG - snapshot at 2024-02-12 12:00:00 (UTC)
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v2',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This PR moves the online (frozen) GTs in autoCond.py to 141X.

The original 141X GTs were derived (with the 2024 HI data taking in mind) as described in https://cms-talk.web.cern.ch/t/gt-online-mc-141x-gts-and-queues-for-2024-heavy-ion-preparations/36724

At the same time the new GTs added here to autoCond include:
- A new tag for the DeDxCalibrationRcd for HI (defined with https://github.com/cms-sw/cmssw/pull/45024, see also https://github.com/cms-sw/cmssw/pull/45016) is added to the Prompt and the HI MC GTs
-  A SecondaryDataset TriggerBits tag is added to the Prompt GT (see https://github.com/cms-sw/cmssw/pull/45092)
- Also added the new LHCInfoPer*_duringFill tags (details for the request and validation in https://cms-talk.web.cern.ch/t/full-track-validation-hlt-express-prompt-update-of-pps-conditions-for-2024-data-taking/36747), which were forgotten in 141X when deriving 141X_dataRun3_Express_v2 from 140X_dataRun3_Express_v3

The new GTs in autoCond are the following ones:
- [141X_dataRun3_HLT_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_HLT_frozen_v1)
   - Same as 141X_dataRun3_HLT_v1/140X_dataRun3_HLT_v3 but with snapshot at 2024-06-13 14:22:43
- [141X_dataRun3_Express_frozen_v2](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Express_frozen_v2)
   - Same as 141X_dataRun3_Express_v2 but with snapshot at 2024-06-13 15:13:03; also added the new LHCInfoPer*_duringFill tags which were forgotten when deriving 141X_dataRun3_Express_v2 from 140X_dataRun3_Express_v3
- [141X_dataRun3_Prompt_frozen_v1](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_dataRun3_Prompt_frozen_v1)
   - Same as 141X_dataRun3_Prompt_v2, but with snapshot at 2024_06_12 13:47:20, and with the addition of the SecondaryDataset TriggerBits tag, and of the new tag for the DeDxCalibrationRcd 
- [141X_mcRun3_2024_realistic_HI_v3](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v3)
   - Adds to 141X_mcRun3_2024_realistic_HI_v2 the new tag for the DeDxCalibrationRcd 

Differences wrt the previous GTs in autoCond are as follows
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_HLT_frozen_v3/141X_dataRun3_HLT_frozen_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Express_frozen_v1/141X_dataRun3_Express_frozen_v2
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_dataRun3_Prompt_frozen_v3/141X_dataRun3_Prompt_frozen_v1
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v2/141X_mcRun3_2024_realistic_HI_v3

#### PR validation:

Succesfully run `runTheMatrix.py -s`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport is needed