### PR TITLE
workaround for -O3/UBSAN compiler error in GeneratorInterface/SherpaInterface

### DIFF
--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -504,6 +504,7 @@ namespace spu {
     EVP_DigestFinal_ex(mdctx, tmp, &md_len);
     EVP_MD_CTX_free(mdctx);
 
+    assert(result);
     //Convert the result
     for (unsigned int k = 0; k < md_len; ++k) {
       sprintf(result + k * 2, "%02x", tmp[k]);


### PR DESCRIPTION
#### PR description:

UBSAN builds of GeneratorInterface/SherpaInterface with '-O3' optimization fail with the error
```
src/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc: In function 'void spu::md5_File(std::string, char*)':
  src/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc:509:14: error: null destination pointer [-Werror=format-overflow=]
   509 |       sprintf(result + k * 2, "%02x", tmp[k]);
      |       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This is almost certainly a compiler error.  This PR adds an assertion that the result pointer can't be null, which is enough to make the compiler happy.

#### PR validation:

Compiles, trivial technical fix.