### PR TITLE
Remove unused variable, fixes cuda warnings

### DIFF
--- a/DataFormats/HcalRecHit/test/test_hcal_reco.cu
+++ b/DataFormats/HcalRecHit/test/test_hcal_reco.cu
@@ -19,7 +19,7 @@ __global__ void kernel_test_hcal_rechits(T *other) {
   other->setTime(rh.time());
 }
 
-__global__ void kernel_test_hcal_hfqie10info() { HFQIE10Info info; }
+__global__ void kernel_test_hcal_hfqie10info() {}
 
 __global__ void kernel_test_hcal_hbhechinfo(HBHEChannelInfo *other) {
   HBHEChannelInfo info{true, true};


### PR DESCRIPTION
Removed unused variable, this should fix the nvcc generated warning [a] which was previously ignore due to bot not using the correct regexp to capture cuda warnings

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-13-2300/DataFormats/HcalRecHit
```
>> Compiling  src/DataFormats/HcalRecHit/test/test_hcal_reco.cu
src/DataFormats/HcalRecHit/test/test_hcal_reco.cu(22): warning #177-D: variable "info" was declared but never referenced
   __attribute__((global)) void kernel_test_hcal_hfqie10info() { HFQIE10Info info; }
```