### PR TITLE
return 0 in case of invalid detId, fixes cuda sign conversion warning

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -105,7 +105,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
         return detId2denseIdHE(detId);
 
       printf("invalid detId: %u\n", detId);
-      return -1;
+      return 0;
     }
   };
 


### PR DESCRIPTION
Just like https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h#L184-L193 , return `0` (instead of `-1`) for invalid detId. This should silence the cuda warning [a] which was previously ignore due to bot not using the correct regexp to capture cuda warnings

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-13-2300/RecoParticleFlow/PFRecHitProducer
```
>> Compiling alpaka/cuda edm plugin src/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
  src/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h(108): warning #68-D: integer conversion resulted in a change of sign
         return -1;
```