### PR TITLE
Saving score as part of AXOL1TL Emulator 

### DIFF
--- a/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
+++ b/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
@@ -33,7 +33,7 @@ typedef BXVector<AXOL1TLScore> AXOL1TLScoreBxCollection;
 typedef l1t::ObjectRef<AXOL1TLScore> AXOL1TLScoreRef;
 typedef l1t::ObjectRefBxCollection<AXOL1TLScore> AXOL1TLScoreRefBxCollection;
 // typedef l1t::ObjectRefPair<AXOL1TLScore> AXOL1TLScoreRefPair;
-// typedef l1t::ObjectRefPairBxCollection<AXOL1TLScore> AXOL1TLScoreRefPairBxCollection; //not sure if pair part is needed
+// typedef l1t::ObjectRefPairBxCollection<AXOL1TLScore> AXOL1TLScoreRefPairBxCollection; //dont think pair part is needed
 
 // class interface
 class AXOL1TLScore {
@@ -41,7 +41,9 @@ public:
   /// constructors
   AXOL1TLScore();  //empty constructor
 
-  AXOL1TLScore(int bxNr, int bxInEvent);
+  AXOL1TLScore(int bxInEvent);
+
+  AXOL1TLScore(int bxInEvent, float score);
 
   /// destructor
   virtual ~AXOL1TLScore();
@@ -56,11 +58,11 @@ public:
   void reset();
 
 private:
-  //axo score value
-  float axoscore_;
-
   /// bunch cross in the GT event record (E,F,0,1,2)
   int m_bxInEvent;
+
+  //axo score value
+  float axoscore_;
 
   //store version or type of network?
   // std::string nnversion;

--- a/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
+++ b/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
@@ -1,0 +1,73 @@
+#ifndef DataFormats_L1TGlobal_AXOL1TLScore_h
+#define DataFormats_L1TGlobal_AXOL1TLScore_h
+
+/**
+* \class AXOL1TLScore
+*
+*
+* Description: L1 micro Global Trigger - Extra NN score emulation information for AXOL1TL.
+* 
+*
+* \author: Melissa Quinnan - UC San Diego
+*
+*
+*/
+
+// system include files
+#include <vector>
+#include <iostream>
+#include <iomanip>
+
+// user include files
+#include "FWCore/Utilities/interface/typedefs.h"
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+#include "DataFormats/L1Trigger/interface/BXVector.h"
+#include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
+
+// forward declarations
+
+// namespace l1t {
+class AXOL1TLScore;
+typedef BXVector<AXOL1TLScore> AXOL1TLScoreBxCollection;
+  
+typedef l1t::ObjectRef<AXOL1TLScore> AXOL1TLScoreRef;
+typedef l1t::ObjectRefBxCollection<AXOL1TLScore> AXOL1TLScoreRefBxCollection;
+// typedef l1t::ObjectRefPair<AXOL1TLScore> AXOL1TLScoreRefPair;
+// typedef l1t::ObjectRefPairBxCollection<AXOL1TLScore> AXOL1TLScoreRefPairBxCollection; //not sure if pair part is needed
+  
+// class interface
+class AXOL1TLScore {
+public:
+
+  /// constructors
+  AXOL1TLScore(); //empty constructor
+		      
+  AXOL1TLScore(int bxNr, int bxInEvent);
+  
+  /// destructor
+  virtual ~AXOL1TLScore();
+  
+  ///set/get axo score and other simple members
+  void setAXOScore(float score) {axoscore_ = score;}
+  void setbxInEventNr(int bxNr) { m_bxInEvent = bxNr; }
+  
+  inline float const& getAXOScore() const { return axoscore_; }
+  inline const int getbxInEventNr() const { return m_bxInEvent; }
+
+  void reset();
+  
+private:
+  
+    
+  //axo score value
+  float axoscore_;
+
+  /// bunch cross in the GT event record (E,F,0,1,2)
+  int m_bxInEvent;
+
+  //store version or type of network?
+  // std::string nnversion; 
+  
+};
+//} l1t namespace
+#endif /*DataFormats_L1TGlobal_AXOL1TLScore_h*/

--- a/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
+++ b/DataFormats/L1TGlobal/interface/AXOL1TLScore.h
@@ -29,36 +29,33 @@
 // namespace l1t {
 class AXOL1TLScore;
 typedef BXVector<AXOL1TLScore> AXOL1TLScoreBxCollection;
-  
+
 typedef l1t::ObjectRef<AXOL1TLScore> AXOL1TLScoreRef;
 typedef l1t::ObjectRefBxCollection<AXOL1TLScore> AXOL1TLScoreRefBxCollection;
 // typedef l1t::ObjectRefPair<AXOL1TLScore> AXOL1TLScoreRefPair;
 // typedef l1t::ObjectRefPairBxCollection<AXOL1TLScore> AXOL1TLScoreRefPairBxCollection; //not sure if pair part is needed
-  
+
 // class interface
 class AXOL1TLScore {
 public:
-
   /// constructors
-  AXOL1TLScore(); //empty constructor
-		      
+  AXOL1TLScore();  //empty constructor
+
   AXOL1TLScore(int bxNr, int bxInEvent);
-  
+
   /// destructor
   virtual ~AXOL1TLScore();
-  
+
   ///set/get axo score and other simple members
-  void setAXOScore(float score) {axoscore_ = score;}
+  void setAXOScore(float score) { axoscore_ = score; }
   void setbxInEventNr(int bxNr) { m_bxInEvent = bxNr; }
-  
+
   inline float const& getAXOScore() const { return axoscore_; }
   inline const int getbxInEventNr() const { return m_bxInEvent; }
 
   void reset();
-  
+
 private:
-  
-    
   //axo score value
   float axoscore_;
 
@@ -66,8 +63,7 @@ private:
   int m_bxInEvent;
 
   //store version or type of network?
-  // std::string nnversion; 
-  
+  // std::string nnversion;
 };
 //} l1t namespace
 #endif /*DataFormats_L1TGlobal_AXOL1TLScore_h*/

--- a/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
+++ b/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
@@ -1,0 +1,31 @@
+/**
+* \class AXOL1TLScore
+*
+*
+*
+* \author: Melissa Quinnan -- UC San Diego
+*
+*
+*/
+
+// this class header
+#include "DataFormats/L1TGlobal/interface/AXOL1TLScore.h"
+
+void AXOL1TLScore::reset() {
+  axoscore_ = 0.0;
+  m_bxInEvent = 0;
+}
+
+AXOL1TLScore::AXOL1TLScore(){
+  reset();
+}
+
+AXOL1TLScore::AXOL1TLScore(int bxNr, int bxInEvent)
+  : m_bxInEvent(bxInEvent) {
+  axoscore_ = 0.0;
+}
+
+//destructor
+AXOL1TLScore::~AXOL1TLScore(){
+  //empty
+}

--- a/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
+++ b/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
@@ -16,16 +16,11 @@ void AXOL1TLScore::reset() {
   m_bxInEvent = 0;
 }
 
-AXOL1TLScore::AXOL1TLScore(){
-  reset();
-}
+AXOL1TLScore::AXOL1TLScore() { reset(); }
 
-AXOL1TLScore::AXOL1TLScore(int bxNr, int bxInEvent)
-  : m_bxInEvent(bxInEvent) {
-  axoscore_ = 0.0;
-}
+AXOL1TLScore::AXOL1TLScore(int bxNr, int bxInEvent) : m_bxInEvent(bxInEvent) { axoscore_ = 0.0; }
 
 //destructor
-AXOL1TLScore::~AXOL1TLScore(){
+AXOL1TLScore::~AXOL1TLScore() {
   //empty
 }

--- a/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
+++ b/DataFormats/L1TGlobal/src/AXOL1TLScore.cc
@@ -18,7 +18,9 @@ void AXOL1TLScore::reset() {
 
 AXOL1TLScore::AXOL1TLScore() { reset(); }
 
-AXOL1TLScore::AXOL1TLScore(int bxNr, int bxInEvent) : m_bxInEvent(bxInEvent) { axoscore_ = 0.0; }
+AXOL1TLScore::AXOL1TLScore(int bxInEvent) : m_bxInEvent(bxInEvent) { axoscore_ = 0.0; }
+
+AXOL1TLScore::AXOL1TLScore(int bxInEvent, float score) : m_bxInEvent(bxInEvent), axoscore_(score) {}
 
 //destructor
 AXOL1TLScore::~AXOL1TLScore() {

--- a/DataFormats/L1TGlobal/src/classes.h
+++ b/DataFormats/L1TGlobal/src/classes.h
@@ -2,6 +2,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "DataFormats/L1TGlobal/interface/AXOL1TLScore.h"
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapRecord.h"
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMapFwd.h"
 #include "DataFormats/L1TGlobal/interface/GlobalObjectMap.h"

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -19,11 +19,8 @@
   <class name="edm::Wrapper<GlobalExtBlkBxCollection>"/>
   <class name="std::vector<GlobalExtBlk>"/>
 
-  <class name="AXOL1TLScore" ClassVersion="17">
-   <version ClassVersion="17" checksum="2400164090"/>
-   <version ClassVersion="16" checksum="1736571921"/>
-   <version ClassVersion="15" checksum="3165857256"/>
-   <version ClassVersion="14" checksum="2589106229"/>
+  <class name="AXOL1TLScore" ClassVersion="18">
+   <version ClassVersion="18" checksum="1744705474"/>
   </class>
   <class name="AXOL1TLScoreBxCollection"/>
   <class name="edm::Wrapper<AXOL1TLScoreBxCollection>"/>

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -19,6 +19,16 @@
   <class name="edm::Wrapper<GlobalExtBlkBxCollection>"/>
   <class name="std::vector<GlobalExtBlk>"/>
 
+  <class name="AXOL1TLScore" ClassVersion="17">
+   <version ClassVersion="17" checksum="2400164090"/>
+   <version ClassVersion="16" checksum="1736571921"/>
+   <version ClassVersion="15" checksum="3165857256"/>
+   <version ClassVersion="14" checksum="2589106229"/>
+  </class>
+  <class name="AXOL1TLScoreBxCollection"/>
+  <class name="edm::Wrapper<AXOL1TLScoreBxCollection>"/>
+  <class name="std::vector<AXOL1TLScore>"/>
+  
   <class name="GlobalObjectMapRecord" ClassVersion="10">
    <version ClassVersion="10" checksum="1219328086"/>
   </class>
@@ -55,6 +65,11 @@
   <class name="GlobalAlgBlkRefPairBxCollection"/>
   <class name="edm::Wrapper<GlobalAlgBlkRefPairBxCollection>"/>
 
+  <class name="AXOL1TLScoreRef"/>
+  <class name="std::vector<AXOL1TLScoreRef>"/>
+  <class name="AXOL1TLScoreRefBxCollection"/>
+  <class name="edm::Wrapper<AXOL1TLScoreRefBxCollection>"/>
+  
 </lcgdict>
 
 

--- a/DataFormats/L1TGlobal/src/classes_def.xml
+++ b/DataFormats/L1TGlobal/src/classes_def.xml
@@ -19,8 +19,8 @@
   <class name="edm::Wrapper<GlobalExtBlkBxCollection>"/>
   <class name="std::vector<GlobalExtBlk>"/>
 
-  <class name="AXOL1TLScore" ClassVersion="18">
-   <version ClassVersion="18" checksum="1744705474"/>
+  <class name="AXOL1TLScore" ClassVersion="3">
+   <version ClassVersion="3" checksum="1744705474"/>
   </class>
   <class name="AXOL1TLScoreBxCollection"/>
   <class name="edm::Wrapper<AXOL1TLScoreBxCollection>"/>

--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -59,6 +59,11 @@ namespace l1t {
 
     void setuGtB(const GlobalBoard*);
 
+    /// get/set score value
+    void setScore(const float scoreval) const;
+    
+    inline float getScore() const {return m_savedscore;}
+
   private:
     /// copy function for copy constructor and operator=
     void copy(const AXOL1TLCondition& cp);
@@ -68,6 +73,10 @@ namespace l1t {
 
     /// pointer to uGt GlobalBoard, to be able to get the trigger objects
     const GlobalBoard* m_gtGTB;
+
+    ///axo score for possible score saving
+    mutable float m_savedscore;
+    
   };
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
+++ b/L1Trigger/L1TGlobal/interface/AXOL1TLCondition.h
@@ -61,8 +61,8 @@ namespace l1t {
 
     /// get/set score value
     void setScore(const float scoreval) const;
-    
-    inline float getScore() const {return m_savedscore;}
+
+    inline float getScore() const { return m_savedscore; }
 
   private:
     /// copy function for copy constructor and operator=
@@ -76,7 +76,6 @@ namespace l1t {
 
     ///axo score for possible score saving
     mutable float m_savedscore;
-    
   };
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -39,6 +39,7 @@
 // Objects to produce for the output record.
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
+#include "DataFormats/L1TGlobal/interface/AXOL1TLScore.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -90,6 +91,9 @@ namespace l1t {
 
     void receiveExternalData(const edm::Event&, const edm::EDGetTokenT<BXVector<GlobalExtBlk>>&, const bool receiveExt);
 
+    void fillAXOScore(int iBxInEvent,
+                      std::unique_ptr<AXOL1TLScoreBxCollection>& AxoScoreRecord);
+    
     /// initialize the class (mainly reserve)
     void init(const int numberPhysTriggers,
               const int nrL1Mu,
@@ -138,7 +142,7 @@ namespace l1t {
     void resetMuonShower();
     void resetCalo();
     void resetExternal();
-
+    
     /// print received Muon dataWord
     void printGmtData(const int iBxInEvent) const;
 
@@ -207,6 +211,8 @@ namespace l1t {
   public:
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
 
+    inline void enableAXOScoreSaving(bool savescore) { m_saveAXOScore = savescore; }
+    
   private:
     // cached stuff
 
@@ -247,6 +253,11 @@ namespace l1t {
 
     GlobalAlgBlk m_uGtAlgBlk;
 
+    //for optional software-only saving of axol1tl score
+    AXOL1TLScore m_uGtAXOScore; //score dataformat
+    float m_storedAXOScore = -999.0; //score from cond class
+    bool m_saveAXOScore = false;
+    
     // cache of maps
     std::vector<AlgorithmEvaluation::ConditionEvaluationMap> m_conditionResultMaps;
 

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -91,9 +91,8 @@ namespace l1t {
 
     void receiveExternalData(const edm::Event&, const edm::EDGetTokenT<BXVector<GlobalExtBlk>>&, const bool receiveExt);
 
-    void fillAXOScore(int iBxInEvent,
-                      std::unique_ptr<AXOL1TLScoreBxCollection>& AxoScoreRecord);
-    
+    void fillAXOScore(int iBxInEvent, std::unique_ptr<AXOL1TLScoreBxCollection>& AxoScoreRecord);
+
     /// initialize the class (mainly reserve)
     void init(const int numberPhysTriggers,
               const int nrL1Mu,
@@ -142,7 +141,7 @@ namespace l1t {
     void resetMuonShower();
     void resetCalo();
     void resetExternal();
-    
+
     /// print received Muon dataWord
     void printGmtData(const int iBxInEvent) const;
 
@@ -212,7 +211,7 @@ namespace l1t {
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
 
     inline void enableAXOScoreSaving(bool savescore) { m_saveAXOScore = savescore; }
-    
+
   private:
     // cached stuff
 
@@ -254,10 +253,10 @@ namespace l1t {
     GlobalAlgBlk m_uGtAlgBlk;
 
     //for optional software-only saving of axol1tl score
-    AXOL1TLScore m_uGtAXOScore; //score dataformat
-    float m_storedAXOScore = -999.0; //score from cond class
+    AXOL1TLScore m_uGtAXOScore;       //score dataformat
+    float m_storedAXOScore = -999.0;  //score from cond class
     bool m_saveAXOScore = false;
-    
+
     // cache of maps
     std::vector<AlgorithmEvaluation::ConditionEvaluationMap> m_conditionResultMaps;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -111,7 +111,6 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_sumInputTag(parSet.getParameter<edm::InputTag>("EtSumInputTag")),
       m_sumZdcInputTag(parSet.getParameter<edm::InputTag>("EtSumZdcInputTag")),
       m_extInputTag(parSet.getParameter<edm::InputTag>("ExtInputTag")),
-      m_axoInputTag(parSet.getParameter<edm::InputTag>("AxoScoreInputTag")),
 
       m_produceL1GtDaqRecord(parSet.getParameter<bool>("ProduceL1GtDaqRecord")),
       m_produceL1GtObjectMapRecord(parSet.getParameter<bool>("ProduceL1GtObjectMapRecord")),

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -566,7 +566,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
   std::unique_ptr<GlobalObjectMapRecord> gtObjectMapRecord(new GlobalObjectMapRecord());
 
   std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(nullptr);
-  if (m_saveAxoScore) {
+  if (m_produceAXOL1TLScore) {
     uGtAXOScoreRecord = std::make_unique<AXOL1TLScoreBxCollection>();
   }
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -73,7 +73,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<bool>("useMuonShowers", false);
 
   //switch for saving AXO score
-  desc.add<bool>("produceAXOL1TLScore", true);
+  desc.add<bool>("produceAXOL1TLScore", false);
 
   // disables resetting the prescale counters each lumisection (needed for offline)
   //  originally, the L1T firmware applied the reset of prescale counters at the end of every LS;
@@ -565,8 +565,10 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
   // * produce the GlobalObjectMapRecord
   std::unique_ptr<GlobalObjectMapRecord> gtObjectMapRecord(new GlobalObjectMapRecord());
 
-  // if (m_produceAXOL1TLScore)
-  std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(new AXOL1TLScoreBxCollection());
+  std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(nullptr);
+  if (m_saveAxoScore) {
+    uGtAXOScoreRecord = std::make_unique<AXOL1TLScoreBxCollection>();
+  }
 
   // fill the boards not depending on the BxInEvent in the L1 GT DAQ record
   // GMT, PSB and FDL depend on BxInEvent

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -571,7 +571,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
   std::unique_ptr<GlobalObjectMapRecord> gtObjectMapRecord(new GlobalObjectMapRecord());
 
   // if (m_saveAxoScore)
-  std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(new AXOL1TLScoreBxCollection(maxEmulBxInEvent));
+  std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(new AXOL1TLScoreBxCollection());
 
   // fill the boards not depending on the BxInEvent in the L1 GT DAQ record
   // GMT, PSB and FDL depend on BxInEvent

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -76,7 +76,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
   //switch for saving AXO score
   desc.add<bool>("saveAxoScore", true);
-  
+
   // disables resetting the prescale counters each lumisection (needed for offline)
   //  originally, the L1T firmware applied the reset of prescale counters at the end of every LS;
   //  this reset was disabled in the L1T firmware starting from run-362658 (November 25th, 2022), see
@@ -138,7 +138,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_resetPSCountersEachLumiSec(parSet.getParameter<bool>("resetPSCountersEachLumiSec")),
       m_semiRandomInitialPSCounters(parSet.getParameter<bool>("semiRandomInitialPSCounters")),
       m_useMuonShowers(parSet.getParameter<bool>("useMuonShowers")),
-      m_saveAxoScore(parSet.getParameter<bool>("saveAxoScore")){
+      m_saveAxoScore(parSet.getParameter<bool>("saveAxoScore")) {
   m_egInputToken = consumes<BXVector<EGamma>>(m_egInputTag);
   m_tauInputToken = consumes<BXVector<Tau>>(m_tauInputTag);
   m_jetInputToken = consumes<BXVector<Jet>>(m_jetInputTag);
@@ -572,7 +572,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   // if (m_saveAxoScore)
   std::unique_ptr<AXOL1TLScoreBxCollection> uGtAXOScoreRecord(new AXOL1TLScoreBxCollection(maxEmulBxInEvent));
-  
+
   // fill the boards not depending on the BxInEvent in the L1 GT DAQ record
   // GMT, PSB and FDL depend on BxInEvent
 
@@ -642,9 +642,8 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     m_uGtBrd->receiveMuonShowerObjectData(iEvent, m_muShowerInputToken, receiveMuShower, m_nrL1MuShower);
 
   //tell board to save axo scores when running GTL
-  if (m_saveAxoScore){
-    m_uGtBrd->enableAXOScoreSaving(receiveAXOScore); }
-  
+  m_uGtBrd->enableAXOScoreSaving(m_saveAxoScore);
+
   m_uGtBrd->receiveExternalData(iEvent, m_extInputToken, receiveExt);
 
   // loop over BxInEvent
@@ -690,9 +689,10 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     }
 
     //save scores to score collection
-    if (m_saveAxoScore){
-      m_uGtBrd->fillAXOScore(iBxInEvent, uGtAXOScoreRecord); }
-    
+    if (m_saveAxoScore) {
+      m_uGtBrd->fillAXOScore(iBxInEvent, uGtAXOScoreRecord);
+    }
+
   }  //End Loop over Bx
 
   // Add explicit reset of Board
@@ -736,7 +736,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     iEvent.put(std::move(gtObjectMapRecord));
   }
 
-  if (m_saveAxoScore){
+  if (m_saveAxoScore) {
     iEvent.put(std::move(uGtAXOScoreRecord), "AXOScore");
   }
 }

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -137,6 +137,10 @@ private:
   edm::InputTag m_extInputTag;
   edm::EDGetTokenT<BXVector<GlobalExtBlk>> m_extInputToken;
 
+  // input tag for saving axol1tl scores
+  edm::InputTag m_axoInputTag;
+  edm::EDGetTokenT<BXVector<AXOL1TLScore>> m_axoInputToken;
+  
   /// logical flag to produce the L1 GT DAQ readout record
   bool m_produceL1GtDaqRecord;
 
@@ -197,6 +201,9 @@ private:
 
   // switch to load muon showers in the global board
   bool m_useMuonShowers;
+
+  //switch to save axo scores in global board
+  bool m_saveAxoScore;
 };
 
 #endif  // L1TGlobalProducer_h

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -140,7 +140,7 @@ private:
   // input tag for saving axol1tl scores
   edm::InputTag m_axoInputTag;
   edm::EDGetTokenT<BXVector<AXOL1TLScore>> m_axoInputToken;
-  
+
   /// logical flag to produce the L1 GT DAQ readout record
   bool m_produceL1GtDaqRecord;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -137,10 +137,6 @@ private:
   edm::InputTag m_extInputTag;
   edm::EDGetTokenT<BXVector<GlobalExtBlk>> m_extInputToken;
 
-  // input tag for saving axol1tl scores
-  edm::InputTag m_axoInputTag;
-  edm::EDGetTokenT<BXVector<AXOL1TLScore>> m_axoInputToken;
-
   /// logical flag to produce the L1 GT DAQ readout record
   bool m_produceL1GtDaqRecord;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -203,7 +203,7 @@ private:
   bool m_useMuonShowers;
 
   //switch to save axo scores in global board
-  bool m_saveAxoScore;
+  bool m_produceAXOL1TLScore;
 };
 
 #endif  // L1TGlobalProducer_h

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -85,6 +85,9 @@ void l1t::AXOL1TLCondition::setGtAXOL1TLTemplate(const AXOL1TLTemplate* caloTemp
 ///   set the pointer to uGT GlobalBoard
 void l1t::AXOL1TLCondition::setuGtB(const GlobalBoard* ptrGTB) { m_gtGTB = ptrGTB; }
 
+/// set score for score saving                 
+void l1t::AXOL1TLCondition::setScore(const float scoreval) const { m_savedscore = scoreval; }
+
 const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   bool condResult = false;
   int useBx = bxEval + m_gtAXOL1TLTemplate->condRelativeBx();
@@ -236,7 +239,9 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   result = ADModelResult.first;
   loss = ADModelResult.second;
   score = ((loss).to_float()) * 16.0;  //scaling to match threshold
-
+  //save score to class variable in case score saving needed
+  setScore(score);
+  
   //number of objects/thrsholds to check
   int iCondition = 0;  // number of conditions: there is only one
   int nObjInCond = m_gtAXOL1TLTemplate->nrObjects();

--- a/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
+++ b/L1Trigger/L1TGlobal/src/AXOL1TLCondition.cc
@@ -85,7 +85,7 @@ void l1t::AXOL1TLCondition::setGtAXOL1TLTemplate(const AXOL1TLTemplate* caloTemp
 ///   set the pointer to uGT GlobalBoard
 void l1t::AXOL1TLCondition::setuGtB(const GlobalBoard* ptrGTB) { m_gtGTB = ptrGTB; }
 
-/// set score for score saving                 
+/// set score for score saving
 void l1t::AXOL1TLCondition::setScore(const float scoreval) const { m_savedscore = scoreval; }
 
 const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
@@ -241,7 +241,7 @@ const bool l1t::AXOL1TLCondition::evaluateCondition(const int bxEval) const {
   score = ((loss).to_float()) * 16.0;  //scaling to match threshold
   //save score to class variable in case score saving needed
   setScore(score);
-  
+
   //number of objects/thrsholds to check
   int iCondition = 0;  // number of conditions: there is only one
   int nObjInCond = m_gtAXOL1TLTemplate->nrObjects();

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -77,7 +77,7 @@ l1t::GlobalBoard::GlobalBoard()
       m_isDebugEnabled(edm::isDebugEnabled()) {
   m_uGtAlgBlk.reset();
   m_uGtAXOScore.reset();
-  
+
   m_gtlAlgorithmOR.reset();
   m_gtlDecisionWord.reset();
 
@@ -494,14 +494,13 @@ void l1t::GlobalBoard::receiveExternalData(const edm::Event& iEvent,
 }
 
 // fill axo score value per bx in event
-void l1t::GlobalBoard::fillAXOScore(int iBxInEvent,
-                                    std::unique_ptr<AXOL1TLScoreBxCollection>& AxoScoreRecord) {
+void l1t::GlobalBoard::fillAXOScore(int iBxInEvent, std::unique_ptr<AXOL1TLScoreBxCollection>& AxoScoreRecord) {
   m_uGtAXOScore.reset();
   m_uGtAXOScore.setbxInEventNr((iBxInEvent & 0xF));
 
   //save stored condition score if Bx is zero, else set to 0
   float scorevalue = 0.0;
-  if (iBxInEvent == 0){
+  if (iBxInEvent == 0) {
     scorevalue = m_storedAXOScore;
   }
 
@@ -673,11 +672,11 @@ void l1t::GlobalBoard::runGTL(const edm::Event&,
 
           cMapResults[itCond->first] = axol1tlCondition;
 
-	  //for optional software-only saving of axol1tl score
-	  //m_storedAXOScore < 0.0 ensures only sets once per condition if score not default of -999
-	  if (m_saveAXOScore && m_storedAXOScore < 0.0) {
-	    m_storedAXOScore = axol1tlCondition->getScore();
-	  }
+          //for optional software-only saving of axol1tl score
+          //m_storedAXOScore < 0.0 ensures only sets once per condition if score not default of -999
+          if (m_saveAXOScore && m_storedAXOScore < 0.0) {
+            m_storedAXOScore = axol1tlCondition->getScore();
+          }
 
           if (m_verbosity && m_isDebugEnabled) {
             std::ostringstream myCout;
@@ -1181,7 +1180,7 @@ void l1t::GlobalBoard::reset() {
   //reset AXO score
   m_storedAXOScore = -999.0;
   m_uGtAXOScore.reset();
-  
+
   m_gtlDecisionWord.reset();
   m_gtlAlgorithmOR.reset();
 }

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -1,0 +1,96 @@
+// system include files
+#include <memory>
+
+// {fmt} headers
+#include <fmt/printf.h>
+
+// ROOT
+#include <TTree.h>
+
+// framework and data formats
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+#include "DataFormats/L1TGlobal/interface/AXOL1TLScore.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//
+// class declaration
+//
+
+class L1AXOTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit L1AXOTreeProducer(edm::ParameterSet const &);
+  ~L1AXOTreeProducer() override = default;
+
+private:
+  void beginJob() override;
+  void analyze(edm::Event const &, edm::EventSetup const &) override;
+  void endJob() override;
+
+private:
+  // output file
+  edm::Service<TFileService> fs_;
+
+  // pointers to the objects that will be stored as branches within the tree
+  float anomaly_score;
+  
+  // tree
+  TTree *tree_;
+
+  // EDM input tokens
+  const edm::EDGetTokenT<AXOL1TLScoreBxCollection> scoreToken_;
+};
+
+L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
+  :anomaly_score(0.0f),
+   tree_(nullptr),
+   scoreToken_(consumes<AXOL1TLScoreBxCollection>(config.getUntrackedParameter<edm::InputTag>("axoscoreToken"))){
+    
+  usesResource(TFileService::kSharedResource);
+  // set up the TTree and its branches
+  tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
+  tree_->Branch("axo_score", &anomaly_score, "axo_score/F");
+}
+
+//
+// member functions
+//
+
+// ------------ method called to for each event  ------------
+void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &setup) {
+
+  //save axo score
+  edm::Handle<AXOL1TLScoreBxCollection> axo;
+  event.getByToken(scoreToken_, axo);
+  
+  float const *ptr;
+
+  if (axo.isValid()) {
+    ptr = &axo->at(0, 0).getAXOScore();
+    anomaly_score = *ptr;
+      
+  } else {
+    edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection not found. Branch will not be filled" << std::endl;
+  }
+  
+  tree_->Fill();
+
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void L1AXOTreeProducer::beginJob(void) {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void L1AXOTreeProducer::endJob() {}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1AXOTreeProducer);

--- a/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1AXOTreeProducer.cc
@@ -41,7 +41,7 @@ private:
 
   // pointers to the objects that will be stored as branches within the tree
   float anomaly_score;
-  
+
   // tree
   TTree *tree_;
 
@@ -50,10 +50,9 @@ private:
 };
 
 L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
-  :anomaly_score(0.0f),
-   tree_(nullptr),
-   scoreToken_(consumes<AXOL1TLScoreBxCollection>(config.getUntrackedParameter<edm::InputTag>("axoscoreToken"))){
-    
+    : anomaly_score(0.0f),
+      tree_(nullptr),
+      scoreToken_(consumes<AXOL1TLScoreBxCollection>(config.getUntrackedParameter<edm::InputTag>("axoscoreToken"))) {
   usesResource(TFileService::kSharedResource);
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1AXOTree", "L1AXOTree");
@@ -66,23 +65,21 @@ L1AXOTreeProducer::L1AXOTreeProducer(edm::ParameterSet const &config)
 
 // ------------ method called to for each event  ------------
 void L1AXOTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &setup) {
-
   //save axo score
   edm::Handle<AXOL1TLScoreBxCollection> axo;
   event.getByToken(scoreToken_, axo);
-  
+
   float const *ptr;
 
   if (axo.isValid()) {
     ptr = &axo->at(0, 0).getAXOScore();
     anomaly_score = *ptr;
-      
+
   } else {
     edm::LogWarning("MissingProduct") << "AXOL1TLScoreBxCollection not found. Branch will not be filled" << std::endl;
   }
-  
-  tree_->Fill();
 
+  tree_->Fill();
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleEMU_cff.py
@@ -8,6 +8,7 @@ from L1Trigger.L1TNtuples.l1UpgradeTfMuonShowerTree_cfi import *
 from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
 from L1Trigger.L1TNtuples.l1EventTree_cfi import *
 from L1Trigger.L1TNtuples.l1uGTTree_cfi import *
+from L1Trigger.L1TNtuples.l1AXOTree_cfi import *
 
 l1UpgradeTfMuonEmuTree = l1UpgradeTfMuonTree.clone()
 l1UpgradeTfMuonEmuTree.bmtfMuonToken = cms.untracked.InputTag("simBmtfDigis","BMTF")
@@ -50,6 +51,9 @@ stage2L1Trigger.toModify(l1UpgradeEmuTree,
 l1uGTEmuTree = l1uGTTree.clone()
 l1uGTEmuTree.ugtToken = cms.InputTag("simGtStage2Digis")
 
+l1AXOEmuTree =  l1AXOTree.clone()
+l1AXOEmuTree.axoscoreToken = cms.untracked.InputTag("simGtStage2Digis","AXOScore")
+
 L1NtupleEMU = cms.Sequence(
   l1EventTree
   +l1UpgradeTfMuonEmuTree
@@ -58,4 +62,5 @@ L1NtupleEMU = cms.Sequence(
   +l1UpgradeEmuTree
 #  +l1MuonEmuTree
   +l1uGTEmuTree
+  +l1AXOEmuTree
 )

--- a/L1Trigger/L1TNtuples/python/l1AXOTree_cfi.py
+++ b/L1Trigger/L1TNtuples/python/l1AXOTree_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+l1AXOTree = cms.EDAnalyzer("L1AXOTreeProducer",
+                           axoscoreToken    = cms.untracked.InputTag("simGtStage2Digis","AXOScore") 
+)


### PR DESCRIPTION
#### PR description:

This adds score-saving to the AXOL1TL software emulation by creating a new "AXOL1TLScore" DataFormat and saving it as an output of the GlobalProducer. It is then saved to the l1 ntuple as a float in the "l1AXOEmuTree". This is enabled by default as a switch in the GlobalProducer "saveAxoScore". This update was presented in the most recent offline sw meeting [1]. No additional dependencies or menu changes are required. 

[1] https://indico.cern.ch/event/1426003/#23-axol1tl-emulator

#### PR validation:

The code was checked with usual cms code checks, and tested by running re-emulation on a test ntuple. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This will likely be back ported into 14_0_X