### PR TITLE
[14.0.X] Introduce `reco::Track::recHitsOk()` and use it to remove try/catch pattern in `SingleLongTrackProducer` 

### DIFF
--- a/DataFormats/TrackReco/interface/Track.h
+++ b/DataFormats/TrackReco/interface/Track.h
@@ -157,6 +157,9 @@ namespace reco {
     /// get the residuals
     const TrackResiduals& residuals() const { return extra_->residuals(); }
 
+    // Check validity of track extra and rechits
+    bool recHitsOk() const { return extra_.isNonnull() && extra_.isAvailable() && extra_->recHitsOk(); }
+
   private:
     /// Reference to additional information stored only on RECO.
     TrackExtraRef extra_;

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -76,6 +76,9 @@ namespace reco {
     TrajParams const& trajParams() const { return m_trajParams; }
     Chi2sFive const& chi2sX5() const { return m_chi2sX5; }
 
+    // Check validity of track rechits
+    bool recHitsOk() const { return m_hitCollection.isNonnull() && m_hitCollection.isAvailable(); }
+
   private:
     edm::RefCore m_hitCollection;
     unsigned int m_firstHit;

--- a/RecoTracker/FinalTrackSelectors/plugins/SingleLongTrackProducer.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SingleLongTrackProducer.cc
@@ -83,65 +83,52 @@ void SingleLongTrackProducer::produce(edm::Event &iEvent, const edm::EventSetup 
     return;
   }
 
-  const reco::Vertex vtx = vertices->at(0);
-
   // Preselection of long quality tracks
+  const reco::Vertex &vtx = vertices->at(0);
   std::vector<reco::Track> selTracks;
   reco::Track bestTrack;
   unsigned int tMuon = 0;
-  double fitProb = 100;
+  double fitProb = std::numeric_limits<double>::max();
 
   for (const auto &track : *tracks) {
     const reco::HitPattern &hitpattern = track.hitPattern();
-    double dR2min = 100.;
+    double dR2min = std::numeric_limits<double>::max();
     double chiNdof = track.normalizedChi2();
     double dxy = std::abs(track.dxy(vtx.position()));
     double dz = std::abs(track.dz(vtx.position()));
 
-    if (track.pt() < minPt)
+    if (track.pt() < minPt || std::abs(track.eta()) > maxEta ||
+        hitpattern.trackerLayersWithMeasurement() < minNumberOfLayers) {
       continue;
+    }
 
-    if (std::abs(track.eta()) > maxEta)
-      continue;
-
-    if (hitpattern.trackerLayersWithMeasurement() < minNumberOfLayers)
-      continue;
-
-    // Long track needs to be close to a good muon (only if requested)
-    if (matchInDr > 0.) {
-      for (const auto &m : *muons) {
-        if (m.isTrackerMuon()) {
+    if (matchInDr > 0.0) {
+      for (const auto &muon : *muons) {
+        if (muon.isTrackerMuon()) {
           tMuon++;
-          reco::Track matchedTrack = *(m.innerTrack());
-          // match to general track in deltaR
-          double dr2 = reco::deltaR2(track, matchedTrack);
-          if (dr2 < dR2min)
-            dR2min = dr2;
+          double dr2 = reco::deltaR2(track, *(muon.innerTrack()));
+          dR2min = std::min(dR2min, dr2);
         }
       }
-      // matchInDr here is defined positive
       if (dR2min >= matchInDr * matchInDr)
         continue;
     }
-    // do vertex consistency:
-    bool vertex_match = dxy < maxDxy && dz < maxDz;
-    if (!(vertex_match))
-      continue;
-    if (track.validFraction() < 1.0)
-      continue;
-    // only save the track with the smallest chiNdof
-    if (chiNdof < fitProb) {
+
+    if (dxy < maxDxy && dz < maxDz && track.validFraction() >= 1.0 && chiNdof < fitProb) {
       fitProb = chiNdof;
       bestTrack = track;
-      bestTrack.setExtra(track.extra());
     }
-    if (debug)
-      edm::LogPrint("SingleLongTrackProducer") << " deltaR2 (general) track to matched Track: " << dR2min;
-    if (debug)
-      edm::LogPrint("SingleLongTrackProducer") << "chi2Ndof:" << chiNdof << " best Track: " << fitProb;
+
+    if (debug) {
+      edm::LogPrint("SingleLongTrackProducer") << "deltaR2 (general) track to matched Track: " << dR2min
+                                               << " chi2Ndof: " << chiNdof << " best Track chi2Ndof: " << fitProb;
+    }
   }
 
-  selTracks.push_back(bestTrack);
+  // Only push if bestTrack was set
+  if (bestTrack.recHitsOk()) {
+    selTracks.push_back(bestTrack);
+  }
 
   if (debug)
     edm::LogPrint("SingleLongTrackProducer")


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45213

#### PR description:

This PR addresses this https://github.com/cms-sw/cmssw/issues/45162#issuecomment-2153404075, by introducing a new helper method  `reco::Track::recHitsOk()` to check the rechits availability content of the input tracks in the track selection logic of  `SingleLongTrackProducer`. 
This allows to remove a `try/catch` pattern in it, causing lots of extraneous exceptions being thrown (and caught) in prompt reco jobs, as reported initially in the issue https://github.com/cms-sw/cmssw/issues/45162.  The implementation (from @borzari) follows the suggestion here https://github.com/cms-sw/cmssw/issues/45162#issuecomment-2154754787.
I profit of this PR to refactor the track selection in `SingleLongTrackProducer` to avoid filling the `selTracks` with tracks without `reco::Track::Extra` attached to them. 

#### PR validation:

 could run this test:

https://github.com/cms-sw/cmssw/blob/4639c105a21c6934798c543c9a7cae72955c9369/DQM/TrackingMonitorSource/test/BuildFile.xml#L2

(even using the whole input file) without crashes. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/45213 to CMSSW_14_0_X for data-taking purposes.