### PR TITLE
Fix broken `DQM/Integration` unit tests after streamers layout update

### DIFF
--- a/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_approx_dqm_sourceclient-live_cfg.py
@@ -87,8 +87,7 @@ elif(offlineTesting):
     #you may need to set manually the GT in the line below
     process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_hlt', '')
 
-
-print("Will process with GlobalTag %s",process.GlobalTag.globaltag.value())
+print("Will process with GlobalTag: %s" % process.GlobalTag.globaltag.value())
 
 #--------------------------------------------
 # Patch to avoid using Run Info information in reconstruction

--- a/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
+++ b/DQM/Integration/python/config/unitteststreamerinputsource_cfi.py
@@ -128,5 +128,6 @@ source = cms.Source("DQMStreamerReader",
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(False),
     endOfRunKills  = cms.untracked.bool(False),
-    inputFileTransitionsEachEvent = cms.untracked.bool(False)
+    inputFileTransitionsEachEvent = cms.untracked.bool(False),
+    unitTest = cms.untracked.bool(True) # stop processing if the input data cannot be deserialized
 )

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient-legacy" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" />  <!-- To be removed once https://github.com/cms-sw/cmssw/issues/43108 is solved -->
-<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py 370580"/>
+<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py 381594"/>
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py"/>
@@ -25,9 +24,10 @@
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_approx_dqm_sourceclient" command="runtest.sh sistrip_approx_dqm_sourceclient-live_cfg.py 362321 hi_run"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
-<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 380649"/>
-<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 380649"/>
-<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 380649"/>
+<test name="TestDQMOnlineClient-ecalgpu_dqm_sourceclient" command="runtest.sh ecalgpu_dqm_sourceclient-live_cfg.py 381594"/>
+<test name="TestDQMOnlineClient-hcalgpu_dqm_sourceclient" command="runtest.sh hcalgpu_dqm_sourceclient-live_cfg.py 381594"/>
+<test name="TestDQMOnlineClient-pixelgpu_dqm_sourceclient" command="runtest.sh pixelgpu_dqm_sourceclient-live_cfg.py 381594"/>
+<test name="TestDQMOnlineClient-pfgpu_dqm_sourceclient" command="runtest.sh pfgpu_dqm_sourceclient-live_cfg.py 381594"/>
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->

--- a/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
+++ b/DQMServices/StreamerIO/plugins/DQMStreamerReader.h
@@ -57,6 +57,7 @@ namespace dqmservices {
     bool const flagEndOfRunKills_;
     bool const flagDeleteDatFiles_;
     std::vector<std::string> const hltSel_;
+    bool const unitTest_;
 
     bool acceptAllEvt_ = false;
     bool setAcceptAllEvt();


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/45224
fixes https://github.com/cms-sw/cmssw/issues/43108

#### PR description:

The goal of this PR (together with its companion `cms-data`  https://github.com/cms-data/DQM-Integration/pull/8) is to update the input streamer files for several unit tests in the `DQM/Integration ` package. This follows the suggestion in https://github.com/cms-sw/cmssw/issues/45224:

   * a) reply to the proposal at
https://github.com/cms-sw/cmssw/issues/43108#issuecomment-1780696627 to improve the test in order to be able to catch this sort of issue and actually implement the change => this is done in commit [c4b5498](https://github.com/cms-sw/cmssw/pull/45231/commits/c4b5498cf86a0c4d3692c3e20d6307770eebf723)
   * b) perform the procedure proposed at
https://github.com/cms-sw/cmssw/pull/44978#issuecomment-2112955723, substitute the current files in cms-data (that have in the meanwhile become broken) with the new format => this is done in the companion `cms-data` PR https://github.com/cms-data/DQM-Integration/pull/8 and in commit [718d63d](https://github.com/cms-sw/cmssw/pull/45231/commits/718d63dcd313136a3e5c3241d607b35e1020754f)

I profit of this PR to fix a small typo in commit [7b4141f](https://github.com/cms-sw/cmssw/pull/45231/commits/7b4141fa111384035237edf0c168c065fa03629e). 

#### PR validation:

Run successfully the following unit tests:
   * `scram b runtests_TestDQMOnlineClient-beamhlt_dqm_sourceclient`
   * `scram b runtests_TestDQMOnlineClient-ecalgpu_dqm_sourceclient`
   * `scram b runtests_TestDQMOnlineClient-hcalgpu_dqm_sourceclient`
   * `scram b runtests_TestDQMOnlineClient-pixelgpu_dqm_sourceclient`
   * `scram b runtests_TestDQMOnlineClient-sistrip_approx_dqm_sourceclient`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, will be backported to CMSSW_14_0_X