### PR TITLE
introduce const variant of `XGBooster::predict `and use it in `PhotonXGBoostEstimator`

### DIFF
--- a/PhysicsTools/XGBoost/interface/XGBooster.h
+++ b/PhysicsTools/XGBoost/interface/XGBooster.h
@@ -23,6 +23,7 @@ namespace pat {
     void set(std::string name, float value);
 
     float predict(const int iterationEnd = 0);
+    float predict(const std::vector<float>& features, const int iterationEnd = 0) const;
 
   private:
     std::vector<float> features_;

--- a/PhysicsTools/XGBoost/src/XGBooster.cc
+++ b/PhysicsTools/XGBoost/src/XGBooster.cc
@@ -79,8 +79,6 @@ void XGBooster::addFeature(std::string name) {
 void XGBooster::set(std::string name, float value) { features_.at(feature_name_to_index_[name]) = value; }
 
 float XGBooster::predict(const int iterationEnd) {
-  float result(-999.);
-
   // check if all feature values are set properly
   for (unsigned int i = 0; i < features_.size(); ++i)
     if (std::isnan(features_.at(i))) {
@@ -94,8 +92,25 @@ float XGBooster::predict(const int iterationEnd) {
       throw std::runtime_error("Feature is not set: " + feature_name);
     }
 
+  float const ret = predict(features_, iterationEnd);
+
+  reset();
+
+  return ret;
+}
+
+float XGBooster::predict(const std::vector<float>& features, const int iterationEnd) const {
+  float result{-999.};
+
+  if (features.empty()) {
+    throw std::runtime_error("Vector of input features is empty");
+  }
+
+  if (feature_name_to_index_.size() != features.size())
+    throw std::runtime_error("Feature size mismatch");
+
   DMatrixHandle dvalues;
-  XGDMatrixCreateFromMat(&features_[0], 1, features_.size(), 9e99, &dvalues);
+  XGDMatrixCreateFromMat(&features[0], 1, features.size(), 9e99, &dvalues);
 
   bst_ulong out_len = 0;
   const float* score = nullptr;
@@ -125,8 +140,6 @@ float XGBooster::predict(const int iterationEnd) {
   }
 
   XGDMatrixFree(dvalues);
-
-  reset();
 
   return result;
 }

--- a/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h
@@ -4,10 +4,11 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include "PhysicsTools/XGBoost/interface/XGBooster.h"
 
+#include <memory>
+
 class PhotonXGBoostEstimator {
 public:
   PhotonXGBoostEstimator(const edm::FileInPath& weightsFile, int best_ntree_limit);
-  ~PhotonXGBoostEstimator();
 
   float computeMva(float rawEnergyIn,
                    float r9In,
@@ -22,7 +23,6 @@ public:
 private:
   std::unique_ptr<pat::XGBooster> booster_;
   int best_ntree_limit_ = -1;
-  std::string config_;
 };
 
 #endif

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonXGBoostProducer.cc
@@ -38,8 +38,8 @@ private:
   const unsigned mvaNTreeLimitB_;
   const unsigned mvaNTreeLimitE_;
   const double mvaThresholdEt_;
-  std::unique_ptr<PhotonXGBoostEstimator> mvaEstimatorB_;
-  std::unique_ptr<PhotonXGBoostEstimator> mvaEstimatorE_;
+  const std::unique_ptr<const PhotonXGBoostEstimator> mvaEstimatorB_;
+  const std::unique_ptr<const PhotonXGBoostEstimator> mvaEstimatorE_;
 };
 
 PhotonXGBoostProducer::PhotonXGBoostProducer(edm::ParameterSet const& config)
@@ -54,9 +54,9 @@ PhotonXGBoostProducer::PhotonXGBoostProducer(edm::ParameterSet const& config)
       mvaFileXgbE_(config.getParameter<edm::FileInPath>("mvaFileXgbE")),
       mvaNTreeLimitB_(config.getParameter<unsigned int>("mvaNTreeLimitB")),
       mvaNTreeLimitE_(config.getParameter<unsigned int>("mvaNTreeLimitE")),
-      mvaThresholdEt_(config.getParameter<double>("mvaThresholdEt")) {
-  mvaEstimatorB_ = std::make_unique<PhotonXGBoostEstimator>(mvaFileXgbB_, mvaNTreeLimitB_);
-  mvaEstimatorE_ = std::make_unique<PhotonXGBoostEstimator>(mvaFileXgbE_, mvaNTreeLimitE_);
+      mvaThresholdEt_(config.getParameter<double>("mvaThresholdEt")),
+      mvaEstimatorB_{std::make_unique<const PhotonXGBoostEstimator>(mvaFileXgbB_, mvaNTreeLimitB_)},
+      mvaEstimatorE_{std::make_unique<const PhotonXGBoostEstimator>(mvaFileXgbE_, mvaNTreeLimitE_)} {
   produces<reco::RecoEcalCandidateIsolationMap>();
 }
 

--- a/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonXGBoostEstimator.cc
@@ -1,5 +1,4 @@
 #include "RecoEgamma/PhotonIdentification/interface/PhotonXGBoostEstimator.h"
-#include <sstream>
 
 PhotonXGBoostEstimator::PhotonXGBoostEstimator(const edm::FileInPath& weightsFile, int best_ntree_limit) {
   booster_ = std::make_unique<pat::XGBooster>(weightsFile.fullPath());
@@ -16,8 +15,6 @@ PhotonXGBoostEstimator::PhotonXGBoostEstimator(const edm::FileInPath& weightsFil
   best_ntree_limit_ = best_ntree_limit;
 }
 
-PhotonXGBoostEstimator::~PhotonXGBoostEstimator() {}
-
 float PhotonXGBoostEstimator::computeMva(float rawEnergyIn,
                                          float r9In,
                                          float sigmaIEtaIEtaIn,
@@ -27,15 +24,7 @@ float PhotonXGBoostEstimator::computeMva(float rawEnergyIn,
                                          float etaIn,
                                          float hOvrEIn,
                                          float ecalPFIsoIn) const {
-  booster_->set("rawEnergy", rawEnergyIn);
-  booster_->set("r9", r9In);
-  booster_->set("sigmaIEtaIEta", sigmaIEtaIEtaIn);
-  booster_->set("etaWidth", etaWidthIn);
-  booster_->set("phiWidth", phiWidthIn);
-  booster_->set("s4", s4In);
-  booster_->set("eta", etaIn);
-  booster_->set("hOvrE", hOvrEIn);
-  booster_->set("ecalPFIso", ecalPFIsoIn);
-
-  return booster_->predict(best_ntree_limit_);
+  return booster_->predict(
+      {rawEnergyIn, r9In, sigmaIEtaIEtaIn, etaWidthIn, phiWidthIn, s4In, etaIn, hOvrEIn, ecalPFIsoIn},
+      best_ntree_limit_);
 }


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/45235

#### PR description:

Addresses https://github.com/cms-sw/cmssw/pull/45085#issuecomment-2167579713 by using the suggestion at https://github.com/cms-sw/cmssw/issues/45235#issuecomment-2171446089.
This avoids to call `XGBooster::predict()` right after a call to `XGBooster::reset()`, leading to evaluating `NaN`-s in the input feature vector.

#### PR validation:

Run the following script:

```bash
#!/bin/bash -ex                                                                                                                                                                                            

jobTag=threads4
hltMenu=/dev/CMSSW_14_0_0/GRun/V141

check_log () {
  grep '0 HLT_DiphotonMVA14p25_Tight_Mass90_v' $1 | grep TrigReport
}

run(){
  echo $2
  cp $1 $2.py
  cat <<EOF >> $2.py                                                                                                                                                                                       
                                                                                                                                                                                                           
process.options.numberOfThreads = 4                                                                                                                                                                        
process.options.numberOfStreams = 4                                                                                                                                                                        
                                                                                                                                                                                                           
process.hltOutputMinimal.fileName = '${2}.root'                                                                                                                                                            
EOF                                                                                                                                                                                                        
  cmsRun "${2}".py &> "${2}".log
  check_log "${2}".log
}

hltGetCmd="hltGetConfiguration ${hltMenu}"
hltGetCmd+=" --globaltag auto:run3_mc_GRun --mc --unprescale --output minimal --max-events -1"
hltGetCmd+=" --input /store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STORM/debug/150724_xgboost/RelVal_Raw_GRun_MC.root"
                                                                                                                                                                                  
configLabel=hlt_"${jobTag}"_onlyDiphotonMVA14p25_Tight_Mass90                                                                                                                                                                                
${hltGetCmd} --paths HLT_DiphotonMVA14p25_Tight_Mass90_v1 > "${configLabel}".py
for job_i in {0..30}; do run "${configLabel}".py "${configLabel}"_"${job_i}"; done; unset job_i;
``` 

and didn't observe crashes, whereas without this it crashes around 10% of times (3 times out of 30).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but if accepted will be backported.
