### PR TITLE
Fix BasicGenParticleValidation warning message in relval 180.0 and 181.0

### DIFF
--- a/Validation/EventGenerator/plugins/BasicGenParticleValidation.cc
+++ b/Validation/EventGenerator/plugins/BasicGenParticleValidation.cc
@@ -276,9 +276,9 @@ bool BasicGenParticleValidation::matchParticles(const HepMC::GenParticle*& hepmc
 
   if (hepmcP->pdg_id() != recoP->pdgId())
     return state;
-  if (std::fabs(hepmcP->momentum().px() - recoP->px()) < std::fabs(matchPr_ * hepmcP->momentum().px()) &&
-      std::fabs(hepmcP->momentum().py() - recoP->py()) < std::fabs(matchPr_ * hepmcP->momentum().py()) &&
-      std::fabs(hepmcP->momentum().pz() - recoP->pz()) < std::fabs(matchPr_ * hepmcP->momentum().pz())) {
+  if (std::fabs(hepmcP->momentum().px() - recoP->px()) <= std::fabs(matchPr_ * hepmcP->momentum().px()) &&
+      std::fabs(hepmcP->momentum().py() - recoP->py()) <= std::fabs(matchPr_ * hepmcP->momentum().py()) &&
+      std::fabs(hepmcP->momentum().pz() - recoP->pz()) <= std::fabs(matchPr_ * hepmcP->momentum().pz())) {
     state = true;
   }
 


### PR DESCRIPTION
#### PR description:

This PR fixes the warning message displayed by the BasicGenParticleValidation when running the step 3 of relval 180.0 and 181.0 . This issue was reported in https://github.com/cms-sw/cmssw/pull/44316#issuecomment-1985806736

#### PR validation:

tested with relvals 180.0 and 181.0

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
