### PR TITLE
fix configuration of ZDC inputs in `L1REPACK:uGT`

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py
@@ -23,28 +23,30 @@ from L1Trigger.Configuration.SimL1Emulator_cff import *
 
 simGtExtFakeStage2Digis.tcdsRecordLabel= cms.InputTag("unpackTcds","tcdsRecord")
 
-simGtStage2Digis.MuonInputTag   = "unpackGtStage2:Muon"
+simGtStage2Digis.MuonInputTag       = "unpackGtStage2:Muon"
 simGtStage2Digis.MuonShowerInputTag = "unpackGtStage2:MuonShower"
-simGtStage2Digis.EGammaInputTag = "unpackGtStage2:EGamma"
-simGtStage2Digis.TauInputTag    = "unpackGtStage2:Tau"
-simGtStage2Digis.JetInputTag    = "unpackGtStage2:Jet"
-simGtStage2Digis.EtSumInputTag  = "unpackGtStage2:EtSum"
-simGtStage2Digis.ExtInputTag    = "unpackGtStage2" # as in default
+simGtStage2Digis.EGammaInputTag     = "unpackGtStage2:EGamma"
+simGtStage2Digis.TauInputTag        = "unpackGtStage2:Tau"
+simGtStage2Digis.JetInputTag        = "unpackGtStage2:Jet"
+simGtStage2Digis.EtSumInputTag      = "unpackGtStage2:EtSum"
+simGtStage2Digis.EtSumZdcInputTag   = "unpackGtStage2:EtSumZDC"
+simGtStage2Digis.ExtInputTag        = "unpackGtStage2" # as in default
 
 
 # Finally, pack the new L1T output back into RAW
-    
+
 # pack simulated uGT
 from EventFilter.L1TRawToDigi.gtStage2Raw_cfi import gtStage2Raw as packGtStage2
-packGtStage2.MuonInputTag   = "unpackGtStage2:Muon"
+packGtStage2.MuonInputTag     = "unpackGtStage2:Muon"
 packGtStage2.ShowerInputLabel = "unpackGtStage2:MuonShower"
-packGtStage2.EGammaInputTag = "unpackGtStage2:EGamma"
-packGtStage2.TauInputTag    = "unpackGtStage2:Tau"
-packGtStage2.JetInputTag    = "unpackGtStage2:Jet"
-packGtStage2.EtSumInputTag  = "unpackGtStage2:EtSum"
-packGtStage2.GtInputTag     = "simGtStage2Digis" # as in default
-packGtStage2.ExtInputTag    = "unpackGtStage2" # as in default
-    
+packGtStage2.EGammaInputTag   = "unpackGtStage2:EGamma"
+packGtStage2.TauInputTag      = "unpackGtStage2:Tau"
+packGtStage2.JetInputTag      = "unpackGtStage2:Jet"
+packGtStage2.EtSumInputTag    = "unpackGtStage2:EtSum"
+packGtStage2.EtSumZDCInputTag = "unpackGtStage2:EtSumZDC"
+packGtStage2.GtInputTag       = "simGtStage2Digis" # as in default
+packGtStage2.ExtInputTag      = "unpackGtStage2" # as in default
+
 
 # combine the new L1 RAW with existing RAW for other FEDs
 import EventFilter.RawDataCollector.rawDataCollectorByLabel_cfi


### PR DESCRIPTION
#### PR description:

`L1REPACK:uGT` does not seem to work in `14_1_X`, probably since the integration of #44019 (this was somewhat anticipated in the review of the latter, https://github.com/cms-sw/cmssw/pull/44019#issuecomment-1953614897).

This PR is a minimal fix. Merely technical. No changes expected.

FYI: @eyigitba 

#### PR validation:

The following test command works in 14_1_X with this PR, and fails (in 14_1_X) without it.
```bash
#!/bin/bash -ex

hltGetConfiguration /dev/CMSSW_14_0_0/GRun \
  --globaltag auto:phase1_2024_realistic \
  --mc \
  --unprescale \
  --output minimal \
  --max-events 100 \
  --input /store/mc/Run3Winter24Digi/TT_TuneCP5_13p6TeV_powheg-pythia8/GEN-SIM-RAW/133X_mcRun3_2024_realistic_v8-v2/80000/dc984f7f-2e54-48c4-8950-5daa848b6db9.root \
  --eras Run3 --l1-emulator uGT --l1 L1Menu_Collisions2024_v1_2_0_xml \
  > hlt.py

cmsRun hlt.py &> hlt.log
```

For the record, this is the runtime error pre-PR.
```
----- Begin Fatal Exception 16-Jun-2024 23:23:50 CEST-----------------------
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 20081 event: 14772855 stream: 1
   [1] Running path 'HLTAnalyzerEndpath'
   [2] Prefetching for module L1TRawToDigi/'hltGtStage2Digis'
   [3] Prefetching for module RawDataCollectorByLabel/'rawDataCollector'
   [4] Calling method for module L1TDigiToRaw/'packGtStage2'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: BXVector<l1t::EtSum>
Looking for module label: simCaloStage2Digis
Looking for productInstanceName: 

   Additional Info:
      [a] If you wish to continue processing events after a ProductNotFound exception,
add "TryToContinue = cms.untracked.vstring('ProductNotFound')" to the "options" PSet in the configuration.

----- End Fatal Exception -------------------------------------------------
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

N/A
