### PR TITLE
Introduce kInvalidDenseId for ECAL and HCAL [14.0.x]

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -1,6 +1,8 @@
 #ifndef RecoParticleFlow_PFRecHitProducer_interface_alpaka_CalorimeterDefinitions_h
 #define RecoParticleFlow_PFRecHitProducer_interface_alpaka_CalorimeterDefinitions_h
 
+#include <limits>
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
@@ -97,6 +99,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
       return retval + kSizeBarrel;
     }
 
+    static constexpr uint32_t kInvalidDenseId = std::numeric_limits<uint32_t>::max();
+
     static constexpr uint32_t detId2denseId(uint32_t detId) {
       const uint32_t subdet = getSubdet(detId);
       if (subdet == HcalBarrel)
@@ -105,7 +109,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
         return detId2denseIdHE(detId);
 
       printf("invalid detId: %u\n", detId);
-      return -1;
+      return kInvalidDenseId;
     }
   };
 
@@ -181,6 +185,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
 
     static constexpr bool checkFlag(uint32_t flagBits, int flag) { return flagBits & (0x1 << flag); }
 
+    static constexpr uint32_t kInvalidDenseId = std::numeric_limits<uint32_t>::max();
+
     static constexpr uint32_t detId2denseId(uint32_t detId) {
       const uint32_t subdet = getSubdet(detId);
       if (subdet == EcalBarrel)
@@ -189,7 +195,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
         return Barrel::kSize + Endcap::denseIndex(detId);
 
       printf("invalid detId: %u\n", detId);
-      return 0;
+      return kInvalidDenseId;
     }
 
     static constexpr bool detIdInRange(uint32_t detId) {

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -152,7 +152,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
         for (uint32_t n = 0; n < 8; n++) {
           pfRecHits.neighbours(i)(n) = -1;
           const uint32_t denseId_neighbour = topology.neighbours(denseId)(n);
-          if (denseId_neighbour != 0xffffffff) {
+          if (denseId_neighbour != CAL::kInvalidDenseId) {
             const uint32_t pfRecHit_neighbour = denseId2pfRecHit[denseId_neighbour];
             if (pfRecHit_neighbour != 0xffffffff)
               pfRecHits.neighbours(i)(n) = (int32_t)pfRecHit_neighbour;

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitTopologyESProducer.cc
@@ -96,7 +96,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
             if (CAL::detIdInRange(neighDetId))
               view.neighbours(denseId)(n) = CAL::detId2denseId(neighDetId);
             else
-              view.neighbours(denseId)(n) = 0xffffffff;
+              view.neighbours(denseId)(n) = CAL::kInvalidDenseId;
           }
         }
       }
@@ -107,13 +107,13 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
           for (auto const detId : geom.getValidDetIds(CAL::kDetectorId, subdet)) {
             const uint32_t denseId = CAL::detId2denseId(detId);
             for (uint32_t n = 0; n < 8; n++) {
-              if (view.neighbours(denseId)[n] == 0xffffffff)
+              if (view.neighbours(denseId)[n] == CAL::kInvalidDenseId)
                 continue;
               const ::reco::PFRecHitsTopologyNeighbours& neighboursOfNeighbour =
                   view.neighbours(view.neighbours(denseId)[n]);
               if (std::find(neighboursOfNeighbour.begin(), neighboursOfNeighbour.end(), denseId) ==
                   neighboursOfNeighbour.end())
-                view.neighbours(denseId)[n] = 0xffffffff;
+                view.neighbours(denseId)[n] = CAL::kInvalidDenseId;
             }
           }
       }


### PR DESCRIPTION
#### PR description:

Introduce `kInvalidDenseId` for ECAL and HCAL, and use it instead of `0` or `-1`.

#### PR validation:

Technical-only changes, validated running the HLT over 100k events, and obtaining identical results.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45238.