### PR TITLE
Herwig LHE matching fix and Matchbox relval for 13_0

### DIFF
--- a/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff.py
@@ -6,7 +6,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,

--- a/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
+++ b/Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff.py
@@ -5,7 +5,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_c
 from Configuration.Generator.Herwig7Settings.Herwig7MGMergingSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7MGMergingSettingsBlock,
@@ -40,7 +40,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe')
 )
 
 

--- a/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -7,5 +7,5 @@ externalLHEProducer = cms.EDProducer('ExternalLHEProducer',
   args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/UL/13TeV/madgraph/V5_2.6.5/dyellell01234j_5f_LO_MLM_v2/DYJets_HT-incl_slc6_amd64_gcc630_CMSSW_9_3_16_tarball.tar.xz','false','slc6_amd64_gcc630','CMSSW_9_3_16'),
   nEvents = cms.untracked.uint32(10),
   generateConcurrently = cms.untracked.bool(True),
-  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+  postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )

--- a/Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff.py
+++ b/Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+    herwig7StableParticlesForDetectorBlock,
+    herwig7CH3SettingsBlock,
+    run = cms.string('InterfaceMatchboxTest'),
+    dumpConfig = cms.untracked.string('HerwigConfig.in'),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    filterEfficiency = cms.untracked.double(1.0),
+    Matchbox = cms.vstring( 'read snippets/Matchbox.in',
+    'read snippets/PPCollider.in',
+    'cd /Herwig/EventHandlers',
+    'set EventHandler:LuminosityFunction:Energy 13000*GeV',
+    '## Model assumptions',
+    'read Matchbox/StandardModelLike.in',
+    'read Matchbox/DiagonalCKM.in',
+    '## Set the order of the couplings',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:OrderInAlphaS 0',
+    'set Factory:OrderInAlphaEW 2',
+    '## Select the process',
+    'do Factory:Process p p -> l+ l-',
+    '# read Matchbox/MadGraph-GoSam.in',
+    '# read Matchbox/MadGraph-MadGraph.in',
+    'read Matchbox/MadGraph-OpenLoops.in',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MinMass 50*GeV',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MaxMass 14000*GeV',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:ScaleChoice /Herwig/MatrixElements/Matchbox/Scales/LeptonPairMassScale',
+    'read Matchbox/MCatNLO-DefaultShower.in',
+    '# read Matchbox/NLO-NoShower.in',
+    '# read Matchbox/LO-NoShower.in',
+    'read Matchbox/FiveFlavourScheme.in',
+    'do /Herwig/MatrixElements/Matchbox/Factory:ProductionMode',
+    ),
+    parameterSets = cms.vstring('herwig7StableParticlesForDetector', 'Matchbox','herwig7CH3PDF', 'herwig7CH3AlphaS','herwig7CH3MPISettings'),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7LHECommonSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7LHECommonSettingsBlock = cms.PSet(
 
         # set the weight option (e.g. for MC@NLO)
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
 
         'set /Herwig/Generators/EventGenerator:EventHandler /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',

--- a/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
+++ b/Configuration/Generator/python/Herwig7Settings/Herwig7MGMergingSettings_cfi.py
@@ -14,6 +14,7 @@ herwig7MGMergingSettingsBlock = cms.PSet(
         'set LesHouchesHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',
         'set LesHouchesHandler:DecayHandler /Herwig/Decays/DecayHandler',
         'set LesHouchesHandler:WeightOption VarNegWeight',
+        'set LesHouchesHandler:EventNumbering LHE',
         'set /Herwig/Generators/EventGenerator:EventHandler  /Herwig/EventHandlers/LesHouchesHandler',
         'create ThePEG::Cuts /Herwig/Cuts/NoCuts',
         'cd /Herwig/EventHandlers',

--- a/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
+++ b/Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff.py
@@ -7,7 +7,7 @@ from Configuration.Generator.Herwig7Settings.Herwig7LHECommonSettings_cfi import
 from Configuration.Generator.Herwig7Settings.Herwig7LHEPowhegSettings_cfi import *
 
 
-generator = cms.EDFilter("Herwig7GeneratorFilter",
+generator = cms.EDFilter("Herwig7HadronizerFilter",
     herwig7CH3SettingsBlock,
     herwig7StableParticlesForDetectorBlock,
     herwig7LHECommonSettingsBlock,

--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -7,7 +7,7 @@ externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
     outputFile = cms.string('cmsgrid_final.lhe'),
     scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh'),
     generateConcurrently = cms.untracked.bool(True),
-    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
+    postGenerationCommand = cms.untracked.vstring('mergeLHE.py', '-n', '-i', 'thread*/cmsgrid_final.lhe', '-o', 'cmsgrid_final.lhe'),
 )
 
 #Link to datacards:

--- a/Configuration/Generator/python/concurrentLumisDisable.py
+++ b/Configuration/Generator/python/concurrentLumisDisable.py
@@ -5,6 +5,7 @@ noConcurrentLumiGenerators = [
     "CosMuoGenProducer",
     "ExhumeGeneratorFilter",
     "Herwig7GeneratorFilter",
+    "Herwig7HadronizerFilter",
     "HydjetGeneratorFilter",
     "Hydjet2GeneratorFilter",
     "PyquenGeneratorFilter",

--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -47,6 +47,8 @@ workflows[520]=['VHToHtt_NLO_Pow_13TeV_py8_taurhonu',['VHToH_Pow_LHE_13TeV','Had
 workflows[535]=['',['TTbar_13TeV_Pow_herwig7','HARVESTGEN']]
 workflows[537]=['',['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7','HARVESTGEN']]
 workflows[538]=['',['DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7','HARVESTGEN']]
+workflows[539]=['',['DY_TuneCH3_13TeV_herwig_madgraph_matchbox','HARVESTGEN']]
+
 # External Decays
 
 workflows[521]=['WTolNuJets_LO_Mad_13TeV_py8_Ta',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCP5_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1716,6 +1716,7 @@ steps['sherpa_ttbar_2j_MENLOPS_13TeV_MASTER']=genvalid('sherpa_ttbar_2j_MENLOPS_
 steps['TTbar_13TeV_Pow_herwig7']=genvalid('Configuration/Generator/python/TT_13TeV_Pow_Herwig7_cff',step1LHEGenDQM)
 steps['DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7']=genvalid('Configuration/Generator/python/DYToLL012Jets_5FS_TuneCH3_13TeV_amcatnloFxFx_herwig7_cff',merge([{'-n':'12'},step1LHEGenDQM]))
 steps['DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7']=genvalid('Configuration/Generator/python/DYToLL01234Jets_5FS_TuneCH3_13TeV_madgraphMLM_herwig7_cff',step1LHEGenDQM)
+steps['DY_TuneCH3_13TeV_herwig_madgraph_matchbox']=genvalid('Configuration/Generator/python/DY_TuneCH3_13TeV_herwig_madgraph_matchbox_cff',step1GenDefaults)
 
 
 # Heavy Ion

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -52,9 +52,11 @@ namespace lhef {
 
     int npLO() const { return npLO_; }
     int npNLO() const { return npNLO_; }
+    int evtnum() const { return evtnum_; }
 
     void setNpLO(int n) { npLO_ = n; }
     void setNpNLO(int n) { npNLO_ = n; }
+    void setEvtNum(int n) { evtnum_ = n; }
 
     void addComment(const std::string &line) { comments.push_back(line); }
 
@@ -93,6 +95,7 @@ namespace lhef {
     std::vector<float> scales_;  //scale value used to exclude EWK-produced partons from matching
     int npLO_;                   //number of partons for LO process (used to steer matching/merging)
     int npNLO_;                  //number of partons for NLO process (used to steer matching/merging)
+    int evtnum_;  //The number of the event (needed to ensure the correct LHE events are saved for MG +Herwig)
   };
 
 }  // namespace lhef

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -192,6 +192,7 @@ void ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                 partonLevel_->weights().end(),
                 std::bind(&LHEEventProduct::addWeight, product.get(), std::placeholders::_1));
   product->setScales(partonLevel_->scales());
+  product->setEvtNum(partonLevel_->evtnum());
   if (nPartonMapping_.empty()) {
     product->setNpLO(partonLevel_->npLO());
     product->setNpNLO(partonLevel_->npNLO());

--- a/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
+++ b/GeneratorInterface/LHEInterface/scripts/addLHEnumbers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+from __future__ import print_function
+import logging
+import argparse
+import sys
+import os
+import re
+
+
+def number_events(input_file, output_file=None, offset=0):
+    if output_file is None:
+        output_file = input_file
+    if not os.path.exists(os.path.dirname(os.path.realpath(output_file))):
+        os.makedirs(os.path.dirname(os.path.realpath(output_file)))
+
+    nevent = offset
+    with open('tmp.txt', 'w') as fw:
+        with open(input_file, 'r') as ftmp:
+            for line in ftmp:
+                if re.search('\s*</event>', line):
+                    nevent += 1
+                    fw.write('<event_num num="' + str(nevent) +  '"> ' + str(nevent) + '</event_num>\n')
+                fw.write(line)
+    if output_file is not None:
+        os.rename("tmp.txt", output_file)
+    else:
+        os.rename("tmp.txt", input_file)
+    return nevent
+
+
+if __name__=="__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Add numbers to lhe")
+    parser.add_argument("input_file", type=str,
+                        help="Input LHE file path.")
+    parser.add_argument("-o", "--output-file", default=None, type=str,
+                        help="Output LHE file path. If not specified, output to input file")
+    args = parser.parse_args()
+
+    logging.info('>>> launch addLHEnumbers.py in %s' % os.path.abspath(os.getcwd()))
+
+    logging.info('>>> Input file: [%s]' % args.input_file)
+    logging.info('>>> Write to output: %s ' % args.output_file)
+
+    number_events(args.input_file, args.output_file)

--- a/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
+++ b/GeneratorInterface/LHEInterface/scripts/mergeLHE.py
@@ -9,6 +9,9 @@ import sys
 import os
 import re
 
+import addLHEnumbers
+
+
 class BaseLHEMerger(object):
     """Base class of the LHE merge schemes"""
 
@@ -62,7 +65,7 @@ class DefaultLHEMerger(BaseLHEMerger):
             % ', '.join([str(len(lines)) for lines in self._header_lines]))
         assert all([
             len(self._header_lines[0]) == len(lines) for lines in self._header_lines]
-            ), inconsistent_error_info % "line number not matches"
+            ), inconsistent_error_info % "line number does not match"
         inconsistent_lines_set = [set() for _ in self._header_lines]
         for line_zip in zip(*self._header_lines):
             if any([k in line_zip[0] for k in allow_diff_keys]):
@@ -253,7 +256,7 @@ class DefaultLHEMerger(BaseLHEMerger):
                     sign = lambda x: -1 if x < 0 else 1
                     for line in ftmp:
                         event_line += 1
-                        if re.search('\s*<event.*>', line):
+                        if re.search('\s*<event.*>', line) and not re.search('\s*<event_num.*>', line):
                             event_line = 0
                         if event_line == 1:
                             # modify the XWGTUP appeared in the first line of the
@@ -366,6 +369,8 @@ def main(argv = None):
                         help=("Bypass the compatibility check for the headers. If true, the header and init block "
                              "will be just a duplicate from the first input file, and events are concatenated without "
                              "modification."))
+    parser.add_argument("-n", "--number-events", action='store_true',
+                        help=("Add a tag to number each lhe event. Needed for Herwig to find correct lhe events"))
     parser.add_argument("--debug", action='store_true',
                         help="Use the debug mode.")
     args = parser.parse_args(argv)
@@ -392,6 +397,11 @@ def main(argv = None):
     if not os.path.exists(os.path.dirname(os.path.realpath(args.output_file))):
         os.makedirs(os.path.dirname(os.path.realpath(args.output_file)))
 
+    if args.number_events:
+        offset = 0
+        for input_file in input_files:
+            offset += addLHEnumbers.number_events(input_file, offset=offset)
+
     # Check arguments
     assert len(input_files) > 0, 'Input LHE files should be more than 0.'
     if len(input_files) == 1:
@@ -408,7 +418,8 @@ def main(argv = None):
     elif args.force_cpp_merger:
         lhe_merger = ExternalCppLHEMerger(input_files, args.output_file)
     else:
-        lhe_merger = DefaultLHEMerger(input_files, args.output_file, bypass_check=args.bypass_check)
+        lhe_merger = DefaultLHEMerger(
+            input_files, args.output_file, bypass_check=args.bypass_check)
 
     # Do merging
     lhe_merger.merge()

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -40,7 +40,8 @@ namespace lhef {
         counted(false),
         readAttemptCounter(0),
         npLO_(-99),
-        npNLO_(-99)
+        npNLO_(-99),
+        evtnum_(-1)
 
   {
     hepeup.NUP = 0;
@@ -106,7 +107,7 @@ namespace lhef {
   }
 
   LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo, const HEPEUP &hepeup)
-      : runInfo(runInfo), hepeup(hepeup), counted(false), readAttemptCounter(0), npLO_(-99), npNLO_(-99) {}
+      : runInfo(runInfo), hepeup(hepeup), counted(false), readAttemptCounter(0), npLO_(-99), npNLO_(-99), evtnum_(-1) {}
 
   LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo,
                      const HEPEUP &hepeup,
@@ -119,7 +120,8 @@ namespace lhef {
         counted(false),
         readAttemptCounter(0),
         npLO_(-99),
-        npNLO_(-99) {}
+        npNLO_(-99),
+        evtnum_(-1) {}
 
   LHEEvent::LHEEvent(const std::shared_ptr<LHERunInfo> &runInfo, const LHEEventProduct &product)
       : runInfo(runInfo),
@@ -132,7 +134,8 @@ namespace lhef {
         originalXWGTUP_(product.originalXWGTUP()),
         scales_(product.scales()),
         npLO_(product.npLO()),
-        npNLO_(product.npNLO()) {}
+        npNLO_(product.npNLO()),
+        evtnum_(product.evtnum()) {}
 
   LHEEvent::~LHEEvent() {}
 

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -141,6 +141,7 @@ namespace lhef {
     int npLO;
     int npNLO;
     std::vector<float> scales;
+    int evtnum = -1;
   };
 
   static void attributesToDom(DOMElement *dom, const Attributes &attributes) {
@@ -215,6 +216,9 @@ namespace lhef {
 
           scales.push_back(scaleval);
         }
+      } else if (name == "event_num") {
+        const char *evtnumstr = XMLSimpleStr(attributes.getValue(XMLString::transcode("num")));
+        sscanf(evtnumstr, "%d", &evtnum);
       }
       xmlEventNodes.push_back(elem);
       return;
@@ -526,6 +530,8 @@ namespace lhef {
           }
           lheevent->setNpLO(handler->npLO);
           lheevent->setNpNLO(handler->npNLO);
+          lheevent->setEvtNum(handler->evtnum);
+          handler->evtnum = -1;
           //fill scales
           if (!handler->scales.empty()) {
             lheevent->setScales(handler->scales);

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -39,9 +39,11 @@ public:
 
   int npLO() const { return npLO_; }
   int npNLO() const { return npNLO_; }
+  int evtnum() const { return evtnum_; }
 
   void setNpLO(int n) { npLO_ = n; }
   void setNpNLO(int n) { npNLO_ = n; }
+  void setEvtNum(int n) { evtnum_ = n; }
 
   const lhef::HEPEUP &hepeup() const { return hepeup_; }
   const PDF *pdf() const { return pdf_.get(); }
@@ -108,6 +110,7 @@ private:
   std::vector<float> scales_;  //scale value used to exclude EWK-produced partons from matching
   int npLO_;                   //number of partons for LO process (used to steer matching/merging)
   int npNLO_;                  //number of partons for NLO process (used to steer matching/merging)
+  int evtnum_;  //The number of the event (needed to ensure the correct LHE events are saved for MG +Herwig)
 };
 
 #endif  // GeneratorEvent_LHEInterface_LHEEventProduct_h

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -209,12 +209,13 @@
 	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="14">
+	<class name="LHEEventProduct" ClassVersion="15">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
   <version ClassVersion="12" checksum="259352862"/>
   <version ClassVersion="13" checksum="3927731647"/>
   <version ClassVersion="14" checksum="905719452"/>
+  <version ClassVersion="15" checksum="898288635"/>
  </class>
  <ioread sourceClass = "LHEEventProduct" version="[13]" targetClass="LHEEventProduct" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
    <![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>


### PR DESCRIPTION
Backports https://github.com/cms-sw/cmssw/pull/42673 and https://github.com/cms-sw/cmssw/pull/42732 (which add a new Herwig7HadronizerFilter, designed to resolve the issue of the wrong lhe events being saved with Herwig) and #43261 (which adds a new workflow 539 for testing the Matchbox mode of Herwig) for use in 2023 gen production.

Should be tested with https://github.com/cms-sw/cmsdist/pull/9247 - the Herwig relvals to run are 535, 537, 538 and 539.