### PR TITLE
Add protection for pathologic cases in MuonBeamspotConstraintValueMapProducer

### DIFF
--- a/RecoMuon/GlobalTrackingTools/plugins/MuonBeamspotConstraintValueMapProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/MuonBeamspotConstraintValueMapProducer.cc
@@ -14,6 +14,7 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/KalmanVertexFit/interface/SingleTrackVertexConstraint.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "RecoVertex/VertexPrimitives/interface/VertexException.h"
 
 class MuonBeamspotConstraintValueMapProducer : public edm::global::EDProducer<> {
 public:
@@ -95,7 +96,7 @@ private:
               chi2s.push_back(std::get<2>(btft));
               tbd = false;
             }
-          } catch (...) {
+          } catch (const VertexException& exc) {
             // Update failed; give up.
           }
         }

--- a/RecoMuon/GlobalTrackingTools/plugins/MuonBeamspotConstraintValueMapProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/MuonBeamspotConstraintValueMapProducer.cc
@@ -86,13 +86,17 @@ private:
           auto pv = pvHandle->at(0);
           VertexState pvs = VertexState(GlobalPoint(Basic3DVector<float>(pv.position())), GlobalError(pv.covariance()));
 
-          SingleTrackVertexConstraint::BTFtuple btft = stvc.constrain(ttkb->build(muon.muonBestTrack()), pvs);
-          if (std::get<0>(btft)) {
-            const reco::Track& trkBS = std::get<1>(btft).track();
-            pts.push_back(trkBS.pt());
-            ptErrs.push_back(trkBS.ptError());
-            chi2s.push_back(std::get<2>(btft));
-            tbd = false;
+          try {
+            SingleTrackVertexConstraint::BTFtuple btft = stvc.constrain(ttkb->build(muon.muonBestTrack()), pvs);
+            if (std::get<0>(btft)) {
+              const reco::Track& trkBS = std::get<1>(btft).track();
+              pts.push_back(trkBS.pt());
+              ptErrs.push_back(trkBS.ptError());
+              chi2s.push_back(std::get<2>(btft));
+              tbd = false;
+            }
+          } catch (...) {
+            // Update failed; give up.
           }
         }
       }


### PR DESCRIPTION
#### PR description:

Address #45189.
A description of the pathologic case being addressed is given [here](https://github.com/cms-sw/cmssw/issues/45189#issuecomment-2173419169).

The fix consists in catching the exception and moving on with the fall-back case (no beamspot update).

#### PR validation:

Checked that it solved the exception in the event reported in #45189 .
