### PR TITLE
Tracking MC truth: fixes and updates to TrackingTruthDumper

### DIFF
--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthDumper.cc
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthDumper.cc
@@ -51,8 +51,8 @@ void TrackingTruthDumper::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto SimVtx = edm::makeValid(iEvent.getHandle(simTVToken_));
 
   edm::LogPrint("DumpTkVtx") << "\n SimVertex / SimTrack structure dump \n";
-  edm::LogPrint("DumpTkVtx") << " SimVertex in the event = " << (*SimTk).size();
-  edm::LogPrint("DumpTkVtx") << " SimTracks in the event = " << (*SimVtx).size();
+  edm::LogPrint("DumpTkVtx") << " SimVertex in the event = " << (*SimVtx).size();
+  edm::LogPrint("DumpTkVtx") << " SimTracks in the event = " << (*SimTk).size();
   edm::LogPrint("DumpTkVtx") << "\n";
   size_t isimvtx(0);
   size_t isimtk(0);
@@ -63,7 +63,8 @@ void TrackingTruthDumper::analyze(const edm::Event& iEvent, const edm::EventSetu
       edm::LogPrint("DumpTkVtx") << "TPs of this vertex: \n";
       isimtk = 0;
       for (const auto& tk : vtx.daughterTracks()) {
-        edm::LogPrint("DumpTkVtx") << "TrackingParticle " << isimtk << " = " << *tk << "\n";
+        bool isMerged = tk->g4Tracks().size() > 1;
+        edm::LogPrint("DumpTkVtx") << "TrackingParticle " << isimtk << " isMerged " << isMerged << "\n" << *tk << "\n";
         isimtk++;
       }
       edm::LogPrint("DumpTkVtx") << "\n";
@@ -72,10 +73,11 @@ void TrackingTruthDumper::analyze(const edm::Event& iEvent, const edm::EventSetu
   }
 
   if (dumpTk_) {
+    edm::LogPrint("DumpTkVtx") << "TrackingParticles: \n";
     isimtk = 0;
     for (const auto& tk : *SimTk) {
       bool isMerged = tk.g4Tracks().size() > 1;
-      edm::LogPrint("DumpTkVtx") << "TrackingParticle " << isimtk << " isMerged " << isMerged << " = " << tk << "\n";
+      edm::LogPrint("DumpTkVtx") << "TrackingParticle " << isimtk << " isMerged " << isMerged << "\n" << tk << "\n";
       isimtk++;
     }
   }


### PR DESCRIPTION
#### PR description:

Minor updates and a fix to the ```TrackingTruthDumper``` test class, used to inspect the ```TrackingParticle``` and ```TrackingVertex``` content of an event.

#### PR validation:

The code produces the desired output, e.g.:

```

 SimVertex / SimTrack structure dump 

 SimVertex in the event = 2
 SimTracks in the event = 3


TrackingVertex 0 = Vertex Position & Event #(-0.000750633,-0.000621845,-3.41805,-2.34691e-10) 0.0
 Associated with 1 tracks
 HepMC vertex position -0.00750633,-0.00621845-34.1805
 Geant vertex position (-0.000750633,-0.000621845,-3.41805,-2.34691e-10)
 Daughter starts:      (-0.000750633,-0.000621845,-3.41805) p (-3.31013,-9.42794,-26.7694,28.5735)


TPs of this vertex: 

TrackingParticle 0 isMerged 0
TP momentum, q, ID, & Event #: (-3.31013,-9.42794,-26.7694,28.5735) 0 22 0.0
 HepMC Track Momentum 9.99215
 Geant Track Momentum  (-3.31013,-9.42794,-26.7694,28.5735)
 Geant Track ID & type 1 22
 TP Vertex (-0.000750633,-0.000621845,-3.41805)
 Source vertex: (-0.000750633,-0.000621845,-3.41805,-2.34691e-10)
 1 Decay vertices
 Decay vertices:      (-39.665,-112.973,-324.187,1.11861e-08)




TrackingVertex 1 = Vertex Position & Event #(-39.665,-112.973,-324.187,1.11861e-08) 0.0
 Associated with 2 tracks
 Geant vertex position (-39.665,-112.973,-324.187,1.11861e-08)
 Daughter starts:      (-39.665,-112.973,-324.187) p (-2.89235,-8.23948,-23.3964,24.9729)
 Daughter starts:      (-39.665,-112.973,-324.187) p (-0.417962,-1.18858,-3.37293,3.60056)
 Source   starts: (-0.000750633,-0.000621845,-3.41805), p (-3.31013,-9.42794,-26.7694,28.5735)


TPs of this vertex: 

TrackingParticle 0 isMerged 0
TP momentum, q, ID, & Event #: (-2.89235,-8.23948,-23.3964,24.9729) -1 11 0.0
 Geant Track Momentum  (-2.89235,-8.23948,-23.3964,24.9729)
 Geant Track ID & type 2 11
 TP Vertex (-39.665,-112.973,-324.187)
 Source vertex: (-39.665,-112.973,-324.187,1.11861e-08)
 0 Decay vertices


TrackingParticle 1 isMerged 0
TP momentum, q, ID, & Event #: (-0.417962,-1.18858,-3.37293,3.60056) 1 -11 0.0
 Geant Track Momentum  (-0.417962,-1.18858,-3.37293,3.60056)
 Geant Track ID & type 3 -11
 TP Vertex (-39.665,-112.973,-324.187)
 Source vertex: (-39.665,-112.973,-324.187,1.11861e-08)
 0 Decay vertices




TrackingParticles: 

TrackingParticle 0 isMerged 0
TP momentum, q, ID, & Event #: (-3.31013,-9.42794,-26.7694,28.5735) 0 22 0.0
 HepMC Track Momentum 9.99215
 Geant Track Momentum  (-3.31013,-9.42794,-26.7694,28.5735)
 Geant Track ID & type 1 22
 TP Vertex (-0.000750633,-0.000621845,-3.41805)
 Source vertex: (-0.000750633,-0.000621845,-3.41805,-2.34691e-10)
 1 Decay vertices
 Decay vertices:      (-39.665,-112.973,-324.187,1.11861e-08)

(...)
```