### PR TITLE
Protect against null `VertexRef` in `DeepBoostedJetTagInfoProducer.cc`

### DIFF
--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -683,6 +683,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
           pv_ass = (*pvas_)[cand];
           if (pv_ass.isNonnull())
             vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
+          else
+            edm::LogWarning("DeepBoostedJetTagInfoProducer") << "Null primary vertex reference";
         } else
           throw edm::Exception(edm::errors::InvalidReference) << "Vertex association missing";
       }

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -681,7 +681,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
         if (use_pvasq_value_map_) {
           pv_ass_quality = (*pvasq_value_map_)[cand];
           pv_ass = (*pvas_)[cand];
-          vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
+          if (pv_ass.isNonnull())
+            vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
         } else
           throw edm::Exception(edm::errors::InvalidReference) << "Vertex association missing";
       }


### PR DESCRIPTION
Avoids an invalid reference exception discussed here:
https://github.com/cms-sw/cmssw/issues/45190

The issue only pops up on AMD for a reason that's not clear to me. 
I have admittedly not investigated why the VertexRef is null. 