### PR TITLE
Fixed artificial new files in StreamerInputModule [14_0]

### DIFF
--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -31,8 +31,6 @@ namespace edm::streamer {
   private:
     void genuineCloseFile() override {
       if (didArtificialFile_) {
-        didArtificialFile_ = false;
-
         return;
       }
       if (pr_.get() != nullptr)


### PR DESCRIPTION
#### PR description:

The genuineCloseFile was incorrectly resetting the member which tracked if this is an artificial file boundary.
This should fix a problem seen in the ECal online calibration.

#### PR validation:

I ran the test given in a private email and the file is now processed without hitting an assert.

backport of #45247