### PR TITLE
Fixed artificial new files in StreamerInputModule

### DIFF
--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -32,8 +32,6 @@ namespace edm::streamer {
   private:
     void genuineCloseFile() override {
       if (didArtificialFile_) {
-        didArtificialFile_ = false;
-
         return;
       }
       if (pr_.get() != nullptr)


### PR DESCRIPTION
#### PR description:

The genuineCloseFile was incorrectly resetting the member which tracked if this is an artificial file boundary.

This should fix a problem seen in the ECal online calibration.

#### PR validation:

Private testing of a previously failing cmsRun configuration now worked.