### PR TITLE
moduleAlloc_setupFile.h: ThreadAllocInfo is struct not class

### DIFF
--- a/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.h
+++ b/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.h
@@ -8,7 +8,7 @@
 namespace edm {
   class ActivityRegistry;
   namespace service::moduleAlloc {
-    class ThreadAllocInfo;
+    struct ThreadAllocInfo;
 
     class Filter {
     public:


### PR DESCRIPTION
#### PR description:

Title says it all. Spotted in CLANG_X IBs:

```
In file included from src/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.cc:32:
  src/PerfTools/AllocMonitor/plugins/ThreadAllocInfo.h:28:3: warning: 'ThreadAllocInfo' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    28 |   struct ThreadAllocInfo {
      |   ^
src/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.h:11:5: note: did you mean struct here?
   11 |     class ThreadAllocInfo;
      |     ^~~~~
      |     struct
In file included from src/PerfTools/AllocMonitor/plugins/ModuleAllocMonitor.cc:27:
  src/PerfTools/AllocMonitor/plugins/ThreadAllocInfo.h:28:3: warning: 'ThreadAllocInfo' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    28 |   struct ThreadAllocInfo {
      |   ^
src/PerfTools/AllocMonitor/plugins/moduleAlloc_setupFile.h:11:5: note: did you mean struct here?
   11 |     class ThreadAllocInfo;
      |     ^~~~~
      |     struct
1 warning generated.
1 warning generated.
```

#### PR validation:

Bot tests