### PR TITLE
Remove unused lambda captures in test_catch2_WaitingThreadPool.cc

### DIFF
--- a/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc
@@ -123,7 +123,7 @@ TEST_CASE("Test WaitingThreadPool", "[edm::WaitingThreadPool") {
 
       {
         using namespace edm::waiting_task::chain;
-        auto h = first([&pool, &count](edm::WaitingTaskHolder h) {
+        auto h = first([&pool](edm::WaitingTaskHolder h) {
                    edm::WaitingTaskWithArenaHolder h2(std::move(h));
                    pool.runAsync(
                        std::move(h2), []() { throw std::runtime_error("error"); }, errorContext);


### PR DESCRIPTION
#### PR description:

Fixes the following warning in CLANG_X IBs:

```
  src/FWCore/Concurrency/test/test_catch2_WaitingThreadPool.cc:126:33: warning: lambda capture 'count' is not used [-Wunused-lambda-capture]
   126 |         auto h = first([&pool, &count](edm::WaitingTaskHolder h) {
      |                              ~~~^~~~~
```

#### PR validation:

Bot tests