### PR TITLE
Remove unused constants from EcalChannelStatus_PayloadInspector.cc

### DIFF
--- a/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
+++ b/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc
@@ -20,7 +20,7 @@
 namespace {
   static constexpr int kEBChannels = 61200, kEEChannels = 14648, NRGBs = 5, NCont = 255;
   // barrel lower and upper bounds on eta and phi
-  static constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;
+  static constexpr int MAX_IETA = 85, MAX_IPHI = 360;
   // endcaps lower and upper bounds on x and y
   static constexpr int IX_MIN = 1, IY_MIN = 1, IX_MAX = 100, IY_MAX = 100;
 


### PR DESCRIPTION
#### PR description:

Fixes the following warnings:

```
  src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc:23:24: warning: unused variable 'MIN_IETA' [-Wunused-const-variable]
    23 |   static constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;
      |                        ^~~~~~~~
  src/CondCore/EcalPlugins/plugins/EcalChannelStatus_PayloadInspector.cc:23:38: warning: unused variable 'MIN_IPHI' [-Wunused-const-variable]
    23 |   static constexpr int MIN_IETA = 1, MIN_IPHI = 1, MAX_IETA = 85, MAX_IPHI = 360;
      |                                      ^~~~~~~~
```

#### PR validation:

Bot tests