### PR TITLE
Avoid using 'module' identifier - is a keyword in C++20

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -355,12 +355,12 @@ namespace pixelgpudetails {
       pixelgpudetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
       uint32_t rawId = detId.rawId;
       uint32_t layer = 0;
-      int side = 0, panel = 0, module = 0;
+      int side = 0, panel = 0, module_ = 0;
       bool barrel = isBarrel(rawId);
       if (barrel) {
         layer = (rawId >> pixelgpudetails::layerStartBit) & pixelgpudetails::layerMask;
-        module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
-        side = (module < 5) ? -1 : 1;
+        module_ = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
+        side = (module_ < 5) ? -1 : 1;
       } else {
         // endcap ids
         layer = 0;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu
@@ -355,12 +355,12 @@ namespace pixelgpudetails {
       pixelgpudetails::DetIdGPU detId = getRawId(cablingMap, fedId, link, roc);
       uint32_t rawId = detId.rawId;
       uint32_t layer = 0;
-      int side = 0, panel = 0, module_ = 0;
+      int side = 0, panel = 0, aModule = 0;
       bool barrel = isBarrel(rawId);
       if (barrel) {
         layer = (rawId >> pixelgpudetails::layerStartBit) & pixelgpudetails::layerMask;
-        module_ = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
-        side = (module_ < 5) ? -1 : 1;
+        aModule = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
+        side = (aModule < 5) ? -1 : 1;
       } else {
         // endcap ids
         layer = 0;


### PR DESCRIPTION
#### PR description:

Fixes these warnings:

```
  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

  src/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelRawToClusterGPUKernel.cu(362): warning #3189-D: "module" is parsed as an identifier rather than a keyword because the tokens that follow it do not match those of a preprocessor directive
           module = (rawId >> pixelgpudetails::moduleStartBit) & pixelgpudetails::moduleMask;
          ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```

#### PR validation:

Bot tests
