### PR TITLE
(DAQ) fix double conting of meta event (14_0_X backport)

### DIFF
--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -76,10 +76,11 @@ namespace evf {
       return (discarded_ || edm::Service<evf::EvFDaqDirector>()->lumisectionDiscarded(ls_));
     }
 
-    void doOutputEvent(EventMsgBuilder const& msg) {
+    void doOutputEvent(EventMsgBuilder const& msg, bool inc) {
       EventMsgView eview(msg.startAddress());
       stream_writer_events_->write(eview);
-      incAccepted();
+      if (inc)
+        incAccepted();
     }
 
     void doOutputEventAsync(std::unique_ptr<EventMsgBuilder> msg, edm::WaitingTaskHolder iHolder) {
@@ -97,9 +98,9 @@ namespace evf {
           if (meta_) {
             auto m = std::move(meta_);
             assert(m->builder_);
-            doOutputEvent(*m->builder_);
+            doOutputEvent(*m->builder_, false);
           }
-          doOutputEvent(*msg);  //msg is written and discarded at this point
+          doOutputEvent(*msg, true);  //msg is written and discarded at this point
         } catch (...) {
           auto tmp = holder;
           tmp.doneWaiting(std::current_exception());


### PR DESCRIPTION
#### PR description:

No counting of meta events in JSON file output count.
Important because it can affect number of accepted events entered in SM database

#### PR validation:

Running the unit test by hand checked that problem is fixed (number of events in dat file matches number of events in jsn file, which is not the case without this fix).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45253
Reason: fix event accounting problem in HLT (urgent)