### PR TITLE
Fixed artificial new files in StreamerInputModule [14.0.9-patchX]

### DIFF
--- a/IOPool/Streamer/interface/StreamerInputModule.h
+++ b/IOPool/Streamer/interface/StreamerInputModule.h
@@ -31,8 +31,6 @@ namespace edm::streamer {
   private:
     void genuineCloseFile() override {
       if (didArtificialFile_) {
-        didArtificialFile_ = false;
-
         return;
       }
       if (pr_.get() != nullptr)


### PR DESCRIPTION
#### PR description:

Quoting @Dr15Jones:

> The genuineCloseFile was incorrectly resetting the member which tracked if this is an artificial file boundary. This should fix a problem seen in the ECal online calibration.

#### PR validation:

Quoting @Dr15Jones:

> I ran the test given in a private email and the file is now processed without hitting an assert.


#### Backport status

backport of #45247