### PR TITLE
Unpacker and DataFormat for L1 Trigger Scouting BMTF source

### DIFF
--- a/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
+++ b/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
@@ -1,0 +1,78 @@
+#ifndef DataFormats_L1Scouting_L1ScoutingBMTFStub_h
+#define DataFormats_L1Scouting_L1ScoutingBMTFStub_h
+
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+
+namespace l1ScoutingRun3 {
+
+  class BMTFStub {
+  public:
+    BMTFStub()
+      : hwPhi_(0),
+        hwPhiB_(0),
+        hwQual_(0),
+        hwEta_(0),
+        hwQEta_(0),
+        station_(0),
+        wheel_(0),
+        sector_(0),
+        tag_(0) {}
+
+    BMTFStub(int hwPhi,
+             int hwPhiB,
+             int hwQual,
+             int hwEta,
+             int hwQEta,
+             int station,
+             int wheel,
+             int sector,
+             int tag)
+      : hwPhi_(hwPhi),
+        hwPhiB_(hwPhiB),
+        hwQual_(hwQual),
+        hwEta_(hwEta),
+        hwQEta_(hwQEta),
+        station_(station),
+        wheel_(wheel),
+        sector_(sector),
+        tag_(tag) {}
+
+    void setHwPhi(int hwPhi) {hwPhi_ = hwPhi;}
+    void setHwPhiB(int hwPhiB) {hwPhiB_ = hwPhiB;}
+    void setHwQual(int hwQual) {hwQual_ = hwQual;}
+    void setHwEta(int hwEta) {hwEta_ = hwEta;}
+    void setHwQEta(int hwQEta) {hwQEta_ = hwQEta;}
+    void setStation(int station) {station_ = station;}
+    void setWheel(int wheel) {wheel_ = wheel;}
+    void setSector(int sector) {sector_ = sector;}
+    void setTag(int tag) {tag_ = tag;}
+
+    int getHwPhi() const {return hwPhi_;}
+    int getHwPhiB() const {return hwPhiB_;}
+    int getHwQual() const {return hwQual_;}
+    int getHwEta() const {return hwEta_;}
+    int getHwQEta() const {return hwQEta_;}
+    int getStation() const {return station_;}
+    int getWheel() const {return wheel_;}
+    int getSector() const {return sector_;}
+    int getTag() const {return tag_;}
+
+
+    private:
+      int hwPhi_;
+      int hwPhiB_;
+      int hwQual_;
+      int hwEta_;
+      int hwQEta_;
+      int station_;
+      int wheel_;
+      int sector_;
+      int tag_;
+          
+  };
+
+  typedef OrbitCollection<BMTFStub> BMTFStubOrbitCollection;
+	
+} // namespace l1ScoutingRun3
+
+#endif //DataFormats_L1Scouting_L1ScoutingBMTFStub_h

--- a/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
+++ b/DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h
@@ -8,71 +8,53 @@ namespace l1ScoutingRun3 {
   class BMTFStub {
   public:
     BMTFStub()
-      : hwPhi_(0),
-        hwPhiB_(0),
-        hwQual_(0),
-        hwEta_(0),
-        hwQEta_(0),
-        station_(0),
-        wheel_(0),
-        sector_(0),
-        tag_(0) {}
+        : hwPhi_(0), hwPhiB_(0), hwQual_(0), hwEta_(0), hwQEta_(0), station_(0), wheel_(0), sector_(0), tag_(0) {}
 
-    BMTFStub(int hwPhi,
-             int hwPhiB,
-             int hwQual,
-             int hwEta,
-             int hwQEta,
-             int station,
-             int wheel,
-             int sector,
-             int tag)
-      : hwPhi_(hwPhi),
-        hwPhiB_(hwPhiB),
-        hwQual_(hwQual),
-        hwEta_(hwEta),
-        hwQEta_(hwQEta),
-        station_(station),
-        wheel_(wheel),
-        sector_(sector),
-        tag_(tag) {}
+    BMTFStub(int hwPhi, int hwPhiB, int hwQual, int hwEta, int hwQEta, int station, int wheel, int sector, int tag)
+        : hwPhi_(hwPhi),
+          hwPhiB_(hwPhiB),
+          hwQual_(hwQual),
+          hwEta_(hwEta),
+          hwQEta_(hwQEta),
+          station_(station),
+          wheel_(wheel),
+          sector_(sector),
+          tag_(tag) {}
 
-    void setHwPhi(int hwPhi) {hwPhi_ = hwPhi;}
-    void setHwPhiB(int hwPhiB) {hwPhiB_ = hwPhiB;}
-    void setHwQual(int hwQual) {hwQual_ = hwQual;}
-    void setHwEta(int hwEta) {hwEta_ = hwEta;}
-    void setHwQEta(int hwQEta) {hwQEta_ = hwQEta;}
-    void setStation(int station) {station_ = station;}
-    void setWheel(int wheel) {wheel_ = wheel;}
-    void setSector(int sector) {sector_ = sector;}
-    void setTag(int tag) {tag_ = tag;}
+    void setHwPhi(int hwPhi) { hwPhi_ = hwPhi; }
+    void setHwPhiB(int hwPhiB) { hwPhiB_ = hwPhiB; }
+    void setHwQual(int hwQual) { hwQual_ = hwQual; }
+    void setHwEta(int hwEta) { hwEta_ = hwEta; }
+    void setHwQEta(int hwQEta) { hwQEta_ = hwQEta; }
+    void setStation(int station) { station_ = station; }
+    void setWheel(int wheel) { wheel_ = wheel; }
+    void setSector(int sector) { sector_ = sector; }
+    void setTag(int tag) { tag_ = tag; }
 
-    int getHwPhi() const {return hwPhi_;}
-    int getHwPhiB() const {return hwPhiB_;}
-    int getHwQual() const {return hwQual_;}
-    int getHwEta() const {return hwEta_;}
-    int getHwQEta() const {return hwQEta_;}
-    int getStation() const {return station_;}
-    int getWheel() const {return wheel_;}
-    int getSector() const {return sector_;}
-    int getTag() const {return tag_;}
+    int hwPhi() const { return hwPhi_; }
+    int hwPhiB() const { return hwPhiB_; }
+    int hwQual() const { return hwQual_; }
+    int hwEta() const { return hwEta_; }
+    int hwQEta() const { return hwQEta_; }
+    int station() const { return station_; }
+    int wheel() const { return wheel_; }
+    int sector() const { return sector_; }
+    int tag() const { return tag_; }
 
-
-    private:
-      int hwPhi_;
-      int hwPhiB_;
-      int hwQual_;
-      int hwEta_;
-      int hwQEta_;
-      int station_;
-      int wheel_;
-      int sector_;
-      int tag_;
-          
+  private:
+    int hwPhi_;
+    int hwPhiB_;
+    int hwQual_;
+    int hwEta_;
+    int hwQEta_;
+    int station_;
+    int wheel_;
+    int sector_;
+    int tag_;
   };
 
   typedef OrbitCollection<BMTFStub> BMTFStubOrbitCollection;
-	
-} // namespace l1ScoutingRun3
 
-#endif //DataFormats_L1Scouting_L1ScoutingBMTFStub_h
+}  // namespace l1ScoutingRun3
+
+#endif  //DataFormats_L1Scouting_L1ScoutingBMTFStub_h

--- a/DataFormats/L1Scouting/src/classes.h
+++ b/DataFormats/L1Scouting/src/classes.h
@@ -4,3 +4,4 @@
 #include "DataFormats/L1Scouting/interface/OrbitCollection.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"

--- a/DataFormats/L1Scouting/src/classes_def.xml
+++ b/DataFormats/L1Scouting/src/classes_def.xml
@@ -1,5 +1,9 @@
 <lcgdict>
 
+  <class name="l1ScoutingRun3::BMTFStub" ClassVersion="3">
+    <version ClassVersion="3" checksum="3502311834"/>
+  </class>
+
   <class name="l1ScoutingRun3::BxSums" ClassVersion="3">
     <version ClassVersion="3" checksum="1112955969"/>
   </class>
@@ -21,19 +25,22 @@
   <class name="l1ScoutingRun3::Tau" ClassVersion="3">
     <version ClassVersion="3" checksum="2889952120"/>
   </class>
-
+  
+  <class name="std::vector<l1ScoutingRun3::BMTFStub>"/>
   <class name="std::vector<l1ScoutingRun3::BxSums>"/>
   <class name="std::vector<l1ScoutingRun3::EGamma>"/>
   <class name="std::vector<l1ScoutingRun3::Jet>"/>
   <class name="std::vector<l1ScoutingRun3::Muon>"/>
   <class name="std::vector<l1ScoutingRun3::Tau>"/>
-
+  
+  <class name="l1ScoutingRun3::BMTFStubOrbitCollection"/>
   <class name="l1ScoutingRun3::BxSumsOrbitCollection"/>
   <class name="l1ScoutingRun3::EGammaOrbitCollection"/>
   <class name="l1ScoutingRun3::JetOrbitCollection"/>
   <class name="l1ScoutingRun3::MuonOrbitCollection"/>
   <class name="l1ScoutingRun3::TauOrbitCollection"/>
 
+  <class name="edm::Wrapper<l1ScoutingRun3::BMTFStubOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::BxSumsOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::EGammaOrbitCollection>"/>
   <class name="edm::Wrapper<l1ScoutingRun3::JetOrbitCollection>"/>

--- a/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
+++ b/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
@@ -10,8 +10,14 @@ file=testL1Scouting.root
 
 cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py --inputFile "$file" || die "Failure using read_L1Scouting_cfg.py $file" $?
 
+# test file for muon, jet, e/gamma and energy sums data formats
 oldFile="testL1Scouting_v3_v3_v3_v3_v3_13_3_0_pre5.root"
 inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$oldFile) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$oldFile" $?
 cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py --inputFile "$inputfile" --bmtfStubVersion 0 || die "Failed to read old file $oldFile" $?
+
+# added BMTF input stubs data format
+oldFile="testL1Scouting_v3_v3_v3_v3_v3_v3_14_1_0_pre4.root"
+inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$oldFile) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$oldFile" $?
+cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py --inputFile "$inputfile" --bmtfStubVersion 3 || die "Failed to read old file $oldFile" $?
 
 exit 0

--- a/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
+++ b/DataFormats/L1Scouting/test/TestL1ScoutingFormat.sh
@@ -8,10 +8,10 @@ cmsRun ${LOCAL_TEST_DIR}/create_L1Scouting_test_file_cfg.py || die 'Failure usin
 
 file=testL1Scouting.root
 
-cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py "$file" || die "Failure using read_L1Scouting_cfg.py $file" $?
+cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py --inputFile "$file" || die "Failure using read_L1Scouting_cfg.py $file" $?
 
 oldFile="testL1Scouting_v3_v3_v3_v3_v3_13_3_0_pre5.root"
 inputfile=$(edmFileInPath DataFormats/L1Scouting/data/$oldFile) || die "Failure edmFileInPath DataFormats/L1Scouting/data/$oldFile" $?
-cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py "$inputfile" || die "Failed to read old file $oldFile" $?
+cmsRun ${LOCAL_TEST_DIR}/read_L1Scouting_cfg.py --inputFile "$inputfile" --bmtfStubVersion 0 || die "Failed to read old file $oldFile" $?
 
 exit 0

--- a/DataFormats/L1Scouting/test/create_L1Scouting_test_file_cfg.py
+++ b/DataFormats/L1Scouting/test/create_L1Scouting_test_file_cfg.py
@@ -13,7 +13,8 @@ process.l1ScoutingTestProducer = cms.EDProducer("TestWriteL1Scouting",
   jetValues = cms.vint32(4, 5, 6, 7),
   eGammaValues = cms.vint32(8, 9, 10),
   tauValues = cms.vint32(11, 12),
-  bxSumsValues = cms.vint32(13)
+  bxSumsValues = cms.vint32(13),
+  bmtfStubValues = cms.vint32(1, 2),
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/DataFormats/L1Scouting/test/read_L1Scouting_cfg.py
+++ b/DataFormats/L1Scouting/test/read_L1Scouting_cfg.py
@@ -1,11 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 import sys
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test L1 Scouting data formats')
+
+parser.add_argument("--inputFile", type=str, help="Input file name (default: testL1Scouting.root)", default="testL1Scouting.root")
+parser.add_argument("--bmtfStubVersion", type=int, help="track data format version (default: 3)", default=3)
+args = parser.parse_args()
 
 process = cms.Process("READ")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+sys.argv[1]))
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring("file:"+args.inputFile))
 process.maxEvents.input = 1
 
 process.l1ScoutingTestAnalyzer = cms.EDAnalyzer("TestReadL1Scouting",
@@ -19,7 +26,10 @@ process.l1ScoutingTestAnalyzer = cms.EDAnalyzer("TestReadL1Scouting",
   tausTag = cms.InputTag("l1ScoutingTestProducer", "", "PROD"),
   expectedTauValues = cms.vint32(11, 12),
   bxSumsTag = cms.InputTag("l1ScoutingTestProducer", "", "PROD"),
-  expectedBxSumsValues = cms.vint32(13)
+  expectedBxSumsValues = cms.vint32(13),
+  bmtfStubClassVersion = cms.int32(args.bmtfStubVersion), 
+  bmtfStubTag = cms.InputTag("l1ScoutingTestProducer", "", "PROD"),
+  expectedBmtfStubValues = cms.vint32(1, 2)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",

--- a/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/blocks.h
@@ -62,6 +62,9 @@ namespace l1ScoutingRun3 {
 
   namespace bmtf {
     struct block {
+      uint32_t header;
+      uint32_t bx;
+      uint32_t orbit;
       uint64_t stub[8];
     };
   }  // namespace bmtf

--- a/EventFilter/L1ScoutingRawToDigi/interface/masks.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/masks.h
@@ -91,18 +91,18 @@ namespace l1ScoutingRun3 {
 
   namespace bmtf {
     struct masksStubs {
-        static constexpr uint64_t valid    = 0x0001;
-        static constexpr uint64_t phi      = 0x0fff;
-        static constexpr uint64_t phiB     = 0x03ff;
-        static constexpr uint64_t qual     = 0x0007;
-        static constexpr uint64_t eta      = 0x007f;
-        static constexpr uint64_t qeta     = 0x007f;
-        static constexpr uint64_t station  = 0x0003;
-        static constexpr uint64_t wheel    = 0x0007;
-        static constexpr uint64_t reserved = 0x0007;
-        static constexpr uint64_t bx       = 0xffff;
+      static constexpr uint64_t valid = 0x0001;
+      static constexpr uint64_t phi = 0x0fff;
+      static constexpr uint64_t phiB = 0x03ff;
+      static constexpr uint64_t qual = 0x0007;
+      static constexpr uint64_t eta = 0x007f;
+      static constexpr uint64_t qeta = 0x007f;
+      static constexpr uint64_t station = 0x0003;
+      static constexpr uint64_t wheel = 0x0007;
+      static constexpr uint64_t reserved = 0x0007;
+      static constexpr uint64_t bx = 0xffff;
     };
-  } // namespace bmtf
+  }  // namespace bmtf
 
   struct header_masks {
     static constexpr uint32_t bxmatch = 0x00ff << header_shifts::bxmatch;

--- a/EventFilter/L1ScoutingRawToDigi/interface/masks.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/masks.h
@@ -89,6 +89,21 @@ namespace l1ScoutingRun3 {
     };
   }  // namespace demux
 
+  namespace bmtf {
+    struct masksStubs {
+        static constexpr uint64_t valid    = 0x0001;
+        static constexpr uint64_t phi      = 0x0fff;
+        static constexpr uint64_t phiB     = 0x03ff;
+        static constexpr uint64_t qual     = 0x0007;
+        static constexpr uint64_t eta      = 0x007f;
+        static constexpr uint64_t qeta     = 0x007f;
+        static constexpr uint64_t station  = 0x0003;
+        static constexpr uint64_t wheel    = 0x0007;
+        static constexpr uint64_t reserved = 0x0007;
+        static constexpr uint64_t bx       = 0xffff;
+    };
+  } // namespace bmtf
+
   struct header_masks {
     static constexpr uint32_t bxmatch = 0x00ff << header_shifts::bxmatch;
     static constexpr uint32_t mAcount = 0x000f << header_shifts::mAcount;

--- a/EventFilter/L1ScoutingRawToDigi/interface/shifts.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/shifts.h
@@ -89,6 +89,22 @@ namespace l1ScoutingRun3 {
     };
   }  // namespace demux
 
+  namespace bmtf {
+    struct shiftsStubs {
+        static constexpr uint32_t valid     =  0;
+        static constexpr uint32_t phi       =  1;
+        static constexpr uint32_t phiB      = 13;
+        static constexpr uint32_t qual      = 23;
+        static constexpr uint32_t eta       = 26;
+        static constexpr uint32_t qeta      = 33;
+        static constexpr uint32_t station   = 40;
+        static constexpr uint32_t wheel     = 42;
+        static constexpr uint32_t reserved  = 45;
+        static constexpr uint32_t bx        = 48;
+    };
+  } // namespace bmtf
+
+
   struct header_shifts {
     static constexpr uint32_t bxmatch = 24;
     static constexpr uint32_t mAcount = 16;

--- a/EventFilter/L1ScoutingRawToDigi/interface/shifts.h
+++ b/EventFilter/L1ScoutingRawToDigi/interface/shifts.h
@@ -91,19 +91,18 @@ namespace l1ScoutingRun3 {
 
   namespace bmtf {
     struct shiftsStubs {
-        static constexpr uint32_t valid     =  0;
-        static constexpr uint32_t phi       =  1;
-        static constexpr uint32_t phiB      = 13;
-        static constexpr uint32_t qual      = 23;
-        static constexpr uint32_t eta       = 26;
-        static constexpr uint32_t qeta      = 33;
-        static constexpr uint32_t station   = 40;
-        static constexpr uint32_t wheel     = 42;
-        static constexpr uint32_t reserved  = 45;
-        static constexpr uint32_t bx        = 48;
+      static constexpr uint32_t valid = 0;
+      static constexpr uint32_t phi = 1;
+      static constexpr uint32_t phiB = 13;
+      static constexpr uint32_t qual = 23;
+      static constexpr uint32_t eta = 26;
+      static constexpr uint32_t qeta = 33;
+      static constexpr uint32_t station = 40;
+      static constexpr uint32_t wheel = 42;
+      static constexpr uint32_t reserved = 45;
+      static constexpr uint32_t bx = 48;
     };
-  } // namespace bmtf
-
+  }  // namespace bmtf
 
   struct header_shifts {
     static constexpr uint32_t bxmatch = 24;

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
@@ -2,10 +2,10 @@
 
 ScBMTFRawToDigi::ScBMTFRawToDigi(const edm::ParameterSet& iConfig) {
   using namespace edm;
-  srcInputTag = iConfig.getParameter<InputTag>("srcInputTag");
+  srcInputTag_ = iConfig.getParameter<InputTag>("srcInputTag");
   sourceIdList_ = iConfig.getParameter<std::vector<int>>("sourceIdList");
   debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
-  
+
   // initialize orbit buffer for BX 1->3564;
   orbitBuffer_ = std::vector<std::vector<l1ScoutingRun3::BMTFStub>>(3565);
   for (auto& bxVec : orbitBuffer_) {
@@ -14,7 +14,7 @@ ScBMTFRawToDigi::ScBMTFRawToDigi(const edm::ParameterSet& iConfig) {
   nStubsOrbit_ = 0;
 
   produces<l1ScoutingRun3::BMTFStubOrbitCollection>().setBranchAlias("BMTFStubOrbitCollection");
-  rawToken = consumes<SDSRawDataCollection>(srcInputTag);
+  rawToken_ = consumes<SDSRawDataCollection>(srcInputTag_);
 }
 
 ScBMTFRawToDigi::~ScBMTFRawToDigi(){};
@@ -23,23 +23,22 @@ void ScBMTFRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace edm;
 
   Handle<SDSRawDataCollection> ScoutingRawDataCollection;
-  iEvent.getByToken(rawToken, ScoutingRawDataCollection);
+  iEvent.getByToken(rawToken_, ScoutingRawDataCollection);
 
   std::unique_ptr<l1ScoutingRun3::BMTFStubOrbitCollection> unpackedStubs(new l1ScoutingRun3::BMTFStubOrbitCollection);
 
-  //for (unsigned int sdsId=SDSNumbering::BmtfMinSDSID; sdsId<=SDSNumbering::BmtfMaxSDSID; sdsId++) {
-  for (const auto& sdsId: sourceIdList_){
-    if ((sdsId<SDSNumbering::BmtfMinSDSID) || (sdsId>SDSNumbering::BmtfMaxSDSID))
-      edm::LogWarning("ScBMTFRawToDigi::produce") 
-      << "Provided a source ID outside the expected range: " << sdsId
-      << ", expected range [" << SDSNumbering::BmtfMinSDSID << ", " << SDSNumbering::BmtfMaxSDSID;
+  for (const auto& sdsId : sourceIdList_) {
+    if ((sdsId < SDSNumbering::BmtfMinSDSID) || (sdsId > SDSNumbering::BmtfMaxSDSID))
+      edm::LogError("ScBMTFRawToDigi::produce")
+          << "Provided a source ID outside the expected range: " << sdsId << ", expected range ["
+          << SDSNumbering::BmtfMinSDSID << ", " << SDSNumbering::BmtfMaxSDSID;
     const FEDRawData& sourceRawData = ScoutingRawDataCollection->FEDData(sdsId);
     size_t orbitSize = sourceRawData.size();
 
-    if((sourceRawData.size()==0) && debug_){
+    if ((sourceRawData.size() == 0) && debug_) {
       std::cout << "No raw data for BMTF FED " << sdsId << std::endl;
     }
-    
+
     // unpack current orbit and store data into the orbitBufferr
     unpackOrbit(sourceRawData.data(), orbitSize, sdsId);
   }
@@ -62,58 +61,57 @@ void ScBMTFRawToDigi::unpackOrbit(const unsigned char* buf, size_t len, int sdsI
   while (pos < len) {
     assert(pos + 4 <= len);
 
-    bmtf::block *bl = (bmtf::block *)(buf + pos);
-    
+    bmtf::block* bl = (bmtf::block*)(buf + pos);
+
     unsigned bx = bl->bx;
     unsigned orbit = (bl->orbit) & 0x7FFFFFFF;
     unsigned sCount = (bl->header) & 0xff;
 
-    size_t pos_increment = 12 + sCount*8;
+    size_t pos_increment = 12 + sCount * 8;
 
     assert(pos_increment <= len);
 
-    pos += 12; // header
+    pos += 12;  // header
 
-    if (debug_){
-      std::cout  << " BMTF #" << sdsId << " Orbit " << orbit << ", BX -> "<< bx << ", nStubs -> " << sCount << std::endl;
-      
+    if (debug_) {
+      std::cout << " BMTF #" << sdsId << " Orbit " << orbit << ", BX -> " << bx << ", nStubs -> " << sCount
+                << std::endl;
     }
 
     // Unpack stubs for the current pair (BX, sector)
     int32_t phi, phiB, tag, qual, eta, qeta, station, wheel, sector;
 
     // map for station and wheel, to find chambers with 2 stubs
-    std::vector<std::vector<bool>> stwh_matrix(4, std::vector<bool>(5,false));
-    for (unsigned int i=0; i<sCount; i++) {
-
+    std::vector<std::vector<bool>> stwh_matrix(4, std::vector<bool>(5, false));
+    for (unsigned int i = 0; i < sCount; i++) {
       uint64_t stub_raw = *(uint64_t*)(buf + pos);
       pos += 8;
-      
-      phi      = ((stub_raw >> bmtf::shiftsStubs::phi     ) & bmtf::masksStubs::phi     );
-      phiB     = ((stub_raw >> bmtf::shiftsStubs::phiB    ) & bmtf::masksStubs::phiB    );
-      qual     = ((stub_raw >> bmtf::shiftsStubs::qual    ) & bmtf::masksStubs::qual    );
-      eta      = ((stub_raw >> bmtf::shiftsStubs::eta     ) & bmtf::masksStubs::eta     );
-      qeta     = ((stub_raw >> bmtf::shiftsStubs::qeta    ) & bmtf::masksStubs::qeta    );
-      station  = ((stub_raw >> bmtf::shiftsStubs::station ) & bmtf::masksStubs::station ) + 1;
-      wheel    = ((stub_raw >> bmtf::shiftsStubs::wheel   ) & bmtf::masksStubs::wheel   );
-      sector   = sdsId - SDSNumbering::BmtfMinSDSID;
-      
-      if (stwh_matrix[station-1][wheel+2]==false) {
+
+      phi = ((stub_raw >> bmtf::shiftsStubs::phi) & bmtf::masksStubs::phi);
+      phiB = ((stub_raw >> bmtf::shiftsStubs::phiB) & bmtf::masksStubs::phiB);
+      qual = ((stub_raw >> bmtf::shiftsStubs::qual) & bmtf::masksStubs::qual);
+      eta = ((stub_raw >> bmtf::shiftsStubs::eta) & bmtf::masksStubs::eta);
+      qeta = ((stub_raw >> bmtf::shiftsStubs::qeta) & bmtf::masksStubs::qeta);
+      station = ((stub_raw >> bmtf::shiftsStubs::station) & bmtf::masksStubs::station) + 1;
+      wheel = ((stub_raw >> bmtf::shiftsStubs::wheel) & bmtf::masksStubs::wheel);
+      sector = sdsId - SDSNumbering::BmtfMinSDSID;
+
+      if (stwh_matrix[station - 1][wheel + 2] == false) {
         tag = 1;
       } else {
         tag = 0;
       }
-      stwh_matrix[station-1][wheel+2] = true;
+      stwh_matrix[station - 1][wheel + 2] = true;
 
-      phi      = phi   >= 2048 ? phi   - 4096 : phi;
-      phiB     = phiB  >=  512 ? phiB  - 1024 : phiB;
-      wheel    = wheel >=    4 ? wheel -    8 : wheel;
+      phi = phi >= 2048 ? phi - 4096 : phi;
+      phiB = phiB >= 512 ? phiB - 1024 : phiB;
+      wheel = wheel >= 4 ? wheel - 8 : wheel;
 
       BMTFStub stub(phi, phiB, qual, eta, qeta, station, wheel, sector, tag);
       orbitBuffer_[bx].push_back(stub);
-      nStubsOrbit_ ++;
+      nStubsOrbit_++;
 
-      if (debug_){
+      if (debug_) {
         std::cout << "Stub " << i << ", raw: 0x" << std::hex << stub_raw << std::dec << std::endl;
         std::cout << "\tPhi: " << phi << std::endl;
         std::cout << "\tPhiB: " << phiB << std::endl;
@@ -126,7 +124,6 @@ void ScBMTFRawToDigi::unpackOrbit(const unsigned char* buf, size_t len, int sdsI
         std::cout << "\tTag: " << tag << std::endl;
       }
     }
-    
 
   }  // end orbit while loop
 }

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
@@ -1,0 +1,117 @@
+#include "EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h"
+
+ScBMTFRawToDigi::ScBMTFRawToDigi(const edm::ParameterSet& iConfig) {
+  using namespace edm;
+  srcInputTag = iConfig.getParameter<InputTag>("srcInputTag");
+  debug_ = iConfig.getUntrackedParameter<bool>("debug", false);
+
+  // initialize orbit buffer for BX 1->3564;
+  orbitBuffer_ = std::vector<std::vector<l1ScoutingRun3::BMTFStub>>(3565);
+  for (auto& bxVec : orbitBuffer_) {
+    bxVec.reserve(32);
+  }
+  nStubsOrbit_ = 0;
+
+  produces<l1ScoutingRun3::BMTFStubOrbitCollection>().setBranchAlias("BMTFStubOrbitCollection");
+  rawToken = consumes<SDSRawDataCollection>(srcInputTag);
+}
+
+ScBMTFRawToDigi::~ScBMTFRawToDigi(){};
+
+void ScBMTFRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  Handle<SDSRawDataCollection> ScoutingRawDataCollection;
+  iEvent.getByToken(rawToken, ScoutingRawDataCollection);
+
+  std::unique_ptr<l1ScoutingRun3::BMTFStubOrbitCollection> unpackedStubs(new l1ScoutingRun3::BMTFStubOrbitCollection);
+
+  for (unsigned int sdsId=SDSNumbering::BmtfMinSDSID; sdsId<SDSNumbering::BmtfMaxSDSID; sdsId++) {
+    // get data and orbit size from i^th source
+    const FEDRawData& sourceRawData = ScoutingRawDataCollection->FEDData(sdsId);
+    size_t orbitSize = sourceRawData.size();
+
+    if((sourceRawData.size()==0) && debug_){
+      std::cout << "No raw data for BMTF FED " << sdsId << std::endl;
+    }
+    
+    // unpack current orbit and store data into the orbitBufferr
+    unpackOrbit(sourceRawData.data(), orbitSize, sdsId);
+  }
+
+  // fill orbit collection and clear the Bx buffer vector
+  unpackedStubs->fillAndClear(orbitBuffer_, nStubsOrbit_);
+
+  // store collection in the event
+  iEvent.put(std::move(unpackedStubs));
+}
+
+void ScBMTFRawToDigi::unpackOrbit(const unsigned char* buf, size_t len, unsigned int sdsId) {
+  using namespace l1ScoutingRun3;
+
+  // reset counters
+  nStubsOrbit_ = 0;
+
+  size_t pos = 0;
+
+  while (pos < len) {
+    assert(pos + 4 <= len);
+
+    bmtf::block *bl = (bmtf::block *)(buf + pos);
+    
+    unsigned bx = bl->bx;
+    unsigned orbit = (bl->orbit) & 0x7FFFFFFF;
+    unsigned sCount = (bl->header) & 0xff;
+
+    pos += 12 + sCount*8;
+
+    assert(pos <= len);
+
+    if (debug_){
+      std::cout  << " BMTF #" << sdsId << " Orbit " << orbit << ", BX -> "<< bx << ", nStubs -> " << sCount << std::endl;
+      
+    }
+
+    // Unpack stubs for the current pair (BX, sector)
+    int32_t phi, phiB, tag, qual, eta, qeta, station, wheel, sector;
+    
+    // map for station and wheel, to find chambers with 2 stubs
+    std::vector<std::vector<bool>> stwh_matrix(4, std::vector<bool>(5,false));
+    for (unsigned int i=0; i<sCount; i++) {
+
+      phi      = ((bl->stub[i] >> bmtf::shiftsStubs::phi     ) & bmtf::masksStubs::phi     );
+      phiB     = ((bl->stub[i] >> bmtf::shiftsStubs::phiB    ) & bmtf::masksStubs::phiB    );
+      qual     = ((bl->stub[i] >> bmtf::shiftsStubs::qual    ) & bmtf::masksStubs::qual    );
+      eta      = ((bl->stub[i] >> bmtf::shiftsStubs::eta     ) & bmtf::masksStubs::eta     );
+      qeta     = ((bl->stub[i] >> bmtf::shiftsStubs::qeta    ) & bmtf::masksStubs::qeta    );
+      station  = ((bl->stub[i] >> bmtf::shiftsStubs::station ) & bmtf::masksStubs::station ) + 1;
+      wheel    = ((bl->stub[i] >> bmtf::shiftsStubs::wheel   ) & bmtf::masksStubs::wheel   );
+      sector   = sdsId - SDSNumbering::BmtfMinSDSID;
+      
+      if (stwh_matrix[station-1][wheel+2]==false) {
+        tag = 1;
+      } else {
+        tag = 0;
+      }
+      stwh_matrix[station-1][wheel+2] = true;
+
+      phi      = phi   >= 2048 ? phi   - 4096 : phi;
+      phiB     = phiB  >=  512 ? phiB  - 1024 : phiB;
+      wheel    = wheel >=    4 ? wheel -    8 : wheel;
+
+      BMTFStub stub(phi, phiB, qual, eta, qeta, station, wheel, sector, tag);
+      orbitBuffer_[bx].push_back(stub);
+      nStubsOrbit_ ++;
+    }
+    
+
+  }  // end orbit while loop
+}
+
+void ScBMTFRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(ScBMTFRawToDigi);

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
@@ -1,0 +1,44 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/L1ScoutingRawData/interface/SDSNumbering.h"
+#include "DataFormats/L1ScoutingRawData/interface/SDSRawDataCollection.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+
+#include "EventFilter/L1ScoutingRawToDigi/interface/shifts.h"
+#include "EventFilter/L1ScoutingRawToDigi/interface/masks.h"
+#include "EventFilter/L1ScoutingRawToDigi/interface/blocks.h"
+#include "L1TriggerScouting/Utilities/interface/printScObjects.h"
+
+#include <memory>
+#include <vector>
+#include <iostream>
+
+class ScBMTFRawToDigi : public edm::stream::EDProducer<> {
+public:
+  explicit ScBMTFRawToDigi(const edm::ParameterSet&);
+  ~ScBMTFRawToDigi() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  void unpackOrbit(const unsigned char* buf, size_t len, unsigned int sdsId);
+
+  // vector holding data for every bunch crossing
+  // before  filling the orbit collection
+  std::vector<std::vector<l1ScoutingRun3::BMTFStub>> orbitBuffer_;
+  int nStubsOrbit_;
+
+  bool debug_ = false;
+  edm::InputTag srcInputTag;
+  edm::EDGetToken rawToken;
+};

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
@@ -40,6 +40,6 @@ private:
 
   bool debug_ = false;
   std::vector<int> sourceIdList_;
-  edm::InputTag srcInputTag;
-  edm::EDGetToken rawToken;
+  edm::InputTag srcInputTag_;
+  edm::EDGetToken rawToken_;
 };

--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.h
@@ -31,7 +31,7 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void unpackOrbit(const unsigned char* buf, size_t len, unsigned int sdsId);
+  void unpackOrbit(const unsigned char* buf, size_t len, int sdsId);
 
   // vector holding data for every bunch crossing
   // before  filling the orbit collection
@@ -39,6 +39,7 @@ private:
   int nStubsOrbit_;
 
   bool debug_ = false;
+  std::vector<int> sourceIdList_;
   edm::InputTag srcInputTag;
   edm::EDGetToken rawToken;
 };

--- a/EventFilter/L1ScoutingRawToDigi/python/ScBMTFRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScBMTFRawToDigi_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+ScBMTFUnpacker = cms.EDProducer('ScBMTFRawToDigi',
+  srcInputTag = cms.InputTag('rawDataCollector'),
+  # print all objects
+  debug = cms.untracked.bool(False)
+)
+

--- a/EventFilter/L1ScoutingRawToDigi/python/ScBMTFRawToDigi_cfi.py
+++ b/EventFilter/L1ScoutingRawToDigi/python/ScBMTFRawToDigi_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 ScBMTFUnpacker = cms.EDProducer('ScBMTFRawToDigi',
   srcInputTag = cms.InputTag('rawDataCollector'),
+  sourceIdList = cms.vint32(10,11,12,13,14,15,16,17,18,19,20,21),
   # print all objects
   debug = cms.untracked.bool(False)
 )


### PR DESCRIPTION
#### PR description:

This PR introduces the unpacker and data format needed to process muon stubs collected with the L1 Scouting system from the BMTF Trigger processors. 

New test file have been added to cms-data in this PR:
* https://github.com/cms-data/DataFormats-L1Scouting/pull/3

#### PR validation:

PR unpacker has been validated with data collected at p5 with the L1 scouting system, running in local, and comparing data results with L1 Trigger objects reconstructed starting from the cdaq Raw data

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be discussed: We would like this PR to be backported in a data-taking release in order to collect data from pp collisions during 2024. 