### PR TITLE
[14_0_X] Protect against null `VertexRef` in `DeepBoostedJetTagInfoProducer.cc`

### DIFF
--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -683,6 +683,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
           pv_ass = (*pvas_)[cand];
           if (pv_ass.isNonnull())
             vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
+          else
+            edm::LogWarning("DeepBoostedJetTagInfoProducer") << "Null primary vertex reference";
         } else
           throw edm::Exception(edm::errors::InvalidReference) << "Vertex association missing";
       }

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -681,7 +681,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
         if (use_pvasq_value_map_) {
           pv_ass_quality = (*pvasq_value_map_)[cand];
           pv_ass = (*pvas_)[cand];
-          vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
+          if (pv_ass.isNonnull())
+            vtx_ass = vtx_ass_from_pfcand(*reco_cand, pv_ass_quality, pv_ass);
         } else
           throw edm::Exception(edm::errors::InvalidReference) << "Vertex association missing";
       }


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45245

