### PR TITLE
Add extended version of SCraw energy plots [14_0_X]

### DIFF
--- a/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/ClusterTask_cfi.py
@@ -349,6 +349,19 @@ ecalClusterTask = cms.untracked.PSet(
             btype = cms.untracked.string('User'),
             description = cms.untracked.string('Energy distribution of the super clusters (low scale).')
         ),
+        SCRawEHigh = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sClusterTask/%(prefix)sCLT SC raw energy (high scale)'),
+            kind = cms.untracked.string('TH1F'),
+            otype = cms.untracked.string('Ecal2P'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(1000.0),
+                nbins = cms.untracked.int32(50),
+                low = cms.untracked.double(0.0),
+                title = cms.untracked.string('energy (GeV)')
+            ),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Energy distribution of the super clusters (high scale).')
+        ),
         SCClusterVsSeed = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             yaxis = cms.untracked.PSet(

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -364,6 +364,7 @@ namespace ecaldqm {
     MESet& meSCELow(MEs_.at("SCELow"));
     MESet& meSCRawE(MEs_.at("SCRawE"));
     MESet& meSCRawELow(MEs_.at("SCRawELow"));
+    MESet& meSCRawEHigh(MEs_.at("SCRawEHigh"));
     MESet& meSCNBCs(MEs_.at("SCNBCs"));
     MESet& meSCNcrystals(MEs_.at("SCNcrystals"));
     MESet& meTrendSCSize(MEs_.at("TrendSCSize"));
@@ -423,6 +424,7 @@ namespace ecaldqm {
 
       meSCRawE.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
       meSCRawELow.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
+      meSCRawEHigh.fill(getEcalDQMSetupObjects(), seedId, rawEnergy);
 
       meSCNBCs.fill(getEcalDQMSetupObjects(), seedId, scItr->clustersSize());
       meSCNcrystals.fill(getEcalDQMSetupObjects(), seedId, size);


### PR DESCRIPTION
#### PR description:

This PR adds a plot in ECAL DQM, "SC Raw Energy (high scale)". This is a copy of an existing plot "SC Raw Energy" but with x-range extended to 1 TeV.

#### PR validation:

PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport to `14_0_X`, which is used in production at the moment. Master PR is #45266 