### PR TITLE
Improve plugins in `Alignment/HIPAlignmentAlgorithm` and add unit tests

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/plugins/HIPTwoBodyDecayAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/plugins/HIPTwoBodyDecayAnalyzer.cc
@@ -51,10 +51,7 @@ private:
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> ttkbuilderToken_;
 
   enum BranchType { BranchType_short_t, BranchType_int_t, BranchType_float_t, BranchType_unknown_t };
-
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   void bookAllBranches();
   bool bookBranch(std::string bname, BranchType btype);
@@ -282,13 +279,13 @@ void HIPTwoBodyDecayAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   tree->Fill();
 }
 
-void HIPTwoBodyDecayAnalyzer::beginJob() {}
-void HIPTwoBodyDecayAnalyzer::endJob() {}
-
 void HIPTwoBodyDecayAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("alcarecotracks", edm::InputTag("ALCARECOTkAlZMuMu"));
+  desc.add<edm::InputTag>("refit1tracks", edm::InputTag("FirstTrackRefitter"));
+  desc.add<edm::InputTag>("refit2tracks", edm::InputTag("HitFilteredTracksTrackFitter"));
+  desc.add<edm::InputTag>("finaltracks", edm::InputTag("FinalTrackRefitter"));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 void HIPTwoBodyDecayAnalyzer::analyzeTrackCollection(std::string strTrackType,

--- a/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
@@ -82,6 +82,14 @@ private:
   double qoverp_[nMaxtracks_];
   double dz_[nMaxtracks_];
   double dxy_[nMaxtracks_];
+  double dzPV_[nMaxtracks_];
+  double dxyPV_[nMaxtracks_];
+  double dzSig_[nMaxtracks_];
+  double dxySig_[nMaxtracks_];
+  double dzPVSig_[nMaxtracks_];
+  double dxyPVSig_[nMaxtracks_];
+  double dzError_[nMaxtracks_];
+  double dxyError_[nMaxtracks_];
   double xPCA_[nMaxtracks_];
   double yPCA_[nMaxtracks_];
   double zPCA_[nMaxtracks_];
@@ -170,6 +178,37 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     qoverp_[nTracks_] = track.qoverp();
     dz_[nTracks_] = track.dz();
     dxy_[nTracks_] = track.dxy();
+    dzError_[nTracks_] = track.dzError();
+    dxyError_[nTracks_] = track.dxyError();
+    dzSig_[nTracks_] = track.dz() / track.dzError();
+    dxySig_[nTracks_] = track.dxy() / track.dxyError();
+
+    const reco::Vertex* closestVertex = nullptr;
+    float minDz = std::numeric_limits<float>::max();
+
+    // Loop over vertices to find the closest one in dz
+    for (const auto& vertex : vertices) {
+      float dz = fabs(track.dz(vertex.position()));
+      if (dz < minDz) {
+        minDz = dz;
+        closestVertex = &vertex;
+      }
+    }
+
+    float dzPV{-999.};
+    float dxyPV{-999.};
+    if (closestVertex) {
+      // Compute dxy and dz with respect to the closest vertex
+      dzPV = track.dz(closestVertex->position());
+      dxyPV = track.dxy(closestVertex->position());
+    }
+
+    dzPV_[nTracks_] = dzPV;
+    dxyPV_[nTracks_] = dxyPV;
+
+    dzPVSig_[nTracks_] = dzPV / track.dzError();
+    dxyPVSig_[nTracks_] = dxyPV / track.dxyError();
+
     xPCA_[nTracks_] = track.vertex().x();
     yPCA_[nTracks_] = track.vertex().y();
     zPCA_[nTracks_] = track.vertex().z();
@@ -218,7 +257,7 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       myalgo = 24;
     } else {
       myalgo = 25;
-      edm::LogWarning("LhcTrackAnalyzer")
+      edm::LogInfo("LhcTrackAnalyzer")
           << "LhcTrackAnalyzer does not support all types of tracks, encountered one from algo "
           << reco::TrackBase::algoName(track.algo());
     }
@@ -276,6 +315,14 @@ void LhcTrackAnalyzer::beginJob()
   rootTree_->Branch("qoverp", &qoverp_, "qoverp[nTracks]/D");
   rootTree_->Branch("dz", &dz_, "dz[nTracks]/D");
   rootTree_->Branch("dxy", &dxy_, "dxy[nTracks]/D");
+  rootTree_->Branch("dzPV", &dzPV_, "dzPV[nTracks]/D");
+  rootTree_->Branch("dxyPV", &dxy_, "dxyPV[nTracks]/D");
+  rootTree_->Branch("dzError", &dzError_, "dzError[nTracks]/D");
+  rootTree_->Branch("dxyError", &dxyError_, "dxyError[nTracks]/D");
+  rootTree_->Branch("dzSig", &dzSig_, "dzSig[nTracks]/D");
+  rootTree_->Branch("dxySig", &dxySig_, "dxySig[nTracks]/D");
+  rootTree_->Branch("dzPVSig", &dzPVSig_, "dzPVSig[nTracks]/D");
+  rootTree_->Branch("dxyPVSig", &dxyPVSig_, "dxyPVSig[nTracks]/D");
   rootTree_->Branch("xPCA", &xPCA_, "xPCA[nTracks]/D");
   rootTree_->Branch("yPCA", &yPCA_, "yPCA[nTracks]/D");
   rootTree_->Branch("zPCA", &zPCA_, "zPCA[nTracks]/D");

--- a/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
@@ -136,7 +136,18 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   // Retrieve the Track information
   //=======================================================
 
-  const auto& vertices = iEvent.get(theVertexCollectionToken);
+  // Declare the handle for the vertex collection
+  const auto& vertexHandle = iEvent.getHandle(theVertexCollectionToken);
+
+  // Check if the handle is valid
+  if (!vertexHandle.isValid()) {
+    edm::LogError("LhcTrackAnalyzer") << "Vertex collection not found or invalid.";
+    return;  // Early return if the vertex collection is not valid
+  }
+
+  // Retrieve the actual product from the handle
+  const reco::VertexCollection& vertices = *vertexHandle;
+
   const auto& vtx = vertices.front();
   if (vtx.isFake()) {
     goodvtx_ = false;
@@ -156,10 +167,20 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   run_ = iEvent.id().run();
   event_ = iEvent.id().event();
 
-  const auto& tracks = iEvent.get(theTrackCollectionToken);
+  const auto& tracksHandle = iEvent.getHandle(theTrackCollectionToken);
+
+  // Check if the handle is valid
+  if (!tracksHandle.isValid()) {
+    edm::LogError("LhcTrackAnalyzer") << "Tracks collection not found or invalid.";
+    return;  // Early return if the vertex collection is not valid
+  }
+
+  // Retrieve the actual product from the handle
+  const reco::TrackCollection& tracks = *tracksHandle;
+
   if (debug_) {
-    edm::LogWarning("LhcTrackAnalyzer") << "LhcTrackAnalyzer::analyze() looping over " << tracks.size() << "tracks."
-                                        << endl;
+    edm::LogInfo("LhcTrackAnalyzer") << "LhcTrackAnalyzer::analyze() looping over " << tracks.size() << "tracks."
+                                     << endl;
   }
 
   for (const auto& track : tracks) {

--- a/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
+++ b/Alignment/HIPAlignmentAlgorithm/plugins/LhcTrackAnalyzer.cc
@@ -158,8 +158,8 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
   const auto& tracks = iEvent.get(theTrackCollectionToken);
   if (debug_) {
-    edm::LogInfo("LhcTrackAnalyzer") << "LhcTrackAnalyzer::analyze() looping over " << tracks.size() << "tracks."
-                                     << endl;
+    edm::LogWarning("LhcTrackAnalyzer") << "LhcTrackAnalyzer::analyze() looping over " << tracks.size() << "tracks."
+                                        << endl;
   }
 
   for (const auto& track : tracks) {
@@ -255,9 +255,15 @@ void LhcTrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       myalgo = 23;
     } else if (track.algo() == reco::TrackBase::detachedQuadStep) {
       myalgo = 24;
-    } else {
+    } else if (track.algo() == reco::TrackBase::displacedGeneralStep) {
       myalgo = 25;
-      edm::LogInfo("LhcTrackAnalyzer")
+    } else if (track.algo() == reco::TrackBase::displacedRegionalStep) {
+      myalgo = 26;
+    } else if (track.algo() == reco::TrackBase::hltIter0) {
+      myalgo = 31;
+    } else {
+      myalgo = reco::TrackBase::algoSize;
+      edm::LogWarning("LhcTrackAnalyzer")
           << "LhcTrackAnalyzer does not support all types of tracks, encountered one from algo "
           << reco::TrackBase::algoName(track.algo());
     }

--- a/Alignment/HIPAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/HIPAlignmentAlgorithm/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<environment>
+  <bin file="testHIPAnalyzers.cc" name="testHIPAnalyzers">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
+</environment>  

--- a/Alignment/HIPAlignmentAlgorithm/test/testHIPAnalyzers.cc
+++ b/Alignment/HIPAlignmentAlgorithm/test/testHIPAnalyzers.cc
@@ -1,0 +1,78 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+// Function to run the catch2 tests
+//___________________________________________________________________________________________
+void runTestForAnalyzer(const std::string& baseConfig, const std::string& analyzerName) {
+  edm::test::TestProcessor::Config config{baseConfig};
+
+  SECTION(analyzerName + " base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  SECTION(analyzerName + " No Runs data") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testWithNoRuns());
+  }
+
+  SECTION(analyzerName + " beginJob and endJob only") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  }
+
+  // the following part is commented because the
+  // HIPTwoBodyDecayAnalyzer crashes on
+  // No "TransientTrackRecord" record found in the EventSetup.
+
+  /* 
+  SECTION("No event data") {
+   edm::test::TestProcessor tester(config);
+   REQUIRE_NOTHROW(tester.test());
+  }
+  */
+
+  SECTION("Run with no LuminosityBlocks") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  }
+
+  SECTION("LuminosityBlock with no Events") {
+    edm::test::TestProcessor tester(config);
+    REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  }
+}
+
+// Function to generate base configuration string
+//___________________________________________________________________________________________
+std::string generateBaseConfig(const std::string& analyzerName, const std::string& rootFileName) {
+  // Define a raw string literal
+  constexpr const char* rawString = R"_(from FWCore.TestProcessor.TestProcess import *
+from Alignment.HIPAlignmentAlgorithm.{}_cfi import {}
+process = TestProcess()
+process.trackAnalyzer = {}
+process.moduleToTest(process.trackAnalyzer)
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+process.add_(cms.ESProducer("TransientTrackBuilderESProducer"))
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('JobReportService'))
+process.add_(cms.Service('TFileService',fileName=cms.string('{}')))
+    )_";
+
+  // Format the raw string literal using fmt::format
+  return fmt::format(rawString, analyzerName, analyzerName, analyzerName, rootFileName);
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("LhcTrackAnalyzer tests", "[LhcTrackAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("lhcTrackAnalyzer", "testHIPAnalyzers1.root");
+  runTestForAnalyzer(baseConfig, "LhcTrackAnalyzer");
+}
+
+//___________________________________________________________________________________________
+TEST_CASE("HIPTwoBodyDecayAnalyzer tests", "[HIPTwoBodyDecayAnalyzer]") {
+  const std::string baseConfig = generateBaseConfig("hipTwoBodyDecayAnalyzer", "testHIPAnalyzers2.root");
+  runTestForAnalyzer(baseConfig, "HIPTwoBodyDecayAnalyzer");
+}


### PR DESCRIPTION
#### PR description:

The main goal of this PR is refresh the class `LhcTrackAnalyzer.cc` to add more branches relevant to study track quantities.
In addition:
   * added a `fillDesciptions` method to `HIPTwoBodyDecayAnalyzer`
   * cleaned up unused methods
   * added `catch2`-based unit tests to test these analyzers. 

#### PR validation:

`scram b runtests_testHIPAnalyzers` runs fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, might be backported to `CMSSW_14_0_X` for data-taking purposes.