### PR TITLE
Include other in the re-scaled pie measurements

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/test/augmentResources.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/test/augmentResources.py
@@ -13,11 +13,15 @@ orig['resources'].append({'time_real_abs': 'real time abs'})
 orig['resources'].append({'time_thread_abs': 'cpu time abs'})
 
 for k in orig['modules']:
-    if k['events'] > 0 and k['label'] != "other":
-        k['time_real_abs'] = k['time_real']/k['events']*events
-        k['time_thread_abs'] = k['time_thread']/k['events']*events
-        time_real_abs += k['time_real_abs']
-        time_thread_abs += k['time_thread_abs']
+    if k['events'] > 0:
+        if k['label'] != "other":
+            k['time_real_abs'] = k['time_real']/k['events']*events
+            k['time_thread_abs'] = k['time_thread']/k['events']*events
+        else:
+            k['time_real_abs'] = k['time_real']
+            k['time_thread_abs'] = k['time_thread']
+        time_real_abs += k['time_real']
+        time_thread_abs += k['time_thread']
     else:
         k['time_real_abs'] = 0
         k['time_thread_abs'] = 0


### PR DESCRIPTION
#### PR description:

Modified the script that augments the JSON file generated by FastTimerService to ensure the "other" pie is no longer silently ignored during scaling. Now, it is accurately propagated as-is in the final, rescaled measurements, maintaining the integrity of all producer data.

#### PR validation:

Verified that the augmented JSON is correct.


