### PR TITLE
[PileUpJetId] Backport of #45270 (Set jet phi for JEC) to 14_0_X

### DIFF
--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -161,6 +161,7 @@ void PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         jecCor_->setJetPt(jet.pt());
       }
       jecCor_->setJetEta(jet.eta());
+      jecCor_->setJetPhi(jet.phi());
       jecCor_->setJetA(jet.jetArea());
       jecCor_->setRho(rho);
       jec = jecCor_->getCorrection();


### PR DESCRIPTION
Backport of #45270

#### PR description:

This PR resolves Issue #45099 by setting jet phi for the `FactorizedJetCorrector ` since the latest JECs now has phi dependence. 

#### PR validation:
- tested using `RunPromptReco.py` and confirmed that the messages no longer appear. 
- passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`