### PR TITLE
Remove Passthrough Pattern Recognition from TICLv4

### DIFF
--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -42,10 +42,10 @@ ticl_v5.toModify(pfTICL, ticlCandidateSrc = cms.InputTag('ticlCandidate'), isTIC
 ticlPFTask = cms.Task(pfTICL)
 
 ticlIterationsTask = cms.Task(
-    ticlCLUE3DHighStepTask,
-    ticlPassthroughStepTask
-
+    ticlCLUE3DHighStepTask
 )
+
+ticl_v5.toModify(ticlIterationsTask , func=lambda x : x.add(ticlPassthroughStepTask))
 ''' For future separate iterations
 ,ticlCLUE3DEMStepTask,
 ,ticlCLUE3DHADStepTask


### PR DESCRIPTION
This PR removes the PassThrough pattern recognition (developed for TICLv5) that was incorrectly introduced in TICLv4.

No changes are expected in physics since the additional collection was not used anywhere else in the TICL workflow.

Should be tested with any *.203 workflow (e.g. 29696.203 and 29896.203 )