### PR TITLE
Move phase2_realistic to the T33 tracker geometry in autoCond

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -100,7 +100,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
+    'phase2_realistic'             :    '140X_mcRun4_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Update the GT for Phase2 in autoCond with the T33 Tracker geometry (instead of previous T25).
This corresponds to the now default D110 CMS geometry, where D110 = T35+C18+M11+I17+O9+F8 and T33 ~ T35

Diff for the phase2 GTs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun4_realistic_v2/140X_mcRun4_realistic_v4
