### PR TITLE
Change CaloRecHitProducer to produce new HCAL RecHit SoA [14.0.x]

### DIFF
--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CaloRecHitSoAProducer.cc
@@ -14,6 +14,9 @@
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/global/EDProducer.h"
 #include "CalorimeterDefinitions.h"
 
+#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"
+
 #define DEBUG false
 
 namespace ALPAKA_ACCELERATOR_NAMESPACE {
@@ -33,17 +36,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       if (DEBUG)
         printf("Found %d recHits\n", num_recHits);
 
-      reco::CaloRecHitHostCollection hostProduct{num_recHits, event.queue()};
+      hcal::RecHitHostCollection hostProduct{num_recHits, event.queue()};
       auto& view = hostProduct.view();
 
       for (int i = 0; i < num_recHits; i++) {
         convertRecHit(view[i], recHits[i]);
 
         if (DEBUG && i < 10)
-          printf("recHit %4d %u %f %f %08x\n", i, view.detId(i), view.energy(i), view.time(i), view.flags(i));
+          printf("recHit %4d %u %f %f\n", i, view.detId(i), view.energy(i), view.timeM0(i));
       }
 
-      reco::CaloRecHitDeviceCollection deviceProduct{num_recHits, event.queue()};
+      hcal::RecHitDeviceCollection deviceProduct{num_recHits, event.queue()};
       alpaka::memcpy(event.queue(), deviceProduct.buffer(), hostProduct.buffer());
       if (synchronise_)
         alpaka::wait(event.queue());
@@ -60,23 +63,29 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   private:
     const edm::EDGetTokenT<edm::SortedCollection<typename CAL::CaloRecHitType>> recHitsToken_;
-    const device::EDPutToken<reco::CaloRecHitDeviceCollection> deviceToken_;
+    const device::EDPutToken<hcal::RecHitDeviceCollection> deviceToken_;
     const bool synchronise_;
 
-    static void convertRecHit(reco::CaloRecHitHostCollection::View::element to,
-                              const typename CAL::CaloRecHitType& from);
+    static void convertRecHit(hcal::RecHitHostCollection::View::element to, const typename CAL::CaloRecHitType& from);
   };
 
   template <>
-  void CaloRecHitSoAProducer<HCAL>::convertRecHit(reco::CaloRecHitHostCollection::View::element to,
+  void CaloRecHitSoAProducer<HCAL>::convertRecHit(hcal::RecHitHostCollection::View::element to,
                                                   const HCAL::CaloRecHitType& from) {
     // Fill SoA from HCAL rec hit
     to.detId() = from.id().rawId();
     to.energy() = from.energy();
-    to.time() = from.time();
-    to.flags() = from.flags();
+    to.timeM0() = from.time();
   }
 
+  /*
+  The ECALRecHitSoAProducer currently has no use, but is available via this
+  module. In the case where ECAL PF Clustering is moved to Alpaka, we can then
+  decide to use this converted solely for ECAL, or if the SoA is available
+  we can switch to using just the ECAL RecHit SoA.
+  */
+
+  /*
   template <>
   void CaloRecHitSoAProducer<ECAL>::convertRecHit(reco::CaloRecHitHostCollection::View::element to,
                                                   const ECAL::CaloRecHitType& from) {
@@ -86,11 +95,14 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     to.time() = from.time();
     to.flags() = from.flagsBits();
   }
+  */
 
   using HCALRecHitSoAProducer = CaloRecHitSoAProducer<HCAL>;
-  using ECALRecHitSoAProducer = CaloRecHitSoAProducer<ECAL>;
+
+  // Purposely commented out; see above.
+  //using ECALRecHitSoAProducer = CaloRecHitSoAProducer<ECAL>;
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
 #include "HeterogeneousCore/AlpakaCore/interface/alpaka/MakerMacros.h"
 DEFINE_FWK_ALPAKA_MODULE(HCALRecHitSoAProducer);
-DEFINE_FWK_ALPAKA_MODULE(ECALRecHitSoAProducer);
+//DEFINE_FWK_ALPAKA_MODULE(ECALRecHitSoAProducer);

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/CalorimeterDefinitions.h
@@ -13,6 +13,9 @@
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitParamsDeviceCollection.h"
 #include "RecoParticleFlow/PFRecHitProducer/interface/alpaka/PFRecHitTopologyDeviceCollection.h"
 
+#include "DataFormats/HcalRecHit/interface/HcalRecHitHostCollection.h"
+#include "DataFormats/HcalRecHit/interface/alpaka/HcalRecHitDeviceCollection.h"
+
 // Forward declaration of EventSetup records, to avoid propagating the dependency on framework headers to device code
 class PFRecHitHCALParamsRecord;
 class PFRecHitHCALTopologyRecord;
@@ -32,8 +35,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::particleFlowRecHitProducer {
 
   struct HCAL {
     using CaloRecHitType = HBHERecHit;
-    using CaloRecHitSoATypeHost = reco::CaloRecHitHostCollection;
-    using CaloRecHitSoATypeDevice = reco::CaloRecHitDeviceCollection;
+    using CaloRecHitSoATypeHost = hcal::RecHitHostCollection;
+    using CaloRecHitSoATypeDevice = hcal::RecHitDeviceCollection;
     using ParameterType = reco::PFRecHitHCALParamsDeviceCollection;
     using ParameterRecordType = PFRecHitHCALParamsRecord;
     using TopologyTypeHost = reco::PFRecHitHCALTopologyHostCollection;

--- a/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
+++ b/RecoParticleFlow/PFRecHitProducer/plugins/alpaka/PFRecHitProducerKernel.dev.cc
@@ -99,7 +99,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     pfrh.detId() = rh.detId();
     pfrh.denseId() = HCAL::detId2denseId(rh.detId());
     pfrh.energy() = rh.energy();
-    pfrh.time() = rh.time();
+    pfrh.time() = rh.timeM0();
     pfrh.depth() = HCAL::getDepth(pfrh.detId());
     const uint32_t subdet = getSubdet(pfrh.detId());
     if (subdet == HcalBarrel)


### PR DESCRIPTION
#### PR description:

Quoting @jsamudio:

> This PR depends on #45238 and #45199. It implements changes to the CaloRecHitSoAProducer which disables the functionality of converting ECAL rechits, and changes the produced SoA to the new HCAL rechit SoA. This is the first integration step for the use of Alpaka HCAL rechits with the PFRecHitProducer.

#### PR validation:

> Validated with workflow 12434.423 and checking the cluster DQM plots as well.

Technical-only changes, validated running the HLT over 100k events, and obtaining identical results.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45263.