### PR TITLE
Use of MTD time in reconstruction: fixes and update

### DIFF
--- a/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
+++ b/RecoMTD/TimingIDTools/plugins/TOFPIDProducer.cc
@@ -277,6 +277,7 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
         //reliable match, revert to raw mtd time uncertainty + tof uncertainty for pion hp
         if (dtsignom < maxDtSignificance_) {
           sigmat0safe = 1. / rsigmat[0];
+          sigmat0 = sigmat0safe;
         }
 
         double tmtd = tmtdIn[trackref];
@@ -327,12 +328,14 @@ void TOFPIDProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
             t0_best = t0_k;
             t0safe = t0_k;
             sigmat0safe = 1. / rsigmat[1];
+            sigmat0 = sigmat0safe;
           }
           if (dtsig_p < maxDtSignificance_ && chisq_p < chisqmin) {
             chisqmin = chisq_p;
             t0_best = t0_p;
             t0safe = t0_p;
             sigmat0safe = 1. / rsigmat[2];
+            sigmat0 = sigmat0safe;
           }
         }
 

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -14,8 +14,8 @@ unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone(
     trackMTDTimeQualityVMapTag = cms.InputTag("mtdTrackQualityMVA:mtdQualMVA"),
     useMVACut = cms.bool(False),
     minTrackTimeQuality = cms.double(0.8),
-    vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D'))),
-                         1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('legacy4D')))}
+    vertexCollections = {0: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID'))),
+                         1: dict(vertexTimeParameters = cms.PSet( algorithm = cms.string('fromTracksPID')))}
     )
 trackWithVertexRefSelectorBeforeSorting4D = trackWithVertexRefSelector.clone(
     vertexTag = "unsortedOfflinePrimaryVertices4D",

--- a/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/DAClusterizerInZT_vect.cc
@@ -238,7 +238,7 @@ DAClusterizerInZT_vect::track_t DAClusterizerInZT_vect::fill(const vector<reco::
     double t_dt2 =
         std::pow(tk.dtErrorExt(), 2.) +
         std::pow(vertexSizeTime_, 2.);  // the ~injected~ timing error, need to add a small minimum vertex size in time
-    if ((tk.dtErrorExt() > TransientTrackBuilder::defaultInvalidTrackTimeReso) || (std::abs(t_t) > t0Max_)) {
+    if ((tk.dtErrorExt() >= TransientTrackBuilder::defaultInvalidTrackTimeReso) || (std::abs(t_t) > t0Max_)) {
       t_dt2 = 0;  // tracks with no time measurement
     } else {
       t_dt2 = 1. / t_dt2;

--- a/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/VertexTimeAlgorithmLegacy4D.cc
@@ -31,7 +31,7 @@ bool VertexTimeAlgorithmLegacy4D::vertexTime(float& vtxTime, float& vtxTimeError
   for (const auto& trk : vtx.originalTracks()) {
     const double time = trk.timeExt();
     const double err = trk.dtErrorExt();
-    if ((time == 0) && (err > TransientTrackBuilder::defaultInvalidTrackTimeReso))
+    if ((time == 0) && (err >= TransientTrackBuilder::defaultInvalidTrackTimeReso))
       continue;  // tracks with no time information, as implemented in TransientTrackBuilder.cc l.17
     const double inverr = err > 0. ? 1.0 / err : 0.;
     const double w = inverr * inverr;


### PR DESCRIPTION
#### PR description:

This PR proposes two fixes and one update to the reconstruction code, related to the use of MTD time information.

1. https://github.com/cms-sw/cmssw/pull/44562 propagated the momentum uncertainty to the estimated time-of-flight for a track, and therefore to the uncertainty of time at the PCA. In doing this, the ``safe`` version provided by ```TOFPIDProducer``` was updated, but the best option, then propagated to the PF candidates, missed the corresponding update. This PR adds such update. The impact is marginal, as can be seen from a test on 100 ttbar events + PU:

![MTD__Tracks_TrackSigmat0Pid](https://github.com/cms-sw/cmssw/assets/4058194/f00aa6f5-5494-4df8-a747-5a2a13e1143d)

2. In the update of the vertex reconstruction code for time use, made in https://github.com/cms-sw/cmssw/pull/43592 , transient tracks were provided with time and time uncertainty information. When this information is not available (negative time uncertainty) or the MVA quality selection is used, and failed (off by default), the uncertainty is moved to a constant large value of 350 ps, set as constexpr in ```TransientTrack:: defaultInvalidTrackTimeReso```. These values are checked both in the DA clustering where time is used, and later in the legacy vertex time calculation, to prevent the use of such tracks. But the test is at present requiring a value larger than the constant, while it should be larger of equal the constant. The main impact of such an issue is to use tracks without time information in the clustering with time 0 and a 350 ps uncertainty. From, a test on 100 ttbar events + PU the consequences look minor on validation plot, one of the possibly most interesting changes is in the distribution of vertex times, which loses a funny spike at zero:

![MTD__Vertices_recPVT](https://github.com/cms-sw/cmssw/assets/4058194/f8d0fa01-df2e-4f6f-8756-22ced9d539b8)

3. @noepalm recently showed at the MTD DPG meeting https://indico.cern.ch/event/1418042/contributions/5972640/attachments/2868431/5021447/Palmeri_MTD_DPG_310524.pdf that the estimate of vertex time with the DA algorithm ```fromTracksPID```, applied so far only to 3D vertices, is improving also the vertex resolution and pull distributions for 4D vertices (second iteration in the 3Dt + 4D chain), when replacing the legacy weighted average approach. This PR proposes such an update in the official workflow.

#### PR validation:

Tests where performed by rerunning the reconstruction step for the  CMSSW_14_1_0_pre4 D110 ttbar + PU200 RelVal on top of the available GEN-SIM-DIGI-RAW sample (100 events).