### PR TITLE
Sigmat0 and sigmat0Safe used to fix nonPID definition for good pions in MtdValidation 

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -384,7 +384,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
       meTrackt0Pid_->Fill(t0Pid[trackref]);
       meTrackSigmat0Pid_->Fill(Sigmat0Pid[trackref]);
       meTrackt0SafePid_->Fill(t0Safe[trackref]);
-      meTrackSigmat0SafePid_->Fill(Sigmat0Safe[trackref]);
+      meTrackSigmat0SafePid_->Fill(std::log10(std::max(Sigmat0Safe[trackref], 0.001f)));
       meTrackMVAQual_->Fill(mtdQualMVA[trackref]);
 
       meTrackSigmaTof_[0]->Fill(SigmaTofPi[trackref] * 1e3);  //save as ps
@@ -936,12 +936,12 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meTrackt0Pid_ = ibook.book1D("Trackt0Pid", "Track t0 as stored in TofPid;t0 [ns]", 100, -1, 1);
   meTrackSigmat0Pid_ = ibook.book1D("TrackSigmat0Pid", "Sigmat0 as stored in TofPid; #sigma_{t0} [ns]", 100, 0, 0.1);
   meTrackt0SafePid_ = ibook.book1D("Trackt0SafePID", "Track t0 Safe as stored in TofPid;t0 [ns]", 100, -1, 1);
-  meTrackSigmat0SafePid_ =
-      ibook.book1D("TrackSigmat0SafePID", "Sigmat0 Safe as stored in TofPid; #sigma_{t0} [ns]", 100, 0, 0.1);
+  meTrackSigmat0SafePid_ = ibook.book1D(
+      "TrackSigmat0SafePID", "Log10(Sigmat0 Safe) as stored in TofPid; Log10(#sigma_{t0} [ns])", 80, -3, 1);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
   meTrackNumHitsNT_ = ibook.book1D(
       "TrackNumHitsNT", "Number of valid MTD hits per track no time associated; Number of hits", 10, -5, 5);
-  meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, 0, 1);
+  meTrackMVAQual_ = ibook.book1D("TrackMVAQual", "Track MVA Quality as stored in Value Map ; MVAQual", 100, -1, 1);
   meTrackPathLenghtvsEta_ = ibook.bookProfile(
       "TrackPathLenghtvsEta", "MTD Track pathlength vs MTD track Eta;|#eta|;Pathlength", 100, 0, 3.2, 100.0, 400.0, "S");
 


### PR DESCRIPTION
PR description:
This PR used the alignment in sigmat0 and sigmat0Safe for good PID in TOFPIDProducer (PR #45279) [1] to fix nonPID definition for good pions in Primary4DVertexValidation class; moreover, update a few Mtd tracks plots in the validation.

PR validation:
 The code was tested on the workflow  TTbar_PU_14TeV (100 events)