### PR TITLE
Add a test for the dependency on host-only types from alpaka libraries

### DIFF
--- a/HeterogeneousCore/AlpakaTest/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/BuildFile.xml
@@ -1,6 +1,14 @@
 <use name="FWCore/Framework"/>
 <use name="HeterogeneousCore/AlpakaCore"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
+<!--
+Let the alpaka libraries depend on the main library.
+The possible syntaxes are:
+  <use name="HeterogeneousCore/AlpakaTest" for="alpaka"/>
+  <use name="1" for="alpaka"/>
+  <flags USE_ALPAKA="1"/>
+-->
+<use name="HeterogeneousCore/AlpakaTest" for="alpaka"/>
 <flags ALPAKA_BACKENDS="1"/>
 <export>
   <lib name="1"/>

--- a/HeterogeneousCore/AlpakaTest/interface/HostOnlyType.h
+++ b/HeterogeneousCore/AlpakaTest/interface/HostOnlyType.h
@@ -1,0 +1,21 @@
+#ifndef HeterogeneousCore_AlpakaTest_interface_HostOnlyType_h
+#define HeterogeneousCore_AlpakaTest_interface_HostOnlyType_h
+
+namespace alpakatest {
+
+  /* A simple class to demonstarte the dependency on host-only types from alpaka libraries */
+  class HostOnlyType {
+  public:
+    HostOnlyType() : value_{0} {}
+    HostOnlyType(int value) : value_{value} {}
+    void set(int value) { value_ = value; }
+    int get() { return value_; }
+    void print();
+
+  private:
+    int value_;
+  };
+
+}  // namespace alpakatest
+
+#endif  // HeterogeneousCore_AlpakaTest_interface_HostOnlyType_h

--- a/HeterogeneousCore/AlpakaTest/interface/alpaka/printAnswer.h
+++ b/HeterogeneousCore/AlpakaTest/interface/alpaka/printAnswer.h
@@ -1,0 +1,12 @@
+#ifndef HeterogeneousCore_AlpakaTest_interface_alpaka_printAnswer_h
+#define HeterogeneousCore_AlpakaTest_interface_alpaka_printAnswer_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::alpakatest {
+
+  void printAnswer();
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::alpakatest
+
+#endif  // HeterogeneousCore_AlpakaTest_interface_alpaka_printAnswer_h

--- a/HeterogeneousCore/AlpakaTest/src/HostOnlyType.cc
+++ b/HeterogeneousCore/AlpakaTest/src/HostOnlyType.cc
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include "HeterogeneousCore/AlpakaTest/interface/HostOnlyType.h"
+
+namespace alpakatest {
+
+  void HostOnlyType::print() { std::cout << "The HostOnlyType value is " << value_ << '\n'; }
+
+}  // namespace alpakatest

--- a/HeterogeneousCore/AlpakaTest/src/alpaka/printAnswer.cc
+++ b/HeterogeneousCore/AlpakaTest/src/alpaka/printAnswer.cc
@@ -1,0 +1,14 @@
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/HostOnlyType.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/printAnswer.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE::alpakatest {
+  using namespace ::alpakatest;
+
+  // A simple function to demonstarte the dependency on host-only types from alpaka libraries
+  void printAnswer() {
+    HostOnlyType answer(42);
+    answer.print();
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE::alpakatest

--- a/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
@@ -13,3 +13,9 @@
   <!-- dependence only to trigger the unit test when AMD GPU is (expected to be) present -->
   <use name="rocm"/>
 </test>
+
+<bin name="alpakaTestPrintAnswer" file="alpaka/printAnswer.cpp">
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <use name='HeterogeneousCore/AlpakaTest'/>
+  <flags ALPAKA_BACKENDS="1"/>
+</bin>

--- a/HeterogeneousCore/AlpakaTest/test/alpaka/printAnswer.cpp
+++ b/HeterogeneousCore/AlpakaTest/test/alpaka/printAnswer.cpp
@@ -1,0 +1,8 @@
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaTest/interface/alpaka/printAnswer.h"
+
+// each test binary is built for a single Alpaka backend
+using namespace ALPAKA_ACCELERATOR_NAMESPACE;
+using namespace ALPAKA_ACCELERATOR_NAMESPACE::alpakatest;
+
+int main() { printAnswer(); }


### PR DESCRIPTION
#### PR description:

Add a test for the dependency on host-only types from alpaka libraries.

Based on the original example by @ariostas.

#### PR validation:

The new unit test is expected to pass, but fails because the build system cannot habdle this kind of dependency, yet.


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Could be backported to 14.0.x once the build rules are updated.