### PR TITLE
Protect `DQMEventInfo` when there is no `PoolDBESSource@GlobalTag` `PSet` in the process history

### DIFF
--- a/DQMServices/Components/plugins/DQMEventInfo.cc
+++ b/DQMServices/Components/plugins/DQMEventInfo.cc
@@ -266,8 +266,16 @@ void DQMEventInfo::analyzeProvInfo(const edm::Event& event) {
     // Getting parameters for that process
     edm::ParameterSet ps;
     event.getProcessParameterSet(processName, ps);
-    // Getting the global tag
-    globalTag_ = ps.getParameterSet("PoolDBESSource@GlobalTag").getParameter<std::string>("globaltag");
+
+    // Check if the 'PoolDBESSource@GlobalTag' ParameterSet exists
+    if (ps.exists("PoolDBESSource@GlobalTag")) {
+      // Getting the global tag
+      globalTag_ = ps.getParameterSet("PoolDBESSource@GlobalTag").getParameter<std::string>("globaltag");
+    } else {
+      // Handle the case where 'PoolDBESSource@GlobalTag' is missing
+      // You can set a default value or take some other action
+      edm::LogInfo("Configuration") << "ParameterSet 'PoolDBESSource@GlobalTag' not found. Using default global tag.";
+    }
 
     versGlobaltag_->Fill(globalTag_);
     // Finaly: Setting globalTagRetrieved_ to true, since we got it now

--- a/DQMServices/Components/python/DQMEventInfo_cfi.py
+++ b/DQMServices/Components/python/DQMEventInfo_cfi.py
@@ -10,6 +10,6 @@ dqmEnv = DQMEDAnalyzer('DQMEventInfo',
     # define folder to store event info (default: EventInfo)
     eventInfoFolder = cms.untracked.string('EventInfo'),
     # use the Global Tag of the last (!) HLT processing
-    showHLTGlobalTag = cms.untracked.bool(True)
+    showHLTGlobalTag = cms.untracked.bool(False)
 )
 


### PR DESCRIPTION
#### PR description:

The goal of this PR is to fix a problem that was created by PR https://github.com/cms-sw/cmssw/pull/45255 and seen in IBs (e.g. in the unit test of the package `DQM/BeamMonitor`, see e.g. [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-23-2300/unitTestLogs/DQM/BeamMonitor#/97-97)). 
Commit 348c6f57e419fa97e5a6912924b78d7a4981f030 protects  the case in which there is no `GlobalTag` parameter in the processing (e.g. an `EmptySource` was used) and as such the `PoolDBESSource@GlobalTag` PSet is missing and cannot be found to fill a monitor element.
I profit of this PR to fix another mistake introduced in https://github.com/cms-sw/cmssw/pull/45255 in commit 29c499d713e930c3476659bd3bb24986dd385e2a (not intended to show by default the HLT GT, but only in selected cases)

#### PR validation:

Run successfully with this branch: `scram b runtests_testOnlineBeamMonitor`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported at https://github.com/cms-sw/cmssw/pull/45282