### PR TITLE
`TestDQMOfflineConfigurationGotAll`: increase the number of  considered DQM sequences

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,300,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,311,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 310">
+<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 311">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>


### PR DESCRIPTION
#### PR description:

This PR offers a fix for the issue that developed in IBs in the `DQMOffline/Configuration` package (see e.g. [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-23-2300/unitTestLogs/DQMOffline/Configuration#/35-35)) presumably due to increase of distinct DQM sequences in release. 

#### PR validation:

`scram b runtests_TestDQMOfflineConfigurationGotAll` runs fine with this PR.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported