### PR TITLE
Fix issue in TauMCEmbedding related to missing Pixel Cluster Shape

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -891,6 +891,7 @@ def customiseMerging(process, changeProcessname=True, reselect=False):
     process.ak4CaloJetsForTrk.srcPVs = cms.InputTag(
         "firstStepPrimaryVertices", "", dataTier
     )
+    process.dedxHitInfo.clusterShapeCache = cms.InputTag("")
 
     # process.muons.FillDetectorBasedIsolation = cms.bool(False)
     # process.muons.FillSelectorMaps = cms.bool(False)


### PR DESCRIPTION
#### PR description:

This PR disables the use of pixel cluster shape in DeDxHitInfoProducer in the TauMCEmbedding workflows. This addresses the issue raised in https://github.com/cms-sw/cmssw/pull/45016#issuecomment-2185726079 .

The use of the SiPixelClusterShape was recently introduced in https://github.com/cms-sw/cmssw/pull/45016 and thus, was not used by the TauMCEmbedding workflows so far, so this PR should not affect the TauMCEmbedding (since the information gathered from the SiPixelClusterShape in DeDxHitInfoProducer is currently only used in the dEdxLikelihoodFit estimator ran in the Run3 UPC era).

#### PR validation:

Tested on relvals 136.901, 136.902, 136.903 and 136.904.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
