### PR TITLE
Algo not found warning removed from L1TStag2uGTTiming module for the …

### DIFF
--- a/DQM/L1TMonitor/src/L1TStage2uGTTiming.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTTiming.cc
@@ -65,22 +65,14 @@ void L1TStage2uGTTiming::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const
   for (unsigned int i = 0; i < unprescaledAlgoShortList_.size(); i++) {
     if (gtUtil_->getAlgBitFromName(unprescaledAlgoShortList_.at(i), algoBitUnpre_)) {
       unprescaledAlgoBitName_.emplace_back(unprescaledAlgoShortList_.at(i), algoBitUnpre_);
-    } else {
-      edm::LogWarning("L1TStage2uGTTiming")
-          << "Algo \"" << unprescaledAlgoShortList_.at(i) << "\" not found in the trigger menu "
-          << gtUtil_->gtTriggerMenuName() << ". Could not retrieve algo bit number.";
-    }
+    } 
   }
 
   int algoBitPre_ = -1;
   for (unsigned int i = 0; i < prescaledAlgoShortList_.size(); i++) {
     if ((gtUtil_->getAlgBitFromName(prescaledAlgoShortList_.at(i), algoBitPre_))) {
       prescaledAlgoBitName_.emplace_back(prescaledAlgoShortList_.at(i), algoBitPre_);
-    } else {
-      edm::LogWarning("L1TStage2uGTTiming")
-          << "Algo \"" << prescaledAlgoShortList_.at(i) << "\" not found in the trigger menu "
-          << gtUtil_->gtTriggerMenuName() << ". Could not retrieve algo bit number.";
-    }
+    } 
   }
 }
 

--- a/DQM/L1TMonitor/src/L1TStage2uGTTiming.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGTTiming.cc
@@ -65,14 +65,22 @@ void L1TStage2uGTTiming::dqmBeginRun(edm::Run const& iRun, edm::EventSetup const
   for (unsigned int i = 0; i < unprescaledAlgoShortList_.size(); i++) {
     if (gtUtil_->getAlgBitFromName(unprescaledAlgoShortList_.at(i), algoBitUnpre_)) {
       unprescaledAlgoBitName_.emplace_back(unprescaledAlgoShortList_.at(i), algoBitUnpre_);
-    } 
+    } else {
+      LogDebug("L1TStage2uGTTiming") << "Algo \"" << unprescaledAlgoShortList_.at(i)
+                                     << "\" not found in the trigger menu " << gtUtil_->gtTriggerMenuName()
+                                     << ". Could not retrieve algo bit number.";
+    }
   }
 
   int algoBitPre_ = -1;
   for (unsigned int i = 0; i < prescaledAlgoShortList_.size(); i++) {
     if ((gtUtil_->getAlgBitFromName(prescaledAlgoShortList_.at(i), algoBitPre_))) {
       prescaledAlgoBitName_.emplace_back(prescaledAlgoShortList_.at(i), algoBitPre_);
-    } 
+    } else {
+      LogDebug("L1TStage2uGTTiming") << "Algo \"" << prescaledAlgoShortList_.at(i)
+                                     << "\" not found in the trigger menu " << gtUtil_->gtTriggerMenuName()
+                                     << ". Could not retrieve algo bit number.";
+    }
   }
 }
 


### PR DESCRIPTION
#### PR description:

In response to comments on #45242
  - Algo not found warning messages removed from the L1TStage2uGTTiming for lookup in Unprescaled/Prescaled algo short list

#### PR validation:

Tested locally with 2023/2024 streamer files