### PR TITLE
Fix shadowed declaration warning in HeterogeneousCore/AlpakaInterface

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h
@@ -59,11 +59,11 @@ namespace cms::alpakatools {
       }
 
       // use a custom deleter to destroy all objects and deallocate the memory
-      auto deleter = [size](Allocator* ptr) {
+      auto deleter = [size](Allocator* allocPtr) {
         for (size_t i = size; i > 0; --i) {
-          std::destroy_at(ptr + i - 1);
+          std::destroy_at(allocPtr + i - 1);
         }
-        std::allocator<Allocator>().deallocate(ptr, size);
+        std::allocator<Allocator>().deallocate(allocPtr, size);
       };
 
       return std::unique_ptr<Allocator[], decltype(deleter)>(ptr, deleter);


### PR DESCRIPTION
#### PR description:

This is a very minor fix to resolve a warning due to a shadowed declaration in the `getDeviceCachingAllocator.h` header of the `HeterogeneousCore/AlpakaInterface` package. The following warning appears many times while building the package I'm working on, which pollutes the logs.

```
/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre3/src/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h: In lambda function:
/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre3/src/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h:62:34: warning: declaration of 'ptr' shadows a previous local [-Wshadow]
   62 |       auto deleter = [size](Allocator* ptr) {
      |                       ~~~~~~~~~~~^~~
/cvmfs/cms.cern.ch/el8_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre3/src/HeterogeneousCore/AlpakaInterface/interface/getDeviceCachingAllocator.h:27:6: note: shadowed declaration is here
   27 |       auto ptr = std::allocator<Allocator>().allocate(size);
      |      ^~~
```

#### PR validation:

The change is small enough to be validated just by looking at it, but I did test it to make sure that it resolved the warning and didn't break anything.
