### PR TITLE
Updates to include HTMHF triggers in GT emulator

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -24,7 +24,7 @@ namespace trigger {
 
     /// enum start value shifted to 81 so as to avoid clashes with PDG codes
 
-    /// L1 - using cases as defined in enum L1GtObject, file:
+    /// L1 - using cases as defined in enum L1GtObject, legacy and stage 1 file:
     /// DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 
     TriggerL1Mu = -81,
@@ -72,11 +72,13 @@ namespace trigger {
     TriggerL1PFMHT = -122,
     TriggerL1PFTrack = -123,
     TriggerL1Vertex = -124,
-    // Phase-1: MuonShower
-    TriggerL1MuShower = -125,  // stage2 (introduced in Run 3)
-    // Phase-1: ZDC+ and ZDC-
-    TriggerL1ZDCP = -126,  // stage2 (introduced in 2023 during Run 3)
-    TriggerL1ZDCM = -127,  // stage2 (introduced in 2023 during Run 3)
+    // Phase-1: MuonShower triggers (Run 3 - 2022)
+    TriggerL1MuShower = -125,  // stage2
+    // Phase-1: ZDC+ and ZDC- triggers for HI (Run 3 - 2023)
+    TriggerL1ZDCP = -126,  // stage2
+    TriggerL1ZDCM = -127,  // stage2
+    // Phase-1: MHTHF triggers
+    TriggerL1HTMHF = -128,  // stage2
 
     /// HLT
     TriggerPhoton = +81,

--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -59,8 +59,8 @@ namespace l1t {
     gtExternal = 28,
     gtZDCP = 29,
     gtZDCM = 30,
-    gtHTMHF = 31,
-    ObjNull = 32,
+    ObjNull = 31,
+    gtHTMHF = 32,
   };
 
   const std::vector<std::pair<GlobalObject, std::string>> kGlobalObjectEnumStringPairs = {
@@ -95,8 +95,8 @@ namespace l1t {
       {gtExternal, "External"},        // 28
       {gtZDCP, "ZDCP"},                // 29
       {gtZDCM, "ZDCM"},                // 30
-      {gtHTMHF, "HTMHF"},              // 31
-      {ObjNull, "ObjNull"},            // 32
+      {ObjNull, "ObjNull"},            // 31
+      {gtHTMHF, "HTMHF"},              // 32
   };
 
   // utility functions to convert GlobalObject enum to std::string and viceversa

--- a/DataFormats/L1TGlobal/interface/GlobalObject.h
+++ b/DataFormats/L1TGlobal/interface/GlobalObject.h
@@ -59,7 +59,8 @@ namespace l1t {
     gtExternal = 28,
     gtZDCP = 29,
     gtZDCM = 30,
-    ObjNull = 31,
+    gtHTMHF = 31,
+    ObjNull = 32,
   };
 
   const std::vector<std::pair<GlobalObject, std::string>> kGlobalObjectEnumStringPairs = {
@@ -94,7 +95,8 @@ namespace l1t {
       {gtExternal, "External"},        // 28
       {gtZDCP, "ZDCP"},                // 29
       {gtZDCM, "ZDCM"},                // 30
-      {ObjNull, "ObjNull"},            // 31
+      {gtHTMHF, "HTMHF"},              // 31
+      {ObjNull, "ObjNull"},            // 32
   };
 
   // utility functions to convert GlobalObject enum to std::string and viceversa

--- a/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
+++ b/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
@@ -99,6 +99,7 @@ TEST_CASE("Test l1t::GlobalObject", "[l1tGlobalObject]") {
     REQUIRE(isValidGlobalObject(28, l1t::gtExternal, "External"));        // 28
     REQUIRE(isValidGlobalObject(29, l1t::gtZDCP, "ZDCP"));                // 29
     REQUIRE(isValidGlobalObject(30, l1t::gtZDCM, "ZDCM"));                // 30
-    REQUIRE(isValidGlobalObject(31, l1t::ObjNull, "ObjNull"));            // 31
+    REQUIRE(isValidGlobalObject(31, l1t::gtHTMHF, "HTMHF"));              // 31
+    REQUIRE(isValidGlobalObject(32, l1t::ObjNull, "ObjNull"));            // 32
   }
 }

--- a/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
+++ b/DataFormats/L1TGlobal/test/test_catch2_l1tGlobalObject.cc
@@ -99,7 +99,7 @@ TEST_CASE("Test l1t::GlobalObject", "[l1tGlobalObject]") {
     REQUIRE(isValidGlobalObject(28, l1t::gtExternal, "External"));        // 28
     REQUIRE(isValidGlobalObject(29, l1t::gtZDCP, "ZDCP"));                // 29
     REQUIRE(isValidGlobalObject(30, l1t::gtZDCM, "ZDCM"));                // 30
-    REQUIRE(isValidGlobalObject(31, l1t::gtHTMHF, "HTMHF"));              // 31
-    REQUIRE(isValidGlobalObject(32, l1t::ObjNull, "ObjNull"));            // 32
+    REQUIRE(isValidGlobalObject(31, l1t::ObjNull, "ObjNull"));            // 31
+    REQUIRE(isValidGlobalObject(32, l1t::gtHTMHF, "HTMHF"));              // 32
   }
 }

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.cc
@@ -304,6 +304,21 @@ void HLTL1TSeed::dumpTriggerFilterObjectWithRefs(trigger::TriggerFilterObjectWit
                            << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
   }
 
+  vector<l1t::EtSumRef> seedsL1EtSumHTMHF;
+  filterproduct.getObjects(trigger::TriggerL1HTMHF, seedsL1EtSumHTMHF);
+  const size_t sizeSeedsL1EtSumHTMHF = seedsL1EtSumHTMHF.size();
+  LogTrace("HLTL1TSeed") << "\n  L1EtSum HTMHF seeds:      " << sizeSeedsL1EtSumHTMHF << endl << endl;
+
+  for (size_t i = 0; i != sizeSeedsL1EtSumHTMHF; i++) {
+    l1t::EtSumRef obj = l1t::EtSumRef(seedsL1EtSumHTMHF[i]);
+
+    LogTrace("HLTL1TSeed") << "\tL1EtSum  HTMHF"
+                           << "\t"
+                           << "pt = " << obj->pt() << "\t"
+                           << "eta =  " << obj->eta() << "\t"
+                           << "phi =  " << obj->phi();  //<< "\t" << "BX = " << obj->bx();
+  }
+
   vector<l1t::EtSumRef> seedsL1EtSumHTM;
   filterproduct.getObjects(trigger::TriggerL1HTM, seedsL1EtSumHTM);
   const size_t sizeSeedsL1EtSumHTM = seedsL1EtSumHTM.size();
@@ -485,6 +500,7 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
   std::list<int> listHTT;
   std::list<int> listHTM;
   std::list<int> listETMHF;
+  std::list<int> listHTMHF;
 
   std::list<int> listJetCounts;
 
@@ -789,6 +805,9 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
             case l1t::gtETMHF: {
               listETMHF.push_back(*itObject);
             } break;
+            case l1t::gtHTMHF: {
+              listHTMHF.push_back(*itObject);
+            } break;
             case l1t::gtTowerCount: {
               listTowerCount.push_back(*itObject);
             } break;
@@ -890,6 +909,9 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
 
   listETMHF.sort();
   listETMHF.unique();
+
+  listHTMHF.sort();
+  listHTMHF.unique();
 
   listJetCounts.sort();
   listJetCounts.unique();
@@ -1111,6 +1133,10 @@ bool HLTL1TSeed::seedsL1TriggerObjectMaps(edm::Event& iEvent, trigger::TriggerFi
         case l1t::EtSum::kMissingEtHF:
           if (!listETMHF.empty())
             filterproduct.addObject(trigger::TriggerL1ETMHF, myref);
+          break;
+        case l1t::EtSum::kMissingHtHF:
+          if (!listHTMHF.empty())
+            filterproduct.addObject(trigger::TriggerL1HTMHF, myref);
           break;
         case l1t::EtSum::kCentrality:
           if (!listCentrality.empty())

--- a/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalDefinitions.h
@@ -44,7 +44,7 @@ namespace l1t {
   /// Type2cor : two particles, different type, with spatial correlations among them
   /// Type3s : three particles, same type
   /// Type4s : four particles, same type
-  /// TypeETM, TypeETT, TypeHTT, TypeHTM  : ETM, ETT, HTT, HTM
+  /// TypeETM, TypeETT, TypeHTT, TypeHTM, TypeETMHF, TypeHTMHF: ETM, ETT, HTT, HTM, ETMHF, HTMHF
   /// TypeExternal: external conditions (logical result only; definition in L1 GT external systems)
   enum GtConditionType {
     TypeNull,
@@ -59,6 +59,7 @@ namespace l1t {
     TypeHTT,
     TypeHTM,
     TypeETMHF,
+    TypeHTMHF,
     TypeTowerCount,
     TypeMinBiasHFP0,
     TypeMinBiasHFM0,

--- a/L1Trigger/L1TGlobal/interface/GlobalScales.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalScales.h
@@ -66,6 +66,7 @@ namespace l1t {
     inline void setHTTScales(ScaleParameters& scales) { m_httScales = scales; }
     inline void setETMScales(ScaleParameters& scales) { m_etmScales = scales; }
     inline void setETMHfScales(ScaleParameters& scales) { m_etmHfScales = scales; }
+    inline void setHTMHfScales(ScaleParameters& scales) { m_htmHfScales = scales; }
     inline void setHTMScales(ScaleParameters& scales) { m_htmScales = scales; }
 
     virtual void setLUT_CalMuEta(const std::string& lutName, std::vector<long long> lut);
@@ -91,6 +92,7 @@ namespace l1t {
     inline const ScaleParameters& getETTEmScales() const { return m_ettEmScales; }
     inline const ScaleParameters& getETMScales() const { return m_etmScales; }
     inline const ScaleParameters& getETMHFScales() const { return m_etmHfScales; }
+    inline const ScaleParameters& getHTMHFScales() const { return m_htmHfScales; }
     inline const ScaleParameters& getHTTScales() const { return m_httScales; }
     inline const ScaleParameters& getHTMScales() const { return m_htmScales; }
 
@@ -134,6 +136,7 @@ namespace l1t {
     ScaleParameters m_httScales;
     ScaleParameters m_etmScales;
     ScaleParameters m_etmHfScales;
+    ScaleParameters m_htmHfScales;
     ScaleParameters m_htmScales;
 
     //LUTs

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -37,7 +37,6 @@
 
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
-#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
@@ -73,7 +72,6 @@ namespace l1t {
     InputTag uGtExtInputTag;
     EDGetToken egToken;
     EDGetToken muToken;
-    EDGetToken muShowerToken;
     EDGetToken tauToken;
     EDGetToken jetToken;
     EDGetToken etsumToken;
@@ -84,7 +82,6 @@ namespace l1t {
     void dumpTestVectors(int bx,
                          std::ofstream& myCout,
                          Handle<BXVector<l1t::Muon>> muons,
-                         Handle<BXVector<l1t::MuonShower>> muonShowers,
                          Handle<BXVector<l1t::EGamma>> egammas,
                          Handle<BXVector<l1t::Tau>> taus,
                          Handle<BXVector<l1t::Jet>> jets,
@@ -92,8 +89,7 @@ namespace l1t {
                          Handle<BXVector<GlobalAlgBlk>> uGtAlg,
                          Handle<BXVector<GlobalExtBlk>> uGtExt);
 
-    cms_uint64_t formatMuon(std::vector<l1t::Muon>::const_iterator mu, int muShowerBit);
-    cms_uint64_t formatNonExistantMuon(int muShowerBit);
+    cms_uint64_t formatMuon(std::vector<l1t::Muon>::const_iterator mu);
     unsigned int formatEG(std::vector<l1t::EGamma>::const_iterator eg);
     unsigned int formatTau(std::vector<l1t::Tau>::const_iterator tau);
     unsigned int formatJet(std::vector<l1t::Jet>::const_iterator jet);
@@ -130,7 +126,6 @@ namespace l1t {
     uGtExtInputTag = iConfig.getParameter<InputTag>("uGtExtInputTag");
     egToken = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<InputTag>("egInputTag"));
     muToken = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<InputTag>("muInputTag"));
-    muShowerToken = consumes<BXVector<l1t::MuonShower>>(iConfig.getParameter<InputTag>("muShowerInputTag"));
     tauToken = consumes<BXVector<l1t::Tau>>(iConfig.getParameter<InputTag>("tauInputTag"));
     jetToken = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<InputTag>("jetInputTag"));
     etsumToken = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<InputTag>("etsumInputTag"));
@@ -173,9 +168,6 @@ namespace l1t {
 
     Handle<BXVector<l1t::Muon>> muons;
     iEvent.getByToken(muToken, muons);
-
-    Handle<BXVector<l1t::MuonShower>> muonShowers;
-    iEvent.getByToken(muShowerToken, muonShowers);
 
     Handle<BXVector<l1t::Tau>> taus;
     iEvent.getByToken(tauToken, taus);
@@ -404,32 +396,6 @@ namespace l1t {
           cout << "No Muon Data in this event " << endl;
         }
 
-        //Loop over Muon Showers
-        nObj = 0;
-        cout << " ------ Muons Showers --------" << endl;
-        if (muonShowers.isValid()) {
-          std::cout << "========= MuonShower BX index = " << i << "; min BX = " << m_minBx << "; max BX = " << m_maxBx
-                    << std::endl;
-          if (i >= muonShowers->getFirstBX() && i <= muonShowers->getLastBX()) {
-            for (std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(i);
-                 muShower != muonShowers->end(i);
-                 ++muShower) {
-              cout << "  " << std::dec << std::setw(2) << std::setfill(' ') << nObj << std::setfill('0') << ")";
-              cout << "   MUS0 " << std::dec << std::setw(1) << muShower->isOneNominalInTime();
-              cout << ";  MUS1 " << std::dec << std::setw(1) << muShower->isOneTightInTime();
-              cout << ";  MUS2 " << std::dec << std::setw(1) << muShower->isTwoLooseDiffSectorsInTime();
-              cout << ";  MUSOOT0 " << std::dec << std::setw(1) << muShower->musOutOfTime0();
-              cout << ";  MUSOOT1 " << std::dec << std::setw(1) << muShower->musOutOfTime1();
-              cout << endl;
-              nObj++;
-            }
-          } else {
-            cout << "No MuonShowers stored for this bx " << i << endl;
-          }
-        } else {
-          cout << "No MuonShower Data in this event " << endl;
-        }
-
         //Loop over Taus
         nObj = 0;
         cout << " ------ Taus ----------" << endl;
@@ -544,7 +510,8 @@ namespace l1t {
                    << std::setfill('0') << etsum->hwPt() << ")";
               if (etsum->getType() == l1t::EtSum::EtSumType::kMissingEt ||
                   etsum->getType() == l1t::EtSum::EtSumType::kMissingHt ||
-                  etsum->getType() == l1t::EtSum::EtSumType::kMissingEtHF)
+                  etsum->getType() == l1t::EtSum::EtSumType::kMissingEtHF ||
+                  etsum->getType() == l1t::EtSum::EtSumType::kMissingHtHF)
                 cout << " Phi " << std::dec << std::setw(3) << etsum->hwPhi() << " (0x" << std::hex << std::setw(2)
                      << std::setfill('0') << etsum->hwPhi() << ")";
               cout << endl;
@@ -600,7 +567,7 @@ namespace l1t {
         //	      (i>=etsums->getFirstBX()  && i<=etsums->getLastBX()) &&
         //	      (i>=uGtAlg->getFirstBX()  && i<=uGtAlg->getLastBX()) &&
         //	      (i>=uGtAlg->getFirstBX()  && i<=uGtAlg->getLastBX()) ) {
-        dumpTestVectors(i, m_testVectorFile, muons, muonShowers, egammas, taus, jets, etsums, uGtAlg, uGtExt);
+        dumpTestVectors(i, m_testVectorFile, muons, egammas, taus, jets, etsums, uGtAlg, uGtExt);
         //	 } else {
         //	      edm::LogWarning("GtRecordDump") << "WARNING: Not enough information to dump test vectors for this bx=" << i << endl;
         //	 }
@@ -634,7 +601,6 @@ namespace l1t {
   void GtRecordDump::dumpTestVectors(int bx,
                                      std::ofstream& myOutFile,
                                      Handle<BXVector<l1t::Muon>> muons,
-                                     Handle<BXVector<l1t::MuonShower>> muonShowers,
                                      Handle<BXVector<l1t::EGamma>> egammas,
                                      Handle<BXVector<l1t::Tau>> taus,
                                      Handle<BXVector<l1t::Jet>> jets,
@@ -646,73 +612,20 @@ namespace l1t {
     // Dump Bx (4 digits)
     myOutFile << std::dec << std::setw(4) << std::setfill('0') << m_absBx;
 
-    // Dump 8 Muons (16 digits + space) + Muon Showers
+    // Dump 8 Muons (16 digits + space)
     int nDumped = 0;
-
-    int muNumber = 0;  //keeps track of which muons get which muon shower information
-    if (muons.isValid() && muonShowers.isValid()) {
+    if (muons.isValid()) {
       for (std::vector<l1t::Muon>::const_iterator mu = muons->begin(bx); mu != muons->end(bx); ++mu) {
-        // loop over valid muons in this bx (muon 0 up to max possible of muon 7)
-        int muShowerBit = 0;  // default value for muon shower bit
-        if (bx >= muonShowers->getFirstBX() && bx <= muonShowers->getLastBX()) {
-          if (muonShowers->size(bx) > 0) {
-            std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(bx);
-            if (muNumber == 0)
-              muShowerBit = muShower->isOneNominalInTime();
-            if (muNumber == 2)
-              muShowerBit = muShower->isOneTightInTime();
-            if (muNumber == 3)
-              muShowerBit = muShower->isTwoLooseDiffSectorsInTime();
-            if (muNumber == 4)
-              muShowerBit = muShower->musOutOfTime0();
-            if (muNumber == 6)
-              muShowerBit = muShower->musOutOfTime1();
-          }
-        }
-        cms_uint64_t packedWd = formatMuon(mu, muShowerBit);
+        cms_uint64_t packedWd = formatMuon(mu);
         if (nDumped < 8) {
           myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << packedWd;
           nDumped++;
         }
-        ++muNumber;  //keeps track of how many muons have been processed
-      }              // end loop over Muons in this bx
-
-      // Muon Shower information can exist, even if a muon object does not exist.  Hence,
-      // now loop over non-existant muons from muNumber up to max of 7 and add the muon shower info
-      int start = muNumber;
-      for (int nonExistantMuon = start; nonExistantMuon < 8; nonExistantMuon++) {
-        int muShowerBit = 0;  // default value for muon shower bit
-        if (bx >= muonShowers->getFirstBX() && bx <= muonShowers->getLastBX()) {
-          if (muonShowers->size(bx) > 0) {
-            std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(bx);
-            if (muNumber == 0)
-              muShowerBit = muShower->isOneNominalInTime();
-            if (muNumber == 2)
-              muShowerBit = muShower->isOneTightInTime();
-            if (muNumber == 3)
-              muShowerBit = muShower->isTwoLooseDiffSectorsInTime();
-            if (muNumber == 4)
-              muShowerBit = muShower->musOutOfTime0();
-            if (muNumber == 6)
-              muShowerBit = muShower->musOutOfTime1();
-          }
-        }
-        cms_uint64_t packedWd = formatNonExistantMuon(muShowerBit);
-        if (nDumped < 8) {
-          myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << packedWd;
-          nDumped++;
-        }
-        ++muNumber;  // keep track of the number of muons processed
-      }              // end loop over non-existant muons
+      }
     }
     for (int i = nDumped; i < 8; i++) {
       myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << empty;
     }
-    if (!muons.isValid())
-      std::cout << "========= WARNING:  ALL MUONS INVALID ==========" << std::endl;
-    if (!muonShowers.isValid())
-      std::cout << "========= WARNING:  ALL MUON SHOWERS INVALID ==========" << std::endl;
-    //===========================================
 
     // Dump 12 EG (8 digits + space)
     nDumped = 0;
@@ -934,7 +847,7 @@ namespace l1t {
     m_absBx++;
   }
 
-  cms_uint64_t GtRecordDump::formatMuon(std::vector<l1t::Muon>::const_iterator mu, int muShowerBit) {
+  cms_uint64_t GtRecordDump::formatMuon(std::vector<l1t::Muon>::const_iterator mu) {
     cms_uint64_t packedVal = 0;
 
     // Pack Bits
@@ -943,7 +856,6 @@ namespace l1t {
     // packedVal |= ((cms_uint64_t)(mu->hwEta() & 0x1ff) << 53);         // removed
     packedVal |= ((cms_uint64_t)(mu->hwPtUnconstrained() & 0xff) << 53);  // added
     packedVal |= ((cms_uint64_t)(mu->hwDXY() & 0x3) << 62);               // added
-    packedVal |= ((cms_uint64_t)(muShowerBit & 0x1) << 61);               // added
     packedVal |= ((cms_uint64_t)(mu->hwEtaAtVtx() & 0x1ff) << 23);        // & 0x1ff) <<9);
     packedVal |= ((cms_uint64_t)(mu->hwPt() & 0x1ff) << 10);              // & 0x1ff) <<0);
     packedVal |= ((cms_uint64_t)(mu->hwChargeValid() & 0x1) << 35);       // & 0x1)   <<28);
@@ -972,34 +884,12 @@ namespace l1t {
     //                << ((cms_uint64_t)(mu->hwPhi() & 0x3ff) << 43) << std::endl;
     //      std::cout << "<< 53; mu->hwPtUnconstrained() = " << std::hex << std::setw(16) << std::setfill('0')
     //                << ((cms_uint64_t)(mu->hwPtUnconstrained() & 0xff) << 53) << std::endl;
-    //      std::cout << "<< 61; muShowerBit             = " << std::hex << std::setw(16) << std::setfill('0')
-    //                << ((cms_uint64_t)(muShowerBit & 0x1) << 61) << std::endl;
     //      std::cout << "<< 62; mu->hwDXY()             = " << std::hex << std::setw(16) << std::setfill('0')
     //                << ((cms_uint64_t)(mu->hwDXY() & 0x3) << 62) << std::endl;
     //      std::cout << "packedWord                     = " << std::hex << std::setw(16) << std::setfill('0') << packedVal
     //                << std::endl;
     //      std::cout << "----------------------" << std::endl;
     //    }
-
-    return packedVal;
-  }
-
-  cms_uint64_t GtRecordDump::formatNonExistantMuon(int muShowerBit) {
-    cms_uint64_t packedVal = 0;
-
-    // Pack Bits
-    packedVal |= ((cms_uint64_t)(0 & 0x3ff) << 43);
-    packedVal |= ((cms_uint64_t)(0 & 0x3ff) << 0);  // & 0x3ff) <<18);
-    // packedVal |= ((cms_uint64_t)(mu->hwEta() & 0x1ff) << 53);         // removed
-    packedVal |= ((cms_uint64_t)(0 & 0xff) << 53);           // added
-    packedVal |= ((cms_uint64_t)(0 & 0x3) << 62);            // added
-    packedVal |= ((cms_uint64_t)(muShowerBit & 0x1) << 61);  // added
-    packedVal |= ((cms_uint64_t)(0 & 0x1ff) << 23);          // & 0x1ff) <<9);
-    packedVal |= ((cms_uint64_t)(0 & 0x1ff) << 10);          // & 0x1ff) <<0);
-    packedVal |= ((cms_uint64_t)(0 & 0x1) << 35);            // & 0x1)   <<28);
-    packedVal |= ((cms_uint64_t)(0 & 0x1) << 34);            // & 0x1)   <<29);
-    packedVal |= ((cms_uint64_t)(0 & 0xf) << 19);            // & 0xf)   <<30);
-    packedVal |= ((cms_uint64_t)(0 & 0x3) << 32);            // & 0x3)   <<34);
 
     return packedVal;
   }

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -37,6 +37,7 @@
 
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
@@ -72,6 +73,7 @@ namespace l1t {
     InputTag uGtExtInputTag;
     EDGetToken egToken;
     EDGetToken muToken;
+    EDGetToken muShowerToken;
     EDGetToken tauToken;
     EDGetToken jetToken;
     EDGetToken etsumToken;
@@ -82,6 +84,7 @@ namespace l1t {
     void dumpTestVectors(int bx,
                          std::ofstream& myCout,
                          Handle<BXVector<l1t::Muon>> muons,
+                         Handle<BXVector<l1t::MuonShower>> muonShowers,
                          Handle<BXVector<l1t::EGamma>> egammas,
                          Handle<BXVector<l1t::Tau>> taus,
                          Handle<BXVector<l1t::Jet>> jets,
@@ -89,7 +92,8 @@ namespace l1t {
                          Handle<BXVector<GlobalAlgBlk>> uGtAlg,
                          Handle<BXVector<GlobalExtBlk>> uGtExt);
 
-    cms_uint64_t formatMuon(std::vector<l1t::Muon>::const_iterator mu);
+    cms_uint64_t formatMuon(std::vector<l1t::Muon>::const_iterator mu, int muShowerBit);
+    cms_uint64_t formatNonExistantMuon(int muShowerBit);
     unsigned int formatEG(std::vector<l1t::EGamma>::const_iterator eg);
     unsigned int formatTau(std::vector<l1t::Tau>::const_iterator tau);
     unsigned int formatJet(std::vector<l1t::Jet>::const_iterator jet);
@@ -126,6 +130,7 @@ namespace l1t {
     uGtExtInputTag = iConfig.getParameter<InputTag>("uGtExtInputTag");
     egToken = consumes<BXVector<l1t::EGamma>>(iConfig.getParameter<InputTag>("egInputTag"));
     muToken = consumes<BXVector<l1t::Muon>>(iConfig.getParameter<InputTag>("muInputTag"));
+    muShowerToken = consumes<BXVector<l1t::MuonShower>>(iConfig.getParameter<InputTag>("muShowerInputTag"));
     tauToken = consumes<BXVector<l1t::Tau>>(iConfig.getParameter<InputTag>("tauInputTag"));
     jetToken = consumes<BXVector<l1t::Jet>>(iConfig.getParameter<InputTag>("jetInputTag"));
     etsumToken = consumes<BXVector<l1t::EtSum>>(iConfig.getParameter<InputTag>("etsumInputTag"));
@@ -168,6 +173,9 @@ namespace l1t {
 
     Handle<BXVector<l1t::Muon>> muons;
     iEvent.getByToken(muToken, muons);
+
+    Handle<BXVector<l1t::MuonShower>> muonShowers;
+    iEvent.getByToken(muShowerToken, muonShowers);
 
     Handle<BXVector<l1t::Tau>> taus;
     iEvent.getByToken(tauToken, taus);
@@ -396,6 +404,32 @@ namespace l1t {
           cout << "No Muon Data in this event " << endl;
         }
 
+        //Loop over Muon Showers
+        nObj = 0;
+        cout << " ------ Muons Showers --------" << endl;
+        if (muonShowers.isValid()) {
+          std::cout << "========= MuonShower BX index = " << i << "; min BX = " << m_minBx << "; max BX = " << m_maxBx
+                    << std::endl;
+          if (i >= muonShowers->getFirstBX() && i <= muonShowers->getLastBX()) {
+            for (std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(i);
+                 muShower != muonShowers->end(i);
+                 ++muShower) {
+              cout << "  " << std::dec << std::setw(2) << std::setfill(' ') << nObj << std::setfill('0') << ")";
+              cout << "   MUS0 " << std::dec << std::setw(1) << muShower->isOneNominalInTime();
+              cout << ";  MUS1 " << std::dec << std::setw(1) << muShower->isOneTightInTime();
+              cout << ";  MUS2 " << std::dec << std::setw(1) << muShower->isTwoLooseDiffSectorsInTime();
+              cout << ";  MUSOOT0 " << std::dec << std::setw(1) << muShower->musOutOfTime0();
+              cout << ";  MUSOOT1 " << std::dec << std::setw(1) << muShower->musOutOfTime1();
+              cout << endl;
+              nObj++;
+            }
+          } else {
+            cout << "No MuonShowers stored for this bx " << i << endl;
+          }
+        } else {
+          cout << "No MuonShower Data in this event " << endl;
+        }
+
         //Loop over Taus
         nObj = 0;
         cout << " ------ Taus ----------" << endl;
@@ -567,7 +601,7 @@ namespace l1t {
         //	      (i>=etsums->getFirstBX()  && i<=etsums->getLastBX()) &&
         //	      (i>=uGtAlg->getFirstBX()  && i<=uGtAlg->getLastBX()) &&
         //	      (i>=uGtAlg->getFirstBX()  && i<=uGtAlg->getLastBX()) ) {
-        dumpTestVectors(i, m_testVectorFile, muons, egammas, taus, jets, etsums, uGtAlg, uGtExt);
+        dumpTestVectors(i, m_testVectorFile, muons, muonShowers, egammas, taus, jets, etsums, uGtAlg, uGtExt);
         //	 } else {
         //	      edm::LogWarning("GtRecordDump") << "WARNING: Not enough information to dump test vectors for this bx=" << i << endl;
         //	 }
@@ -601,6 +635,7 @@ namespace l1t {
   void GtRecordDump::dumpTestVectors(int bx,
                                      std::ofstream& myOutFile,
                                      Handle<BXVector<l1t::Muon>> muons,
+                                     Handle<BXVector<l1t::MuonShower>> muonShowers,
                                      Handle<BXVector<l1t::EGamma>> egammas,
                                      Handle<BXVector<l1t::Tau>> taus,
                                      Handle<BXVector<l1t::Jet>> jets,
@@ -612,20 +647,73 @@ namespace l1t {
     // Dump Bx (4 digits)
     myOutFile << std::dec << std::setw(4) << std::setfill('0') << m_absBx;
 
-    // Dump 8 Muons (16 digits + space)
+    // Dump 8 Muons (16 digits + space) + Muon Showers
     int nDumped = 0;
-    if (muons.isValid()) {
+
+    int muNumber = 0;  //keeps track of which muons get which muon shower information
+    if (muons.isValid() && muonShowers.isValid()) {
       for (std::vector<l1t::Muon>::const_iterator mu = muons->begin(bx); mu != muons->end(bx); ++mu) {
-        cms_uint64_t packedWd = formatMuon(mu);
+        // loop over valid muons in this bx (muon 0 up to max possible of muon 7)
+        int muShowerBit = 0;  // default value for muon shower bit
+        if (bx >= muonShowers->getFirstBX() && bx <= muonShowers->getLastBX()) {
+          if (muonShowers->size(bx) > 0) {
+            std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(bx);
+            if (muNumber == 0)
+              muShowerBit = muShower->isOneNominalInTime();
+            if (muNumber == 2)
+              muShowerBit = muShower->isOneTightInTime();
+            if (muNumber == 3)
+              muShowerBit = muShower->isTwoLooseDiffSectorsInTime();
+            if (muNumber == 4)
+              muShowerBit = muShower->musOutOfTime0();
+            if (muNumber == 6)
+              muShowerBit = muShower->musOutOfTime1();
+          }
+        }
+        cms_uint64_t packedWd = formatMuon(mu, muShowerBit);
         if (nDumped < 8) {
           myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << packedWd;
           nDumped++;
         }
-      }
+        ++muNumber;  //keeps track of how many muons have been processed
+      }              // end loop over Muons in this bx
+
+      // Muon Shower information can exist, even if a muon object does not exist.  Hence,
+      // now loop over non-existant muons from muNumber up to max of 7 and add the muon shower info
+      int start = muNumber;
+      for (int nonExistantMuon = start; nonExistantMuon < 8; nonExistantMuon++) {
+        int muShowerBit = 0;  // default value for muon shower bit
+        if (bx >= muonShowers->getFirstBX() && bx <= muonShowers->getLastBX()) {
+          if (muonShowers->size(bx) > 0) {
+            std::vector<l1t::MuonShower>::const_iterator muShower = muonShowers->begin(bx);
+            if (muNumber == 0)
+              muShowerBit = muShower->isOneNominalInTime();
+            if (muNumber == 2)
+              muShowerBit = muShower->isOneTightInTime();
+            if (muNumber == 3)
+              muShowerBit = muShower->isTwoLooseDiffSectorsInTime();
+            if (muNumber == 4)
+              muShowerBit = muShower->musOutOfTime0();
+            if (muNumber == 6)
+              muShowerBit = muShower->musOutOfTime1();
+          }
+        }
+        cms_uint64_t packedWd = formatNonExistantMuon(muShowerBit);
+        if (nDumped < 8) {
+          myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << packedWd;
+          nDumped++;
+        }
+        ++muNumber;  // keep track of the number of muons processed
+      }              // end loop over non-existant muons
     }
     for (int i = nDumped; i < 8; i++) {
       myOutFile << " " << std::hex << std::setw(16) << std::setfill('0') << empty;
     }
+    if (!muons.isValid())
+      std::cout << "========= WARNING:  ALL MUONS INVALID ==========" << std::endl;
+    if (!muonShowers.isValid())
+      std::cout << "========= WARNING:  ALL MUON SHOWERS INVALID ==========" << std::endl;
+    //===========================================
 
     // Dump 12 EG (8 digits + space)
     nDumped = 0;
@@ -847,7 +935,7 @@ namespace l1t {
     m_absBx++;
   }
 
-  cms_uint64_t GtRecordDump::formatMuon(std::vector<l1t::Muon>::const_iterator mu) {
+  cms_uint64_t GtRecordDump::formatMuon(std::vector<l1t::Muon>::const_iterator mu, int muShowerBit) {
     cms_uint64_t packedVal = 0;
 
     // Pack Bits
@@ -856,6 +944,7 @@ namespace l1t {
     // packedVal |= ((cms_uint64_t)(mu->hwEta() & 0x1ff) << 53);         // removed
     packedVal |= ((cms_uint64_t)(mu->hwPtUnconstrained() & 0xff) << 53);  // added
     packedVal |= ((cms_uint64_t)(mu->hwDXY() & 0x3) << 62);               // added
+    packedVal |= ((cms_uint64_t)(muShowerBit & 0x1) << 61);               // added
     packedVal |= ((cms_uint64_t)(mu->hwEtaAtVtx() & 0x1ff) << 23);        // & 0x1ff) <<9);
     packedVal |= ((cms_uint64_t)(mu->hwPt() & 0x1ff) << 10);              // & 0x1ff) <<0);
     packedVal |= ((cms_uint64_t)(mu->hwChargeValid() & 0x1) << 35);       // & 0x1)   <<28);
@@ -884,12 +973,34 @@ namespace l1t {
     //                << ((cms_uint64_t)(mu->hwPhi() & 0x3ff) << 43) << std::endl;
     //      std::cout << "<< 53; mu->hwPtUnconstrained() = " << std::hex << std::setw(16) << std::setfill('0')
     //                << ((cms_uint64_t)(mu->hwPtUnconstrained() & 0xff) << 53) << std::endl;
+    //      std::cout << "<< 61; muShowerBit             = " << std::hex << std::setw(16) << std::setfill('0')
+    //                << ((cms_uint64_t)(muShowerBit & 0x1) << 61) << std::endl;
     //      std::cout << "<< 62; mu->hwDXY()             = " << std::hex << std::setw(16) << std::setfill('0')
     //                << ((cms_uint64_t)(mu->hwDXY() & 0x3) << 62) << std::endl;
     //      std::cout << "packedWord                     = " << std::hex << std::setw(16) << std::setfill('0') << packedVal
     //                << std::endl;
     //      std::cout << "----------------------" << std::endl;
     //    }
+
+    return packedVal;
+  }
+
+  cms_uint64_t GtRecordDump::formatNonExistantMuon(int muShowerBit) {
+    cms_uint64_t packedVal = 0;
+
+    // Pack Bits
+    packedVal |= ((cms_uint64_t)(0 & 0x3ff) << 43);
+    packedVal |= ((cms_uint64_t)(0 & 0x3ff) << 0);  // & 0x3ff) <<18);
+    // packedVal |= ((cms_uint64_t)(mu->hwEta() & 0x1ff) << 53);         // removed
+    packedVal |= ((cms_uint64_t)(0 & 0xff) << 53);           // added
+    packedVal |= ((cms_uint64_t)(0 & 0x3) << 62);            // added
+    packedVal |= ((cms_uint64_t)(muShowerBit & 0x1) << 61);  // added
+    packedVal |= ((cms_uint64_t)(0 & 0x1ff) << 23);          // & 0x1ff) <<9);
+    packedVal |= ((cms_uint64_t)(0 & 0x1ff) << 10);          // & 0x1ff) <<0);
+    packedVal |= ((cms_uint64_t)(0 & 0x1) << 35);            // & 0x1)   <<28);
+    packedVal |= ((cms_uint64_t)(0 & 0x1) << 34);            // & 0x1)   <<29);
+    packedVal |= ((cms_uint64_t)(0 & 0xf) << 19);            // & 0xf)   <<30);
+    packedVal |= ((cms_uint64_t)(0 & 0x3) << 32);            // & 0x3)   <<34);
 
     return packedVal;
   }

--- a/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
+++ b/L1Trigger/L1TGlobal/plugins/TriggerMenuParser.cc
@@ -26,6 +26,8 @@
  *                - extended for Zero Degree Calorimeter triggers (used for Run 3 HI data-taking)
  * \new features: Melissa Quinnan, Elisa Fontanesi
  *                - extended for AXOL1TL anomaly detection triggers (used for Run 3 data-taking)
+ * \new features: Elisa Fontanesi
+ *                - extended for HTMHF triggers (introduced for the Run 3 2024 data-taking)
  *
  * $Date$
  * $Revision$
@@ -297,6 +299,7 @@ void l1t::TriggerMenuParser::parseCondFormats(const L1TUtmTriggerMenu* utmMenu) 
                    condition.getType() == esConditionType::MissingEt ||
                    condition.getType() == esConditionType::MissingHt ||
                    condition.getType() == esConditionType::MissingEtHF ||
+                   condition.getType() == esConditionType::MissingHtHF ||
                    condition.getType() == esConditionType::TowerCount ||
                    condition.getType() == esConditionType::MinBiasHFP0 ||
                    condition.getType() == esConditionType::MinBiasHFM0 ||
@@ -578,6 +581,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
   GlobalScales::ScaleParameters ettEmScales;
   GlobalScales::ScaleParameters etmScales;
   GlobalScales::ScaleParameters etmHfScales;
+  GlobalScales::ScaleParameters htmHfScales;
   GlobalScales::ScaleParameters httScales;
   GlobalScales::ScaleParameters htmScales;
   GlobalScales::ScaleParameters zdcScales;
@@ -604,6 +608,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
       scaleParam = &etmScales;
     else if (scale.getObjectType() == esObjectType::ETMHF)
       scaleParam = &etmHfScales;
+    else if (scale.getObjectType() == esObjectType::HTMHF)
+      scaleParam = &htmHfScales;
     else if (scale.getObjectType() == esObjectType::HTT)
       scaleParam = &httScales;
     else if (scale.getObjectType() == esObjectType::HTM)
@@ -632,7 +638,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
           // There are no scales for these in the XML so the other case statements will not be seen....do it here.
           if (scale.getObjectType() == esObjectType::ETT || scale.getObjectType() == esObjectType::HTT ||
               scale.getObjectType() == esObjectType::ETM || scale.getObjectType() == esObjectType::HTM ||
-              scale.getObjectType() == esObjectType::ETTEM || scale.getObjectType() == esObjectType::ETMHF) {
+              scale.getObjectType() == esObjectType::ETTEM || scale.getObjectType() == esObjectType::ETMHF ||
+              scale.getObjectType() == esObjectType::HTMHF) {
             scaleParam->etaMin = -1.;
             scaleParam->etaMax = -1.;
             scaleParam->etaStep = -1.;
@@ -702,6 +709,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
   m_gtScales.setETTEmScales(ettEmScales);
   m_gtScales.setETMScales(etmScales);
   m_gtScales.setETMHfScales(etmHfScales);
+  m_gtScales.setHTMHfScales(htmHfScales);
   m_gtScales.setHTTScales(httScales);
   m_gtScales.setHTMScales(htmScales);
   m_gtScales.setHTMScales(zdcScales);
@@ -729,6 +737,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parseCalMuPhi_LUTS(scaleMap, "HTM", "MU");
     parseCalMuPhi_LUTS(scaleMap, "ETM", "MU");
     parseCalMuPhi_LUTS(scaleMap, "ETMHF", "MU");
+    parseCalMuPhi_LUTS(scaleMap, "HTMHF", "MU");
 
     // Now the Pt LUTs  (??? more combinations needed ??)
     // ---------------
@@ -739,6 +748,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parsePt_LUTS(scaleMap, "Mass", "TAU", precisions["PRECISION-EG-TAU-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "ETM", precisions["PRECISION-EG-ETM-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "ETMHF", precisions["PRECISION-EG-ETMHF-MassPt"]);
+    parsePt_LUTS(scaleMap, "Mass", "HTMHF", precisions["PRECISION-EG-HTMHF-MassPt"]);
     parsePt_LUTS(scaleMap, "Mass", "HTM", precisions["PRECISION-EG-HTM-MassPt"]);
 
     // Now the Pt LUTs  for TBPT calculation (??? CCLA following what was done for MASS pt LUTs for now ??)
@@ -749,6 +759,7 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parsePt_LUTS(scaleMap, "TwoBody", "TAU", precisions["PRECISION-EG-TAU-TwoBodyPt"]);
     parsePt_LUTS(scaleMap, "TwoBody", "ETM", precisions["PRECISION-EG-ETM-TwoBodyPt"]);
     parsePt_LUTS(scaleMap, "TwoBody", "ETMHF", precisions["PRECISION-EG-ETMHF-TwoBodyPt"]);
+    parsePt_LUTS(scaleMap, "TwoBody", "HTMHF", precisions["PRECISION-EG-HTMHF-TwoBodyPt"]);
     parsePt_LUTS(scaleMap, "TwoBody", "HTM", precisions["PRECISION-EG-HTM-TwoBodyPt"]);
 
     // Now the Delta Eta/Cosh LUTs (must be done in groups)
@@ -790,6 +801,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "EG", "ETMHF", precisions["PRECISION-EG-ETMHF-Delta"], precisions["PRECISION-EG-ETMHF-Math"]);
     parseDeltaPhi_Cos_LUTS(
+        scaleMap, "EG", "HTMHF", precisions["PRECISION-EG-HTMHF-Delta"], precisions["PRECISION-EG-HTMHF-Math"]);
+    parseDeltaPhi_Cos_LUTS(
         scaleMap, "EG", "HTM", precisions["PRECISION-EG-HTM-Delta"], precisions["PRECISION-EG-HTM-Math"]);
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "EG", "MU", precisions["PRECISION-EG-MU-Delta"], precisions["PRECISION-EG-MU-Math"]);
@@ -803,6 +816,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "JET", "ETMHF", precisions["PRECISION-JET-ETMHF-Delta"], precisions["PRECISION-JET-ETMHF-Math"]);
     parseDeltaPhi_Cos_LUTS(
+        scaleMap, "JET", "HTMHF", precisions["PRECISION-JET-HTMHF-Delta"], precisions["PRECISION-JET-HTMHF-Math"]);
+    parseDeltaPhi_Cos_LUTS(
         scaleMap, "JET", "HTM", precisions["PRECISION-JET-HTM-Delta"], precisions["PRECISION-JET-HTM-Math"]);
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "JET", "MU", precisions["PRECISION-JET-MU-Delta"], precisions["PRECISION-JET-MU-Math"]);
@@ -814,6 +829,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "TAU", "ETMHF", precisions["PRECISION-TAU-ETMHF-Delta"], precisions["PRECISION-TAU-ETMHF-Math"]);
     parseDeltaPhi_Cos_LUTS(
+        scaleMap, "TAU", "HTMHF", precisions["PRECISION-TAU-HTMHF-Delta"], precisions["PRECISION-TAU-HTMHF-Math"]);
+    parseDeltaPhi_Cos_LUTS(
         scaleMap, "TAU", "HTM", precisions["PRECISION-TAU-HTM-Delta"], precisions["PRECISION-TAU-HTM-Math"]);
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "TAU", "MU", precisions["PRECISION-TAU-MU-Delta"], precisions["PRECISION-TAU-MU-Math"]);
@@ -822,6 +839,8 @@ bool l1t::TriggerMenuParser::parseScales(std::map<std::string, tmeventsetup::esS
         scaleMap, "MU", "ETM", precisions["PRECISION-MU-ETM-Delta"], precisions["PRECISION-MU-ETM-Math"]);
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "MU", "ETMHF", precisions["PRECISION-MU-ETMHF-Delta"], precisions["PRECISION-MU-ETMHF-Math"]);
+    parseDeltaPhi_Cos_LUTS(
+        scaleMap, "MU", "HTMHF", precisions["PRECISION-MU-HTMHF-Delta"], precisions["PRECISION-MU-HTMHF-Math"]);
     parseDeltaPhi_Cos_LUTS(
         scaleMap, "MU", "HTM", precisions["PRECISION-MU-HTM-Delta"], precisions["PRECISION-MU-HTM-Math"]);
     parseDeltaPhi_Cos_LUTS(
@@ -2211,6 +2230,9 @@ bool l1t::TriggerMenuParser::parseEnergySum(L1TUtmCondition condEnergySum, unsig
   } else if (condEnergySum.getType() == esConditionType::MissingEtHF) {
     energySumObjType = GlobalObject::gtETMHF;
     cType = TypeETMHF;
+  } else if (condEnergySum.getType() == esConditionType::MissingHtHF) {
+    energySumObjType = GlobalObject::gtHTMHF;
+    cType = TypeHTMHF;
   } else if (condEnergySum.getType() == esConditionType::TowerCount) {
     energySumObjType = GlobalObject::gtTowerCount;
     cType = TypeTowerCount;
@@ -2576,6 +2598,9 @@ bool l1t::TriggerMenuParser::parseEnergySumCorr(const L1TUtmObject* corrESum, un
   } else if (corrESum->getType() == esObjectType::ETMHF) {
     energySumObjType = GlobalObject::gtETMHF;
     cType = TypeETMHF;
+  } else if (corrESum->getType() == esObjectType::HTMHF) {
+    energySumObjType = GlobalObject::gtHTMHF;
+    cType = TypeHTMHF;
   } else if (corrESum->getType() == esObjectType::TOWERCOUNT) {
     energySumObjType = GlobalObject::gtTowerCount;
     cType = TypeTowerCount;
@@ -3128,7 +3153,8 @@ bool l1t::TriggerMenuParser::parseCorrelation(L1TUtmCondition corrCond, unsigned
       condCateg[jj] = CondCalo;
 
     } else if (object.getType() == esObjectType::ETM || object.getType() == esObjectType::ETMHF ||
-               object.getType() == esObjectType::TOWERCOUNT || object.getType() == esObjectType::HTM) {
+               object.getType() == esObjectType::HTMHF || object.getType() == esObjectType::TOWERCOUNT ||
+               object.getType() == esObjectType::HTM) {
       // we have Energy Sum
       parseEnergySumCorr(&object, chipNr);
       corrIndexVal[jj] = (m_corEnergySumTemplate[chipNr]).size() - 1;
@@ -3144,6 +3170,9 @@ bool l1t::TriggerMenuParser::parseCorrelation(L1TUtmCondition corrCond, unsigned
         } break;
         case esObjectType::ETMHF: {
           objType[jj] = GlobalObject::gtETMHF;
+        } break;
+        case esObjectType::HTMHF: {
+          objType[jj] = GlobalObject::gtHTMHF;
         } break;
         case esObjectType::TOWERCOUNT: {
           objType[jj] = GlobalObject::gtTowerCount;
@@ -3581,7 +3610,8 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const L1TUtmCond
       condCateg[jj] = CondCalo;
 
     } else if (object.getType() == esObjectType::ETM || object.getType() == esObjectType::ETMHF ||
-               object.getType() == esObjectType::TOWERCOUNT || object.getType() == esObjectType::HTM) {
+               object.getType() == esObjectType::HTMHF || object.getType() == esObjectType::TOWERCOUNT ||
+               object.getType() == esObjectType::HTM) {
       // we have Energy Sum
       parseEnergySumCorr(&object, chipNr);
       corrIndexVal[jj] = (m_corEnergySumTemplate[chipNr]).size() - 1;
@@ -3597,6 +3627,9 @@ bool l1t::TriggerMenuParser::parseCorrelationWithOverlapRemoval(const L1TUtmCond
         } break;
         case esObjectType::ETMHF: {
           objType[jj] = GlobalObject::gtETMHF;
+        } break;
+        case esObjectType::HTMHF: {
+          objType[jj] = GlobalObject::gtHTMHF;
         } break;
         case esObjectType::TOWERCOUNT: {
           objType[jj] = GlobalObject::gtTowerCount;

--- a/L1Trigger/L1TGlobal/src/CorrCondition.cc
+++ b/L1Trigger/L1TGlobal/src/CorrCondition.cc
@@ -577,6 +577,10 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
             type = l1t::EtSum::EtSumType::kMissingEtHF;
             lutObj0 = "ETMHF";
             break;
+          case gtHTMHF:
+            type = l1t::EtSum::EtSumType::kMissingHtHF;
+            lutObj0 = "HTMHF";
+            break;
           case gtMinBiasHFP0:
           case gtMinBiasHFM0:
           case gtMinBiasHFP1:
@@ -643,6 +647,20 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
               }
 
               binEdges = m_gtScales->getETMHFScales().etBins.at(etBin0);
+              et0Phy = 0.5 * (binEdges.second + binEdges.first);
+            } else if (cndObjTypeVec[0] == gtHTMHF) {
+              std::pair<double, double> binEdges = m_gtScales->getHTMHFScales().phiBins.at(phiIndex0);
+              phi0Phy = 0.5 * (binEdges.second + binEdges.first);
+              eta0Phy = 0.;  //No Eta for Energy Sums
+
+              etBin0 = etIndex0;
+              int ssize = m_gtScales->getHTMHFScales().etBins.size();
+              assert(ssize > 0);
+              if (etBin0 >= ssize) {
+                etBin0 = ssize - 1;
+              }
+
+              binEdges = m_gtScales->getHTMHFScales().etBins.at(etBin0);
               et0Phy = 0.5 * (binEdges.second + binEdges.first);
             }
 
@@ -854,6 +872,10 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
               type = l1t::EtSum::EtSumType::kMissingEtHF;
               lutObj1 = "ETMHF";
               break;
+            case gtHTMHF:
+              type = l1t::EtSum::EtSumType::kMissingHtHF;
+              lutObj1 = "HTMHF";
+              break;
             case gtMinBiasHFP0:
             case gtMinBiasHFM0:
             case gtMinBiasHFP1:
@@ -921,6 +943,20 @@ const bool l1t::CorrCondition::evaluateCondition(const int bxEval) const {
                 }
 
                 binEdges = m_gtScales->getETMHFScales().etBins.at(etBin1);
+                et1Phy = 0.5 * (binEdges.second + binEdges.first);
+              } else if (cndObjTypeVec[1] == gtHTMHF) {
+                std::pair<double, double> binEdges = m_gtScales->getHTMHFScales().phiBins.at(phiIndex1);
+                phi1Phy = 0.5 * (binEdges.second + binEdges.first);
+                eta1Phy = 0.;  //No Eta for Energy Sums
+
+                etBin1 = etIndex1;
+                int ssize = m_gtScales->getHTMHFScales().etBins.size();
+                assert(ssize > 0);
+                if (etBin1 >= ssize) {
+                  etBin1 = ssize - 1;
+                }
+
+                binEdges = m_gtScales->getHTMHFScales().etBins.at(etBin1);
                 et1Phy = 0.5 * (binEdges.second + binEdges.first);
               }
 

--- a/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
+++ b/L1Trigger/L1TGlobal/src/EnergySumCondition.cc
@@ -147,6 +147,10 @@ const bool l1t::EnergySumCondition::evaluateCondition(const int bxEval) const {
       type = l1t::EtSum::EtSumType::kMissingEtHF;
       MissingEnergy = true;
       break;
+    case gtHTMHF:
+      type = l1t::EtSum::EtSumType::kMissingHtHF;
+      MissingEnergy = true;
+      break;
     case gtTowerCount:
       type = l1t::EtSum::EtSumType::kTowerCount;
       MissingEnergy = false;

--- a/L1Trigger/L1TGlobal/src/EnergySumTemplate.cc
+++ b/L1Trigger/L1TGlobal/src/EnergySumTemplate.cc
@@ -88,6 +88,8 @@ void EnergySumTemplate::print(std::ostream& myCout) const {
       myCout << "    phi               = " << std::hex << m_objectParameter[i].phiRange0Word << std::endl;
     } else if (m_condType == l1t::TypeETMHF) {
       myCout << "    phi               = " << std::hex << m_objectParameter[i].phiRange0Word << std::endl;
+    } else if (m_condType == l1t::TypeHTMHF) {
+      myCout << "    phi               = " << std::hex << m_objectParameter[i].phiRange0Word << std::endl;
     }
   }
 

--- a/L1Trigger/L1TGlobal/src/GlobalCondition.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalCondition.cc
@@ -113,6 +113,7 @@ const int GlobalCondition::nrObjects() const {
     case l1t::TypeHTT:
     case l1t::TypeHTM:
     case l1t::TypeETMHF:
+    case l1t::TypeHTMHF:
     case l1t::TypeTowerCount:
     case l1t::TypeMinBiasHFP0:
     case l1t::TypeMinBiasHFM0:
@@ -324,6 +325,12 @@ void GlobalCondition::print(std::ostream& myCout) const {
     }
 
     break;
+    case l1t::TypeHTMHF: {
+      myCout << "  Condition type:     "
+             << "TypeHTMHF" << std::endl;
+    }
+
+    break;
     case l1t::TypeTowerCount: {
       myCout << "  Condition type:     "
              << "TypeTowerCount" << std::endl;
@@ -498,6 +505,11 @@ void GlobalCondition::print(std::ostream& myCout) const {
 
       case l1t::gtETMHF: {
         myCout << " ETMHF ";
+      }
+
+      break;
+      case l1t::gtHTMHF: {
+        myCout << " HTMHF ";
       }
 
       break;

--- a/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalDefinitions.cc
@@ -62,6 +62,7 @@ namespace {
       {"l1t::TypeHTT", l1t::TypeHTT},
       {"l1t::TypeHTM", l1t::TypeHTM},
       {"l1t::TypeETMHF", l1t::TypeETMHF},
+      {"l1t::TypeHTMHF", l1t::TypeHTMHF},
       {"l1t::TypeTowerCount", l1t::TypeTowerCount},
       {"l1t::TypeMinBiasHFP0", l1t::TypeMinBiasHFP0},
       {"l1t::TypeMinBiasHFM0", l1t::TypeMinBiasHFM0},

--- a/L1Trigger/L1TGlobal/test/testVectorCode_data.py
+++ b/L1Trigger/L1TGlobal/test/testVectorCode_data.py
@@ -89,10 +89,14 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        "/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/8daa24c0-6005-41a8-a4f1-bd75b5bdf7a2.root",
-        "/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/cbe27e9e-1471-4eda-b011-5b56739f88bd.root",
-        "/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/03978c75-76b5-4334-aa88-9fb938f2540e.root",
-        "/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/e822a72d-988a-4cb0-9e40-f7b90fdeb6fc.root",
+        "/store/data/Run2024E/EphemeralHLTPhysics0/RAW/v1/000/381/065/00000/0041494e-c2c5-4008-a687-5a856740b2f9.root",
+        "/store/data/Run2024E/EphemeralHLTPhysics0/RAW/v1/000/381/065/00000/00dc1cfe-994b-4e7a-9ea5-7883435a95e2.root",
+        "/store/data/Run2024E/EphemeralHLTPhysics0/RAW/v1/000/381/065/00000/007244f0-fbac-480a-a8b4-d7d6fd31b01f.root",
+        "/store/data/Run2024E/EphemeralHLTPhysics0/RAW/v1/000/381/065/00000/033842c3-61c6-43af-8e9f-d698bfd10282.root",
+        #"/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/8daa24c0-6005-41a8-a4f1-bd75b5bdf7a2.root",
+        #"/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/cbe27e9e-1471-4eda-b011-5b56739f88bd.root",
+        #"/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/03978c75-76b5-4334-aa88-9fb938f2540e.root",
+        #"/store/data/Run2023D/EphemeralHLTPhysics0/RAW/v1/000/369/870/00000/e822a72d-988a-4cb0-9e40-f7b90fdeb6fc.root",
     ),
     skipEvents = cms.untracked.uint32(skip)
     )
@@ -123,7 +127,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, '124X_dataRun3_Prompt_v4', '')
 # ----------------
 process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
-xmlMenu="L1Menu_Collisions2024_v1_1_0.xml"
+xmlMenu="L1Menu_Collisions2024_v1_3_0.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 
@@ -172,7 +176,7 @@ process.simGtStage2Digis.MuonShowerInputTag  = cms.InputTag("gtStage2Digis", "Mu
 process.simGtStage2Digis.EGammaInputTag      = cms.InputTag("gtStage2Digis", "EGamma")
 process.simGtStage2Digis.TauInputTag         = cms.InputTag("gtStage2Digis", "Tau")
 process.simGtStage2Digis.JetInputTag         = cms.InputTag("gtStage2Digis", "Jet")
-process.simGtStage2Digis.EtSumInputTag       = cms.InputTag("gtStage2Digis", "ETSum")
+process.simGtStage2Digis.EtSumInputTag       = cms.InputTag("gtStage2Digis", "EtSum")
 process.simGtStage2Digis.EtSumZdcInputTag    = cms.InputTag("etSumZdcProducer")
 process.simGtStage2Digis.EmulateBxInEvent    = cms.int32(1)
     
@@ -182,7 +186,7 @@ process.dumpGTRecord = cms.EDAnalyzer("l1t::GtRecordDump",
 		                      muShowerInputTag = cms.InputTag("gtStage2Digis", "MuonShower"),
 		                      tauInputTag      = cms.InputTag("gtStage2Digis", "Tau"),
                                       jetInputTag      = cms.InputTag("gtStage2Digis", "Jet"),
-                                      etsumInputTag    = cms.InputTag("gtStage2Digis", "ETSum"),
+                                      etsumInputTag    = cms.InputTag("gtStage2Digis", "EtSum"),
                                       uGtAlgInputTag   = cms.InputTag("simGtStage2Digis"),
                                       uGtExtInputTag   = cms.InputTag("simGtExtFakeProd"),
                                       uGtObjectMapInputTag = cms.InputTag("simGtStage2Digis"),


### PR DESCRIPTION
#### PR description:
This PR includes updates to include HTMHF triggers in GT emulator for the version 2024_v1_3_0 of the L1 menu (end of 2024 pp data-taking), as detailed in the following:
* Inclusion of HTMHF object type in ESum in the GT data formats
* Updates of the TriggerMenuParser to properly parse the new condition from the xml menu (according to new utm libraries utm_0.13.0: see [code](https://gitlab.cern.ch/cms-l1t-utm/utm/-/tree/utm_0.13.0?ref_type=tags) and [documentation](https://globaltrigger.web.cern.ch/globaltrigger/release/utm/latest_doc/html/releaseNotes/v0_13_0.html)).
* Propagation of the HTMHF trigger implementation to EnergySum condition (and correlations)
* Propagation of the type definition changes to DataFormats/HLTReco and HLTL1TSeed module

#### PR validation:
The PR has been prepared starting from CMSSW_14_1_X_2024-06-23-0000:
```
cmsrel CMSSW_14_1_X_2024-06-23-0000
cd CMSSW_14_1_X_2024-06-23-0000/src
cmsenv
git cms-init
git cms-addpkg L1Trigger/L1TGlobal
git cms-addpkg DataFormats/L1TGlobal
git cms-addpkg DataFormats/HLTReco
git cms-addpkg HLTrigger/HLTfilters
scram b && scram b code-checks && scram b code-format && scram b
```

Test vectors have been produced by running the GT emulator standalone on a single orbit (3564 events) of EphemeralHLTPhysics 2024E (run 381065). Counts from the newly integrated triggers L1_MHTHF* in [L1Menu_Collisions2024_v1_3_0](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/development/L1Menu_Collisions2024_v1_3_0) are obseved:

| L1 seeds    | Counts |
| ---------- | ------- |
|L1_MHTHF100 | 179 |
|L1_MHTHF120 | 99 |
|L1_MHTHF125 | 86 |   
|L1_MHTHF130 | 72 |
|L1_MHTHF150 | 44 |

#### Backport:
Backport to CMSSW_14_0_X needed by the time of the deployment of the next L1+HLT menus: https://github.com/cms-sw/cmssw/pull/45356.


[cc: @eyigitba @slaurila @caruta @cavana @nabrandman ]