### PR TITLE
Fix lost Dict Def: Add HcalRecHitSoA for HcalRecHit package

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -62,7 +62,7 @@ equivDict = \
          {'TrackInfo'             : ['reco::TrackingRecHitInfo']},
          {'EgammaCandidates'      : ['reco::GsfElectron.*','reco::Photon.*']},
          {'HcalIsolatedTrack'     : ['reco::IsolatedPixelTrackCandidate', 'reco::EcalIsolatedParticleCandidate', 'reco::HcalIsolatedTrackCandidate']},
-         {'HcalRecHit'            : ['HFRecHit','HORecHit','ZDCRecHit','HBHERecHit']},
+         {'HcalRecHit'            : ['HFRecHit','HORecHit','ZDCRecHit','HBHERecHit','HcalRecHitSoA']},
          {'PFRootEvent'           : ['EventColin::']},
          {'CaloTowers'            : ['CaloTower.*']},
          {'GsfTrackReco'          : ['GsfTrack.*']},


### PR DESCRIPTION
This fixes the lost dictionary definition errors we see in IBs (https://cmssdt.cern.ch/SDT/cgi-bin/showDupDict.py/el8_amd64_gcc12/www/fri/14.1-fri-11/CMSSW_14_1_X_2024-06-21-1100/testLogs/dupDict-lostDefs.log) and PR tests. New dictionaries were added via https://github.com/cms-sw/cmssw/pull/45199/files but mapping was missing for these new dict in Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py