### PR TITLE
DataFormats/EcalDigi: change triggerType_ and attenuation_dB_ to explicitly signed types

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
@@ -316,12 +316,12 @@ private:
   /** Type of test trigger
    * @return triggerType
    */
-  char triggerType_;
+  int8_t triggerType_;
 
   /**  Logarithmic attenuator setting in -10dB unit. Between 0 and
    *  5*(-10dB), -1 if unknown.
    */
-  char attenuation_dB_;
+  int8_t attenuation_dB_;
 
   /** Bunch crossing Id 
    */

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -57,7 +57,8 @@
    <class name="EcalPnDiodeDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="3691846555"/>
    </class>
-   <class name="EcalMatacqDigi" ClassVersion="12">
+   <class name="EcalMatacqDigi" ClassVersion="13">
+    <version ClassVersion="13" checksum="700444767"/>
     <version ClassVersion="12" checksum="1211538371"/>
     <version ClassVersion="11" checksum="515819338"/>
     <version ClassVersion="10" checksum="804498184"/>


### PR DESCRIPTION
#### PR description:

We are getting compilation warnings from nvcc on aarch64:

```
  src/DataFormats/EcalDigi/interface/EcalMatacqDigi.h(279): warning #68-D: integer conversion resulted in a change of sign
       triggerType_ = -1;
                     ^
  src/DataFormats/EcalDigi/interface/EcalMatacqDigi.h(287): warning #68-D: integer conversion resulted in a change of sign
       attenuation_dB_ = -1;
```
These are being produced because those data members are declared as type `char`, which does not have a defined signedness, and nvcc on aarch64 defaults to unsigned char.  This PR changes those values to an explicitly signed type `int8_t`.  I'd consider this a real bug, as making assumptions about whether `char` is signed or not can lead to genuine logic errors.

This change does require incrementing the ClassVersion.

As an aside: since the other member data in this DataFormat use ROOT types, I considered using a signed char ROOT type--but they don't have one!  `Char_t` claims to be signed, but it is a typedef for bare `char`, so the ROOT type has exactly the same bug of assuming that `char` has a well-defined signedness.  Issue opened at https://github.com/root-project/root/issues/15927 (which I expect will be ignored, as it will open a can of worms).

#### PR validation:

Compiles, trivial technical change except that it does bump the ClassVersion.