### PR TITLE
CTPPS validation: workaround for -O3 ASAN compilation issue

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -605,7 +605,10 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
 
   // make single-RP-reco plots
   for (const auto &proton : *hRecoProtonsSingleRP) {
-    CTPPSDetId rpId((*proton.contributingLocalTracks().begin())->rpId());
+    // workaround for https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2142898754
+    const auto& pcLTiter = *proton.contributingLocalTracks().begin();
+    assert(pcLTiter.isNonnull());
+    CTPPSDetId rpId(pcLTiter->rpId());
     unsigned int decRPId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
 
     const bool n1f1 = (armTrackCounter_N[rpId.arm()] == 1 && armTrackCounter_F[rpId.arm()] == 1);

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc
@@ -606,7 +606,7 @@ void CTPPSProtonReconstructionPlotter::analyze(const edm::Event &event, const ed
   // make single-RP-reco plots
   for (const auto &proton : *hRecoProtonsSingleRP) {
     // workaround for https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2142898754
-    const auto& pcLTiter = *proton.contributingLocalTracks().begin();
+    const auto &pcLTiter = *proton.contributingLocalTracks().begin();
     assert(pcLTiter.isNonnull());
     CTPPSDetId rpId(pcLTiter->rpId());
     unsigned int decRPId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();


### PR DESCRIPTION
#### PR description:
With `-O3` optimization in the ASAN builds, `Validation/CTPPS/plugins/ValidationCTPPSPlugins/CTPPSTrackDistributionPlotter.cc` is failing to compile with errors of the form:
```
In file included from src/DataFormats/Common/interface/RefVector.h:18,
                 from src/DataFormats/ProtonReco/interface/ForwardProton.h:14,
                 from src/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:20:
In member function 'edm::RefVectorIterator<C, T, F>::reference edm::RefVectorIterator<C, T, F>::operator*() const [with C = std::vector<CTPPSLocalTrackLite>; T = CTPPSLocalTrackLite; F = edm::refhelper::FindUsingAdvance<std::vector<CTPPSLocalTrackLite>, CTPPSLocalTrackLite>]',
    inlined from 'virtual void CTPPSProtonReconstructionPlotter::analyze(const edm::Event&, const edm::EventSetup&)' at src/Validation/CTPPS/plugins/CTPPSProtonReconstructionPlotter.cc:608:22:
  src/DataFormats/Common/interface/RefVectorIterator.h:49:39: error: 'this' pointer is null [-Werror=nonnull]
    49 |       return (*nestedRefVector_)[iter_];
```
For various reasons detailed in https://github.com/cms-sw/cmssw/issues/44931#issuecomment-2142898754 this has to be a compiler bug.  Nevertheless, this PR provides a workaround for the compilation errors.

#### PR validation:

Compiles, purely technical fix, harmless.