### PR TITLE
`HcalRespCorrs_PayloadInspector`: add comparison and correlation of two response corrections payloads

### DIFF
--- a/CondCore/HcalPlugins/interface/HcalObjRepresent.h
+++ b/CondCore/HcalPlugins/interface/HcalObjRepresent.h
@@ -113,10 +113,6 @@ namespace HcalObjRepresent {
     }
 
     ////NOTE to be implemented in PayloadInspector classes
-    virtual float getValue(Item* item) {
-      throw cms::Exception("Value definition not found") << "getValue definition not found for " << payload_->myname();
-    };
-
     virtual float getValue(const Item* item) {
       throw cms::Exception("Value definition not found") << "getValue definition not found for " << payload_->myname();
     }

--- a/CondCore/HcalPlugins/interface/HcalObjRepresent.h
+++ b/CondCore/HcalPlugins/interface/HcalObjRepresent.h
@@ -108,10 +108,18 @@ namespace HcalObjRepresent {
       setTopoModeFromValConts();
     }
 
+    const std::vector<std::pair<std::string, std::vector<Item> > > getAllItems() {
+      return (*payload_).getAllContainers();
+    }
+
     ////NOTE to be implemented in PayloadInspector classes
     virtual float getValue(Item* item) {
       throw cms::Exception("Value definition not found") << "getValue definition not found for " << payload_->myname();
     };
+
+    virtual float getValue(const Item* item) {
+      throw cms::Exception("Value definition not found") << "getValue definition not found for " << payload_->myname();
+    }
 
     //Gets Hcal Object at given coordinate
     //Currently unused but remains as a potentially useful function

--- a/CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalChannelQuality_PayloadInspector.cc
@@ -27,7 +27,7 @@ namespace {
   public:
     HcalChannelStatusContainer(std::shared_ptr<HcalChannelQuality> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalChannelQuality, HcalChannelStatus>(payload, run) {}
-    float getValue(HcalChannelStatus* chan) override { return chan->getValue() / 32770; }
+    float getValue(const HcalChannelStatus* chan) override { return chan->getValue() / 32770; }
   };
 
   /******************************************

--- a/CondCore/HcalPlugins/plugins/HcalGains_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalGains_PayloadInspector.cc
@@ -27,7 +27,7 @@ namespace {
   public:
     HcalGainContainer(std::shared_ptr<HcalGains> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalGains, HcalGain>(payload, run) {}
-    float getValue(HcalGain* gain) override {
+    float getValue(const HcalGain* gain) override {
       return gain->getValue(0) + gain->getValue(1) + gain->getValue(2) + gain->getValue(3);
     }
   };

--- a/CondCore/HcalPlugins/plugins/HcalL1TriggerObjects_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalL1TriggerObjects_PayloadInspector.cc
@@ -28,7 +28,7 @@ namespace {
   public:
     HcalL1TriggerObjectContainer(std::shared_ptr<HcalL1TriggerObjects> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalL1TriggerObjects, HcalL1TriggerObject>(payload, run) {}
-    float getValue(HcalL1TriggerObject* trig) override { return trig->getRespGain(); }
+    float getValue(const HcalL1TriggerObject* trig) override { return trig->getRespGain(); }
   };
 
   /******************************************

--- a/CondCore/HcalPlugins/plugins/HcalPedestalWidths_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalPedestalWidths_PayloadInspector.cc
@@ -24,7 +24,7 @@ namespace {
   public:
     HcalPedestalWidthContainer(std::shared_ptr<HcalPedestalWidths> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalPedestalWidths, HcalPedestalWidth>(payload, run) {}
-    float getValue(HcalPedestalWidth* ped) override {
+    float getValue(const HcalPedestalWidth* ped) override {
       return (ped->getWidth(0) + ped->getWidth(1) + ped->getWidth(2) + ped->getWidth(3)) / 4;
     }
   };

--- a/CondCore/HcalPlugins/plugins/HcalPedestals_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalPedestals_PayloadInspector.cc
@@ -24,7 +24,7 @@ namespace {
   public:
     HcalPedestalContainer(std::shared_ptr<HcalPedestals> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalPedestals, HcalPedestal>(payload, run) {}
-    float getValue(HcalPedestal* ped) override {
+    float getValue(const HcalPedestal* ped) override {
       return (ped->getValue(0) + ped->getValue(1) + ped->getValue(2) + ped->getValue(3)) / 4;
     }
   };

--- a/CondCore/HcalPlugins/plugins/HcalRespCorrs_PayloadInspector.cc
+++ b/CondCore/HcalPlugins/plugins/HcalRespCorrs_PayloadInspector.cc
@@ -1,4 +1,3 @@
-
 #include "CondCore/Utilities/interface/PayloadInspectorModule.h"
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
@@ -9,6 +8,7 @@
 // the data format of the condition to be inspected
 #include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
 
+#include "TLegend.h"
 #include "TH2F.h"
 #include "TCanvas.h"
 #include "TLine.h"
@@ -21,11 +21,13 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   class HcalRespCorrContainer : public HcalObjRepresent::HcalDataContainer<HcalRespCorrs, HcalRespCorr> {
   public:
     HcalRespCorrContainer(std::shared_ptr<HcalRespCorrs> payload, unsigned int run)
         : HcalObjRepresent::HcalDataContainer<HcalRespCorrs, HcalRespCorr>(payload, run) {}
-    float getValue(HcalRespCorr* rCor) override { return rCor->getValue(); }
+    float getValue(const HcalRespCorr* rCor) override { return rCor->getValue(); }
   };
 
   /******************************************
@@ -37,7 +39,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -59,7 +61,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -77,6 +79,406 @@ namespace {
         return false;
     }  // fill method
   };
+
+  /**********************************************************
+     1d plots of HCAL RespCorrs comparison between 2 IOVs
+  **********************************************************/
+  template <int ntags, IOVMultiplicity nIOVs>
+  class HcalRespCorrsComparatorBase : public cond::payloadInspector::PlotImage<HcalRespCorrs, nIOVs, ntags> {
+  public:
+    HcalRespCorrsComparatorBase()
+        : cond::payloadInspector::PlotImage<HcalRespCorrs, nIOVs, ntags>("HcalRespCorrs Comparison") {}
+
+    using MetaData = std::tuple<cond::Time_t, cond::Hash>;
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      MetaData lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<HcalRespCorrs> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<HcalRespCorrs> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      HcalRespCorrContainer* last_objContainer = new HcalRespCorrContainer(last_payload, std::get<0>(lastiov));
+      HcalRespCorrContainer* first_objContainer = new HcalRespCorrContainer(first_payload, std::get<0>(firstiov));
+
+      const auto& lastItems = last_objContainer->getAllItems();
+      const auto& firstItems = first_objContainer->getAllItems();
+
+      assert(lastItems.size() == firstItems.size());
+
+      TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+      canvas.Divide(3, 2);
+
+      std::map<std::string, std::shared_ptr<TH1F>> first_plots;
+      std::map<std::string, std::shared_ptr<TH1F>> last_plots;
+
+      // Prepare the output vector
+      std::vector<std::string> parts(lastItems.size());
+
+      // Use std::transform to extract the strings
+      std::transform(lastItems.begin(),
+                     lastItems.end(),
+                     parts.begin(),
+                     [](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) {
+                       return pair.first;  // Extract the std::string part
+                     });
+
+      auto legend = TLegend(0.13, 0.85, 0.98, 0.95);
+      legend.SetTextSize(0.032);
+
+      unsigned int count{0};
+      for (const auto& part : parts) {
+        count++;
+        first_plots[part] =
+            std::make_shared<TH1F>(Form("f_%s_%s", part.c_str(), firstIOVsince.c_str()),
+                                   Form("Response corrections [%s];correction factor;entries", part.c_str()),
+                                   100,
+                                   0.,
+                                   3.);
+
+        // Use std::find_if to find the matching pair
+        auto it = std::find_if(
+            firstItems.begin(),
+            firstItems.end(),
+            [&part](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) { return pair.first == part; });
+
+        // Check if we found the element
+        if (it != firstItems.end()) {
+          const std::vector<HcalRespCorr>& result = it->second;  // Retrieve the vector<HcalRespCorr>
+          if (DEBUG) {
+            std::cout << "Found vector<HcalRespCorr> for key: " << part << std::endl;
+          }
+          for (auto& item : result) {
+            HcalDetId detId = HcalDetId(item.rawId());
+            if (DEBUG) {
+              int iphi = detId.iphi();
+              int ieta = detId.ieta();
+              int depth = detId.depth();
+
+              std::cout << detId << " iphi" << iphi << " ieta: " << ieta << " depth:" << depth << std::endl;
+            }
+            if (detId != HcalDetId())
+              first_plots[part]->Fill(first_objContainer->getValue(&item));
+          }
+
+          // You can now work with the result vector
+        } else {
+          std::cout << "Key not found: " << part << std::endl;
+        }
+
+        last_plots[part] =
+            std::make_shared<TH1F>(Form("l_%s_%s", part.c_str(), lastIOVsince.c_str()),
+                                   Form("Response Corrections [%s];correction factor;entries", part.c_str()),
+                                   100,
+                                   0,
+                                   3.);
+
+        // Use std::find_if to find the matching pair
+        auto it2 = std::find_if(
+            lastItems.begin(), lastItems.end(), [&part](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) {
+              return pair.first == part;
+            });
+
+        // Check if we found the element
+        if (it2 != lastItems.end()) {
+          const std::vector<HcalRespCorr>& result = it2->second;  // Retrieve the vector<HcalRespCorr>
+          if (DEBUG) {
+            std::cout << "Found vector<HcalRespCorr> for key: " << part << std::endl;
+          }
+          for (auto& item : result) {
+            HcalDetId detId = HcalDetId(item.rawId());
+            if (DEBUG) {
+              int iphi = detId.iphi();
+              int ieta = detId.ieta();
+              int depth = detId.depth();
+
+              std::cout << detId << " iphi" << iphi << " ieta: " << ieta << " depth:" << depth << std::endl;
+            }
+            if (detId != HcalDetId())
+              last_plots[part]->Fill(last_objContainer->getValue(&item));
+          }
+
+          // You can now work with the result vector
+        } else {
+          std::cout << "Key not found: " << part << std::endl;
+        }
+
+        canvas.cd(count);
+
+        canvas.cd(count)->SetTopMargin(0.05);
+        canvas.cd(count)->SetLeftMargin(0.13);
+        canvas.cd(count)->SetRightMargin(0.02);
+
+        if (count == 1) {
+          legend.AddEntry(first_plots[part].get(), (std::get<1>(firstiov)).c_str(), "L");
+          legend.AddEntry(last_plots[part].get(), (std::get<1>(lastiov)).c_str(), "L");
+        }
+
+        const auto& extrema = getExtrema(first_plots[part].get(), last_plots[part].get());
+        first_plots[part]->SetMaximum(1.1 * extrema.second);
+
+        beautifyPlot(first_plots[part], kBlue);
+        first_plots[part]->Draw();
+        beautifyPlot(last_plots[part], kRed);
+        last_plots[part]->Draw("same");
+
+        // Add the first TPaveText box with mean and RMS at the top
+        addStatisticsPaveText(first_plots[part].get(), "Resp Corr", 0.80);
+
+        // Add the second TPaveText box with mean and RMS slightly lower
+        addStatisticsPaveText(last_plots[part].get(), "Resp Corr", 0.70);
+
+        legend.Draw("same");
+      }
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+  private:
+    bool DEBUG{false};
+
+    void beautifyPlot(std::shared_ptr<TH1F> hist, int kColor) {
+      hist->SetStats(kFALSE);
+      hist->SetLineWidth(2);
+      hist->SetLineColor(kColor);
+      hist->GetXaxis()->CenterTitle(true);
+      hist->GetYaxis()->CenterTitle(true);
+      hist->GetXaxis()->SetTitleFont(42);
+      hist->GetYaxis()->SetTitleFont(42);
+      hist->GetXaxis()->SetTitleSize(0.05);
+      hist->GetYaxis()->SetTitleSize(0.05);
+      hist->GetXaxis()->SetTitleOffset(0.9);
+      hist->GetYaxis()->SetTitleOffset(1.5);
+      hist->GetXaxis()->SetLabelFont(42);
+      hist->GetYaxis()->SetLabelFont(42);
+      hist->GetYaxis()->SetLabelSize(.05);
+      hist->GetXaxis()->SetLabelSize(.05);
+    }
+
+    std::pair<float, float> getExtrema(TH1* h1, TH1* h2) {
+      float theMax(-9999.);
+      float theMin(9999.);
+      theMax = h1->GetMaximum() > h2->GetMaximum() ? h1->GetMaximum() : h2->GetMaximum();
+      theMin = h1->GetMinimum() < h2->GetMaximum() ? h1->GetMinimum() : h2->GetMinimum();
+
+      float add_min = theMin > 0. ? -0.05 : 0.05;
+      float add_max = theMax > 0. ? 0.05 : -0.05;
+
+      auto result = std::make_pair(theMin * (1 + add_min), theMax * (1 + add_max));
+      return result;
+    }
+
+    // Function to add a TPaveText with mean and RMS at a specific vertical position
+    void addStatisticsPaveText(TH1* hist, const std::string& label, double yPosition) {
+      // Get the histogram's statistics
+      double mean = hist->GetMean();
+      double rms = hist->GetRMS();
+
+      // Format mean and RMS to 4 significant digits
+      std::ostringstream meanStream;
+      meanStream << std::setprecision(4) << std::scientific << mean;
+      std::string meanStr = meanStream.str();
+
+      std::ostringstream rmsStream;
+      rmsStream << std::setprecision(4) << std::scientific << rms;
+      std::string rmsStr = rmsStream.str();
+
+      // Calculate NDC positions
+      double x1 = 0.55;
+      double x2 = 0.95;
+      double y1 = yPosition - 0.1;  // Height of 0.05 NDC units
+      double y2 = yPosition;
+
+      // Create a TPaveText for mean and RMS
+      TPaveText* statsPave = new TPaveText(x1, y1, x2, y2, "NDC");
+      statsPave->SetFillColor(0);  // Transparent background
+      statsPave->SetBorderSize(1);
+      statsPave->SetLineColor(hist->GetLineColor());
+      statsPave->SetTextColor(hist->GetLineColor());
+      statsPave->SetTextAlign(12);  // Align left and vertically centered
+
+      // Add mean and RMS to the TPaveText
+      statsPave->AddText((label + " Mean: " + meanStr).c_str());
+      statsPave->AddText((label + " RMS: " + rmsStr).c_str());
+
+      // Draw the TPaveText
+      statsPave->Draw();
+    }
+  };
+
+  using HcalRespCorrsComparatorSingleTag = HcalRespCorrsComparatorBase<1, MULTI_IOV>;
+  using HcalRespCorrsComparatorTwoTags = HcalRespCorrsComparatorBase<2, SINGLE_IOV>;
+
+  /**********************************************************
+     2d plots of HCAL RespCorrs comparison between 2 IOVs
+  **********************************************************/
+  template <int ntags, IOVMultiplicity nIOVs>
+  class HcalRespCorrsCorrelationBase : public cond::payloadInspector::PlotImage<HcalRespCorrs, nIOVs, ntags> {
+  public:
+    HcalRespCorrsCorrelationBase()
+        : cond::payloadInspector::PlotImage<HcalRespCorrs, nIOVs, ntags>("HcalRespCorrs Comparison") {}
+
+    using MetaData = std::tuple<cond::Time_t, cond::Hash>;
+
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      MetaData lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<HcalRespCorrs> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<HcalRespCorrs> first_payload = this->fetchPayload(std::get<1>(firstiov));
+
+      std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
+      std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
+
+      HcalRespCorrContainer* last_objContainer = new HcalRespCorrContainer(last_payload, std::get<0>(lastiov));
+      HcalRespCorrContainer* first_objContainer = new HcalRespCorrContainer(first_payload, std::get<0>(firstiov));
+
+      const auto& lastItems = last_objContainer->getAllItems();
+      const auto& firstItems = first_objContainer->getAllItems();
+
+      assert(lastItems.size() == firstItems.size());
+
+      TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+      canvas.Divide(3, 2);
+
+      std::map<std::string, std::shared_ptr<TH2F>> plots;
+
+      // Prepare the output vector
+      std::vector<std::string> parts(lastItems.size());
+
+      // Use std::transform to extract the strings
+      std::transform(lastItems.begin(),
+                     lastItems.end(),
+                     parts.begin(),
+                     [](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) {
+                       return pair.first;  // Extract the std::string part
+                     });
+
+      auto legend = TLegend(0.13, 0.85, 0.98, 0.95);
+      legend.SetTextSize(0.032);
+
+      unsigned int count{0};
+      for (const auto& part : parts) {
+        count++;
+        plots[part] =
+            std::make_shared<TH2F>(Form("%s_%s_vs_%s", part.c_str(), firstIOVsince.c_str(), lastIOVsince.c_str()),
+                                   Form("%s;correction factor (#bf{#color[2]{%s}}, IOV #bf{#color[2]{%s}});correction "
+                                        "factor (#bf{#color[4]{%s}}, IOV #bf{#color[4]{%s}})",
+                                        part.c_str(),
+                                        tagname1.c_str(),
+                                        firstIOVsince.c_str(),
+                                        tagname2.c_str(),
+                                        lastIOVsince.c_str()),
+                                   100,
+                                   0.,
+                                   3.,
+                                   100,
+                                   0.,
+                                   3.);
+
+        // Use std::find_if to find the matching pair
+        auto it = std::find_if(
+            firstItems.begin(),
+            firstItems.end(),
+            [&part](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) { return pair.first == part; });
+
+        // Use std::find_if to find the matching pair
+        auto it2 = std::find_if(
+            lastItems.begin(), lastItems.end(), [&part](const std::pair<std::string, std::vector<HcalRespCorr>>& pair) {
+              return pair.first == part;
+            });
+
+        // Check if we found the element
+        if (it != firstItems.end() && it2 != lastItems.end()) {
+          const std::vector<HcalRespCorr>& result = it->second;    // Retrieve the vector<HcalRespCorr>
+          const std::vector<HcalRespCorr>& result2 = it2->second;  // Retrieve the vector<HcalRespCorr>
+
+          for (auto& item : result) {
+            HcalDetId detId = HcalDetId(item.rawId());
+            if (detId == HcalDetId()) {
+              continue;
+            }
+            for (auto& item2 : result2) {
+              HcalDetId detId2 = HcalDetId(item2.rawId());
+              if (detId == detId2) {
+                plots[part]->Fill(first_objContainer->getValue(&item), last_objContainer->getValue(&item2));
+              }
+            }
+          }
+        }
+
+        canvas.cd(count);
+
+        canvas.cd(count)->SetTopMargin(0.05);
+        canvas.cd(count)->SetLeftMargin(0.13);
+        canvas.cd(count)->SetRightMargin(0.02);
+
+        beautifyPlot(plots[part]);
+        plots[part]->Draw();
+      }
+
+      std::string fileName(this->m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }
+
+    void beautifyPlot(std::shared_ptr<TH2F> hist) {
+      hist->SetStats(kFALSE);
+      hist->GetXaxis()->CenterTitle(true);
+      hist->GetYaxis()->CenterTitle(true);
+      hist->GetXaxis()->SetTitleFont(42);
+      hist->GetYaxis()->SetTitleFont(42);
+      hist->GetXaxis()->SetTitleSize(0.035);
+      hist->GetYaxis()->SetTitleSize(0.035);
+      hist->GetXaxis()->SetTitleOffset(1.55);
+      hist->GetYaxis()->SetTitleOffset(1.55);
+      hist->GetXaxis()->SetLabelFont(42);
+      hist->GetYaxis()->SetLabelFont(42);
+      hist->GetYaxis()->SetLabelSize(.05);
+      hist->GetXaxis()->SetLabelSize(.05);
+    }
+  };
+
+  using HcalRespCorrsCorrelationSingleTag = HcalRespCorrsCorrelationBase<1, MULTI_IOV>;
+  using HcalRespCorrsCorrelationTwoTags = HcalRespCorrsCorrelationBase<2, SINGLE_IOV>;
+
   /******************************************
      2d plot of HCAL RespCorr of 1 IOV
   ******************************************/
@@ -86,7 +488,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -108,7 +510,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -135,7 +537,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -157,7 +559,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -184,7 +586,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -206,7 +608,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -233,7 +635,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -255,7 +657,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -282,7 +684,7 @@ namespace {
       setSingleIov(true);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov = iovs.front();
       std::shared_ptr<HcalRespCorrs> payload = fetchPayload(std::get<1>(iov));
       if (payload.get()) {
@@ -304,7 +706,7 @@ namespace {
       setSingleIov(false);
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
       auto iov1 = iovs.front();
       auto iov2 = iovs.back();
 
@@ -328,6 +730,10 @@ namespace {
 PAYLOAD_INSPECTOR_MODULE(HcalRespCorrs) {
   PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsPlotAll);
   PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsRatioAll);
+  PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsComparatorSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsComparatorTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsCorrelationSingleTag);
+  PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsCorrelationTwoTags);
   PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsEtaPlotAll);
   PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsEtaRatioAll);
   PAYLOAD_INSPECTOR_CLASS(HcalRespCorrsPhiPlotAll);

--- a/CondCore/HcalPlugins/test/testHcalRespCorr.sh
+++ b/CondCore/HcalPlugins/test/testHcalRespCorr.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+if [ -d $W_DIR/plots ]; then
+    rm -fr $W_DIR/plots
+fi
+
+mkdir $W_DIR/plots
+
+getPayloadData.py \
+    --plugin pluginHcalRespCorrs_PayloadInspector \
+    --plot plot_HcalRespCorrsRatioAll \
+    --tag HcalRespCorrs_2024_v1.0_data \
+    --tagtwo HcalRespCorrs_2024_v2.0_data  \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots/HcalRespCorrsRatio2D.png
+
+getPayloadData.py \
+    --plugin pluginHcalRespCorrs_PayloadInspector \
+    --plot plot_HcalRespCorrsComparatorTwoTags \
+    --tag HcalRespCorrs_2024_v1.0_data \
+    --tagtwo HcalRespCorrs_2024_v2.0_data  \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots/HcalRespCorrsCompareTwoTags.png
+
+getPayloadData.py \
+    --plugin pluginHcalRespCorrs_PayloadInspector \
+    --plot plot_HcalRespCorrsCorrelationTwoTags \
+    --tag HcalRespCorrs_2024_v1.0_data \
+    --tagtwo HcalRespCorrs_2024_v2.0_data  \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;
+
+mv *.png $W_DIR/plots/HcalRespCorrsCorrelateTwoTags.png


### PR DESCRIPTION
#### PR description:

Updated `HcalRespCorrs_PayloadInspector`.
Implemented:
  * `HcalRespCorrsComparatorBase` (and its derived classes)
  * `HcalRespCorrsCorrelationBase` (and its derived classes)

The added plot are in the same style as the ones used for https://its.cern.ch/jira/browse/CMSALCA-283

#### PR validation:

Run the testing script added in this PR:

```
getPayloadData.py \
    --plugin pluginHcalRespCorrs_PayloadInspector \
    --plot plot_HcalRespCorrsComparatorTwoTags \
    --tag HcalRespCorrs_2024_v1.0_data \
    --tagtwo HcalRespCorrs_2024_v2.0_data  \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;

getPayloadData.py \
    --plugin pluginHcalRespCorrs_PayloadInspector \
    --plot plot_HcalRespCorrsCorrelationTwoTags \
    --tag HcalRespCorrs_2024_v1.0_data \
    --tagtwo HcalRespCorrs_2024_v2.0_data  \
    --time_type Run \
    --iovs '{"start_iov": "1", "end_iov": "1"}' \
    --iovstwo '{"start_iov": "1", "end_iov": "1"}' \
    --db Prod \
    --test;
```

and obtained the following plots.
![HcalRespCorrsCompareTwoTags](https://github.com/cms-sw/cmssw/assets/5082376/8cbfd5e6-61c0-466a-8fa5-826aa96c936f)

![HcalRespCorrsCorrelateTwoTags](https://github.com/cms-sw/cmssw/assets/5082376/66c907aa-3a19-40c3-96b0-7c84a2fd5343)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, not to be backported.