### PR TITLE
MTD geometry: fix RecoMTD/DetLayers unit test 

### DIFF
--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -13,7 +13,10 @@
 #include <iomanip>
 #include <vector>
 
+#include "DataFormats/Math/interface/Rounding.h"
+
 using namespace std;
+using namespace cms_rounding;
 
 MTDDetSector::MTDDetSector(vector<const GeomDet*>::const_iterator first,
                            vector<const GeomDet*>::const_iterator last,
@@ -178,14 +181,21 @@ bool MTDDetSector::add(size_t idet,
 }
 
 std::ostream& operator<<(std::ostream& os, const MTDDetSector& id) {
-  os << " MTDDetSector at " << std::fixed << id.specificSurface().position() << std::endl
-     << " L/W/T   : " << std::setw(14) << id.specificSurface().bounds().length() << " / " << std::setw(14)
-     << id.specificSurface().bounds().width() << " / " << std::setw(14) << id.specificSurface().bounds().thickness()
+  auto fround = [&](double in) {
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(3) << std::setw(14) << roundIfNear0(in);
+    return ss.str();
+  };
+
+  os << " MTDDetSector at " << std::fixed << std::setprecision(3) << roundVecIfNear0(id.specificSurface().position())
      << std::endl
-     << " rmin    : " << std::setw(14) << id.specificSurface().innerRadius() << std::endl
-     << " rmax    : " << std::setw(14) << id.specificSurface().outerRadius() << std::endl
-     << " phi ref : " << std::setw(14) << id.specificSurface().position().phi() << std::endl
-     << " phi w/2 : " << std::setw(14) << id.specificSurface().phiHalfExtension() << std::endl;
+     << " L/W/T   : " << fround(id.specificSurface().bounds().length()) << " / "
+     << fround(id.specificSurface().bounds().width()) << " / " << fround(id.specificSurface().bounds().thickness())
+     << std::endl
+     << " rmin    : " << fround(id.specificSurface().innerRadius()) << std::endl
+     << " rmax    : " << fround(id.specificSurface().outerRadius()) << std::endl
+     << " phi ref : " << fround(id.specificSurface().position().phi()) << std::endl
+     << " phi w/2 : " << fround(id.specificSurface().phiHalfExtension()) << std::endl;
   return os;
 }
 

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -56,21 +56,21 @@ public:
 private:
   std::unique_ptr<MeasurementEstimator> theEstimator;
 
-  inline std::string fround(const double in) const {
+  inline std::string fround(const double in, const size_t prec) const {
     std::stringstream ss;
-    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundIfNear0(in);
+    ss << std::setprecision(prec) << std::fixed << std::setw(14) << roundIfNear0(in);
     return ss.str();
   }
 
-  inline std::string fvecround(const GlobalPoint vecin) const {
+  inline std::string fvecround(const GlobalPoint vecin, const size_t prec) const {
     std::stringstream ss;
-    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
+    ss << std::setprecision(prec) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
     return ss.str();
   }
 
-  inline std::string fvecround(const GlobalVector vecin) const {
+  inline std::string fvecround(const GlobalVector vecin, const size_t prec) const {
     std::stringstream ss;
-    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
+    ss << std::setprecision(prec) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
     return ss.str();
   }
 
@@ -99,30 +99,44 @@ void MTDRecoGeometryAnalyzer::analyze(edm::StreamID, edm::Event const&, edm::Eve
 
   LogVerbatim("MTDLayerDump") << "\n*** allBTLLayers(): " << std::fixed << std::setw(14) << geo->allBTLLayers().size();
   for (auto dl = geo->allBTLLayers().begin(); dl != geo->allBTLLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDumpFull") << "  " << static_cast<int>(dl - geo->allBTLLayers().begin()) << " "
+                                    << dumpLayer(*dl);
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allBTLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
   LogVerbatim("MTDLayerDump") << "\n*** allETLLayers(): " << std::fixed << std::setw(14) << geo->allETLLayers().size();
   for (auto dl = geo->allETLLayers().begin(); dl != geo->allETLLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDumpFull") << "  " << static_cast<int>(dl - geo->allETLLayers().begin()) << " "
+                                    << dumpLayer(*dl);
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allETLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
+  LogVerbatim("MTDLayerDumpFull") << "\n*** allForwardLayers(): " << std::fixed << std::setw(14)
+                                  << geo->allForwardLayers().size();
   LogVerbatim("MTDLayerDump") << "\n*** allForwardLayers(): " << std::fixed << std::setw(14)
                               << geo->allForwardLayers().size();
   for (auto dl = geo->allForwardLayers().begin(); dl != geo->allForwardLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDumpFull") << "  " << static_cast<int>(dl - geo->allForwardLayers().begin()) << " "
+                                    << dumpLayer(*dl);
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allForwardLayers().begin()) << " "
                                 << dumpLayer(*dl);
   }
 
+  LogVerbatim("MTDLayerDumpFull") << "\n*** allBackwardLayers(): " << std::fixed << std::setw(14)
+                                  << geo->allBackwardLayers().size();
   LogVerbatim("MTDLayerDump") << "\n*** allBackwardLayers(): " << std::fixed << std::setw(14)
                               << geo->allBackwardLayers().size();
   for (auto dl = geo->allBackwardLayers().begin(); dl != geo->allBackwardLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDumpFull") << "  " << static_cast<int>(dl - geo->allBackwardLayers().begin()) << " "
+                                    << dumpLayer(*dl);
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allBackwardLayers().begin()) << " "
                                 << dumpLayer(*dl);
   }
 
+  LogVerbatim("MTDLayerDumpFull") << "\n*** allLayers(): " << std::fixed << std::setw(14) << geo->allLayers().size();
   LogVerbatim("MTDLayerDump") << "\n*** allLayers(): " << std::fixed << std::setw(14) << geo->allLayers().size();
   for (auto dl = geo->allLayers().begin(); dl != geo->allLayers().end(); ++dl) {
+    LogVerbatim("MTDLayerDumpFull") << "  " << static_cast<int>(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
     LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
   }
 
@@ -136,6 +150,9 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
   for (const auto& ilay : layers) {
     const MTDTrayBarrelLayer* layer = static_cast<const MTDTrayBarrelLayer*>(ilay);
 
+    LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nBTL layer " << std::setw(4) << layer->subDetector()
+                                    << " rods = " << std::setw(14) << layer->rods().size()
+                                    << " dets = " << std::setw(14) << layer->basicComponents().size();
     LogVerbatim("MTDLayerDump") << std::fixed << "\nBTL layer " << std::setw(4) << layer->subDetector()
                                 << " rods = " << std::setw(14) << layer->rods().size() << " dets = " << std::setw(14)
                                 << layer->basicComponents().size();
@@ -143,17 +160,26 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
     unsigned int irodInd(0);
     for (const auto& irod : layer->rods()) {
       irodInd++;
+      LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nRod " << irodInd
+                                      << " dets = " << irod->basicComponents().size() << "\n";
       LogVerbatim("MTDLayerDump") << std::fixed << "\nRod " << irodInd << " dets = " << irod->basicComponents().size()
                                   << "\n";
       for (const auto& imod : irod->basicComponents()) {
         BTLDetId modId(imod->geographicalId().rawId());
+        LogVerbatim("MTDLayerDumpFull") << std::fixed << "BTLDetId " << modId.rawId() << " side = " << std::setw(4)
+                                        << modId.mtdSide() << " rod = " << modId.mtdRR()
+                                        << " type/RU/mod = " << std::setw(1) << modId.modType() << "/" << std::setw(1)
+                                        << modId.runit() << "/" << std::setw(2) << modId.module()
+                                        << " R = " << fround(imod->position().perp(), 4)
+                                        << " phi = " << fround(imod->position().phi(), 4)
+                                        << " Z = " << fround(imod->position().z(), 4);
         LogVerbatim("MTDLayerDump") << std::fixed << "BTLDetId " << modId.rawId() << " side = " << std::setw(4)
                                     << modId.mtdSide() << " rod = " << modId.mtdRR()
                                     << " type/RU/mod = " << std::setw(1) << modId.modType() << "/" << std::setw(1)
                                     << modId.runit() << "/" << std::setw(2) << modId.module()
-                                    << " R = " << fround(imod->position().perp())
-                                    << " phi = " << fround(imod->position().phi())
-                                    << " Z = " << fround(imod->position().z());
+                                    << " R = " << fround(imod->position().perp(), 2)
+                                    << " phi = " << fround(imod->position().phi(), 2)
+                                    << " Z = " << fround(imod->position().z(), 2);
       }
     }
 
@@ -174,37 +200,57 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, cyl);
-    LogVerbatim("MTDLayerDump") << "\ntestBTLLayers: at " << fvecround(tsos.globalPosition())
-                                << " R=" << fround(tsos.globalPosition().perp())
-                                << " phi=" << fround(tsos.globalPosition().phi())
-                                << " Z=" << fround(tsos.globalPosition().z())
-                                << " p = " << fvecround(tsos.globalMomentum());
+    LogVerbatim("MTDLayerDumpFull") << "\ntestBTLLayers: at " << fvecround(tsos.globalPosition(), 4)
+                                    << " R=" << fround(tsos.globalPosition().perp(), 4)
+                                    << " phi=" << fround(tsos.globalPosition().phi(), 4)
+                                    << " Z=" << fround(tsos.globalPosition().z(), 4)
+                                    << " p = " << fvecround(tsos.globalMomentum(), 4);
+    LogVerbatim("MTDLayerDump") << "\ntestBTLLayers: at " << fvecround(tsos.globalPosition(), 2)
+                                << " R=" << fround(tsos.globalPosition().perp(), 2)
+                                << " phi=" << fround(tsos.globalPosition().phi(), 2)
+                                << " Z=" << fround(tsos.globalPosition().z(), 2)
+                                << " p = " << fvecround(tsos.globalMomentum(), 2);
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
+    LogVerbatim("MTDLayerDumpFull") << "is compatible: " << comp.first
+                                    << " at: R=" << fround(comp.second.globalPosition().perp(), 4)
+                                    << " phi=" << fround(comp.second.globalPosition().phi(), 4)
+                                    << " Z=" << fround(comp.second.globalPosition().z(), 4);
     LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first
-                                << " at: R=" << fround(comp.second.globalPosition().perp())
-                                << " phi=" << fround(comp.second.globalPosition().phi())
-                                << " Z=" << fround(comp.second.globalPosition().z());
+                                << " at: R=" << fround(comp.second.globalPosition().perp(), 2)
+                                << " phi=" << fround(comp.second.globalPosition().phi(), 2)
+                                << " Z=" << fround(comp.second.globalPosition().z(), 2);
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (!compDets.empty()) {
+      LogVerbatim("MTDLayerDumpFull") << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+                                      << "  final state pos: " << fvecround(compDets.front().second.globalPosition(), 4)
+                                      << "\n"
+                                      << "  det         pos: " << fvecround(compDets.front().first->position(), 4)
+                                      << " id: " << std::hex
+                                      << BTLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
+                                      << "\n"
+                                      << "  distance "
+                                      << fround((tsos.globalPosition() - compDets.front().first->position()).mag(), 2);
       LogVerbatim("MTDLayerDump") << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
-                                  << "  final state pos: " << fvecround(compDets.front().second.globalPosition())
+                                  << "  final state pos: " << fvecround(compDets.front().second.globalPosition(), 2)
                                   << "\n"
-                                  << "  det         pos: " << fvecround(compDets.front().first->position())
+                                  << "  det         pos: " << fvecround(compDets.front().first->position(), 2)
                                   << " id: " << std::hex
                                   << BTLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
                                   << "\n"
                                   << "  distance "
-                                  << fround((tsos.globalPosition() - compDets.front().first->position()).mag());
+                                  << fround((tsos.globalPosition() - compDets.front().first->position()).mag(), 2);
     } else {
+      LogVerbatim("MTDLayerDumpFull") << " ERROR : no compatible det found";
       LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found";
     }
 
     // scan in phi at the given z
-    LogVerbatim("MTDLayerDump") << "\nBTL phi scan at Z = " << aZ << "\n";
+    LogVerbatim("MTDLayerDumpFull") << "\nBTL phi scan at Z = " << fround(aZ, 4) << "\n";
+    LogVerbatim("MTDLayerDump") << "\nBTL phi scan at Z = " << fround(aZ, 2) << "\n";
     aPhi = (int)(-piRadians * 1000) / 1000.;
     double dPhi = 0.005;
     uint32_t nTot(0);
@@ -224,10 +270,14 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
           ss << " " << BTLDetId(dets.first->geographicalId().rawId()).rawId();
         }
       }
+      LogVerbatim("MTDLayerDumpFull") << "BTL scan at phi = " << std::fixed << std::setw(5) << aPhi
+                                      << " compatible dets = " << std::setw(14) << compDets.size() << ss.str();
       LogVerbatim("MTDLayerDump") << "BTL scan at phi = " << std::fixed << std::setw(5) << aPhi
                                   << " compatible dets = " << std::setw(14) << compDets.size() << ss.str();
       aPhi += dPhi;
     }
+    LogVerbatim("MTDLayerDumpFull") << "\nBTL scan total points = " << nTot << " compatible = " << nComp
+                                    << " fraction = " << double(nComp) / double(nTot);
     LogVerbatim("MTDLayerDump") << "\nBTL scan total points = " << nTot << " compatible = " << nComp
                                 << " fraction = " << double(nComp) / double(nTot);
   }
@@ -241,8 +291,15 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
   for (const auto& ilay : layers) {
     const MTDSectorForwardDoubleLayer* layer = static_cast<const MTDSectorForwardDoubleLayer*>(ilay);
 
+    LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
+                                    << " at z = " << fround(layer->surface().position().z(), 4)
+                                    << " sectors = " << std::setw(14) << layer->sectors().size()
+                                    << " dets = " << std::setw(14) << layer->basicComponents().size()
+                                    << " front dets = " << std::setw(14)
+                                    << layer->frontLayer()->basicComponents().size() << " back dets = " << std::setw(14)
+                                    << layer->backLayer()->basicComponents().size();
     LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
-                                << " at z = " << fround(layer->surface().position().z())
+                                << " at z = " << fround(layer->surface().position().z(), 2)
                                 << " sectors = " << std::setw(14) << layer->sectors().size()
                                 << " dets = " << std::setw(14) << layer->basicComponents().size()
                                 << " front dets = " << std::setw(14) << layer->frontLayer()->basicComponents().size()
@@ -251,14 +308,21 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
     unsigned int isectInd(0);
     for (const auto& isector : layer->sectors()) {
       isectInd++;
+      LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nSector " << std::setw(4) << isectInd << "\n" << (*isector);
       LogVerbatim("MTDLayerDump") << std::fixed << "\nSector " << std::setw(4) << isectInd << "\n" << (*isector);
       for (const auto& imod : isector->basicComponents()) {
         ETLDetId modId(imod->geographicalId().rawId());
+        LogVerbatim("MTDLayerDumpFull") << std::fixed << "ETLDetId " << modId.rawId() << " side = " << std::setw(4)
+                                        << modId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc()
+                                        << " " << std::setw(4) << modId.discSide() << " " << std::setw(4)
+                                        << modId.sector() << " mod/type = " << std::setw(4) << modId.module() << " "
+                                        << std::setw(4) << modId.modType()
+                                        << " pos = " << fvecround(imod->position(), 4);
         LogVerbatim("MTDLayerDump") << std::fixed << "ETLDetId " << modId.rawId() << " side = " << std::setw(4)
                                     << modId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " "
                                     << std::setw(4) << modId.discSide() << " " << std::setw(4) << modId.sector()
                                     << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
-                                    << modId.modType() << " pos = " << fvecround(imod->position());
+                                    << modId.modType() << " pos = " << fvecround(imod->position(), 2);
       }
     }
   }
@@ -283,36 +347,56 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << fvecround(tsos.globalPosition())
-                                << " R=" << fround(tsos.globalPosition().perp())
-                                << " phi=" << fround(tsos.globalPosition().phi())
-                                << " Z=" << fround(tsos.globalPosition().z())
-                                << " p = " << fvecround(tsos.globalMomentum());
+    LogVerbatim("MTDLayerDumpFull") << "\ntestETLLayers: at " << fvecround(tsos.globalPosition(), 4)
+                                    << " R=" << fround(tsos.globalPosition().perp(), 4)
+                                    << " phi=" << fround(tsos.globalPosition().phi(), 4)
+                                    << " Z=" << fround(tsos.globalPosition().z(), 4)
+                                    << " p = " << fvecround(tsos.globalMomentum(), 4);
+    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << fvecround(tsos.globalPosition(), 2)
+                                << " R=" << fround(tsos.globalPosition().perp(), 2)
+                                << " phi=" << fround(tsos.globalPosition().phi(), 2)
+                                << " Z=" << fround(tsos.globalPosition().z(), 2)
+                                << " p = " << fvecround(tsos.globalMomentum(), 2);
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
+    LogVerbatim("MTDLayerDumpFull") << std::fixed << "is compatible: " << comp.first
+                                    << " at: R=" << fround(comp.second.globalPosition().perp(), 4)
+                                    << " phi=" << fround(comp.second.globalPosition().phi(), 4)
+                                    << " Z=" << fround(comp.second.globalPosition().z(), 4);
     LogVerbatim("MTDLayerDump") << std::fixed << "is compatible: " << comp.first
-                                << " at: R=" << fround(comp.second.globalPosition().perp())
-                                << " phi=" << fround(comp.second.globalPosition().phi())
-                                << " Z=" << fround(comp.second.globalPosition().z());
+                                << " at: R=" << fround(comp.second.globalPosition().perp(), 2)
+                                << " phi=" << fround(comp.second.globalPosition().phi(), 2)
+                                << " Z=" << fround(comp.second.globalPosition().z(), 2);
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (!compDets.empty()) {
-      LogVerbatim("MTDLayerDump")
+      LogVerbatim("MTDLayerDumpFull")
           << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
-          << "  final state pos: " << fvecround(compDets.front().second.globalPosition()) << "\n"
-          << "  det         pos: " << fvecround(compDets.front().first->position()) << " id: " << std::hex
+          << "  final state pos: " << fvecround(compDets.front().second.globalPosition(), 4) << "\n"
+          << "  det         pos: " << fvecround(compDets.front().first->position(), 4) << " id: " << std::hex
           << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
           << "  distance "
-          << fround((compDets.front().second.globalPosition() - compDets.front().first->position()).mag());
+          << fround((compDets.front().second.globalPosition() - compDets.front().first->position()).mag(), 4);
+      LogVerbatim("MTDLayerDump")
+          << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+          << "  final state pos: " << fvecround(compDets.front().second.globalPosition(), 2) << "\n"
+          << "  det         pos: " << fvecround(compDets.front().first->position(), 2) << " id: " << std::hex
+          << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
+          << "  distance "
+          << fround((compDets.front().second.globalPosition() - compDets.front().first->position()).mag(), 2);
     } else {
       if (layer->isCrack(gp)) {
+        LogVerbatim("MTDLayerDumpFull") << " MTD crack found ";
         LogVerbatim("MTDLayerDump") << " MTD crack found ";
       } else {
+        LogVerbatim("MTDLayerDumpFull") << " ERROR : no compatible det found in MTD"
+                                        << " at: R=" << fround(gp.perp(), 4)
+                                        << " phi= " << fround(gp.phi().degrees(), 4) << " Z= " << fround(gp.z(), 4);
         LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found in MTD"
-                                    << " at: R=" << fround(gp.perp()) << " phi= " << fround(gp.phi().degrees())
-                                    << " Z= " << fround(gp.z());
+                                    << " at: R=" << fround(gp.perp(), 4) << " phi= " << fround(gp.phi().degrees(), 2)
+                                    << " Z= " << fround(gp.z(), 2);
       }
     }
   }
@@ -328,10 +412,10 @@ string MTDRecoGeometryAnalyzer::dumpLayer(const DetLayer* layer) const {
   sur = &(layer->surface());
   if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
     output << std::fixed << " subdet = " << std::setw(4) << layer->subDetector() << " Barrel = " << layer->isBarrel()
-           << " Forward = " << layer->isForward() << "  Cylinder of radius: " << fround(bc->radius());
+           << " Forward = " << layer->isForward() << "  Cylinder of radius: " << fround(bc->radius(), 4);
   } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
     output << std::fixed << " subdet = " << std::setw(4) << layer->subDetector() << " Barrel = " << layer->isBarrel()
-           << " Forward = " << layer->isForward() << "  Disk at: " << fround(bd->position().z());
+           << " Forward = " << layer->isForward() << "  Disk at: " << fround(bd->position().z(), 4);
   }
   return output.str();
 }

--- a/RecoMTD/DetLayers/test/TestETLNavigation.cc
+++ b/RecoMTD/DetLayers/test/TestETLNavigation.cc
@@ -17,8 +17,11 @@
 
 #include <sstream>
 
+#include "DataFormats/Math/interface/Rounding.h"
+
 using namespace std;
 using namespace edm;
+using namespace cms_rounding;
 
 class TestETLNavigation : public global::EDAnalyzer<> {
 public:
@@ -27,6 +30,18 @@ public:
   void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
 
 private:
+  inline std::string fround(const double in) const {
+    std::stringstream ss;
+    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundIfNear0(in);
+    return ss.str();
+  }
+
+  inline std::string fvecround(const GlobalPoint vecin) const {
+    std::stringstream ss;
+    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
+    return ss.str();
+  }
+
   const edm::ESInputTag tag_;
   edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> geomToken_;
 };
@@ -48,7 +63,7 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
     const MTDSectorForwardDoubleLayer* layer = static_cast<const MTDSectorForwardDoubleLayer*>(ilay);
 
     LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
-                                << " at z = " << std::setw(14) << layer->surface().position().z()
+                                << " at z = " << fround(layer->surface().position().z())
                                 << " sectors = " << std::setw(14) << layer->sectors().size()
                                 << " dets = " << std::setw(14) << layer->basicComponents().size()
                                 << " front dets = " << std::setw(14) << layer->frontLayer()->basicComponents().size()
@@ -67,7 +82,7 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
                                     << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " " << std::setw(4)
                                     << modId.discSide() << " " << std::setw(4) << modId.sector()
                                     << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
-                                    << modId.modType() << " pos = " << std::setprecision(4) << imod->position();
+                                    << modId.modType() << " pos = " << fvecround(imod->position());
         for (int iside = -1; iside <= 1; iside += 2) {
           size_t idetNew = isector->hshift(modId, iside);
           if (idetNew >= isector->basicComponents().size()) {
@@ -80,8 +95,8 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
                                         << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " "
                                         << std::setw(4) << newId.discSide() << " " << std::setw(4) << newId.sector()
                                         << " mod/type = " << std::setw(4) << newId.module() << " " << std::setw(4)
-                                        << newId.modType() << " pos = " << std::setprecision(4)
-                                        << isector->basicComponents()[idetNew]->position();
+                                        << newId.modType()
+                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position());
           }
         }
         for (int iside = -1; iside <= 1; iside += 2) {
@@ -96,8 +111,8 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
                   << std::fixed << ".......closest.vshift= " << std::setw(2) << iside << " side = " << std::setw(4)
                   << newId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " " << std::setw(4)
                   << newId.discSide() << " " << std::setw(4) << newId.sector() << " mod/type = " << std::setw(4)
-                  << newId.module() << " " << std::setw(4) << newId.modType() << " pos = " << std::setprecision(4)
-                  << isector->basicComponents()[closest]->position();
+                  << newId.module() << " " << std::setw(4) << newId.modType()
+                  << " pos = " << fvecround(isector->basicComponents()[closest]->position());
             }
           } else {
             ETLDetId newId(isector->basicComponents()[idetNew]->geographicalId().rawId());
@@ -106,8 +121,8 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
                                         << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " "
                                         << std::setw(4) << newId.discSide() << " " << std::setw(4) << newId.sector()
                                         << " mod/type = " << std::setw(4) << newId.module() << " " << std::setw(4)
-                                        << newId.modType() << " pos = " << std::setprecision(4)
-                                        << isector->basicComponents()[idetNew]->position();
+                                        << newId.modType()
+                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position());
           }
         }
       }

--- a/RecoMTD/DetLayers/test/TestETLNavigation.cc
+++ b/RecoMTD/DetLayers/test/TestETLNavigation.cc
@@ -30,15 +30,15 @@ public:
   void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
 
 private:
-  inline std::string fround(const double in) const {
+  inline std::string fround(const double in, const size_t prec) const {
     std::stringstream ss;
-    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundIfNear0(in);
+    ss << std::setprecision(prec) << std::fixed << std::setw(14) << roundIfNear0(in);
     return ss.str();
   }
 
-  inline std::string fvecround(const GlobalPoint vecin) const {
+  inline std::string fvecround(const GlobalPoint vecin, const size_t prec) const {
     std::stringstream ss;
-    ss << std::setprecision(3) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
+    ss << std::setprecision(prec) << std::fixed << std::setw(14) << roundVecIfNear0(vecin);
     return ss.str();
   }
 
@@ -57,13 +57,21 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
 
   // dump of ETL layers structure
 
+  LogVerbatim("MTDLayerDumpFull") << "\n\nTest of ETL navigation \n\n";
   LogVerbatim("MTDLayerDump") << "\n\nTest of ETL navigation \n\n";
 
   for (const auto& ilay : layers) {
     const MTDSectorForwardDoubleLayer* layer = static_cast<const MTDSectorForwardDoubleLayer*>(ilay);
 
+    LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
+                                    << " at z = " << fround(layer->surface().position().z(), 4)
+                                    << " sectors = " << std::setw(14) << layer->sectors().size()
+                                    << " dets = " << std::setw(14) << layer->basicComponents().size()
+                                    << " front dets = " << std::setw(14)
+                                    << layer->frontLayer()->basicComponents().size() << " back dets = " << std::setw(14)
+                                    << layer->backLayer()->basicComponents().size();
     LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
-                                << " at z = " << fround(layer->surface().position().z())
+                                << " at z = " << fround(layer->surface().position().z(), 2)
                                 << " sectors = " << std::setw(14) << layer->sectors().size()
                                 << " dets = " << std::setw(14) << layer->basicComponents().size()
                                 << " front dets = " << std::setw(14) << layer->frontLayer()->basicComponents().size()
@@ -72,57 +80,86 @@ void TestETLNavigation::analyze(edm::StreamID, edm::Event const&, edm::EventSetu
     unsigned int isectInd(0);
     for (const auto& isector : layer->sectors()) {
       isectInd++;
+      LogVerbatim("MTDLayerDumpFull") << std::fixed << "\nSector " << std::setw(4) << isectInd << "\n" << (*isector);
       LogVerbatim("MTDLayerDump") << std::fixed << "\nSector " << std::setw(4) << isectInd << "\n" << (*isector);
       unsigned int imodInd(0);
       for (const auto& imod : isector->basicComponents()) {
         imodInd++;
         ETLDetId modId(imod->geographicalId().rawId());
+        LogVerbatim("MTDLayerDumpFull") << std::fixed << std::setw(5) << imodInd << " ETLDetId " << modId.rawId()
+                                        << " side = " << std::setw(4) << modId.mtdSide()
+                                        << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " "
+                                        << std::setw(4) << modId.discSide() << " " << std::setw(4) << modId.sector()
+                                        << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
+                                        << modId.modType() << " pos = " << fvecround(imod->position(), 4);
         LogVerbatim("MTDLayerDump") << std::fixed << std::setw(5) << imodInd << " ETLDetId " << modId.rawId()
                                     << " side = " << std::setw(4) << modId.mtdSide()
                                     << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " " << std::setw(4)
                                     << modId.discSide() << " " << std::setw(4) << modId.sector()
                                     << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
-                                    << modId.modType() << " pos = " << fvecround(imod->position());
+                                    << modId.modType() << " pos = " << fvecround(imod->position(), 2);
         for (int iside = -1; iside <= 1; iside += 2) {
           size_t idetNew = isector->hshift(modId, iside);
           if (idetNew >= isector->basicComponents().size()) {
+            LogVerbatim("MTDLayerDumpFull")
+                << "...............hshift= " << std::fixed << std::setw(2) << iside << " out of range";
             LogVerbatim("MTDLayerDump") << "...............hshift= " << std::fixed << std::setw(2) << iside
                                         << " out of range";
           } else {
             ETLDetId newId(isector->basicComponents()[idetNew]->geographicalId().rawId());
+            LogVerbatim("MTDLayerDumpFull")
+                << std::fixed << "...............hshift= " << std::setw(2) << iside << " side = " << std::setw(4)
+                << newId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " " << std::setw(4)
+                << newId.discSide() << " " << std::setw(4) << newId.sector() << " mod/type = " << std::setw(4)
+                << newId.module() << " " << std::setw(4) << newId.modType()
+                << " pos = " << fvecround(isector->basicComponents()[idetNew]->position(), 4);
             LogVerbatim("MTDLayerDump") << std::fixed << "...............hshift= " << std::setw(2) << iside
                                         << " side = " << std::setw(4) << newId.mtdSide()
                                         << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " "
                                         << std::setw(4) << newId.discSide() << " " << std::setw(4) << newId.sector()
                                         << " mod/type = " << std::setw(4) << newId.module() << " " << std::setw(4)
                                         << newId.modType()
-                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position());
+                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position(), 2);
           }
         }
         for (int iside = -1; iside <= 1; iside += 2) {
           size_t closest(isector->basicComponents().size());
           size_t idetNew = isector->vshift(modId, iside, closest);
           if (idetNew >= isector->basicComponents().size()) {
+            LogVerbatim("MTDLayerDumpFull")
+                << "...............vshift= " << std::fixed << std::setw(2) << iside << " out of range";
             LogVerbatim("MTDLayerDump") << "...............vshift= " << std::fixed << std::setw(2) << iside
                                         << " out of range";
             if (closest < isector->basicComponents().size()) {
               ETLDetId newId(isector->basicComponents()[closest]->geographicalId().rawId());
+              LogVerbatim("MTDLayerDumpFull")
+                  << std::fixed << ".......closest.vshift= " << std::setw(2) << iside << " side = " << std::setw(4)
+                  << newId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " " << std::setw(4)
+                  << newId.discSide() << " " << std::setw(4) << newId.sector() << " mod/type = " << std::setw(4)
+                  << newId.module() << " " << std::setw(4) << newId.modType()
+                  << " pos = " << fvecround(isector->basicComponents()[closest]->position(), 4);
               LogVerbatim("MTDLayerDump")
                   << std::fixed << ".......closest.vshift= " << std::setw(2) << iside << " side = " << std::setw(4)
                   << newId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " " << std::setw(4)
                   << newId.discSide() << " " << std::setw(4) << newId.sector() << " mod/type = " << std::setw(4)
                   << newId.module() << " " << std::setw(4) << newId.modType()
-                  << " pos = " << fvecround(isector->basicComponents()[closest]->position());
+                  << " pos = " << fvecround(isector->basicComponents()[closest]->position(), 2);
             }
           } else {
             ETLDetId newId(isector->basicComponents()[idetNew]->geographicalId().rawId());
+            LogVerbatim("MTDLayerDumpFull")
+                << std::fixed << "...............vshift= " << std::setw(2) << iside << " side = " << std::setw(4)
+                << newId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " " << std::setw(4)
+                << newId.discSide() << " " << std::setw(4) << newId.sector() << " mod/type = " << std::setw(4)
+                << newId.module() << " " << std::setw(4) << newId.modType()
+                << " pos = " << fvecround(isector->basicComponents()[idetNew]->position(), 4);
             LogVerbatim("MTDLayerDump") << std::fixed << "...............vshift= " << std::setw(2) << iside
                                         << " side = " << std::setw(4) << newId.mtdSide()
                                         << " Disc/Side/Sector = " << std::setw(4) << newId.nDisc() << " "
                                         << std::setw(4) << newId.discSide() << " " << std::setw(4) << newId.sector()
                                         << " mod/type = " << std::setw(4) << newId.module() << " " << std::setw(4)
                                         << newId.modType()
-                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position());
+                                        << " pos = " << fvecround(isector->basicComponents()[idetNew]->position(), 2);
           }
         }
       }

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -16,11 +16,17 @@ process.MessageLogger.cerr.threshold = cms.untracked.string('DEBUG')
 process.MessageLogger.cerr.DEBUG = cms.untracked.PSet(
     limit = cms.untracked.int32(0)
 )
-process.MessageLogger.cerr.MTDLayerDump = cms.untracked.PSet(
+process.MessageLogger.cerr.MTDLayerDumpFull = cms.untracked.PSet(
     limit = cms.untracked.int32(-1)
 )
-process.MessageLogger.cerr.MTDDetLayers = cms.untracked.PSet(
+process.MessageLogger.cerr.MTDDetLayersFull = cms.untracked.PSet(
     limit = cms.untracked.int32(-1)
+)
+process.MessageLogger.cerr.MTDLayerDump = cms.untracked.PSet(
+    limit = cms.untracked.int32(0)
+)
+process.MessageLogger.cerr.MTDDetLayers = cms.untracked.PSet(
+    limit = cms.untracked.int32(0)
 )
 process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     MTDLayerDump = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

As a consequence of the move of all MTD geometry unit tests to scenario D110 in https://github.com/cms-sw/cmssw/pull/45211 , the unit test for the tracking geometry navigation in ```RecoMTD/DetLayers``` starts to fail on aarch64 architecture https://github.com/cms-sw/cmssw/pull/45211#issuecomment-2182787318 , due to some numerical differences in the output of operations displayed in the reference file. 

The underlying geometry calculations are made using ```float``` for performance reasons, and on operations involving space measurements of a size O(100 cm) does not always guarantee to display identical results at the micron level on both amd64 and aarch64. For this reason:

- a better formatting and rounding is adopted in this test, with a configurable precision;
- a 4 decimal digits precision is kept for direct inspection, but a safer 2 digits precision is used in the unit test (and corresponding reference, that needs to be updated in parallel to this PR)

#### PR validation:

The unit test comparison succeed on both amd64 and aarch64 (lxplus-arm.cern.ch).