### PR TITLE
Protect ECAL time reconstruction for events without EB

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/alpaka/EcalUncalibRecHitMultiFitAlgoPortable.dev.cc
@@ -118,20 +118,22 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE::ecal::multifit {
       // TODO: small kernel only for EB. It needs to be checked if
       /// fusing such small kernels is beneficial in here
       //
-      // we are running only over EB digis
-      // therefore we need to create threads/blocks only for that
-      auto const threadsFixMGPA = threads_1d;
-      auto const blocksFixMGPA = cms::alpakatools::divide_up_by(kMaxSamples * ebSize, threadsFixMGPA);
-      auto workDivTimeFixMGPAslew1D = cms::alpakatools::make_workdiv<Acc1D>(blocksFixMGPA, threadsFixMGPA);
-      alpaka::exec<Acc1D>(queue,
-                          workDivTimeFixMGPAslew1D,
-                          Kernel_time_compute_fixMGPAslew{},
-                          digisDevEB.const_view(),
-                          digisDevEE.const_view(),
-                          conditionsDev.const_view(),
-                          scratch.sample_valuesDevBuf.value().data(),
-                          scratch.sample_value_errorsDevBuf.value().data(),
-                          scratch.useless_sample_valuesDevBuf.value().data());
+      if (ebSize > 0) {
+        // we are running only over EB digis
+        // therefore we need to create threads/blocks only for that
+        auto const threadsFixMGPA = threads_1d;
+        auto const blocksFixMGPA = cms::alpakatools::divide_up_by(kMaxSamples * ebSize, threadsFixMGPA);
+        auto workDivTimeFixMGPAslew1D = cms::alpakatools::make_workdiv<Acc1D>(blocksFixMGPA, threadsFixMGPA);
+        alpaka::exec<Acc1D>(queue,
+                            workDivTimeFixMGPAslew1D,
+                            Kernel_time_compute_fixMGPAslew{},
+                            digisDevEB.const_view(),
+                            digisDevEE.const_view(),
+                            conditionsDev.const_view(),
+                            scratch.sample_valuesDevBuf.value().data(),
+                            scratch.sample_value_errorsDevBuf.value().data(),
+                            scratch.useless_sample_valuesDevBuf.value().data());
+      }
 
       auto const threads_nullhypot = threads_1d;
       auto const blocks_nullhypot = blocks_1d;


### PR DESCRIPTION
#### PR description:

Protect the ECAL time reconstruction for events without any rechits in the ECAL barrel.

#### PR validation:

Fixes HLT crashes observed in run 382460, described in #45312.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14.0.x for data taking.