### PR TITLE
Added PixelClusterCountsAuditor

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
+++ b/Calibration/LumiAlCaRecoProducers/plugins/BuildFile.xml
@@ -9,22 +9,6 @@
 <use name="DataFormats/Luminosity"/>
 <use name="CondFormats/DataRecord"/>
 <flags EDM_PLUGIN="1"/>
-<library file="AlcaPCCProducer.cc" name="AlcaPCCProducer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="RawPCCProducer.cc" name="RawPCCProducer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="CorrPCCProducer.cc" name="CorrPCCProducer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="AlcaPCCEventProducer.cc" name="AlcaPCCEventProducer">
-  <flags EDM_PLUGIN="1"/>
-</library>
-
-<library file="AlcaPCCIntegrator.cc" name="AlcaPCCIntegrator">
+<library file="*.cc" name="CalibrationLumiAlCaRecoProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Calibration/LumiAlCaRecoProducers/plugins/PixelClusterCountsAuditor.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/PixelClusterCountsAuditor.cc
@@ -1,0 +1,66 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+
+#include "DataFormats/Luminosity/interface/PixelClusterCounts.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+namespace {
+  struct Empty {};
+}  // namespace
+class PixelClusterCountsAuditor : public edm::global::EDAnalyzer<edm::LuminosityBlockCache<Empty>> {
+public:
+  PixelClusterCountsAuditor(edm::ParameterSet const& iPSet);
+
+  void analyze(edm::StreamID id, edm::Event const&, edm::EventSetup const&) const final {}
+  std::shared_ptr<Empty> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  std::vector<edm::EDGetTokenT<reco::PixelClusterCounts>> tokens_;
+};
+
+PixelClusterCountsAuditor::PixelClusterCountsAuditor(edm::ParameterSet const& iPSet) {
+  auto tags = iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("counts");
+  tokens_.reserve(tags.size());
+  for (auto const& t : tags) {
+    tokens_.emplace_back(consumes<reco::PixelClusterCounts, edm::InLumi>(t));
+  }
+}
+void PixelClusterCountsAuditor::fillDescriptions(edm::ConfigurationDescriptions& iConfig) {
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::vector<edm::InputTag>>("counts")->setComment(
+      "Which PixelClusterCounts to retrieve from the LuminosityBlock");
+  iConfig.addDefault(desc);
+}
+
+std::shared_ptr<Empty> PixelClusterCountsAuditor::globalBeginLuminosityBlock(edm::LuminosityBlock const& iLumi,
+                                                                             edm::EventSetup const&) const {
+  for (auto t : tokens_) {
+    auto h = iLumi.getHandle(t);
+    auto prov = h.provenance();
+    auto const& c = *h;
+    edm::LogSystem("PixelClusterCountsAudit")
+        .format("Branch: {}\n readCounts: {}\n readRocCounts: {}\n readEvents: {}\n readModID: {}\n readRocID: {}",
+                prov->branchName(),
+                c.readCounts().size(),
+                c.readRocCounts().size(),
+                c.readEvents().size(),
+                c.readModID().size(),
+                c.readRocID().size());
+  }
+  return {};
+}
+
+void PixelClusterCountsAuditor::globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const {}
+
+DEFINE_FWK_MODULE(PixelClusterCountsAuditor);


### PR DESCRIPTION

#### PR description:

- A simple EDAnalyzer for auditing the size of data in reco::PixelClusterCounts
- Also reduced number of shared libraries created in the package

#### PR validation:

Code compiles and was used to diagnose excessive job size seen in Tier 0.