### PR TITLE
`TauAnalysis/MCEmbeddingTools`: use `run2_HLTconditions_2016` to select the list of triggers to match in 2016 eras

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/python/SelectingProcedure_cff.py
+++ b/TauAnalysis/MCEmbeddingTools/python/SelectingProcedure_cff.py
@@ -3,7 +3,7 @@ from Configuration.StandardSequences.PAT_cff import *
 
 from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import patMuons
 from HLTrigger.HLTfilters.triggerResultsFilter_cfi import *
-
+from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
 
 ## Trigger requirements
 doubleMuonHLTTrigger = cms.EDFilter("TriggerResultsFilter",
@@ -11,10 +11,10 @@ doubleMuonHLTTrigger = cms.EDFilter("TriggerResultsFilter",
     l1tResults = cms.InputTag(""),
     throw = cms.bool(False),
     triggerConditions = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*") # from 2017 on (up to Run 3, it seems)
-    # triggerConditions = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*") # for 2016
 )
 
-
+run2_HLTconditions_2016.toModify(doubleMuonHLTTrigger,
+                                 triggerConditions = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v* OR HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*"])
 
 ## Muon selection
 patMuonsAfterKinCuts = cms.EDFilter("PATMuonSelector",


### PR DESCRIPTION
#### PR description:

I casually noticed that in the [unit tests logs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_X_2024-06-26-2300/unitTestLogs/TauAnalysis/MCEmbeddingTools#/97) there are instances of this warning:

```
%MSG
%MSG-w Configuration:  TriggerResultsFilter:doubleMuonHLTTrigger  27-Jun-2024 04:26:32 CEST Run: 275886 Event: 86542608
requested pattern "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*" does not match any HLT paths - known paths are:

[...]
```

this can be fixed by take advantage of the `run2_HLTconditions_2016` modifier to select the appropriate list of trigger paths to match.

#### PR validation:

`scram b runtests_testTauEmbeddingWorkflow2016postVFP`
`scram b runtests_testTauEmbeddingWorkflow2016preVFP`

run fine.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
