### PR TITLE
[14_1_X] Rename MUODPG nano flatTable producers

### DIFF
--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -5,9 +5,8 @@ from PhysicsTools.NanoAOD.common_cff import *
 from DPGAnalysis.MuonTools.nano_mu_global_cff import *
 from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
 
-muDPGNanoProducerBkg = cms.Sequence(lhcInfoTableProducer
-                                   + lumiTableProducer
-                                   + muDigiProducersBkg)
+muDPGNanoProducerBkg = cms.Sequence(globalTables
+                                   + muDigiTablesBkg)
 
 def muDPGNanoBkgCustomize(process) :
 

--- a/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducerBkg_cff.py
@@ -11,8 +11,7 @@ muDPGNanoProducerBkg = cms.Sequence(globalTables
 def muDPGNanoBkgCustomize(process) :
 
      for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOEDMAODSIMoutput", "NANOAODSIMoutput"]:
-          if hasattr(process, output):
-               getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
-               getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")           
+          if hasattr(process, output) and "keep edmTriggerResults_*_*_*" in getattr(process,output).outputCommands:
+               getattr(process,output).outputCommands.remove("keep edmTriggerResults_*_*_*")
      
      return process

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -33,8 +33,7 @@ def muDPGNanoCustomize(process) :
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
 
      for output in ["NANOEDMAODoutput", "NANOAODoutput", "NANOEDMAODSIMoutput", "NANOAODSIMoutput"]:
-          if hasattr(process, output):
-               getattr(process,output).outputCommands.append("keep nanoaodFlatTable_*Table*_*_*")
-               getattr(process,output).outputCommands.append("drop edmTriggerResults_*_*_*")
+          if hasattr(process, output) and "keep edmTriggerResults_*_*_*" in getattr(process,output).outputCommands:
+               getattr(process,output).outputCommands.remove("keep edmTriggerResults_*_*_*")
 
      return process

--- a/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
+++ b/DPGAnalysis/MuonTools/python/muNtupleProducer_cff.py
@@ -7,20 +7,18 @@ from DPGAnalysis.MuonTools.nano_mu_digi_cff import *
 from DPGAnalysis.MuonTools.nano_mu_local_reco_cff import *
 from DPGAnalysis.MuonTools.nano_mu_reco_cff import *
 from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
-from DPGAnalysis.MuonTools.nano_mu_l1t_cff import *
 
-muDPGNanoProducer = cms.Sequence(lhcInfoTableProducer
-                                + lumiTableProducer
-                                + muDigiProducers
-                                + muLocalRecoProducers
-                                + muRecoProducers
-                                + muL1TriggerProducers
+muDPGNanoProducer = cms.Sequence(globalTables
+                                + muDigiTables
+                                + muLocalRecoTables
+                                + muRecoTables
+                                + muL1TriggerTables
                                )
 
 def muDPGNanoCustomize(process) :
 
-     if hasattr(process, "dtrpcPointFlatTableProducer") and \
-        hasattr(process, "cscrpcPointFlatTableProducer") and \
+     if hasattr(process, "dtrpcPointFlatTable") and \
+        hasattr(process, "cscrpcPointFlatTable") and \
         hasattr(process, "RawToDigiTask"):
           process.load("RecoLocalMuon.RPCRecHit.rpcPointProducer_cff")
           process.rpcPointProducer.dt4DSegments =  'dt4DSegments'
@@ -28,7 +26,7 @@ def muDPGNanoCustomize(process) :
           process.rpcPointProducer.ExtrapolatedRegion = 0.6
           process.RawToDigiTask.add(process.rpcPointProducer)
 
-     if hasattr(process, "muGEMMuonExtTableProducer") or hasattr(process, "muCSCTnPFlatTableProducer"):
+     if hasattr(process, "muGEMMuonExtTable") or hasattr(process, "muCSCTnPFlatTable"):
           process.load("TrackingTools/TransientTrack/TransientTrackBuilder_cfi")
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
           process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")

--- a/DPGAnalysis/MuonTools/python/nano_mu_digi_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_digi_cff.py
@@ -5,17 +5,18 @@ from DPGAnalysis.MuonTools.common_cff import *
 
 from DPGAnalysis.MuonTools.dtDigiFlatTableProducer_cfi import dtDigiFlatTableProducer
 
-dtDigiFlatTableProducer.name = "dtDigi"
-dtDigiFlatTableProducer.src = "muonDTDigis"
-dtDigiFlatTableProducer.doc = "DT digi information"
+dtDigiFlatTable = dtDigiFlatTableProducer.clone(
+    name = "dtDigi", 
+    src = "muonDTDigis", 
+    doc = "DT digi information",
 
-dtDigiFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         time = Var("time()", float, doc = "digi time"),
         wire = Var("wire()", "int16", doc="wire - [1:X] range"
                                       "<br />(X varies for different chambers SLs and layers)")
-)
+    ),
 
-dtDigiFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         wheel = DetIdVar("wheel()", "int16", doc = "wheel  -  [-2:2] range"),
         sector = DetIdVar("sector()", "int16", doc = "sector - [1:14] range"
                                             "<br />sector 13 used for the second MB4 of sector 4"
@@ -25,21 +26,22 @@ dtDigiFlatTableProducer.detIdVariables = cms.PSet(
                                                     "<br />SL 1 and 3 are phi SLs"
                                                     "<br />SL 2 is theta SL"),
         layer = DetIdVar("layer()", "int16", doc = "layer  -  [1:4] range")
+     )
 )
-
 
 from DPGAnalysis.MuonTools.rpcDigiFlatTableProducer_cfi import rpcDigiFlatTableProducer
 
-rpcDigiFlatTableProducer.name = "rpcDigi"
-rpcDigiFlatTableProducer.src = "muonRPCDigis"
-rpcDigiFlatTableProducer.doc = "RPC digi information"
+rpcDigiFlatTable = rpcDigiFlatTableProducer.clone(
+    name = "rpcDigi",
+    src = "muonRPCDigis",
+    doc = "RPC digi information",
 
-rpcDigiFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         strip = Var("strip()", "uint8", doc = "index of the readout strip associated to the digi"),
         bx = Var("bx()", int, doc="bunch crossing associated to the digi")
-)
+    ),
 
-rpcDigiFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         region = DetIdVar("region()", "int16", doc = "0: barrel, +/-1: endcap"),
         ring = DetIdVar("ring()", "int16", doc = "ring id:"
                                         "<br />wheel number in barrel - [-2:+2] range"
@@ -54,20 +56,22 @@ rpcDigiFlatTableProducer.detIdVariables = cms.PSet(
         roll = DetIdVar("roll()", "int16", doc = "roll id (also known as eta partition):"
                                         "<br />each chamber is divided along the strip direction"),
         rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+    )
 )
 
 from DPGAnalysis.MuonTools.gemDigiFlatTableProducer_cfi import gemDigiFlatTableProducer
 
-gemDigiFlatTableProducer.name = "gemDigi"
-gemDigiFlatTableProducer.src = "muonGEMDigis"
-gemDigiFlatTableProducer.doc = "GEM digi information"
+gemDigiFlatTable = gemDigiFlatTableProducer.clone(
+    name = "gemDigi",
+    src = "muonGEMDigis",
+    doc = "GEM digi information",
 
-gemDigiFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         strip = Var("strip()", "int16", doc = "index of the readout strip associated to the digi"),
         bx = Var("bx()", "int16", doc="bunch crossing associated to the digi")
-)
+    ),
 
-gemDigiFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         station = DetIdVar("station()", "int16", doc = "GEM station <br />(always 1 for GE1/1)"),
         region = DetIdVar("region()", "int16", doc = "GE11 region where the digi is detected"
                                             "<br />(int, positive endcap: +1, negative endcap: -1)"),
@@ -77,84 +81,88 @@ gemDigiFlatTableProducer.detIdVariables = cms.PSet(
                                               "<br />(chambers numbered from 0 to 35)"),
         layer = DetIdVar("layer()", "int16", doc = "GE11 layer where the hit is reconstructed"
                                           "<br />(layer1: 1, layer2: 2)")        
+    )
 )
-
-
 
 from DPGAnalysis.MuonTools.gemohStatusFlatTableProducer_cfi import gemohStatusFlatTableProducer
 
-gemohStatusFlatTableProducer.name = "gemOHStatus"
-gemohStatusFlatTableProducer.src = "muonGEMDigis:OHStatus:"
-gemohStatusFlatTableProducer.doc = "GEM OH status information"
+gemohStatusFlatTable = gemohStatusFlatTableProducer.clone(
+    name = "gemOHStatus",
+    src = "muonGEMDigis:OHStatus:",
+    doc = "GEM OH status information",
 
+    variables = cms.PSet(
+        chamberType = Var("chamberType()", "int", doc = "two digits number that specifies the module within a chamber<br /> 11,12 for GE1/1 chambers layer 1,2<br /> 21,22,23,24 for GE2/1 chambers module 1,2,3,4"),
+        vfatMask = Var("vfatMask()", "uint", doc = "24 bit word that specifies the VFAT Mask<br /> nth bit == 0 means that the VFAT_n was masked from the DAQ in the event"),
+        zsMask = Var("zsMask()", "uint", doc = "24 bit word that specifies the Zero Suppression<br /> nth bit == 1 means that the VFAT_n was zero suppressed"),
+        missingVFATs = Var("missingVFATs()", "uint", doc = "24 bit word that specifies the missing VFAT mask<br /> nth bit == 1 means that the VFAT_n was expected in the payload but not found"),
+        errors = Var("errors()", "uint16", doc = "code for GEM OH errors<br /> non-zero values indicate errors"),
+        warnings = Var("warnings()", "uint16", doc = "code for GEM OH warnings<br /> non-zero values indicate warnings")
+    ),
 
-gemohStatusFlatTableProducer.variables = cms.PSet(
-chamberType = Var("chamberType()", "int", doc = "two digits number that specifies the module within a chamber<br /> 11,12 for GE1/1 chambers layer 1,2<br /> 21,22,23,24 for GE2/1 chambers module 1,2,3,4"),
-vfatMask = Var("vfatMask()", "uint", doc = "24 bit word that specifies the VFAT Mask<br /> nth bit == 0 means that the VFAT_n was masked from the DAQ in the event"),
-zsMask = Var("zsMask()", "uint", doc = "24 bit word that specifies the Zero Suppression<br /> nth bit == 1 means that the VFAT_n was zero suppressed"),
-missingVFATs = Var("missingVFATs()", "uint", doc = "24 bit word that specifies the missing VFAT mask<br /> nth bit == 1 means that the VFAT_n was expected in the payload but not found"),
-errors = Var("errors()", "uint16", doc = "code for GEM OH errors<br /> non-zero values indicate errors"),
-warnings = Var("warnings()", "uint16", doc = "code for GEM OH warnings<br /> non-zero values indicate warnings")
-)
-
-gemohStatusFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         station = DetIdVar("station()", "int16", doc = "GEM station <br />always 1 for GE1/1)"),
         region = DetIdVar("region()", "int16", doc = "region with which the GEMOHStatus is associated"
                                             "<br />int, positive endcap: +1, negative endcap: -1"),
         chamber = DetIdVar("chamber()", "int16", doc = "chamber with which the GEMOHStatus is associated"),
         layer = DetIdVar("layer()", "int16", doc = "layer with which the GEMOHStatus is associated<br /> either 1 or 2 for GE1/1 and GE2/1")
+    )
 )
 
 
 from DPGAnalysis.MuonTools.cscWireDigiFlatTableProducer_cfi import cscWireDigiFlatTableProducer
 
-cscWireDigiFlatTableProducer.name = "cscWireDigi"
-cscWireDigiFlatTableProducer.src = "muonCSCDigis:MuonCSCWireDigi"
-cscWireDigiFlatTableProducer.doc = "CSC wire digi information"
+cscWireDigiFlatTable = cscWireDigiFlatTableProducer.clone(
+    name = "cscWireDigi",
+    src = "muonCSCDigis:MuonCSCWireDigi",
+    doc = "CSC wire digi information",
 
-cscWireDigiFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         timeBin = Var("getTimeBin()", "int16", doc = ""),
         wireGroup = Var("getWireGroup()", "int16", doc=""),
         wireGroupBX = Var("getWireGroupBX()", "int16", doc="")
-)
+    ),
 
-cscWireDigiFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         endcap = DetIdVar("endcap()", "int16", doc = ""),
         station = DetIdVar("station()", "int16", doc = ""),
         ring = DetIdVar("ring()", "int16", doc = ""),
         chamber = DetIdVar("chamber()", "int16", doc = ""),
         layer = DetIdVar("layer()", "int16", doc = "")
+    )
 )
 
 from DPGAnalysis.MuonTools.cscAlctDigiFlatTableProducer_cfi import cscAlctDigiFlatTableProducer
 
-cscAlctDigiFlatTableProducer.name = "cscALCTDigi"
-cscAlctDigiFlatTableProducer.src = "muonCSCDigis:MuonCSCALCTDigi:"
-cscAlctDigiFlatTableProducer.doc = "CSC ALCT digi information"
+cscAlctDigiFlatTable = cscAlctDigiFlatTableProducer.clone(
+    name = "cscALCTDigi",
+    src = "muonCSCDigis:MuonCSCALCTDigi:",
+    doc = "CSC ALCT digi information",
 
-cscAlctDigiFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         keyWireGroup = Var("getKeyWG()", "int16", doc = ""),
         bx = Var("getBX()", "int16", doc="")
-)
+    ),
 
-cscAlctDigiFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         endcap = DetIdVar("endcap()", "int16", doc = ""),
         station = DetIdVar("station()", "int16", doc = ""),
         ring = DetIdVar("ring()", "int16", doc = ""),
         chamber = DetIdVar("chamber()", "int16", doc = ""),
         layer = DetIdVar("layer()", "int16", doc = "")
+    )
 )
 
-muDigiProducers = cms.Sequence(dtDigiFlatTableProducer
-                               + rpcDigiFlatTableProducer
-                               + gemDigiFlatTableProducer
-                               + gemohStatusFlatTableProducer
-                              )
+muDigiTables = cms.Sequence(dtDigiFlatTable
+                            + rpcDigiFlatTable
+                            + gemDigiFlatTable
+                            + gemohStatusFlatTable
+                        )
 
-muDigiProducersBkg = cms.Sequence(dtDigiFlatTableProducer
-                                  + rpcDigiFlatTableProducer
-                                  + cscAlctDigiFlatTableProducer
-                                  + cscWireDigiFlatTableProducer
-                                  + gemDigiFlatTableProducer
-                                  + gemohStatusFlatTableProducer
-                                 )
+muDigiTablesBkg = cms.Sequence(dtDigiFlatTable
+                               + rpcDigiFlatTable
+                               + cscAlctDigiFlatTable
+                               + cscWireDigiFlatTable
+                               + gemDigiFlatTable
+                               + gemohStatusFlatTable
+                        )

--- a/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_global_cff.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.NanoAOD.common_cff import *
+from PhysicsTools.NanoAOD.nano_cff import lhcInfoTable
 
-lumiTableProducer = cms.EDProducer("SimpleOnlineLuminosityFlatTableProducer",
+lumiTable = cms.EDProducer("SimpleOnlineLuminosityFlatTableProducer",
     src = cms.InputTag("onlineMetaDataDigis"),
     name = cms.string("lumi"),
     doc  = cms.string("Online luminosity information"),
@@ -12,4 +13,4 @@ lumiTableProducer = cms.EDProducer("SimpleOnlineLuminosityFlatTableProducer",
     )
 )
 
-lhcInfoTableProducer = cms.EDProducer("LHCInfoProducer")
+globalTables = cms.Sequence(lumiTable + lhcInfoTable)

--- a/DPGAnalysis/MuonTools/python/nano_mu_l1t_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_l1t_cff.py
@@ -2,18 +2,18 @@ import FWCore.ParameterSet.Config as cms
 
 from DPGAnalysis.MuonTools.muDTTPGPhiFlatTableProducer_cfi import muDTTPGPhiFlatTableProducer
 
-muBmtfInFlatTableProducer = muDTTPGPhiFlatTableProducer.clone()
-muTwinMuxInFlatTableProducer = muDTTPGPhiFlatTableProducer.clone(tag = 'TM_IN', name = 'ltTwinMuxIn',  src = cms.InputTag('twinMuxStage2Digis','PhIn'))
-muTwinMuxOutFlatTableProducer = muDTTPGPhiFlatTableProducer.clone(tag = 'TM_OUT', name = 'ltTwinMuxOut', src = cms.InputTag('twinMuxStage2Digis','PhOut'))
+muBmtfInFlatTable = muDTTPGPhiFlatTableProducer.clone()
+muTwinMuxInFlatTable = muDTTPGPhiFlatTableProducer.clone(tag = 'TM_IN', name = 'ltTwinMuxIn',  src = cms.InputTag('twinMuxStage2Digis','PhIn'))
+muTwinMuxOutFlatTable = muDTTPGPhiFlatTableProducer.clone(tag = 'TM_OUT', name = 'ltTwinMuxOut', src = cms.InputTag('twinMuxStage2Digis','PhOut'))
 
 from DPGAnalysis.MuonTools.muDTTPGThetaFlatTableProducer_cfi import muDTTPGThetaFlatTableProducer
 
-muBmtfInThFlatTableProducer = muDTTPGThetaFlatTableProducer.clone()
-muTwinMuxInThFlatTableProducer = muDTTPGThetaFlatTableProducer.clone(tag = 'TM_IN', name = 'ltTwinMuxInTh', src = cms.InputTag('twinMuxStage2Digis','ThIn'))
+muBmtfInThFlatTable = muDTTPGThetaFlatTableProducer.clone()
+muTwinMuxInThFlatTable = muDTTPGThetaFlatTableProducer.clone(tag = 'TM_IN', name = 'ltTwinMuxInTh', src = cms.InputTag('twinMuxStage2Digis','ThIn'))
 
-muL1TriggerProducers = cms.Sequence(muTwinMuxInFlatTableProducer
-                                    + muTwinMuxOutFlatTableProducer
-                                    + muBmtfInFlatTableProducer
-                                    + muTwinMuxInThFlatTableProducer
-                                    + muBmtfInThFlatTableProducer
-                                   )
+muL1TriggerTables = cms.Sequence(muTwinMuxInFlatTable
+                                 + muTwinMuxOutFlatTable
+                                 + muBmtfInFlatTable
+                                 + muTwinMuxInThFlatTable
+                                 + muBmtfInThFlatTable
+                                )

--- a/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_local_reco_cff.py
@@ -1,15 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-from DPGAnalysis.MuonTools.dtSegmentFlatTableProducer_cfi import dtSegmentFlatTableProducer
-
 from PhysicsTools.NanoAOD.common_cff import *
 from DPGAnalysis.MuonTools.common_cff import *
 
-dtSegmentFlatTableProducer.name = "dtSegment"
-dtSegmentFlatTableProducer.src =  "dt4DSegments"
-dtSegmentFlatTableProducer.doc =  "DT segment information"
+from DPGAnalysis.MuonTools.dtSegmentFlatTableProducer_cfi import dtSegmentFlatTableProducer
 
-dtSegmentFlatTableProducer.variables = cms.PSet(
+dtSegmentFlatTable = dtSegmentFlatTableProducer.clone(
+    name = "dtSegment",
+    src =  "dt4DSegments",
+    doc =  "DT segment information",
+
+    variables = cms.PSet(
         seg4D_hasPhi = Var("hasPhi()", bool, doc = "has segment phi view - bool"),
         seg4D_hasZed = Var("hasZed()", bool, doc = "has segment zed view - bool"),
         seg4D_posLoc_x = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
@@ -27,35 +28,39 @@ dtSegmentFlatTableProducer.variables = cms.PSet(
         seg2D_z_t0 = Var(f"? hasZed() ? zSegment().t0() : {defaults.FLOAT}", float, doc = "t0 from segments with z view - ns"),
         seg2D_z_nHits = Var(f"? hasZed() ? zSegment().specificRecHits().size() : 0", "int16", doc = "# hits in z view - [0:4] range"),
         seg2D_z_normChi2 = Var(f"? hasZed() ? (zSegment().chi2() / zSegment().degreesOfFreedom()) : {defaults.FLOAT_POS}", float, doc = "chi2/n.d.o.f. from segments with z view"),
-)
+    ),
 
-dtSegmentFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         wheel = DetIdVar("wheel()", "int16", doc = "wheel  -  [-2:2] range"),
         sector = DetIdVar("sector()", "int16", doc = "sector - [1:14] range"
                                             "<br />sector 13 used for the second MB4 of sector 4"
                                             "<br />sector 14 used for the second MB4 of sector 10"),
         station = DetIdVar("station()", "int16", doc = "station - [1:4] range")
-)
+    ),
 
-dtSegmentFlatTableProducer.globalPosVariables = cms.PSet(
+    globalPosVariables = cms.PSet(
         seg4D_posGlb_phi = GlobGeomVar("phi().value()", doc = "position phi in global coordinates - radians [-pi:pi]"),
         seg4D_posGlb_eta = GlobGeomVar("eta()", doc = "position eta in global coordinates"),
-)
+    ),
 
-dtSegmentFlatTableProducer.globalDirVariables = cms.PSet(
+    globalDirVariables = cms.PSet(
         seg4D_dirGlb_phi = GlobGeomVar("phi().value()", doc = "direction phi in global coordinates - radians [-pi:pi]"),
         seg4D_dirGlb_eta = GlobGeomVar("eta()", doc = "direction eta in global coordinates"),
+    )
 )
 
 from DPGAnalysis.MuonTools.muDTSegmentExtTableProducer_cfi import muDTSegmentExtTableProducer
 
+muDTSegmentExtTable = muDTSegmentExtTableProducer.clone()
+
 from DPGAnalysis.MuonTools.rpcRecHitFlatTableProducer_cfi import rpcRecHitFlatTableProducer
 
-rpcRecHitFlatTableProducer.name = "rpcRecHit"
-rpcRecHitFlatTableProducer.src = "rpcRecHits"
-rpcRecHitFlatTableProducer.doc =  "RPC rec-hit information"
+rpcRecHitFlatTable = rpcRecHitFlatTableProducer.clone(
+    name = "rpcRecHit",
+    src = "rpcRecHits",
+    doc =  "RPC rec-hit information",
 
-rpcRecHitFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         bx = Var("BunchX()", int, doc="bunch crossing number"),
         time = Var("time()", float, doc = "time information in ns"),
         firstClusterStrip = Var("firstClusterStrip()", "int16", doc = "lowest-numbered strip in the cluster"),
@@ -63,9 +68,9 @@ rpcRecHitFlatTableProducer.variables = cms.PSet(
         coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
         coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
         coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
-)
+    ),
 
-rpcRecHitFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         region = DetIdVar("region()", "int16", doc = "0: barrel, +-1: endcap"),
         ring = DetIdVar("ring()", "int16", doc = "ring id:"
                                         "<br />wheel number in barrel (from -2 to +2)"
@@ -80,17 +85,21 @@ rpcRecHitFlatTableProducer.detIdVariables = cms.PSet(
         roll = DetIdVar("roll()", "int16", doc = "roll id (also known as eta partition):"
                                         "<br />each chamber is divided along the strip direction"),
         rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+    )
 )
 
-dtrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'dtrpcPointProducer', src = cms.InputTag('rpcPointProducer','RPCDTExtrapolatedPoints'), doc = "DT extrapolated point on RPC")
+dtrpcPointFlatTable = rpcRecHitFlatTableProducer.clone(
+    name = 'dtToRpc',
+    src = cms.InputTag('rpcPointProducer','RPCDTExtrapolatedPoints'),
+    doc = "DT extrapolated point on RPC",
 
-dtrpcPointFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
         coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
         coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
-)
+    ),
 
-dtrpcPointFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         region = DetIdVar("region()", "int16", doc = "0: barrel, +-1: endcap"),
         ring = DetIdVar("ring()", "int16", doc = "ring id:"
                                         "<br />wheel number in barrel (from -2 to +2)"
@@ -105,18 +114,21 @@ dtrpcPointFlatTableProducer.detIdVariables = cms.PSet(
         roll = DetIdVar("roll()", "int16", doc = "roll id (also known as eta partition):"
                                         "<br />each chamber is divided along the strip direction"),
         rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+    )
 )
-cscrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'cscToRpc',
-                                                                src = cms.InputTag('rpcPointProducer','RPCCSCExtrapolatedPoints'),
-                                                                doc = "CSC segment extrapolated on RPC")
 
-cscrpcPointFlatTableProducer.variables = cms.PSet(
+cscrpcPointFlatTable = rpcRecHitFlatTableProducer.clone(
+    name = 'cscToRpc',
+    src = cms.InputTag('rpcPointProducer','RPCCSCExtrapolatedPoints'),
+    doc = "CSC segment extrapolated on RPC",
+
+    variables = cms.PSet(
         coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
         coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
         coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
-)
+    ),
 
-cscrpcPointFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         region = DetIdVar("region()", "int16", doc = "0: barrel, +-1: endcap"),
         ring = DetIdVar("ring()", "int16", doc = "ring id:"
                                         "<br />wheel number in barrel (from -2 to +2)"
@@ -131,52 +143,26 @@ cscrpcPointFlatTableProducer.detIdVariables = cms.PSet(
         roll = DetIdVar("roll()", "int16", doc = "roll id (also known as eta partition):"
                                         "<br />each chamber is divided along the strip direction"),
         rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
+    )
 )
-
-dtrpcPointFlatTableProducer = rpcRecHitFlatTableProducer.clone(name = 'dtToRpc',
-                                                               src = cms.InputTag('rpcPointProducer','RPCDTExtrapolatedPoints'),
-                                                               doc = "DT segment extrapolated on RPC")
-
-dtrpcPointFlatTableProducer.variables = cms.PSet(
-        coordX = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
-        coordY = Var("localPosition().y()", float, doc = "position y in local coordinates - cm"),
-        coordZ = Var("localPosition().z()", float, doc = "position z in local coordinates - cm"),
-)
-
-dtrpcPointFlatTableProducer.detIdVariables = cms.PSet(
-        region = DetIdVar("region()", "int16", doc = "0: barrel, +-1: endcap"),
-        ring = DetIdVar("ring()", "int16", doc = "ring id:"
-                                        "<br />wheel number in barrel (from -2 to +2)"
-                                        "<br />ring number in endcap (from 1 to 3)"),
-        station = DetIdVar("station()", "int16", doc = "chambers at same R in barrel, chambers at same Z ion endcap"),
-        layer = DetIdVar("layer()", "int16", doc = "layer id:"
-                                          "<br />in station 1 and 2 for barrel, we have two layers of chambers:"
-                                          "<br />layer 1 is the inner chamber and layer 2 is the outer chamber"),
-        sector = DetIdVar("sector()", "int16", doc = "group of chambers at same phi"),
-        subsector = DetIdVar("subsector()", "int16", doc = "Some sectors are divided along the phi direction in subsectors "
-                                                  "(from 1 to 4 in Barrel, from 1 to 6 in Endcap)"),
-        roll = DetIdVar("roll()", "int16", doc = "roll id (also known as eta partition):"
-                                        "<br />each chamber is divided along the strip direction"),
-        rawId = DetIdVar("rawId()", "uint", doc = "unique detector unit ID")
-)
-
 
 from DPGAnalysis.MuonTools.gemRecHitFlatTableProducer_cfi import gemRecHitFlatTableProducer
 
-gemRecHitFlatTableProducer.name = "gemRecHit"
-gemRecHitFlatTableProducer.src = "gemRecHits"
-gemRecHitFlatTableProducer.doc =  "GEM rec-hit information"
+gemRecHitFlatTable = gemRecHitFlatTableProducer.clone(
+    name = "gemRecHit",
+    src = "gemRecHits",
+    doc =  "GEM rec-hit information",
 
-gemRecHitFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         bx = Var("BunchX()", int, doc="bunch crossing number"),
         clusterSize = Var("clusterSize()", "int16", doc = "number of strips in the cluster"),        loc_x = Var("localPosition().x()", float, doc = "hit position x in local coordinates - cm"),
         firstClusterStrip = Var("firstClusterStrip()", "int16", doc = "lowest-numbered strip in the cluster"),
         loc_phi = Var("localPosition().phi().value()", float, doc = "hit position phi in local coordinates - rad"),
         loc_y = Var("localPosition().y()", float, doc = "hit position y in local coordinates - cm"),
         loc_z = Var("localPosition().z()", float, doc = "hit position z in local coordinates - cm"),
-)
+    ),
 
-gemRecHitFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         roll = DetIdVar("roll()", "int16", doc = "roll id, also known as eta partition:"
                                         "<br />(partitions numbered from 1 to 8)"),
         region = DetIdVar("region()", "int16", doc = "GE11 region where the hit is reconstructed"
@@ -185,23 +171,25 @@ gemRecHitFlatTableProducer.detIdVariables = cms.PSet(
                                               "<br />(chambers numbered from 0 to 35)"),
         layer = DetIdVar("layer()", "int16", doc = "GE11 layer where the hit is reconstructed"
                                           "<br />(layer1: 1, layer2: 2)")        
-)
+    ),
 
-gemRecHitFlatTableProducer.globalPosVariables = cms.PSet(
+    globalPosVariables = cms.PSet(
         g_r = GlobGeomVar("perp()", doc = "hit position r in global coordinates - cm"),
         g_phi = GlobGeomVar("phi().value()", doc = "hit position phi in global coordinates -  radians [-pi:pi]"),
         g_x = GlobGeomVar("x()", doc = "hit position x in global coordinates - cm"),
         g_y = GlobGeomVar("y()", doc = "hit position y in global coordinates - cm"),
         g_z = GlobGeomVar("z()", doc = "hit position z in global coordinates - cm")
+    )
 )
 
 from DPGAnalysis.MuonTools.gemSegmentFlatTableProducer_cfi import gemSegmentFlatTableProducer
 
-gemSegmentFlatTableProducer.name = "gemSegment"
-gemSegmentFlatTableProducer.src = "gemSegments"
-gemSegmentFlatTableProducer.doc =  "GEM segment information"
+gemSegmentFlatTable = gemSegmentFlatTableProducer.clone(
+    name = "gemSegment",
+    src = "gemSegments",
+    doc =  "GEM segment information",
 
-gemSegmentFlatTableProducer.variables = cms.PSet(
+    variables = cms.PSet(
         chi2 = Var("chi2()", int, doc = "chi2 from segment fit"),
         bx = Var("bunchX()", int, doc="bunch crossing number"),
         posLoc_x = Var("localPosition().x()", float, doc = "position x in local coordinates - cm"),
@@ -210,35 +198,36 @@ gemSegmentFlatTableProducer.variables = cms.PSet(
         dirLoc_x = Var("localDirection().x()", float, doc = "direction x in local coordinates"),
         dirLoc_y = Var("localDirection().y()", float, doc = "direction y in local coordinates"),
         dirLoc_z = Var("localDirection().z()", float, doc = "direction z in local coordinates"),
-)
+    ),
 
-gemSegmentFlatTableProducer.detIdVariables = cms.PSet(
+    detIdVariables = cms.PSet(
         region = DetIdVar("region()", "int16", doc = "GE11 region where the hit is reconstructed"
                                             "<br />(int, positive endcap: +1, negative endcap: -1)"),
         ring = DetIdVar("ring()", "int16", doc = ""),
         station = DetIdVar("station()", "int16", doc = "GEM station <br />(always 1 for GE1/1)"),
         chamber = DetIdVar("chamber()", "int16", doc = "GE11 superchamber where the hit is reconstructed"
                                               "<br />(chambers numbered from 0 to 35)")
-)
-
-gemSegmentFlatTableProducer.globalPosVariables = cms.PSet(
+    ),
+    
+    globalPosVariables = cms.PSet(
         posGlb_x = GlobGeomVar("x()", doc = "position x in global coordinates - cm"),
         posGlb_y = GlobGeomVar("y()", doc = "position y in global coordinates - cm"),
         posGlb_z = GlobGeomVar("z()", doc = "position z in global coordinates - cm"),
         posGlb_phi = GlobGeomVar("phi().value()", doc = "position phi in global coordinates - radians [-pi:pi]"),
         posGlb_eta = GlobGeomVar("eta()", doc = "position eta in global coordinates"),
-)
+    ),
 
-gemSegmentFlatTableProducer.globalDirVariables = cms.PSet(
+    globalDirVariables = cms.PSet(
         dirGlb_phi = GlobGeomVar("phi().value()", doc = "direction phi in global coordinates - radians [-pi:pi]"),
         dirGlb_eta = GlobGeomVar("eta()", doc = "direction eta in global coordinates"),
+    )
 )
 
-muLocalRecoProducers = cms.Sequence(rpcRecHitFlatTableProducer
-                                    + dtrpcPointFlatTableProducer
-                                    + cscrpcPointFlatTableProducer
-                                    + gemRecHitFlatTableProducer
-                                    + dtSegmentFlatTableProducer
-                                    + muDTSegmentExtTableProducer
-                                    + gemSegmentFlatTableProducer
-                                   )
+muLocalRecoTables = cms.Sequence(rpcRecHitFlatTable
+                                 + dtrpcPointFlatTable
+                                 + cscrpcPointFlatTable
+                                 + gemRecHitFlatTable
+                                 + dtSegmentFlatTable
+                                 + muDTSegmentExtTable
+                                 + gemSegmentFlatTable
+                                )

--- a/DPGAnalysis/MuonTools/python/nano_mu_reco_cff.py
+++ b/DPGAnalysis/MuonTools/python/nano_mu_reco_cff.py
@@ -7,7 +7,7 @@ from PhysicsTools.NanoAOD.simplePATMuonFlatTableProducer_cfi import simplePATMuo
 
 from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import *
 
-muonFlatTableProducer = simplePATMuonFlatTableProducer.clone(
+muonFlatTable = simplePATMuonFlatTableProducer.clone(
     src = cms.InputTag("patMuons"),
     name = cms.string("muon"),
     doc  = cms.string("RECO muon information"),
@@ -50,17 +50,22 @@ muonFlatTableProducer = simplePATMuonFlatTableProducer.clone(
 
 from DPGAnalysis.MuonTools.muDTMuonExtTableProducer_cfi import muDTMuonExtTableProducer
 
+muDTMuonExtTable = muDTMuonExtTableProducer.clone()
+
 from RecoMuon.TrackingTools.MuonServiceProxy_cff import MuonServiceProxy
 
 from DPGAnalysis.MuonTools.muGEMMuonExtTableProducer_cfi import muGEMMuonExtTableProducer
-muGEMMuonExtTableProducer.ServiceParameters = MuonServiceProxy.ServiceParameters
+
+muGEMMuonExtTable = muGEMMuonExtTableProducer.clone()
+muGEMMuonExtTable.ServiceParameters = MuonServiceProxy.ServiceParameters
 
 from DPGAnalysis.MuonTools.muCSCTnPFlatTableProducer_cfi import muCSCTnPFlatTableProducer
-muCSCTnPFlatTableProducer.ServiceParameters = MuonServiceProxy.ServiceParameters
+muCSCTnPFlatTable = muCSCTnPFlatTableProducer.clone()
+muCSCTnPFlatTable.ServiceParameters = MuonServiceProxy.ServiceParameters
 
-muRecoProducers = cms.Sequence(patMuons
-                               + muonFlatTableProducer
-                               + muDTMuonExtTableProducer
-                               + muGEMMuonExtTableProducer
-                               + muCSCTnPFlatTableProducer
-                              )
+muRecoTables = cms.Sequence(patMuons
+                            + muonFlatTable
+                            + muDTMuonExtTable
+                            + muGEMMuonExtTable
+                            + muCSCTnPFlatTable
+                            )


### PR DESCRIPTION
#### PR description:

The PR addresses a (second) issue observed when attempting the cantral production of the MUODPG nano custom flavour:

`Configuration/DataProcessing/test/RunMerge.py` retains, out of collections from `NANOEDMAODoutput`, only the ones whose producer's name is of the form `*Table`.
The MUOPDG nano flavour sequence was adapted accordingly.

A small difference in the event content, too small to affect event-size significantly, is expected.

#### PR validation:

Tested using dedicated `runTheMatrix.py` workflows.
Also, in 14_0_X, I tested that running the actual [PdmV production workflow](https://cms-pdmv-prod.web.cern.ch/rereco/api/requests/get_cmsdriver/ReReco-Run2024E-Muon1-ZMu_PromptMUODPGNano-00001), followed by `Configuration/DataProcessing/test/RunMerge.py`, produces a properly-filled ntuple.

#### PR backport:

This PR is intended to be backported to `CMSSW_14_0_X`

