### PR TITLE
[14.0.X] Improve `DetectorStateFilter` to check DCS state of selected combinations of Tracker partitions

### DIFF
--- a/DQM/TrackerCommon/test/test_DetectorStateFilter.sh
+++ b/DQM/TrackerCommon/test/test_DetectorStateFilter.sh
@@ -53,3 +53,48 @@ else
   echo "WARNING!!! The number of events in the strip filter file ($stripCounts) does NOT match expectations (10)."
   exit 1
 fi
+
+# Now take as input file an express FEVT file from 2024 pp running, run 380032
+# https://cmsoms.cern.ch/cms/runs/lumisection?cms_run=380032
+# it has all partitions ON excepted TIBTID (which was affected by a bad setting of the DCS bit)
+
+INPUTFILE="/store/express/Run2024C/ExpressPhysics/FEVT/Express-v1/000/380/032/00000/26a18459-49a8-4e3c-849c-9b3e4c09712e.root"
+
+# test Strips
+printf "TESTING Strips with all partitions...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/test_DetectorStateFilter_cfg.py maxEvents=10 isStrip=True inputFiles=$INPUTFILE outputFile=outStrips_run380032_all.root || die "Failure filtering on strips" $?
+
+printf "TESTING Strips with only TIBTID partitions...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/test_DetectorStateFilter_cfg.py maxEvents=10 isStrip=True inputFiles=$INPUTFILE testCombinations='TIBTID' outputFile=outStrips_run380032_TIBTID.root || die "Failure filtering on strips" $?
+
+printf "TESTING Strips with several OK partition combinations...\n\n"
+cmsRun ${SCRAM_TEST_PATH}/test_DetectorStateFilter_cfg.py maxEvents=10 isStrip=True inputFiles=$INPUTFILE testCombinations='TOB+TECp+TECm','TIBTID+TECp+TECm','TECp+TECm' outputFile=outStrips_run380032_OKCombos.root || die "Failure filtering on strips" $?
+
+# count events
+allPartsCounts=`countEvents outStrips_run380032_all_numEvent10.root`
+onlyTIBTIDCounts=`countEvents outStrips_run380032_TIBTID_numEvent10.root`
+combinationCounts=`countEvents outStrips_run380032_OKCombos_numEvent10.root`
+
+if [[ $allPartsCounts -eq 0 ]]
+then
+  echo "The number of events in the all partitions filter file matches expectations ($allPartsCounts)."
+else
+  echo "WARNING!!! The number of events in the pixel filter file ($allPartsCounts) does NOT match expectations (0)."
+  exit 1
+fi
+
+if [[ $onlyTIBTIDCounts -eq 0 ]]
+then
+  echo "The number of events in the all partitions filter file matches expectations ($onlyTIBTIDCounts)."
+else
+  echo "WARNING!!! The number of events in the pixel filter file ($onlyTIBTIDCounts) does NOT match expectations (0)."
+  exit 1
+fi
+
+if [[ $combinationCounts -eq 10 ]]
+then
+  echo "The number of events in the all partitions filter file matches expectations ($combinationCounts)."
+else
+  echo "WARNING!!! The number of events in the pixel filter file ($combinationCounts) does NOT match expectations (10)."
+  exit 1
+fi

--- a/DQM/TrackerCommon/test/test_DetectorStateFilter_cfg.py
+++ b/DQM/TrackerCommon/test/test_DetectorStateFilter_cfg.py
@@ -16,6 +16,12 @@ options.register('isStrip',
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.bool, # string, int, or float
                  "true filters on Strips, false filters on Pixels")
+# Register the option as a list of strings
+options.register('testCombinations',
+                 '',  # Default value as an empty string
+                 VarParsing.VarParsing.multiplicity.list,  # Allows multiple values
+                 VarParsing.VarParsing.varType.string,  # Specifies that the values are strings
+                 "List of combinations of partitions to test")
 options.parseArguments()
 
 # import of standard configurations
@@ -71,7 +77,8 @@ process.SiPixelFilter = detectorStateFilter.clone(DetectorType = 'pixel',
                                                   DebugOn = True)
 
 process.SiStripFilter = detectorStateFilter.clone(DetectorType = 'sistrip',
-                                                  DebugOn = True)
+                                                  DebugOn = True,
+                                                  acceptedCombinations = options.testCombinations)
 
 #process.analysis_step = cms.Path(process.detectorStateFilter)
 if(options.isStrip) :


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/45275

#### PR description:

This PR concerns an issue regarding the Tracker DCS bits, and the cases in Run 3 where one of these bits went to "False" during data-taking, but Tracker certified the data as good (which led to overriding the content of the DCS-only json) [^1]. The most recent case of this was [run-380032](https://cmsoms.cern.ch/cms/runs/lumisection?cms_run=380032) (which Tracker marked good, and HLT later marked bad) [^2].

This concerns HLT because of (at least) two reasons.

  - (A) These Tracker-HV DCS bits are used in the online-dqm clients which measure the HLT beamspot: if at least one of the bits is "False", the determination of the online beamspot (which is critical in the HLT reconstruction) may not be updated, so it may be compromised.

  - (B) There is a significant number of triggers (~70 triggers, roughly 10% of the physics triggers in the menu) using the tracker-HV DCS bits in the online trigger decision. These are typically triggers for displaced objects whose rates become too large if the pixel or tracker are really "off", so they use the DCS bits as protection. This means that, when one of these bits are "False", these triggers collect no data. If LSs where the tracker-HV DCS bits were "False" are allowed to enter "golden" jsons (which is currently the case), the analyses using these triggers should in principle use a dedicated json to determine the luminosity recorded by these triggers (in this dedicated json, the LSs with TrackerHV=False would be excluded).

A proposed solution to this issue, since as far as I understand the problem is that usually only *one* DCS partition of the Strip detector (i.e. either one of `TIBTID`, `TOB`, `TECp`, `TECm`) turns to "DCS = false" despite delivering good data, but the filter we're using both for the HLT beamspot and the HLT paths (`DetectorStateFilter` ) 


```python
process.hltStripTrackerHVOn = cms.EDFilter( "DetectorStateFilter",
    DebugOn = cms.untracked.bool( False ),
    DetectorType = cms.untracked.string( "sistrip" ),
    DcsStatusLabel = cms.untracked.InputTag( "" ),
    DCSRecordLabel = cms.untracked.InputTag( "hltOnlineMetaDataDigis" )
)
```

requires all of partitions to be ON (cf [^3] ).
To avoid that situation, one could conceive to change the logic of the filter to require a looser combination (e.g. at least one partition ON, or at least two, or whatever is deemed safer to avoid exploding in rate).
This PR equips `DetectorStateFilter` to check the DCS state of selected combinations of Tracker partitions in order to leverage this idea. The default behaviour of the filter is NOT changed in this PR. Changing the content of the HLT menu will need to be followed up in a dedicated CMSHLT JIRA ticket, while the changing of the online beamspot clients is in the hands of the BeamSpot team.

#### PR validation:

Relies on the augmented unit test `scram b runtests_test_DetectorStateFilter` in which the functionality is tested. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Verbatim backport of https://github.com/cms-sw/cmssw/pull/45275 for 2024 data-taking purposes.
 
[^1]:  https://indico.cern.ch/event/1271493/contributions/5539298/attachments/2698908/4684210/TrkDPGRun368343.pdf
[^2]: https://indico.cern.ch/event/1396796/contributions/5960214/attachments/2858301/5002113/TkDQM_Expert_Tutorial_May24.pdf#page=38
[^3]: https://github.com/cms-sw/cmssw/blob/9030bf6e5bc33e617ca03ac40e8586ea8b86abc2/DQM/TrackerCommon/plugins/DetectorStateFilter.cc#L117-L118