### PR TITLE
fix overloaded `book1DD` method in `DQMStore`

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -163,7 +163,7 @@ namespace dqm {
       template <typename FUNC = NOOP, std::enable_if_t<not std::is_arithmetic<FUNC>::value, int> = 0>
       MonitorElement* book1DD(
           TString const& name, TString const& title, int nchX, float const* xbinsize, FUNC onbooking = NOOP()) {
-        return bookME(name, MonitorElementData::Kind::TH1F, [=]() {
+        return bookME(name, MonitorElementData::Kind::TH1D, [=]() {
           auto th1 = new TH1D(name, title, nchX, xbinsize);
           onbooking(th1);
           return th1;


### PR DESCRIPTION
#### PR description:

This PR is a bugfix for the commit 086454574882d4e0ffaee77e7c326bc030f6e71a introduced in https://github.com/cms-sw/cmssw/pull/45225 (thanks to @rubenforti for spotting).

#### PR validation:

Run the unit tests (`scram b runtests_testTrackingDATAMC`) of the `DQM/TrackingMonitorSource` and looked at ME-s booked with the overloaded method and checked it is a `TH1D` indeed.

![Screenshot from 2024-06-27 11-35-06](https://github.com/cms-sw/cmssw/assets/5082376/834097f8-23ba-455a-a3d4-295d64e43674)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but it will be backported at https://github.com/cms-sw/cmssw/pull/45315.