### PR TITLE
Improve handling of phase-2 geometries and add unit tests for `Fireworks/Geometry` package

### DIFF
--- a/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
+++ b/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py
@@ -43,7 +43,7 @@ def versionCheck(ver):
       print("")
       help()
 
-def recoGeoLoad(score):
+def recoGeoLoad(score, properties):
     print("Loading configuration for tag ", options.tag ,"...\n")
 
     if score == "Run1":
@@ -64,7 +64,7 @@ def recoGeoLoad(score):
        process.GlobalTag.globaltag = autoCond['upgrade2017']
        process.load('Configuration.Geometry.GeometryExtended2017Reco_cff')
        
-    elif  score == "2021":
+    elif score == "2021":
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
        from Configuration.AlCa.autoCond import autoCond
        process.GlobalTag.globaltag = autoCond['upgrade2021']
@@ -78,10 +78,32 @@ def recoGeoLoad(score):
     elif "2026" in score:
        versionCheck(options.version)
        process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-       from Configuration.AlCa.autoCond import autoCond
-       process.GlobalTag.globaltag = autoCond['phase2_realistic']
+
+       # Import the required configuration from the CMSSW module
+       from Configuration.AlCa.autoCond import autoCond  # Ensure autoCond is imported
+
+       # Ensure options.version is defined and set correctly
+       version_key = '2026' + options.version  # This constructs the key for accessing the properties dictionary
+       print(f"Constructed version key: {version_key}")
+
+       # Check if the key exists in properties for 2026
+       if version_key in properties[2026]:
+          # Get the specific global tag for this version
+          global_tag_key = properties[2026][version_key]['GT']
+          print(f"Global tag key from properties: {global_tag_key}")
+
+          # Check if this key exists in autoCond
+          if global_tag_key.replace("auto:", "") in autoCond:
+             # Set the global tag
+             from Configuration.AlCa.GlobalTag import GlobalTag
+             process.GlobalTag = GlobalTag(process.GlobalTag, global_tag_key, '')
+          else:
+             raise KeyError(f"Global tag key '{global_tag_key}' not found in autoCond.")
+       else:
+          raise KeyError(f"Version key '{version_key}' not found in properties[2026].")
        process.load('Configuration.Geometry.GeometryExtended2026'+options.version+'Reco_cff')
-       
+       process.trackerGeometry.applyAlignment = cms.bool(False)
+
     elif score == "MaPSA":
        process.load('Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff')
        process.load('Geometry.TrackerCommonData.mapsaGeometryXML_cfi')
@@ -114,10 +136,7 @@ def recoGeoLoad(score):
       help()
 
 
-
-
 options = VarParsing.VarParsing ()
-
 
 defaultOutputFileName="cmsRecoGeom.root"
 
@@ -171,16 +190,33 @@ options.register ('out',
 
 options.parseArguments()
 
+from Configuration.PyReleaseValidation.upgradeWorkflowComponents import upgradeProperties as properties
+# Determine version_key based on the value of options.tag
+if options.tag == "2026" or options.tag == "MaPSA":
+   prop_key = 2026
+   version_key = options.tag + options.version
+elif options.tag == "2017" or options.tag == "2021": #(this leads to crashes in tests ?)
+   prop_key = 2017
+   version_key = options.tag
+else:
+   prop_key = None
+   version_key = None
 
-
-
-process = cms.Process("DUMP")
+if(prop_key and version_key):
+   print(f"Constructed version key: {version_key}")
+   era_key = properties[prop_key][str(version_key)]['Era']
+   print(f"Constructed era key: {era_key}")
+   from Configuration.StandardSequences.Eras import eras
+   era = getattr(eras, era_key)
+   process = cms.Process("DUMP",era)
+else:
+   process = cms.Process("DUMP")
 process.add_(cms.Service("InitRootHandlers", ResetRootErrHandler = cms.untracked.bool(False)))
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
 
 
-recoGeoLoad(options.tag)
+recoGeoLoad(options.tag,properties)
 
 if ( options.tgeo == True):
     if (options.out == defaultOutputFileName ):

--- a/Fireworks/Geometry/test/BuildFile.xml
+++ b/Fireworks/Geometry/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="test_dumpRecoGeometry" command="test_dumpRecoGeometry.sh"/>

--- a/Fireworks/Geometry/test/test_dumpRecoGeometry.sh
+++ b/Fireworks/Geometry/test/test_dumpRecoGeometry.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -x
+function die { echo $1: status $2 ; exit $2; }
+
+# Define the base directory where the geometry files are located
+GEOMETRY_DIR="${CMSSW_BASE}/src/Configuration/Geometry/python"
+if [ ! -e ${GEOMETRY_DIR} ] ; then
+  GEOMETRY_DIR="${CMSSW_RELEASE_BASE}/src/Configuration/Geometry/python"
+fi
+
+# Define the list of tags
+TAGS=("Run1" "2015" "2017" "2026") #"2021"
+
+# Function to extract the available versions for 2026
+get_2026_versions() {
+  local files=($(ls ${GEOMETRY_DIR}/GeometryExtended2026D*Reco*))
+  if [ ${#files[@]} -eq 0 ]; then
+    echo "No files found for 2026 versions."
+    exit 1
+  fi
+
+  local versions=()
+  for file in "${files[@]}"; do
+    local version=$(basename "$file" | sed -n 's/.*GeometryExtended2026D\([0-9]\{1,3\}\).*/\1/p')
+    if [[ "$version" =~ ^[0-9]{1,3}$ ]]; then
+      versions+=("D${version}")
+    fi
+  done
+
+  # Return the unique sorted list of versions
+  echo "${versions[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '
+}
+
+# Iterate over each tag
+for TAG in "${TAGS[@]}"; do
+  if [ "$TAG" == "2026" ]; then
+    # Get all the versions for 2026
+    VERSIONS=($(get_2026_versions))
+    for VERSION in "${VERSIONS[@]}"; do
+      echo "Running for 2026 with version $VERSION"
+      cmsRun $CMSSW_BASE/src/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py tag=2026 version=$VERSION
+      # Check the exit status of the command
+      if [ $? -ne 0 ]; then
+        echo "Error running cmsRun for tag=2026 and version=$VERSION"
+        exit 1
+      fi
+    done
+  else
+    echo "Running for tag $TAG"
+    cmsRun $CMSSW_BASE/src/Fireworks/Geometry/python/dumpRecoGeometry_cfg.py tag=$TAG
+    # Check the exit status of the command
+    if [ $? -ne 0 ]; then
+      echo "Error running cmsRun for tag=$TAG"
+      exit 1
+    fi
+  fi
+done


### PR DESCRIPTION
#### PR description:

This is in response of https://github.com/cms-sw/cmssw/issues/43097#issuecomment-2180065547.
   * https://github.com/cms-sw/cmssw/pull/45328/commits/9fe55e7fa5e6b687805e2c6dfe1a7e5bd358bc38 : improves the handing of phase-2 global tags and eras in `dumpRecoGeometry`
   * https://github.com/cms-sw/cmssw/pull/45328/commits/d7d4b43869c202467c39273407c4e8fba63b5c83 : adds a testing script for `dumpRecoGeometry`

#### PR validation:

Run `scram b runtests_test_dumpRecoGeometry`, that reveals the issue https://github.com/cms-sw/cmssw/issues/43097#issuecomment-2180210128.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
