### PR TITLE
EcalMatacqDigi: change default values of triggerType and attenuation_dB

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
+++ b/DataFormats/EcalDigi/interface/EcalMatacqDigi.h
@@ -276,7 +276,7 @@ public:
 #if (ECAL_MATACQ_DIGI_VERS >= 2)
     bxId_ = -1;
     l1a_ = -1;
-    triggerType_ = -1;
+    triggerType_ = 0;
     orbitId_ = -1;
     trigRec_ = -1;
     postTrig_ = -1;
@@ -284,7 +284,7 @@ public:
     delayA_ = -1;
     emtcDelay_ = -1;
     emtcPhase_ = -1;
-    attenuation_dB_ = -1;
+    attenuation_dB_ = 0;
     laserPower_ = -1;
     tv_sec_ = 0;
     tv_usec_ = 0;


### PR DESCRIPTION
#### PR description:

This fixes the following warnings (emitted by cuda compiler):

```
  src/DataFormats/EcalDigi/interface/EcalMatacqDigi.h(287): warning #68-D: integer conversion resulted in a change of sign
       attenuation_dB_ = -1;
                        ^

  src/DataFormats/EcalDigi/interface/EcalMatacqDigi.h(279): warning #68-D: integer conversion resulted in a change of sign
       triggerType_ = -1;
```

#### PR validation:

Bot tests
