### PR TITLE
Update clone_ptr

### DIFF
--- a/FWCore/Utilities/test/test_catch2_clone_ptr.cc
+++ b/FWCore/Utilities/test/test_catch2_clone_ptr.cc
@@ -73,6 +73,7 @@ TEST_CASE("Test clone_ptr", "[clone_ptr]") {
   SECTION("in vector") {
     A::Guard ag;
     std::vector<B> vb(1);
+    vb.reserve(2);
     B b;
     b.a.reset(new A(-2));
     B c;


### PR DESCRIPTION
#### PR description:

- clone_ptr no longer inherits from std::unique_ptr
- worked around an apparent gcc13 link-time-optimization incorrect warning about incorrect indexing of the internal storage of a std::vector.

#### PR validation:

Code compiles without the warning and unit tests pass.

fixes #45323