### PR TITLE
Update of MTD validation: 4D vertices association with truth

### DIFF
--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -646,6 +646,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("TimeSignalPull", "Pull for signal; t_{rec} - t_{sim}/#sigma_{t rec}", 100, -10., 10.);
   mePUvsRealV_ =
       ibook.bookProfile("PUvsReal", "#PU vertices vs #real matched vertices;#PU;#real ", 100, 0, 300, 100, 0, 200);
+  mePUvsFakeV_ =
+      ibook.bookProfile("PUvsFake", "#PU vertices vs #fake matched vertices;#PU;#fake ", 100, 0, 300, 100, 0, 20);
   mePUvsOtherFakeV_ = ibook.bookProfile(
       "PUvsOtherFake", "#PU vertices vs #other fake matched vertices;#PU;#other fake ", 100, 0, 300, 100, 0, 20);
   mePUvsSplitV_ =
@@ -704,10 +706,6 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
       "PUTrackRelSumPt", "Relative Sum of Pt of PU tracks for matched vertices; PUSumPt/SumPt", 50, 0., 1.);
   mePUTrackRelSumPt2_ = ibook.book1D(
       "PUTrackRelSumPt2", "Relative Sum of Pt2 for PU tracks for matched vertices; PUSumPt2/SumPt2", 50, 0., 1.);
-
-  mePUvsFakeV_ =
-      ibook.bookProfile("PUvsFake", "#PU vertices vs #fake matched vertices;#PU;#fake ", 100, 0, 300, 100, 0, 20);
-
   mePUTrackRecLVRelMult_ = ibook.book1D(
       "PUTrackRecLVRelMult", "Relative multiplicity of PU tracks for matched LV; #PUTrks/#Trks", 50, 0., 1.);
   meFakeTrackRecLVRelMult_ = ibook.book1D(


### PR DESCRIPTION
PR description:
 This PR updates the Primary4DVertexValidation class [1], in particular the matchReco2Sim function. 
Matching between reco and sim vertices is performed based on a Private code from Wolfram Erdmann, which was ported on CMSSW with some issues that the present PR aims to handle. More details are given in the presentation [2].
The cut on MVA in matchReco2Sim [3], that select for RECO-SIM vertex matching only tracks with good time information, was moved in the use of time information to define weights. 
Furthermore, a bug was fixed in the one-to-one match at lines 1766 [4], where the indices of the reco vertices dominated via wos by that simulated vertex are stored with a push back of the index of the recovertex, which not only saves the simulated event corresponding to the wosmatch (i.e. the higher contribution to the wos), but also the lower ones that comes early in the loop, and this happens because saving information about wosmatch and pushing-back the wos_dominated_recv are done at the same time.
In this new version of the code, wos_dominated_recv is correctly filled outside simevent loop, after filling information about wosmatch.

PR validation: 
The code was tested on the workflow TTbar_PU_14TeV

[1]https://github.com/cms-sw/cmssw/blob/master/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
[2]https://indico.cern.ch/event/1428838/contributions/6010350/attachments/2882474/5050701/MTD_DPG_June_DelliGatti.pdf
[3]https://github.com/cms-sw/cmssw/blob/master/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc#L1744
[4]https://github.com/cms-sw/cmssw/blob/master/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc#L1766 
