### PR TITLE
Update/fix SimBeamSpot tag for Run3 HI MC GT in 14_1_X

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -98,7 +98,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
     'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
-    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v3',
+    'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v4'
 }


### PR DESCRIPTION
Update on the SimBeamSpot tag for the HI MC production in run3. Previously, the HI SimBeamSpot tag was not synced with the 2023 PbPb vertex smearing parameters. Therefore, the new tag is updated using the vertex smearing parameters obtained from 2023 PbPb data. The updated GT in autoCond includes that tag.

The following GTs have been updated by including the updated SimBeamSpot (only the 141X GT is updated in autoCond  for this release):

- [140X_mcRun3_2023_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2023_realistic_HI_v4)
- [141X_mcRun3_2024_realistic_HI_v4](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/141X_mcRun3_2024_realistic_HI_v4)

Differences with the previous HI MC GTs in autoCond:

- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2023_realistic_HI_v3/140X_mcRun3_2023_realistic_HI_v4
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/141X_mcRun3_2024_realistic_HI_v3/141X_mcRun3_2024_realistic_HI_v4
