### PR TITLE
L1 Scouting Online Selection modules

### DIFF
--- a/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
+++ b/EventFilter/L1ScoutingRawToDigi/plugins/ScBMTFRawToDigi.cc
@@ -13,7 +13,7 @@ ScBMTFRawToDigi::ScBMTFRawToDigi(const edm::ParameterSet& iConfig) {
   }
   nStubsOrbit_ = 0;
 
-  produces<l1ScoutingRun3::BMTFStubOrbitCollection>().setBranchAlias("BMTFStubOrbitCollection");
+  produces<l1ScoutingRun3::BMTFStubOrbitCollection>("BMTFStub").setBranchAlias("BMTFStubOrbitCollection");
   rawToken_ = consumes<SDSRawDataCollection>(srcInputTag_);
 }
 
@@ -47,7 +47,7 @@ void ScBMTFRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   unpackedStubs->fillAndClear(orbitBuffer_, nStubsOrbit_);
 
   // store collection in the event
-  iEvent.put(std::move(unpackedStubs));
+  iEvent.put(std::move(unpackedStubs), "BMTFStub");
 }
 
 void ScBMTFRawToDigi::unpackOrbit(const unsigned char* buf, size_t len, int sdsId) {

--- a/L1TriggerScouting/OnlineProcessing/BuildFile.xml
+++ b/L1TriggerScouting/OnlineProcessing/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/Utilities"/>
+<use name="EventFilter/Utilities"/>
+<use name="DataFormats/FEDRawData"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/L1Scouting"/>
+<use name="L1TriggerScouting/Utilities"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/L1TriggerScouting/OnlineProcessing/plugins/BuildFile.xml
+++ b/L1TriggerScouting/OnlineProcessing/plugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/L1Scouting"/>
+<use name="L1TriggerScouting/Utilities"/>
+<flags EDM_PLUGIN="1"/>

--- a/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
@@ -22,42 +22,38 @@
 class FinalBxSelector : public edm::stream::EDFilter<> {
 public:
   explicit FinalBxSelector(const edm::ParameterSet&);
-	~FinalBxSelector() {}
-	static void fillDescriptions(edm::ConfigurationDescriptions&);
+  ~FinalBxSelector() {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-	bool filter(edm::Event&, const edm::EventSetup&) override;
-  
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+
   // tokens for BX selected by each analysis
   std::vector<edm::EDGetTokenT<std::vector<unsigned>>> selectedBxsToken_;
 };
 
+FinalBxSelector::FinalBxSelector(const edm::ParameterSet& iPSet) {
+  // get the list of selected BXs
+  std::vector<edm::InputTag> bxLabels = iPSet.getParameter<std::vector<edm::InputTag>>("analysisLabels");
+  for (const auto& bxLabel : bxLabels) {
+    selectedBxsToken_.push_back(consumes<std::vector<unsigned>>(bxLabel));
+  }
 
-FinalBxSelector::FinalBxSelector(const edm::ParameterSet& iPSet){
-    
-    // get the list of selected BXs
-    std::vector<edm::InputTag> bxLabels = iPSet.getParameter<std::vector<edm::InputTag>>("analysisLabels");
-    for (const auto& bxLabel: bxLabels){
-      selectedBxsToken_.push_back(consumes<std::vector<unsigned>>(bxLabel));
-    }
-
-    produces<std::vector<unsigned>>("SelBx").setBranchAlias("SelectedBxs");
-
+  produces<std::vector<unsigned>>("SelBx").setBranchAlias("SelectedBxs");
 }
 
 // ------------ method called for each ORBIT  ------------
 bool FinalBxSelector::filter(edm::Event& iEvent, const edm::EventSetup&) {
-  
-  bool noBxSelected=true;
+  bool noBxSelected = true;
   std::set<unsigned> uniqueBxs;
 
-  for (const auto& token: selectedBxsToken_){
+  for (const auto& token : selectedBxsToken_) {
     edm::Handle<std::vector<unsigned>> bxList;
     iEvent.getByToken(token, bxList);
 
-    for(const unsigned& bx: *bxList){
+    for (const unsigned& bx : *bxList) {
       uniqueBxs.insert(bx);
-      noBxSelected=false;
+      noBxSelected = false;
     }
   }
 

--- a/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/FinalBxSelector.cc
@@ -1,0 +1,76 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+#include <vector>
+#include <set>
+
+/*
+ * Filter orbits that don't contain at least one selected BX
+ * from a BxSelector module and produce a vector of selected BXs
+ */
+class FinalBxSelector : public edm::stream::EDFilter<> {
+public:
+  explicit FinalBxSelector(const edm::ParameterSet&);
+	~FinalBxSelector() {}
+	static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+	bool filter(edm::Event&, const edm::EventSetup&) override;
+  
+  // tokens for BX selected by each analysis
+  std::vector<edm::EDGetTokenT<std::vector<unsigned>>> selectedBxsToken_;
+};
+
+
+FinalBxSelector::FinalBxSelector(const edm::ParameterSet& iPSet){
+    
+    // get the list of selected BXs
+    std::vector<edm::InputTag> bxLabels = iPSet.getParameter<std::vector<edm::InputTag>>("analysisLabels");
+    for (const auto& bxLabel: bxLabels){
+      selectedBxsToken_.push_back(consumes<std::vector<unsigned>>(bxLabel));
+    }
+
+    produces<std::vector<unsigned>>("SelBx").setBranchAlias("SelectedBxs");
+
+}
+
+// ------------ method called for each ORBIT  ------------
+bool FinalBxSelector::filter(edm::Event& iEvent, const edm::EventSetup&) {
+  
+  bool noBxSelected=true;
+  std::set<unsigned> uniqueBxs;
+
+  for (const auto& token: selectedBxsToken_){
+    edm::Handle<std::vector<unsigned>> bxList;
+    iEvent.getByToken(token, bxList);
+
+    for(const unsigned& bx: *bxList){
+      uniqueBxs.insert(bx);
+      noBxSelected=false;
+    }
+  }
+
+  auto selectedBxs = std::make_unique<std::vector<unsigned>>(uniqueBxs.begin(), uniqueBxs.end());
+  iEvent.put(std::move(selectedBxs), "SelBx");
+
+  return !noBxSelected;
+}
+
+void FinalBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(FinalBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
@@ -1,0 +1,100 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+// L1 scouting
+#include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using namespace l1ScoutingRun3;
+
+class JetBxSelector : public edm::stream::EDProducer<> {
+public:
+  explicit JetBxSelector(const edm::ParameterSet&);
+  ~JetBxSelector() {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // tokens for scouting data
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Jet>>    jetsTokenData_;
+
+  // SELECTION THRESHOLDS
+  int minNJet_;
+  std::vector<double> minJetEt_;
+  std::vector<double> maxJetEta_;
+};
+
+
+JetBxSelector::JetBxSelector(const edm::ParameterSet& iPSet)
+  : jetsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("jetsTag"))),
+    minNJet_(iPSet.getParameter<int>("minNJet")),
+    minJetEt_(iPSet.getParameter<std::vector<double>>("minJetEt")),
+    maxJetEta_(iPSet.getParameter<std::vector<double>>("maxJetEta"))
+
+  {
+
+    produces<std::vector<unsigned>>("SelBx").setBranchAlias("JetSelectedBx");
+
+  }
+
+
+// ------------ method called for each ORBIT  ------------
+void JetBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
+
+  edm::Handle<OrbitCollection<l1ScoutingRun3::Jet>> jetsCollection;
+
+  iEvent.getByToken(jetsTokenData_, jetsCollection);
+
+  std::unique_ptr<std::vector<unsigned>> jetBx(new std::vector<unsigned>);
+
+  // loop over valid bunch crossings
+  for (const unsigned& bx : jetsCollection->getFilledBxs()) {
+
+    const auto& jets = jetsCollection->bxIterator(bx);
+
+    // we have at least N jets
+    if (jets.size()<minNJet_) continue;
+
+    // it must be in a certain eta region with an pT and quality threshold
+    bool jetCond = false;
+    int nAccJets = 0;
+    for (const auto& jet : jets) {
+      jetCond = ( std::abs(demux::fEta(jet.hwEta()))<maxJetEta_[nAccJets] ) &&
+                ( demux::fEt(jet.hwEt())>=minJetEt_[nAccJets] );
+      if (jetCond) nAccJets++;   // found jet meeting requirements
+      if (nAccJets==minNJet_) break; // found all requested jets
+    }
+
+    if (nAccJets<minNJet_) continue;
+
+    jetBx->push_back(bx);
+
+   } // end orbit loop
+
+  iEvent.put(std::move(jetBx), "SelBx");
+}
+
+void JetBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(JetBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
@@ -33,7 +33,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // tokens for scouting data
-  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Jet>>    jetsTokenData_;
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Jet>> jetsTokenData_;
 
   // SELECTION THRESHOLDS
   int minNJet_;
@@ -41,23 +41,18 @@ private:
   std::vector<double> maxJetEta_;
 };
 
-
 JetBxSelector::JetBxSelector(const edm::ParameterSet& iPSet)
-  : jetsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("jetsTag"))),
-    minNJet_(iPSet.getParameter<int>("minNJet")),
-    minJetEt_(iPSet.getParameter<std::vector<double>>("minJetEt")),
-    maxJetEta_(iPSet.getParameter<std::vector<double>>("maxJetEta"))
+    : jetsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("jetsTag"))),
+      minNJet_(iPSet.getParameter<int>("minNJet")),
+      minJetEt_(iPSet.getParameter<std::vector<double>>("minJetEt")),
+      maxJetEta_(iPSet.getParameter<std::vector<double>>("maxJetEta"))
 
-  {
-
-    produces<std::vector<unsigned>>("SelBx").setBranchAlias("JetSelectedBx");
-
-  }
-
+{
+  produces<std::vector<unsigned>>("SelBx").setBranchAlias("JetSelectedBx");
+}
 
 // ------------ method called for each ORBIT  ------------
 void JetBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
-
   edm::Handle<OrbitCollection<l1ScoutingRun3::Jet>> jetsCollection;
 
   iEvent.getByToken(jetsTokenData_, jetsCollection);
@@ -66,27 +61,30 @@ void JetBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
 
   // loop over valid bunch crossings
   for (const unsigned& bx : jetsCollection->getFilledBxs()) {
-
     const auto& jets = jetsCollection->bxIterator(bx);
 
     // we have at least N jets
-    if (jets.size()<minNJet_) continue;
+    if (jets.size() < minNJet_)
+      continue;
 
     // it must be in a certain eta region with an pT and quality threshold
     bool jetCond = false;
     int nAccJets = 0;
     for (const auto& jet : jets) {
-      jetCond = ( std::abs(demux::fEta(jet.hwEta()))<maxJetEta_[nAccJets] ) &&
-                ( demux::fEt(jet.hwEt())>=minJetEt_[nAccJets] );
-      if (jetCond) nAccJets++;   // found jet meeting requirements
-      if (nAccJets==minNJet_) break; // found all requested jets
+      jetCond = (std::abs(demux::fEta(jet.hwEta())) < maxJetEta_[nAccJets]) &&
+                (demux::fEt(jet.hwEt()) >= minJetEt_[nAccJets]);
+      if (jetCond)
+        nAccJets++;  // found jet meeting requirements
+      if (nAccJets == minNJet_)
+        break;  // found all requested jets
     }
 
-    if (nAccJets<minNJet_) continue;
+    if (nAccJets < minNJet_)
+      continue;
 
     jetBx->push_back(bx);
 
-   } // end orbit loop
+  }  // end orbit loop
 
   iEvent.put(std::move(jetBx), "SelBx");
 }

--- a/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/JetBxSelector.cc
@@ -48,6 +48,9 @@ JetBxSelector::JetBxSelector(const edm::ParameterSet& iPSet)
       maxJetEta_(iPSet.getParameter<std::vector<double>>("maxJetEta"))
 
 {
+  if ((minJetEt_.size() != (size_t)minNJet_) || (maxJetEta_.size() != (size_t)minNJet_))
+    throw cms::Exception("JetBxSelector::JetBxSelector") << "size mismatch: size of minJetEt or maxJetEta != minNJet.";
+
   produces<std::vector<unsigned>>("SelBx").setBranchAlias("JetSelectedBx");
 }
 

--- a/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
@@ -12,7 +12,7 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/Span.h"
 
-// L1 scouting 
+// L1 scouting
 #include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
 #include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
@@ -27,51 +27,47 @@ template <typename T>
 class MaskOrbitBx : public edm::stream::EDProducer<> {
 public:
   explicit MaskOrbitBx(const edm::ParameterSet&);
-	~MaskOrbitBx() {}
-	static void fillDescriptions(edm::ConfigurationDescriptions&);
+  ~MaskOrbitBx() {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-	void produce(edm::Event&, const edm::EventSetup&) override;
-  
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
   std::vector<std::vector<T>> orbitBuffer_;
 
-	// tokens for scouting data
-	edm::EDGetTokenT<OrbitCollection<T>> tokenData_;
+  // tokens for scouting data
+  edm::EDGetTokenT<OrbitCollection<T>> tokenData_;
 
   // BX to be keep
   edm::EDGetTokenT<std::vector<unsigned>> tokenSelBxs_;
 
   std::string productLabel_;
 
-  const int NBX = 3565; 
+  const int NBX = 3565;
 };
 
 template <typename T>
 MaskOrbitBx<T>::MaskOrbitBx(const edm::ParameterSet& iPSet)
-	: tokenData_(consumes<OrbitCollection<T>>(iPSet.getParameter<edm::InputTag>("dataTag"))),
-    tokenSelBxs_(consumes<std::vector<unsigned>>(iPSet.getParameter<edm::InputTag>("selectBxs"))),
-    productLabel_(iPSet.getParameter<std::string>("productLabel"))
-	{
-    
-    // prepare module buffer
-    orbitBuffer_ = std::vector<std::vector<T>>(NBX);
-  
-    // products
-    produces<OrbitCollection<T>>(productLabel_).setBranchAlias(productLabel_+"OrbitCollection");
-	}
+    : tokenData_(consumes<OrbitCollection<T>>(iPSet.getParameter<edm::InputTag>("dataTag"))),
+      tokenSelBxs_(consumes<std::vector<unsigned>>(iPSet.getParameter<edm::InputTag>("selectBxs"))),
+      productLabel_(iPSet.getParameter<std::string>("productLabel")) {
+  // prepare module buffer
+  orbitBuffer_ = std::vector<std::vector<T>>(NBX);
 
+  // products
+  produces<OrbitCollection<T>>(productLabel_).setBranchAlias(productLabel_ + "OrbitCollection");
+}
 
 // ------------ method called for each ORBIT  ------------
 template <typename T>
 void MaskOrbitBx<T>::produce(edm::Event& iEvent, const edm::EventSetup&) {
-  
   // get selected BXs
   edm::Handle<std::vector<unsigned>> selBxs;
-  iEvent.getByToken(tokenSelBxs_, selBxs); 
+  iEvent.getByToken(tokenSelBxs_, selBxs);
 
   // get the data
-	edm::Handle<OrbitCollection<T>> objCollection; 
-	iEvent.getByToken(tokenData_, objCollection); 
+  edm::Handle<OrbitCollection<T>> objCollection;
+  iEvent.getByToken(tokenData_, objCollection);
 
   // prepare new collections
   std::unique_ptr<OrbitCollection<T>> selectedObjs(new OrbitCollection<T>);
@@ -79,8 +75,8 @@ void MaskOrbitBx<T>::produce(edm::Event& iEvent, const edm::EventSetup&) {
   int nObjOrbit_ = 0;
 
   // fill collections with objects
-  for (const unsigned& bx: *selBxs){
-    for (const auto& obj: objCollection->bxIterator(bx)){
+  for (const unsigned& bx : *selBxs) {
+    for (const auto& obj : objCollection->bxIterator(bx)) {
       orbitBuffer_[bx].push_back(obj);
       nObjOrbit_++;
     }
@@ -92,7 +88,7 @@ void MaskOrbitBx<T>::produce(edm::Event& iEvent, const edm::EventSetup&) {
   // store collections in the event
   iEvent.put(std::move(selectedObjs), productLabel_);
 
-} // end produce
+}  // end produce
 
 template <typename T>
 void MaskOrbitBx<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -100,7 +96,6 @@ void MaskOrbitBx<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
-
 
 typedef MaskOrbitBx<l1ScoutingRun3::Muon> MaskOrbitBxScoutingMuon;
 typedef MaskOrbitBx<l1ScoutingRun3::Jet> MaskOrbitBxScoutingJet;

--- a/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MaskOrbitBx.cc
@@ -1,0 +1,117 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+// L1 scouting 
+#include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingBMTFStub.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+
+#include <vector>
+#include <set>
+
+using namespace l1ScoutingRun3;
+
+template <typename T>
+class MaskOrbitBx : public edm::stream::EDProducer<> {
+public:
+  explicit MaskOrbitBx(const edm::ParameterSet&);
+	~MaskOrbitBx() {}
+	static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+	void produce(edm::Event&, const edm::EventSetup&) override;
+  
+  std::vector<std::vector<T>> orbitBuffer_;
+
+	// tokens for scouting data
+	edm::EDGetTokenT<OrbitCollection<T>> tokenData_;
+
+  // BX to be keep
+  edm::EDGetTokenT<std::vector<unsigned>> tokenSelBxs_;
+
+  std::string productLabel_;
+
+  const int NBX = 3565; 
+};
+
+template <typename T>
+MaskOrbitBx<T>::MaskOrbitBx(const edm::ParameterSet& iPSet)
+	: tokenData_(consumes<OrbitCollection<T>>(iPSet.getParameter<edm::InputTag>("dataTag"))),
+    tokenSelBxs_(consumes<std::vector<unsigned>>(iPSet.getParameter<edm::InputTag>("selectBxs"))),
+    productLabel_(iPSet.getParameter<std::string>("productLabel"))
+	{
+    
+    // prepare module buffer
+    orbitBuffer_ = std::vector<std::vector<T>>(NBX);
+  
+    // products
+    produces<OrbitCollection<T>>(productLabel_).setBranchAlias(productLabel_+"OrbitCollection");
+	}
+
+
+// ------------ method called for each ORBIT  ------------
+template <typename T>
+void MaskOrbitBx<T>::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  
+  // get selected BXs
+  edm::Handle<std::vector<unsigned>> selBxs;
+  iEvent.getByToken(tokenSelBxs_, selBxs); 
+
+  // get the data
+	edm::Handle<OrbitCollection<T>> objCollection; 
+	iEvent.getByToken(tokenData_, objCollection); 
+
+  // prepare new collections
+  std::unique_ptr<OrbitCollection<T>> selectedObjs(new OrbitCollection<T>);
+
+  int nObjOrbit_ = 0;
+
+  // fill collections with objects
+  for (const unsigned& bx: *selBxs){
+    for (const auto& obj: objCollection->bxIterator(bx)){
+      orbitBuffer_[bx].push_back(obj);
+      nObjOrbit_++;
+    }
+  }
+
+  // fill orbit collection and clear the Bx buffer vector
+  selectedObjs->fillAndClear(orbitBuffer_, nObjOrbit_);
+
+  // store collections in the event
+  iEvent.put(std::move(selectedObjs), productLabel_);
+
+} // end produce
+
+template <typename T>
+void MaskOrbitBx<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+
+typedef MaskOrbitBx<l1ScoutingRun3::Muon> MaskOrbitBxScoutingMuon;
+typedef MaskOrbitBx<l1ScoutingRun3::Jet> MaskOrbitBxScoutingJet;
+typedef MaskOrbitBx<l1ScoutingRun3::EGamma> MaskOrbitBxScoutingEGamma;
+typedef MaskOrbitBx<l1ScoutingRun3::Tau> MaskOrbitBxScoutingTau;
+typedef MaskOrbitBx<l1ScoutingRun3::BxSums> MaskOrbitBxScoutingBxSums;
+typedef MaskOrbitBx<l1ScoutingRun3::BMTFStub> MaskOrbitBxScoutingBMTFStub;
+
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingMuon);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingJet);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingEGamma);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingTau);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingBxSums);
+DEFINE_FWK_MODULE(MaskOrbitBxScoutingBMTFStub);

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
@@ -33,7 +33,7 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // tokens for scouting data
-  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Muon>>   muonsTokenData_;
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Muon>> muonsTokenData_;
 
   // SELECTION THRESHOLDS
   int minNMu_;
@@ -44,26 +44,21 @@ private:
   std::vector<int> minMuHwQual_;
 };
 
-
 MuBxSelector::MuBxSelector(const edm::ParameterSet& iPSet)
-  : muonsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("muonsTag"))),
-    minNMu_(iPSet.getParameter<int>("minNMu")),
-    minMuPt_(iPSet.getParameter<std::vector<double>>("minMuPt")),
-    maxMuEta_(iPSet.getParameter<std::vector<double>>("maxMuEta")),
-    minMuTfIndex_(iPSet.getParameter<std::vector<int>>("minMuTfIndex")),
-    maxMuTfIndex_(iPSet.getParameter<std::vector<int>>("maxMuTfIndex")),
-    minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual"))
+    : muonsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("muonsTag"))),
+      minNMu_(iPSet.getParameter<int>("minNMu")),
+      minMuPt_(iPSet.getParameter<std::vector<double>>("minMuPt")),
+      maxMuEta_(iPSet.getParameter<std::vector<double>>("maxMuEta")),
+      minMuTfIndex_(iPSet.getParameter<std::vector<int>>("minMuTfIndex")),
+      maxMuTfIndex_(iPSet.getParameter<std::vector<int>>("maxMuTfIndex")),
+      minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual"))
 
-  {
-
-    produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuSelectedBx");
-
-  }
-
+{
+  produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuSelectedBx");
+}
 
 // ------------ method called for each ORBIT  ------------
 void MuBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
-
   edm::Handle<OrbitCollection<l1ScoutingRun3::Muon>> muonsCollection;
 
   iEvent.getByToken(muonsTokenData_, muonsCollection);
@@ -72,29 +67,31 @@ void MuBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
 
   // loop over valid bunch crossings
   for (const unsigned& bx : muonsCollection->getFilledBxs()) {
-
     const auto& muons = muonsCollection->bxIterator(bx);
 
     // we have at least a muon
-    if (muons.size()<minNMu_) continue;
+    if (muons.size() < minNMu_)
+      continue;
 
     // it must be in a certain eta region with an pT and quality threshold
     bool muCond = false;
     int nAccMus = 0;
     for (const auto& muon : muons) {
-      muCond = ( std::abs(ugmt::fEta(muon.hwEta()))<maxMuEta_[nAccMus] ) &&
-               ( muon.tfMuonIndex()<=maxMuTfIndex_[nAccMus] ) && ( muon.tfMuonIndex()>=minMuTfIndex_[nAccMus] ) &&
-               ( ugmt::fPt(muon.hwPt())>=minMuPt_[nAccMus] ) &&
-               ( muon.hwQual()>=minMuHwQual_[nAccMus] );
-      if (muCond) nAccMus++; // found muon meeting requirements
-      if (nAccMus==minNMu_) break; // found all requested muons
+      muCond = (std::abs(ugmt::fEta(muon.hwEta())) < maxMuEta_[nAccMus]) &&
+               (muon.tfMuonIndex() <= maxMuTfIndex_[nAccMus]) && (muon.tfMuonIndex() >= minMuTfIndex_[nAccMus]) &&
+               (ugmt::fPt(muon.hwPt()) >= minMuPt_[nAccMus]) && (muon.hwQual() >= minMuHwQual_[nAccMus]);
+      if (muCond)
+        nAccMus++;  // found muon meeting requirements
+      if (nAccMus == minNMu_)
+        break;  // found all requested muons
     }
 
-    if (nAccMus<minNMu_) continue;
+    if (nAccMus < minNMu_)
+      continue;
 
     muBx->push_back(bx);
 
-   } // end orbit loop
+  }  // end orbit loop
 
   iEvent.put(std::move(muBx), "SelBx");
 }

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
@@ -1,0 +1,108 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+// L1 scouting
+#include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using namespace l1ScoutingRun3;
+
+class MuBxSelector : public edm::stream::EDProducer<> {
+public:
+  explicit MuBxSelector(const edm::ParameterSet&);
+  ~MuBxSelector() {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // tokens for scouting data
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Muon>>   muonsTokenData_;
+
+  // SELECTION THRESHOLDS
+  int minNMu_;
+  std::vector<double> minMuPt_;
+  std::vector<double> maxMuEta_;
+  std::vector<int> minMuTfIndex_;
+  std::vector<int> maxMuTfIndex_;
+  std::vector<int> minMuHwQual_;
+};
+
+
+MuBxSelector::MuBxSelector(const edm::ParameterSet& iPSet)
+  : muonsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("muonsTag"))),
+    minNMu_(iPSet.getParameter<int>("minNMu")),
+    minMuPt_(iPSet.getParameter<std::vector<double>>("minMuPt")),
+    maxMuEta_(iPSet.getParameter<std::vector<double>>("maxMuEta")),
+    minMuTfIndex_(iPSet.getParameter<std::vector<int>>("minMuTfIndex")),
+    maxMuTfIndex_(iPSet.getParameter<std::vector<int>>("maxMuTfIndex")),
+    minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual"))
+
+  {
+
+    produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuSelectedBx");
+
+  }
+
+
+// ------------ method called for each ORBIT  ------------
+void MuBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
+
+  edm::Handle<OrbitCollection<l1ScoutingRun3::Muon>> muonsCollection;
+
+  iEvent.getByToken(muonsTokenData_, muonsCollection);
+
+  std::unique_ptr<std::vector<unsigned>> muBx(new std::vector<unsigned>);
+
+  // loop over valid bunch crossings
+  for (const unsigned& bx : muonsCollection->getFilledBxs()) {
+
+    const auto& muons = muonsCollection->bxIterator(bx);
+
+    // we have at least a muon
+    if (muons.size()<minNMu_) continue;
+
+    // it must be in a certain eta region with an pT and quality threshold
+    bool muCond = false;
+    int nAccMus = 0;
+    for (const auto& muon : muons) {
+      muCond = ( std::abs(ugmt::fEta(muon.hwEta()))<maxMuEta_[nAccMus] ) &&
+               ( muon.tfMuonIndex()<=maxMuTfIndex_[nAccMus] ) && ( muon.tfMuonIndex()>=minMuTfIndex_[nAccMus] ) &&
+               ( ugmt::fPt(muon.hwPt())>=minMuPt_[nAccMus] ) &&
+               ( muon.hwQual()>=minMuHwQual_[nAccMus] );
+      if (muCond) nAccMus++; // found muon meeting requirements
+      if (nAccMus==minNMu_) break; // found all requested muons
+    }
+
+    if (nAccMus<minNMu_) continue;
+
+    muBx->push_back(bx);
+
+   } // end orbit loop
+
+  iEvent.put(std::move(muBx), "SelBx");
+}
+
+void MuBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(MuBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuBxSelector.cc
@@ -54,6 +54,12 @@ MuBxSelector::MuBxSelector(const edm::ParameterSet& iPSet)
       minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual"))
 
 {
+  if ((minMuPt_.size() != (size_t)(size_t)minNMu_) || (maxMuEta_.size() != (size_t)minNMu_) ||
+      (minMuTfIndex_.size() != (size_t)minNMu_) || (maxMuTfIndex_.size() != (size_t)minNMu_) ||
+      (minMuHwQual_.size() != (size_t)minNMu_))
+    throw cms::Exception("MuBxSelector::MuBxSelector")
+        << "size mismatch: size of minMuPt or maxMuEta or minMuTfIndex or maxMuTfIndex or minMuHwQual  != minNMu.";
+
   produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuSelectedBx");
 }
 

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
@@ -65,6 +65,14 @@ MuTagJetBxSelector::MuTagJetBxSelector(const edm::ParameterSet& iPSet)
       maxMuTfIndex_(iPSet.getParameter<std::vector<int>>("maxMuTfIndex")),
       minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual")),
       maxDR_(iPSet.getParameter<std::vector<double>>("maxDR")) {
+  if ((minJetEt_.size() != (size_t)minNJet_) || (maxJetEta_.size() != (size_t)minNJet_) ||
+      (minMuPt_.size() != (size_t)minNJet_) || (maxMuEta_.size() != (size_t)minNJet_) ||
+      (minMuTfIndex_.size() != (size_t)minNJet_) || (maxMuTfIndex_.size() != (size_t)minNJet_) ||
+      (minMuHwQual_.size() != (size_t)minNJet_) || (maxDR_.size() != (size_t)minNJet_))
+    throw cms::Exception("MuTagJetBxSelector::MuTagJetBxSelector")
+        << "size mismatch: size of minJetEt or maxJetEta or  minMuPt or maxMuEta or minMuTfIndex or maxMuTfIndex or "
+           "minMuHwQual or maxDR != minNMu.";
+
   produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuTagJetSelectedBx");
 }
 

--- a/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
+++ b/L1TriggerScouting/OnlineProcessing/plugins/MuTagJetBxSelector.cc
@@ -1,0 +1,138 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Span.h"
+
+// L1 scouting
+#include "DataFormats/L1Scouting/interface/L1ScoutingMuon.h"
+#include "DataFormats/L1Scouting/interface/L1ScoutingCalo.h"
+#include "DataFormats/L1Scouting/interface/OrbitCollection.h"
+#include "L1TriggerScouting/Utilities/interface/conversion.h"
+
+// root libraries
+#include "TLorentzVector.h"
+#include "Math/VectorUtil.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+using namespace l1ScoutingRun3;
+
+class MuTagJetBxSelector : public edm::stream::EDProducer<> {
+public:
+  explicit MuTagJetBxSelector(const edm::ParameterSet&);
+  ~MuTagJetBxSelector() {}
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // tokens for scouting data
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Muon>>   muonsTokenData_;
+  edm::EDGetTokenT<OrbitCollection<l1ScoutingRun3::Jet>>    jetsTokenData_;
+
+  // SELECTION THRESHOLDS
+  int minNJet_;
+  std::vector<double> minJetEt_;
+  std::vector<double> maxJetEta_;
+  std::vector<double> minMuPt_;
+  std::vector<double> maxMuEta_;
+  std::vector<int> minMuTfIndex_;
+  std::vector<int> maxMuTfIndex_;
+  std::vector<int> minMuHwQual_;
+  std::vector<double> maxDR_;
+};
+
+
+MuTagJetBxSelector::MuTagJetBxSelector(const edm::ParameterSet& iPSet)
+  : muonsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("muonsTag"))),
+    jetsTokenData_(consumes(iPSet.getParameter<edm::InputTag>("jetsTag"))),
+    minNJet_(iPSet.getParameter<int>("minNJet")),
+    minJetEt_(iPSet.getParameter<std::vector<double>>("minJetEt")),
+    maxJetEta_(iPSet.getParameter<std::vector<double>>("maxJetEta")),
+    minMuPt_(iPSet.getParameter<std::vector<double>>("minMuPt")),
+    maxMuEta_(iPSet.getParameter<std::vector<double>>("maxMuEta")),
+    minMuTfIndex_(iPSet.getParameter<std::vector<int>>("minMuTfIndex")),
+    maxMuTfIndex_(iPSet.getParameter<std::vector<int>>("maxMuTfIndex")),
+    minMuHwQual_(iPSet.getParameter<std::vector<int>>("minMuHwQual")),
+    maxDR_(iPSet.getParameter<std::vector<double>>("maxDR"))
+  {
+
+    produces<std::vector<unsigned>>("SelBx").setBranchAlias("MuTagJetSelectedBx");
+
+  }
+
+
+// ------------ method called for each ORBIT  ------------
+void MuTagJetBxSelector::produce(edm::Event& iEvent, const edm::EventSetup&) {
+
+  edm::Handle<OrbitCollection<l1ScoutingRun3::Muon>> muonsCollection;
+  edm::Handle<OrbitCollection<l1ScoutingRun3::Jet>>  jetsCollection;
+
+  iEvent.getByToken(muonsTokenData_, muonsCollection);
+  iEvent.getByToken(jetsTokenData_, jetsCollection);
+
+  std::unique_ptr<std::vector<unsigned>> muTagJetBx(new std::vector<unsigned>);
+
+  // loop over valid bunch crossings
+  for (const unsigned& bx : jetsCollection->getFilledBxs()) {
+
+    const auto& jets = jetsCollection->bxIterator(bx);
+    const auto& muons = muonsCollection->bxIterator(bx);
+
+    // we have at least N jets and N muons
+    if (jets.size()<minNJet_ && muons.size()<minNJet_) continue;
+
+    // it must satisfy certain requirements
+    bool jetCond = false;
+    bool muCond = false;
+    int nAccJets = 0;
+    for (const auto& jet : jets) {
+      jetCond = ( std::abs(demux::fEta(jet.hwEta()))<maxJetEta_[nAccJets] ) &&
+                ( demux::fEt(jet.hwEt())>=minJetEt_[nAccJets] );
+      if (!jetCond) continue; // jet does not satisfy requirements, next one
+      ROOT::Math::PtEtaPhiMVector jetLV(demux::fEt(jet.hwEt()), demux::fEta(jet.hwEta()), demux::fPhi(jet.hwPhi()), 0);
+
+      for (const auto& muon : muons) {
+        muCond = ( std::abs(ugmt::fEta(muon.hwEta()))<maxMuEta_[nAccJets] ) &&
+                 ( muon.tfMuonIndex()<=maxMuTfIndex_[nAccJets] ) && ( muon.tfMuonIndex()>=minMuTfIndex_[nAccJets] ) &&
+                 ( ugmt::fPt(muon.hwPt())>=minMuPt_[nAccJets] ) && ( muon.hwQual()>=minMuHwQual_[nAccJets] );
+        if (!muCond) continue; // muon does not satisfy requirements, next one
+        ROOT::Math::PtEtaPhiMVector muLV(ugmt::fPt(muon.hwPt()), ugmt::fEta(muon.hwEta()), ugmt::fPhi(muon.hwPhi()), 0.1057);
+
+        float dr = ROOT::Math::VectorUtil::DeltaR(jetLV, muLV);
+        if (dr < maxDR_[nAccJets]) {
+          nAccJets++; // found mu-tag for current jet, end muon loop
+          break;
+        }
+      }
+
+      if (nAccJets==minNJet_) break; // found all requested mu-tagged jets
+    }
+
+    if (nAccJets<minNJet_) continue;
+
+    muTagJetBx->push_back(bx);
+
+   } // end orbit loop
+
+  iEvent.put(std::move(muTagJetBx), "SelBx");
+}
+
+void MuTagJetBxSelector::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(MuTagJetBxSelector);

--- a/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
+++ b/L1TriggerScouting/OnlineProcessing/test/L1ScoutingSelector.py
@@ -1,0 +1,205 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import sys
+
+options = VarParsing.VarParsing ('analysis')
+
+options.register ("numOrbits",
+                  -1,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Number of orbits/events to process")
+
+options.register ("inFile",
+                  "file:",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Path to the input file")
+
+options.register ("outFile",
+                  "file:/tmp/out.root",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Path of the output file")
+
+options.register ("nThreads",
+                  4,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Number of threads")
+
+options.register ("nStreams",
+                  4,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Number of streams")
+
+options.register ("debug",
+                  False,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "Run in debug mode")
+
+options.parseArguments()
+
+process = cms.Process( "SCRATES" )
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.numOrbits)
+)
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "WARNING"
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+process.Timing = cms.Service("Timing",
+    summaryOnly = cms.untracked.bool(True),
+    useJobReport = cms.untracked.bool(True)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(options.inFile)
+)
+
+process.DijetEt30 = cms.EDProducer("JetBxSelector",
+    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
+    minNJet          = cms.int32(2),
+    minJetEt         = cms.vdouble(30, 30),
+    maxJetEta        = cms.vdouble(99.9, 99.9)
+)
+
+process.HMJetMult4Et20 = cms.EDProducer("JetBxSelector",
+    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
+    minNJet          = cms.int32(4),
+    minJetEt         = cms.vdouble(20, 20, 20, 20),
+    maxJetEta        = cms.vdouble(99.9, 99.9, 99.9, 99.9),
+)
+
+process.SingleMuPt0BMTF = cms.EDProducer("MuBxSelector",
+    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
+    minNMu           = cms.int32(1),
+    minMuPt          = cms.vdouble(0.0),
+    maxMuEta         = cms.vdouble(99.9),
+    minMuTfIndex     = cms.vint32(36),
+    maxMuTfIndex     = cms.vint32(71),
+    minMuHwQual    = cms.vint32(0),
+)
+
+process.DoubleMuPt0Qual8 = cms.EDProducer("MuBxSelector",
+    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
+    minNMu           = cms.int32(2),
+    minMuPt        = cms.vdouble(0, 0),
+    maxMuEta       = cms.vdouble(99.9, 99.9),
+    minMuTfIndex     = cms.vint32(0, 0),
+    maxMuTfIndex     = cms.vint32(107, 107),
+    minMuHwQual      = cms.vint32(8, 8),
+)
+
+process.MuTagJetEt30Dr0p4 = cms.EDProducer("MuTagJetBxSelector",
+    muonsTag         = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
+    jetsTag          = cms.InputTag("l1ScCaloUnpacker", "Jet"),
+    minNJet          = cms.int32(1),
+    minJetEt         = cms.vdouble(30),
+    maxJetEta        = cms.vdouble(99.9),
+    minMuPt          = cms.vdouble(0),
+    maxMuEta         = cms.vdouble(99.9),
+    minMuTfIndex     = cms.vint32(0),
+    maxMuTfIndex     = cms.vint32(107),
+    minMuHwQual      = cms.vint32(8),
+    maxDR            = cms.vdouble(0.4),
+)
+
+process.FinalBxSelector = cms.EDFilter("FinalBxSelector",
+    analysisLabels   = cms.VInputTag(
+        cms.InputTag("DijetEt30", "SelBx"),
+        cms.InputTag("SingleMuPt0BMTF", "SelBx"),
+        cms.InputTag("DoubleMuPt0Qual8", "SelBx"),
+        cms.InputTag("HMJetMult4Et20", "SelBx"),
+        cms.InputTag("MuTagJetEt30Dr0p4", "SelBx")
+    ),
+)
+
+process.bxSelectors = cms.Sequence(
+    process.DijetEt30 +
+    process.HMJetMult4Et20 +
+    process.SingleMuPt0BMTF +
+    process.DoubleMuPt0Qual8 +
+    process.MuTagJetEt30Dr0p4
+)
+
+# Final collection producers
+process.FinalBxSelectorMuon = cms.EDProducer("MaskOrbitBxScoutingMuon",
+    dataTag = cms.InputTag("l1ScGmtUnpacker",  "Muon"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("Muon")
+)
+
+process.FinalBxSelectorJet = cms.EDProducer("MaskOrbitBxScoutingJet",
+    dataTag = cms.InputTag("l1ScCaloUnpacker",  "Jet"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("Jet")
+)
+
+process.FinalBxSelectorEGamma = cms.EDProducer("MaskOrbitBxScoutingEGamma",
+    dataTag = cms.InputTag("l1ScCaloUnpacker",  "EGamma"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("EGamma")
+)
+
+process.FinalBxSelectorTau = cms.EDProducer("MaskOrbitBxScoutingTau",
+    dataTag = cms.InputTag("l1ScCaloUnpacker",  "Tau"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("Tau")
+)
+
+process.FinalBxSelectorBxSums = cms.EDProducer("MaskOrbitBxScoutingBxSums",
+    dataTag = cms.InputTag("l1ScCaloUnpacker",  "EtSum"),
+    selectBxs = cms.InputTag("FinalBxSelector", "SelBx"),
+    productLabel = cms.string("EtSum")
+)
+
+process.MaskedCollections = cms.Sequence(
+    process.FinalBxSelectorMuon +
+    process.FinalBxSelectorJet +
+    process.FinalBxSelectorEGamma +
+    process.FinalBxSelectorTau +
+    process.FinalBxSelectorBxSums
+)
+
+process.pL1ScoutingSelected = cms.Path(process.bxSelectors + process.FinalBxSelector+process.MaskedCollections)
+
+process.hltOutputL1ScoutingSelection = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string(options.outFile),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring("pL1ScoutingSelected")
+    ),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_DijetEt30_*_*',
+        'keep *_HMJetMult4Et20_*_*',
+        'keep *_SingleMuPt0BMTF_*_*',
+        'keep *_DoubleMuPt0Qual8_*_*',
+        'keep *_MuTagJetEt30Dr0p4_*_*',
+        'keep *_FinalBxSelector*_*_*',
+    )
+)
+
+process.options.numberOfThreads = options.nThreads
+process.options.numberOfStreams = options.nStreams
+
+#options to override compression algorithm and level for the streamer output
+C_LEVEL_UNDEFINED = -1
+C_ALGO_UNDEFINED = ""
+for moduleName in process.__dict__['_Process__outputmodules']:
+    modified_module = getattr(process,moduleName)
+    if -1 != C_LEVEL_UNDEFINED:
+        modified_module.compression_level=cms.untracked.int32(-1)
+    if "" != C_ALGO_UNDEFINED:
+        modified_module.compression_algorithm=cms.untracked.string("")
+
+process.options.numberOfThreads = options.nThreads
+process.options.numberOfStreams = options.nStreams
+
+process.epL1ScoutingSelection = cms.EndPath(process.hltOutputL1ScoutingSelection)
+process.HLTSchedule = cms.Schedule(process.epL1ScoutingSelection)
+


### PR DESCRIPTION
#### PR description:
This PR introduces the modules used for the L1 Scouting Online selection, which will complement the "Zero bias" stream. 
The selection stream was discussed during L1 Trigger DPG meetings (e.g. [link](https://indico.cern.ch/event/1425692/contributions/5996288/attachments/2874131/5032890/24_06_10__L1DPG__stream-rates%20(1).pdf ))

Related to this PR, a new category is introduced with https://github.com/cms-sw/cms-bot/pull/2276.

#### PR validation:

The PR has been validate using files collected in the "Zero Bias" stream, e.g.
```
cmsRun test/L1ScoutingSelector.py inFile=file:root://xrootd-cms.infn.it///store/data/Run2024F/L1Scouting/L1SCOUT/v1/000/382/580/00000/00c66a36-4a65-4b2a-a637-0b02629cb1da.root numOrbits=100 outFile=/tmp/dump.root
```
In parallel, it was successfully tested in the Scouting system at P5.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

We would like this PR to be backported in a data-taking release (14_0_X) in order to collect data from pp collisions during 2024.