### PR TITLE
Add 2024 L1T modifier & modifiers for changing BMTF quality calculation 

### DIFF
--- a/Configuration/Eras/python/Era_Run3_2024_cff.py
+++ b/Configuration/Eras/python/Era_Run3_2024_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
 
-Run3_2024 = cms.ModifierChain(Run3)
+Run3_2024 = cms.ModifierChain(Run3, run3_2024_L1T)

--- a/Configuration/Eras/python/Modifier_run3_2024_L1T_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_2024_L1T_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_2024_L1T = cms.Modifier()

--- a/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1TMuonBarrelKalmanAlgo.h
@@ -141,6 +141,8 @@ private:
   //double pointResolutionPhiB_;
   //point resolution for vertex
   double pointResolutionVertex_;
+  //Toggle for the new quality calculation in the emulator
+  bool useNewQualityCalculation_;
 
   //Sorter
   class StubSorter {

--- a/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonBarrel/python/simKBmtfDigis_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_run3_2024_L1T_cff import run3_2024_L1T
 
 bmtfKalmanTrackingSettings = cms.PSet(
     verbose = cms.bool(False),  # 
@@ -46,9 +47,14 @@ bmtfKalmanTrackingSettings = cms.PSet(
     pointResolutionPhiB = cms.double(500.),
     pointResolutionPhiBH = cms.vdouble(151., 173., 155., 153.),
     pointResolutionPhiBL = cms.vdouble(17866., 19306., 23984., 23746.),
-    pointResolutionVertex = cms.double(1.)
-)
+    pointResolutionVertex = cms.double(1.),
 
+    useNewQualityCalculation = cms.bool(False),
+)
+run3_2024_L1T.toModify(
+    bmtfKalmanTrackingSettings,
+    useNewQualityCalculation = cms.bool(True),
+)
 
 
 simKBmtfDigis = cms.EDProducer("L1TMuonBarrelKalmanTrackProducer",

--- a/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanAlgo.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1TMuonBarrelKalmanAlgo.cc
@@ -39,7 +39,8 @@ L1TMuonBarrelKalmanAlgo::L1TMuonBarrelKalmanAlgo(const edm::ParameterSet& settin
       pointResolutionPhiB_(settings.getParameter<double>("pointResolutionPhiB")),
       pointResolutionPhiBH_(settings.getParameter<std::vector<double> >("pointResolutionPhiBH")),
       pointResolutionPhiBL_(settings.getParameter<std::vector<double> >("pointResolutionPhiBL")),
-      pointResolutionVertex_(settings.getParameter<double>("pointResolutionVertex"))
+      pointResolutionVertex_(settings.getParameter<double>("pointResolutionVertex")),
+      useNewQualityCalculation_(settings.getParameter<bool>("useNewQualityCalculation"))
 
 {}
 
@@ -99,16 +100,20 @@ l1t::RegionalMuonCand L1TMuonBarrelKalmanAlgo::convertToBMTF(const L1MuKBMTrack&
   int processor = track.sector();
   int HF = track.hasFineEta();
 
-  int quality;
-  int r = rank(track);
-  if (r < 192)
-    quality = 12;
-  else if (r < 204)
-    quality = 13;
-  else if (r < 220)
-    quality = 14;
-  else
-    quality = 15;
+  int quality = 0;
+  if (useNewQualityCalculation_) {
+    int r = rank(track);
+    if (r < 192)
+      quality = 12;
+    else if (r < 204)
+      quality = 13;
+    else if (r < 220)
+      quality = 14;
+    else
+      quality = 15;
+  } else {
+    quality = 12 | (rank(track) >> 6);
+  }
 
   int dxy = abs(track.dxy()) >> 8;
   if (dxy > 3)


### PR DESCRIPTION
### PR description:

This PR adds an Era based modifier to the new BMTF quality calculation introduced by https://github.com/cms-sw/cmssw/pull/44432, to allow for use of the old versus new quality calculation in the planned upcoming re-reco + MC campaign. The default is to use the old calculation and for Run3_2024 Eras and beyond to use the new calculation.

As a note, this does introduce a modifier file I have created personally, I don't know if there is a standard for who can create these or when they should be made, and it is introduced to the Run3_2024 era.

@slaurila @eyigitba: FYI

### PR validation:

All code compiles and has had formatting applied. The settings+flag has been tested in L1 re-emulation under different eras to trigger the correct quality calculation.

### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport and is not expected to be backported.