### PR TITLE
Add missing header in AllocatorConfig.h [14.0.x]

### DIFF
--- a/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h
@@ -2,6 +2,7 @@
 #define HeterogeneousCore_AlpakaInterface_interface_AllocatorConfig_h
 
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 
 namespace cms::alpakatools {


### PR DESCRIPTION
#### PR description:

The header checks are failing with
```
src/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h:42:5: error: 'uint8_t' does not name a type
   42 |     uint8_t fillAllocationValue = 0xA5;
      |     ^~~~~~~
src/HeterogeneousCore/AlpakaInterface/interface/AllocatorConfig.h:6:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```

This PR adds the missing include header file.

#### PR validation:

Header checks should now pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #45359.