### PR TITLE
Phase2-hgx358A Fix a bug in the conversion code for HGCal scintillator xml files

### DIFF
--- a/Geometry/HGCalCommonData/test/HGCalConvert.cpp
+++ b/Geometry/HGCalCommonData/test/HGCalConvert.cpp
@@ -1471,7 +1471,7 @@ void ConvertScintillatorV1::convert(const char* infile, const char* outfile1, co
     fOut << "\n  </Vector>\n";
     fOut << "  <Vector name=" << apost << "TileRMax6" << apost << " type=" << apost << "numeric" << apost
          << " nEntries=" << apost << ringR6.size() << apost << ">";
-    for (it1 = ringR.begin(); it1 != ringR.end(); ++it1) {
+    for (it1 = ringR6.begin(); it1 != ringR6.end(); ++it1) {
       std::string last = ((l4 + 1) == ringR6.size()) ? " " : ",";
       if (l4 % 6 == 0)
         fOut << "\n    " << std::setw(8) << std::setprecision(6) << (it1->second).second << "*mm" << last;


### PR DESCRIPTION
#### PR description:

Fix a bug in the conversion code for HGCal scintillator XML files. The results from the conversion code are to be combined with the results from PR #45354

#### PR validation:

Obtained a new set of XML files to be combined with the new silicon files once the PR #45354 is merged

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special