### PR TITLE
Phase2-hgx358C Add a few new modes to enable cog computation for wafers as default for the future V19 version of HGCal

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalCons/v19/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/hgcalCons/v19/hgcalCons.xml
@@ -38,7 +38,7 @@
   <SpecPar name="HGCalEELayer">
     <PartSelector path="//HGCalEELayer.*"/>    
     <Parameter name="Volume" value="HGCalEELayer" eval="false"/>
-    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8CalibCell" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8FineCell" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
     <Parameter name="LevelTop"            value="12"/>
@@ -102,7 +102,7 @@
   <SpecPar name="HGCalHESiliconLayer">
     <PartSelector path="//HGCalHESiliconLayer.*"/>
     <Parameter name="Volume" value="HGCalHESiliconLayer" eval="false"/>
-    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8CalibCell" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::Hexagon8FineCell" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
     <Parameter name="LevelTop"            value="12"/>
@@ -166,7 +166,7 @@
   <SpecPar name="HGCalHEScintillatorSensitive">
     <PartSelector path="//HGCalHEScintillatorSensitive.*"/>
     <Parameter name="Volume" value="HGCalHEScintillatorSensitive" eval="false"/>
-    <Parameter name="GeometryMode" value="HGCalGeometryMode::TrapezoidFineCassette" eval="false"/>
+    <Parameter name="GeometryMode" value="HGCalGeometryMode::TrapezoidFinCell" eval="false"/>
     <Parameter name="LevelZSide"          value="3"/>
     <Parameter name="LevelTop"            value="9"/>
     <Parameter name="LevelTop"            value="11"/>

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -51,7 +51,8 @@ public:
   double calibCellRad(bool hd) const { return (hd ? hgpar_->calibCellRHD_ : hgpar_->calibCellRLD_); }
   bool cassetteMode() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
-            (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
+            (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell) ||
+            (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   bool cassetteShiftScintillator(int zside, int layer, int iphi) const;
   bool cassetteShiftSilicon(int zside, int layer, int waferU, int waferV) const;
@@ -113,7 +114,17 @@ public:
   std::pair<float, float> localToGlobal8(
       int zside, int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
   std::pair<float, float> locateCell(int cell, int lay, int type, bool reco) const;
-  std::pair<float, float> locateCell(int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool cog, bool debug) const;
+  std::pair<float, float> locateCell(int zside,
+                                     int lay,
+                                     int waferU,
+                                     int waferV,
+                                     int cellU,
+                                     int cellV,
+                                     bool reco,
+                                     bool all,
+                                     bool norot,
+                                     bool cog,
+                                     bool debug) const;
   std::pair<float, float> locateCell(const HGCSiliconDetId&, bool cog, bool debug) const;
   std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;
@@ -151,7 +162,8 @@ public:
   inline int tileSiPM(int sipm) const { return ((sipm > 0) ? HGCalTypes::SiPMSmall : HGCalTypes::SiPMLarge); }
   bool tileTrapezoid() const {
     return ((mode_ == HGCalGeometryMode::Trapezoid) || (mode_ == HGCalGeometryMode::TrapezoidFile) ||
-            (mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
+            (mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
+            (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   std::pair<int, int> tileType(int layer, int ring, int phi) const;
   inline bool trapezoidFile() const {
@@ -180,15 +192,15 @@ public:
   inline bool waferHexagon8() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8) || (mode_ == HGCalGeometryMode::Hexagon8Full) ||
             (mode_ == HGCalGeometryMode::Hexagon8File) || (mode_ == HGCalGeometryMode::Hexagon8Module) ||
-            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));
+            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) ||
+            (mode_ == HGCalGeometryMode::Hexagon8FineCell));
   }
   inline bool waferHexagon8File() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8File) || (mode_ == HGCalGeometryMode::Hexagon8Module) ||
-            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));
+            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) ||
+            (mode_ == HGCalGeometryMode::Hexagon8FineCell));
   }
-  inline bool waferHexagon8Fine() const {
-    return ((mode_ == HGCalGeometryMode::Hexagon8FineCell));
-  }
+  inline bool waferHexagon8Fine() const { return ((mode_ == HGCalGeometryMode::Hexagon8FineCell)); }
   inline bool waferHexagon8Module() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8Module) || (mode_ == HGCalGeometryMode::Hexagon8Cassette) ||
             (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -51,7 +51,7 @@ public:
   double calibCellRad(bool hd) const { return (hd ? hgpar_->calibCellRHD_ : hgpar_->calibCellRLD_); }
   bool cassetteMode() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::TrapezoidCassette) ||
-            (mode_ == HGCalGeometryMode::Hexagon8CalibCell));
+            (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   bool cassetteShiftScintillator(int zside, int layer, int iphi) const;
   bool cassetteShiftSilicon(int zside, int layer, int waferU, int waferV) const;
@@ -113,10 +113,8 @@ public:
   std::pair<float, float> localToGlobal8(
       int zside, int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
   std::pair<float, float> locateCell(int cell, int lay, int type, bool reco) const;
-  std::pair<float, float> locateCell(
-      int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug)
-      const;
-  std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug) const;
+  std::pair<float, float> locateCell(int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool cog, bool debug) const;
+  std::pair<float, float> locateCell(const HGCSiliconDetId&, bool cog, bool debug) const;
   std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;
   std::pair<float, float> locateCellTrap(int zside, int lay, int ieta, int iphi, bool reco, bool debug) const;
@@ -153,12 +151,12 @@ public:
   inline int tileSiPM(int sipm) const { return ((sipm > 0) ? HGCalTypes::SiPMSmall : HGCalTypes::SiPMLarge); }
   bool tileTrapezoid() const {
     return ((mode_ == HGCalGeometryMode::Trapezoid) || (mode_ == HGCalGeometryMode::TrapezoidFile) ||
-            (mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette));
+            (mode_ == HGCalGeometryMode::TrapezoidModule) || (mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   std::pair<int, int> tileType(int layer, int ring, int phi) const;
   inline bool trapezoidFile() const {
     return ((mode_ == HGCalGeometryMode::TrapezoidFile) || (mode_ == HGCalGeometryMode::TrapezoidModule) ||
-            (mode_ == HGCalGeometryMode::TrapezoidCassette));
+            (mode_ == HGCalGeometryMode::TrapezoidCassette) || (mode_ == HGCalGeometryMode::TrapezoidFineCell));
   }
   inline bool v17OrLess() const { return (mode_ < HGCalGeometryMode::Hexagon8CalibCell); }
   inline unsigned int volumes() const { return hgpar_->moduleLayR_.size(); }
@@ -182,15 +180,18 @@ public:
   inline bool waferHexagon8() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8) || (mode_ == HGCalGeometryMode::Hexagon8Full) ||
             (mode_ == HGCalGeometryMode::Hexagon8File) || (mode_ == HGCalGeometryMode::Hexagon8Module) ||
-            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell));
+            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));
   }
   inline bool waferHexagon8File() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8File) || (mode_ == HGCalGeometryMode::Hexagon8Module) ||
-            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell));
+            (mode_ == HGCalGeometryMode::Hexagon8Cassette) || (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));
+  }
+  inline bool waferHexagon8Fine() const {
+    return ((mode_ == HGCalGeometryMode::Hexagon8FineCell));
   }
   inline bool waferHexagon8Module() const {
     return ((mode_ == HGCalGeometryMode::Hexagon8Module) || (mode_ == HGCalGeometryMode::Hexagon8Cassette) ||
-            (mode_ == HGCalGeometryMode::Hexagon8CalibCell));
+            (mode_ == HGCalGeometryMode::Hexagon8CalibCell) || (mode_ == HGCalGeometryMode::Hexagon8FineCell));
   }
   bool waferInLayer(int wafer, int lay, bool reco) const;
   bool waferFullInLayer(int wafer, int lay, bool reco) const;

--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -146,6 +146,12 @@ public:
   std::vector<int> numberCells(int lay, bool reco) const;
   int numberCellsHexagon(int wafer) const;
   int numberCellsHexagon(int lay, int waferU, int waferV, bool flag) const;
+  inline int partialWaferType(int lay, int waferU, int waferV) const {
+    int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
+    auto ktr = hgpar_->waferInfoMap_.find(indx);
+    int part = (ktr != hgpar_->waferInfoMap_.end()) ? (ktr->second).part : HGCalTypes::WaferFull;
+    return part;
+  }
   std::pair<double, double> rangeR(double z, bool reco) const;
   std::pair<double, double> rangeRLayer(int lay, bool reco) const;
   std::pair<double, double> rangeZ(bool reco) const;

--- a/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeometryMode.h
@@ -37,6 +37,8 @@ namespace HGCalGeometryMode {
     Hexagon8Cassette = 10,
     TrapezoidCassette = 11,
     Hexagon8CalibCell = 12,
+    TrapezoidFineCell = 13,
+    Hexagon8FineCell = 14,
   };
 
   enum WaferMode { Polyhedra = 0, ExtrudedPolygon = 1 };

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -325,7 +325,7 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
       return HGCalWaferMask::goodCell(cellU, cellV, ncell, part, rotn);
     } else if (waferHexagon8() || waferHexagon6()) {
       const auto& xy =
-          ((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false)
+	((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false, false)
                              : locateCell(cellU, lay, waferU, reco));
       double rpos = sqrt(xy.first * xy.first + xy.second * xy.second);
       return ((rpos >= hgpar_->rMinLayHex_[indx.first]) && (rpos <= hgpar_->rMaxLayHex_[indx.first]));
@@ -836,8 +836,7 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int cell, int lay, int typ
   return std::make_pair(x, y);
 }
 
-std::pair<float, float> HGCalDDDConstants::locateCell(
-    int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug)
+std::pair<float, float> HGCalDDDConstants::locateCell(int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool cog, bool debug)
     const {
   double x(0), y(0);
   int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
@@ -859,7 +858,7 @@ std::pair<float, float> HGCalDDDConstants::locateCell(
       if (ktr != hgpar_->waferInfoMap_.end())
         place = HGCalCell::cellPlacementIndex(1, HGCalTypes::layerFrontBack(layertype), (ktr->second).orient);
     }
-    auto xy = hgcell_->cellUV2XY2(cellU, cellV, place, type);
+    auto xy = (waferHexagon8Fine() || cog) ? cellOffset_->cellOffsetUV2XY1(cellU, cellV, place, type) : hgcell_->cellUV2XY2(cellU, cellV, place, type);
     x = xy.first;
     y = xy.second;
     if (debug)
@@ -919,8 +918,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(
   return (rotx ? getXY(lay, x, y, false) : std::make_pair(x, y));
 }
 
-std::pair<float, float> HGCalDDDConstants::locateCell(const HGCSiliconDetId& id, bool debug) const {
-  return locateCell(id.zside(), id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, debug);
+std::pair<float, float> HGCalDDDConstants::locateCell(const HGCSiliconDetId& id, bool cog, bool debug) const {
+  return locateCell(id.zside(), id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, cog, debug);
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCScintillatorDetId& id, bool debug) const {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -325,7 +325,7 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
       return HGCalWaferMask::goodCell(cellU, cellV, ncell, part, rotn);
     } else if (waferHexagon8() || waferHexagon6()) {
       const auto& xy =
-	((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false, false)
+          ((waferHexagon8()) ? locateCell(zside, lay, waferU, waferV, cellU, cellV, reco, true, false, false, false)
                              : locateCell(cellU, lay, waferU, reco));
       double rpos = sqrt(xy.first * xy.first + xy.second * xy.second);
       return ((rpos >= hgpar_->rMinLayHex_[indx.first]) && (rpos <= hgpar_->rMaxLayHex_[indx.first]));
@@ -836,8 +836,17 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int cell, int lay, int typ
   return std::make_pair(x, y);
 }
 
-std::pair<float, float> HGCalDDDConstants::locateCell(int zside, int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool cog, bool debug)
-    const {
+std::pair<float, float> HGCalDDDConstants::locateCell(int zside,
+                                                      int lay,
+                                                      int waferU,
+                                                      int waferV,
+                                                      int cellU,
+                                                      int cellV,
+                                                      bool reco,
+                                                      bool all,
+                                                      bool norot,
+                                                      bool cog,
+                                                      bool debug) const {
   double x(0), y(0);
   int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
   auto itr = hgpar_->typesInLayers_.find(indx);
@@ -858,7 +867,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int zside, int lay, int wa
       if (ktr != hgpar_->waferInfoMap_.end())
         place = HGCalCell::cellPlacementIndex(1, HGCalTypes::layerFrontBack(layertype), (ktr->second).orient);
     }
-    auto xy = (waferHexagon8Fine() || cog) ? cellOffset_->cellOffsetUV2XY1(cellU, cellV, place, type) : hgcell_->cellUV2XY2(cellU, cellV, place, type);
+    auto xy = (waferHexagon8Fine() || cog) ? cellOffset_->cellOffsetUV2XY1(cellU, cellV, place, type)
+                                           : hgcell_->cellUV2XY2(cellU, cellV, place, type);
     x = xy.first;
     y = xy.second;
     if (debug)
@@ -919,7 +929,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int zside, int lay, int wa
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCSiliconDetId& id, bool cog, bool debug) const {
-  return locateCell(id.zside(), id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, cog, debug);
+  return locateCell(
+      id.zside(), id.layer(), id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, cog, debug);
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(const HGCScintillatorDetId& id, bool debug) const {

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -867,7 +867,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int zside,
       if (ktr != hgpar_->waferInfoMap_.end())
         place = HGCalCell::cellPlacementIndex(1, HGCalTypes::layerFrontBack(layertype), (ktr->second).orient);
     }
-    auto xy = (waferHexagon8Fine() || cog) ? cellOffset_->cellOffsetUV2XY1(cellU, cellV, place, type)
+    int part = partialWaferType(lay, waferU, waferV);
+    auto xy = (waferHexagon8Fine() || cog) ? cellOffset_->cellOffsetUV2XY1(cellU, cellV, place, type, part)
                                            : hgcell_->cellUV2XY2(cellU, cellV, place, type);
     x = xy.first;
     y = xy.second;

--- a/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeometryMode.cc
@@ -16,6 +16,8 @@ HGCalStringToEnumParser<HGCalGeometryMode::GeometryMode>::HGCalStringToEnumParse
   enumMap["HGCalGeometryMode::Hexagon8Cassette"] = HGCalGeometryMode::Hexagon8Cassette;
   enumMap["HGCalGeometryMode::TrapezoidCassette"] = HGCalGeometryMode::TrapezoidCassette;
   enumMap["HGCalGeometryMode::Hexagon8CalibCell"] = HGCalGeometryMode::Hexagon8CalibCell;
+  enumMap["HGCalGeometryMode::TrapezoidFineCell"] = HGCalGeometryMode::TrapezoidFineCell;
+  enumMap["HGCalGeometryMode::Hexagon8FineCell"] = HGCalGeometryMode::Hexagon8FineCell;
 }
 
 template <>

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -172,7 +172,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
       } else {
         std::array<int, 5> kxy, lxy;
         kxy = hgdc.assignCellHex(localx, localy, zside, i + loff, reco_, false, false);
-        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false, false);
         lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_, false, false);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff
@@ -182,7 +182,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
                                       << lxy[3] << ":" << lxy[4] << ") Dist "
                                       << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellHex(-localx, -localy, zside, i + loff, reco_, false, false);
-        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false);
+        xy = hgdc.locateCell(zside, i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true, false, false, false);
         lxy = hgdc.assignCellHex(xy.first, xy.second, zside, i + loff, reco_, false, false);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff

--- a/Geometry/HGCalCommonData/test/HGCalPartialIDTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalPartialIDTester.cc
@@ -154,7 +154,7 @@ void HGCalPartialIDTester::beginRun(edm::Run const &iRun, edm::EventSetup const 
       double dR(0);
       if ((waferU_[i] != 0) || (waferV_[i] != 0)) {
         std::pair<float, float> xy =
-	  hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
+            hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
         double dx = (xpos_[i] - xy.first);
         double dy = (ypos_[i] - xy.second);
         dR = std::sqrt(dx * dx + dy * dy);
@@ -173,8 +173,8 @@ void HGCalPartialIDTester::beginRun(edm::Run const &iRun, edm::EventSetup const 
             xx, ypos_[i], zside_[i], layer_[i], waferU, waferV, cellU, cellV, waferType, wt, false, debug_);
         info = hgcCons_->waferInfo(layer_[i], waferU, waferV);
         if ((waferU_[i] != 0) || (waferV_[i] != 0)) {
-          std::pair<float, float> xy =
-	    hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
+          std::pair<float, float> xy = hgcCons_->locateCell(
+              zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
           double dx = (xpos_[i] - xy.first);
           double dy = (ypos_[i] - xy.second);
           dR = std::sqrt(dx * dx + dy * dy);

--- a/Geometry/HGCalCommonData/test/HGCalPartialIDTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalPartialIDTester.cc
@@ -154,7 +154,7 @@ void HGCalPartialIDTester::beginRun(edm::Run const &iRun, edm::EventSetup const 
       double dR(0);
       if ((waferU_[i] != 0) || (waferV_[i] != 0)) {
         std::pair<float, float> xy =
-            hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false);
+	  hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
         double dx = (xpos_[i] - xy.first);
         double dy = (ypos_[i] - xy.second);
         dR = std::sqrt(dx * dx + dy * dy);
@@ -174,7 +174,7 @@ void HGCalPartialIDTester::beginRun(edm::Run const &iRun, edm::EventSetup const 
         info = hgcCons_->waferInfo(layer_[i], waferU, waferV);
         if ((waferU_[i] != 0) || (waferV_[i] != 0)) {
           std::pair<float, float> xy =
-              hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false);
+	    hgcCons_->locateCell(zside_[i], layer_[i], waferU, waferV, cellU, cellV, false, true, false, false, false);
           double dx = (xpos_[i] - xy.first);
           double dy = (ypos_[i] - xy.second);
           dR = std::sqrt(dx * dx + dy * dy);

--- a/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalPartialWaferTester.cc
@@ -107,7 +107,7 @@ void HGCalPartialWaferTester::analyze(const edm::Event&, const edm::EventSetup& 
             ++alltry;
             double zpos = hgdc.waferZ(layer, reco);
             int zside = (zpos > 0) ? 1 : -1;
-            auto xy = hgdc.locateCell(zside, layer, waferU, waferV, ui, vi, reco, all, norot, debug1);
+            auto xy = hgdc.locateCell(zside, layer, waferU, waferV, ui, vi, reco, all, norot, false, debug1);
             int lay(layer), cU(0), cV(0), wType(-1), wU(0), wV(0);
             double wt(0);
             hgdc.waferFromPosition(HGCalParameters::k_ScaleToDDD * xy.first,

--- a/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
@@ -184,7 +184,8 @@ void HGCalValidityTester::beginRun(edm::Run const &iRun, edm::EventSetup const &
       HGCSiliconDetId id(detIds_[k].first);
       layer = id.layer();
       zside = id.zside();
-      xy = cons->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false, false);
+      xy = cons->locateCell(
+          zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false, false);
       valid = cons->isValidHex8(layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false);
       auto cell = cons->assignCellHex(zside * xy.first, xy.second, zside, layer, true, false, false);
       HGCSiliconDetId newId(id.det(), id.zside(), cell[2], id.layer(), cell[0], cell[1], cell[3], cell[4]);

--- a/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalValidityTester.cc
@@ -184,7 +184,7 @@ void HGCalValidityTester::beginRun(edm::Run const &iRun, edm::EventSetup const &
       HGCSiliconDetId id(detIds_[k].first);
       layer = id.layer();
       zside = id.zside();
-      xy = cons->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
+      xy = cons->locateCell(zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false, false);
       valid = cons->isValidHex8(layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false);
       auto cell = cons->assignCellHex(zside * xy.first, xy.second, zside, layer, true, false, false);
       HGCSiliconDetId newId(id.det(), id.zside(), cell[2], id.layer(), cell[0], cell[1], cell[3], cell[4]);

--- a/Geometry/HGCalGeometry/interface/HGCalGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalGeometry.h
@@ -70,6 +70,7 @@ public:
                   CaloSubdetectorGeometry::DimVec& dimVector,
                   CaloSubdetectorGeometry::IVec& dinsVector) const override;
 
+  GlobalPoint getPosition(const DetId& id, bool cog, bool debug) const;
   GlobalPoint getPosition(const DetId& id, bool debug = false) const;
   GlobalPoint getWaferPosition(const DetId& id) const;
 

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -204,7 +204,7 @@ bool HGCalGeometry::present(const DetId& detId) const {
 GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
   return getPosition(detid, false, debug);
 }
-  
+
 GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug) const {
   unsigned int cellIndex = indexFor(detid);
   GlobalPoint glob;
@@ -236,7 +236,8 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug)
                                         << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
                                         << id.iCell2;
       }
-      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
+      xy = m_topology.dddConstants().locateCell(
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);
@@ -322,7 +323,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
+      xy = m_topology.dddConstants().locateCell(
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       float dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
@@ -378,7 +380,8 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
+      xy = m_topology.dddConstants().locateCell(
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
       dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
       float dz = -id.zSide * m_cellVec[cellIndex].param()[FlatHexagon::k_dZ];
@@ -438,7 +441,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debug);
+      xy = m_topology.dddConstants().locateCell(
+          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debug);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       for (unsigned int i = 0; i < ncorner; ++i) {
         double xloc = xy.first + signx[i] * dx;

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -202,6 +202,10 @@ bool HGCalGeometry::present(const DetId& detId) const {
 }
 
 GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
+  return getPosition(detid, false, debug);
+}
+  
+GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool cog, bool debug) const {
   unsigned int cellIndex = indexFor(detid);
   GlobalPoint glob;
   unsigned int maxSize = (m_topology.tileTrapezoid() ? m_cellVec2.size() : m_cellVec.size());
@@ -232,8 +236,7 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
                                         << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
                                         << id.iCell2;
       }
-      xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);
+      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true, cog, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);
@@ -319,8 +322,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
+      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       float dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
@@ -376,8 +378,7 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
+      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debugLocate);
       dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
       float dz = -id.zSide * m_cellVec[cellIndex].param()[FlatHexagon::k_dZ];
@@ -437,8 +438,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(
-          id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debug);
+      xy = m_topology.dddConstants().locateCell(id.zSide, id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, false, debug);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       for (unsigned int i = 0; i < ncorner; ++i) {
         double xloc = xy.first + signx[i] * dx;

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.icc
@@ -167,6 +167,7 @@ typename HGCalSiNoiseMap<T>::SiCellOpCharacteristics HGCalSiNoiseMap<T>::getSiCe
                                    true,
                                    true,
                                    false,
+                                   false,
                                    false));
   double radius = sqrt(std::pow(xy.first, 2) + std::pow(xy.second, 2));  //in cm
 

--- a/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HFNoseNumberingScheme.cc
@@ -60,7 +60,7 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
     HFNoseDetId id = HFNoseDetId(index);
     lay = id.layer();
     xy = hgcons_.locateCell(
-        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
+        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
   }
@@ -89,7 +89,7 @@ void HFNoseNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& p
         double wt = 0, xx = (zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
         hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
-        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, true);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, false, true);
         edm::LogVerbatim("HGCSim") << "HFNoseNumberingScheme " << HFNoseDetId(index) << " position " << xy.first << ":"
                                    << xy.second;
       }

--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -210,7 +210,7 @@ bool HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
     HGCSiliconDetId id = HGCSiliconDetId(index);
     lay = id.layer();
     xy = hgcons_.locateCell(
-        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false);
+        id.zside(), lay, id.waferU(), id.waferV(), id.cellU(), id.cellV(), false, true, false, false, false);
     z1 = hgcons_.waferZ(lay, false);
     ok = true;
     tolR = 14.0;
@@ -253,7 +253,7 @@ bool HGCalNumberingScheme::checkPosition(uint32_t index, const G4ThreeVector& po
         double wt(0), xx(zside * pos.x());
         int waferU, waferV, cellU, cellV, waferType;
         hgcons_.waferFromPosition(xx, pos.y(), zside, lay, waferU, waferV, cellU, cellV, waferType, wt, false, true);
-        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, true);
+        xy = hgcons_.locateCell(zside, lay, waferU, waferV, cellU, cellV, false, true, false, false, true);
         double dx = (xx - xy.first);
         double dy = (pos.y() - xy.second);
         double dR = std::sqrt(dx * dx + dy * dy);

--- a/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCGeometryValidation.cc
@@ -199,7 +199,7 @@ void HGCGeometryValidation::analyze(const edm::Event &iEvent, const edm::EventSe
         layer = id.layer();
         zside = id.zside();
         xy = hgcGeometry_[dtype]->locateCell(
-            zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false);
+            zside, layer, id.waferU(), id.waferV(), id.cellU(), id.cellV(), true, true, false, false, false);
       } else {
         HGCScintillatorDetId id(hitIdx[i]);
         dtype = 2;

--- a/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitStudy.cc
@@ -169,7 +169,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false, false);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->waferHexagon8()) {
@@ -182,7 +182,7 @@ void HGCalSimHitStudy::analyzeHits(int ih, std::string const& name, std::vector<
       type = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false);
+      xy = hgcons_[ih]->locateCell(zside, layer, sector, sector2, cell, cell2, false, true, false, false, false);
       h_W2_[ih]->Fill(sector2);
       h_C2_[ih]->Fill(cell2);
     } else if (hgcons_[ih]->tileTrapezoid()) {

--- a/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
+++ b/Validation/HGCalValidation/plugins/HGCalSimHitValidation.cc
@@ -206,7 +206,7 @@ void HGCalSimHitValidation::analyzeHits(std::vector<PCaloHit>& hits) {
     HepGeom::Point3D<float> gcoord;
     std::pair<float, float> xy;
     if (hgcons_->waferHexagon8()) {
-      xy = hgcons_->locateCell(zside, layer, sector, subsector, cell, cell2, false, true, false, false);
+      xy = hgcons_->locateCell(zside, layer, sector, subsector, cell, cell2, false, true, false, false, false);
     } else {
       xy = hgcons_->locateCellTrap(zside, layer, sector, cell, false, false);
     }

--- a/Validation/HGCalValidation/test/HGCHitValidation.cc
+++ b/Validation/HGCalValidation/test/HGCHitValidation.cc
@@ -483,7 +483,7 @@ void HGCHitValidation::analyzeHGCalSimHit(edm::Handle<std::vector<PCaloHit>> con
       celltype = detId.type();
       layer = detId.layer();
       zside = detId.zside();
-      xy = hgcCons_[idet]->locateCell(zside, layer, wafer, wafer2, cell, cell2, false, true, false, false);
+      xy = hgcCons_[idet]->locateCell(zside, layer, wafer, wafer2, cell, cell2, false, true, false, false, false);
     } else if (hgcCons_[idet]->tileTrapezoid()) {
       HGCScintillatorDetId detId = HGCScintillatorDetId(id);
       subdet = (int)(detId.det());

--- a/Validation/HGCalValidation/test/HGCalWaferStudy.cc
+++ b/Validation/HGCalValidation/test/HGCalWaferStudy.cc
@@ -167,14 +167,14 @@ void HGCalWaferStudy::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
           xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false);
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false, false);
         } else if (hgcons_[k]->waferHexagon8()) {
           HGCSiliconDetId detId = HGCSiliconDetId(id);
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
           xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false);
+              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false, false);
         } else {
           int subdet, sector, type, cell;
           HGCalTestNumbering::unpackHexagonIndex(id, subdet, zside, layer, sector, type, cell);

--- a/Validation/HGCalValidation/test/HGCalWaferStudy.cc
+++ b/Validation/HGCalValidation/test/HGCalWaferStudy.cc
@@ -166,15 +166,33 @@ void HGCalWaferStudy::analyze(const edm::Event& iEvent, const edm::EventSetup& i
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false, false);
+          xy = hgcons_[k]->locateCell(zside,
+                                      layer,
+                                      detId.waferU(),
+                                      detId.waferV(),
+                                      detId.cellU(),
+                                      detId.cellV(),
+                                      false,
+                                      true,
+                                      false,
+                                      false,
+                                      false);
         } else if (hgcons_[k]->waferHexagon8()) {
           HGCSiliconDetId detId = HGCSiliconDetId(id);
           layer = detId.layer();
           zside = detId.zside();
           wvtype = hgcons_[k]->waferVirtual(layer, detId.waferU(), detId.waferV());
-          xy = hgcons_[k]->locateCell(
-              zside, layer, detId.waferU(), detId.waferV(), detId.cellU(), detId.cellV(), false, true, false, false, false);
+          xy = hgcons_[k]->locateCell(zside,
+                                      layer,
+                                      detId.waferU(),
+                                      detId.waferV(),
+                                      detId.cellU(),
+                                      detId.cellV(),
+                                      false,
+                                      true,
+                                      false,
+                                      false,
+                                      false);
         } else {
           int subdet, sector, type, cell;
           HGCalTestNumbering::unpackHexagonIndex(id, subdet, zside, layer, sector, type, cell);


### PR DESCRIPTION
#### PR description:

Add a few new modes to enable cog computation for wafers as default for the future V19 version of HGCal

#### PR validation:

Use the runTheMatrix test workflow

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special