### PR TITLE
Fix HepMC3 conversion on MC without event weights (particle guns)

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -98,10 +98,16 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   hepmc_event->add_attribute("alphaQED", std::make_shared<HepMC3::DoubleAttribute>(genEventInfoHandle->alphaQED()));
 
   hepmc_event->weights() = genEventInfoHandle->weights();
+  // add dummy weight if necessary
+  if (hepmc_event->weights().size() == 0) {
+    hepmc_event->weights().push_back(1.);
+  }
 
   // resize cross section to number of weights
-  xsec_->set_cross_section(std::vector<double>(hepmc_event->weights().size(), xsec_->xsec(0)),
-                           std::vector<double>(hepmc_event->weights().size(), xsec_->xsec_err(0)));
+  if (xsec_->xsecs().size() < hepmc_event->weights().size()) {
+    xsec_->set_cross_section(std::vector<double>(hepmc_event->weights().size(), xsec_->xsec(0)),
+                             std::vector<double>(hepmc_event->weights().size(), xsec_->xsec_err(0)));
+  }
   hepmc_event->set_cross_section(xsec_);
 
   // Set PDF

--- a/GeneratorInterface/RivetInterface/test/BuildFile.xml
+++ b/GeneratorInterface/RivetInterface/test/BuildFile.xml
@@ -12,4 +12,5 @@
 <test name="test-particleLevel_fromHepMC3" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromHepMC3_cfg.py"/>
 <test name="test-particleLevel_fromGenParticles" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromGenParticles_cfg.py"/>
 <test name="test-particleLevel_fromMiniAod" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py"/>
+<test name="test-particleLevel_fromPtGun" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/particleLevel_fromPtGun_cfg.py"/>
 <test name="test-HTXS" command="cmsRun ${LOCALTOP}/src/GeneratorInterface/RivetInterface/test/runRivetHTXS_cfg.py"/>

--- a/GeneratorInterface/RivetInterface/test/particleLevel_fromPtGun_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/particleLevel_fromPtGun_cfg.py
@@ -1,0 +1,61 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TQAF")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff")
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDFilter("Pythia8PtGun",
+    PGunParameters = cms.PSet(
+        AddAntiParticle = cms.bool(True),
+        MaxEta = cms.double(2.5),
+        MaxPhi = cms.double(3.14159265359),
+        MaxPt = cms.double(10.01),
+        MinEta = cms.double(-2.5),
+        MinPhi = cms.double(-3.14159265359),
+        MinPt = cms.double(9.99),
+        ParticleID = cms.vint32(11)
+    ),
+    PythiaParameters = cms.PSet(
+        parameterSets = cms.vstring()
+    ),
+    Verbosity = cms.untracked.int32(0),
+    firstRun = cms.untracked.uint32(1),
+    psethack = cms.string('single electron pt 10')
+)
+
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    abortOnUnknownPDGCode = cms.untracked.bool(False),
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared")
+)
+
+
+## define maximal number of events to loop over
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+## configure process options
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    wantSummary      = cms.untracked.bool(True)
+)
+
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("GeneratorInterface.RivetInterface.genParticles2HepMC_cfi")
+process.load("GeneratorInterface.RivetInterface.particleLevel_cfi")
+process.particleLevel.src = cms.InputTag("genParticles2HepMC:unsmeared")
+
+process.path = cms.Path(process.generator*process.genParticles*process.genParticles2HepMC*process.particleLevel)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("particleLevel.root"),
+    outputCommands = cms.untracked.vstring(
+        "drop *",
+        "keep *_genParticles_*_*",
+        "keep *_particleLevel_*_*",
+    ),
+)
+process.outPath = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

* Resolves https://github.com/cms-sw/cmssw/pull/44603#issuecomment-2205161533 by adding dummy event weights if none are present (most likely for particle guns)
* Add test to avoid this problem in the future

#### PR validation:

```
% runTheMatrix.py -l 11601.0 --ibeos -t 4
...
1 1 1 1 1 tests passed, 0 0 0 0 0 failed
```