### PR TITLE
Fix CachingAllocator debug for non-async operations

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1102,10 +1102,12 @@ upgradeWFs['PatatrackECALOnlyAlpaka'] = PatatrackWorkflow(
     digi = {
         # customize the ECAL Local Reco part of the HLT menu for Alpaka
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
-        '--procModifiers': 'alpaka'
+        '--procModifiers': 'alpaka',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
@@ -1276,10 +1278,12 @@ upgradeWFs['PatatrackHCALOnlyGPUProfiling'] = PatatrackWorkflow(
 upgradeWFs['PatatrackHCALOnlyAlpakaValidation'] = PatatrackWorkflow(
     digi = {
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
-        '--procModifiers': 'alpaka'
+        '--procModifiers': 'alpaka',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         '-s': 'HARVESTING:@hcalOnlyValidation'
@@ -1294,10 +1298,12 @@ upgradeWFs['PatatrackHCALOnlyAlpakaValidation'] = PatatrackWorkflow(
 upgradeWFs['PatatrackHCALOnlyGPUandAlpakaValidation'] = PatatrackWorkflow(
     digi = {
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
-        '-s' : 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnlyLegacy+reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation+pfClusterHBHEOnlyAlpakaComparisonSequence,DQM:@hcalOnly+@hcal2Only+hcalOnlyOfflineSourceSequenceAlpaka',
-        '--procModifiers': 'alpaka'
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnlyLegacy+reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation+pfClusterHBHEOnlyAlpakaComparisonSequence,DQM:@hcalOnly+@hcal2Only+hcalOnlyOfflineSourceSequenceAlpaka',
+        '--procModifiers': 'alpaka',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         '-s': 'HARVESTING:@hcalOnlyValidation'
@@ -1329,11 +1335,13 @@ upgradeWFs['PatatrackHCALOnlyAlpakaProfiling'] = PatatrackWorkflow(
 upgradeWFs['PatatrackFullRecoAlpaka'] = PatatrackWorkflow(
     digi = {
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
         '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
-        '--procModifiers': 'alpaka,pixelNtupletFit'
+        '--procModifiers': 'alpaka,pixelNtupletFit',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         # skip the @pixelTrackingOnlyDQM harvesting
@@ -1646,16 +1654,15 @@ upgradeWFs['PatatrackFullRecoTripletsGPUValidation'] = PatatrackWorkflow(
     offset = 0.597,
 )
 
-
-# Alpaka workflows
-
 upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
     digi = {
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
-        '--procModifiers': 'alpaka'
+        '--procModifiers': 'alpaka',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
@@ -1667,10 +1674,12 @@ upgradeWFs['PatatrackPixelOnlyAlpaka'] = PatatrackWorkflow(
 upgradeWFs['PatatrackPixelOnlyAlpakaValidation'] = PatatrackWorkflow(
     digi = {
         '--procModifiers': 'alpaka', # alpaka modifier activates customiseHLTForAlpaka
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
-        '--procModifiers': 'alpakaValidation'
+        '--procModifiers': 'alpakaValidation',
+        '--customise' : 'HeterogeneousCore/AlpakaServices/customiseAlpakaServiceMemoryFilling.customiseAlpakaServiceMemoryFilling',
     },
     harvest = {
         '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'

--- a/HeterogeneousCore/AlpakaCore/README.md
+++ b/HeterogeneousCore/AlpakaCore/README.md
@@ -358,13 +358,8 @@ There are a few different options for using Alpaka-based modules in the CMSSW co
 In all cases the configuration must load the necessary `ProcessAccelerator` objects (see below) For accelerators used in production, these are aggregated in `Configuration.StandardSequences.Accelerators_cff`. The `runTheMatrix.py` handles the loading of this `Accelerators_cff` automatically. The HLT menus also load the necessary `ProcessAccelerator`s.
 ```python
 ## Load explicitly
-# One ProcessAccelerator for each accelerator technology
+# One ProcessAccelerator for each accelerator technology, plus a generic one for Alpaka
 process.load("Configuration.StandardSequences.Accelerators_cff")
-
-# And one ProcessAccelerator for Alpaka
-# (eventually to be absorbed to Accelerators_cff)
-process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
-
 ```
 
 ### Explicit module type (non-portable)

--- a/HeterogeneousCore/AlpakaServices/python/customiseAlpakaServiceMemoryFilling.py
+++ b/HeterogeneousCore/AlpakaServices/python/customiseAlpakaServiceMemoryFilling.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseAlpakaServiceMemoryFilling(process):
+  # load all variants of the AlpakaService
+  # ProcessAcceleratorAlpaka will take care of removing the unused ones
+
+  process.load('HeterogeneousCore.AlpakaServices.AlpakaServiceSerialSync_cfi')
+
+  # load the CUDAService and the AlpakaService for the CUDA backend, if available
+  try:
+      process.load('HeterogeneousCore.CUDAServices.CUDAService_cfi')
+      process.load('HeterogeneousCore.AlpakaServices.AlpakaServiceCudaAsync_cfi')
+  except:
+      pass
+
+  # load the ROCmService and the AlpakaService for the ROCm backend, if available
+  try:
+      process.load('HeterogeneousCore.ROCmServices.ROCmService_cfi')
+      process.load('HeterogeneousCore.AlpakaServices.AlpakaServiceROCmAsync_cfi')
+  except:
+      pass
+
+  # enable junk memory filling for all AlpakaServices
+  for name in process.services_():
+    if name.startswith('AlpakaService'):
+      service = getattr(process, name)
+      # host allocator
+      service.hostAllocator.fillAllocations = True
+      service.hostAllocator.fillAllocationValue = 0xB4
+      service.hostAllocator.fillReallocations = True
+      service.hostAllocator.fillReallocationValue = 0x78
+      service.hostAllocator.fillDeallocations = True
+      service.hostAllocator.fillDeallocationValue = 0x4B
+      service.hostAllocator.fillCaches = True
+      service.hostAllocator.fillCacheValue = 0x87
+      # device allocator
+      service.deviceAllocator.fillAllocations = True
+      service.deviceAllocator.fillAllocationValue = 0xA5
+      service.deviceAllocator.fillReallocations = True
+      service.deviceAllocator.fillReallocationValue = 0x69
+      service.deviceAllocator.fillDeallocations = True
+      service.deviceAllocator.fillDeallocationValue = 0x5A
+      service.deviceAllocator.fillCaches = True
+      service.deviceAllocator.fillCacheValue = 0x96
+
+  return process


### PR DESCRIPTION
#### PR description:

@VinInn pointed out that filling memory asynchronously may be incorrect if the memory is later being set synchronously, without using a queue.
This is often the case with pinned host memory buffers, where the allocation and memset may be asynchronous, but the content is accessed directly using host-only operations.

This change makes the allocator wait for the memset to complete before returning the memory buffer to the user code.

It also adds a customisation function to activate memory filling, and uses it in the non-profling Alpaka workflows.

#### PR validation:

The new tests pass.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14.0.x to fix the same bug there.