### PR TITLE
Update HLTPixelTrackFilter to store candidates

### DIFF
--- a/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
+++ b/HLTrigger/special/plugins/HLTPixelTrackFilter.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -11,24 +11,25 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 //
 // class declaration
 //
 
-class HLTPixelTrackFilter : public edm::stream::EDFilter<> {
+class HLTPixelTrackFilter : public HLTFilter {
 public:
   explicit HLTPixelTrackFilter(const edm::ParameterSet&);
   ~HLTPixelTrackFilter() override;
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
-
   edm::InputTag inputTag_;        // input tag identifying product containing pixel clusters
   unsigned int min_pixelTracks_;  // minimum number of clusters
   unsigned int max_pixelTracks_;  // maximum number of clusters
-  edm::EDGetTokenT<reco::TrackCollection> inputToken_;
+  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> inputToken_;
 };
 
 //
@@ -36,10 +37,11 @@ private:
 //
 
 HLTPixelTrackFilter::HLTPixelTrackFilter(const edm::ParameterSet& config)
-    : inputTag_(config.getParameter<edm::InputTag>("pixelTracks")),
+    : HLTFilter(config),
+      inputTag_(config.getParameter<edm::InputTag>("pixelTracks")),
       min_pixelTracks_(config.getParameter<unsigned int>("minPixelTracks")),
       max_pixelTracks_(config.getParameter<unsigned int>("maxPixelTracks")) {
-  inputToken_ = consumes<reco::TrackCollection>(inputTag_);
+  inputToken_ = consumes<reco::RecoChargedCandidateCollection>(inputTag_);
   LogDebug("") << "Using the " << inputTag_ << " input collection";
   LogDebug("") << "Requesting at least " << min_pixelTracks_ << " PixelTracks";
   if (max_pixelTracks_ > 0)
@@ -50,6 +52,7 @@ HLTPixelTrackFilter::~HLTPixelTrackFilter() = default;
 
 void HLTPixelTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("pixelTracks", edm::InputTag("hltPixelTracks"));
   desc.add<unsigned int>("minPixelTracks", 0);
   desc.add<unsigned int>("maxPixelTracks", 0);
@@ -60,12 +63,22 @@ void HLTPixelTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 // member functions
 //
 // ------------ method called to produce the data  ------------
-bool HLTPixelTrackFilter::filter(edm::Event& event, const edm::EventSetup& iSetup) {
+bool HLTPixelTrackFilter::hltFilter(edm::Event& event,
+                                    const edm::EventSetup& iSetup,
+                                    trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+  if (saveTags())
+    filterproduct.addCollectionTag(inputTag_);
+
   // get hold of products from Event
-  edm::Handle<reco::TrackCollection> trackColl;
-  event.getByToken(inputToken_, trackColl);
+  const auto& trackColl = event.getHandle(inputToken_);
 
   unsigned int numTracks = trackColl->size();
+  for (size_t i = 0; i < numTracks; i++)
+    filterproduct.addObject(trigger::TriggerTrack, reco::RecoChargedCandidateRef(trackColl, i));
+
   LogDebug("") << "Number of tracks accepted: " << numTracks;
   bool accept = (numTracks >= min_pixelTracks_);
   if (max_pixelTracks_ > 0)


### PR DESCRIPTION
#### PR description:

This PR updates the HLTPixelTrackFilter to store the online candidates used in the filter. One problem faced in the HIN UPC low pT pixel track triggers used in the PbPb 2023 data tacking, is that the candidates were not stored in the event since the path was relying on a standard filter (CandViewCountFilter) instead of a filter derived from HLTFilter class, which has made the study of the track trigger efficiency challenging. To avoid this in the 2024 data tacking, the HLTPixelTrackFilter is updated to derive from the HLTFilter class and have the option to store the candidates, so it could be used in the HIN UPC triggers.

@vince502 @mandrenguyen 

#### PR validation:

Tested locally by re-emulating the HLT menu and replacing the hltSinglePixelTrackLowPtForUPC module in the HLT_HIon_cff.py menu using the HLTPixelTrackFilter.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
