### PR TITLE
`ObjectSelectorBase` add option to not throw on missing input

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlDiMuonAndVertex_cff.py
@@ -23,7 +23,8 @@ ALCARECOTkAlDiMuonVertexTracks = TracksFromVertex.AlignmentTracksFromVertexSelec
 TkAlDiMuonAndVertexGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                                   src = cms.InputTag("genParticles"),
                                                   cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                                  filter = cms.bool(False))
+                                                  filter = cms.bool(False),
+                                                  throwOnMissing = cms.untracked.bool(False))
 
 ##################################################################
 # The sequence

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_cff.py
@@ -53,7 +53,8 @@ ALCARECOTkAlJpsiMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 TkAlJpsiMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                            src = cms.InputTag("genParticles"),
                                            cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                           filter = cms.bool(False))
+                                           filter = cms.bool(False),
+                                           throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlJpsiMuMu = cms.Sequence(ALCARECOTkAlJpsiMuMuHLT+ALCARECOTkAlJpsiMuMuDCSFilter+ALCARECOTkAlJpsiMuMuGoodMuons+ALCARECOTkAlJpsiMuMu+TkAlJpsiMuMuGenMuonSelector)
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_cff.py
@@ -56,9 +56,10 @@ ALCARECOTkAlUpsilonMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 
 ## for the GEN level information
 TkAlUpsilonMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
-                                        src = cms.InputTag("genParticles"),
-                                        cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                        filter = cms.bool(False))
+                                              src = cms.InputTag("genParticles"),
+                                              cut = cms.string("abs(pdgId) == 13"), # Select only muons
+                                              filter = cms.bool(False),
+                                              throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlUpsilonMuMu = cms.Sequence(ALCARECOTkAlUpsilonMuMuHLT+ALCARECOTkAlUpsilonMuMuDCSFilter+ALCARECOTkAlUpsilonMuMuGoodMuons+ALCARECOTkAlUpsilonMuMuRelCombIsoMuons+ALCARECOTkAlUpsilonMuMu+TkAlUpsilonMuMuGenMuonSelector)
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_cff.py
@@ -55,7 +55,8 @@ ALCARECOTkAlZMuMu.TwoBodyDecaySelector.numberOfCandidates = 1
 TkAlZMuMuGenMuonSelector = cms.EDFilter("GenParticleSelector",
                                         src = cms.InputTag("genParticles"),
                                         cut = cms.string("abs(pdgId) == 13"), # Select only muons
-                                        filter = cms.bool(False))
+                                        filter = cms.bool(False),
+                                        throwOnMissing = cms.untracked.bool(False))
 
 seqALCARECOTkAlZMuMu = cms.Sequence(ALCARECOTkAlZMuMuHLT+ALCARECOTkAlZMuMuDCSFilter+ALCARECOTkAlZMuMuGoodMuons+ALCARECOTkAlZMuMuRelCombIsoMuons+ALCARECOTkAlZMuMu+TkAlZMuMuGenMuonSelector)
 

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -59,7 +59,7 @@ private:
     selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
     if (!throwOnMissing_ && !source.isValid()) {
-      return false;
+      return !filter_;
     }
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -38,6 +38,7 @@ public:
         srcToken_(
             this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
         filter_(false),
+        throwOnMissing_(cfg.template getUntrackedParameter<bool>("throwOnMissing", true)),
         selectorInit_(this->consumesCollector()),
         selector_(cfg, this->consumesCollector()),
         sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
@@ -57,6 +58,9 @@ private:
   bool filter(edm::Event& evt, const edm::EventSetup& es) override {
     selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
+    if (!throwOnMissing_ && !source.isValid()) {
+      return false;
+    }
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);
     selector_.select(source, evt, es);
@@ -70,6 +74,8 @@ private:
   edm::EDGetTokenT<typename Selector::collection> srcToken_;
   /// filter event
   bool filter_;
+  /// trhow on missing
+  bool throwOnMissing_;
   /// Object collection selector
   Init selectorInit_;
   Selector selector_;


### PR DESCRIPTION
fixes https://github.com/cms-sw/cmssw/issues/45384

#### PR description:

Title say it all, and use it to fix workflows broken as pointed out in https://github.com/cms-sw/cmssw/issues/45384#issue-2392129336

#### PR validation:

` runTheMatrix.py -l 1001.3` runs with this addition.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A