### PR TITLE
New SimBeamSpotHLLHC tags in Phase-2 MC GT and make Phase-2 workflows consume it

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -100,7 +100,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024 detector for Heavy Ion
     'phase1_2024_realistic_hi'     :    '141X_mcRun3_2024_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             :    '140X_mcRun4_realistic_v4'
+    'phase2_realistic'             :    '141X_mcRun4_realistic_v1'
 }
 
 aliases = {
@@ -125,6 +125,10 @@ autoCond = autoCondHLT(autoCond)
 # dedicated GlobalTags for phase-2 (specializing conditions for each geometry)
 from Configuration.AlCa.autoCondPhase2 import autoCondPhase2
 autoCond = autoCondPhase2(autoCond)
+
+# special GTs for phase-2 with BeamSpot at 13 TeV (instead of 14 TeV)
+from Configuration.AlCa.autoCondModifiers import autoCondBSHLLHC13TeV
+autoCond = autoCondBSHLLHC13TeV(autoCond)
 
 # special cases modifier for autoCond GTs
 from Configuration.AlCa.autoCondModifiers import autoCond0T

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -125,3 +125,20 @@ def autoCondRelValForRun3(autoCond):
     autoCond.update(GlobalTagRelValForRun3)
     return autoCond
 
+def autoCondBSHLLHC13TeV(autoCond):
+
+    GlobalTagBSHLLHC13TeV = {}
+    SimBeamSpotForHLLHC13TeV = ','.join( ['SimBeamSpotHLLHCObjects_z4p3cm_t193ns_13TeV_nominal_mc_v1', "SimBeamSpotHLLHCObjectsRcd", connectionString, "", "2024-07-04 15:00:00.000"] )
+
+    for key,val in autoCond.items():
+        if 'phase2_realistic' in key:
+            # If 'phase2_realistic_T' is in key, it means it was already modified
+            # by autoCondPhase2: simply add to the already existing tuple
+            if 'phase2_realistic_T' in key:
+                GlobalTagBSHLLHC13TeV[key+'_13TeV'] = autoCond[key] + (SimBeamSpotForHLLHC13TeV,)
+            # Else, build the tuple as done in the rest of the autoCondModifiers
+            else:
+                GlobalTagBSHLLHC13TeV[key+'_13TeV'] = (autoCond[key], SimBeamSpotForHLLHC13TeV)
+
+    autoCond.update(GlobalTagBSHLLHC13TeV)
+    return autoCond

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1148,7 +1148,7 @@ steps['Cosmics_Phase2']=merge([{'cfg':'UndergroundCosmicMu_cfi.py',
                                 '--scenario':'cosmics',
                                 '--era': phase2CosInfo['Era'],
                                 '--geometry': phase2CosInfo['Geom'],
-                                '--beamspot':'HLLHC14TeV'},Kby(666,100000),step1Defaults])
+                                '--beamspot':'DBrealisticHLLHC'},Kby(666,100000),step1Defaults])
 
 steps['BeamHalo']=merge([{'cfg':'BeamHalo_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Defaults])
 steps['BeamHalo_13']=merge([{'cfg':'BeamHalo_13TeV_cfi.py','--scenario':'cosmics'},Kby(9,100),step1Up2015Defaults])
@@ -4311,8 +4311,8 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
 
     upgradeStepDict['GenSimHLBeamSpot'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
-                                       '--conditions' : gt,
-                                       '--beamspot' : 'HLLHC',
+                                       '--conditions' : gt+'_13TeV',
+                                       '--beamspot' : 'DBrealisticHLLHC',
                                        '--datatier' : 'GEN-SIM',
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom
@@ -4321,7 +4321,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
     upgradeStepDict['GenSimHLBeamSpot14'][k]= {'-s' : 'GEN,SIM',
                                        '-n' : 10,
                                        '--conditions' : gt,
-                                       '--beamspot' : 'HLLHC14TeV',
+                                       '--beamspot' : 'DBrealisticHLLHC',
                                        '--datatier' : 'GEN-SIM',
                                        '--eventcontent': 'FEVTDEBUG',
                                        '--geometry' : geom

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -1,6 +1,7 @@
 VtxSmeared = {
     'DBdesign':                      'IOMC.EventVertexGenerators.VtxSmearedDesign_cfi',
     'DBrealistic':                   'IOMC.EventVertexGenerators.VtxSmearedRealistic_cfi',
+    'DBrealisticHLLHC':              'IOMC.EventVertexGenerators.VtxSmearedRealisticHLLHC_cfi',
     'NoSmear':                       'Configuration.StandardSequences.VtxSmearedNoSmear_cff',              
     'BetafuncEarlyCollision':        'IOMC.EventVertexGenerators.VtxSmearedBetafuncEarlyCollision_cfi',    
     'BeamProfile':                   'IOMC.EventVertexGenerators.VtxSmearedBeamProfile_cfi',               

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHLLHC_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealisticHLLHC_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+# Load HLLHCEvtVtxGenerator and read parameters from GT (SimBeamSpotHLLHCObjectsRcd)
+from IOMC.EventVertexGenerators.HLLHCEvtVtxGenerator_cfi import HLLHCEvtVtxGenerator
+VtxSmeared = HLLHCEvtVtxGenerator.clone(
+    src = "generator:unsmeared",
+    readDB = True
+)


### PR DESCRIPTION
#### PR description:
In order to complete https://github.com/cms-AlCaDB/AlCaTools/issues/95, and following the discussion in [this AlCaDB CMSTalk post](https://cms-talk.web.cern.ch/t/mc-request-for-a-new-phase2-realistic-gt/43128), in this PR I'm adding the new SimBeamSpotHLLHC tags to the Phase-2 MC GT, and I'm updating the Phase-2 relvals to consume it, similarly to what was done for Run1/2/3 MC GTs in https://github.com/cms-sw/cmssw/pull/43242.

In order to consume these tags I have introduced a new `DBrealisticHLLHC` vertex smearing scenario which is configured through `IOMC.EventVertexGenerators.VtxSmearedRealisticHLLHC_cfi` to use the HLLHCEvtVtxGenerator and read the parameters from the GT.
The GenSim steps of the Phase2 workflows are now updated to used this scenario by default.

Since only one Phase-2 GT is currently available in autoCond, the 14 TeV tag is added by default to the GT (see links below), while the 13 TeV tag is added to a new `autoCondBSHLLHC13TeV` modifier, which creates new symbolic `phase2` GTs with an additional `_13TeV` in the name, that will be consumed where the `HLLHC` scenario used to be used.

New tags and GTs:
- Tags:
  - `SimBeamSpotHLLHCObjects_z4p3cm_t193ns_14TeV_nominal_mc_v1` ([Conddb link](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/SimBeamSpotHLLHCObjects_z4p3cm_t193ns_14TeV_nominal_mc_v1))
    - Payload Inspector link: https://cern.ch/67bba
  - `SimBeamSpotHLLHCObjects_z4p3cm_t193ns_13TeV_nominal_mc_v1` ([Conddb link](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/tags/SimBeamSpotHLLHCObjects_z4p3cm_t193ns_13TeV_nominal_mc_v1))
    - Payload Inspector link: https://cern.ch/zcega
  - Payload Inspector of the difference: https://cern.ch/vw5tc
- GT
  - `141X_mcRun4_realistic_v1` ([Conddb link]())
    - Diff wrt previous GT: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun4_realistic_v4/141X_mcRun4_realistic_v1

#### PR validation:
Run:
```
# For HLLHC scenario
runTheMatrix.py -l 29661.0 --ibeos -j 8
# For HLLHC14TeV scenario
runTheMatrix.py --what upgrade -l 20027.0 --ibeos -j 8
```
and verified that:
 - they finish successfully
 - the GS step of the workflows is configured with the correct `--conditions` and `--beamspot` values

#### Backport:
Not a backport, no backport needed