### PR TITLE
Backport to 14_0_X of PR#45386 "Updated EcalUncalibRecHitTimingCCAlgo to correct for bias at high energies"

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimingCCAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimingCCAlgo.h
@@ -24,7 +24,8 @@ public:
                        const EcalMGPAGainRatio* aGain,
                        const FullSampleVector& fullpulse,
                        const float targetTimePrecision,
-                       const bool correctForOOT = true) const;
+                       const bool correctForOOT = true,
+					   const bool correctForSlew = true ) const;
 
 private:
   const float startTime_;
@@ -38,7 +39,7 @@ private:
   static constexpr float ONE_MINUS_GOLDEN_RATIO = 1.0 - GOLDEN_RATIO;
 
   FullSampleVector interpolatePulse(const FullSampleVector& fullpulse, const float t = 0) const;
-  float computeCC(const std::vector<float>& samples, const FullSampleVector& sigmalTemplate, const float t) const;
+  float computeCC(const std::vector<float>& samples, const std::vector<float>& weights, const FullSampleVector& sigmalTemplate, const float t) const;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimingCCAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimingCCAlgo.h
@@ -25,7 +25,7 @@ public:
                        const FullSampleVector& fullpulse,
                        const float targetTimePrecision,
                        const bool correctForOOT = true,
-					   const bool correctForSlew = true ) const;
+                       const bool correctForSlew = true) const;
 
 private:
   const float startTime_;
@@ -39,7 +39,10 @@ private:
   static constexpr float ONE_MINUS_GOLDEN_RATIO = 1.0 - GOLDEN_RATIO;
 
   FullSampleVector interpolatePulse(const FullSampleVector& fullpulse, const float t = 0) const;
-  float computeCC(const std::vector<float>& samples, const std::vector<float>& weights, const FullSampleVector& sigmalTemplate, const float t) const;
+  float computeCC(const std::vector<float>& samples,
+                  const std::vector<float>& weights,
+                  const FullSampleVector& sigmalTemplate,
+                  const float t) const;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
@@ -9,13 +9,19 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
                                                     const EcalMGPAGainRatio* aGain,
                                                     const FullSampleVector& fullpulse,
                                                     const float targetTimePrecision,
-                                                    const bool correctForOOT) const {
+                                                    const bool correctForOOT,
+													const bool correctForSlew ) const {
+
   constexpr unsigned int nsample = EcalDataFrame::MAXSAMPLES;
 
   double maxamplitude = -std::numeric_limits<double>::max();
   float pulsenorm = 0.;
 
+  bool doOOTAmpCorrection(correctForOOT);
   std::vector<float> pedSubSamples(nsample);
+  std::vector<float> weights(nsample,1.f);
+  float minADC = (dataFrame.sample(0)).adc();
+  for (unsigned int iSample = 1; iSample < nsample; iSample++) { if( (dataFrame.sample(iSample)).adc() < minADC ) minADC = (dataFrame.sample(iSample)).adc(); }
   for (unsigned int iSample = 0; iSample < nsample; iSample++) {
     const EcalMGPASample& sample = dataFrame.sample(iSample);
 
@@ -48,10 +54,17 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
     if (amplitude > maxamplitude) {
       maxamplitude = amplitude;
     }
-    pulsenorm += fullpulse(iSample);
+
+	if( iSample > 0 && correctForSlew ){ 
+		int GainIdPrev = dataFrame.sample(iSample - 1).gainId();
+		bool GainIdInRange = GainIdPrev >= 1 && GainIdPrev <= 3 && gainId >= 1 && gainId <= 3;
+		bool GainSlew = GainIdPrev < gainId;
+        if( GainIdInRange && GainSlew ) weights[iSample - 1] = 0.f;
+	}
+
   }
 
-  if (correctForOOT) {
+  if( doOOTAmpCorrection ){
     int ipulse = -1;
     for (auto const& amplit : amplitudes) {
       ipulse++;
@@ -61,7 +74,7 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
       for (unsigned int isample = firstsamplet; isample < nsample; ++isample) {
         auto const pulse = fullpulse(isample + offset);
-        pedSubSamples[isample] = std::max(0., pedSubSamples[isample] - amplit * pulse / pulsenorm);
+        pedSubSamples[isample] = pedSubSamples[isample] - ( amplit * pulse / pulsenorm );
       }
     }
   }
@@ -74,9 +87,9 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
   int counter = 0;
 
-  float cc1 = computeCC(pedSubSamples, fullpulse, t1);
+  float cc1 = computeCC(pedSubSamples, weights, fullpulse, t1);
   ++counter;
-  float cc2 = computeCC(pedSubSamples, fullpulse, t2);
+  float cc2 = computeCC(pedSubSamples, weights, fullpulse, t2);
   ++counter;
 
   while (std::abs(t3 - t0) > targetTimePrecision && counter < MAX_NUM_OF_ITERATIONS) {
@@ -85,23 +98,22 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
       t1 = t2;
       t2 = GOLDEN_RATIO * t2 + ONE_MINUS_GOLDEN_RATIO * t3;
       cc1 = cc2;
-      cc2 = computeCC(pedSubSamples, fullpulse, t2);
+      cc2 = computeCC(pedSubSamples, weights, fullpulse, t2);
       ++counter;
     } else {
       t3 = t2;
       t2 = t1;
       t1 = GOLDEN_RATIO * t1 + ONE_MINUS_GOLDEN_RATIO * t0;
       cc2 = cc1;
-      cc1 = computeCC(pedSubSamples, fullpulse, t1);
+      cc1 = computeCC(pedSubSamples, weights, fullpulse, t1);
       ++counter;
     }
   }
 
   float tM = (t3 + t0) / 2 - GLOBAL_TIME_SHIFT;
-  if (counter < MIN_NUM_OF_ITERATIONS || counter > MAX_NUM_OF_ITERATIONS - 1) {
-    tM = TIME_WHEN_NOT_CONVERGING * ecalPh1::Samp_Period;
-  }
-  return -tM / ecalPh1::Samp_Period;
+  if (counter < MIN_NUM_OF_ITERATIONS || counter > MAX_NUM_OF_ITERATIONS - 1) { tM = TIME_WHEN_NOT_CONVERGING * ecalPh1::Samp_Period; }
+  float cct = -tM / ecalPh1::Samp_Period;
+  return cct;
 }
 
 FullSampleVector EcalUncalibRecHitTimingCCAlgo::interpolatePulse(const FullSampleVector& fullpulse,
@@ -144,6 +156,7 @@ FullSampleVector EcalUncalibRecHitTimingCCAlgo::interpolatePulse(const FullSampl
 }
 
 float EcalUncalibRecHitTimingCCAlgo::computeCC(const std::vector<float>& samples,
+											   const std::vector<float>& weights,
                                                const FullSampleVector& signalTemplate,
                                                const float time) const {
   constexpr int exclude = 1;
@@ -152,9 +165,9 @@ float EcalUncalibRecHitTimingCCAlgo::computeCC(const std::vector<float>& samples
   float cc = 0.;
   auto interpolated = interpolatePulse(signalTemplate, time);
   for (int i = exclude; i < int(samples.size() - exclude); ++i) {
-    powerSamples += std::pow(samples[i], 2);
-    powerTemplate += std::pow(interpolated[i], 2);
-    cc += interpolated[i] * samples[i];
+    powerSamples += std::pow(samples[i], 2) * weights[i];
+    powerTemplate += std::pow(interpolated[i], 2) * weights[i];
+    cc += interpolated[i] * samples[i] * weights[i];
   }
 
   float denominator = std::sqrt(powerTemplate * powerSamples);

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
@@ -17,11 +17,8 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
   double maxamplitude = -std::numeric_limits<double>::max();
   float pulsenorm = 0.;
 
-  bool doOOTAmpCorrection(correctForOOT);
   std::vector<float> pedSubSamples(nsample);
   std::vector<float> weights(nsample,1.f);
-  float minADC = (dataFrame.sample(0)).adc();
-  for (unsigned int iSample = 1; iSample < nsample; iSample++) { if( (dataFrame.sample(iSample)).adc() < minADC ) minADC = (dataFrame.sample(iSample)).adc(); }
   for (unsigned int iSample = 0; iSample < nsample; iSample++) {
     const EcalMGPASample& sample = dataFrame.sample(iSample);
 
@@ -51,6 +48,8 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
     pedSubSamples[iSample] = amplitude;
 
+    pulsenorm += fullpulse(iSample);
+
     if (amplitude > maxamplitude) {
       maxamplitude = amplitude;
     }
@@ -64,7 +63,7 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
   }
 
-  if( doOOTAmpCorrection ){
+  if( correctForOOT ){
     int ipulse = -1;
     for (auto const& amplit : amplitudes) {
       ipulse++;
@@ -112,8 +111,7 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
   float tM = (t3 + t0) / 2 - GLOBAL_TIME_SHIFT;
   if (counter < MIN_NUM_OF_ITERATIONS || counter > MAX_NUM_OF_ITERATIONS - 1) { tM = TIME_WHEN_NOT_CONVERGING * ecalPh1::Samp_Period; }
-  float cct = -tM / ecalPh1::Samp_Period;
-  return cct;
+  return -tM / ecalPh1::Samp_Period;
 }
 
 FullSampleVector EcalUncalibRecHitTimingCCAlgo::interpolatePulse(const FullSampleVector& fullpulse,

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitTimingCCAlgo.cc
@@ -10,15 +10,14 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
                                                     const FullSampleVector& fullpulse,
                                                     const float targetTimePrecision,
                                                     const bool correctForOOT,
-													const bool correctForSlew ) const {
-
+                                                    const bool correctForSlew) const {
   constexpr unsigned int nsample = EcalDataFrame::MAXSAMPLES;
 
   double maxamplitude = -std::numeric_limits<double>::max();
   float pulsenorm = 0.;
 
   std::vector<float> pedSubSamples(nsample);
-  std::vector<float> weights(nsample,1.f);
+  std::vector<float> weights(nsample, 1.f);
   for (unsigned int iSample = 0; iSample < nsample; iSample++) {
     const EcalMGPASample& sample = dataFrame.sample(iSample);
 
@@ -54,16 +53,16 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
       maxamplitude = amplitude;
     }
 
-	if( iSample > 0 && correctForSlew ){ 
-		int GainIdPrev = dataFrame.sample(iSample - 1).gainId();
-		bool GainIdInRange = GainIdPrev >= 1 && GainIdPrev <= 3 && gainId >= 1 && gainId <= 3;
-		bool GainSlew = GainIdPrev < gainId;
-        if( GainIdInRange && GainSlew ) weights[iSample - 1] = 0.f;
-	}
-
+    if (iSample > 0 && correctForSlew) {
+      int GainIdPrev = dataFrame.sample(iSample - 1).gainId();
+      bool GainIdInRange = GainIdPrev >= 1 && GainIdPrev <= 3 && gainId >= 1 && gainId <= 3;
+      bool GainSlew = GainIdPrev < gainId;
+      if (GainIdInRange && GainSlew)
+        weights[iSample - 1] = 0.f;
+    }
   }
 
-  if( correctForOOT ){
+  if (correctForOOT) {
     int ipulse = -1;
     for (auto const& amplit : amplitudes) {
       ipulse++;
@@ -73,7 +72,7 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
 
       for (unsigned int isample = firstsamplet; isample < nsample; ++isample) {
         auto const pulse = fullpulse(isample + offset);
-        pedSubSamples[isample] = pedSubSamples[isample] - ( amplit * pulse / pulsenorm );
+        pedSubSamples[isample] = pedSubSamples[isample] - (amplit * pulse / pulsenorm);
       }
     }
   }
@@ -110,7 +109,9 @@ double EcalUncalibRecHitTimingCCAlgo::computeTimeCC(const EcalDataFrame& dataFra
   }
 
   float tM = (t3 + t0) / 2 - GLOBAL_TIME_SHIFT;
-  if (counter < MIN_NUM_OF_ITERATIONS || counter > MAX_NUM_OF_ITERATIONS - 1) { tM = TIME_WHEN_NOT_CONVERGING * ecalPh1::Samp_Period; }
+  if (counter < MIN_NUM_OF_ITERATIONS || counter > MAX_NUM_OF_ITERATIONS - 1) {
+    tM = TIME_WHEN_NOT_CONVERGING * ecalPh1::Samp_Period;
+  }
   return -tM / ecalPh1::Samp_Period;
 }
 
@@ -154,7 +155,7 @@ FullSampleVector EcalUncalibRecHitTimingCCAlgo::interpolatePulse(const FullSampl
 }
 
 float EcalUncalibRecHitTimingCCAlgo::computeCC(const std::vector<float>& samples,
-											   const std::vector<float>& weights,
+                                               const std::vector<float>& weights,
                                                const FullSampleVector& signalTemplate,
                                                const float time) const {
   constexpr int exclude = 1;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -644,7 +644,8 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
         for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes[ibx] = uncalibRecHit.outOfTimeAmplitude(ibx);
 
-        bool const doSlewCorrection = barrel ? crossCorrelationUseSlewCorrectionEB_ : crossCorrelationUseSlewCorrectionEE_;
+        bool const doSlewCorrection =
+            barrel ? crossCorrelationUseSlewCorrectionEB_ : crossCorrelationUseSlewCorrectionEE_;
 
         float jitter = computeCC_->computeTimeCC(
                            *itdg, amplitudes, aped, aGain, fullpulse, CCtargetTimePrecision_, true, doSlewCorrection) +

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -640,19 +640,24 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
         uncalibRecHit.setJitterError(0.);  // not computed with weights
 
       } else if (timealgo_ == crossCorrelationMethod) {
-		
         std::vector<double> amplitudes(activeBX.size());
         for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes[ibx] = uncalibRecHit.outOfTimeAmplitude(ibx);
 
-		bool const doSlewCorrection = barrel ? useSlewCorrectionEB_ : useSlewCorrectionEE_;
-		
-        float jitter =
-            computeCC_->computeTimeCC(*itdg, amplitudes, aped, aGain, fullpulse, CCtargetTimePrecision_, true, doSlewCorrection ) +
-            CCTimeShiftWrtRations_ / ecalcctiming::clockToNS;
-        float noCorrectedJitter =
-            computeCC_->computeTimeCC(*itdg, amplitudes, aped, aGain, fullpulse, CCtargetTimePrecisionForDelayedPulses_, false, doSlewCorrection ) +
-            CCTimeShiftWrtRations_ / ecalcctiming::clockToNS;
+        bool const doSlewCorrection = barrel ? useSlewCorrectionEB_ : useSlewCorrectionEE_;
+
+        float jitter = computeCC_->computeTimeCC(
+                           *itdg, amplitudes, aped, aGain, fullpulse, CCtargetTimePrecision_, true, doSlewCorrection) +
+                       CCTimeShiftWrtRations_ / ecalcctiming::clockToNS;
+        float noCorrectedJitter = computeCC_->computeTimeCC(*itdg,
+                                                            amplitudes,
+                                                            aped,
+                                                            aGain,
+                                                            fullpulse,
+                                                            CCtargetTimePrecisionForDelayedPulses_,
+                                                            false,
+                                                            doSlewCorrection) +
+                                  CCTimeShiftWrtRations_ / ecalcctiming::clockToNS;
 
         uncalibRecHit.setJitter(jitter);
         uncalibRecHit.setNonCorrectedTime(jitter, noCorrectedJitter);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -169,8 +169,8 @@ private:
   double CCTimeShiftWrtRations_;
   double CCtargetTimePrecision_;
   double CCtargetTimePrecisionForDelayedPulses_;
-  bool useSlewCorrectionEB_;
-  bool useSlewCorrectionEE_;
+  bool crossCorrelationUseSlewCorrectionEB_;
+  bool crossCorrelationUseSlewCorrectionEE_;
 };
 
 EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet& ps, edm::ConsumesCollector& c)
@@ -240,8 +240,8 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
     CCminTimeToBeLateMin_ = ps.getParameter<double>("crossCorrelationMinTimeToBeLateMin") / ecalcctiming::clockToNS;
     CCminTimeToBeLateMax_ = ps.getParameter<double>("crossCorrelationMinTimeToBeLateMax") / ecalcctiming::clockToNS;
     CCTimeShiftWrtRations_ = ps.getParameter<double>("crossCorrelationTimeShiftWrtRations");
-    useSlewCorrectionEB_ = ps.getParameter<bool>("useSlewCorrectionEB");
-    useSlewCorrectionEE_ = ps.getParameter<bool>("useSlewCorrectionEE");
+    crossCorrelationUseSlewCorrectionEB_ = ps.getParameter<bool>("crossCorrelationUseSlewCorrectionEB");
+    crossCorrelationUseSlewCorrectionEE_ = ps.getParameter<bool>("crossCorrelationUseSlewCorrectionEE");
     computeCC_ = std::make_unique<EcalUncalibRecHitTimingCCAlgo>(startTime, stopTime);
   } else if (timeAlgoName != "None")
     edm::LogError("EcalUncalibRecHitError") << "No time estimation algorithm defined";
@@ -644,7 +644,7 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
         for (unsigned int ibx = 0; ibx < activeBX.size(); ++ibx)
           amplitudes[ibx] = uncalibRecHit.outOfTimeAmplitude(ibx);
 
-        bool const doSlewCorrection = barrel ? useSlewCorrectionEB_ : useSlewCorrectionEE_;
+        bool const doSlewCorrection = barrel ? crossCorrelationUseSlewCorrectionEB_ : crossCorrelationUseSlewCorrectionEE_;
 
         float jitter = computeCC_->computeTimeCC(
                            *itdg, amplitudes, aped, aGain, fullpulse, CCtargetTimePrecision_, true, doSlewCorrection) +
@@ -794,8 +794,8 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerMultiFit::getAlgoDescription
               edm::ParameterDescription<double>("outOfTimeThresholdGain61mEE", 1000, true) and
               edm::ParameterDescription<double>("amplitudeThresholdEB", 10, true) and
               edm::ParameterDescription<double>("amplitudeThresholdEE", 10, true) and
-              edm::ParameterDescription<bool>("useSlewCorrectionEB", true, true) and
-              edm::ParameterDescription<bool>("useSlewCorrectionEE", false, true) and
+              edm::ParameterDescription<bool>("crossCorrelationUseSlewCorrectionEB", true, true) and
+              edm::ParameterDescription<bool>("crossCorrelationUseSlewCorrectionEE", false, true) and
               edm::ParameterDescription<double>("crossCorrelationStartTime", -25.0, true) and
               edm::ParameterDescription<double>("crossCorrelationStopTime", 25.0, true) and
               edm::ParameterDescription<double>("crossCorrelationTargetTimePrecision", 0.01, true) and

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -522,7 +522,6 @@ void EcalUncalibRecHitWorkerMultiFit::run(const edm::Event& evt,
       // === time computation ===
       if (timealgo_ == ratioMethod) {
         // ratio method
-        //std::cout << " Using Ratio method !!!!!!!!!!! " << std::endl;
         constexpr float clockToNsConstant = 25.;
         constexpr float invClockToNs = 1. / clockToNsConstant;
         if (not barrel) {
@@ -770,8 +769,8 @@ edm::ParameterSetDescription EcalUncalibRecHitWorkerMultiFit::getAlgoDescription
                                                              true) and
               edm::ParameterDescription<std::vector<double>>("EBamplitudeFitParameters", {1.138, 1.652}, true) and
               edm::ParameterDescription<std::vector<double>>("EEamplitudeFitParameters", {1.890, 1.400}, true) and
-              edm::ParameterDescription<edm::ESInputTag>("timeCalibTag", edm::ESInputTag(":CC"), true) and
-              edm::ParameterDescription<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag(":CC"), true) and
+              edm::ParameterDescription<edm::ESInputTag>("timeCalibTag", edm::ESInputTag(), true) and
+              edm::ParameterDescription<edm::ESInputTag>("timeOffsetTag", edm::ESInputTag(), true) and
               edm::ParameterDescription<double>("EBtimeFitLimits_Lower", 0.2, true) and
               edm::ParameterDescription<double>("EBtimeFitLimits_Upper", 1.4, true) and
               edm::ParameterDescription<double>("EEtimeFitLimits_Lower", 0.2, true) and

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -14,6 +14,8 @@ run3_ecal.toModify(ecalMultiFitUncalibRecHit,
         outOfTimeThresholdGain12mEB = 3.0,
         outOfTimeThresholdGain61pEB = 3.0,
         outOfTimeThresholdGain61mEB = 3.0,
+        useSlewCorrectionEB = True,
+        useSlewCorrectionEE = False,
         timeCalibTag = ':CC',
         timeOffsetTag = ':CC'
     )

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -14,8 +14,6 @@ run3_ecal.toModify(ecalMultiFitUncalibRecHit,
         outOfTimeThresholdGain12mEB = 3.0,
         outOfTimeThresholdGain61pEB = 3.0,
         outOfTimeThresholdGain61mEB = 3.0,
-        useSlewCorrectionEB = True,
-        useSlewCorrectionEE = False,
         timeCalibTag = ':CC',
         timeOffsetTag = ':CC'
     )


### PR DESCRIPTION
Backport of PR#45386 "Updated EcalUncalibRecHitTimingCCAlgo to correct for bias at high energies"

Added correction for MPGA slew issue to CC time reconstruction algorithm
Added useSlewCorrectionEB and useSlewCorrectionEE parameters to activate slew correction code
Tested and presented in ECAL DPG : https://indico.cern.ch/event/1433850/