### PR TITLE
Update GTs and modifiers for L1T 2024 menu L1Menu_Collisions2024_v1_3_0_xml [14_0_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -90,13 +90,13 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2023 detector for Heavy Ion
     'phase1_2023_realistic_hi'     :    '140X_mcRun3_2023_realistic_HI_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2024
-    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v10',
+    'phase1_2024_design'           :    '140X_mcRun3_2024_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v11',
+    'phase1_2024_realistic'        :    '140X_mcRun3_2024_realistic_v15',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v12',
+    'phase1_2024_cosmics'          :    '140X_mcRun3_2024cosmics_realistic_deco_v13',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2024, Strip tracker in DECO mode
-    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v10',
+    'phase1_2024_cosmics_design'   :    '140X_mcRun3_2024cosmics_design_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             :    '140X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -115,7 +115,7 @@ def autoCondRelValForRun3(autoCond):
 
     GlobalTagRelValForRun3 = {}
     L1GtTriggerMenuForRelValForRun3 =    ','.join( ['L1Menu_Collisions2015_25nsStage1_v5' , "L1GtTriggerMenuRcd",             connectionString, "", "2023-01-28 12:00:00.000"] )
-    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_2_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-04-28 12:00:00.000"] )
+    L1TUtmTriggerMenuForRelValForRun3 =  ','.join( ['L1Menu_Collisions2024_v1_3_0_xml'    , "L1TUtmTriggerMenuRcd",           connectionString, "", "2024-07-03 12:00:00.000"] )
 
     for key,val in autoCond.items():
         if 'run3_data' in key or 'run3_hlt' in key :


### PR DESCRIPTION
Update L1T menu in the 2024 MC GTs with L1Menu_Collisions2024_v1_3_0_xml, as from [cmsTalk](https://cms-talk.web.cern.ch/t/gt-mc-data-relval-update-of-the-2024-l1t-menu-tag-l1menu-collisions2024-v1-3-0/43046), as well as the modifier for the L1T menu to be used in data RelVals.

The new L1T menu tag replaces the previous L1Menu_Collisions2024_v1_2_0_xml. The difference wrt the previous tag is summarized [here](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/development/L1Menu_Collisions2024_v1_3_0) , and the new or removed seeds can be visible also via the Payload Inspector:
![L1TDiff](https://github.com/cms-sw/cmssw/assets/4069749/570abe57-e767-4be9-89f4-5cafe7d2668b)

The updated 2024 MC GTs in autoCond are the following:
- [140X_mcRun3_2024_realistic_v15](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_realistic_v15)
- [140X_mcRun3_2024_design_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024_design_v11)
- [140X_mcRun3_2024cosmics_realistic_deco_v13](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v13)
- [140X_mcRun3_2024cosmics_design_deco_v11](https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v11)

And the difference wrt the GTs previously in autocond are the following:
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_realistic_v14/140X_mcRun3_2024_realistic_v15
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024_design_v10/140X_mcRun3_2024_design_v11
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_realistic_deco_v12/140X_mcRun3_2024cosmics_realistic_deco_v13
- https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/140X_mcRun3_2024cosmics_design_deco_v10/140X_mcRun3_2024cosmics_design_deco_v11

Please notice that the new `phase1_2024_realistic` GT includes also three additional updates that were not yet propagated to autocond, and therefore pile-up here on top of the L1T menu change:
- 140X_mcRun3_2024_realistic_v12:
   - Update GEM Channel mapping for 2024 MC conditions. See [cmsTalk](https://cms-talk.web.cern.ch/t/gt-data-2024-data-taking-from-gem-channel-mapping-and-strip-masking-updates/36149/3)
- 140X_mcRun3_2024_realistic_v13:
   - Update HLT PF hadron Calibration and JECs in preparation for Run3Summer24 campaign See details of the conditions in  [cmsTalk]( https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716)
- 140X_mcRun3_2024_realistic_v14: 
   - Update offline PF hadron calibration for 2024 MC i.e. Run3Summer24 campaign (See details in [cmsTalk](https://cms-talk.web.cern.ch/t/call-for-run3winter24-mc-conditions-in-133x/30716/11)). The offline JECs derived with this PF HC should follow soon once they are ready

backport of #45389
