### PR TITLE
Catch VertexException in PATLeptonTimeLifeInfoProducer when fitVertex fails

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
@@ -53,9 +53,14 @@ private:
   static bool fitVertex(const std::vector<reco::TransientTrack>& transTrk, TransientVertex& transVtx) {
     if (transTrk.size() < 2)
       return false;
-    KalmanVertexFitter kvf(true);
-    transVtx = kvf.vertex(transTrk);
-    return transVtx.hasRefittedTracks() && transVtx.refittedTracks().size() == transTrk.size();
+    try {
+      KalmanVertexFitter kvf(true);
+      transVtx = kvf.vertex(transTrk);
+      return transVtx.hasRefittedTracks() && transVtx.refittedTracks().size() == transTrk.size();
+    } catch (VertexException& e) {
+      edm::LogWarning("PATLeptonTimeLifeInfoProducer") << " fitVertex failed: " << e.what();
+      return false;
+    }
   }
 
   //--- configuration parameters


### PR DESCRIPTION
#### PR description:

VertexException was occurring in PATLeptonTimeLifeInfoProducer when fitVertex failed. This PR fixes the issue by catching such exceptions in the fitVertex method and returning false.
How to reproduce exception:
```
edmCopyPickMerge outputFile=mini.root inputFiles=/store/mc/Run3Summer22MiniAODv4/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/MINIAODSIM/130X_mcRun3_2022_realistic_v5-v2/30000/d8195b83-9e92-4dd4-b286-dc358ec9568a.root eventsToProcess=1:26427:49708440
cmsDriver.py nano --filein file:mini.root --fileout file:nano.root --eventcontent NANOAODSIM --datatier NANOAODSIM --step NANO --nThreads 1 --conditions auto:phase1_2022_realistic --era Run3 --mc -n -1
```
Exception message:
```
----- Begin Fatal Exception 06-Jul-2024 07:38:06 CEST-----------------------
An exception of category 'VertexException' occurred while
   [0] Processing  Event run: 1 lumi: 26427 event: 49708440 stream: 0
   [1] Running path 'NANOAODSIMoutput_step'
   [2] Prefetching for module NanoAODOutputModule/'NANOAODSIMoutput'
   [3] Prefetching for module SimplePATTau2TrackTimeLifeInfoFlatTableProducer/'tauTimeLifeInfoTable'
   [4] Calling method for module PATTauTimeLifeInfoProducer/'tauTimeLifeInfos'
Exception Message:
BasicSingleVertexState::could not invert weight matrix
----- End Fatal Exception -------------------------------------------------

```
No changes to the output are expected.

#### PR validation:

Validated on several miniAOD files in `CMSSW_14_0_6_patch1` and `CMSSW_14_1_0_pre5` releases, for which the processing was originally failing due to the exception described above.

FYI @mbluj 