### PR TITLE
[14_0_X] Catch VertexException in PATLeptonTimeLifeInfoProducer when fitVertex fails

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonTimeLifeInfoProducer.cc
@@ -53,9 +53,14 @@ private:
   static bool fitVertex(const std::vector<reco::TransientTrack>& transTrk, TransientVertex& transVtx) {
     if (transTrk.size() < 2)
       return false;
-    KalmanVertexFitter kvf(true);
-    transVtx = kvf.vertex(transTrk);
-    return transVtx.hasRefittedTracks() && transVtx.refittedTracks().size() == transTrk.size();
+    try {
+      KalmanVertexFitter kvf(true);
+      transVtx = kvf.vertex(transTrk);
+      return transVtx.hasRefittedTracks() && transVtx.refittedTracks().size() == transTrk.size();
+    } catch (VertexException& e) {
+      edm::LogWarning("PATLeptonTimeLifeInfoProducer") << " fitVertex failed: " << e.what();
+      return false;
+    }
   }
 
   //--- configuration parameters


### PR DESCRIPTION
#### PR description:

VertexException was occurring in PATLeptonTimeLifeInfoProducer when fitVertex failed. This PR fixes the issue by catching such exceptions in the fitVertex method and returning false.

#### PR validation:

Validated on a miniAOD file, on which the processing was originally failing due to the exception described above.

This PR is a backport of #45393 into 14_0_X.
