### PR TITLE
Add OutputModule test for TestProcessor

### DIFF
--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -41,6 +41,7 @@ namespace edm {
     void write(EventForOutput const& e) override;
     void writeLuminosityBlock(LuminosityBlockForOutput const&) override;
     void writeRun(RunForOutput const&) override;
+    const std::vector<std::string> crosscheck_;
     const bool verbose_;
   };
 
@@ -58,6 +59,7 @@ namespace edm {
   GetProductCheckerOutputModule::GetProductCheckerOutputModule(ParameterSet const& iPSet)
       : one::OutputModuleBase(iPSet),
         one::OutputModule<>(iPSet),
+        crosscheck_(iPSet.getUntrackedParameter<std::vector<std::string>>("crosscheck")),
         verbose_(iPSet.getUntrackedParameter<bool>("verbose")) {}
 
   // GetProductCheckerOutputModule::GetProductCheckerOutputModule(GetProductCheckerOutputModule const& rhs) {
@@ -108,10 +110,40 @@ namespace edm {
       }
     }
   }
+  namespace {
+    std::string canonicalName(std::string const& iOriginal) {
+      if (iOriginal.empty()) {
+        return iOriginal;
+      }
+      if (iOriginal.back() == '.') {
+        return iOriginal.substr(0, iOriginal.size() - 1);
+      }
+      return iOriginal;
+    }
+  }  // namespace
   void GetProductCheckerOutputModule::write(EventForOutput const& e) {
     std::ostringstream str;
     str << e.id();
     check(e, str.str(), keptProducts()[InEvent], verbose_);
+    if (not crosscheck_.empty()) {
+      std::set<std::string> expectedProducts(crosscheck_.begin(), crosscheck_.end());
+      for (auto const& kp : keptProducts()[InEvent]) {
+        auto bn = canonicalName(kp.first->branchName());
+        auto found = expectedProducts.find(bn);
+        if (found == expectedProducts.end()) {
+          throw cms::Exception("CrosscheckFailed") << "unexpected kept product " << bn;
+        }
+        expectedProducts.erase(bn);
+      }
+      if (not expectedProducts.empty()) {
+        cms::Exception e("CrosscheckFailed");
+        e << "Did not find the expected products:\n";
+        for (auto const& p : expectedProducts) {
+          e << p << "\n";
+        }
+        throw e;
+      }
+    }
   }
   void GetProductCheckerOutputModule::writeLuminosityBlock(LuminosityBlockForOutput const& l) {
     std::ostringstream str;
@@ -135,6 +167,8 @@ namespace edm {
   void GetProductCheckerOutputModule::fillDescriptions(ConfigurationDescriptions& descriptions) {
     ParameterSetDescription desc;
     one::OutputModule<>::fillDescription(desc);
+    desc.addUntracked<std::vector<std::string>>("crosscheck", {})
+        ->setComment("Branch names that should be in the event. If empty no check done.");
     desc.addUntracked<bool>("verbose", false);
     descriptions.add("productChecker", desc);
   }

--- a/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
+++ b/FWCore/TestProcessor/test/testprocessor_t.cppunit.cc
@@ -33,6 +33,7 @@ class testTestProcessor : public CppUnit::TestFixture {
   CPPUNIT_TEST(addProductTest);
   CPPUNIT_TEST(missingProductTest);
   CPPUNIT_TEST(filterTest);
+  CPPUNIT_TEST(outputModuleTest);
   CPPUNIT_TEST(extraProcessTest);
   CPPUNIT_TEST(eventSetupTest);
   CPPUNIT_TEST(eventSetupPutTest);
@@ -55,6 +56,7 @@ public:
   void addProductTest();
   void missingProductTest();
   void filterTest();
+  void outputModuleTest();
   void extraProcessTest();
   void eventSetupTest();
   void eventSetupPutTest();
@@ -149,6 +151,20 @@ void testTestProcessor::filterTest() {
   CPPUNIT_ASSERT(tester.test().modulePassed());
 }
 
+void testTestProcessor::outputModuleTest() {
+  char const* kTest =
+      "from FWCore.TestProcessor.TestProcess import *\n"
+      "process = TestProcess()\n"
+      "process.MessageLogger.cerr.INFO.limit=10000\n"
+      "process.foo = cms.OutputModule('GetProductCheckerOutputModule', verbose=cms.untracked.bool(True),"
+      " outputCommands = cms.untracked.vstring('drop *','keep edmtestIntProduct_in__TEST'),\n"
+      " crosscheck = cms.untracked.vstring('edmtestIntProduct_in__TEST'))\n"
+      "process.moduleToTest(process.foo)\n";
+  edm::test::TestProcessor::Config config(kTest);
+  auto token = config.produces<edmtest::IntProduct>("in");
+  edm::test::TestProcessor tester(config);
+  tester.test(std::make_pair(token, std::make_unique<edmtest::IntProduct>(1)));
+}
 void testTestProcessor::extraProcessTest() {
   char const* kTest =
       "from FWCore.TestProcessor.TestProcess import *\n"


### PR DESCRIPTION
#### PR description:

- Added test to prove that TestProcessor can be used with OutputModules
- Extended GetProductCheckerOutputModule to allow checking that the expected kept data products were actually available. 

#### PR validation:

Code compiles and local running of new test worked.