### PR TITLE
Make nTS loops configurable

### DIFF
--- a/DPGAnalysis/HcalNanoAOD/plugins/HcalDigiSortedTableProducer.cc
+++ b/DPGAnalysis/HcalNanoAOD/plugins/HcalDigiSortedTableProducer.cc
@@ -216,7 +216,7 @@ void HcalDigiSortedTableProducer::produce(edm::Event& iEvent, const edm::EventSe
   hbNanoTable->addColumn<bool>("valid", hbDigiTable_->valids_, "valid");
   hbNanoTable->addColumn<uint8_t>("sipmTypes", hbDigiTable_->sipmTypes_, "sipmTypes");
 
-  for (unsigned int iTS = 0; iTS < 8; ++iTS) {
+  for (unsigned int iTS = 0; iTS < nTS_HB_; ++iTS) {
     hbNanoTable->addColumn<int>(
         std::string("adc") + std::to_string(iTS), hbDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
     hbNanoTable->addColumn<int>(
@@ -246,7 +246,7 @@ void HcalDigiSortedTableProducer::produce(edm::Event& iEvent, const edm::EventSe
   heNanoTable->addColumn<bool>("valid", heDigiTable_->valids_, "valid");
   heNanoTable->addColumn<uint8_t>("sipmTypes", heDigiTable_->sipmTypes_, "sipmTypes");
 
-  for (unsigned int iTS = 0; iTS < 8; ++iTS) {
+  for (unsigned int iTS = 0; iTS < nTS_HE_; ++iTS) {
     heNanoTable->addColumn<int>(
         std::string("adc") + std::to_string(iTS), heDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
     heNanoTable->addColumn<int>(
@@ -275,7 +275,7 @@ void HcalDigiSortedTableProducer::produce(edm::Event& iEvent, const edm::EventSe
   hfNanoTable->addColumn<bool>("valid", hfDigiTable_->valids_, "valid");
   //hfNanoTable->addColumn<uint8_t>("sipmTypes", hfDigiTable_->sipmTypes_, "sipmTypes");
 
-  for (unsigned int iTS = 0; iTS < 3; ++iTS) {
+  for (unsigned int iTS = 0; iTS < nTS_HF_; ++iTS) {
     hfNanoTable->addColumn<int>(
         std::string("adc") + std::to_string(iTS), hfDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
     hfNanoTable->addColumn<int>(
@@ -307,7 +307,7 @@ void HcalDigiSortedTableProducer::produce(edm::Event& iEvent, const edm::EventSe
   hoNanoTable->addColumn<int>("soi", hoDigiTable_->sois_, "soi");
   hoNanoTable->addColumn<bool>("valid", hoDigiTable_->valids_, "valid");
 
-  for (unsigned int iTS = 0; iTS < 10; ++iTS) {
+  for (unsigned int iTS = 0; iTS < nTS_HO_; ++iTS) {
     hoNanoTable->addColumn<int>(
         std::string("adc") + std::to_string(iTS), hoDigiTable_->adcs_[iTS], std::string("adc") + std::to_string(iTS));
     hoNanoTable->addColumn<int>(std::string("capid") + std::to_string(iTS),


### PR DESCRIPTION
#### PR description:

Local and global runs in HF require different number of time slices (3 for global and 6 for local). The sizes in the definitions of the digi tables already contain the variables but the for loops that fill those tables has hardcoded numbers instead of variables. This is a fix to make the nTS modification from the configuration script to work properly. This change was originally done locally by Alexi Mestvirishvili.

#### PR validation:

I ran the script in https://gitlab.cern.ch/cmshcal/hcalpfg/hcalnanoprod/-/blob/main/test/globalrun_cfg.py with default inputs and the output file had 3 time slices for HF, as expected. I also ran the script in https://gitlab.cern.ch/cmshcal/hcalpfg/hcalnanoprod/-/blob/main/test/localrun_cfg.py the same way. I edited the line: process.hcalDigiSortedTable.nTS_HF = cms.untracked.uint32(x) with x=6, 8 and 12. The output files from these instances were created with 6, 8 and 12 time slices for HF, respectively.