### PR TITLE
Explicitly initialize bTag

### DIFF
--- a/HLTriggerOffline/Higgs/plugins/MatchStruct.h
+++ b/HLTriggerOffline/Higgs/plugins/MatchStruct.h
@@ -34,6 +34,7 @@ struct MatchStruct {
         pt(cand->pt()),
         eta(cand->eta()),
         phi(cand->phi()),
+        bTag(0),
         thepointer(cand)
 
   {}


### PR DESCRIPTION
#### PR description:

Fix maybe-uninitialized [warning](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_UBSAN_X_2024-07-08-2300/HLTriggerOffline/Higgs) in UBSAN IBs:

```
  src/HLTriggerOffline/Higgs/plugins/MatchStruct.h:23:8: warning: '<unnamed>.MatchStruct::bTag' may be used uninitialized [-Wmaybe-uninitialized]
    23 | struct MatchStruct {
      |        ^~~~~~~~~~~
src/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc: In member function 'void HLTHiggsSubAnalysis::analyze(const edm::Event&, const edm::EventSetup&, EVTColContainer*)':
src/HLTriggerOffline/Higgs/plugins/HLTHiggsSubAnalysis.cc:408:76: note: '<anonymous>' declared here
  408 |             matches->push_back(MatchStruct(&cols->genJets->at(i), it->first));
      |                                                                            ^
```

#### PR validation:

Bot tests