### PR TITLE
[Do not merge][AsNeeded] Testing force link of CondFormatsDataRecord

### DIFF
--- a/CondCore/ESSources/BuildFile.xml
+++ b/CondCore/ESSources/BuildFile.xml
@@ -2,6 +2,8 @@
 <use name="FWCore/PluginManager"/>
 <use name="CondCore/CondDB"/>
 <use name="CondFormats/SerializationHelper"/>
+<use name="CondFormats/DataRecord"/>
+<flags LDFLAGS="-Wl,--no-as-needed -lCondFormatsDataRecord -Wl,-as-needed"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
Please ignore this PR. This is just to test `ASNEEDED` IBs to see what it takes to run unit tests and relvals. 
- force link `CondFormatsDataRecord` library to `CondCore/ESSources` 