### PR TITLE
Update nano relval matrix

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1007,7 +1007,6 @@ class ConfigBuilder(object):
         self.RECOSIMDefaultCFF="Configuration/StandardSequences/RecoSim_cff"
         self.PATDefaultCFF="Configuration/StandardSequences/PAT_cff"
         self.NANODefaultCFF="PhysicsTools/NanoAOD/nano_cff"
-        self.NANOGENDefaultCFF="PhysicsTools/NanoAOD/nanogen_cff"
         self.SKIMDefaultCFF="Configuration/StandardSequences/Skims_cff"
         self.POSTRECODefaultCFF="Configuration/StandardSequences/PostRecoGenerator_cff"
         self.VALIDATIONDefaultCFF="Configuration/StandardSequences/Validation_cff"
@@ -1057,7 +1056,6 @@ class ConfigBuilder(object):
         self.PATDefaultSeq='miniAOD'
         self.PATGENDefaultSeq='miniGEN'
         #TODO: Check based of file input
-        self.NANOGENDefaultSeq='nanogenSequence'
         self.NANODefaultSeq='nanoSequence'
         self.NANODefaultCustom='nanoAOD_customizeCommon'
 
@@ -1843,18 +1841,6 @@ class ConfigBuilder(object):
             if len(self._options.customise_commands) > 1:
                 self._options.customise_commands = self._options.customise_commands + " \n"
             self._options.customise_commands = self._options.customise_commands + "process.unpackedPatTrigger.triggerResults= cms.InputTag( 'TriggerResults::"+self._options.hltProcess+"' )\n"
-
-    def prepare_NANOGEN(self, stepSpec = "nanoAOD"):
-        ''' Enrich the schedule with NANOGEN '''
-        # TODO: Need to modify this based on the input file type
-        fromGen = any([x in self.stepMap for x in ['LHE', 'GEN', 'AOD']])
-        _,_nanogenSeq,_nanogenCff = self.loadDefaultOrSpecifiedCFF(stepSpec,self.NANOGENDefaultCFF)
-        self.scheduleSequence(_nanogenSeq,'nanoAOD_step')
-        custom = "customizeNanoGEN" if fromGen else "customizeNanoGENFromMini"
-        if self._options.runUnscheduled:
-            self._options.customisation_file_unsch.insert(0, '.'.join([_nanogenCff, custom]))
-        else:
-            self._options.customisation_file.insert(0, '.'.join([_nanogenCff, custom]))
 
     def prepare_SKIM(self, stepSpec = "all"):
         ''' Enrich the schedule with skimming fragments'''

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -38,8 +38,3 @@ workflows[541]=['',['BuToKstarJPsiToMuMu_forSTEAM_13TeV','HARVESTGEN']]
 #workflows[543]=['',['Upsilon4sBaBarExample_BpBm_Dstarpipi_D0Kpi_nonres_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
 #workflows[544]=['',['LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
 workflows[545]=['',['BsToMuMu_forSTEAM_13TeV','HARVESTGEN']]
-
-# Miscellaneous
-workflows[546]=['',['DYToLL_M-50_13TeV_pythia8','NANOGENFromGen']]
-workflows[547]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCP5_13TeV_MLM_5f_max4j_LHE_pythia8','NANOGENFromGen']]
-workflows[548]=['',['TTbar_Pow_LHE_13TeV','Hadronizer_TuneCP5_13TeV_powhegEmissionVeto2p_pythia8','NANOGENFromGen']] 

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -1,312 +1,367 @@
-from  Configuration.PyReleaseValidation.relval_steps import *
+from Configuration.PyReleaseValidation.relval_steps import *
 import math
 
-## as simple class to number workflows dynamically
+
 class WFN:
+    # a simple class to number workflows dynamically
     def __init__(self, offset):
         self.offset = offset
-        self.index=0
-        self.subindex=0
+        self.index = 0
+        self.subindex = 1
+
     def __call__(self):
-        if self.subindex==100:
+        if self.subindex == 100:
             print("this is not going to work nicely")
-            self.subindex=0/0
-        r=float(f'{self.offset}.{self.index}{self.subindex:02d}')
-        self.subindex+=1
+            self.subindex = 0 / 0
+        r = float(f'{self.offset}.{self.index}{self.subindex:02d}')
+        self.subindex += 1
         return r
-    def next(self):
-        self.index+=1
-        self.subindex=0
+
+    def next(self, index=None):
+        if index is None:
+            self.index += 1
+        else:
+            # manually set the index if given
+            assert index > self.index
+            self.index = index
+        self.subindex = 1
+
     def subnext(self):
         # go to the next tenth for the subindex 10 because of 02d formating
-        self.subindex = math.ceil(self.subindex/10.)*10
+        self.subindex = math.ceil(self.subindex / 10.) * 10 + 1
+
 
 workflows = Matrix()
 
-_runOnly20events={'-n':'20'}
-_run10kevents={'-n':'10000'}
-
-_NANO_data = merge([{'-s':'NANO,DQM:@nanoAODDQM',
-                     '--process':'NANO',
-                     '--data':'',
-                     '--eventcontent':'NANOAOD,DQM',
-                     '--datatier':'NANOAOD,DQMIO',
-                     '-n':'10000',
-                     '--customise':'"Configuration/DataProcessing/Utils.addMonitoring"'
-                 }])
-_HARVEST_nano = merge([{'-s':'HARVESTING:@nanoAODDQM',
-                        '--filetype':'DQM',
-                        '--filein':'file:step2_inDQM.root',
-                        '--conditions':'auto:run2_data'## this is fake for harvesting
-                    }])
-_HARVEST_data = merge([_HARVEST_nano, {'--data':''}])
+_NANO_data = merge([{'-s': 'NANO,DQM:@nanoAODDQM',
+                     '--process': 'NANO',
+                     '--data': '',
+                     '--eventcontent': 'NANOAOD,DQM',
+                     '--datatier': 'NANOAOD,DQMIO',
+                     '-n': '10000',
+                     '--customise': '"Configuration/DataProcessing/Utils.addMonitoring"'
+                     }])
+_HARVEST_nano = merge([{'-s': 'HARVESTING:@nanoAODDQM',
+                        '--filetype': 'DQM',
+                        '--filein': 'file:step2_inDQM.root',
+                        '--conditions': 'auto:run2_data'  # this is fake for harvesting
+                        }])
+_HARVEST_data = merge([_HARVEST_nano, {'--data': ''}])
 
 
-run2_lumis={ 277168: [[1, 1708]],
-             277194: [[913, 913], [916, 916], [919, 919], [932, 932], [939, 939]],
-             283877: [[1, 1496]],
-             299649: [[155, 332]],
-             303885: [[60, 2052]],
-             305040: [[200, 700]],
-             305050: [[200, 700]],
-             305234: [[1, 200]],
-             305377: [[1, 500]],
-             315489: [[1, 100]],
-             320822: [[1, 200]],
-         }
-run3_lumis={}
+run2_lumis = {277168: [[1, 1708]],
+              277194: [[913, 913], [916, 916], [919, 919], [932, 932], [939, 939]],
+              283877: [[1, 1496]],
+              299649: [[155, 332]],
+              303885: [[60, 2052]],
+              305040: [[200, 700]],
+              305050: [[200, 700]],
+              305234: [[1, 200]],
+              305377: [[1, 500]],
+              315489: [[1, 100]],
+              320822: [[1, 200]],
+              }
+run3_lumis = {}
 
-_NANO_mc = merge([{'-s':'NANO,DQM:@nanoAODDQM',
-                   '--process':'NANO',
-                   '--mc':'',
-                   '--eventcontent':'NANOAODSIM,DQM',
-                   '--datatier':'NANOAODSIM,DQMIO',
-                   '-n':'10000',
-                   '--customise':'"Configuration/DataProcessing/Utils.addMonitoring"'
-               }])
-_HARVEST_mc = merge([_HARVEST_nano, {'--mc':''}])
+_NANO_mc = merge([{'-s': 'NANO,DQM:@nanoAODDQM',
+                   '--process': 'NANO',
+                   '--mc': '',
+                   '--eventcontent': 'NANOAODSIM,DQM',
+                   '--datatier': 'NANOAODSIM,DQMIO',
+                   '-n': '10000',
+                   '--customise': '"Configuration/DataProcessing/Utils.addMonitoring"'
+                   }])
+_HARVEST_mc = merge([_HARVEST_nano, {'--mc': ''}])
 steps['HRV_NANO_mc'] = _HARVEST_mc
 steps['HRV_NANO_data'] = _HARVEST_data
 
-##10.6 INPUT and worflows
-steps['TTbarMINIAOD10.6_UL16v2'] = {'INPUT':InputInfo(location='STD',
-                                                      dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM')}
-steps['NANO_mc10.6ul16v2']=merge([{'--era':'Run2_2016,run2_nanoAOD_106Xv2',
-                                   '--conditions':'auto:run2_mc'},
+################################################################
+# 10.6 INPUT and workflows
+steps['TTbarMINIAOD10.6_UL16v2'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM')}
+steps['NANO_mc10.6ul16v2'] = merge([{'--era': 'Run2_2016,run2_nanoAOD_106Xv2',
+                                   '--conditions': 'auto:run2_mc'},
+                                    _NANO_mc])
+# 2017 looking Monte-Carlo: two versions in 10.6
+steps['TTbarMINIAOD10.6_UL17v2'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM')}
+steps['NANO_mc10.6ul17v2'] = merge([{'--era': 'Run2_2017,run2_nanoAOD_106Xv2',
+                                   '--conditions': 'auto:phase1_2017_realistic'},
+                                    _NANO_mc])
+
+steps['TTbarMINIAOD10.6_UL18v2'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM')}
+steps['NANO_mc10.6ul18v2'] = merge([{'--era': 'Run2_2018,run2_nanoAOD_106Xv2',
+                                   '--conditions': 'auto:phase1_2018_realistic'},
+                                    _NANO_mc])
+
+# HIPM_UL2016_MiniAODv2 campaign is CMSSW_10_6_25
+steps['MuonEG2016MINIAOD10.6v2'] = {'INPUT': InputInfo(location='STD', ls=run2_lumis,
+                                                       dataSet='/MuonEG/Run2016E-HIPM_UL2016_MiniAODv2-v2/MINIAOD')}
+steps['NANO_data10.6ul16v2'] = merge([{'--era': 'Run2_2016_HIPM,run2_nanoAOD_106Xv2',
+                                     '--conditions': 'auto:run2_data'},
+                                      _NANO_data])
+# UL2017_MiniAODv2 campaign is CMSSW_10_6_20
+steps['MuonEG2017MINIAOD10.6v2'] = {'INPUT': InputInfo(location='STD', ls=run2_lumis,
+                                                       dataSet='/MuonEG/Run2017F-UL2017_MiniAODv2-v1/MINIAOD')}
+steps['NANO_data10.6ul17v2'] = merge([{'--era': 'Run2_2017,run2_nanoAOD_106Xv2',
+                                     '--conditions': 'auto:run2_data'},
+                                      _NANO_data])
+
+# UL2018_MiniAODv2 campaign is CMSSW_10_6_20
+steps['MuonEG2018MINIAOD10.6v2'] = {'INPUT': InputInfo(location='STD', ls=run2_lumis,
+                                                       dataSet='/MuonEG/Run2018D-UL2018_MiniAODv2-v1/MINIAOD')}
+steps['NANO_data10.6ul18v2'] = merge([{'--era': 'Run2_2018,run2_nanoAOD_106Xv2',
+                                     '--conditions': 'auto:run2_data'},
+                                      _NANO_data])
+
+################################################################
+# Run2UL re-MINI/NANO
+steps['NANO_mc_UL16APVreMINI'] = merge([{'--era': 'Run2_2016_HIPM',
+                                         '--conditions': 'auto:run2_mc_pre_vfp'},
+                                        _NANO_mc])
+steps['NANO_mc_UL16reMINI'] = merge([{'--era': 'Run2_2016',
+                                      '--conditions': 'auto:run2_mc'},
+                                     _NANO_mc])
+steps['NANO_mc_UL17reMINI'] = merge([{'--era': 'Run2_2017',
+                                      '--conditions': 'auto:phase1_2017_realistic'},
+                                     _NANO_mc])
+steps['NANO_mc_UL18reMINI'] = merge([{'--era': 'Run2_2018',
+                                      '--conditions': 'auto:phase1_2018_realistic'},
+                                     _NANO_mc])
+
+steps['NANO_data_UL16APVreMINI'] = merge([{'--era': 'Run2_2016_HIPM',
+                                         '--conditions': 'auto:run2_data'},
+                                          _NANO_data])
+steps['NANO_data_UL16reMINI'] = merge([{'--era': 'Run2_2016',
+                                      '--conditions': 'auto:run2_data'},
+                                       _NANO_data])
+steps['NANO_data_UL17reMINI'] = merge([{'--era': 'Run2_2017',
+                                      '--conditions': 'auto:run2_data'},
+                                       _NANO_data])
+steps['NANO_data_UL18reMINI'] = merge([{'--era': 'Run2_2018',
+                                      '--conditions': 'auto:run2_data'},
+                                       _NANO_data])
+
+################################################################
+# 13.0 workflows
+steps['TTbarMINIAOD13.0'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM')}
+
+steps['NANO_mc13.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:phase1_2023_realistic'},
+                              _NANO_mc])
+
+
+# 13.0 workflows -- data
+steps['MuonEG2023MINIAOD13.0'] = {'INPUT': InputInfo(location='STD', ls={368489: [[46, 546]]},
+                                                     dataSet='/MuonEG/Run2023C-22Sep2023_v4-v1/MINIAOD')}
+
+steps['ScoutingPFRun32022RAW13.0'] = {'INPUT': InputInfo(
+    dataSet='/ScoutingPFRun3/Run2022D-v1/RAW', label='2022D', events=100000, location='STD', ls=Run2022D)}
+
+
+steps['NANO_data13.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:run3_data'},
+                                _NANO_data])
+
+steps['NANO_data13.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
+                                       steps['NANO_data13.0']])
+
+
+steps['scoutingNANO_data13.0'] = merge([{'-s': 'NANO:@Scout'},
+                                        steps['NANO_data13.0']])
+
+
+################################################################
+# current release cycle workflows : 14.0
+steps['TTbarMINIAOD14.0'] = {'INPUT': InputInfo(
+    location='STD', dataSet='/RelValTTbar_14TeV/CMSSW_14_0_0-PU_140X_mcRun3_2024_realistic_v3_STD_2024_PU-v2/MINIAODSIM')}
+
+steps['NANO_mc14.0'] = merge([{'--era': 'Run3', '--conditions': 'auto:phase1_2024_realistic'},
+                              _NANO_mc])
+
+steps['muPOGNANO_mc14.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
+                                   steps['NANO_mc14.0']])
+
+steps['EGMNANO_mc14.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
+                                 steps['NANO_mc14.0']])
+
+steps['BTVNANO_mc14.0'] = merge([{'-s': 'NANO:@BTV', '-n': '1000'},
+                                 steps['NANO_mc14.0']])
+
+steps['lepTrackInfoNANO_mc14.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
+                                          steps['NANO_mc14.0']])
+
+steps['jmeNANO_mc14.0'] = merge([{'-s': 'NANO:@JME ', '-n': '1000'},
+                                 steps['NANO_mc14.0']])
+
+steps['jmeNANO_rePuppi_mc14.0'] = merge([{'-s': 'NANO:@JMErePuppi ', '-n': '1000'},
+                                         steps['NANO_mc14.0']])
+
+steps['scoutingNANO_mc14.0'] = merge([{'-s': 'NANO:@Scout'},
+                                      steps['NANO_mc14.0']])
+
+# 14.0 workflows -- data
+lumis_Run2024D = {380306: [[28, 273]]}
+steps['MuonEG2024MINIAOD14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
+                                                     dataSet='/MuonEG/Run2024D-PromptReco-v1/MINIAOD')}
+
+steps['ScoutingPFRun32024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
+                                                         dataSet='/ScoutingPFRun3/Run2024D-v1/HLTSCOUT')}
+
+steps['ZMuSkim2024RAWRECO14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
+                                                      dataSet='/Muon0/Run2024D-ZMu-PromptReco-v1/RAW-RECO')}
+
+steps['ZeroBias2024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls=lumis_Run2024D,
+                                                   dataSet='/ZeroBias/Run2024D-v1/RAW')}
+
+steps['TestEnablesEcalHcal2024RAW14.0'] = {'INPUT': InputInfo(location='STD', ls={383173: [[151, 162]]},
+                                                              dataSet='/TestEnablesEcalHcal/Run2024F-Express-v1/RAW')}
+
+steps['NANO_data14.0'] = merge([{'--era': 'Run3_2024', '--conditions': 'auto:run3_data_prompt'},
+                                _NANO_data])
+
+steps['NANO_data14.0_prompt'] = merge([{'-s': 'NANO:@Prompt,DQM:@nanoAODDQM', '-n': '1000'},
+                                       steps['NANO_data14.0']])
+
+steps['muPOGNANO_data14.0'] = merge([{'-s': 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n': '1000'},
+                                     steps['NANO_data14.0']])
+
+steps['EGMNANO_data14.0'] = merge([{'-s': 'NANO:@EGM,DQM:@nanoAODDQM', '-n': '1000'},
+                                   steps['NANO_data14.0']])
+
+steps['BTVNANO_data14.0'] = merge([{'-s': 'NANO:@BTV', '-n': '1000'},
+                                   steps['NANO_data14.0']])
+
+steps['lepTrackInfoNANO_data14.0'] = merge([{'-s': 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n': '1000'},
+                                           steps['NANO_data14.0']])
+
+steps['jmeNANO_data14.0'] = merge([{'-s': 'NANO:@JME', '-n': '1000'},
+                                   steps['NANO_data14.0']])
+
+steps['jmeNANO_rePuppi_data14.0'] = merge([{'-s': 'NANO:@JMErePuppi', '-n': '1000'},
+                                          steps['NANO_data14.0']])
+
+steps['scoutingNANO_data14.0'] = merge([{'-s': 'NANO:@Scout'},
+                                        steps['NANO_data14.0']])
+
+# DPG custom NANO
+steps['muDPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@MUDPG', '-n': '100'},
+                                     steps['NANO_data14.0']])
+
+steps['muDPGNANOBkg_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@MUDPGBKG', '-n': '100'},
+                                        steps['NANO_data14.0']])
+
+steps['hcalDPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,RECO,NANO:@HCAL', '-n': '100',
+                                        '--processName': 'NANO'},
+                                       steps['NANO_data14.0']])
+
+steps['hcalDPGCalibNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,RECO,NANO:@HCALCalib', '-n': '100',
+                                             '--processName': 'NANO'},
+                                            steps['NANO_data14.0']])
+
+steps['l1DPGNANO_data14.0'] = merge([{'-s': 'RAW2DIGI,NANO:@L1DPG', '-n': '100'},
+                                     steps['NANO_data14.0']])
+
+################################################################
+# NANOGEN
+steps['NANOGENFromGen'] = merge([{'-s': 'NANO:@GEN,DQM:@nanogenDQM',
+                                  '-n': 1000,
+                                  '--conditions': 'auto:run2_mc'},
+                                 _NANO_mc])
+steps['NANOGENFromMini'] = merge([{'-s': 'NANO:@GENFromMini,DQM:@nanogenDQM',
+                                   '-n': 1000,
+                                   '--conditions': 'auto:run2_mc'},
                                   _NANO_mc])
-##2017 looking Monte-Carlo: two versions in 10.6
-steps['TTbarMINIAOD10.6_UL17v2'] = {'INPUT':InputInfo(location='STD',
-                                                      dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM')}
-steps['NANO_mc10.6ul17v2']=merge([{'--era':'Run2_2017,run2_nanoAOD_106Xv2',
-                                   '--conditions':'auto:phase1_2017_realistic'},
-                                  _NANO_mc])
 
-steps['TTbarMINIAOD10.6_UL18v2'] = {'INPUT':InputInfo(location='STD',
-                                                      dataSet='/TTJets_SingleLeptFromT_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM')}
-steps['NANO_mc10.6ul18v2']=merge([{'--era':'Run2_2018,run2_nanoAOD_106Xv2',
-                                   '--conditions':'auto:phase1_2018_realistic'},
-                                  _NANO_mc])
+################################################################
+_wfn = WFN(2500)
+######## 2500.0xx ########
+# Run2, 10_6_X MiniAOD input (current recommendation for 2016--2018)
+workflows[_wfn()] = ['NANOmc106Xul16v2', ['TTbarMINIAOD10.6_UL16v2', 'NANO_mc10.6ul16v2', 'HRV_NANO_mc']]
+workflows[_wfn()] = ['NANOmc106Xul17v2', ['TTbarMINIAOD10.6_UL17v2', 'NANO_mc10.6ul17v2', 'HRV_NANO_mc']]
+workflows[_wfn()] = ['NANOmc106Xul18v2', ['TTbarMINIAOD10.6_UL18v2', 'NANO_mc10.6ul18v2', 'HRV_NANO_mc']]
 
-##HIPM_UL2016_MiniAODv2 campaign is CMSSW_10_6_25
-steps['MuonEG2016MINIAOD10.6v2'] = {'INPUT':InputInfo(location='STD',ls=run2_lumis,
-                                                      dataSet='/MuonEG/Run2016E-HIPM_UL2016_MiniAODv2-v2/MINIAOD')}
-steps['NANO_data10.6ul16v2']=merge([{'--era':'Run2_2016,run2_nanoAOD_106Xv2,tracker_apv_vfp30_2016',
-                                     '--conditions':'auto:run2_data'},
-                                    _NANO_data])
-##UL2017_MiniAODv2 campaign is CMSSW_10_6_20
-steps['MuonEG2017MINIAOD10.6v2'] = {'INPUT':InputInfo(location='STD',ls=run2_lumis,
-                                                      dataSet='/MuonEG/Run2017F-UL2017_MiniAODv2-v1/MINIAOD')}
-steps['NANO_data10.6ul17v2']=merge([{'--era':'Run2_2017,run2_nanoAOD_106Xv2',
-                                     '--conditions':'auto:run2_data'},
-                                    _NANO_data])
-
-##UL2018_MiniAODv2 campaign is CMSSW_10_6_20
-steps['MuonEG2018MINIAOD10.6v2'] = {'INPUT':InputInfo(location='STD',ls=run2_lumis,
-                                                      dataSet='/MuonEG/Run2018D-UL2018_MiniAODv2-v1/MINIAOD')}
-steps['NANO_data10.6ul18v2']=merge([{'--era':'Run2_2018,run2_nanoAOD_106Xv2',
-                                     '--conditions':'auto:run2_data'},
-                                    _NANO_data])
-##12.2 INPUT (mc only)
-steps['TTbarMINIAOD12.2'] = {'INPUT':InputInfo(location='STD',
-                                               dataSet='/TTToSemiLeptonic_TuneCP5_13p6TeV-powheg-pythia8/Run3Winter22MiniAOD-FlatPU0to70_122X_mcRun3_2021_realistic_v9-v2/MINIAODSIM')}
-steps['NANO_mc12.2']=merge([{'--era':'Run3,run3_nanoAOD_122',
-                             '--conditions':'auto:phase1_2022_realistic'},
-                            _NANO_mc])
-
-##12.4 INPUT
-steps['TTbarMINIAOD12.4'] = {'INPUT':InputInfo(location='STD',
-                                               dataSet='/TT_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv3-124X_mcRun3_2022_realistic_v12-v3/MINIAODSIM')}
-steps['NANO_mc12.4']=merge([{'--era':'Run3,run3_nanoAOD_124',
-                             '--conditions':'124X_mcRun3_2022_realistic_v12'},
-                            _NANO_mc])
-
-steps['MuonEG2022MINIAOD12.4'] = {'INPUT':InputInfo(location='STD',ls=run3_lumis,
-                                                    dataSet='/MuonEG/Run2022D-PromptReco-v2/MINIAOD')}
-steps['NANO_data12.4']=merge([{'--era':'Run3,run3_nanoAOD_124',
-                               '--conditions':'auto:run3_data'},
-                              _NANO_data])
-steps['NANO_data12.4_prompt']=merge([{'-n' : '1000'},
-                                     steps['NANO_data12.4']])
-steps['NANO_data12.4_prompt']['-s']=steps['NANO_data12.4_prompt']['-s'].replace('NANO','NANO:@PHYS+@L1')
-
-###13.0 workflows
-steps['TTBarMINIAOD13.0'] = {'INPUT':InputInfo(location='STD',
-                                               dataSet='/RelValTTbar_14TeV/CMSSW_13_0_0-PU_130X_mcRun3_2022_realistic_v2_HS-v4/MINIAODSIM')}
-
-steps['NANO_mc13.0']=merge([{'--era':'Run3',
-                             '--conditions':'130X_mcRun3_2022_realistic_v2'},
-                            _NANO_mc])
-
-steps['MuonEG2023MINIAOD13.0'] = { 'INPUT':InputInfo(location='STD',ls=run3_lumis,
-                                                     dataSet='/MuonEG/Run2023C-PromptReco-v4/MINIAOD')}
-
-steps['ZMuSkim2023DRAWRECO13.0'] = { 'INPUT':InputInfo(location='STD',ls={ 370775: [[1, 168]]},
-                                                     dataSet='/Muon0/Run2023D-ZMu-PromptReco-v2/RAW-RECO')}
-
-steps['ZeroBias2023DRAW13.0']={'INPUT':InputInfo(location='STD', ls={369978: [[1, 800]]},
-                                             dataSet='/ZeroBias/Run2023D-v1/RAW')}
-
-steps['TestEnablesEcalHcal2023C']={'INPUT':InputInfo(location='STD', ls={368489: [[46,546]]},
-                                                     dataSet='/TestEnablesEcalHcal/Run2023C-Express-v4/RAW')}
-
-steps['NANO_data13.0']=merge([{'--era':'Run3',
-                               '--conditions':'auto:run3_data'},
-                              _NANO_data])
-
-steps['NANO_data13.0_prompt']=merge([{'-n' : '1000'},
-                                     steps['NANO_data13.0']])
-steps['NANO_data13.0_prompt']['-s']=steps['NANO_data13.0_prompt']['-s'].replace('NANO','NANO:@PHYS+@L1')
-
-steps['muDPGNANO_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:@MUDPG',
-                                    '-n' : '100',},
-                                   steps['NANO_data13.0']])
-
-steps['muDPGNANOBkg_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:@MUDPGBKG',
-                                       '-n' : '100',},
-                                      steps['NANO_data13.0']])
-
-steps['hcalDPGNANO_data13.0']=merge([{'-s' : 'RAW2DIGI,RECO,NANO:@HCAL',
-                                      '-n' : '100',
-                                      '--processName': 'NANO',},
-                                     steps['NANO_data13.0']])
-
-steps['hcalDPGCalibNANO_data13.0']=merge([{'-s' : 'RAW2DIGI,RECO,NANO:@HCALCalib',
-                                           '-n' : '100',
-                                           '--processName': 'NANO',},
-                                          steps['NANO_data13.0']])
-
-steps['muPOGNANO_data13.0']=merge([{'-s' : 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n' : '1000'},
-                                   steps['NANO_data13.0']])
-
-steps['l1DPGNANO_data13.0']=merge([{'-s' : 'RAW2DIGI,NANO:@L1DPG',
-                                    '-n' : '100'},
-                                   steps['NANO_data13.0']])
- 
-steps['EGMNano_data13.0'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '1000'},
-                                    steps['NANO_data13.0']])
-
-steps['EGMNano_mc13.0'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '1000'},
-                                 steps['NANO_mc13.0']])
-
-steps['BTVNANO_data13.0']=merge([{'-s' : 'NANO:@BTV',
-                                    '-n' : '1000'},
-                                    steps['NANO_data13.0']])
-
-steps['jmeNANO_data13.0'] = merge([{'-s':'NANO:@JME', '-n' : '1000'},
-                                 steps['NANO_data13.0']])
-
-steps['lepTrackInfoNANO_data13.0']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM',
-                                          '-n' : '1000'},
-                                         steps['NANO_data13.0']])
-
-steps['jmeNANO_rePuppi_data13.0']= merge([{'-s':'NANO:@JMErePuppi', '-n' : '1000'},
-                                 steps['NANO_data13.0']])
-
-###current release cycle workflows : 13.2
-steps['TTBarMINIAOD13.2'] = {'INPUT':InputInfo(location='STD',
-                                               dataSet='/RelValTTbar_14TeV/CMSSW_13_2_0-PU_131X_mcRun3_2023_realistic_v9-v1/MINIAODSIM')}
-
-steps['NANO_mc13.2']=merge([{'--era':'Run3',
-                             '--conditions':'auto:phase1_2022_realistic'},
-                            _NANO_mc])
-
-steps['muPOGNANO_mc13.2']=merge([{'-s' : 'NANO:@MUPOG,DQM:@nanoAODDQM', '-n' : '1000'},
-                                    steps['NANO_mc13.2']])
-
-steps['EGMNano_mc13.2'] = merge([{'-s':'NANO:@EGM,DQM:@nanoAODDQM', '-n' : '1000'},
-                                 steps['NANO_mc13.2']])
-
-
-steps['BTVNANO_mc13.2']=merge([{'-s' : 'NANO:@BTV',
-                                    '-n' : '1000'},
-                                    steps['NANO_mc13.2']])
-
-steps['lepTrackInfoNANO_mc13.2']=merge([{'-s' : 'NANO:@LepTrackInfo,DQM:@nanoAODDQM', '-n' : '1000'},
-                                       steps['NANO_mc13.2']])
- 
-steps['jmeNANO_mc13.2']=merge([{'-s' : 'NANO:@JME ', '-n' : '1000'},
-                                    steps['NANO_mc13.2']])
-
-steps['jmeNANO_rePuppi_mc13.2']=merge([{'-s' : 'NANO:@JMErePuppi ', '-n' : '1000'},
-                                    steps['NANO_mc13.2']])
-
-##13.X INPUT
-steps['ScoutingPFRun32022DRAW13.X']={'INPUT':InputInfo(dataSet='/ScoutingPFRun3/Run2022D-v1/RAW',label='2022D',events=100000,location='STD', ls=Run2022D)}
-
-steps['NANO_dataRun3ScoutingPF13.X']=merge([{'-s':'NANO:@Scout'},
-                                            steps['NANO_data13.0']])
-
-steps['TTBarMINIAOD13.3'] = {'INPUT':InputInfo(location='STD',
-                                               dataSet='/RelValTTbar_14TeV/CMSSW_13_3_0-PU_133X_mcRun3_2023_realistic_v3-v1/MINIAODSIM')}
-
-steps['NANO_mc13.3']=merge([{'--era':'Run3',
-                             '--conditions':'133X_mcRun3_2023_realistic_v3'},
-                            _NANO_mc])
-
-steps['NANO_mcScouting13.X']=merge([{'-s':'NANO:@Scout'},
-                                    steps['NANO_mc13.3']])
-
-_wfn=WFN(2500)
-################
-#10.6 input
-workflows[_wfn()] = ['NANOmc106Xul16v2', ['TTbarMINIAOD10.6_UL16v2','NANO_mc10.6ul16v2', 'HRV_NANO_mc']]
-workflows[_wfn()] = ['NANOmc106Xul17v2', ['TTbarMINIAOD10.6_UL17v2','NANO_mc10.6ul17v2', 'HRV_NANO_mc']]
-workflows[_wfn()] = ['NANOmc106Xul18v2', ['TTbarMINIAOD10.6_UL18v2','NANO_mc10.6ul18v2', 'HRV_NANO_mc']]
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata106Xul16v2', ['MuonEG2016MINIAOD10.6v2', 'NANO_data10.6ul16v2', 'HRV_NANO_data']]
 workflows[_wfn()] = ['NANOdata106Xul17v2', ['MuonEG2017MINIAOD10.6v2', 'NANO_data10.6ul17v2', 'HRV_NANO_data']]
 workflows[_wfn()] = ['NANOdata106Xul18v2', ['MuonEG2018MINIAOD10.6v2', 'NANO_data10.6ul18v2', 'HRV_NANO_data']]
 
-_wfn.next()
-################
-#12.2 input
-workflows[_wfn()] = ['NANOmc122Xrun3', ['TTbarMINIAOD12.2','NANO_mc12.2', 'HRV_NANO_mc']]
-
-_wfn.next()
-################
-#12.4 input
-workflows[_wfn()] = ['NANOmc124Xrun3', ['TTbarMINIAOD12.4','NANO_mc12.4', 'HRV_NANO_mc']]
+# Run2, 10_6_X AOD, reMINI+reNANO
 _wfn.subnext()
-workflows[_wfn()] = ['NANOdata124Xrun3', ['MuonEG2022MINIAOD12.4','NANO_data12.4', 'HRV_NANO_data']]
-workflows[_wfn()] = ['NANOdata124Xrun3', ['MuonEG2022MINIAOD12.4','NANO_data12.4_prompt', 'HRV_NANO_data']]
+workflows[_wfn()] = ['NANOmcUL16APVreMINI', ['TTbar_13_reminiaod2016UL_preVFP_INPUT', 'REMINIAOD_mc2016UL_preVFP', 'NANO_mc_UL16APVreMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOmcUL16reMINI', ['TTbar_13_reminiaod2016UL_postVFP_INPUT', 'REMINIAOD_mc2016UL_postVFP', 'NANO_mc_UL16reMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOmcUL17reMINI', ['TTbar_13_reminiaod2017UL_INPUT', 'REMINIAOD_mc2017UL', 'NANO_mc_UL17reMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOmcUL18reMINI', ['TTbar_13_reminiaod2018UL_INPUT', 'REMINIAOD_mc2018UL', 'NANO_mc_UL18reMINI', 'HRV_NANO_data']]  # noqa
 
-_wfn.next()
-################
-#13.0 workflows
-workflows[_wfn()] = ['NANOmc130X', ['TTBarMINIAOD13.0', 'NANO_mc13.0', 'HRV_NANO_mc']]
-workflows[_wfn()] = ['EGMNANOmc130X', ['TTBarMINIAOD13.0', 'EGMNano_mc13.0']]
 _wfn.subnext()
-workflows[_wfn()] = ['muDPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'muDPGNANO_data13.0']]
-workflows[_wfn()] = ['muDPGNANOBkg130Xrun3', ['ZeroBias2023DRAW13.0', 'muDPGNANOBkg_data13.0']]
-workflows[_wfn()] = ['hcalDPGNANO130Xrun3', ['ZeroBias2023DRAW13.0', 'hcalDPGNANO_data13.0']]
-workflows[_wfn()] = ['hcalDPGCalibNANO130Xrun3', ['TestEnablesEcalHcal2023C', 'hcalDPGCalibNANO_data13.0']]
+workflows[_wfn()] = ['NANOdataUL16APVreMINI', ['RunJetHT2016E_reminiaodUL', 'REMINIAOD_data2016UL_HIPM', 'NANO_data_UL16APVreMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOdataUL16reMINI', ['RunJetHT2016H_reminiaodUL', 'REMINIAOD_data2016UL', 'NANO_data_UL16reMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOdataUL17reMINI', ['RunJetHT2017F_reminiaodUL', 'REMINIAOD_data2017UL', 'NANO_data_UL17reMINI', 'HRV_NANO_data']]  # noqa
+workflows[_wfn()] = ['NANOdataUL18reMINI', ['RunJetHT2018D_reminiaodUL', 'REMINIAOD_data2018UL', 'NANO_data_UL18reMINI', 'HRV_NANO_data']]  # noqa
+
+_wfn.next(1)
+######## 2500.1xx ########
+# Run3, 13_0_X input (current recommendation for 2022--2023)
+workflows[_wfn()] = ['NANOmc130X', ['TTbarMINIAOD13.0', 'NANO_mc13.0', 'HRV_NANO_mc']]
+
 _wfn.subnext()
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0', 'HRV_NANO_data']]
 workflows[_wfn()] = ['NANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'NANO_data13.0_prompt', 'HRV_NANO_data']]
-workflows[_wfn()] = ['muPOGNANO130Xrun3', ['MuonEG2023MINIAOD13.0', 'muPOGNANO_data13.0']]
-workflows[_wfn()] = ['l1DPGNANO130Xrun3', ['ZMuSkim2023DRAWRECO13.0', 'l1DPGNANO_data13.0']]
-workflows[_wfn()] = ['EGMNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'EGMNano_data13.0']]
-workflows[_wfn()] = ['BTVNANO_data13.0', ['MuonEG2023MINIAOD13.0', 'BTVNANO_data13.0']]
-workflows[_wfn()] = ['jmeNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNANO_data13.0']]
-workflows[_wfn()] = ['lepTrackInfoNANOdata130Xrun3', ['MuonEG2023MINIAOD13.0', 'lepTrackInfoNANO_data13.0']]
-workflows[_wfn()] = ['jmeNANOrePuppidata130Xrun3', ['MuonEG2023MINIAOD13.0', 'jmeNANO_rePuppi_data13.0']]
 
-_wfn.next()
-################
-#13.2 workflows
-workflows[_wfn()] = ['NANOmc132X', ['TTBarMINIAOD13.2', 'NANO_mc13.2', 'HRV_NANO_mc']]
-workflows[_wfn()] = ['muPOGNANOmc132X', ['TTBarMINIAOD13.2', 'muPOGNANO_mc13.2']]
-workflows[_wfn()] = ['EGMNANOmc132X', ['TTBarMINIAOD13.2', 'EGMNano_mc13.2']]
-workflows[_wfn()] = ['BTVNANO_mc13.2', ['TTBarMINIAOD13.2', 'BTVNANO_mc13.2']]
-workflows[_wfn()] = ['jmeNANOmc132X', ['TTBarMINIAOD13.2', 'jmeNANO_mc13.2']]
-workflows[_wfn()] = ['lepTrackInfoNANOmc132X', ['TTBarMINIAOD13.2', 'lepTrackInfoNANO_mc13.2']]
-workflows[_wfn()] = ['jmeNANOrePuppimc132X', ['TTBarMINIAOD13.2', 'jmeNANO_rePuppi_mc13.2']]
-
-_wfn.next()
-################
-#13.X workflows
-workflows[_wfn()] = ['ScoutingNanodata13X',['ScoutingPFRun32022DRAW13.X', 'NANO_dataRun3ScoutingPF13.X']]
+# POG/PAG custom NANOs, MC
 _wfn.subnext()
-workflows[_wfn()] = ['ScoutingNanomc13X',['TTBarMINIAOD13.3','NANO_mcScouting13.X']]
 
-################
+# POG/PAG custom NANOs, data
+_wfn.subnext()
+workflows[_wfn()] = ['ScoutingNANOdata130Xrun3', ['ScoutingPFRun32022RAW13.0', 'scoutingNANO_data13.0']]
+
+# DPG custom NANOs, data
+_wfn.subnext()
+
+_wfn.next(2)
+######## 2500.2xx ########
+# Run3, 14_0_X input (current production release for MC / prompt RECO)
+workflows[_wfn()] = ['NANOmc140X', ['TTbarMINIAOD14.0', 'NANO_mc14.0', 'HRV_NANO_mc']]
+
+_wfn.subnext()
+workflows[_wfn()] = ['NANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'NANO_data14.0', 'HRV_NANO_data']]
+workflows[_wfn()] = ['NANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'NANO_data14.0_prompt', 'HRV_NANO_data']]
+
+# POG/PAG custom NANOs, MC
+_wfn.subnext()
+workflows[_wfn()] = ['muPOGNANOmc140X', ['TTbarMINIAOD14.0', 'muPOGNANO_mc14.0']]
+workflows[_wfn()] = ['EGMNANOmc140X', ['TTbarMINIAOD14.0', 'EGMNANO_mc14.0']]
+workflows[_wfn()] = ['BTVNANOmc140X', ['TTbarMINIAOD14.0', 'BTVNANO_mc14.0']]
+workflows[_wfn()] = ['jmeNANOmc140X', ['TTbarMINIAOD14.0', 'jmeNANO_mc14.0']]
+workflows[_wfn()] = ['jmeNANOrePuppimc140X', ['TTbarMINIAOD14.0', 'jmeNANO_rePuppi_mc14.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOmc140X', ['TTbarMINIAOD14.0', 'lepTrackInfoNANO_mc14.0']]
+workflows[_wfn()] = ['ScoutingNANOmc140X', ['TTbarMINIAOD14.0', 'scoutingNANO_mc14.0']]
+
+# POG/PAG custom NANOs, data
+_wfn.subnext()
+workflows[_wfn()] = ['muPOGNANO140Xrun3', ['MuonEG2024MINIAOD14.0', 'muPOGNANO_data14.0']]
+workflows[_wfn()] = ['EGMNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'EGMNANO_data14.0']]
+workflows[_wfn()] = ['BTVNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'BTVNANO_data14.0']]
+workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_data14.0']]
+workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
+workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
+workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
+
+# DPG custom NANOs, data
+_wfn.subnext()
+workflows[_wfn()] = ['l1DPGNANO140Xrun3', ['ZMuSkim2024RAWRECO14.0', 'l1DPGNANO_data14.0']]
+workflows[_wfn()] = ['muDPGNANO140Xrun3', ['ZMuSkim2024RAWRECO14.0', 'muDPGNANO_data14.0']]
+workflows[_wfn()] = ['muDPGNANOBkg140Xrun3', ['ZeroBias2024RAW14.0', 'muDPGNANOBkg_data14.0']]
+workflows[_wfn()] = ['hcalDPGNANO140Xrun3', ['ZeroBias2024RAW14.0', 'hcalDPGNANO_data14.0']]
+workflows[_wfn()] = ['hcalDPGCalibNANO140Xrun3', ['TestEnablesEcalHcal2024RAW14.0', 'hcalDPGCalibNANO_data14.0']]
+
+_wfn.next(9)
+######## 2500.9xx ########
+# NANOGEN
+workflows[_wfn()] = ['', ['TTbarMINIAOD10.6_UL18v2', 'NANOGENFromMini']]
+workflows[_wfn()] = ['', ['TTbarMINIAOD14.0', 'NANOGENFromMini']]
+_wfn.subnext()
+workflows[_wfn()] = ['', ['DYToLL_M-50_13TeV_pythia8', 'NANOGENFromGen']]
+workflows[_wfn()] = ['', ['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV',
+                          'Hadronizer_TuneCP5_13TeV_MLM_5f_max4j_LHE_pythia8', 'NANOGENFromGen']]
+workflows[_wfn()] = ['', ['TTbar_Pow_LHE_13TeV', 'Hadronizer_TuneCP5_13TeV_powhegEmissionVeto2p_pythia8', 'NANOGENFromGen']]

--- a/Configuration/PyReleaseValidation/python/relval_nano.py
+++ b/Configuration/PyReleaseValidation/python/relval_nano.py
@@ -345,7 +345,7 @@ workflows[_wfn()] = ['BTVNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'BTVNANO_d
 workflows[_wfn()] = ['jmeNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_data14.0']]
 workflows[_wfn()] = ['jmeNANOrePuppidata140Xrun3', ['MuonEG2024MINIAOD14.0', 'jmeNANO_rePuppi_data14.0']]
 workflows[_wfn()] = ['lepTrackInfoNANOdata140Xrun3', ['MuonEG2024MINIAOD14.0', 'lepTrackInfoNANO_data14.0']]
-workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
+# workflows[_wfn()] = ['ScoutingNANOdata140Xrun3', ['ScoutingPFRun32024RAW14.0', 'scoutingNANO_data14.0']]
 
 # DPG custom NANOs, data
 _wfn.subnext()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -4149,16 +4149,11 @@ steps['MINIAODMCUP18bParking']   =merge([{'--conditions':'auto:phase1_2018_reali
 steps['MINIAODMCUP18FS']   =merge([{'--filein':'file:step1.root','--fast':'','--conditions':'auto:phase1_2018_realistic','--era':'Run2_2018_FastSim'},stepMiniAODMC])
 
 stepNanoAODDefaults = { '-s': 'NANO,DQM:@nanoAODDQM', '-n': 1000 }
-stepNanoGenDefaults = { '-s': 'NANOGEN,DQM:@nanogenDQM', '-n': 1000 }
 stepNanoAODData = merge([{ '--data':'', '--eventcontent' : 'NANOAOD,DQM' ,'--datatier': 'NANOAOD,DQMIO'    }, stepNanoAODDefaults ])
 stepNanoAODMC   = merge([{ '--mc':''  , '--eventcontent' : 'NANOAODSIM,DQM','--datatier': 'NANOAODSIM,DQMIO' }, stepNanoAODDefaults ])
 stepNanoEDMData = merge([{ '--data':'', '--eventcontent' : 'NANOEDMAOD,DQM' ,'--datatier': 'NANOAOD,DQMIO'     }, stepNanoAODDefaults ])
 stepNanoEDMMC   = merge([{ '--mc':''  , '--eventcontent' : 'NANOEDMAODSIM,DQM','--datatier': 'NANOAODSIM,DQMIO'    }, stepNanoAODDefaults ])
 stepNanoEDMMCProd   = merge([{ '--mc':'', '-s': 'NANO', '--eventcontent' : 'NANOEDMAODSIM','--datatier': 'NANOAODSIM'    }, stepNanoAODDefaults ])
-stepNanoGen     = merge([{ '--mc':''  , '--eventcontent' : 'NANOAODGEN,DQM','--datatier': 'NANOAODSIM,DQMIO' }, stepNanoGenDefaults ])
-
-steps['NANOGENFromGen']   = merge([{'--conditions': 'auto:run2_mc', '--customise' : 'PhysicsTools/NanoAOD/nanogen_cff.customizeNanoGEN'}, stepNanoGen ])
-steps['NANOGENFromMini']  = merge([{'--conditions': 'auto:run2_mc'}, stepNanoGen ])
 
 steps['NANOEDMMC2018_PROD'] = merge([{'--conditions': 'auto:phase1_2018_realistic', '--era': 'Run2_2018', '--filein':'file:step3_inMINIAODSIM.root'}, stepNanoEDMMCProd ])
 steps['NANOUP15'] = merge([{ '--conditions':'auto:run2_mc', '--era':'Run2_2016','-n':'10', '--filein':'file:step3_inMINIAODSIM.root','--nThreads':'2'}, stepNanoEDMMCProd ])

--- a/Configuration/PyReleaseValidation/scripts/README.md
+++ b/Configuration/PyReleaseValidation/scripts/README.md
@@ -327,7 +327,7 @@ MC workflows for pp collisions:
 | 12834.7 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2024 	| mkFit 	|  	
 | 14034.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	|  	*FastSim* |  	
 | 14234.0 	| RelValTTbar_14TeV 	| phase1_2023_realistic 	| Run3_2023_FastSim 	| *FastSim*  Run3_Flat55To75_PoissonOOTPU 	|  	
-| 2500.4 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3 	| NanoAOD from existing MINI 	|  	
+| 2500.201 	| RelValTTbar_14TeV 	| phase1_2022_realistic 	| Run3 	| NanoAOD from existing MINI 	|  	
 | | | | | | 
 | **Phase2** 	|  	|  	|  	|  	**Geometry** |  	
 | |  	|  	|  	|  	|  	

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
                     12834.7,    # RelValTTbar_14TeV             2024 mkFit
                     14034.0,    # RelValTTbar_14TeV             Run3_2023_FastSim 
                     14234.0,    # RelValTTbar_14TeV             Run3_2023_FastSim   PU = Run3_Flat55To75_PoissonOOTPU
-                    2500.4,     # RelValTTbar_14TeV             NanoAOD from existing MINI
+                    2500.201,   # RelValTTbar_14TeV             NanoAOD from existing MINI
 
                     # Phase2
                     29634.0,    # RelValTTbar_14TeV                     phase2_realistic_T33        Extended2026D110         (Phase-2 baseline)   

--- a/PhysicsTools/NanoAOD/python/NanoAODEDMEventContent_cff.py
+++ b/PhysicsTools/NanoAOD/python/NanoAODEDMEventContent_cff.py
@@ -19,12 +19,3 @@ NANOAODSIMEventContent = NanoAODEDMEventContent.clone(
     compressionLevel = cms.untracked.int32(9),
     compressionAlgorithm = cms.untracked.string("LZMA"),
 )
-
-NanoGenOutput = NanoAODEDMEventContent.outputCommands[:]
-NanoGenOutput.remove("keep edmTriggerResults_*_*_*")
-
-NANOAODGENEventContent = cms.PSet(
-    compressionLevel = cms.untracked.int32(9),
-    compressionAlgorithm = cms.untracked.string("LZMA"),
-    outputCommands = cms.untracked.vstring(NanoGenOutput)
-)

--- a/PhysicsTools/NanoAOD/python/autoNANO.py
+++ b/PhysicsTools/NanoAOD/python/autoNANO.py
@@ -1,27 +1,27 @@
 def expandNanoMapping(seqList, mapping, key):
-    maxLevel=30
-    level=0
-    while '@' in repr(seqList) and level<maxLevel:
-        level+=1
+    maxLevel = 30
+    level = 0
+    while '@' in repr(seqList) and level < maxLevel:
+        level += 1
         for specifiedCommand in seqList:
             if specifiedCommand.startswith('@'):
-                location=specifiedCommand[1:]
+                location = specifiedCommand[1:]
                 if not location in mapping:
-                    raise Exception("Impossible to map "+location+" from "+repr(mapping))
-                mappedTo=mapping[location]
+                    raise Exception("Impossible to map " + location + " from " + repr(mapping))
+                mappedTo = mapping[location]
                 # no mapping for specified key
                 # NOTE: mising key of key=None is interpreted differently than empty string:
                 #  - An empty string recalls the default for the given key
                 #  - None is interpreted as "ignore this"
-                insertAt=seqList.index(specifiedCommand)
+                insertAt = seqList.index(specifiedCommand)
                 seqList.remove(specifiedCommand)
                 if key in mappedTo and mappedTo[key] is not None:
-                    allToInsert=mappedTo[key].split('+')
-                    for offset,toInsert in enumerate(allToInsert):
-                        seqList.insert(insertAt+offset,toInsert)
-                break;
-        if level==maxLevel:
-            raise Exception("Could not fully expand "+repr(seqList)+" from "+repr(mapping))
+                    allToInsert = mappedTo[key].split('+')
+                    for offset, toInsert in enumerate(allToInsert):
+                        seqList.insert(insertAt + offset, toInsert)
+                break
+        if level == maxLevel:
+            raise Exception("Could not fully expand " + repr(seqList) + " from " + repr(mapping))
 
 
 autoNANO = {
@@ -29,39 +29,48 @@ autoNANO = {
     'PHYS': {'sequence': '',
              'customize': ''},
     # L1 flavours: add tables through customize, supposed to be combined with PHYS
-    'L1' : {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomize'},
-    'L1FULL' : {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull'},
-    #scouting nano
-    'Scout' : {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff'},
-    'JME' : { 'sequence': '@PHYS',
-              'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},
-    'JMErePuppi' : { 'sequence': '@PHYS',
-                     'customize': '@PHYS+@JME+PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET'},
+    'L1': {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomize'},
+    'L1FULL': {'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull'},
+    # scouting nano
+    'Scout': {'sequence': 'PhysicsTools/NanoAOD/custom_run3scouting_cff'},
+    # JME nano
+    'JME': {'sequence': '@PHYS',
+            'customize': '@PHYS+PhysicsTools/NanoAOD/custom_jme_cff.PrepJMECustomNanoAOD'},
+    'JMErePuppi': {'sequence': '@PHYS',
+                   'customize': '@PHYS+@JME+PhysicsTools/NanoAOD/custom_jme_cff.RecomputePuppiWeightsAndMET'},
     # L1 DPG (standalone with full calo TP info, L1T reemulation customization)
     'L1DPG' : {'sequence': 'DPGAnalysis/L1TNanoAOD/l1tNano_cff.l1tNanoSequence',
-               'customize': 'PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull,DPGAnalysis/L1TNanoAOD/l1tNano_cff.addCaloFull,L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW'},
+               'customize': ','.join(['PhysicsTools/NanoAOD/l1trig_cff.nanoL1TrigObjCustomizeFull',
+                                      'DPGAnalysis/L1TNanoAOD/l1tNano_cff.addCaloFull',
+                                      'L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW'])},
     # Muon POG flavours : add tables through customize, supposed to be combined with PHYS
-    'MUPOG' : {'sequence': '@PHYS',
-               'customize' : '@PHYS+PhysicsTools/NanoAOD/custom_muon_cff.PrepMuonCustomNanoAOD'},
+    'MUPOG': {'sequence': '@PHYS',
+              'customize': '@PHYS+PhysicsTools/NanoAOD/custom_muon_cff.PrepMuonCustomNanoAOD'},
     # MUDPG flavours: use their own sequence
-    'MUDPG' : {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoProducer',
-               'customize': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoCustomize'},
-    'MUDPGBKG' : {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoProducerBkg',
-                  'customize': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoBkgCustomize'},
-    # HCAL favlours:
-    'HCAL' : {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask'},
-    'HCALCalib' : { 'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
-                    'customize': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.customiseHcalCalib'},
-    #EGM flavours: add variables through customize
-    'EGM' : {'sequence': '@PHYS',
-             'customize' : '@PHYS+PhysicsTools/NanoAOD/egamma_custom_cff.addExtraEGammaVarsCustomize'},
+    'MUDPG': {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoProducer',
+              'customize': 'DPGAnalysis/MuonTools/muNtupleProducer_cff.muDPGNanoCustomize'},
+    'MUDPGBKG': {'sequence': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoProducerBkg',
+                 'customize': 'DPGAnalysis/MuonTools/muNtupleProducerBkg_cff.muDPGNanoBkgCustomize'},
+    # HCAL flavors:
+    'HCAL': {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask'},
+    'HCALCalib': {'sequence': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.hcalNanoTask',
+                  'customize': 'DPGAnalysis/HcalNanoAOD/hcalNano_cff.customiseHcalCalib'},
+    # EGM flavours: add variables through customize
+    'EGM': {'sequence': '@PHYS',
+            'customize': '@PHYS+PhysicsTools/NanoAOD/egamma_custom_cff.addExtraEGammaVarsCustomize'},
     # PromptReco config: PHYS+L1
-    'Prompt' : {'sequence': '@PHYS',
-                'customize': '@PHYS+@L1'},
+    'Prompt': {'sequence': '@PHYS',
+               'customize': '@PHYS+@L1'},
     # Add lepton track parameters through customize combined with PHYS
     'LepTrackInfo' : {'sequence': '@PHYS',
                       'customize': '@PHYS+PhysicsTools/NanoAOD/leptonTimeLifeInfo_common_cff.addTrackVarsToTimeLifeInfo'},
     # Custom BTV Nano for SF measurements or tagger training
-    'BTV' : {'sequence': '@PHYS',
-             'customize':'@PHYS+PhysicsTools/NanoAOD/custom_btv_cff.BTVCustomNanoAOD'}
+    'BTV': {'sequence': '@PHYS',
+            'customize': '@PHYS+PhysicsTools/NanoAOD/custom_btv_cff.BTVCustomNanoAOD'},
+    # NANOGEN (from LHE/GEN/AOD)
+    'GEN': {'sequence': 'PhysicsTools/NanoAOD/nanogen_cff.nanogenSequence',
+            'customize': 'PhysicsTools/NanoAOD/nanogen_cff.customizeNanoGEN'},
+    # NANOGEN (from MiniAOD)
+    'GENFromMini': {'sequence': 'PhysicsTools/NanoAOD/nanogen_cff.nanogenSequence',
+                    'customize': 'PhysicsTools/NanoAOD/nanogen_cff.customizeNanoGENFromMini'},
 }

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -57,6 +57,10 @@ def nanoGenCommonCustomize(process):
     setGenPhiPrecision(process, CandVars.phi.precision)
     setGenMassPrecision(process, CandVars.mass.precision)
 
+    for output in ("NANOEDMAODSIMoutput", "NANOAODSIMoutput"):
+        if hasattr(process, output):
+            getattr(process, output).outputCommands.append("drop edmTriggerResults_*_*_*")
+
 def customizeNanoGENFromMini(process):
     process.nanogenSequence.insert(0, process.genParticles2HepMCHiggsVtx)
     process.nanogenSequence.insert(0, process.genParticles2HepMC)
@@ -71,6 +75,7 @@ def customizeNanoGENFromMini(process):
     process.genParticleTable.src = "prunedGenParticles"
     process.patJetPartonsNano.particles = "prunedGenParticles"
     process.particleLevel.src = "genParticles2HepMC:unsmeared"
+    process.genIso.genPart = "prunedGenParticles"
 
     process.genJetTable.src = "slimmedGenJets"
     process.genJetAK8Table.src = "slimmedGenJetsAK8"


### PR DESCRIPTION
#### PR description:

Updated NANO relval matrix:
 - updated workflows to 140X
 - added Run2UL reMINI + reNANO workflows
 - moved NANOGEN from relval_generator to relval_nano

Also added the support for NANOGEN with the autoNANO syntax:
 - from GEN inputs: `-s NANO:@GEN --eventcontent NANOAOD`
 - from MiniAOD: `-s NANO:@GENFromMini --eventcontent NANOAOD`

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
