### PR TITLE
Alpaka Pixel: Reading `layerStart` at Runtime and Variable `thePitch*` 

### DIFF
--- a/DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
+++ b/DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h
@@ -23,7 +23,7 @@ namespace pixelClustering {
   constexpr uint16_t clusterThresholdPhase2OtherLayers = 4000;
 
   constexpr uint32_t maxNumDigis = 3 * 256 * 1024;  // @PU=200 µ=530k σ=50k this is >4σ away
-  constexpr uint16_t maxNumModules = 4000;
+  constexpr uint16_t maxNumModules = 5000;          // This is an upperlimit taking into account D110 has 4000 modules
 
   constexpr int32_t maxNumClustersPerModules = maxHitsInModule();
   constexpr uint16_t invalidModuleId = std::numeric_limits<uint16_t>::max() - 1;

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -208,7 +208,7 @@ namespace phase2PixelTopology {
 
   constexpr uint32_t numberOfLayers = 28;
   constexpr int nPairs = 23 + 6 + 14 + 8 + 4;  // include far forward layer pairs
-  constexpr uint16_t numberOfModules = 3892;
+  constexpr uint16_t numberOfModules = 4000;
 
   constexpr uint32_t maxNumClustersPerModules = 1024;
 
@@ -378,7 +378,7 @@ namespace pixelTopology {
     static constexpr int maxDYsize = 10;
     static constexpr int maxDYPred = 20;
 
-    static constexpr uint16_t numberOfModules = 3892;
+    static constexpr uint16_t numberOfModules = phase2PixelTopology::numberOfModules;
 
     // 1000 bins < 1024 bins (10 bits) must be:
     // - < 32*32 (warpSize*warpSize for block prefix scan for CUDA)
@@ -475,7 +475,7 @@ namespace pixelTopology {
     static constexpr int maxDYsize = 20;
     static constexpr int maxDYPred = 20;
 
-    static constexpr uint16_t numberOfModules = 1856;
+    static constexpr uint16_t numberOfModules = phase1PixelTopology::numberOfModules;
 
     static constexpr uint16_t numRowsInRoc = 80;
     static constexpr uint16_t numColsInRoc = 52;

--- a/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h
@@ -61,8 +61,6 @@ namespace pixelCPEforDevice {
   struct CommonParams {
     float theThicknessB;
     float theThicknessE;
-    float thePitchX;
-    float thePitchY;
 
     uint16_t maxModuleStride;
     uint8_t numberOfLaddersInBarrel;
@@ -77,6 +75,8 @@ namespace pixelCPEforDevice {
 
     float shiftX;
     float shiftY;
+    float thePitchX;
+    float thePitchY;
     float chargeWidthX;
     float chargeWidthY;
     uint16_t pixmx;  // max pix charge
@@ -239,10 +239,10 @@ namespace pixelCPEforDevice {
     // Use an explicit FMA instruction instead of simply (position * pitch + shift) to make sure that
     // different compiler optimizations do not produce different code on different architectures.
     float xPos = std::fmaf(0.5f * ((float)mx - (float)detParams.nRows) - TrackerTraits::bigPixXCorrection,
-                           comParams.thePitchX,
+                           detParams.thePitchX,
                            detParams.shiftX);
     float yPos = std::fmaf(0.5f * ((float)my - (float)detParams.nCols) - TrackerTraits::bigPixYCorrection,
-                           comParams.thePitchY,
+                           detParams.thePitchY,
                            detParams.shiftY);
 
     float cotalpha = 0, cotbeta = 0;
@@ -259,7 +259,7 @@ namespace pixelCPEforDevice {
                             detParams.chargeWidthX,  // lorentz shift in cm
                             thickness,
                             cotalpha,
-                            comParams.thePitchX,
+                            detParams.thePitchX,
                             TrackerTraits::isBigPixX(cp.minRow[ic]),
                             TrackerTraits::isBigPixX(cp.maxRow[ic]));
 
@@ -271,7 +271,7 @@ namespace pixelCPEforDevice {
                             detParams.chargeWidthY,  // lorentz shift in cm
                             thickness,
                             cotbeta,
-                            comParams.thePitchY,
+                            detParams.thePitchY,
                             TrackerTraits::isBigPixY(cp.minCol[ic]),
                             TrackerTraits::isBigPixY(cp.maxCol[ic]));
 
@@ -374,7 +374,7 @@ namespace pixelCPEforDevice {
     cp.status[ic].isOneY = isOneY;
     cp.status[ic].isBigY = (isOneY & isBigY) | isEdgeY;
 
-    auto xoff = -float(TrackerTraits::xOffset) * comParams.thePitchX;
+    auto xoff = -float(TrackerTraits::xOffset) * detParams.thePitchX;
     int low_value = 0;
     int high_value = kNumErrorBins - 1;
     int bin_value = float(kNumErrorBins) * (cp.xpos[ic] + xoff) / (2 * xoff);


### PR DESCRIPTION
#### PR description:

This PR proposes two things:

- reading the layer module start numbers from the TrackerGeometry when filling the `PixelCPEFastParamsHost` `ESProduct`. This makes `TrackerTraits::layerStart` obsolete;
- moving the pixel pitch from `CommonParams` to `DetParams` since, with T33, 3D sensors have a different pitch (tiny difference, but still);

It's a first piece of a wider effort to allow more flexible the detector geometry that can be used by the pixel CA. 

Note: the `layerStart` array in `Geometry/CommonTopologies/interface/SimplePixelTopology.h` could be dropped but at the moment is needed by the *old* CUDA modules.

This solves https://github.com/cms-sw/cmssw/issues/45177 and allows to run Alpaka pixel tracks on D110.

#### PR validation:

Running `29634.402`