### PR TITLE
MTD Validation: update of the BTL SimHit validation

### DIFF
--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -372,7 +372,7 @@ void BtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL SIM local X;X_{SIM}^{LOC} [mm]", 100, -30., 30.);
   meHitYlocal_ = ibook.book1D("BtlHitYlocal", "BTL SIM local Y;Y_{SIM}^{LOC} [mm]", 100, -1.65, 1.65);
-  meHitZlocal_ = ibook.book1D("BtlHitZlocal", "BTL SIM local z;z_{SIM}^{LOC} [mm]", 100, -2., 2.);
+  meHitZlocal_ = ibook.book1D("BtlHitZlocal", "BTL SIM local Z;Z_{SIM}^{LOC} [mm]", 100, -2., 2.);
 
   meOccupancy_ = ibook.book2D(
       "BtlOccupancy", "BTL SIM hits occupancy;z_{SIM} [cm];#phi_{SIM} [rad]", 130, -260., 260., 200, -3.15, 3.15);


### PR DESCRIPTION
This PR updates the BtlSimHitsValidation plugin adding new monitoring histograms for hits produced by different trackIDs in the same BTL crystals.

The new histograms add 6 kB to the output DQM rootfile:
new file size:   267.81 KiB       MTD/BTL
old file size:    261.81 KiB       MTD/BTL

#### PR validation:

The updated validation code has been tested in the CMSSW_14_1_0_pre5 release with the workflows 27634.0_TTbar_14TeV+2026D105, 27834.0_TTbar_14TeV+2026D105PU, and 27834.99_TTbar_14TeV+2026D105PU_PMXS1S2:
the new code produces identical histograms to the current SimHit validation, except for the histogram of the number of hits from different trackIDs in the same cell, which is now filled after the cut to the cell total energy.

A note about the workflow with premixing (27834.99_TTbar_14TeV+2026D105PU_PMXS1S2): in both the old and the new code, the SimHits of the pileup events are not seen by the SimHit validation. The replay doesn't seem to work in this case because we store the accumulated SimHits in the MTD premix.