### PR TITLE
Add SC8 jets to L1T event content

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -207,6 +207,7 @@ def _appendPhase2Digis(obj):
         'keep *_l1tSC4PFL1PuppiCorrectedEmulatorMHT_*_*',
         'keep *_l1tSC4PFL1PuppiExtendedCorrectedEmulator_*_*',
         'keep *_l1tSC4PFL1PuppiExtendedCorrectedEmulatorMHT_*_*',
+	'keep *_l1tSC8PFL1PuppiCorrectedEmulator_*_*',
         'keep *_l1tPhase1JetProducer9x9_*_*', 
         'keep *_l1tPhase1JetCalibrator9x9_*_*',
         'keep *_l1tPhase1JetSumsProducer9x9_*_*',


### PR DESCRIPTION
#### PR description:

Adding the Phase-2 SC8 Puppi Jet collection to the L1T event content. The collection was added to the sequence already here: https://github.com/cms-sw/cmssw/pull/43233

#### PR validation:

Not done, but is a trivial change given the collection exists already.

Not a backport, but might do it to 14_0 if still in time for the MC production.