### PR TITLE
Add alpaka modifier to HLTHgcalTiclPFClusteringForEgammaUnseededSequence

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTHgcalTiclPFClusteringForEgammaUnseededSequence_cfi.py
@@ -14,5 +14,17 @@ from ..modules.particleFlowSuperClusterHGCalFromTICLUnseeded_cfi import *
 from ..modules.ticlLayerTileProducer_cfi import *
 from ..modules.ticlSeedingGlobal_cfi import *
 from ..modules.ticlTrackstersCLUE3DHigh_cfi import *
+from ..modules.hltHgcalSoARecHitsProducer_cfi import *
+from ..modules.hltHgcalSoARecHitsLayerClustersProducer_cfi import *
+from ..modules.hltHgcalSoALayerClustersProducer_cfi import *
+from ..modules.hltHgcalLayerClustersFromSoAProducer_cfi import *
 
 HLTHgcalTiclPFClusteringForEgammaUnseededSequence = cms.Sequence(hgcalDigis+HGCalUncalibRecHit+HGCalRecHit+particleFlowRecHitHGC+hgcalLayerClustersEE+hgcalLayerClustersHSci+hgcalLayerClustersHSi+hgcalMergeLayerClusters+filteredLayerClustersCLUE3DHigh+ticlSeedingGlobal+ticlLayerTileProducer+ticlTrackstersCLUE3DHigh+particleFlowClusterHGCalFromTICLUnseeded+particleFlowSuperClusterHGCalFromTICLUnseeded)
+
+_HLTHgcalTiclPFClusteringForEgammaUnseededSequence_heterogeneous = cms.Sequence(hgcalDigis+HGCalUncalibRecHit+HGCalRecHit+particleFlowRecHitHGC+hltHgcalSoARecHitsProducer+hltHgcalSoARecHitsLayerClustersProducer+hltHgcalSoALayerClustersProducer+hltHgCalLayerClustersFromSoAProducer+hgcalLayerClustersHSci+hgcalLayerClustersHSi+hgcalMergeLayerClusters+filteredLayerClustersCLUE3DHigh+ticlSeedingGlobal+ticlLayerTileProducer+ticlTrackstersCLUE3DHigh+particleFlowClusterHGCalFromTICLUnseeded+particleFlowSuperClusterHGCalFromTICLUnseeded)
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toReplaceWith(HLTHgcalTiclPFClusteringForEgammaUnseededSequence, _HLTHgcalTiclPFClusteringForEgammaUnseededSequence_heterogeneous)
+alpaka.toModify(hgcalMergeLayerClusters,
+        layerClustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer"),
+        time_layerclustersEE = cms.InputTag("hltHgCalLayerClustersFromSoAProducer", "timeLayerCluster"))


### PR DESCRIPTION
This PR is meant to fix #45426 adding the alpaka procModifier to `HLTHgcalTiclPFClusteringForEgammaUnseededSequence` adding the correct sequence needed after the introduction of #45178 

## Test
Tested on workflow 24834.402 (D98)

Would need to test on workflow with `alpaka` procModifier enabled, for example the *402 workflows. 