### PR TITLE
Change thresholds on LED and FEStatus Quality plots ECAL DQM [14_0_X]

### DIFF
--- a/DQM/EcalMonitorClient/interface/RawDataClient.h
+++ b/DQM/EcalMonitorClient/interface/RawDataClient.h
@@ -14,7 +14,7 @@ namespace ecaldqm {
 
   private:
     void setParams(edm::ParameterSet const&) override;
-
+    int minEvents_;
     float synchErrThresholdFactor_;
   };
 

--- a/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/RawDataClient_cfi.py
@@ -4,9 +4,11 @@ from DQM.EcalMonitorTasks.OccupancyTask_cfi import ecalOccupancyTask
 from DQM.EcalMonitorTasks.RawDataTask_cfi import ecalRawDataTask
 
 synchErrThresholdFactor = 1.
+minEvents = 400
 
 ecalRawDataClient = cms.untracked.PSet(
     params = cms.untracked.PSet(
+        minEvents = cms.untracked.int32(minEvents),
         synchErrThresholdFactor = cms.untracked.double(synchErrThresholdFactor)
     ),
     sources = cms.untracked.PSet(
@@ -20,7 +22,7 @@ ecalRawDataClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH2F'),
             otype = cms.untracked.string('Ecal3P'),
             btype = cms.untracked.string('SuperCrystal'),
-            description = cms.untracked.string('Summary of the raw data (DCC and front-end) quality. A channel is red if it has nonzero events with FE status that is different from any of ENABLED, DISABLED, SUPPRESSED, FIFOFULL, FIFOFULL_L1ADESYNC, and FORCEDZS. A FED can also go red if its number of L1A desynchronization errors is greater than ' + str(synchErrThresholdFactor) + ' * log10(total entries).')
+            description = cms.untracked.string('Summary of the raw data (DCC and front-end) quality. A channel is red if it has '+ str(minEvents)+' or more events with FE status that is different from any of ENABLED, DISABLED, SUPPRESSED, FIFOFULL, FIFOFULL_L1ADESYNC, and FORCEDZS. A FED can also go red if its number of L1A desynchronization errors is greater than ' + str(synchErrThresholdFactor) + ' * log10(total entries).')
         ),
         ErrorsSummary = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sSFT front-end status errors summary'),

--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -165,6 +165,10 @@ namespace ecaldqm {
 
         float aRmsThr(sqrt(pow(aMean * toleranceAmpRMSRatio_, 2) + pow(3., 2)));
 
+        //Temporarily disabling all cuts on LED Quality plot.
+        qItr->setBinContent(doMask ? kMGood : kGood);
+
+        /*
         EcalScDetId scid = EEDetId(id).sc();  //Get the Endcap SC id for the given crystal id.
 
         //For the known bad Supercrystals in the SClist, bad quality flag is only set based on the amplitude RMS
@@ -180,7 +184,7 @@ namespace ecaldqm {
             qItr->setBinContent(doMask ? kMBad : kBad);
           else
             qItr->setBinContent(doMask ? kMGood : kGood);
-        }
+        }*/
       }
 
       towerAverage_(meQualitySummary, meQuality, 0.2);

--- a/DQM/EcalMonitorClient/src/RawDataClient.cc
+++ b/DQM/EcalMonitorClient/src/RawDataClient.cc
@@ -11,11 +11,12 @@
 
 namespace ecaldqm {
 
-  RawDataClient::RawDataClient() : DQWorkerClient(), synchErrThresholdFactor_(0.) {
+  RawDataClient::RawDataClient() : DQWorkerClient(), minEvents_(0), synchErrThresholdFactor_(0.) {
     qualitySummaries_.insert("QualitySummary");
   }
 
   void RawDataClient::setParams(edm::ParameterSet const& _params) {
+    minEvents_ = _params.getUntrackedParameter<int>("minEvents");
     synchErrThresholdFactor_ = _params.getUntrackedParameter<double>("synchErrThresholdFactor");
   }
 
@@ -57,7 +58,7 @@ namespace ecaldqm {
       for (unsigned iS(0); iS < nFEFlags; iS++) {
         float entries(sFEStatus.getBinContent(getEcalDQMSetupObjects(), id, iS + 1));
         towerEntries += entries;
-        if (entries > 0. && iS != Enabled && iS != Suppressed && iS != ForcedFullSupp && iS != FIFOFull &&
+        if (entries > minEvents_ && iS != Enabled && iS != Suppressed && iS != ForcedFullSupp && iS != FIFOFull &&
             iS != ForcedZS)
           towerStatus = doMask ? kMBad : kBad;
       }


### PR DESCRIPTION
#### PR description:

This PR does the following:

1. Disables all cuts on the LED Quality plot until the experts can tune the parameters.
2. Adds a cut on minimum no.of events to turn the FEStatus quality to RED, to reduce false alarm on transient issues.

#### PR validation:
PR is validated by running the ECAL online DQM configuration and verifying the plots on a test DQM GUI.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a backport to 14_0_X used in production at the moment.
Master PR is https://github.com/cms-sw/cmssw/pull/45429
