### PR TITLE
Make ProductResolverWrapper to return the EventSetupRecordKey

### DIFF
--- a/CondCore/BaseKeyedPlugins/BuildFile.xml
+++ b/CondCore/BaseKeyedPlugins/BuildFile.xml
@@ -1,4 +1,7 @@
+<use name="CondCore/CondDB"/>
 <use name="CondCore/ESSources"/>
 <use name="CondFormats/Calibration"/>
+<use name="CondFormats/Common"/>
+<use name="CondFormats/DataRecord"/>
 <use name="CondFormats/DTObjects"/>
 <flags EDM_PLUGIN="1"/>

--- a/CondCore/ESSources/interface/ProductResolver.h
+++ b/CondCore/ESSources/interface/ProductResolver.h
@@ -10,6 +10,7 @@
 // user include files
 #include "FWCore/Framework/interface/ESSourceProductResolverTemplate.h"
 #include "FWCore/Framework/interface/DataKey.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
 
 #include "CondCore/CondDB/interface/IOVProxy.h"
 #include "CondCore/CondDB/interface/PayloadProxy.h"
@@ -69,6 +70,7 @@ namespace cond {
     virtual edm::eventsetup::TypeTag type() const = 0;
     virtual ProxyP proxy(unsigned int iovIndex) const = 0;
     virtual esResolverP esResolver(unsigned int iovIndex) const = 0;
+    virtual edm::eventsetup::EventSetupRecordKey recordKey() const = 0;
 
     ProductResolverWrapperBase();
     // late initialize (to allow to load ALL library first)
@@ -173,6 +175,13 @@ public:
   edm::eventsetup::TypeTag type() const override { return m_type; }
   ProxyP proxy(unsigned int iovIndex) const override { return m_proxies.at(iovIndex); }
   esResolverP esResolver(unsigned int iovIndex) const override { return m_esResolvers.at(iovIndex); }
+
+  // ProductResolverWrapper returning the Key for the RecordT
+  // guarantees the proper linking order between the Records and
+  // CondDBESSource
+  edm::eventsetup::EventSetupRecordKey recordKey() const final {
+    return edm::eventsetup::EventSetupRecordKey::makeKey<RecordT>();
+  }
 
 private:
   std::string m_source;

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -320,10 +320,13 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
     (*b).second->proxy(0)->loadMore(visitor);
 
     /// required by eventsetup
-    EventSetupRecordKey recordKey(EventSetupRecordKey::TypeTag::findType((*b).first));
+    EventSetupRecordKey recordKey = b->second->recordKey();
     if (recordKey.type() != EventSetupRecordKey::TypeTag()) {
       findingRecordWithKey(recordKey);
       usingRecordWithKey(recordKey);
+    } else {
+      edm::LogWarning("CondDBESSource") << "Failed to load key for record " << b->first
+                                        << ". No data from this record will be available.";
     }
   }
 


### PR DESCRIPTION
#### PR description:

This change guarantees the proper linking order between Records and `CondDBESSource`, and should allow `--as-needed` linker option to function.

Resolves https://github.com/cms-sw/cmssw/issues/45331
Resolves https://github.com/cms-sw/framework-team/issues/949

#### PR validation:

Checked that dummy a call to `edm::eventsetup::EventSetupRecordKey::makeKey()` in the `ProductResolver` constructor was sufficient to guarantee the proper link order.  The version of the change in this PR enforces the call in a more natural way.
