### PR TITLE
Improve Framework behavior after exceptions in begin/end transitions (Job, Stream, ProcessBlock)

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -267,8 +267,11 @@ int main(int argc, const char* argv[]) {
         TaskCleanupSentry sentry{proc.get()};
 
         alwaysAddContext = false;
+
+        proc.on();
         context = "Calling beginJob";
         proc->beginJob();
+
         // EventSetupsController uses pointers to the ParameterSet
         // owned by ProcessDesc while it is dealing with sharing of
         // ESProducers among the top-level process and the
@@ -276,17 +279,15 @@ int main(int argc, const char* argv[]) {
         // alive until the beginJob transition has finished.
         processDesc.reset();
 
-        alwaysAddContext = false;
         context =
             "Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)";
-        proc.on();
         auto status = proc->runToCompletion();
         if (status == edm::EventProcessor::epSignal) {
           returnCode = edm::errors::CaughtSignal;
         }
-        proc.off();
 
-        context = "Calling endJob";
+        proc.off();
+        context = "Calling endJob and endStream";
         proc->endJob();
       });
       return returnCode;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -35,6 +35,8 @@ configured in the user's main() function, and is set running.
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
+#include "oneapi/tbb/task_group.h"
+
 #include <atomic>
 #include <map>
 #include <memory>
@@ -46,6 +48,7 @@ configured in the user's main() function, and is set running.
 
 namespace edm {
 
+  class ExceptionCollector;
   class ExceptionToActionTable;
   class BranchIDListHelper;
   class MergeableRunProductMetadata;
@@ -119,6 +122,10 @@ namespace edm {
        the first time 'run' is called
        */
     void beginJob();
+
+    void beginStreams();
+
+    void endStreams(ExceptionCollector&) noexcept;
 
     /**This should be called before the EventProcessor is destroyed
        throws if any module's endJob throws an exception.
@@ -351,6 +358,8 @@ namespace edm {
     std::shared_ptr<std::recursive_mutex> sourceMutex_;
     PrincipalCache principalCache_;
     bool beginJobCalled_;
+    bool beginJobStartedModules_ = false;
+    bool beginJobSucceeded_ = false;
     bool shouldWeStop_;
     bool fileModeNoMerge_;
     std::string exceptionMessageFiles_;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -74,9 +74,9 @@
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/BranchType.h"
-#include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
@@ -85,6 +85,7 @@
 #include <array>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <vector>
@@ -100,13 +101,11 @@ namespace edm {
     class ESRecordsToProductResolverIndices;
   }
 
-  class ActivityRegistry;
   class BranchIDListHelper;
   class EventTransitionInfo;
   class ExceptionCollector;
   class MergeableRunProductMetadata;
   class OutputModuleCommunicator;
-  class ProcessContext;
   class ProductRegistry;
   class PreallocationConfiguration;
   class StreamSchedule;
@@ -171,11 +170,14 @@ namespace edm {
 
     void beginJob(ProductRegistry const&,
                   eventsetup::ESRecordsToProductResolverIndices const&,
-                  ProcessBlockHelperBase const&);
+                  ProcessBlockHelperBase const&,
+                  PathsAndConsumesOfModulesBase const&,
+                  ProcessContext const&);
     void endJob(ExceptionCollector& collector);
+    void sendFwkSummaryToMessageLogger() const;
 
-    void beginStream(unsigned int);
-    void endStream(unsigned int);
+    void beginStream(unsigned int streamID);
+    void endStream(unsigned int streamID, ExceptionCollector& collector, std::mutex& collectorMutex) noexcept;
 
     // Write the luminosity block
     void writeLumiAsync(WaitingTaskHolder iTask,

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -23,6 +24,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <vector>
 
@@ -32,6 +34,7 @@ namespace edm {
   class BranchIDListHelper;
   class EventPrincipal;
   class EventSetupImpl;
+  class ExceptionCollector;
   class HistoryAppender;
   class LuminosityBlockPrincipal;
   class LumiTransitionInfo;
@@ -86,7 +89,7 @@ namespace edm {
     std::vector<ModuleProcessName> keepOnlyConsumedUnscheduledModules(bool deleteModules);
 
     void doBeginJob();
-    void doEndJob();
+    void doEndJob(ExceptionCollector&);
 
     void doEventAsync(WaitingTaskHolder iHolder,
                       EventPrincipal const& principal,
@@ -113,8 +116,8 @@ namespace edm {
                                    LumiTransitionInfo const& iTransitionInfo,
                                    bool cleaningUpAfterException);
 
-    void doBeginStream(unsigned int);
-    void doEndStream(unsigned int);
+    void doBeginStream(unsigned int streamID);
+    void doEndStream(unsigned int streamID, ExceptionCollector& collector, std::mutex& collectorMutex) noexcept;
     void doStreamBeginRunAsync(WaitingTaskHolder iHolder, unsigned int iID, RunTransitionInfo const&);
 
     void doStreamEndRunAsync(WaitingTaskHolder iHolder,
@@ -238,7 +241,7 @@ namespace edm {
 
   private:
     void beginJob();
-    void endJob();
+    void endJob(ExceptionCollector&);
     void processAsync(WaitingTaskHolder iHolder,
                       EventPrincipal const& e,
                       std::vector<std::shared_ptr<const EventSetupImpl>> const*);

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -5,11 +5,13 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/UnscheduledCallProducer.h"
 #include "FWCore/Framework/interface/WorkerRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <utility>
@@ -70,12 +72,12 @@ namespace edm {
 
     void beginJob(ProductRegistry const& iRegistry,
                   eventsetup::ESRecordsToProductResolverIndices const&,
-                  ProcessBlockHelperBase const&);
-    void endJob();
-    void endJob(ExceptionCollector& collector);
+                  ProcessBlockHelperBase const&,
+                  GlobalContext const&);
+    void endJob(ExceptionCollector&, GlobalContext const&);
 
-    void beginStream(StreamID iID, StreamContext& streamContext);
-    void endStream(StreamID iID, StreamContext& streamContext);
+    void beginStream(StreamID, StreamContext const&);
+    void endStream(StreamID, StreamContext const&, ExceptionCollector&, std::mutex& collectorMutex) noexcept;
 
     AllWorkers const& allWorkers() const { return allWorkers_; }
     AllWorkers const& unscheduledWorkers() const { return unscheduled_.workers(); }

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -9,7 +9,9 @@
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
+#include <exception>
 #include <functional>
 
 static const std::string kFilterType("EDFilter");
@@ -78,61 +80,85 @@ namespace edm {
     }
   }
 
-  void WorkerManager::endJob() {
+  void WorkerManager::beginJob(ProductRegistry const& iRegistry,
+                               eventsetup::ESRecordsToProductResolverIndices const& iESIndices,
+                               ProcessBlockHelperBase const& processBlockHelperBase,
+                               GlobalContext const& globalContext) {
+    std::exception_ptr exceptionPtr;
+    CMS_SA_ALLOW try {
+      auto const processBlockLookup = iRegistry.productLookup(InProcess);
+      auto const runLookup = iRegistry.productLookup(InRun);
+      auto const lumiLookup = iRegistry.productLookup(InLumi);
+      auto const eventLookup = iRegistry.productLookup(InEvent);
+      if (!allWorkers_.empty()) {
+        auto const& processName = allWorkers_[0]->description()->processName();
+        auto processBlockModuleToIndicies = processBlockLookup->indiciesForModulesInProcess(processName);
+        auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
+        auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
+        auto eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
+        for (auto& worker : allWorkers_) {
+          worker->updateLookup(InProcess, *processBlockLookup);
+          worker->updateLookup(InRun, *runLookup);
+          worker->updateLookup(InLumi, *lumiLookup);
+          worker->updateLookup(InEvent, *eventLookup);
+          worker->updateLookup(iESIndices);
+          worker->resolvePutIndicies(InProcess, processBlockModuleToIndicies);
+          worker->resolvePutIndicies(InRun, runModuleToIndicies);
+          worker->resolvePutIndicies(InLumi, lumiModuleToIndicies);
+          worker->resolvePutIndicies(InEvent, eventModuleToIndicies);
+          worker->selectInputProcessBlocks(iRegistry, processBlockHelperBase);
+        }
+      }
+    } catch (...) {
+      exceptionPtr = std::current_exception();
+    }
+
     for (auto& worker : allWorkers_) {
-      worker->endJob();
+      CMS_SA_ALLOW try { worker->beginJob(globalContext); } catch (...) {
+        if (!exceptionPtr) {
+          exceptionPtr = std::current_exception();
+        }
+      }
+    }
+    if (exceptionPtr) {
+      std::rethrow_exception(exceptionPtr);
     }
   }
 
-  void WorkerManager::endJob(ExceptionCollector& collector) {
+  void WorkerManager::endJob(ExceptionCollector& collector, GlobalContext const& globalContext) {
     for (auto& worker : allWorkers_) {
       try {
-        convertException::wrap([&]() { worker->endJob(); });
+        convertException::wrap([&worker, &globalContext]() { worker->endJob(globalContext); });
       } catch (cms::Exception const& ex) {
         collector.addException(ex);
       }
     }
   }
 
-  void WorkerManager::beginJob(ProductRegistry const& iRegistry,
-                               eventsetup::ESRecordsToProductResolverIndices const& iESIndices,
-                               ProcessBlockHelperBase const& processBlockHelperBase) {
-    auto const processBlockLookup = iRegistry.productLookup(InProcess);
-    auto const runLookup = iRegistry.productLookup(InRun);
-    auto const lumiLookup = iRegistry.productLookup(InLumi);
-    auto const eventLookup = iRegistry.productLookup(InEvent);
-    if (!allWorkers_.empty()) {
-      auto const& processName = allWorkers_[0]->description()->processName();
-      auto processBlockModuleToIndicies = processBlockLookup->indiciesForModulesInProcess(processName);
-      auto runModuleToIndicies = runLookup->indiciesForModulesInProcess(processName);
-      auto lumiModuleToIndicies = lumiLookup->indiciesForModulesInProcess(processName);
-      auto eventModuleToIndicies = eventLookup->indiciesForModulesInProcess(processName);
-      for (auto& worker : allWorkers_) {
-        worker->updateLookup(InProcess, *processBlockLookup);
-        worker->updateLookup(InRun, *runLookup);
-        worker->updateLookup(InLumi, *lumiLookup);
-        worker->updateLookup(InEvent, *eventLookup);
-        worker->updateLookup(iESIndices);
-        worker->resolvePutIndicies(InProcess, processBlockModuleToIndicies);
-        worker->resolvePutIndicies(InRun, runModuleToIndicies);
-        worker->resolvePutIndicies(InLumi, lumiModuleToIndicies);
-        worker->resolvePutIndicies(InEvent, eventModuleToIndicies);
-        worker->selectInputProcessBlocks(iRegistry, processBlockHelperBase);
+  void WorkerManager::beginStream(StreamID streamID, StreamContext const& streamContext) {
+    std::exception_ptr exceptionPtr;
+    for (auto& worker : allWorkers_) {
+      CMS_SA_ALLOW try { worker->beginStream(streamID, streamContext); } catch (...) {
+        if (!exceptionPtr) {
+          exceptionPtr = std::current_exception();
+        }
       }
-
-      for_all(allWorkers_, std::bind(&Worker::beginJob, std::placeholders::_1));
+    }
+    if (exceptionPtr) {
+      std::rethrow_exception(exceptionPtr);
     }
   }
 
-  void WorkerManager::beginStream(StreamID iID, StreamContext& streamContext) {
+  void WorkerManager::endStream(StreamID streamID,
+                                StreamContext const& streamContext,
+                                ExceptionCollector& collector,
+                                std::mutex& collectorMutex) noexcept {
     for (auto& worker : allWorkers_) {
-      worker->beginStream(iID, streamContext);
-    }
-  }
-
-  void WorkerManager::endStream(StreamID iID, StreamContext& streamContext) {
-    for (auto& worker : allWorkers_) {
-      worker->endStream(iID, streamContext);
+      CMS_SA_ALLOW try { worker->endStream(streamID, streamContext); } catch (...) {
+        std::exception_ptr exceptionPtr = std::current_exception();
+        std::lock_guard<std::mutex> collectorLock(collectorMutex);
+        collector.call([&exceptionPtr]() { std::rethrow_exception(exceptionPtr); });
+      }
     }
   }
 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
@@ -390,7 +391,8 @@ void testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations 
 
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::one::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
-  w.beginJob();
+  edm::GlobalContext globalContext(edm::GlobalContext::Transition::kBeginJob, nullptr);
+  w.beginJob(globalContext);
   edm::OutputModuleCommunicatorT<edm::one::OutputModuleBase> comm(iMod.get());
   for (auto& keyVal : m_transToFunc) {
     testTransition(iMod, &w, &comm, keyVal.first, iExpect, keyVal.second);

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Concurrency/interface/FinalWaitingTask.h"
@@ -465,7 +466,10 @@ testStreamFilter::testStreamFilter()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginJob] = [](edm::Worker* iBase) { iBase->beginJob(); };
+  m_transToFunc[Trans::kBeginJob] = [](edm::Worker* iBase) {
+    edm::GlobalContext globalContext(edm::GlobalContext::Transition::kBeginJob, nullptr);
+    iBase->beginJob(globalContext);
+  };
   m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext);
@@ -552,7 +556,10 @@ testStreamFilter::testStreamFilter()
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext);
   };
-  m_transToFunc[Trans::kEndJob] = [](edm::Worker* iBase) { iBase->endJob(); };
+  m_transToFunc[Trans::kEndJob] = [](edm::Worker* iBase) {
+    edm::GlobalContext globalContext(edm::GlobalContext::Transition::kEndJob, nullptr);
+    iBase->endJob(globalContext);
+  };
 }
 
 namespace {
@@ -587,14 +594,17 @@ template <typename T, typename U>
 void testStreamFilter::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
   oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
-  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wOther{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wBeginJobEndJob{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDFilterAdaptorBase> wBeginStreamEndStream{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wStreamLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wGlobalRun{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDFilterAdaptorBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
-    edm::Worker* worker = &wOther;
-    if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+    edm::Worker* worker = &wBeginJobEndJob;
+    if (keyVal.first == Trans::kBeginStream || keyVal.first == Trans::kEndStream) {
+      worker = &wBeginStreamEndStream;
+    } else if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Concurrency/interface/FinalWaitingTask.h"
@@ -426,7 +427,10 @@ testStreamProducer::testStreamProducer()
   m_actReg.reset(new edm::ActivityRegistry);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginJob] = [](edm::Worker* iBase) { iBase->beginJob(); };
+  m_transToFunc[Trans::kBeginJob] = [](edm::Worker* iBase) {
+    edm::GlobalContext globalContext(edm::GlobalContext::Transition::kBeginJob, nullptr);
+    iBase->beginJob(globalContext);
+  };
   m_transToFunc[Trans::kBeginStream] = [](edm::Worker* iBase) {
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext);
@@ -513,7 +517,10 @@ testStreamProducer::testStreamProducer()
     edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext);
   };
-  m_transToFunc[Trans::kEndJob] = [](edm::Worker* iBase) { iBase->endJob(); };
+  m_transToFunc[Trans::kEndJob] = [](edm::Worker* iBase) {
+    edm::GlobalContext globalContext(edm::GlobalContext::Transition::kEndJob, nullptr);
+    iBase->endJob(globalContext);
+  };
 }
 
 namespace {
@@ -548,14 +555,17 @@ template <typename T, typename U>
 void testStreamProducer::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
   oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
 
-  edm::WorkerT<edm::stream::EDProducerAdaptorBase> wOther{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDProducerAdaptorBase> wBeginJobEndJob{iMod, m_desc, nullptr};
+  edm::WorkerT<edm::stream::EDProducerAdaptorBase> wBeginStreamEndStream{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wGlobalLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wStreamLumi{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wGlobalRun{iMod, m_desc, nullptr};
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> wStreamRun{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
-    edm::Worker* worker = &wOther;
-    if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
+    edm::Worker* worker = &wBeginJobEndJob;
+    if (keyVal.first == Trans::kBeginStream || keyVal.first == Trans::kEndStream) {
+      worker = &wBeginStreamEndStream;
+    } else if (keyVal.first == Trans::kStreamBeginLuminosityBlock || keyVal.first == Trans::kStreamEndLuminosityBlock) {
       worker = &wStreamLumi;
     } else if (keyVal.first == Trans::kGlobalBeginLuminosityBlock || keyVal.first == Trans::kGlobalEndLuminosityBlock) {
       worker = &wGlobalLumi;

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -35,6 +35,7 @@ Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
 ++ finished: begin job
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: begin stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: begin stream for module: stream = 0 label = 'one' id = 4
@@ -67,6 +68,7 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'result2' id = 6
 ++++ starting: begin stream for module: stream = 0 label = 'result4' id = 7
 ++++ finished: begin stream for module: stream = 0 label = 'result4' id = 7
+++ finished: begin stream 0
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
@@ -544,6 +546,7 @@ ModuleCallingContext state = Running
 ++++ finished: end process block
 ++++ starting: write process block
 ++++ finished: write process block
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'get' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 4
@@ -576,6 +579,8 @@ ModuleCallingContext state = Running
 ++++ finished: end stream for module: stream = 0 label = 'result2' id = 6
 ++++ starting: end stream for module: stream = 0 label = 'result4' id = 7
 ++++ finished: end stream for module: stream = 0 label = 'result4' id = 7
+++ finished: end stream 0
+++ starting: end job
 ++++ starting: end job for module with label 'one' id = 4
 Module type=IntProducer, Module label=one, Parameter Set ID=dd3aecb8f6531b74585c9fe89286679e
 ++++ finished: end job for module with label 'one' id = 4

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -27,6 +27,7 @@
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
 ++ finished: begin job
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin stream for module: stream = 0 label = 'one' id = 3
 ++++ starting: begin stream for module: stream = 0 label = 'getOne' id = 4
@@ -35,6 +36,7 @@
 ++++ finished: begin stream for module: stream = 0 label = 'two' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ finished: begin stream for module: stream = 0 label = 'getTwo' id = 6
+++ finished: begin stream 0
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
@@ -168,6 +170,7 @@
 ++++ finished: end process block
 ++++ starting: write process block
 ++++ finished: write process block
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'one' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'one' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'getOne' id = 4
@@ -176,6 +179,8 @@
 ++++ finished: end stream for module: stream = 0 label = 'two' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'getTwo' id = 6
 ++++ finished: end stream for module: stream = 0 label = 'getTwo' id = 6
+++ finished: end stream 0
+++ starting: end job
 ++++ starting: end job for module with label 'one' id = 3
 ++++ finished: end job for module with label 'one' id = 3
 ++++ starting: end job for module with label 'getOne' id = 4

--- a/FWCore/Integration/plugins/TestServiceOne.cc
+++ b/FWCore/Integration/plugins/TestServiceOne.cc
@@ -57,8 +57,35 @@ namespace edmtest {
   TestServiceOne::TestServiceOne(edm::ParameterSet const& iPS, edm::ActivityRegistry& iRegistry)
       : verbose_(iPS.getUntrackedParameter<bool>("verbose")),
         printTimestamps_(iPS.getUntrackedParameter<bool>("printTimestamps")) {
+    iRegistry.watchPreBeginJob(this, &TestServiceOne::preBeginJob);
+    iRegistry.watchPostBeginJob(this, &TestServiceOne::postBeginJob);
+    iRegistry.watchPreEndJob(this, &TestServiceOne::preEndJob);
+    iRegistry.watchPostEndJob(this, &TestServiceOne::postEndJob);
+
+    iRegistry.watchPreModuleBeginJob(this, &TestServiceOne::preModuleBeginJob);
+    iRegistry.watchPostModuleBeginJob(this, &TestServiceOne::postModuleBeginJob);
+    iRegistry.watchPreModuleEndJob(this, &TestServiceOne::preModuleEndJob);
+    iRegistry.watchPostModuleEndJob(this, &TestServiceOne::postModuleEndJob);
+
+    iRegistry.watchPreBeginStream(this, &TestServiceOne::preBeginStream);
+    iRegistry.watchPostBeginStream(this, &TestServiceOne::postBeginStream);
+    iRegistry.watchPreEndStream(this, &TestServiceOne::preEndStream);
+    iRegistry.watchPostEndStream(this, &TestServiceOne::postEndStream);
+
+    iRegistry.watchPreModuleBeginStream(this, &TestServiceOne::preModuleBeginStream);
+    iRegistry.watchPostModuleBeginStream(this, &TestServiceOne::postModuleBeginStream);
+    iRegistry.watchPreModuleEndStream(this, &TestServiceOne::preModuleEndStream);
+    iRegistry.watchPostModuleEndStream(this, &TestServiceOne::postModuleEndStream);
+
     iRegistry.watchPreBeginProcessBlock(this, &TestServiceOne::preBeginProcessBlock);
+    iRegistry.watchPostBeginProcessBlock(this, &TestServiceOne::postBeginProcessBlock);
     iRegistry.watchPreEndProcessBlock(this, &TestServiceOne::preEndProcessBlock);
+    iRegistry.watchPostEndProcessBlock(this, &TestServiceOne::postEndProcessBlock);
+
+    iRegistry.watchPreModuleBeginProcessBlock(this, &TestServiceOne::preModuleBeginProcessBlock);
+    iRegistry.watchPostModuleBeginProcessBlock(this, &TestServiceOne::postModuleBeginProcessBlock);
+    iRegistry.watchPreModuleEndProcessBlock(this, &TestServiceOne::preModuleEndProcessBlock);
+    iRegistry.watchPostModuleEndProcessBlock(this, &TestServiceOne::postModuleEndProcessBlock);
 
     iRegistry.watchPreStreamBeginLumi(this, &TestServiceOne::preStreamBeginLumi);
     iRegistry.watchPostStreamBeginLumi(this, &TestServiceOne::postStreamBeginLumi);
@@ -115,15 +142,211 @@ namespace edmtest {
     descriptions.add("TestServiceOne", desc);
   }
 
-  void TestServiceOne::preBeginProcessBlock(GlobalContext const&) {
+  void TestServiceOne::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&) {
+    ++nPreBeginJob_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preBeginProcessBlock";
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preBeginJob " << TimeStamper(printTimestamps_);
     }
   }
 
-  void TestServiceOne::preEndProcessBlock(GlobalContext const&) {
+  void TestServiceOne::postBeginJob() {
+    ++nPostBeginJob_;
     if (verbose_) {
-      edm::LogAbsolute("TestServiceOne") << "test message from TestServiceOne::preEndProcessBlock";
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postBeginJob " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::preEndJob() {
+    ++nPreEndJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preEndJob " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::postEndJob() {
+    ++nPostEndJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postEndJob " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::preModuleBeginJob(edm::ModuleDescription const& desc) {
+    ++nPreModuleBeginJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleBeginJob " << TimeStamper(printTimestamps_)
+          << " label = " << desc.moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleBeginJob(edm::ModuleDescription const& desc) {
+    ++nPostModuleBeginJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleBeginJob " << TimeStamper(printTimestamps_)
+          << " label = " << desc.moduleLabel();
+    }
+  }
+
+  void TestServiceOne::preModuleEndJob(edm::ModuleDescription const& desc) {
+    ++nPreModuleEndJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleEndJob " << TimeStamper(printTimestamps_)
+          << " label = " << desc.moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleEndJob(edm::ModuleDescription const& desc) {
+    ++nPostModuleEndJob_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleEndJob " << TimeStamper(printTimestamps_)
+          << " label = " << desc.moduleLabel();
+    }
+  }
+
+  void TestServiceOne::preBeginStream(edm::StreamContext const& sc) {
+    ++nPreBeginStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preBeginStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID();
+    }
+  }
+
+  void TestServiceOne::postBeginStream(edm::StreamContext const& sc) {
+    ++nPostBeginStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postBeginStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID();
+    }
+  }
+
+  void TestServiceOne::preEndStream(edm::StreamContext const& sc) {
+    ++nPreEndStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::preEndStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID();
+    }
+  }
+
+  void TestServiceOne::postEndStream(edm::StreamContext const& sc) {
+    ++nPostEndStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamIndent << "TestServiceOne::postEndStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID();
+    }
+  }
+
+  void TestServiceOne::preModuleBeginStream(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
+    ++nPreModuleBeginStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleBeginStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleBeginStream(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
+    ++nPostModuleBeginStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleBeginStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::preModuleEndStream(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
+    ++nPreModuleEndStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::preModuleEndStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleEndStream(edm::StreamContext const& sc, edm::ModuleCallingContext const& mcc) {
+    ++nPostModuleEndStream_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << streamModuleIndent << "TestServiceOne::postModuleEndStream " << TimeStamper(printTimestamps_)
+          << " stream = " << sc.streamID() << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::preBeginProcessBlock(edm::GlobalContext const&) {
+    ++nPreBeginProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preBeginProcessBlock " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::postBeginProcessBlock(edm::GlobalContext const&) {
+    ++nPostBeginProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postBeginProcessBlock " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::preEndProcessBlock(edm::GlobalContext const&) {
+    ++nPreEndProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::preEndProcessBlock " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::postEndProcessBlock(edm::GlobalContext const&) {
+    ++nPostEndProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalIndent << "TestServiceOne::postEndProcessBlock " << TimeStamper(printTimestamps_);
+    }
+  }
+
+  void TestServiceOne::preModuleBeginProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+    ++nPreModuleBeginProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleBeginProcessBlock " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleBeginProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+    ++nPostModuleBeginProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleBeginProcessBlock " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::preModuleEndProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+    ++nPreModuleEndProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::preModuleEndProcessBlock " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel();
+    }
+  }
+
+  void TestServiceOne::postModuleEndProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+    ++nPostModuleEndProcessBlock_;
+    if (verbose_) {
+      edm::LogAbsolute out("TestServiceOne");
+      out << globalModuleIndent << "TestServiceOne::postModuleEndProcessBlock " << TimeStamper(printTimestamps_)
+          << " label = " << mcc.moduleDescription()->moduleLabel();
     }
   }
 
@@ -466,6 +689,36 @@ namespace edmtest {
           << " run = " << gc.luminosityBlockID().run();
     }
   }
+
+  unsigned int TestServiceOne::nPreBeginJob() const { return nPreBeginJob_.load(); }
+  unsigned int TestServiceOne::nPostBeginJob() const { return nPostBeginJob_.load(); }
+  unsigned int TestServiceOne::nPreEndJob() const { return nPreEndJob_.load(); }
+  unsigned int TestServiceOne::nPostEndJob() const { return nPostEndJob_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleBeginJob() const { return nPreModuleBeginJob_.load(); }
+  unsigned int TestServiceOne::nPostModuleBeginJob() const { return nPostModuleBeginJob_.load(); }
+  unsigned int TestServiceOne::nPreModuleEndJob() const { return nPreModuleEndJob_.load(); }
+  unsigned int TestServiceOne::nPostModuleEndJob() const { return nPostModuleEndJob_.load(); }
+
+  unsigned int TestServiceOne::nPreBeginStream() const { return nPreBeginStream_.load(); }
+  unsigned int TestServiceOne::nPostBeginStream() const { return nPostBeginStream_.load(); }
+  unsigned int TestServiceOne::nPreEndStream() const { return nPreEndStream_.load(); }
+  unsigned int TestServiceOne::nPostEndStream() const { return nPostEndStream_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleBeginStream() const { return nPreModuleBeginStream_.load(); }
+  unsigned int TestServiceOne::nPostModuleBeginStream() const { return nPostModuleBeginStream_.load(); }
+  unsigned int TestServiceOne::nPreModuleEndStream() const { return nPreModuleEndStream_.load(); }
+  unsigned int TestServiceOne::nPostModuleEndStream() const { return nPostModuleEndStream_.load(); }
+
+  unsigned int TestServiceOne::nPreBeginProcessBlock() const { return nPreBeginProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPostBeginProcessBlock() const { return nPostBeginProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPreEndProcessBlock() const { return nPreEndProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPostEndProcessBlock() const { return nPostEndProcessBlock_.load(); }
+
+  unsigned int TestServiceOne::nPreModuleBeginProcessBlock() const { return nPreModuleBeginProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPostModuleBeginProcessBlock() const { return nPostModuleBeginProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPreModuleEndProcessBlock() const { return nPreModuleEndProcessBlock_.load(); }
+  unsigned int TestServiceOne::nPostModuleEndProcessBlock() const { return nPostModuleEndProcessBlock_.load(); }
 
   unsigned int TestServiceOne::nPreStreamBeginLumi() const { return nPreStreamBeginLumi_.load(); }
   unsigned int TestServiceOne::nPostStreamBeginLumi() const { return nPostStreamBeginLumi_.load(); }

--- a/FWCore/Integration/plugins/TestServiceOne.h
+++ b/FWCore/Integration/plugins/TestServiceOne.h
@@ -14,6 +14,7 @@
 // Original Author:  W. David Dagenhart
 //         Created:  13 March 2024
 
+#include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
@@ -28,8 +29,35 @@ namespace edmtest {
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
+    void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
+    void postBeginJob();
+    void preEndJob();
+    void postEndJob();
+
+    void preModuleBeginJob(edm::ModuleDescription const&);
+    void postModuleBeginJob(edm::ModuleDescription const&);
+    void preModuleEndJob(edm::ModuleDescription const&);
+    void postModuleEndJob(edm::ModuleDescription const&);
+
+    void preBeginStream(edm::StreamContext const&);
+    void postBeginStream(edm::StreamContext const&);
+    void preEndStream(edm::StreamContext const&);
+    void postEndStream(edm::StreamContext const&);
+
+    void preModuleBeginStream(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleBeginStream(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void preModuleEndStream(edm::StreamContext const&, edm::ModuleCallingContext const&);
+    void postModuleEndStream(edm::StreamContext const&, edm::ModuleCallingContext const&);
+
     void preBeginProcessBlock(edm::GlobalContext const&);
+    void postBeginProcessBlock(edm::GlobalContext const&);
     void preEndProcessBlock(edm::GlobalContext const&);
+    void postEndProcessBlock(edm::GlobalContext const&);
+
+    void preModuleBeginProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleBeginProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void preModuleEndProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+    void postModuleEndProcessBlock(edm::GlobalContext const&, edm::ModuleCallingContext const&);
 
     void preStreamBeginLumi(edm::StreamContext const&);
     void postStreamBeginLumi(edm::StreamContext const&);
@@ -76,6 +104,36 @@ namespace edmtest {
 
     void preGlobalWriteRun(edm::GlobalContext const&);
     void postGlobalWriteRun(edm::GlobalContext const&);
+
+    unsigned int nPreBeginJob() const;
+    unsigned int nPostBeginJob() const;
+    unsigned int nPreEndJob() const;
+    unsigned int nPostEndJob() const;
+
+    unsigned int nPreModuleBeginJob() const;
+    unsigned int nPostModuleBeginJob() const;
+    unsigned int nPreModuleEndJob() const;
+    unsigned int nPostModuleEndJob() const;
+
+    unsigned int nPreBeginStream() const;
+    unsigned int nPostBeginStream() const;
+    unsigned int nPreEndStream() const;
+    unsigned int nPostEndStream() const;
+
+    unsigned int nPreModuleBeginStream() const;
+    unsigned int nPostModuleBeginStream() const;
+    unsigned int nPreModuleEndStream() const;
+    unsigned int nPostModuleEndStream() const;
+
+    unsigned int nPreBeginProcessBlock() const;
+    unsigned int nPostBeginProcessBlock() const;
+    unsigned int nPreEndProcessBlock() const;
+    unsigned int nPostEndProcessBlock() const;
+
+    unsigned int nPreModuleBeginProcessBlock() const;
+    unsigned int nPostModuleBeginProcessBlock() const;
+    unsigned int nPreModuleEndProcessBlock() const;
+    unsigned int nPostModuleEndProcessBlock() const;
 
     unsigned int nPreStreamBeginLumi() const;
     unsigned int nPostStreamBeginLumi() const;
@@ -126,6 +184,36 @@ namespace edmtest {
   private:
     bool verbose_;
     bool printTimestamps_;
+
+    std::atomic<unsigned int> nPreBeginJob_ = 0;
+    std::atomic<unsigned int> nPostBeginJob_ = 0;
+    std::atomic<unsigned int> nPreEndJob_ = 0;
+    std::atomic<unsigned int> nPostEndJob_ = 0;
+
+    std::atomic<unsigned int> nPreModuleBeginJob_ = 0;
+    std::atomic<unsigned int> nPostModuleBeginJob_ = 0;
+    std::atomic<unsigned int> nPreModuleEndJob_ = 0;
+    std::atomic<unsigned int> nPostModuleEndJob_ = 0;
+
+    std::atomic<unsigned int> nPreBeginStream_ = 0;
+    std::atomic<unsigned int> nPostBeginStream_ = 0;
+    std::atomic<unsigned int> nPreEndStream_ = 0;
+    std::atomic<unsigned int> nPostEndStream_ = 0;
+
+    std::atomic<unsigned int> nPreModuleBeginStream_ = 0;
+    std::atomic<unsigned int> nPostModuleBeginStream_ = 0;
+    std::atomic<unsigned int> nPreModuleEndStream_ = 0;
+    std::atomic<unsigned int> nPostModuleEndStream_ = 0;
+
+    std::atomic<unsigned int> nPreBeginProcessBlock_ = 0;
+    std::atomic<unsigned int> nPostBeginProcessBlock_ = 0;
+    std::atomic<unsigned int> nPreEndProcessBlock_ = 0;
+    std::atomic<unsigned int> nPostEndProcessBlock_ = 0;
+
+    std::atomic<unsigned int> nPreModuleBeginProcessBlock_ = 0;
+    std::atomic<unsigned int> nPostModuleBeginProcessBlock_ = 0;
+    std::atomic<unsigned int> nPreModuleEndProcessBlock_ = 0;
+    std::atomic<unsigned int> nPostModuleEndProcessBlock_ = 0;
 
     std::atomic<unsigned int> nPreStreamBeginLumi_ = 0;
     std::atomic<unsigned int> nPostStreamBeginLumi_ = 0;

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -115,7 +115,7 @@
   <test name="TestFWCoreIntegrationEDLooperESProcuer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testEDLooperESProducer_cfg.py"/>
   <test name="TestFWCoreIntegrationDelayedReaderTest" command="delayedreader_throw_test.sh"/>
 
-  <test name="TestFrameworkExceptionHandling" command="run_TestFrameworkExceptionHandling.sh ${value}" for="1,9"/>
+  <test name="TestFrameworkExceptionHandling" command="run_TestFrameworkExceptionHandling.sh ${value}" for="1,15"/>
   <test name="TestFWCoreIntegrationTryToContinuePath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py"/>
   <test name="TestFWCoreIntegrationTryToContinuePathMessage" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py 2>&amp;1 | fgrep 'applying TryToContinue on Exception'"/>
   <test name="TestFWCoreIntegrationTryToContinueTask" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/test_TryToContinue_cfg.py --useTask"/>

--- a/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
+++ b/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
@@ -5,79 +5,121 @@ LOCAL_TEST_DIR=${SCRAM_TEST_PATH}
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
 logfile=testFrameworkExceptionHandling$1.log
-echo $logfile
 cmsRun ${LOCAL_TEST_DIR}/testFrameworkExceptionHandling_cfg.py testNumber=$1 &> $logfile && die "cmsRun testFrameworkExceptionHandling_cfg.py testNumber=$1" 1
+
+echo "There are two instances of ExceptionThrowingProducer with different module labels in this test."
+echo "Usually one of them is configured to throw an intentional exception (an exception message should"
+echo "always show up in the log file). The shell script and both modules run tests on how the Framework"
+echo "handles the exception. The modules separately report in the log and here whether those tests PASSED"
+echo "or FAILED."
+echo ""
+
+grep "ExceptionThrowingProducer FAILED" $logfile && die " - FAILED because found the following string in the log file: ExceptionThrowingProducer FAILED " 1
+grep "ExceptionThrowingProducer PASSED" $logfile || die " - FAILED because cannot find the following string in the log file: ExceptionThrowingProducer PASSED " $?
 
 # Look for the content that we expect to be in the exception messages.
 # The first five should be the same in all log files.
 # The other two or three are different for each case.
 
-grep "Begin Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: Begin Fatal Exception " $?
+grep -q "Begin Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: Begin Fatal Exception " $?
 
-grep "An exception of category 'IntentionalTestException' occurred while" $logfile || die " - Cannot find the following string in the exception message: An exception of category 'IntentionalTestException' occurred while " $?
+grep -q "An exception of category 'IntentionalTestException' occurred while" $logfile || die " - Cannot find the following string in the exception message: An exception of category 'IntentionalTestException' occurred while " $?
 
-grep "Calling method for module ExceptionThrowingProducer/'throwException'" $logfile || die " - Cannot find the following string in the exception message: Calling method for module ExceptionThrowingProducer/'throwException' " $?
+grep -q "Calling method for module ExceptionThrowingProducer/'throwException'" $logfile || die " - Cannot find the following string in the exception message: Calling method for module ExceptionThrowingProducer/'throwException' " $?
 
-grep "Exception Message:" $logfile || die " - Cannot find the following string in the exception message: Exception Message: " $?
+grep -q "Exception Message:" $logfile || die " - Cannot find the following string in the exception message: Exception Message: " $?
 
-grep "End Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: End Fatal Exception " $?
-
-grep "ExceptionThrowingProducer PASSED" $logfile || die " - FAILED because cannot find the following string in the log file: ExceptionThrowingProducer PASSED " $?
-grep "ExceptionThrowingProducer FAILED" $logfile && die " - FAILED because found the following string in the log file: ExceptionThrowingProducer FAILED " 1
+grep -q "End Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: End Fatal Exception " $?
 
 if [ $1 -eq 1 ]
 then
-    grep "Processing  Event run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: Processing  Event run: 3 lumi: 1 event: 5 " $?
-    grep "Running path 'path1'" $logfile || die " - Cannot find the following string in the exception message: Running path 'path1' " $?
-    grep "ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5 " $?
+    grep -q "Processing  Event run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: Processing  Event run: 3 lumi: 1 event: 5 " $?
+    grep -q "Running path 'path1'" $logfile || die " - Cannot find the following string in the exception message: Running path 'path1' " $?
+    grep -q "ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5 " $?
 fi
 
 if [ $1 -eq 2 ]
 then
-    grep "Processing global begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing global begin Run run: 4 " $?
-    grep "ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
+    grep -q "Processing global begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing global begin Run run: 4 " $?
+    grep -q "ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
 fi
 
 if [ $1 -eq 3 ]
 then
-    grep "Processing global begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
-    grep "ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
+    grep -q "Processing global begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
+    grep -q "ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
 fi
 
 if [ $1 -eq 4 ]
 then
-    grep "Processing global end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing global end Run run: 3 " $?
-    grep "ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
+    grep -q "Processing global end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing global end Run run: 3 " $?
+    grep -q "ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
 fi
 
 if [ $1 -eq 5 ]
 then
-    grep "Processing global end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global end LuminosityBlock run: 3 luminosityBlock: 1 " $?
-    grep "ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
+    grep -q "Processing global end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global end LuminosityBlock run: 3 luminosityBlock: 1 " $?
+    grep -q "ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
 fi
 
 if [ $1 -eq 6 ]
 then
-    grep "Processing  stream begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin Run run: 4 " $?
-    grep "ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
+    grep -q "Processing  stream begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin Run run: 4 " $?
+    grep -q "ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
 fi
 
 if [ $1 -eq 7 ]
 then
-    grep "Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
-    grep "ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
+    grep -q "Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
+    grep -q "ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
 fi
 
 if [ $1 -eq 8 ]
 then
-   grep "Processing  stream end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end Run run: 3 " $?
-   grep "ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
+   grep -q "Processing  stream end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end Run run: 3 " $?
+   grep -q "ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
 fi
 
 if [ $1 -eq 9 ]
 then
-    grep "Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1 " $?
-    grep "ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
+    grep -q "Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1 " $?
+    grep -q "ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
+fi
+
+if [ $1 -eq 10 ]
+then
+    grep -q "Processing begin Job" $logfile || die " - Cannot find the following string in the exception message: Processing begin Job " $?
+    grep -q "ExceptionThrowingProducer::beginJob, module configured to throw during beginJob" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::beginJob, module configured to throw during beginJob " $?
+fi
+
+if [ $1 -eq 11 ]
+then
+    grep -q "Processing  begin Stream stream: 2" $logfile || die " - Cannot find the following string in the exception message: Processing  begin Stream stream: 2 " $?
+    grep -q "ExceptionThrowingProducer::beginStream, module configured to throw during beginStream for stream: 2" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::beginStream, module configured to throw during beginStream for stream: 2 " $?
+fi
+
+if [ $1 -eq 12 ]
+then
+    grep -q "Processing begin ProcessBlock" $logfile || die " - Cannot find the following string in the exception message: Processing begin ProcessBlock " $?
+    grep -q "ExceptionThrowingProducer::beginProcessBlock, module configured to throw during beginProcessBlock" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::beginProcessBlock, module configured to throw during beginProcessBlock " $?
+fi
+
+if [ $1 -eq 13 ]
+then
+    grep -q "Processing end ProcessBlock" $logfile || die " - Cannot find the following string in the exception message: Processing end ProcessBlock " $?
+    grep -q "ExceptionThrowingProducer::endProcessBlock, module configured to throw during endProcessBlock" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::endProcessBlock, module configured to throw during endProcessBlock " $?
+fi
+
+if [ $1 -eq 14 ]
+then
+    grep -q "Processing  end Stream stream: 2" $logfile || die " - Cannot find the following string in the exception message: Processing  end Stream stream: 2 " $?
+    grep -q "ExceptionThrowingProducer::endStream, module configured to throw during endStream for stream: 2" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::endStream, module configured to throw during endStream for stream: 2 " $?
+fi
+
+if [ $1 -eq 15 ]
+then
+    grep -q "Processing endJob" $logfile || die " - Cannot find the following string in the exception message: Processing endJob " $?
+    grep -q "ExceptionThrowingProducer::endJob, module configured to throw during endJob" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::endJob, module configured to throw during endJob " $?
 fi
 
 exit 0

--- a/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
+++ b/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
@@ -3,7 +3,7 @@
 #
 # cmsRun FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py testNumber=1
 #
-# with the value assigned to testNumber having a value from 1 to 9.
+# with the value assigned to testNumber having a value from 1 to 16.
 # That value specifies which transition to throw an exception in.
 # If the value is not specified, then no exception is thrown.
 
@@ -19,6 +19,9 @@ nLumis = nRuns*nLumisPerRun
 nEvents = nRuns*nEventsPerRun
 
 process = cms.Process("TEST")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 
@@ -62,7 +65,9 @@ process.options = cms.untracked.PSet(
 
 process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
 
-process.throwException = cms.EDProducer("ExceptionThrowingProducer")
+process.throwException = cms.EDProducer("ExceptionThrowingProducer",
+    verbose = cms.untracked.bool(False)
+)
 process.doNotThrowException = cms.EDProducer("ExceptionThrowingProducer")
 
 print('testNumber', options.testNumber)
@@ -111,14 +116,51 @@ elif options.testNumber == 7:
     process.doNotThrowException.expectedOffsetNoStreamEndLumi = cms.untracked.uint32(1)
 elif options.testNumber == 8:
     process.throwException.eventIDThrowOnStreamEndRun = cms.untracked.EventID(3, 0, 0)
-    process.throwException.expectedStreamBeginRun = cms.untracked.uint32(3)
-    process.doNotThrowException.expectedStreamBeginRun = cms.untracked.uint32(3)
 elif options.testNumber == 9:
     process.throwException.eventIDThrowOnStreamEndLumi = cms.untracked.EventID(3, 1, 0)
-    process.throwException.expectedStreamBeginLumi = cms.untracked.uint32(3)
-    process.doNotThrowException.expectedStreamBeginLumi = cms.untracked.uint32(3)
+elif options.testNumber == 10:
+    process.throwException.throwInBeginJob = cms.untracked.bool(True)
+    process.throwException.expectedNEndJob = cms.untracked.uint32(0)
+    process.throwException.expectedOffsetNoEndJob = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedNBeginStream = cms.untracked.uint32(0)
+    process.doNotThrowException.expectedNBeginProcessBlock = cms.untracked.uint32(0)
+    process.doNotThrowException.expectedNEndProcessBlock = cms.untracked.uint32(0)
+    process.doNotThrowException.expectedNEndStream = cms.untracked.uint32(0)
+    process.doNotThrowException.expectNoRunsProcessed = cms.untracked.bool(True)
+    process.doNotThrowException.expectedOffsetNoEndJob = cms.untracked.uint32(1)
+elif options.testNumber == 11:
+    process.throwException.throwInBeginStream = cms.untracked.bool(True)
+    process.throwException.expectedNBeginStream = cms.untracked.uint32(4)
+    process.throwException.expectedNBeginProcessBlock = cms.untracked.uint32(0)
+    process.throwException.expectedNEndProcessBlock = cms.untracked.uint32(0)
+    process.throwException.expectedNEndStream = cms.untracked.uint32(3)
+    process.throwException.expectNoRunsProcessed = cms.untracked.bool(True)
+    process.throwException.expectedOffsetNoEndStream = cms.untracked.uint32(1)
+    process.doNotThrowException.expectedNBeginStream = cms.untracked.uint32(4)
+    process.doNotThrowException.expectedNBeginProcessBlock = cms.untracked.uint32(0)
+    process.doNotThrowException.expectedNEndProcessBlock = cms.untracked.uint32(0)
+    process.doNotThrowException.expectedNEndStream = cms.untracked.uint32(4)
+    process.doNotThrowException.expectNoRunsProcessed = cms.untracked.bool(True)
+    process.doNotThrowException.expectedOffsetNoEndStream = cms.untracked.uint32(1)
+elif options.testNumber == 12:
+    process.throwException.throwInBeginProcessBlock = cms.untracked.bool(True)
+    process.throwException.expectedNEndProcessBlock = cms.untracked.uint32(0)
+    process.throwException.expectNoRunsProcessed = cms.untracked.bool(True)
+    process.throwException.expectedOffsetNoEndProcessBlock = cms.untracked.uint32(1)
+    process.doNotThrowException.expectNoRunsProcessed = cms.untracked.bool(True)
+    process.doNotThrowException.expectedOffsetNoEndProcessBlock = cms.untracked.uint32(1)
+elif options.testNumber == 13:
+    process.throwException.throwInEndProcessBlock = cms.untracked.bool(True)
+elif options.testNumber == 14:
+    process.throwException.throwInEndStream = cms.untracked.bool(True)
+elif options.testNumber == 15:
+    process.throwException.throwInEndJob = cms.untracked.bool(True)
+# This one does not throw. It is not used in the unit test but was useful
+# when manually debugging the test itself and manually debugging other things.
+elif options.testNumber == 16:
+    process.throwException.throwInEndJob = cms.untracked.bool(False)
 else:
-    print("The parameter named testNumber is out of range. An exception will not be thrown. Supported values range from 1 to 9.")
+    print("The parameter named testNumber is out of range. An exception will not be thrown. Supported values range from 1 to 16.")
     print("The proper syntax for setting the parameter is:")
     print("")
     print ("    cmsRun FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py testNumber=1")

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -64,8 +64,9 @@ Module type=TestFindProduct, Module label=a1, Parameter Set ID=a7caa43fcf5ef35de
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
-++ starting: begin job
 ++ finished: begin job
+++ starting: begin job
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 3
 ++++ starting: begin stream for module: stream = 0 label = 'a1' id = 4
@@ -132,6 +133,9 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 12
 ++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 13
 ++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 13
+++ finished: begin stream 0
+++ starting: begin stream 0
+++ finished: begin stream 0
 ++++ starting: begin process block
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
@@ -1661,6 +1665,7 @@ GlobalContext: transition = WriteProcessBlock
     ProcessContext: COPY 6f4335e86de793448be83fe14f12dcb7
     parent ProcessContext: PROD1 cf8fb4a5e3c9a108eac33826b2a17969
 
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 3
 ++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 3
 ++++ starting: end stream for module: stream = 0 label = 'a1' id = 4
@@ -1727,6 +1732,10 @@ ModuleCallingContext state = Running
 ++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 12
 ++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 13
 ++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 13
+++ finished: end stream 0
+++ starting: end stream 0
+++ finished: end stream 0
+++ starting: end job
 ++++ starting: end job for module with label 'intProducerA' id = 8
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=56ea7c8bbb02df4e1c3b945954838318
 ++++ finished: end job for module with label 'intProducerA' id = 8

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -35,6 +35,7 @@ Module type=IntProducer, Module label=intProducer, Parameter Set ID=b4b90439a301
 ++++ starting: begin job for module with label 'p' id = 2
 ++++ finished: begin job for module with label 'p' id = 2
 ++ finished: begin job
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
@@ -65,6 +66,7 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 6
 ++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 6
+++ finished: begin stream 0
 ++++ starting: begin process block
 GlobalContext: transition = BeginProcessBlock
     run: 0 luminosityBlock: 0
@@ -812,6 +814,7 @@ GlobalContext: transition = WriteProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 9a42d7e4995aeb2a3c9d04a3ef0f3879
 
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 3
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
@@ -842,6 +845,8 @@ ModuleCallingContext state = Running
 ++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 6
 ++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 6
+++ finished: end stream 0
+++ starting: end job
 ++++ starting: end job for module with label 'intProducerU' id = 5
 ++++ finished: end job for module with label 'intProducerU' id = 5
 ++++ starting: end job for module with label 'intVectorProducer' id = 6

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -72,6 +72,7 @@
 ++++ finished: constructing module with label 'out' id = 35
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
 ++ starting: begin job
+++ finished: begin job
 ++ starting: begin job
 ++ starting: begin job
 ++++ starting: begin job for module with label 'thingWithMergeProducer' id = 5
@@ -147,7 +148,11 @@
 ++++ finished: begin job for module with label 'path3' id = 27
 ++++ starting: begin job for module with label 'path4' id = 28
 ++++ finished: begin job for module with label 'path4' id = 28
-++ finished: begin job
+++ starting: begin stream 0
+++ finished: begin stream 0
+++ starting: begin stream 0
+++ finished: begin stream 0
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ starting: begin stream for module: stream = 0 label = 'get' id = 6
@@ -162,6 +167,10 @@
 ++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 10
 ++++ starting: begin stream for module: stream = 0 label = 'noPut' id = 11
 ++++ finished: begin stream for module: stream = 0 label = 'noPut' id = 11
+++ finished: begin stream 0
+++ starting: begin stream 0
+++ finished: begin stream 0
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ starting: begin stream for module: stream = 0 label = 'test' id = 18
@@ -176,6 +185,8 @@
 ++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 23
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 23
+++ finished: begin stream 0
+++ starting: begin stream 0
 ++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: begin stream for module: stream = 0 label = 'test' id = 30
@@ -190,6 +201,7 @@
 ++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++ starting: begin stream for module: stream = 0 label = 'out' id = 35
 ++++ finished: begin stream for module: stream = 0 label = 'out' id = 35
+++ finished: begin stream 0
 ++++ starting: begin process block
 ++++ finished: begin process block
 ++++ starting: begin process block
@@ -7339,6 +7351,11 @@
 ++++++ starting: write process block for module: label = 'out' id = 23
 ++++++ finished: write process block for module: label = 'out' id = 23
 ++++ finished: write process block
+++ starting: end stream 0
+++ finished: end stream 0
+++ starting: end stream 0
+++ finished: end stream 0
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 5
 ++++ starting: end stream for module: stream = 0 label = 'get' id = 6
@@ -7353,6 +7370,10 @@
 ++++ finished: end stream for module: stream = 0 label = 'getInt' id = 10
 ++++ starting: end stream for module: stream = 0 label = 'noPut' id = 11
 ++++ finished: end stream for module: stream = 0 label = 'noPut' id = 11
+++ finished: end stream 0
+++ starting: end stream 0
+++ finished: end stream 0
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 17
 ++++ starting: end stream for module: stream = 0 label = 'test' id = 18
@@ -7367,6 +7388,8 @@
 ++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 22
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 23
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 23
+++ finished: end stream 0
+++ starting: end stream 0
 ++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 29
 ++++ starting: end stream for module: stream = 0 label = 'test' id = 30
@@ -7381,6 +7404,9 @@
 ++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 34
 ++++ starting: end stream for module: stream = 0 label = 'out' id = 35
 ++++ finished: end stream for module: stream = 0 label = 'out' id = 35
+++ finished: end stream 0
+++ starting: end job
+++ finished: end job
 ++++ starting: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ finished: end job for module with label 'thingWithMergeProducer' id = 5
 ++++ starting: end job for module with label 'get' id = 6
@@ -7451,4 +7477,3 @@
 ++++ finished: end job for module with label 'path3' id = 27
 ++++ starting: end job for module with label 'path4' id = 28
 ++++ finished: end job for module with label 'path4' id = 28
-++ finished: end job

--- a/FWCore/ServiceRegistry/interface/GlobalContext.h
+++ b/FWCore/ServiceRegistry/interface/GlobalContext.h
@@ -23,6 +23,10 @@ information about the current state of global processing.
 #include <iosfwd>
 #include <string_view>
 
+namespace cms {
+  class Exception;
+}
+
 namespace edm {
 
   class ProcessContext;
@@ -76,6 +80,7 @@ namespace edm {
 
   void exceptionContext(std::ostream&, GlobalContext const&);
   std::ostream& operator<<(std::ostream&, GlobalContext const&);
+  void exceptionContext(cms::Exception&, GlobalContext const&, char const* context);
 
   std::string_view transitionName(GlobalContext::Transition);
 }  // namespace edm

--- a/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
+++ b/FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h
@@ -6,6 +6,7 @@ namespace edm {
   class GlobalContext;
   class ModuleCallingContext;
   class ParentContext;
+  class PathsAndConsumesOfModulesBase;
   class ProcessContext;
   class ServiceToken;
   class StreamContext;

--- a/FWCore/ServiceRegistry/interface/StreamContext.h
+++ b/FWCore/ServiceRegistry/interface/StreamContext.h
@@ -6,10 +6,10 @@
  Description: Holds pointer to ProcessContext, StreamID,
  transition, EventID and timestamp.
  This is intended primarily to be passed to Services
- as an argument to their callback functions.
-
- Usage:
-
+ as an argument to their callback functions. It is also
+ used internally by the Framework to hold information
+ that can be added to exception messages about the
+ context where an exception was thrown.
 
 */
 //

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -18,41 +18,6 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-//ActivityRegistry::ActivityRegistry() {
-//}
-
-// ActivityRegistry::ActivityRegistry(ActivityRegistry const& rhs) {
-//    // do actual copying here;
-// }
-
-//ActivityRegistry::~ActivityRegistry() {
-//}
-
-//
-// assignment operators
-//
-// ActivityRegistry const& ActivityRegistry::operator=(ActivityRegistry const& rhs) {
-//   //An exception safe implementation is
-//   ActivityRegistry temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
 namespace edm {
   namespace {
     template <typename T>
@@ -135,6 +100,12 @@ namespace edm {
   void ActivityRegistry::connectLocals(ActivityRegistry& iOther) {
     preBeginJobSignal_.connect(std::cref(iOther.preBeginJobSignal_));
 
+    preBeginStreamSignal_.connect(std::cref(iOther.preBeginStreamSignal_));
+    postBeginStreamSignal_.connect(std::cref(iOther.postBeginStreamSignal_));
+
+    preEndStreamSignal_.connect(std::cref(iOther.preEndStreamSignal_));
+    postEndStreamSignal_.connect(std::cref(iOther.postEndStreamSignal_));
+
     preModuleBeginStreamSignal_.connect(std::cref(iOther.preModuleBeginStreamSignal_));
     postModuleBeginStreamSignal_.connect(std::cref(iOther.postModuleBeginStreamSignal_));
 
@@ -191,36 +162,6 @@ namespace edm {
 
     prePathEventSignal_.connect(std::cref(iOther.prePathEventSignal_));
     postPathEventSignal_.connect(std::cref(iOther.postPathEventSignal_));
-
-    //preProcessEventSignal_.connect(std::cref(iOther.preProcessEventSignal_));
-    //postProcessEventSignal_.connect(std::cref(iOther.postProcessEventSignal_));
-
-    //preBeginRunSignal_.connect(std::cref(iOther.preBeginRunSignal_));
-    //postBeginRunSignal_.connect(std::cref(iOther.postBeginRunSignal_));
-
-    //preEndRunSignal_.connect(std::cref(iOther.preEndRunSignal_));
-    //postEndRunSignal_.connect(std::cref(iOther.postEndRunSignal_));
-
-    //preBeginLumiSignal_.connect(std::cref(iOther.preBeginLumiSignal_));
-    //postBeginLumiSignal_.connect(std::cref(iOther.postBeginLumiSignal_));
-
-    //preEndLumiSignal_.connect(std::cref(iOther.preEndLumiSignal_));
-    //postEndLumiSignal_.connect(std::cref(iOther.postEndLumiSignal_));
-
-    //preProcessPathSignal_.connect(std::cref(iOther.preProcessPathSignal_));
-    //postProcessPathSignal_.connect(std::cref(iOther.postProcessPathSignal_));
-
-    //prePathBeginRunSignal_.connect(std::cref(iOther.prePathBeginRunSignal_));
-    //postPathBeginRunSignal_.connect(std::cref(iOther.postPathBeginRunSignal_));
-
-    //prePathEndRunSignal_.connect(std::cref(iOther.prePathEndRunSignal_));
-    //postPathEndRunSignal_.connect(std::cref(iOther.postPathEndRunSignal_));
-
-    //prePathBeginLumiSignal_.connect(std::cref(iOther.prePathBeginLumiSignal_));
-    //postPathBeginLumiSignal_.connect(std::cref(iOther.postPathBeginLumiSignal_));
-
-    //prePathEndLumiSignal_.connect(std::cref(iOther.prePathEndLumiSignal_));
-    //postPathEndLumiSignal_.connect(std::cref(iOther.postPathEndLumiSignal_));
 
     preModuleConstructionSignal_.connect(std::cref(iOther.preModuleConstructionSignal_));
     postModuleConstructionSignal_.connect(std::cref(iOther.postModuleConstructionSignal_));
@@ -316,21 +257,6 @@ namespace edm {
     postESModuleAcquireSignal_.connect(std::cref(iOther.postESModuleAcquireSignal_));
 
     postESModuleRegistrationSignal_.connect(std::cref(iOther.postESModuleRegistrationSignal_));
-
-    //preModuleSignal_.connect(std::cref(iOther.preModuleSignal_));
-    //postModuleSignal_.connect(std::cref(iOther.postModuleSignal_));
-
-    //preModuleBeginRunSignal_.connect(std::cref(iOther.preModuleBeginRunSignal_));
-    //postModuleBeginRunSignal_.connect(std::cref(iOther.postModuleBeginRunSignal_));
-
-    //preModuleEndRunSignal_.connect(std::cref(iOther.preModuleEndRunSignal_));
-    //postModuleEndRunSignal_.connect(std::cref(iOther.postModuleEndRunSignal_));
-
-    //preModuleBeginLumiSignal_.connect(std::cref(iOther.preModuleBeginLumiSignal_));
-    //postModuleBeginLumiSignal_.connect(std::cref(iOther.postModuleBeginLumiSignal_));
-
-    //preModuleEndLumiSignal_.connect(std::cref(iOther.preModuleEndLumiSignal_));
-    //postModuleEndLumiSignal_.connect(std::cref(iOther.postModuleEndLumiSignal_));
   }
 
   void ActivityRegistry::connect(ActivityRegistry& iOther) {
@@ -375,6 +301,12 @@ namespace edm {
 
     copySlotsToFrom(preCloseFileSignal_, iOther.preCloseFileSignal_);
     copySlotsToFromReverse(postCloseFileSignal_, iOther.postCloseFileSignal_);
+
+    copySlotsToFrom(preBeginStreamSignal_, iOther.preBeginStreamSignal_);
+    copySlotsToFromReverse(postBeginStreamSignal_, iOther.postBeginStreamSignal_);
+
+    copySlotsToFrom(preEndStreamSignal_, iOther.preEndStreamSignal_);
+    copySlotsToFromReverse(postEndStreamSignal_, iOther.postEndStreamSignal_);
 
     copySlotsToFrom(preModuleBeginStreamSignal_, iOther.preModuleBeginStreamSignal_);
     copySlotsToFromReverse(postModuleBeginStreamSignal_, iOther.postModuleBeginStreamSignal_);
@@ -437,37 +369,6 @@ namespace edm {
     copySlotsToFrom(preGlobalEarlyTerminationSignal_, iOther.preGlobalEarlyTerminationSignal_);
     copySlotsToFrom(preSourceEarlyTerminationSignal_, iOther.preSourceEarlyTerminationSignal_);
 
-    /*
-    copySlotsToFrom(preProcessEventSignal_, iOther.preProcessEventSignal_);
-    copySlotsToFromReverse(postProcessEventSignal_, iOther.postProcessEventSignal_);
-
-    copySlotsToFrom(preBeginRunSignal_, iOther.preBeginRunSignal_);
-    copySlotsToFromReverse(postBeginRunSignal_, iOther.postBeginRunSignal_);
-
-    copySlotsToFrom(preEndRunSignal_, iOther.preEndRunSignal_);
-    copySlotsToFromReverse(postEndRunSignal_, iOther.postEndRunSignal_);
-
-    copySlotsToFrom(preBeginLumiSignal_, iOther.preBeginLumiSignal_);
-    copySlotsToFromReverse(postBeginLumiSignal_, iOther.postBeginLumiSignal_);
-
-    copySlotsToFrom(preEndLumiSignal_, iOther.preEndLumiSignal_);
-    copySlotsToFromReverse(postEndLumiSignal_, iOther.postEndLumiSignal_);
-
-    copySlotsToFrom(preProcessPathSignal_, iOther.preProcessPathSignal_);
-    copySlotsToFromReverse(postProcessPathSignal_, iOther.postProcessPathSignal_);
-
-    copySlotsToFrom(prePathBeginRunSignal_, iOther.prePathBeginRunSignal_);
-    copySlotsToFromReverse(postPathBeginRunSignal_, iOther.postPathBeginRunSignal_);
-
-    copySlotsToFrom(prePathEndRunSignal_, iOther.prePathEndRunSignal_);
-    copySlotsToFromReverse(postPathEndRunSignal_, iOther.postPathEndRunSignal_);
-
-    copySlotsToFrom(prePathBeginLumiSignal_, iOther.prePathBeginLumiSignal_);
-    copySlotsToFromReverse(postPathBeginLumiSignal_, iOther.postPathBeginLumiSignal_);
-
-    copySlotsToFrom(prePathEndLumiSignal_, iOther.prePathEndLumiSignal_);
-    copySlotsToFromReverse(postPathEndLumiSignal_, iOther.postPathEndLumiSignal_);
-*/
     copySlotsToFrom(preModuleConstructionSignal_, iOther.preModuleConstructionSignal_);
     copySlotsToFromReverse(postModuleConstructionSignal_, iOther.postModuleConstructionSignal_);
 
@@ -562,22 +463,7 @@ namespace edm {
     copySlotsToFromReverse(postESModuleAcquireSignal_, iOther.postESModuleAcquireSignal_);
 
     copySlotsToFromReverse(postESModuleRegistrationSignal_, iOther.postESModuleRegistrationSignal_);
-    /*
-    copySlotsToFrom(preModuleSignal_, iOther.preModuleSignal_);
-    copySlotsToFromReverse(postModuleSignal_, iOther.postModuleSignal_);
 
-    copySlotsToFrom(preModuleBeginRunSignal_, iOther.preModuleBeginRunSignal_);
-    copySlotsToFromReverse(postModuleBeginRunSignal_, iOther.postModuleBeginRunSignal_);
-
-    copySlotsToFrom(preModuleEndRunSignal_, iOther.preModuleEndRunSignal_);
-    copySlotsToFromReverse(postModuleEndRunSignal_, iOther.postModuleEndRunSignal_);
-
-    copySlotsToFrom(preModuleBeginLumiSignal_, iOther.preModuleBeginLumiSignal_);
-    copySlotsToFromReverse(postModuleBeginLumiSignal_, iOther.postModuleBeginLumiSignal_);
-
-    copySlotsToFrom(preModuleEndLumiSignal_, iOther.preModuleEndLumiSignal_);
-    copySlotsToFromReverse(postModuleEndLumiSignal_, iOther.postModuleEndLumiSignal_);
-     */
     copySlotsToFrom(preSourceConstructionSignal_, iOther.preSourceConstructionSignal_);
     copySlotsToFromReverse(postSourceConstructionSignal_, iOther.postSourceConstructionSignal_);
 
@@ -585,12 +471,4 @@ namespace edm {
     copySlotsToFrom(preESSyncIOVSignal_, iOther.preESSyncIOVSignal_);
     copySlotsToFromReverse(postESSyncIOVSignal_, iOther.postESSyncIOVSignal_);
   }
-
-  //
-  // const member functions
-  //
-
-  //
-  // static member functions
-  //
 }  // namespace edm

--- a/FWCore/ServiceRegistry/src/GlobalContext.cc
+++ b/FWCore/ServiceRegistry/src/GlobalContext.cc
@@ -1,7 +1,9 @@
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include <ostream>
+#include <sstream>
 
 namespace edm {
 
@@ -116,6 +118,15 @@ namespace edm {
         os << "write LuminosityBlock " << gc.luminosityBlockID();
         break;
     }
+  }
+
+  void exceptionContext(cms::Exception& ex, GlobalContext const& globalContext, char const* context) {
+    std::ostringstream ost;
+    if (context && *context != '\0') {
+      ex.addContext(context);
+    }
+    exceptionContext(ost, globalContext);
+    ex.addContext(ost.str());
   }
 
   std::string_view transitionName(GlobalContext::Transition iTrans) {

--- a/FWCore/Services/plugins/Tracer.cc
+++ b/FWCore/Services/plugins/Tracer.cc
@@ -65,7 +65,13 @@ namespace edm {
 
       void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
       void postBeginJob();
+      void preEndJob();
       void postEndJob();
+
+      void preBeginStream(StreamContext const&);
+      void postBeginStream(StreamContext const&);
+      void preEndStream(StreamContext const&);
+      void postEndStream(StreamContext const&);
 
       void preSourceEvent(StreamID);
       void postSourceEvent(StreamID);
@@ -269,7 +275,13 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry& iRegistry)
 
   iRegistry.watchPreBeginJob(this, &Tracer::preBeginJob);
   iRegistry.watchPostBeginJob(this, &Tracer::postBeginJob);
+  iRegistry.watchPreEndJob(this, &Tracer::preEndJob);
   iRegistry.watchPostEndJob(this, &Tracer::postEndJob);
+
+  iRegistry.watchPreBeginStream(this, &Tracer::preBeginStream);
+  iRegistry.watchPostBeginStream(this, &Tracer::postBeginStream);
+  iRegistry.watchPreEndStream(this, &Tracer::preEndStream);
+  iRegistry.watchPostEndStream(this, &Tracer::postEndStream);
 
   iRegistry.watchPreSourceEvent(this, &Tracer::preSourceEvent);
   iRegistry.watchPostSourceEvent(this, &Tracer::postSourceEvent);
@@ -605,8 +617,28 @@ void Tracer::postBeginJob() {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: begin job";
 }
 
+void Tracer::preEndJob() {
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " starting: end job";
+}
+
 void Tracer::postEndJob() {
   LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: end job";
+}
+
+void Tracer::preBeginStream(StreamContext const& sc) {
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " starting: begin stream " << sc.streamID();
+}
+
+void Tracer::postBeginStream(StreamContext const& sc) {
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: begin stream " << sc.streamID();
+}
+
+void Tracer::preEndStream(StreamContext const& sc) {
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " starting: end stream " << sc.streamID();
+}
+
+void Tracer::postEndStream(StreamContext const& sc) {
+  LogAbsolute("Tracer") << TimeStamper(printTimestamps_) << indention_ << " finished: end stream " << sc.streamID();
 }
 
 void Tracer::preSourceEvent(StreamID sid) {

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -52,6 +52,8 @@
 
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
 
+#include <mutex>
+
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -417,10 +419,9 @@ namespace edm {
       actReg_->eventSetupConfigurationSignal_(esp_->recordsToResolverIndices(), processContext_);
       //NOTE: this may throw
       //checkForModuleDependencyCorrectness(pathsAndConsumesOfModules, false);
-      actReg_->preBeginJobSignal_(pathsAndConsumesOfModules, processContext_);
 
-      schedule_->beginJob(*preg_, esp_->recordsToResolverIndices(), *processBlockHelper_);
-      actReg_->postBeginJobSignal_();
+      schedule_->beginJob(
+          *preg_, esp_->recordsToResolverIndices(), *processBlockHelper_, pathsAndConsumesOfModules, processContext_);
 
       for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
         schedule_->beginStream(i);
@@ -686,13 +687,14 @@ namespace edm {
       // Collects exceptions, so we don't throw before all operations are performed.
       ExceptionCollector c(
           "Multiple exceptions were thrown while executing endJob. An exception message follows for each.\n");
+      std::mutex collectorMutex;
 
       //make the services available
       ServiceRegistry::Operate operate(serviceToken_);
 
       //NOTE: this really should go elsewhere in the future
       for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
-        c.call([this, i]() { this->schedule_->endStream(i); });
+        schedule_->endStream(i, c, collectorMutex);
       }
       auto actReg = actReg_.get();
       c.call([actReg]() { actReg->preEndJobSignal_(); });

--- a/FWCore/Utilities/src/ExceptionCollector.cc
+++ b/FWCore/Utilities/src/ExceptionCollector.cc
@@ -44,7 +44,9 @@ namespace edm {
         firstException_.reset(ex.clone());
         accumulatedExceptions_ = std::make_unique<MultipleException>(ex.returnCode(), initialMessage_);
       }
-      *accumulatedExceptions_ << nExceptions_ << "\n" << ex.explainSelf();
+      *accumulatedExceptions_ << "----- Exception " << nExceptions_ << " -----"
+                              << "\n"
+                              << ex.explainSelf();
     }
   }
 

--- a/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.cc
@@ -192,6 +192,11 @@ namespace edm {
 
       activityRegistry.watchPreallocate(this, &RandomNumberGeneratorService::preallocate);
 
+      activityRegistry.watchPreBeginJob(this, &RandomNumberGeneratorService::preBeginJob);
+      activityRegistry.watchPostBeginJob(this, &RandomNumberGeneratorService::postBeginJob);
+      activityRegistry.watchPreEndJob(this, &RandomNumberGeneratorService::preEndJob);
+      activityRegistry.watchPostEndJob(this, &RandomNumberGeneratorService::postEndJob);
+
       if (enableChecking_) {
         activityRegistry.watchPreModuleBeginStream(this, &RandomNumberGeneratorService::preModuleBeginStream);
         activityRegistry.watchPostModuleBeginStream(this, &RandomNumberGeneratorService::postModuleBeginStream);
@@ -222,11 +227,11 @@ namespace edm {
 
     CLHEP::HepRandomEngine& RandomNumberGeneratorService::getEngine(StreamID const& streamID) {
       ModuleCallingContext const* mcc = CurrentModuleOnThread::getCurrentModuleOnThread();
-      if (mcc == nullptr) {
+      if (mcc == nullptr || beginJobEndJobActive_) {
         throw Exception(errors::LogicError)
             << "RandomNumberGeneratorService::getEngine\n"
                "Requested a random number engine from the RandomNumberGeneratorService\n"
-               "when no module was active. ModuleCallingContext is null\n";
+               "while ModuleCallingContext is null or during beginJob or endJob transitions.\n";
       }
       unsigned int moduleID = mcc->moduleDescription()->id();
 
@@ -256,11 +261,11 @@ namespace edm {
 
     CLHEP::HepRandomEngine& RandomNumberGeneratorService::getEngine(LuminosityBlockIndex const& lumiIndex) {
       ModuleCallingContext const* mcc = CurrentModuleOnThread::getCurrentModuleOnThread();
-      if (mcc == nullptr) {
+      if (mcc == nullptr || beginJobEndJobActive_) {
         throw Exception(errors::LogicError)
             << "RandomNumberGeneratorService::getEngine\n"
                "Requested a random number engine from the RandomNumberGeneratorService\n"
-               "when no module was active. ModuleCallingContext is null\n";
+               "while ModuleCallingContext is null or during beginJob or endJob transitions.\n";
       }
       unsigned int moduleID = mcc->moduleDescription()->id();
 
@@ -302,11 +307,11 @@ namespace edm {
     std::uint32_t RandomNumberGeneratorService::mySeed() const {
       std::string label;
       ModuleCallingContext const* mcc = CurrentModuleOnThread::getCurrentModuleOnThread();
-      if (mcc == nullptr) {
+      if (mcc == nullptr || beginJobEndJobActive_) {
         throw Exception(errors::LogicError)
-            << "RandomNumberGeneratorService::getEngine()\n"
-               "Requested a random number engine from the RandomNumberGeneratorService\n"
-               "from an unallowed transition. ModuleCallingContext is null\n";
+            << "RandomNumberGeneratorService::mySeed()\n"
+               "Requested a random number seed from the RandomNumberGeneratorService\n"
+               "while ModuleCallingContext is null or during beginJob or endJob transitions.\n";
       } else {
         label = mcc->moduleDescription()->moduleLabel();
       }
@@ -422,6 +427,16 @@ namespace edm {
         print(std::cout);
       }
     }
+
+    void RandomNumberGeneratorService::preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&) {
+      beginJobEndJobActive_ = true;
+    }
+
+    void RandomNumberGeneratorService::postBeginJob() { beginJobEndJobActive_ = false; }
+
+    void RandomNumberGeneratorService::preEndJob() { beginJobEndJobActive_ = true; }
+
+    void RandomNumberGeneratorService::postEndJob() { beginJobEndJobActive_ = false; }
 
     void RandomNumberGeneratorService::preBeginLumi(LuminosityBlock const& lumi) {
       if (!restoreStateTag_.label().empty()) {

--- a/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/plugins/RandomNumberGeneratorService.h
@@ -11,6 +11,7 @@
   (originally in FWCore/Services)
 */
 
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
@@ -91,6 +92,11 @@ namespace edm {
       void postEventRead(Event const& event) override;
       void setLumiCache(LuminosityBlockIndex, std::vector<RandomEngineState> const& iStates) override;
       void setEventCache(StreamID, std::vector<RandomEngineState> const& iStates) override;
+
+      void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
+      void postBeginJob();
+      void preEndJob();
+      void postEndJob();
 
       /// These next 12 functions are only used to check that random numbers are not
       /// being generated in these methods when enable checking is configured on.
@@ -270,6 +276,7 @@ namespace edm {
       bool enableChecking_;
 
       std::uint32_t eventSeedOffset_;
+      bool beginJobEndJobActive_ = false;
 
       bool verbose_;
 

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ExceptionCollector.h"
 
 #include "TH1F.h"
 
@@ -82,6 +83,7 @@ namespace edm {
     void beginJob(eventsetup::ESRecordsToProductResolverIndices const&);
     void beginStream(edm::StreamID);
     void endStream();
+    void endStream(ExceptionCollector&);
 
     void beginRun(const edm::Run& run, const edm::EventSetup& setup);
     void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup);

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "TFile.h"
@@ -318,17 +319,24 @@ namespace edm {
     }
   }
 
-  void BMixingModule::beginStream(edm::StreamID iID) {
+  void BMixingModule::beginStream(edm::StreamID streamID) {
     for (size_t endIdx = 0; endIdx < maxNbSources_; ++endIdx) {
       if (inputSources_[endIdx])
-        inputSources_[endIdx]->beginStream(iID);
+        inputSources_[endIdx]->beginStream(streamID);
     }
   }
 
   void BMixingModule::endStream() {
+    ExceptionCollector exceptionCollector(
+        "Multiple exceptions were thrown while executing endStream and endJob for mixing modules. "
+        "An exception message follows for each.\n");
+
     for (size_t endIdx = 0; endIdx < maxNbSources_; ++endIdx) {
       if (inputSources_[endIdx])
-        inputSources_[endIdx]->endStream();
+        inputSources_[endIdx]->endStream(exceptionCollector);
+    }
+    if (exceptionCollector.hasThrown()) {
+      exceptionCollector.rethrow();
     }
   }
 

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/WorkerManager.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistryfwd.h"
 
 #include <memory>
 #include <string>
@@ -37,11 +38,15 @@ namespace edm {
 
     void setupPileUpEvent(EventPrincipal& ep, const EventSetupImpl& setup, StreamContext& sContext);
 
-    void beginJob(ProductRegistry const& iRegistry, eventsetup::ESRecordsToProductResolverIndices const&);
-    void endJob() { workerManager_.endJob(); }
+    void beginJob(ProductRegistry const& iRegistry,
+                  eventsetup::ESRecordsToProductResolverIndices const&,
+                  GlobalContext const&);
+    void endJob(ExceptionCollector& exceptionCollector, GlobalContext const& globalContext) {
+      workerManager_.endJob(exceptionCollector, globalContext);
+    }
 
-    void beginStream(edm::StreamID iID, StreamContext& sContext);
-    void endStream(edm::StreamID iID, StreamContext& sContext);
+    void beginStream(edm::StreamID, StreamContext const&);
+    void endStream(edm::StreamID, StreamContext const&, ExceptionCollector&);
 
   private:
     std::unique_ptr<ExceptionToActionTable> exceptionToActionTable_;


### PR DESCRIPTION
#### PR description:

Improve the behavior of the Framework after exceptions in beginJob, endJob, beginStream, endStream, beginProcessBlock and endProcessBlock transitions. This is the fourth and final PR in a series of PRs modifying the behavior of the Framework after exceptions so that it more consistently handles exceptions in all the begin/end transitions. The first PR handled stream lumi exceptions (PR #44624). The second PR handled global lumi exceptions (PR #44840). The third PR handled run transitions (PR #45017). The comments at the head of the first PR state the design for the new behavior we are implementing.

The intent is that nothing in the output will change if there are not any exceptions. In some cases, ordering of operations may change where that ordering is not supposed to matter. There are some minor differences related to signals.
* PreBeginStream, PostBeginStream, PreEndStream, and PostEndStream signals are newly added. Probably they were inadvertently omitted before.
* The PreBeginJob, PostBeginJob, PreEndJob, and PostEndJob enclose less than before to be more like runs and lumis. Some input source, looper and subprocess signals are no longer enclosed between the higher level Pre and Post signals, but the same module level signals are still enclosed.
* There are functions used by the looper called replaceModule (rarely or possibly never actually used). The module level signals are   not enclosed by transition level signals when called from the replaceModule function. beginStream and beginJob are the module level transitions that are run there when a module is replaced.

This work was motivated by discussions related to Issues https://github.com/cms-sw/cmssw/issues/43831 and https://github.com/cms-sw/cmssw/issues/42501.

#### PR validation:

An existing unit test covering exceptions in different transitions is extended to cover the most salient cases. Additional manual testing of many various cases was also done. Existing unit tests pass.
