### PR TITLE
Xgbooster protection

### DIFF
--- a/PhysicsTools/XGBoost/BuildFile.xml
+++ b/PhysicsTools/XGBoost/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="FWCore/MessageLogger"/>
 <use name="xgboost"/>
 <export>
   <lib name="1"/>

--- a/PhysicsTools/XGBoost/interface/XGBooster.h
+++ b/PhysicsTools/XGBoost/interface/XGBooster.h
@@ -22,11 +22,20 @@ namespace pat {
 
     void set(std::string name, float value);
 
+    const std::string& name(unsigned int feature) const;
+
+    /// Protected predict
+    /// Requires explicit setting of each feature by name
     float predict(const int iterationEnd = 0);
+
+    /// Const unprotected predict
+    /// User must ensure consistency of the input features
+    /// and its values with the model
     float predict(const std::vector<float>& features, const int iterationEnd = 0) const;
 
   private:
     std::vector<float> features_;
+    std::vector<bool> status_;
     std::map<std::string, unsigned int> feature_name_to_index_;
     BoosterHandle booster_;
   };

--- a/PhysicsTools/XGBoost/src/XGBooster.cc
+++ b/PhysicsTools/XGBoost/src/XGBooster.cc
@@ -71,9 +71,7 @@ XGBooster::XGBooster(std::string model_file, std::string model_features) : XGBoo
   }
 }
 
-void XGBooster::reset() {
-  std::fill(status_.begin(), status_.end(), false);
-}
+void XGBooster::reset() { std::fill(status_.begin(), status_.end(), false); }
 
 void XGBooster::addFeature(std::string name) {
   features_.push_back(0);
@@ -87,8 +85,7 @@ void XGBooster::set(std::string name, float value) {
   status_.at(i) = true;
 }
 
-const std::string& XGBooster::name(unsigned int feature) const
-{
+const std::string& XGBooster::name(unsigned int feature) const {
   for (const auto& pair : feature_name_to_index_) {
     if (pair.second == feature)
       return pair.first;
@@ -105,12 +102,11 @@ float XGBooster::predict(const int iterationEnd) {
     }
     // Check for invalid input
     if (std::isnan(features_.at(i))) {
-      edm::LogWarning("InvalidInput") <<
-	"Invalid input is provided (NaN). Feature name " + name(i);
+      edm::LogWarning("InvalidInput") << "Invalid input is provided (NaN). Feature name " + name(i);
       return -998.;
     }
   }
-  
+
   float const ret = predict(features_, iterationEnd);
 
   reset();

--- a/PhysicsTools/XGBoost/test/BuildFile.xml
+++ b/PhysicsTools/XGBoost/test/BuildFile.xml
@@ -1,0 +1,8 @@
+<bin name="testXGBooster" file="testXGBooster.cpp">
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/MessageLogger"/>
+    <use name="PhysicsTools/XGBoost"/>
+    <use name="cppunit"/>
+    <use name="xgboost"/>
+</bin>

--- a/PhysicsTools/XGBoost/test/testXGBooster.cpp
+++ b/PhysicsTools/XGBoost/test/testXGBooster.cpp
@@ -1,0 +1,142 @@
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/TestResult.h>
+#include <cppunit/TestResultCollector.h>
+#include <cppunit/TextOutputter.h>
+#include "PhysicsTools/XGBoost/interface/XGBooster.h"
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+#include <iostream>
+#include <xgboost/c_api.h>
+#include <cmath>  // For NAN
+
+class XGBoosterTest : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(XGBoosterTest);
+  CPPUNIT_TEST(testModelFileNotFound);
+  CPPUNIT_TEST(testSetAndPredict);
+  CPPUNIT_TEST(testInvalidFeatureValue);
+  CPPUNIT_TEST(testUnsetFeature);
+  CPPUNIT_TEST(testPredict);
+  CPPUNIT_TEST_SUITE_END();
+  
+public:
+  void setUp() override {
+    std::string model_name = "test_model.xgb";
+    
+    // Prepare a test model
+    generateTestModel(model_name);
+    
+    // Load the model
+    std::ifstream modelFile(model_name);
+    if (!modelFile.good()) {
+      throw std::runtime_error("Model file not found");
+    }
+    booster = new pat::XGBooster(model_name);
+
+    // Add features to the booster 
+    featureNames = {"feature1", "feature2", "feature3", "feature4"};
+    for (const auto& featureName : featureNames) {
+      booster->addFeature(featureName);
+    }
+  }
+
+  void tearDown() override {
+    delete booster;
+  }
+
+  //
+  // Tests
+  //
+  
+  void testModelFileNotFound() {
+    CPPUNIT_ASSERT_THROW(pat::XGBooster("nonexistent_model.xgb"), std::runtime_error);
+  }
+
+  void testSetAndPredict() {
+    booster->set(featureNames[0], 0.5);
+    booster->set(featureNames[1], 1.2);
+    booster->set(featureNames[2], -0.3);
+    booster->set(featureNames[3], 0.8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, booster->predict(), 1e-5);
+  }
+
+  void testPredict() {
+    std::vector<float> values = { 0.5, 1.2, -0.3, 0.8 };
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, booster->predict(values), 1e-5);
+  }
+  
+  void testInvalidFeatureValue() {
+    booster->set(featureNames[0], NAN);
+    booster->set(featureNames[1], 1.2);
+    booster->set(featureNames[2], -0.3);
+    booster->set(featureNames[3], 0.8);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-998, booster->predict(), 1e-5);
+  }
+
+  void testUnsetFeature() {
+    booster->set(featureNames[0], 0.5);
+    booster->set(featureNames[1], 1.2);
+    booster->set(featureNames[2], -0.3);
+    CPPUNIT_ASSERT_THROW(booster->predict(), std::runtime_error);
+  }
+
+
+private:
+    pat::XGBooster* booster;
+    std::vector<std::string> featureNames;
+
+  void generateTestModel(const std::string& modelPath) {
+        // Define a fixed dataset
+        const int num_rows = 6;
+        const int num_cols = 4;
+        float data[num_rows * num_cols] = {
+            1.0, 2.0, 3.0, 4.0,
+            5.0, 6.0, 7.0, 8.0,
+            9.0, 10.0, 11.0, 12.0,
+            13.0, 14.0, 15.0, 16.0,
+            17.0, 18.0, 19.0, 20.0,
+            21.0, 22.0, 23.0, 24.0
+        };
+        float labels[num_rows] = {0, 1, 0, 1, 0, 1};
+
+        // Create DMatrix
+        DMatrixHandle dtrain;
+        XGDMatrixCreateFromMat(data, num_rows, num_cols, NAN, &dtrain);
+        XGDMatrixSetFloatInfo(dtrain, "label", labels, num_rows);
+
+        // Set parameters
+        BoosterHandle booster;
+        XGBoosterCreate(&dtrain, 1, &booster);
+        XGBoosterSetParam(booster, "max_depth", "2");
+        XGBoosterSetParam(booster, "eta", "1");
+        XGBoosterSetParam(booster, "objective", "binary:logistic");
+
+        // Train the model
+        for (int iter = 0; iter < 10; ++iter) {
+            XGBoosterUpdateOneIter(booster, iter, dtrain);
+        }
+
+        // Save the model
+        XGBoosterSaveModel(booster, modelPath.c_str());
+
+        // Free memory
+        XGBoosterFree(booster);
+        XGDMatrixFree(dtrain);
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(XGBoosterTest);
+
+int main(int argc, char** argv) {
+    CppUnit::TextUi::TestRunner runner;
+    runner.addTest(XGBoosterTest::suite());
+
+    // Add a progress listener
+    CppUnit::BriefTestProgressListener progress;
+    runner.eventManager().addListener(&progress);
+    
+    // Return 0 if all tests passed, 1 if there were any failures
+    return runner.run() ? 0 : 1;
+}

--- a/PhysicsTools/XGBoost/test/testXGBooster.cpp
+++ b/PhysicsTools/XGBoost/test/testXGBooster.cpp
@@ -20,14 +20,14 @@ class XGBoosterTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testUnsetFeature);
   CPPUNIT_TEST(testPredict);
   CPPUNIT_TEST_SUITE_END();
-  
+
 public:
   void setUp() override {
     std::string model_name = "test_model.xgb";
-    
+
     // Prepare a test model
     generateTestModel(model_name);
-    
+
     // Load the model
     std::ifstream modelFile(model_name);
     if (!modelFile.good()) {
@@ -35,24 +35,20 @@ public:
     }
     booster = new pat::XGBooster(model_name);
 
-    // Add features to the booster 
+    // Add features to the booster
     featureNames = {"feature1", "feature2", "feature3", "feature4"};
     for (const auto& featureName : featureNames) {
       booster->addFeature(featureName);
     }
   }
 
-  void tearDown() override {
-    delete booster;
-  }
+  void tearDown() override { delete booster; }
 
   //
   // Tests
   //
-  
-  void testModelFileNotFound() {
-    CPPUNIT_ASSERT_THROW(pat::XGBooster("nonexistent_model.xgb"), std::runtime_error);
-  }
+
+  void testModelFileNotFound() { CPPUNIT_ASSERT_THROW(pat::XGBooster("nonexistent_model.xgb"), std::runtime_error); }
 
   void testSetAndPredict() {
     booster->set(featureNames[0], 0.5);
@@ -63,10 +59,10 @@ public:
   }
 
   void testPredict() {
-    std::vector<float> values = { 0.5, 1.2, -0.3, 0.8 };
+    std::vector<float> values = {0.5, 1.2, -0.3, 0.8};
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, booster->predict(values), 1e-5);
   }
-  
+
   void testInvalidFeatureValue() {
     booster->set(featureNames[0], NAN);
     booster->set(featureNames[1], 1.2);
@@ -82,61 +78,54 @@ public:
     CPPUNIT_ASSERT_THROW(booster->predict(), std::runtime_error);
   }
 
-
 private:
-    pat::XGBooster* booster;
-    std::vector<std::string> featureNames;
+  pat::XGBooster* booster;
+  std::vector<std::string> featureNames;
 
   void generateTestModel(const std::string& modelPath) {
-        // Define a fixed dataset
-        const int num_rows = 6;
-        const int num_cols = 4;
-        float data[num_rows * num_cols] = {
-            1.0, 2.0, 3.0, 4.0,
-            5.0, 6.0, 7.0, 8.0,
-            9.0, 10.0, 11.0, 12.0,
-            13.0, 14.0, 15.0, 16.0,
-            17.0, 18.0, 19.0, 20.0,
-            21.0, 22.0, 23.0, 24.0
-        };
-        float labels[num_rows] = {0, 1, 0, 1, 0, 1};
+    // Define a fixed dataset
+    const int num_rows = 6;
+    const int num_cols = 4;
+    float data[num_rows * num_cols] = {1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0, 12.0,
+                                       13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0};
+    float labels[num_rows] = {0, 1, 0, 1, 0, 1};
 
-        // Create DMatrix
-        DMatrixHandle dtrain;
-        XGDMatrixCreateFromMat(data, num_rows, num_cols, NAN, &dtrain);
-        XGDMatrixSetFloatInfo(dtrain, "label", labels, num_rows);
+    // Create DMatrix
+    DMatrixHandle dtrain;
+    XGDMatrixCreateFromMat(data, num_rows, num_cols, NAN, &dtrain);
+    XGDMatrixSetFloatInfo(dtrain, "label", labels, num_rows);
 
-        // Set parameters
-        BoosterHandle booster;
-        XGBoosterCreate(&dtrain, 1, &booster);
-        XGBoosterSetParam(booster, "max_depth", "2");
-        XGBoosterSetParam(booster, "eta", "1");
-        XGBoosterSetParam(booster, "objective", "binary:logistic");
+    // Set parameters
+    BoosterHandle booster;
+    XGBoosterCreate(&dtrain, 1, &booster);
+    XGBoosterSetParam(booster, "max_depth", "2");
+    XGBoosterSetParam(booster, "eta", "1");
+    XGBoosterSetParam(booster, "objective", "binary:logistic");
 
-        // Train the model
-        for (int iter = 0; iter < 10; ++iter) {
-            XGBoosterUpdateOneIter(booster, iter, dtrain);
-        }
-
-        // Save the model
-        XGBoosterSaveModel(booster, modelPath.c_str());
-
-        // Free memory
-        XGBoosterFree(booster);
-        XGDMatrixFree(dtrain);
+    // Train the model
+    for (int iter = 0; iter < 10; ++iter) {
+      XGBoosterUpdateOneIter(booster, iter, dtrain);
     }
+
+    // Save the model
+    XGBoosterSaveModel(booster, modelPath.c_str());
+
+    // Free memory
+    XGBoosterFree(booster);
+    XGDMatrixFree(dtrain);
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(XGBoosterTest);
 
 int main(int argc, char** argv) {
-    CppUnit::TextUi::TestRunner runner;
-    runner.addTest(XGBoosterTest::suite());
+  CppUnit::TextUi::TestRunner runner;
+  runner.addTest(XGBoosterTest::suite());
 
-    // Add a progress listener
-    CppUnit::BriefTestProgressListener progress;
-    runner.eventManager().addListener(&progress);
-    
-    // Return 0 if all tests passed, 1 if there were any failures
-    return runner.run() ? 0 : 1;
+  // Add a progress listener
+  CppUnit::BriefTestProgressListener progress;
+  runner.eventManager().addListener(&progress);
+
+  // Return 0 if all tests passed, 1 if there were any failures
+  return runner.run() ? 0 : 1;
 }


### PR DESCRIPTION
#### PR description:

Replaced the exception for invalid input (NaN) with a warning and specific return code, which allows to keep track of such failures offline to verify that it does not have an impact on physics results. The cause of NaN values is not understood and the failure is not reproducible, but it's a very rare event and it is not expected to have any impact on physics results. The change is needed to prevent unnecessary exception and job failure.

For details see: https://github.com/cms-sw/cmssw/issues/45398

The code is also modified a bit to separate protection against unset inputs from invalid input.

#### PR validation:

Add a unit tests, which tests all major use cases and their potential failures.

