### PR TITLE
Add L1Ntupler for NanoDST

### DIFF
--- a/L1Trigger/L1TNtuples/python/L1NtupleNanoDST_cff.py
+++ b/L1Trigger/L1TNtuples/python/L1NtupleNanoDST_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TNtuples.l1EventTree_cfi import *
+from L1Trigger.L1TNtuples.l1UpgradeTree_cfi import *
+from L1Trigger.L1TNtuples.l1uGTTree_cfi import *
+from L1Trigger.L1TNtuples.l1uGTTestcrateTree_cfi import *
+
+# use L1 objects from unpacked uGT output
+l1UpgradeTree.egToken = cms.untracked.InputTag("gtStage2Digis","EGamma")
+l1UpgradeTree.tauTokens = cms.untracked.VInputTag(cms.InputTag("gtStage2Digis","Tau"))
+l1UpgradeTree.jetToken = cms.untracked.InputTag("gtStage2Digis","Jet")
+l1UpgradeTree.muonToken = cms.untracked.InputTag("gtStage2Digis","Muon")
+l1UpgradeTree.sumToken = cms.untracked.InputTag("gtStage2Digis","EtSum")
+
+L1NtupleNANO = cms.Sequence(
+  l1EventTree
+  +l1UpgradeTree
+  +l1uGTTestcrateTree
+  +l1uGTTree
+)

--- a/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
+++ b/L1Trigger/L1TNtuples/python/customiseL1Ntuple.py
@@ -82,6 +82,23 @@ def L1NtupleRAW(process):
 
     return process
 
+def L1NtupleNanoDST(process):
+
+    L1NtupleTFileOut(process)
+
+    process.load('L1Trigger.L1TNtuples.L1NtupleNanoDST_cff')
+    process.l1ntuplenano = cms.Path(
+        process.L1NtupleNANO
+    )
+
+    process.schedule.append(process.l1ntuplenano)
+
+    # unpack uGT/test crate from the dedicated FED selectors post this update: https://its.cern.ch/jira/browse/CMSHLT-3172
+    process.gtStage2Digis.InputLabel = cms.InputTag("hltFEDSelectorL1")
+    process.gtTestcrateStage2Digis.InputLabel = cms.InputTag("hltFEDSelectorL1uGTTest")
+
+    return process
+
 def L1NtupleNANO(process):
 
     L1NtupleTFileOut(process)


### PR DESCRIPTION
#### PR description:

Following the addition of the uGT testcrate to NanoDST in [CMSHLT-3162](https://its.cern.ch/jira/browse/CMSHLT-3162) and the change from saving digi to raw for the production crate [in CMSHLT-3172](https://its.cern.ch/jira/browse/CMSHLT-3172) this introduces a new type of L1Ntupler configuration for the NanoDST (`L1Accept`) dataset which saves the production and test crate uGT decision trees.

This is based on the `L1TNtuples/python/L1NtupleNANO_cff.py` though the NANO there probably refers to NanoAOD.

#### PR validation:

Tested with this cmsDriver command since it does not affect any central workflows:

```
cmsDriver.py l1Ntuple -s RAW2DIGI \   
-n -1 --no_output --era=Run3 \
--data --conditions=140X_dataRun3_Prompt_v2  \
--customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleNanoDST \
--filein file:/eos/cms/tier0/store/data/Run2024F/L1Accept/RAW/v1/000/383/034/00000/e4da3f6d-3e47-4868-8100-061245f4a62e.root
```

The output file contains what is expected and properly filled:
```
 TFile*		L1Ntuple_L1A_Run383001_test_200k.root	
  KEY: TDirectoryFile	l1EventTree;1	l1EventTree
  KEY: TDirectoryFile	l1UpgradeTree;1	l1UpgradeTree
  KEY: TDirectoryFile	l1uGTTestcrateTree;1	l1uGTTestcrateTree
  KEY: TDirectoryFile	l1uGTTree;1	l1uGTTree
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport needed afaik.

FYI @caruta @eyigitba @slaurila @aloeliger @epalencia 
