### PR TITLE
Store track momentum at hit for PbPb UPC dEdX calibration

### DIFF
--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -130,7 +130,6 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     int NClusterSaturating = 0;
     DeDxHitCollection dedxHits;
 
-    dedxHits.reserve(track->recHitsSize() / 2);
     if (useDeDxHits) {
       if (usePixel)
         dedxHits = (*pixelDeDxHits)[track];

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -17,6 +17,7 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
     calibrationPath    = cms.string("file:Gains.root"),
     shapeTest          = cms.bool(True),
     clusterShapeCache  = cms.InputTag("siPixelClusterShapeCache"),
+    storeMomentumAtHit = cms.bool(False),
 
     lowPtTracksPrescalePass = cms.uint32(100),   # prescale factor for low pt tracks above the dEdx cut
     lowPtTracksPrescaleFail = cms.uint32(2000), # prescale factor for low pt tracks below the dEdx cut
@@ -91,7 +92,7 @@ run3_common.toModify(dedxHitInfo,
 
 # dEdx for Run-3 UPC
 from Configuration.Eras.Modifier_run3_upc_cff import run3_upc
-run3_upc.toModify(dedxHitInfo, minTrackPt = 0)
+run3_upc.toModify(dedxHitInfo, minTrackPt = 0, storeMomentumAtHit = True)
 
 from RecoTracker.DeDx.dedxHitCalibrator_cfi import dedxHitCalibrator as _dedxHitCalibrator
 from SimGeneral.MixingModule.SiStripSimParameters_cfi import SiStripSimBlock as _SiStripSimBlock


### PR DESCRIPTION
#### PR description:

This PR creates a value map containing the magnitude of the track global momentum at each hit needed to perform the dEdx calibration for PbPb UPC. This value map is only produced and stored when using the run3_upc era modifier.

@mandrenguyen @sikler 

#### PR validation:

Tested with relvals 180, 180.1, 181, 181.1 and 142.901

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
