### PR TITLE
Run3-alca248 Attach a parameter to write the content in the tree for tracks only in a given momentum range

### DIFF
--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -261,7 +261,7 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
 #endif
       bool select(true);
       if (fillInRange_) {
-        if ((t_p < pTrackLow_) || (t_p < pTrackHigh_))
+        if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
           select = false;
       }
       if (select) {
@@ -270,7 +270,7 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
       }
       if (t_p < pTrackLow_) {
         ++nLow_;
-      } else if (t_p < pTrackHigh_) {
+      } else if (t_p > pTrackHigh_) {
         ++nHigh_;
       } else {
         ++nRange_;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -46,6 +46,7 @@ private:
 
   const double pTrackLow_, pTrackHigh_;
   const int useRaw_, dataType_, unCorrect_;
+  const bool fillInRange_;
   const edm::InputTag labelIsoTkVar_, labelIsoTkEvt_;
   const std::vector<int> debEvents_;
   const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
@@ -88,6 +89,7 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
       useRaw_(iConfig.getUntrackedParameter<int>("useRaw", 0)),
       dataType_(iConfig.getUntrackedParameter<int>("dataType", 0)),
       unCorrect_(iConfig.getUntrackedParameter<int>("unCorrect", 0)),
+      fillInRange_(iConfig.getUntrackedParameter<bool>("fillInRange", false)),
       labelIsoTkVar_(iConfig.getParameter<edm::InputTag>("isoTrackVarLabel")),
       labelIsoTkEvt_(iConfig.getParameter<edm::InputTag>("isoTrackEvtLabel")),
       debEvents_(iConfig.getParameter<std::vector<int>>("debugEvents")),
@@ -109,7 +111,7 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n\t momentumLow_ " << pTrackLow_
                                    << "\t momentumHigh_ " << pTrackHigh_ << "\t useRaw_ " << useRaw_
-                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_ << " and "
+                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_ << "\t fillInRange " << fillInRange_ << "\t and "
                                    << debEvents_.size() << " events to be debugged";
 }
 
@@ -256,9 +258,15 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
       if (debug)
         edm::LogVerbatim("HcalIsoTrack") << "eHcal:eHcal10:eHCal30 " << t_eHcal << ":" << t_eHcal10 << t_eHcal30;
 #endif
-      tree->Fill();
-      edm::LogVerbatim("HcalIsoTrackX") << "Run " << t_Run << " Event " << t_Event << " p " << t_p;
-
+      bool select(true);
+      if (fillInRange_) {
+	if ((t_p < pTrackLow_) || (t_p < pTrackHigh_))
+	  select = false;
+      }
+      if (select) {
+	tree->Fill();
+	edm::LogVerbatim("HcalIsoTrackX") << "Run " << t_Run << " Event " << t_Event << " p " << t_p;
+      }
       if (t_p < pTrackLow_) {
         ++nLow_;
       } else if (t_p < pTrackHigh_) {
@@ -402,6 +410,7 @@ void HcalIsoTrackAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.addUntracked<int>("useRaw", 0);
   desc.addUntracked<int>("dataType", 0);
   desc.addUntracked<int>("unCorrect", 0);
+  desc.addUntracked<bool>("fillInRange", false);
   desc.add<edm::InputTag>("isoTrackVarLabel", edm::InputTag("alcaHcalIsotrkProducer", "HcalIsoTrack"));
   desc.add<edm::InputTag>("isoTrackEvtLabel", edm::InputTag("alcaHcalIsotrkProducer", "HcalIsoTrackEvent"));
   std::vector<int> events;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrackAnalyzer.cc
@@ -111,8 +111,9 @@ HcalIsoTrackAnalyzer::HcalIsoTrackAnalyzer(const edm::ParameterSet& iConfig)
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n\t momentumLow_ " << pTrackLow_
                                    << "\t momentumHigh_ " << pTrackHigh_ << "\t useRaw_ " << useRaw_
-                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_ << "\t fillInRange " << fillInRange_ << "\t and "
-                                   << debEvents_.size() << " events to be debugged";
+                                   << "\t dataType_      " << dataType_ << "\t unCorrect " << unCorrect_
+                                   << "\t fillInRange " << fillInRange_ << "\t and " << debEvents_.size()
+                                   << " events to be debugged";
 }
 
 HcalIsoTrackAnalyzer::~HcalIsoTrackAnalyzer() {
@@ -260,12 +261,12 @@ void HcalIsoTrackAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup con
 #endif
       bool select(true);
       if (fillInRange_) {
-	if ((t_p < pTrackLow_) || (t_p < pTrackHigh_))
-	  select = false;
+        if ((t_p < pTrackLow_) || (t_p < pTrackHigh_))
+          select = false;
       }
       if (select) {
-	tree->Fill();
-	edm::LogVerbatim("HcalIsoTrackX") << "Run " << t_Run << " Event " << t_Event << " p " << t_p;
+        tree->Fill();
+        edm::LogVerbatim("HcalIsoTrackX") << "Run " << t_Run << " Event " << t_Event << " p " << t_p;
       }
       if (t_p < pTrackLow_) {
         ++nLow_;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -145,7 +145,7 @@ private:
   const int prescaleLow_, prescaleHigh_;
   const int useRaw_, dataType_, mode_;
   const bool ignoreTrigger_, useL1Trigger_;
-  const bool unCorrect_, getCharge_, collapseDepth_;
+  const bool unCorrect_, getCharge_, collapseDepth_, fillInRange_;
   const double hitEthrEB_, hitEthrEE0_, hitEthrEE1_;
   const double hitEthrEE2_, hitEthrEE3_;
   const double hitEthrEELo_, hitEthrEEHi_;
@@ -250,8 +250,9 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       ignoreTrigger_(iConfig.getUntrackedParameter<bool>("ignoreTriggers", false)),
       useL1Trigger_(iConfig.getUntrackedParameter<bool>("useL1Trigger", false)),
       unCorrect_(iConfig.getUntrackedParameter<bool>("unCorrect", false)),
-      getCharge_(iConfig.getUntrackedParameter<bool>("getCharge")),
+      getCharge_(iConfig.getUntrackedParameter<bool>("getCharge", false)),
       collapseDepth_(iConfig.getUntrackedParameter<bool>("collapseDepth", false)),
+      fillInRange_(iConfig.getUntrackedParameter<bool>("fillInRange", false)),
       hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
       hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
       hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1")),
@@ -378,7 +379,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t GetCharge " << getCharge_ << "\t L1TrigName_    " << l1TrigName_
+      << collapseDepth_ << "\t GetCharge " << getCharge_ << "\t FillInRange " << fillInRange_<< "\t L1TrigName_    " << l1TrigName_
       << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":"
       << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_
       << " and " << debEvents_.size() << " events to be debugged";
@@ -945,6 +946,7 @@ void HcalIsoTrkAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<bool>("unCorrect", false);
   desc.addUntracked<bool>("getCharge", false);
   desc.addUntracked<bool>("collapseDepth", false);
+  desc.addUntracked<bool>("fillInRange", false);
   desc.addUntracked<std::string>("l1TrigName", "L1_SingleJet60");
   desc.addUntracked<int>("outMode", 11);
   std::vector<int> dummy;
@@ -1304,6 +1306,10 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
             accept = true;
           }
         }
+	if (fillInRange_) {
+	  if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
+	    accept = false;
+	}
         if (accept) {
           tree->Fill();
           edm::LogVerbatim("HcalIsoTrackX")

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -379,10 +379,10 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t GetCharge " << getCharge_ << "\t FillInRange " << fillInRange_<< "\t L1TrigName_    " << l1TrigName_
-      << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":"
-      << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_
-      << " and " << debEvents_.size() << " events to be debugged";
+      << collapseDepth_ << "\t GetCharge " << getCharge_ << "\t FillInRange " << fillInRange_ << "\t L1TrigName_    "
+      << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE "
+      << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
+      << hitEthrEEHi_ << " and " << debEvents_.size() << " events to be debugged";
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_;
   for (unsigned int k = 0; k < trigNames_.size(); ++k) {
@@ -1306,10 +1306,10 @@ std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVec
             accept = true;
           }
         }
-	if (fillInRange_) {
-	  if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
-	    accept = false;
-	}
+        if (fillInRange_) {
+          if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
+            accept = false;
+        }
         if (accept) {
           tree->Fill();
           edm::LogVerbatim("HcalIsoTrackX")

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
@@ -129,7 +129,7 @@ private:
   const int prescaleLow_, prescaleHigh_;
   const int useRaw_, dataType_, mode_;
   const bool ignoreTrigger_, useL1Trigger_;
-  const bool unCorrect_, collapseDepth_;
+  const bool unCorrect_, collapseDepth_, fillTreeRange_;
   const double hitEthrEB_, hitEthrEE0_, hitEthrEE1_;
   const double hitEthrEE2_, hitEthrEE3_;
   const double hitEthrEELo_, hitEthrEEHi_;
@@ -229,6 +229,7 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
       useL1Trigger_(iConfig.getUntrackedParameter<bool>("useL1Trigger", false)),
       unCorrect_(iConfig.getUntrackedParameter<bool>("unCorrect", false)),
       collapseDepth_(iConfig.getUntrackedParameter<bool>("collapseDepth", false)),
+      fillTreeRange_(iConfig.getUntrackedParameter<bool>("fillTreeRange", false)),
       hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
       hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
       hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1")),
@@ -332,7 +333,7 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
                                    << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
                                    << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_
                                    << "\t dataType_      " << dataType_ << "\t mode_          " << mode_
-                                   << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_
+                                   << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_ << "\t fillTreeRange " << fillTreeRange_
                                    << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
                                    << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
                                    << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
@@ -852,6 +853,7 @@ void HcalIsoTrkSimAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<int>("dataType", 0);
   desc.addUntracked<bool>("unCorrect", false);
   desc.addUntracked<bool>("collapseDepth", false);
+  desc.addUntracked<bool>("fillTreeRange", false);
   desc.addUntracked<std::string>("l1TrigName", "L1_SingleJet60");
   desc.addUntracked<int>("outMode", 11);
   std::vector<int> dummy;
@@ -1182,6 +1184,10 @@ std::array<int, 3> HcalIsoTrkSimAnalyzer::fillTree(std::vector<math::XYZTLorentz
             accept = true;
           }
         }
+	if (fillTreeRange_) {
+	  if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
+	    accept = false;
+	}
         if (accept) {
           tree->Fill();
           nSave++;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
@@ -333,11 +333,11 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
                                    << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
                                    << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_
                                    << "\t dataType_      " << dataType_ << "\t mode_          " << mode_
-                                   << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_ << "\t fillTreeRange " << fillTreeRange_
-                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
-                                   << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
-                                   << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
-                                   << hitEthrEEHi_;
+                                   << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_
+                                   << "\t fillTreeRange " << fillTreeRange_ << "\t L1TrigName_    " << l1TrigName_
+                                   << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
+                                   << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
+                                   << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_;
   for (unsigned int k = 0; k < trigNames_.size(); ++k) {
@@ -1184,10 +1184,10 @@ std::array<int, 3> HcalIsoTrkSimAnalyzer::fillTree(std::vector<math::XYZTLorentz
             accept = true;
           }
         }
-	if (fillTreeRange_) {
-	  if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
-	    accept = false;
-	}
+        if (fillTreeRange_) {
+          if ((t_p < pTrackLow_) || (t_p > pTrackHigh_))
+            accept = false;
+        }
         if (accept) {
           tree->Fill();
           nSave++;


### PR DESCRIPTION
#### PR description:

Attach a parameter to write the content in the tree for tracks only in a given momentum range

#### PR validation:

Tested with the latest AlCaReco files

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special