### PR TITLE
fix check on `shrEnergyM0TotalAccum` in HCAL-Alpaka kernel [`14_0_X`]

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
+++ b/RecoLocalCalo/HcalRecProducers/plugins/alpaka/Mahi.dev.cc
@@ -617,12 +617,8 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                     outputGPU.chi2()[gch] = -9999.f;
 
                   // check as in cpu version if mahi is not needed
-                  // FIXME: KNOWN ISSUE: observed a problem when rawCharge and pedestal
-                  // are basically equal and generate -0.00000...
-                  // needs to be treated properly
-                  if (!(shrEnergyM0TotalAccum[lch] > 0 && energym0_per_ts_gain0 > ts4Thresh)) {
-                    // do not need to run mahi minimization
-                    //outputEnergy[gch] = 0; energy already inited to 0
+                  // (use "not" and ">", instead of "<=", to ensure that a NaN value will pass the check, and the hit be flagged as invalid)
+                  if (not(energym0_per_ts_gain0 > ts4Thresh)) {
                     outputGPU.chi2()[gch] = -9999.f;
                   }
                 }
@@ -700,6 +696,15 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
                   outputGPU.detId()[gch] = id;
                   outputGPU.energyM0()[gch] = method0_energy;
                   outputGPU.timeM0()[gch] = time;
+
+                  // check as in cpu version if mahi is not needed
+                  // FIXME: KNOWN ISSUE: observed a problem when rawCharge and pedestal
+                  // are basically equal and generate -0.00000...
+                  // needs to be treated properly
+                  // (use "not" and ">", instead of "<=", to ensure that a NaN value will pass the check, and the hit be flagged as invalid)
+                  if (not(shrEnergyM0TotalAccum[lch] > 0)) {
+                    outputGPU.chi2()[gch] = -9999.f;
+                  }
 
 #ifdef HCAL_MAHI_GPUDEBUG
                   printf("tsTOT = %f tstrig = %f ts4Thresh = %f\n",


### PR DESCRIPTION
backport of #45452

#### PR description:

From the description of #45452:

>This PR fixes how the values in the array `shrEnergyM0TotalAccum` in shared memory are used in one of the HCAL-Alpaka kernels.
> 
>The per-channel value of `shrEnergyM0TotalAccum[lch]` is filled summing values across "samples", and this is done concurrently on GPU. The issue is that the same value is accessed before threads are synchronised. In the examples tested offline, this tends to return almost-always the correct results on GPU, but incorrect ones on CPU (or rather, "serial_sync" backend) as the samples in the latter case are processed one at the time.
>
>This change and related validation (see below) were discussed offline last week with @fwyzard and @kakwok.

#### PR validation:

See the validation section of #45452.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported, please specify to which release cycle the backport is meant for:

#45452

Fix relevant to 2024 data-taking.
