### PR TITLE
Implement a workaround for `-Warray-bounds` in LTO builds

### DIFF
--- a/RecoTracker/PixelSeeding/plugins/BuildFile.xml
+++ b/RecoTracker/PixelSeeding/plugins/BuildFile.xml
@@ -22,7 +22,7 @@
 </library>
 
 <library file="alpaka/*.cc" name="RecoTrackerPixelSeedingPortable">
- <use name="alpaka"/>
+  <use name="alpaka"/>
   <use name="DataFormats/Portable"/>
   <use name="DataFormats/TrackSoA"/>
   <use name="DataFormats/TrackingRecHitSoA"/>
@@ -31,6 +31,8 @@
   <use name="HeterogeneousCore/AlpakaInterface"/>
   <use name="RecoLocalTracker/Records"/>
   <use name="RecoLocalTracker/SiPixelRecHits"/>
+  <!-- work around for cms-sw/cmssw#45179 -->
+  <use name="no-array-bounds-flag" for="alpaka/serial"/>
   <flags ALPAKA_BACKENDS="1"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

Implement a workaround for `-Warray-bounds` in LTO builds.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

No backport foreseen.