### PR TITLE
Track selection update in MTD Validation

### DIFF
--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -36,10 +36,6 @@ private:
   MonitorElement* meEtlEtaEff2_[2];
   MonitorElement* meEtlPhiEff2_[2];
   MonitorElement* meEtlPtEff2_[2];
-  MonitorElement* meMVAPtSelEff_;
-  MonitorElement* meMVAEtaSelEff_;
-  MonitorElement* meMVAPtMatchEff_;
-  MonitorElement* meMVAEtaMatchEff_;
   MonitorElement* meTPPtSelEff_;
   MonitorElement* meTPEtaSelEff_;
   MonitorElement* meTPPtMatchEff_;
@@ -120,9 +116,6 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meETLTrackEffPhi2MtdZpos = igetter.get(folder_ + "TrackETLEffPhi2MtdZpos");
   MonitorElement* meETLTrackEffPt2MtdZpos = igetter.get(folder_ + "TrackETLEffPt2MtdZpos");
   MonitorElement* meTrackPtTot = igetter.get(folder_ + "TrackPtTot");
-  MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
-  MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
-  MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
   MonitorElement* meExtraPtMtd = igetter.get(folder_ + "ExtraPtMtd");
   MonitorElement* meExtraPtEtl2Mtd = igetter.get(folder_ + "ExtraPtEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
@@ -132,9 +125,6 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meTrackMatchedTPmtdEffPtTot = igetter.get(folder_ + "MatchedTPmtdEffPtTot");
   MonitorElement* meTrackMatchedTPmtdEffPtMtd = igetter.get(folder_ + "MatchedTPmtdEffPtMtd");
   MonitorElement* meTrackEtaTot = igetter.get(folder_ + "TrackEtaTot");
-  MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
-  MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
-  MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
   MonitorElement* meExtraEtaMtd = igetter.get(folder_ + "ExtraEtaMtd");
   MonitorElement* meExtraEtaEtl2Mtd = igetter.get(folder_ + "ExtraEtaEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
@@ -157,15 +147,13 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
       !meETLTrackEffEta2MtdZneg || !meETLTrackEffPhi2MtdZneg || !meETLTrackEffPt2MtdZneg || !meETLTrackEffEtaTotZpos ||
       !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos || !meETLTrackEffPhiMtdZpos ||
       !meETLTrackEffPtMtdZpos || !meETLTrackEffEta2MtdZpos || !meETLTrackEffPhi2MtdZpos || !meETLTrackEffPt2MtdZpos ||
-      !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot ||
-      !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd || !meTrackMatchedTPEffPtTot ||
-      !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd ||
-      !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot ||
-      !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd || !meTrackMatchedTPEffEtaEtl2Mtd ||
-      !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd || !meTrackNumHits || !meTrackNumHitsNT ||
-      !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd || !meExtraEtaMtd || !meExtraEtaEtl2Mtd ||
-      !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone || !meExtraMTDfailExtenderEta ||
-      !meExtraMTDfailExtenderPt) {
+      !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd ||
+      !meTrackMatchedTPEffPtEtl2Mtd || !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd ||
+      !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd ||
+      !meTrackMatchedTPEffEtaEtl2Mtd || !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd ||
+      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd ||
+      !meExtraEtaMtd || !meExtraEtaEtl2Mtd || !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone ||
+      !meExtraMTDfailExtenderEta || !meExtraMTDfailExtenderPt) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -327,51 +315,19 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTotLV, meExtraEtaEtl2Eff_);
 
-  meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
-                                "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
-                                meMVATrackEffPtTot->getNbinsX(),
-                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffPtTot, meMVATrackEffPtTot, meMVAPtSelEff_);
-
-  meMVAEtaSelEff_ = ibook.book1D("MVAEtaSelEff",
-                                 "Track selected efficiency VS Eta;Eta;Efficiency",
-                                 meMVATrackEffEtaTot->getNbinsX(),
-                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffEtaTot, meMVATrackEffEtaTot, meMVAEtaSelEff_);
-
-  meMVAPtMatchEff_ = ibook.book1D("MVAPtMatchEff",
-                                  "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
-                                  meMVATrackMatchedEffPtTot->getNbinsX(),
-                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffPtMtd, meMVATrackMatchedEffPtTot, meMVAPtMatchEff_);
-
-  meMVAEtaMatchEff_ = ibook.book1D("MVAEtaMatchEff",
-                                   "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
-                                   meMVATrackMatchedEffEtaTot->getNbinsX(),
-                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffEtaMtd, meMVATrackMatchedEffEtaTot, meMVAEtaMatchEff_);
-
   meTPPtSelEff_ = ibook.book1D("TPPtSelEff",
                                "Track selected efficiency TP VS Pt;Pt [GeV];Efficiency",
-                               meMVATrackEffPtTot->getNbinsX(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+                               meTrackPtTot->getNbinsX(),
+                               meTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meTrackPtTot->getTH1()->GetXaxis()->GetXmax());
   meTPPtSelEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meTrackMatchedTPEffPtTot, meTrackPtTot, meTPPtSelEff_);
 
   meTPEtaSelEff_ = ibook.book1D("TPEtaSelEff",
                                 "Track selected efficiency TP VS Eta;Eta;Efficiency",
-                                meMVATrackEffEtaTot->getNbinsX(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                                meTrackEtaTot->getNbinsX(),
+                                meTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
   meTPEtaSelEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meTrackMatchedTPEffEtaTot, meTrackEtaTot, meTPEtaSelEff_);
 
@@ -409,17 +365,17 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
 
   meTPmtdPtSelEff_ = ibook.book1D("TPmtdPtSelEff",
                                   "Track selected efficiency TP-mtd hit VS Pt;Pt [GeV];Efficiency",
-                                  meMVATrackEffPtTot->getNbinsX(),
-                                  meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+                                  meTrackPtTot->getNbinsX(),
+                                  meTrackPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meTrackPtTot->getTH1()->GetXaxis()->GetXmax());
   meTPmtdPtSelEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meTrackMatchedTPmtdEffPtTot, meTrackPtTot, meTPmtdPtSelEff_);
 
   meTPmtdEtaSelEff_ = ibook.book1D("TPmtdEtaSelEff",
                                    "Track selected efficiency TPmtd hit VS Eta;Eta;Efficiency",
-                                   meMVATrackEffEtaTot->getNbinsX(),
-                                   meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                   meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                                   meTrackEtaTot->getNbinsX(),
+                                   meTrackEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meTrackEtaTot->getTH1()->GetXaxis()->GetXmax());
   meTPmtdEtaSelEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meTrackMatchedTPmtdEffEtaTot, meTrackEtaTot, meTPmtdEtaSelEff_);
 
@@ -458,10 +414,6 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
     meEtlPhiEff2_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff2_[i]->getTH1()->SetMinimum(0.);
   }
-  meMVAPtSelEff_->getTH1()->SetMinimum(0.);
-  meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
-  meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
-  meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
 
   meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
                                      "Efficiency to match hits at BTL surface of extrapolated tracks associated to LV",

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -126,6 +126,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meExtraPtMtd = igetter.get(folder_ + "ExtraPtMtd");
   MonitorElement* meExtraPtEtl2Mtd = igetter.get(folder_ + "ExtraPtEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
+  MonitorElement* meTrackMatchedTPEffPtTotLV = igetter.get(folder_ + "MatchedTPEffPtTotLV");
   MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
   MonitorElement* meTrackMatchedTPEffPtEtl2Mtd = igetter.get(folder_ + "MatchedTPEffPtEtl2Mtd");
   MonitorElement* meTrackMatchedTPmtdEffPtTot = igetter.get(folder_ + "MatchedTPmtdEffPtTot");
@@ -137,6 +138,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meExtraEtaMtd = igetter.get(folder_ + "ExtraEtaMtd");
   MonitorElement* meExtraEtaEtl2Mtd = igetter.get(folder_ + "ExtraEtaEtl2Mtd");
   MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
+  MonitorElement* meTrackMatchedTPEffEtaTotLV = igetter.get(folder_ + "MatchedTPEffEtaTotLV");
   MonitorElement* meTrackMatchedTPEffEtaMtd = igetter.get(folder_ + "MatchedTPEffEtaMtd");
   MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd = igetter.get(folder_ + "MatchedTPEffEtaEtl2Mtd");
   MonitorElement* meTrackMatchedTPmtdEffEtaTot = igetter.get(folder_ + "MatchedTPmtdEffEtaTot");
@@ -157,12 +159,13 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
       !meETLTrackEffPtMtdZpos || !meETLTrackEffEta2MtdZpos || !meETLTrackEffPhi2MtdZpos || !meETLTrackEffPt2MtdZpos ||
       !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot || !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot ||
       !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd || !meTrackMatchedTPEffPtTot ||
-      !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd || !meTrackMatchedTPmtdEffPtTot ||
-      !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaMtd ||
-      !meTrackMatchedTPEffEtaEtl2Mtd || !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd ||
-      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd ||
-      !meExtraEtaMtd || !meExtraEtaEtl2Mtd || !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone ||
-      !meExtraMTDfailExtenderEta || !meExtraMTDfailExtenderPt) {
+      !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd ||
+      !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot ||
+      !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd || !meTrackMatchedTPEffEtaEtl2Mtd ||
+      !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd || !meTrackNumHits || !meTrackNumHitsNT ||
+      !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd || !meExtraEtaMtd || !meExtraEtaEtl2Mtd ||
+      !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone || !meExtraMTDfailExtenderEta ||
+      !meExtraMTDfailExtenderPt) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -289,37 +292,40 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meEtlPtEff2_[1]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffPt2MtdZpos, meETLTrackEffPtTotZpos, meEtlPtEff2_[1]);
 
-  meExtraPtEff_ = ibook.book1D("ExtraPtEff",
-                               "MTD matching efficiency wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                               meMVATrackEffPtTot->getNbinsX(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraPtEff_ =
+      ibook.book1D("ExtraPtEff",
+                   "MTD matching efficiency wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
+                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTot, meExtraPtEff_);
+  computeEfficiency1D(meExtraPtMtd, meTrackMatchedTPEffPtTotLV, meExtraPtEff_);
 
-  meExtraPtEtl2Eff_ = ibook.book1D("ExtraPtEtl2Eff",
-                                   "MTD matching efficiency (2 ETL) wrt extrapolated track VS Pt;Pt [GeV];Efficiency",
-                                   meMVATrackEffPtTot->getNbinsX(),
-                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                   meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraPtEtl2Eff_ =
+      ibook.book1D("ExtraPtEtl2Eff",
+                   "MTD matching efficiency (2 ETL) wrt extrapolated track associated to LV VS Pt;Pt [GeV];Efficiency",
+                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraPtEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTot, meExtraPtEtl2Eff_);
+  computeEfficiency1D(meExtraPtEtl2Mtd, meTrackMatchedTPEffPtTotLV, meExtraPtEtl2Eff_);
 
   meExtraEtaEff_ = ibook.book1D("ExtraEtaEff",
-                                "MTD matching efficiency wrt extrapolated track VS Eta;Eta;Efficiency",
-                                meMVATrackEffEtaTot->getNbinsX(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                                "MTD matching efficiency wrt extrapolated track associated to LV VS Eta;Eta;Efficiency",
+                                meTrackMatchedTPEffEtaTotLV->getNbinsX(),
+                                meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                                meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraEtaEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTot, meExtraEtaEff_);
+  computeEfficiency1D(meExtraEtaMtd, meTrackMatchedTPEffEtaTotLV, meExtraEtaEff_);
 
-  meExtraEtaEtl2Eff_ = ibook.book1D("ExtraEtaEtl2Eff",
-                                    "MTD matching efficiency (2 ETL) wrt extrapolated track VS Eta;Eta;Efficiency",
-                                    meMVATrackEffEtaTot->getNbinsX(),
-                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                    meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraEtaEtl2Eff_ =
+      ibook.book1D("ExtraEtaEtl2Eff",
+                   "MTD matching efficiency (2 ETL) wrt extrapolated track associated to LV VS Eta;Eta;Efficiency",
+                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraEtaEtl2Eff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTot, meExtraEtaEtl2Eff_);
+  computeEfficiency1D(meExtraEtaEtl2Mtd, meTrackMatchedTPEffEtaTotLV, meExtraEtaEtl2Eff_);
 
   meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
                                 "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
@@ -458,7 +464,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
 
   meExtraPhiAtBTLEff_ = ibook.book1D("ExtraPhiAtBTLEff",
-                                     "Efficiency to match hits at BTL surface",
+                                     "Efficiency to match hits at BTL surface of extrapolated tracks associated to LV",
                                      meExtraPhiAtBTL->getNbinsX(),
                                      meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmin(),
                                      meExtraPhiAtBTL->getTH1()->GetXaxis()->GetXmax());
@@ -469,21 +475,21 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
 
   meExtraMTDfailExtenderEtaEff_ =
       ibook.book1D("ExtraMTDfailExtenderEtaEff",
-                   "Track extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
-                   meTrackMatchedTPEffEtaTot->getNbinsX(),
-                   meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+                   "Track associated to LV extrapolated at MTD surface no extender efficiency VS Eta;Eta;Efficiency",
+                   meTrackMatchedTPEffEtaTotLV->getNbinsX(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmin(),
+                   meTrackMatchedTPEffEtaTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraMTDfailExtenderEtaEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTot, meExtraMTDfailExtenderEtaEff_);
+  computeEfficiency1D(meExtraMTDfailExtenderEta, meTrackMatchedTPEffEtaTotLV, meExtraMTDfailExtenderEtaEff_);
 
-  meExtraMTDfailExtenderPtEff_ =
-      ibook.book1D("ExtraMTDfailExtenderPtEff",
-                   "Track extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
-                   meTrackMatchedTPEffPtTot->getNbinsX(),
-                   meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                   meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meExtraMTDfailExtenderPtEff_ = ibook.book1D(
+      "ExtraMTDfailExtenderPtEff",
+      "Track associated to LV extrapolated at MTD surface no extender efficiency VS Pt;Pt [GeV];Efficiency",
+      meTrackMatchedTPEffPtTotLV->getNbinsX(),
+      meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmin(),
+      meTrackMatchedTPEffPtTotLV->getTH1()->GetXaxis()->GetXmax());
   meExtraMTDfailExtenderPtEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTot, meExtraMTDfailExtenderPtEff_);
+  computeEfficiency1D(meExtraMTDfailExtenderPt, meTrackMatchedTPEffPtTotLV, meExtraMTDfailExtenderPtEff_);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ----------

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -31,9 +31,11 @@ private:
   MonitorElement* meBtlPhiEff_;
   MonitorElement* meBtlPtEff_;
   MonitorElement* meEtlEtaEff_[2];
+  MonitorElement* meEtlEtaEffLowPt_[2];
   MonitorElement* meEtlPhiEff_[2];
   MonitorElement* meEtlPtEff_[2];
   MonitorElement* meEtlEtaEff2_[2];
+  MonitorElement* meEtlEtaEff2LowPt_[2];
   MonitorElement* meEtlPhiEff2_[2];
   MonitorElement* meEtlPtEff2_[2];
   MonitorElement* meTPPtSelEff_;
@@ -98,12 +100,18 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meBTLTrackEffPhiMtd = igetter.get(folder_ + "TrackBTLEffPhiMtd");
   MonitorElement* meBTLTrackEffPtMtd = igetter.get(folder_ + "TrackBTLEffPtMtd");
   MonitorElement* meETLTrackEffEtaTotZneg = igetter.get(folder_ + "TrackETLEffEtaTotZneg");
+  MonitorElement* meETLTrackEffEtaTotLowPt0 = igetter.get(folder_ + "TrackETLEffEtaTotLowPt0");
+  MonitorElement* meETLTrackEffEtaTotLowPt1 = igetter.get(folder_ + "TrackETLEffEtaTotLowPt1");
   MonitorElement* meETLTrackEffPhiTotZneg = igetter.get(folder_ + "TrackETLEffPhiTotZneg");
   MonitorElement* meETLTrackEffPtTotZneg = igetter.get(folder_ + "TrackETLEffPtTotZneg");
   MonitorElement* meETLTrackEffEtaMtdZneg = igetter.get(folder_ + "TrackETLEffEtaMtdZneg");
+  MonitorElement* meETLTrackEffEtaMtdLowPt0 = igetter.get(folder_ + "TrackETLEffEtaMtdLowPt0");
+  MonitorElement* meETLTrackEffEtaMtdLowPt1 = igetter.get(folder_ + "TrackETLEffEtaMtdLowPt1");
   MonitorElement* meETLTrackEffPhiMtdZneg = igetter.get(folder_ + "TrackETLEffPhiMtdZneg");
   MonitorElement* meETLTrackEffPtMtdZneg = igetter.get(folder_ + "TrackETLEffPtMtdZneg");
   MonitorElement* meETLTrackEffEta2MtdZneg = igetter.get(folder_ + "TrackETLEffEta2MtdZneg");
+  MonitorElement* meETLTrackEffEta2MtdLowPt0 = igetter.get(folder_ + "TrackETLEffEta2MtdLowPt0");
+  MonitorElement* meETLTrackEffEta2MtdLowPt1 = igetter.get(folder_ + "TrackETLEffEta2MtdLowPt1");
   MonitorElement* meETLTrackEffPhi2MtdZneg = igetter.get(folder_ + "TrackETLEffPhi2MtdZneg");
   MonitorElement* meETLTrackEffPt2MtdZneg = igetter.get(folder_ + "TrackETLEffPt2MtdZneg");
   MonitorElement* meETLTrackEffEtaTotZpos = igetter.get(folder_ + "TrackETLEffEtaTotZpos");
@@ -143,17 +151,19 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
-      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZneg || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
-      !meETLTrackEffEta2MtdZneg || !meETLTrackEffPhi2MtdZneg || !meETLTrackEffPt2MtdZneg || !meETLTrackEffEtaTotZpos ||
-      !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos || !meETLTrackEffPhiMtdZpos ||
-      !meETLTrackEffPtMtdZpos || !meETLTrackEffEta2MtdZpos || !meETLTrackEffPhi2MtdZpos || !meETLTrackEffPt2MtdZpos ||
-      !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd ||
-      !meTrackMatchedTPEffPtEtl2Mtd || !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd ||
-      !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd ||
-      !meTrackMatchedTPEffEtaEtl2Mtd || !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd ||
-      !meTrackNumHits || !meTrackNumHitsNT || !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd ||
-      !meExtraEtaMtd || !meExtraEtaEtl2Mtd || !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone ||
-      !meExtraMTDfailExtenderEta || !meExtraMTDfailExtenderPt) {
+      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaTotLowPt0 || !meETLTrackEffEtaTotLowPt1 || !meETLTrackEffEtaMtdZneg ||
+      !meETLTrackEffEtaMtdLowPt0 || !meETLTrackEffEtaMtdLowPt1 || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
+      !meETLTrackEffEta2MtdZneg || !meETLTrackEffEta2MtdLowPt0 || !meETLTrackEffEta2MtdLowPt1 ||
+      !meETLTrackEffPhi2MtdZneg || !meETLTrackEffPt2MtdZneg || !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos ||
+      !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos || !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos ||
+      !meETLTrackEffEta2MtdZpos || !meETLTrackEffPhi2MtdZpos || !meETLTrackEffPt2MtdZpos || !meTrackMatchedTPEffPtTot ||
+      !meTrackMatchedTPEffPtTotLV || !meTrackMatchedTPEffPtMtd || !meTrackMatchedTPEffPtEtl2Mtd ||
+      !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd || !meTrackMatchedTPEffEtaTot ||
+      !meTrackMatchedTPEffEtaTotLV || !meTrackMatchedTPEffEtaMtd || !meTrackMatchedTPEffEtaEtl2Mtd ||
+      !meTrackMatchedTPmtdEffEtaTot || !meTrackMatchedTPmtdEffEtaMtd || !meTrackNumHits || !meTrackNumHitsNT ||
+      !meTrackPtTot || !meTrackEtaTot || !meExtraPtMtd || !meExtraPtEtl2Mtd || !meExtraEtaMtd || !meExtraEtaEtl2Mtd ||
+      !meExtraPhiAtBTL || !meExtraPhiAtBTLmatched || !meExtraBTLeneInCone || !meExtraMTDfailExtenderEta ||
+      !meExtraMTDfailExtenderPt) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -192,6 +202,14 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meEtlEtaEff_[0]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffEtaMtdZneg, meETLTrackEffEtaTotZneg, meEtlEtaEff_[0]);
 
+  meEtlEtaEffLowPt_[0] = ibook.book1D("EtlEtaEffLowPt0",
+                                      " Track Efficiency VS Eta, 0.2 < pt < 0.45;#eta;Efficiency",
+                                      meETLTrackEffEtaTotLowPt0->getNbinsX(),
+                                      meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEffLowPt_[0]->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEffEtaMtdLowPt0, meETLTrackEffEtaTotLowPt0, meEtlEtaEffLowPt_[0]);
+
   meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZneg",
                                  "Track Efficiency VS Phi (-Z);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZneg->getNbinsX(),
@@ -215,6 +233,14 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEff_[1]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffEtaMtdZpos, meETLTrackEffEtaTotZpos, meEtlEtaEff_[1]);
+
+  meEtlEtaEffLowPt_[1] = ibook.book1D("EtlEtaEffLowPt1",
+                                      " Track Efficiency VS Eta, 0.45 < pt < 0.7;#eta;Efficiency",
+                                      meETLTrackEffEtaTotLowPt1->getNbinsX(),
+                                      meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
+                                      meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEffLowPt_[1]->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEffEtaMtdLowPt1, meETLTrackEffEtaTotLowPt1, meEtlEtaEffLowPt_[1]);
 
   meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZpos",
                                  "Track Efficiency VS Phi (+Z);#phi [rad];Efficiency",
@@ -240,8 +266,16 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meEtlEtaEff2_[0]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffEta2MtdZneg, meETLTrackEffEtaTotZneg, meEtlEtaEff2_[0]);
 
+  meEtlEtaEff2LowPt_[0] = ibook.book1D("EtlEtaEff2LowPt0",
+                                       " Track Efficiency VS Eta (2 hits), 0.2 < pt < 0.45;#eta;Efficiency",
+                                       meETLTrackEffEtaTotLowPt0->getNbinsX(),
+                                       meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEffEtaTotLowPt0->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEff2LowPt_[0]->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEffEta2MtdLowPt0, meETLTrackEffEtaTotLowPt0, meEtlEtaEff2LowPt_[0]);
+
   meEtlPhiEff2_[0] = ibook.book1D("EtlPhiEff2Zneg",
-                                  "Track Efficiency VS Phi (-Z, 2 hit);#phi [rad];Efficiency",
+                                  "Track Efficiency VS Phi (-Z, 2 hits);#phi [rad];Efficiency",
                                   meETLTrackEffPhiTotZneg->getNbinsX(),
                                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
@@ -249,7 +283,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meETLTrackEffPhi2MtdZneg, meETLTrackEffPhiTotZneg, meEtlPhiEff2_[0]);
 
   meEtlPtEff2_[0] = ibook.book1D("EtlPtEff2Zneg",
-                                 "Track Efficiency VS Pt (-Z, 2 hit);Pt [GeV];Efficiency",
+                                 "Track Efficiency VS Pt (-Z, 2 hits);Pt [GeV];Efficiency",
                                  meETLTrackEffPtTotZneg->getNbinsX(),
                                  meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
@@ -257,15 +291,23 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meETLTrackEffPt2MtdZneg, meETLTrackEffPtTotZneg, meEtlPtEff2_[0]);
 
   meEtlEtaEff2_[1] = ibook.book1D("EtlEtaEff2Zpos",
-                                  "Track Efficiency VS Eta (+Z, 2 hit);#eta;Efficiency",
+                                  "Track Efficiency VS Eta (+Z, 2 hits);#eta;Efficiency",
                                   meETLTrackEffEtaTotZpos->getNbinsX(),
                                   meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                   meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
   meEtlEtaEff2_[1]->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meETLTrackEffEta2MtdZpos, meETLTrackEffEtaTotZpos, meEtlEtaEff2_[1]);
 
+  meEtlEtaEff2LowPt_[1] = ibook.book1D("EtlEtaEff2LowPt1",
+                                       " Track Efficiency VS Eta (2 hits), 0.45 < pt < 0.7;#eta;Efficiency",
+                                       meETLTrackEffEtaTotLowPt1->getNbinsX(),
+                                       meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmin(),
+                                       meETLTrackEffEtaTotLowPt1->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEff2LowPt_[1]->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meETLTrackEffEta2MtdLowPt1, meETLTrackEffEtaTotLowPt1, meEtlEtaEff2LowPt_[1]);
+
   meEtlPhiEff2_[1] = ibook.book1D("EtlPhiEff2Zpos",
-                                  "Track Efficiency VS Phi (+Z, 2 hit);#phi [rad];Efficiency",
+                                  "Track Efficiency VS Phi (+Z, 2 hits);#phi [rad];Efficiency",
                                   meETLTrackEffPhiTotZpos->getNbinsX(),
                                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
@@ -273,7 +315,7 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   computeEfficiency1D(meETLTrackEffPhi2MtdZpos, meETLTrackEffPhiTotZpos, meEtlPhiEff2_[1]);
 
   meEtlPtEff2_[1] = ibook.book1D("EtlPtEff2Zpos",
-                                 "Track Efficiency VS Pt (+Z, 2 hit);Pt [GeV];Efficiency",
+                                 "Track Efficiency VS Pt (+Z, 2 hits);Pt [GeV];Efficiency",
                                  meETLTrackEffPtTotZpos->getNbinsX(),
                                  meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
@@ -408,9 +450,11 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   meBtlPtEff_->getTH1()->SetMinimum(0.);
   for (int i = 0; i < 2; i++) {
     meEtlEtaEff_[i]->getTH1()->SetMinimum(0.);
+    meEtlEtaEffLowPt_[i]->getTH1()->SetMinimum(0.);
     meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
     meEtlEtaEff2_[i]->getTH1()->SetMinimum(0.);
+    meEtlEtaEff2LowPt_[i]->getTH1()->SetMinimum(0.);
     meEtlPhiEff2_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff2_[i]->getTH1()->SetMinimum(0.);
   }

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -330,7 +330,7 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
     index++;
 
     if (trackAssoc[trackref] == -1) {
-      LogInfo("mtdTracks") << "Extended track not associated";
+      LogWarning("mtdTracks") << "Extended track not associated";
       continue;
     }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -232,6 +232,7 @@ private:
   MonitorElement* meETLTrackMatchedTP2DPtvsPtMtd_;
 
   MonitorElement* meTrackMatchedTPEffPtTot_;
+  MonitorElement* meTrackMatchedTPEffPtTotLV_;
   MonitorElement* meTrackMatchedTPEffPtMtd_;
   MonitorElement* meTrackMatchedTPEffPtEtl2Mtd_;
   MonitorElement* meTrackMatchedTPmtdEffPtTot_;
@@ -243,6 +244,7 @@ private:
   MonitorElement* meExtraEtaMtd_;
   MonitorElement* meExtraEtaEtl2Mtd_;
   MonitorElement* meTrackMatchedTPEffEtaTot_;
+  MonitorElement* meTrackMatchedTPEffEtaTotLV_;
   MonitorElement* meTrackMatchedTPEffEtaMtd_;
   MonitorElement* meTrackMatchedTPEffEtaEtl2Mtd_;
   MonitorElement* meTrackMatchedTPmtdEffEtaTot_;
@@ -579,11 +581,17 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
         const bool withMTD = (simClustersRefs != tp2SimAssociationMap.end());
         if (noCrack) {
           meTrackMatchedTPEffPtTot_->Fill(trackGen.pt());
+          if (mvaTPSelLV(**tp_info)) {
+            meTrackMatchedTPEffPtTotLV_->Fill(trackGen.pt());
+          }
           if (withMTD) {
             meTrackMatchedTPmtdEffPtTot_->Fill(trackGen.pt());
           }
         }
         meTrackMatchedTPEffEtaTot_->Fill(std::abs(trackGen.eta()));
+        if (mvaTPSelLV(**tp_info)) {
+          meTrackMatchedTPEffEtaTotLV_->Fill(std::abs(trackGen.eta()));
+        }
         if (withMTD) {
           meTrackMatchedTPmtdEffEtaTot_->Fill(std::abs(trackGen.eta()));
         }
@@ -997,13 +1005,19 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffPtMtd_ = ibook.book1D(
       "MVAMatchedEffPtMtd", "Pt of tracks associated to LV matched to GEN with time; track pt [GeV] ", 110, 0., 11.);
 
-  meExtraPtMtd_ = ibook.book1D("ExtraPtMtd", "Pt of tracks extrapolated to hits; track pt [GeV] ", 110, 0., 11.);
-  meExtraPtEtl2Mtd_ =
-      ibook.book1D("ExtraPtEtl2Mtd", "Pt of tracks extrapolated to hits, 2 ETL layers; track pt [GeV] ", 110, 0., 11.);
+  meExtraPtMtd_ =
+      ibook.book1D("ExtraPtMtd", "Pt of tracks associated to LV extrapolated to hits; track pt [GeV] ", 110, 0., 11.);
+  meExtraPtEtl2Mtd_ = ibook.book1D("ExtraPtEtl2Mtd",
+                                   "Pt of tracks associated to LV extrapolated to hits, 2 ETL layers; track pt [GeV] ",
+                                   110,
+                                   0.,
+                                   11.);
 
   meTrackPtTot_ = ibook.book1D("TrackPtTot", "Pt of tracks ; track pt [GeV] ", 110, 0., 11.);
   meTrackMatchedTPEffPtTot_ =
-      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks  matched to TP; track pt [GeV] ", 110, 0., 11.);
+      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks matched to TP; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtTotLV_ =
+      ibook.book1D("MatchedTPEffPtTotLV", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
   meTrackMatchedTPEffPtMtd_ =
       ibook.book1D("MatchedTPEffPtMtd", "Pt of tracks  matched to TP with time; track pt [GeV] ", 110, 0., 11.);
   meTrackMatchedTPEffPtEtl2Mtd_ = ibook.book1D(
@@ -1143,13 +1157,16 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Eta of tracks associated to LV matched to GEN with time; track eta ", 66, 0., 3.3);
 
-  meExtraEtaMtd_ = ibook.book1D("ExtraEtaMtd", "Eta of tracks extrapolated to hits; track eta ", 66, 0., 3.3);
-  meExtraEtaEtl2Mtd_ =
-      ibook.book1D("ExtraEtaEtl2Mtd", "Eta of tracks extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
+  meExtraEtaMtd_ =
+      ibook.book1D("ExtraEtaMtd", "Eta of tracks associated to LV extrapolated to hits; track eta ", 66, 0., 3.3);
+  meExtraEtaEtl2Mtd_ = ibook.book1D(
+      "ExtraEtaEtl2Mtd", "Eta of tracks associated to LV extrapolated to hits, 2 ETL layers; track eta ", 66, 0., 3.3);
 
   meTrackEtaTot_ = ibook.book1D("TrackEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
   meTrackMatchedTPEffEtaTot_ =
-      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks  matched to TP; track eta ", 66, 0., 3.3);
+      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks matched to TP; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaTotLV_ =
+      ibook.book1D("MatchedTPEffEtaTotLV", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
   meMVATrackEffEtaTot_ = ibook.book1D("MVAEffEtaTot", "Eta of tracks ; track eta ", 66, 0., 3.3);
   meTrackMatchedTPEffEtaMtd_ =
       ibook.book1D("MatchedTPEffEtaMtd", "Eta of tracks  matched to TP with time; track eta ", 66, 0., 3.3);
@@ -1168,28 +1185,33 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
   meMVATrackZposResTot_ = ibook.book1D(
       "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for associated tracks;Z_{PCA} - Z_{sim} [cm] ", 100, -0.1, 0.1);
 
-  meExtraPhiAtBTL_ =
-      ibook.book1D("ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks; phi [deg]", 720, -180., 180.);
-  meExtraPhiAtBTLmatched_ = ibook.book1D("ExtraPhiAtBTLmatched",
-                                         "Phi at BTL surface of extrapolated tracksi matched with BTL hits; phi [deg]",
-                                         720,
-                                         -180.,
-                                         180.);
-  meExtraBTLeneInCone_ = ibook.book1D(
-      "ExtraBTLeneInCone", "BTL reconstructed energy in cone arounnd extrapolated track; E [MeV]", 100, 0., 50.);
+  meExtraPhiAtBTL_ = ibook.book1D(
+      "ExtraPhiAtBTL", "Phi at BTL surface of extrapolated tracks associated to LV; phi [deg]", 720, -180., 180.);
+  meExtraPhiAtBTLmatched_ =
+      ibook.book1D("ExtraPhiAtBTLmatched",
+                   "Phi at BTL surface of extrapolated tracks associated to LV matched with BTL hits; phi [deg]",
+                   720,
+                   -180.,
+                   180.);
+  meExtraBTLeneInCone_ =
+      ibook.book1D("ExtraBTLeneInCone",
+                   "BTL reconstructed energy in cone arounnd extrapolated track associated to LV; E [MeV]",
+                   100,
+                   0.,
+                   50.);
   meExtraMTDfailExtenderEta_ =
       ibook.book1D("ExtraMTDfailExtenderEta",
-                   "Eta of tracks extrapolated to MTD with no track extender match to hits; track eta",
+                   "Eta of tracks associated to LV extrapolated to MTD with no track extender match to hits; track eta",
                    66,
                    0.,
                    3.3);
   ;
-  meExtraMTDfailExtenderPt_ =
-      ibook.book1D("ExtraMTDfailExtenderPt",
-                   "Pt of tracks extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
-                   110,
-                   0.,
-                   11.);
+  meExtraMTDfailExtenderPt_ = ibook.book1D(
+      "ExtraMTDfailExtenderPt",
+      "Pt of tracks associated to lV extrapolated to MTD with no track extender match to hits; track pt [GeV] ",
+      110,
+      0.,
+      11.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexHarvester.cc
@@ -28,10 +28,10 @@ private:
   const std::string folder_;
 
   // --- Histograms
-  MonitorElement* meMVAPtSelEff_;
-  MonitorElement* meMVAEtaSelEff_;
-  MonitorElement* meMVAPtMatchEff_;
-  MonitorElement* meMVAEtaMatchEff_;
+  MonitorElement* meTPPtSelEff_;
+  MonitorElement* meTPEtaSelEff_;
+  MonitorElement* meTPPtMatchEff_;
+  MonitorElement* meTPEtaMatchEff_;
 
   MonitorElement* meBarrelTruePi_;
   MonitorElement* meBarrelTrueK_;
@@ -124,17 +124,17 @@ void Primary4DVertexHarvester::incrementME(MonitorElement* base, MonitorElement*
 // ------------ endjob tasks ----------------------------
 void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& igetter) {
   // --- Get the monitoring histograms
-  MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
-  MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
-  MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
-  MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
-  MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
-  MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
+  MonitorElement* meTrackEffPtTot = igetter.get(folder_ + "EffPtTot");
+  MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
+  MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
+  MonitorElement* meTrackEffEtaTot = igetter.get(folder_ + "EffEtaTot");
+  MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
+  MonitorElement* meTrackMatchedTPEffEtaMtd = igetter.get(folder_ + "MatchedTPEffEtaMtd");
   MonitorElement* meRecoVtxVsLineDensity = igetter.get(folder_ + "RecoVtxVsLineDensity");
   MonitorElement* meRecVerNumber = igetter.get(folder_ + "RecVerNumber");
 
-  if (!meMVATrackEffEtaTot || !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd || !meMVATrackEffEtaTot ||
-      !meMVATrackMatchedEffEtaTot || !meMVATrackMatchedEffEtaMtd || !meRecoVtxVsLineDensity || !meRecVerNumber) {
+  if (!meTrackEffPtTot || !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtMtd || !meTrackEffEtaTot ||
+      !meTrackMatchedTPEffEtaTot || !meTrackMatchedTPEffEtaMtd || !meRecoVtxVsLineDensity || !meRecVerNumber) {
     edm::LogError("Primary4DVertexHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -155,37 +155,37 @@ void Primary4DVertexHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGe
 
   // --- Book  histograms
   ibook.cd(folder_);
-  meMVAPtSelEff_ = ibook.book1D("MVAPtSelEff",
-                                "Track selected efficiency VS Pt;Pt [GeV];Efficiency",
-                                meMVATrackEffPtTot->getNbinsX(),
-                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAPtSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffPtTot, meMVATrackEffPtTot, meMVAPtSelEff_);
+  meTPPtSelEff_ = ibook.book1D("TPPtSelEff",
+                               "Track associated to LV selected efficiency TP VS Pt;Pt [GeV];Efficiency",
+                               meTrackEffPtTot->getNbinsX(),
+                               meTrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meTrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffPtTot, meTrackEffPtTot, meTPPtSelEff_);
 
-  meMVAEtaSelEff_ = ibook.book1D("MVAEtaSelEff",
-                                 "Track selected efficiency VS Eta;Eta;Efficiency",
-                                 meMVATrackEffEtaTot->getNbinsX(),
-                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                 meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAEtaSelEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffEtaTot, meMVATrackEffEtaTot, meMVAEtaSelEff_);
+  meTPEtaSelEff_ = ibook.book1D("TPEtaSelEff",
+                                "Track associated to LV selected efficiency TP VS Eta;Eta;Efficiency",
+                                meTrackEffEtaTot->getNbinsX(),
+                                meTrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meTrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffEtaTot, meTrackEffEtaTot, meTPEtaSelEff_);
 
-  meMVAPtMatchEff_ = ibook.book1D("MVAPtMatchEff",
-                                  "Track matched to GEN efficiency VS Pt;Pt [GeV];Efficiency",
-                                  meMVATrackMatchedEffPtTot->getNbinsX(),
-                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmin(),
-                                  meMVATrackMatchedEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAPtMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffPtMtd, meMVATrackMatchedEffPtTot, meMVAPtMatchEff_);
+  meTPPtMatchEff_ = ibook.book1D("TPPtMatchEff",
+                                 "Track associated to LV matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
+                                 meTrackMatchedTPEffPtTot->getNbinsX(),
+                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffPtMtd, meTrackMatchedTPEffPtTot, meTPPtMatchEff_);
 
-  meMVAEtaMatchEff_ = ibook.book1D("MVAEtaMatchEff",
-                                   "Track matched to GEN efficiency VS Eta;Eta;Efficiency",
-                                   meMVATrackMatchedEffEtaTot->getNbinsX(),
-                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
-                                   meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
-  meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
-  computeEfficiency1D(meMVATrackMatchedEffEtaMtd, meMVATrackMatchedEffEtaTot, meMVAEtaMatchEff_);
+  meTPEtaMatchEff_ = ibook.book1D("TPEtaMatchEff",
+                                  "Track associated to LV matched to TP efficiency VS Eta;Eta;Efficiency",
+                                  meTrackMatchedTPEffEtaTot->getNbinsX(),
+                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffEtaMtd, meTrackMatchedTPEffEtaTot, meTPEtaMatchEff_);
 
   MonitorElement* meBarrelPIDp = igetter.get(folder_ + "BarrelPIDp");
   MonitorElement* meEndcapPIDp = igetter.get(folder_ + "EndcapPIDp");

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -269,8 +269,7 @@ private:
   static constexpr double zWosMatchMax_ = 1.;
   static constexpr double etacutGEN_ = 4.;   // |eta| < 4;
   static constexpr double etacutREC_ = 3.;   // |eta| < 3;
-  static constexpr double pTcutBTL_ = 0.7;   // PT > 0.7 GeV
-  static constexpr double pTcutETL_ = 0.2;   // PT > 0.2 GeV
+  static constexpr double pTcut_ = 0.7;      // PT > 0.7 GeV
   static constexpr double deltaZcut_ = 0.1;  // dz separation 1 mm
   static constexpr double trackMaxBtlEta_ = 1.5;
   static constexpr double trackMinEtlEta_ = 1.6;
@@ -2841,17 +2840,14 @@ const bool Primary4DVertexValidation::trkTPSelLV(const TrackingParticle& tp) {
 
   auto r_pv = std::sqrt(x_pv * x_pv + y_pv * y_pv);
 
-  match = tp.charge() != 0 &&
-          ((std::abs(tp.eta()) <= trackMaxBtlEta_ && tp.pt() > pTcutBTL_) ^
-           (std::abs(tp.eta()) > trackMaxBtlEta_ && std::abs(tp.eta()) < etacutGEN_ && tp.pt() > pTcutETL_)) &&
-          r_pv < rBTL_ && std::abs(z_pv) < zETL_;
+  match =
+      tp.charge() != 0 && std::abs(tp.eta()) < etacutGEN_ && tp.pt() > pTcut_ && r_pv < rBTL_ && std::abs(z_pv) < zETL_;
   return match;
 }
 
 const bool Primary4DVertexValidation::trkRecSel(const reco::TrackBase& trk) {
   bool match = false;
-  match = (std::abs(trk.eta()) <= trackMaxBtlEta_ && trk.pt() > pTcutBTL_) ^
-          (std::abs(trk.eta()) > trackMaxBtlEta_ && std::abs(trk.eta()) < etacutREC_ && trk.pt() > pTcutETL_);
+  match = std::abs(trk.eta()) <= etacutREC_ && trk.pt() > pTcut_;
   return match;
 }
 

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -252,8 +252,8 @@ private:
                                  const unsigned int&);
   void printSimVtxRecoVtxInfo(const struct Primary4DVertexValidation::simPrimaryVertex&,
                               const struct Primary4DVertexValidation::recoPrimaryVertex&);
-  const bool mvaTPSel(const TrackingParticle&);
-  const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&, const double&, const double&);
+  const bool trkTPSelLV(const TrackingParticle&);
+  const bool trkRecSel(const reco::TrackBase&);
 
   // ----------member data ---------------------------
 
@@ -269,7 +269,8 @@ private:
   static constexpr double zWosMatchMax_ = 1.;
   static constexpr double etacutGEN_ = 4.;   // |eta| < 4;
   static constexpr double etacutREC_ = 3.;   // |eta| < 3;
-  static constexpr double pTcut_ = 0.7;      // PT > 0.7 GeV
+  static constexpr double pTcutBTL_ = 0.7;   // PT > 0.7 GeV
+  static constexpr double pTcutETL_ = 0.2;   // PT > 0.2 GeV
   static constexpr double deltaZcut_ = 0.1;  // dz separation 1 mm
   static constexpr double trackMaxBtlEta_ = 1.5;
   static constexpr double trackMinEtlEta_ = 1.6;
@@ -281,6 +282,8 @@ private:
   static constexpr double minThrSumPt2_ = 1.e-3;
   static constexpr double minThrMetPt_ = 1.e-3;
   static constexpr double minThrSumPz_ = 1.e-4;
+  static constexpr double rBTL_ = 110.0;
+  static constexpr double zETL_ = 290.0;
 
   static constexpr float c_cm_ns = geant_units::operators::convertMmToCm(CLHEP::c_light);  // [mm/ns] -> [cm/ns]
 
@@ -327,21 +330,21 @@ private:
   edm::ESGetToken<HepPDT::ParticleDataTable, edm::DefaultRecord> pdtToken_;
 
   // histogram declaration
-  MonitorElement* meMVATrackEffPtTot_;
-  MonitorElement* meMVATrackMatchedEffPtTot_;
-  MonitorElement* meMVATrackMatchedEffPtMtd_;
-  MonitorElement* meMVATrackEffEtaTot_;
-  MonitorElement* meMVATrackMatchedEffEtaTot_;
-  MonitorElement* meMVATrackMatchedEffEtaMtd_;
-  MonitorElement* meMVATrackResTot_;
-  MonitorElement* meMVATrackPullTot_;
+  MonitorElement* meTrackEffPtTot_;
+  MonitorElement* meTrackMatchedTPEffPtTot_;
+  MonitorElement* meTrackMatchedTPEffPtMtd_;
+  MonitorElement* meTrackEffEtaTot_;
+  MonitorElement* meTrackMatchedTPEffEtaTot_;
+  MonitorElement* meTrackMatchedTPEffEtaMtd_;
+  MonitorElement* meTrackMatchedTPResTot_;
+  MonitorElement* meTrackMatchedTPPullTot_;
   MonitorElement* meTrackResTot_;
   MonitorElement* meTrackPullTot_;
   MonitorElement* meTrackRes_[3];
   MonitorElement* meTrackPull_[3];
   MonitorElement* meTrackResMass_[3];
   MonitorElement* meTrackResMassTrue_[3];
-  MonitorElement* meMVATrackZposResTot_;
+  MonitorElement* meTrackMatchedTPZposResTot_;
   MonitorElement* meTrackZposResTot_;
   MonitorElement* meTrackZposRes_[3];
   MonitorElement* meTrack3DposRes_[3];
@@ -560,18 +563,22 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                                edm::EventSetup const& iSetup) {
   ibook.setCurrentFolder(folder_);
   // --- histograms booking
-  meMVATrackEffPtTot_ = ibook.book1D("MVAEffPtTot", "Pt of tracks associated to LV; track pt [GeV] ", 110, 0., 11.);
-  meMVATrackEffEtaTot_ = ibook.book1D("MVAEffEtaTot", "Eta of tracks associated to LV; track eta ", 66, 0., 3.3);
-  meMVATrackMatchedEffPtTot_ =
-      ibook.book1D("MVAMatchedEffPtTot", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
-  meMVATrackMatchedEffPtMtd_ = ibook.book1D(
-      "MVAMatchedEffPtMtd", "Pt of tracks associated to LV matched to TP with time; track pt [GeV] ", 110, 0., 11.);
-  meMVATrackMatchedEffEtaTot_ =
-      ibook.book1D("MVAMatchedEffEtaTot", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
-  meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
-      "MVAMatchedEffEtaMtd", "Eta of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
-  meMVATrackResTot_ = ibook.book1D(
-      "MVATrackRes", "t_{rec} - t_{sim} for tracks from LV MVA sel.; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
+  meTrackEffPtTot_ = ibook.book1D("EffPtTot", "Pt of tracks associated to LV; track pt [GeV] ", 110, 0., 11.);
+  meTrackEffEtaTot_ = ibook.book1D("EffEtaTot", "Eta of tracks associated to LV; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffPtTot_ =
+      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtMtd_ = ibook.book1D(
+      "MatchedTPEffPtMtd", "Pt of tracks associated to LV matched to TP with time; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffEtaTot_ =
+      ibook.book1D("MatchedTPEffEtaTot", "Eta of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaMtd_ = ibook.book1D(
+      "MatchedTPEffEtaMtd", "Eta of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPResTot_ =
+      ibook.book1D("MatchedTPTrackRes",
+                   "t_{rec} - t_{sim} for tracks associated to LV matched to TP; t_{rec} - t_{sim} [ns] ",
+                   120,
+                   -0.15,
+                   0.15);
   meTrackResTot_ = ibook.book1D("TrackRes", "t_{rec} - t_{sim} for tracks; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meTrackRes_[0] = ibook.book1D(
       "TrackRes-LowMVA", "t_{rec} - t_{sim} for tracks with MVA < 0.5; t_{rec} - t_{sim} [ns] ", 100, -1., 1.);
@@ -602,8 +609,8 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
                                           -1.,
                                           1.);
   }
-  meMVATrackPullTot_ =
-      ibook.book1D("MVATrackPull", "Pull for tracks from LV MAV sel.; (t_{rec}-t_{sim})/#sigma_{t}", 50, -5., 5.);
+  meTrackMatchedTPPullTot_ = ibook.book1D(
+      "MatchedTPTrackPull", "Pull for tracks associated to LV matched to TP; (t_{rec}-t_{sim})/#sigma_{t}", 50, -5., 5.);
   meTrackPullTot_ = ibook.book1D("TrackPull", "Pull for tracks; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPull_[0] =
       ibook.book1D("TrackPull-LowMVA", "Pull for tracks with MVA < 0.5; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
@@ -611,8 +618,12 @@ void Primary4DVertexValidation::bookHistograms(DQMStore::IBooker& ibook,
       "TrackPull-MediumMVA", "Pull for tracks with 0.5 < MVA < 0.8; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
   meTrackPull_[2] =
       ibook.book1D("TrackPull-HighMVA", "Pull for tracks with MVA > 0.8; (t_{rec}-t_{sim})/#sigma_{t}", 100, -10., 10.);
-  meMVATrackZposResTot_ = ibook.book1D(
-      "MVATrackZposResTot", "Z_{PCA} - Z_{sim} for tracks from LV MVA sel.;Z_{PCA} - Z_{sim} [cm] ", 50, -0.1, 0.1);
+  meTrackMatchedTPZposResTot_ =
+      ibook.book1D("MatchedTPTrackZposResTot",
+                   "Z_{PCA} - Z_{sim} for tracks associated to LV matched to TP;Z_{PCA} - Z_{sim} [cm] ",
+                   50,
+                   -0.1,
+                   0.1);
   meTrackZposResTot_ =
       ibook.book1D("TrackZposResTot", "Z_{PCA} - Z_{sim} for tracks;Z_{PCA} - Z_{sim} [cm] ", 50, -0.5, 0.5);
   meTrackZposRes_[0] = ibook.book1D(
@@ -2073,7 +2084,7 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
         unsigned int nJets = 0, nJetsnoPU = 0, nJetsnoFake = 0;
         for (auto iTrack = vertex->tracks_begin(); iTrack != vertex->tracks_end(); ++iTrack) {
           if (trackAssoc[*iTrack] == -1) {
-            LogTrace("mtdTracks") << "Extended track not associated";
+            edm::LogWarning("mtdTracks") << "Extended track not associated";
             continue;
           }
 
@@ -2081,12 +2092,12 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
             continue;
           bool noCrack = std::abs((*iTrack)->eta()) < trackMaxBtlEta_ || std::abs((*iTrack)->eta()) > trackMinEtlEta_;
 
-          bool selectRecoTrk = mvaRecSel(**iTrack, *vertex, t0Safe[*iTrack], sigmat0Safe[*iTrack]);
+          bool selectRecoTrk = trkRecSel(**iTrack);
           if (selectedLVMatching && selectRecoTrk) {
             if (noCrack) {
-              meMVATrackEffPtTot_->Fill((*iTrack)->pt());
+              meTrackEffPtTot_->Fill((*iTrack)->pt());
             }
-            meMVATrackEffEtaTot_->Fill(std::abs((*iTrack)->eta()));
+            meTrackEffEtaTot_->Fill(std::abs((*iTrack)->eta()));
           }
 
           auto tp_info = getMatchedTP(*iTrack, vsim).first;
@@ -2176,26 +2187,26 @@ void Primary4DVertexValidation::analyze(const edm::Event& iEvent, const edm::Eve
             }
 
             // select TPs associated to the signal event
-            bool selectTP = mvaTPSel(**tp_info);
+            bool selectTP = trkTPSelLV(**tp_info);
 
             if (selectedLVMatching && selectRecoTrk && selectTP) {
-              meMVATrackZposResTot_->Fill((*iTrack)->vz() - vzsim);
+              meTrackMatchedTPZposResTot_->Fill((*iTrack)->vz() - vzsim);
               if (noCrack) {
-                meMVATrackMatchedEffPtTot_->Fill((*iTrack)->pt());
+                meTrackMatchedTPEffPtTot_->Fill((*iTrack)->pt());
               }
-              meMVATrackMatchedEffEtaTot_->Fill(std::abs((*iTrack)->eta()));
+              meTrackMatchedTPEffEtaTot_->Fill(std::abs((*iTrack)->eta()));
             }
 
             if (sigmat0Safe[*iTrack] == -1)
               continue;
 
             if (selectedLVMatching && selectRecoTrk && selectTP) {
-              meMVATrackResTot_->Fill(t0Safe[*iTrack] - vtsim);
-              meMVATrackPullTot_->Fill((t0Safe[*iTrack] - vtsim) / sigmat0Safe[*iTrack]);
+              meTrackMatchedTPResTot_->Fill(t0Safe[*iTrack] - vtsim);
+              meTrackMatchedTPPullTot_->Fill((t0Safe[*iTrack] - vtsim) / sigmat0Safe[*iTrack]);
               if (noCrack) {
-                meMVATrackMatchedEffPtMtd_->Fill((*iTrack)->pt());
+                meTrackMatchedTPEffPtMtd_->Fill((*iTrack)->pt());
               }
-              meMVATrackMatchedEffEtaMtd_->Fill(std::abs((*iTrack)->eta()));
+              meTrackMatchedTPEffEtaMtd_->Fill(std::abs((*iTrack)->eta()));
 
               unsigned int noPIDtype = 0;
               bool noPID = false, isPi = false, isK = false, isP = false;
@@ -2818,24 +2829,29 @@ void Primary4DVertexValidation::printSimVtxRecoVtxInfo(
   }
 }
 
-const bool Primary4DVertexValidation::mvaTPSel(const TrackingParticle& tp) {
+const bool Primary4DVertexValidation::trkTPSelLV(const TrackingParticle& tp) {
   bool match = false;
   if (tp.status() != 1) {
     return match;
   }
-  match = tp.charge() != 0 && tp.pt() > pTcut_ && std::abs(tp.eta()) < etacutGEN_;
+
+  auto x_pv = tp.parentVertex()->position().x();
+  auto y_pv = tp.parentVertex()->position().y();
+  auto z_pv = tp.parentVertex()->position().z();
+
+  auto r_pv = std::sqrt(x_pv * x_pv + y_pv * y_pv);
+
+  match = tp.charge() != 0 &&
+          ((std::abs(tp.eta()) <= trackMaxBtlEta_ && tp.pt() > pTcutBTL_) ^
+           (std::abs(tp.eta()) > trackMaxBtlEta_ && std::abs(tp.eta()) < etacutGEN_ && tp.pt() > pTcutETL_)) &&
+          r_pv < rBTL_ && std::abs(z_pv) < zETL_;
   return match;
 }
 
-const bool Primary4DVertexValidation::mvaRecSel(const reco::TrackBase& trk,
-                                                const reco::Vertex& vtx,
-                                                const double& t0,
-                                                const double& st0) {
+const bool Primary4DVertexValidation::trkRecSel(const reco::TrackBase& trk) {
   bool match = false;
-  match = trk.pt() > pTcut_ && std::abs(trk.eta()) < etacutREC_ && std::abs(trk.vz() - vtx.z()) <= deltaZcut_;
-  if (st0 > 0.) {
-    match = match && std::abs(t0 - vtx.t()) < 3. * st0;
-  }
+  match = (std::abs(trk.eta()) <= trackMaxBtlEta_ && trk.pt() > pTcutBTL_) ^
+          (std::abs(trk.eta()) > trackMaxBtlEta_ && std::abs(trk.eta()) < etacutREC_ && trk.pt() > pTcutETL_);
   return match;
 }
 

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -10,11 +10,11 @@ process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 
-process.load("Configuration.Geometry.GeometryExtended2026D98Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D110Reco_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', '')
 process.load('RecoLocalFastTime.FTLClusterizer.MTDCPEESProducer_cfi')
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 


### PR DESCRIPTION
PR description:  
This PR updates track selection in MtdValidation and moves mtdValidation_cfg.py to D110 scenario.
In particular, some efficiency plot for extrapolated tracks were fixed after an issue introduced with PR #44859, which moved detailed extrapolation check in MtdTracksValidation only on tracks associated to TP from signal event, without changing the corresponding harvester.
Furthermore, track selection in validation for tracks and vertices was updated and made consistent.
Finally, efficiency plots for tracks matched to Gen particles were removed, leaving only those with tracks associated to TP, and some efficiency plots to monitor low-pt tracks in ETL were added.     

The code was tested on the workflow  TTbar_PU_14TeV and SinglePiFlatPt0p7To10, with geometry scenario 2026D110.
