### PR TITLE
Fix clang compilation issues with RecoTracker/FinalTrackSelectors

### DIFF
--- a/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
+++ b/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h
@@ -2,6 +2,7 @@
 #define RecoTracker_FinalTrackSelectors_TrackMVAClassifierBase_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 


### PR DESCRIPTION
#### PR description:

In recent IBs, the CLANG builds are failing on RecoTracker/FinalTrackSelectors with errors like
```
In file included from src/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc:1:
In file included from src/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h:4:
In file included from src/DataFormats/TrackReco/interface/TrackFwd.h:4:
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/vector:60:
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/bits/stl_algobase.h:67:
  /data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/bits/stl_iterator.h:1107:2: error: arithmetic on a pointer to an incomplete type 'const reco::Track'
  1107 |         ++_M_current;
      |         ^ ~~~~~~~~~~
src/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h:71:28: note: in instantiation of member function '__gnu_cxx::__normal_iterator<const reco::Track *, std::vector<reco::Track>>::operator++' requested here
   71 |       for (auto const& trk : tracks) {
      |                            ^
src/DataFormats/TrackReco/interface/TrackFwd.h:14:9: note: forward declaration of 'reco::Track'
   14 |   class Track;
      |         ^
In file included from src/RecoTracker/FinalTrackSelectors/plugins/DefaultTrackMVAClassifier.cc:1:
  src/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h:86:28: error: cannot increment value of type 'const_iterator' (aka '__normal_iterator<const reco::Track *, std::vector<reco::Track, std::allocator<reco::Track>>>')
    86 |       for (auto const& trk : tracks) {
      |                            ^
src/RecoTracker/FinalTrackSelectors/interface/TrackMVAClassifier.h:86:30: note: in implicit call to 'operator++' for iterator of type 'const reco::TrackCollection' (aka 'const vector<Track>')
   86 |       for (auto const& trk : tracks) {
      |                              ^~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/gcc/12.3.1-40d504be6370b5a30e3947a6e575ca28/lib/gcc/x86_64-redhat-linux-gnu/12.3.1/../../../../include/c++/12.3.1/bits/stl_vector.h:878:7: note: selected 'begin' function with iterator type 'const_iterator' (aka '__normal_iterator<const reco::Track *, std::vector<reco::Track, std::allocator<reco::Track>>>')
  878 |       begin() const _GLIBCXX_NOEXCEPT
      |       ^
```
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-14-2300/RecoTracker/FinalTrackSelectors

I don't know why these errors have suddenly appeared--perhaps a change in the includes elsewhere--but they appear to be correct.  It's legitimate for the compiler to need to know `sizeof(Track)` at the point where it is complaining.  This PR trivially adds an include of Track.h.  It doesn't appear that this header is included outside of this package (according to `cms-checkdeps`), so this should have minimal impact elsewhere.

#### PR validation:

Trivial technical change, compiles, no impact on physics or timing performance expected, compilation time differences should be trivial.