### PR TITLE
Initialize variables in MuonROI

### DIFF
--- a/L1Trigger/Phase2L1GMT/plugins/MuonROI.h
+++ b/L1Trigger/Phase2L1GMT/plugins/MuonROI.h
@@ -13,7 +13,8 @@ namespace Phase2L1GMT {
 
   class MuonROI {
   public:
-    MuonROI(int bx, uint charge, uint pt, uint quality) : bx_(bx), charge_(charge), pt_(pt), quality_(quality) {}
+    MuonROI(int bx, uint charge, uint pt, uint quality)
+        : bx_(bx), charge_(charge), pt_(pt), quality_(quality), isGlobal_(false), offline_pt_(0.f) {}
 
     const int bx() const { return bx_; }
 


### PR DESCRIPTION
#### PR description:

valgrind reported use of uninitialized variables

#### PR validation:
Code compiles. Have not yet rerun valgrind.