### PR TITLE
(DAQ) Add WatcherSource (ECAL) to DAQ output file unit tests

### DIFF
--- a/EventFilter/Utilities/test/RunBUFU.sh
+++ b/EventFilter/Utilities/test/RunBUFU.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-function diebu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_bu.log;  rm -rf $3/{ramdisk,data,dqmdisk,*.py}; exit $2 ; }
-function diefu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_fu.log;  rm -rf $3/{ramdisk,data,dqmdisk,*.py}; exit $2 ; }
-function diedqm { echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_dqm.log; rm -rf $3/{ramdisk,data,dqmdisk,*.py}; exit $2 ; }
+function diebu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_bu.log;  rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function diefu {  echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_fu.log;  rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function diedqm { echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_dqm.log; rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
+function dieecal { echo Failure $1: status $2 ; echo "" ; echo "----- Error -----"; echo ""; cat out_2_ecal.log; rm -rf $3/{ramdisk,data,dqmdisk,ecalInDir,*.py}; exit $2 ; }
 
 FUSCRIPT="unittest_FU.py"
 if [ ! -z $1 ]; then
@@ -31,29 +32,46 @@ cp ${SCRIPTDIR}/startFU.py ${OUTDIR}
 cp ${SCRIPTDIR}/unittest_FU.py ${OUTDIR}
 cp ${SCRIPTDIR}/unittest_FU_daqsource.py ${OUTDIR}
 cp ${SCRIPTDIR}/test_dqmstream.py ${OUTDIR}
+cp ${SCRIPTDIR}/testECALCalib_cfg.py ${OUTDIR}
 cd ${OUTDIR}
 
-rm -rf $OUTDIR/{ramdisk,data,dqmdisk,*.log}
+rm -rf $OUTDIR/{ramdisk,data,dqmdisk,ecalInDir,*.log}
 
 runnumber="100101"
 echo "Running test with FRD file header v1 (no index JSONs)"
-CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=20 eventsPerLS=35 frdFileVersion=1"
+CMDLINE_STARTBU="cmsRun startBU.py runNumber=${runnumber} fffBaseDir=${OUTDIR} maxLS=2 fedMeanSize=128 eventsPerFile=40 eventsPerLS=55 frdFileVersion=1"
 #CMDLINE_STARTFU="cmsRun startFU.py runNumber=${runnumber} fffBaseDir=${OUTDIR}"
 CMDLINE_STARTFU="cmsRun ${FUSCRIPT} runNumber=${runnumber} fffBaseDir=${OUTDIR}"
+mkdir dqmdisk/run${runnumber} -p
 ${CMDLINE_STARTBU}  > out_2_bu.log 2>&1 || diebu "${CMDLINE_STARTBU}" $? $OUTDIR
 ${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR
 
-#prepare DQM files
-mkdir dqmdisk/run${runnumber} -p
+#prepare DQM and ECAL Calibration files
 cat data/run${runnumber}/run${runnumber}_ls0000_streamDQM_pid*.ini > dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.dat
 cat data/run${runnumber}/run${runnumber}_ls0001_streamDQM_pid*.dat >> dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.dat
+
+rm -rf $OUTDIR/{data}
+${CMDLINE_STARTFU}  > out_2_fu.log 2>&1 || diefu "${CMDLINE_STARTFU}" $? $OUTDIR
+
+#prepare DQM and ECAL Calibration files, merged from two processes, containing two metadata events
+cat data/run${runnumber}/run${runnumber}_ls0001_streamDQM_pid*.dat >> dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.dat
+
 find dqmdisk
 echo '{"data": [12950, 1620, 0, "run'${runnumber}'_ls0001_streamDQM_test.dat", 40823782, 1999348078, 135, 13150, 0, "Failsafe"]}' > dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.jsn
 
+mkdir ecalInDir
+cp dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.dat ecalInDir/
+
+echo "Running DQM source"
 CMDLINE_STARTDQM="cmsRun test_dqmstream.py runInputDir=./dqmdisk runNumber=100101 maxLS=1 eventsPerLS=35"
 ${CMDLINE_STARTDQM} > out_2_dqm.log 2>&1 || diedqm "${CMDLINE_STARTDQM}" $? $OUTDIR
 
-rm -rf $OUTDIR/{ramdisk,data,*.log}
+echo "Running ECAL Calibration source"
+CMDLINE_STARTECAL="cmsRun testECALCalib_cfg.py"
+${CMDLINE_STARTECAL} > out_2_ecal.log 2>&1 || dieecal "${CMDLINE_STARTECAL}" $? $OUTDIR
+
+
+rm -rf $OUTDIR/{ramdisk,data,dqmdisk,ecalInDir,*.log}
 
 ###################
 echo "Running test with FRD file header v1 (no index JSONs) and empty files"
@@ -70,10 +88,11 @@ cat data/run${runnumber}/run${runnumber}_ls0001_streamDQM_pid*.dat >> dqmdisk/ru
 find dqmdisk
 echo '{"data": [12950, 1620, 0, "run'${runnumber}'_ls0001_streamDQM_test.dat", 40823782, 1999348078, 135, 13150, 0, "Failsafe"]}' > dqmdisk/run${runnumber}/run${runnumber}_ls0001_streamDQM_test.jsn
 
+echo "Running DQM source"
 CMDLINE_STARTDQM="cmsRun test_dqmstream.py runInputDir=./dqmdisk runNumber=100101 maxLS=1 eventsPerLS=0"
 ${CMDLINE_STARTDQM} > out_2_dqm.log 2>&1 || diedqm "${CMDLINE_STARTDQM}" $? $OUTDIR
 
-rm -rf $OUTDIR/{ramdisk,data,*.log}
+rm -rf $OUTDIR/{ramdisk,data,dqmdisk,*.log}
 
 ################
 echo "Running test with FRD file header v2"

--- a/EventFilter/Utilities/test/testECALCalib_cfg.py
+++ b/EventFilter/Utilities/test/testECALCalib_cfg.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TRANSFER")
+
+import FWCore.Framework.test.cmsExceptionsFatal_cff
+process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+process.source = cms.Source("WatcherSource",
+                            inputDir = cms.string("."),
+                            filePatterns = cms.vstring("ecalInDir/.*\.dat"),
+                            inprocessDir = cms.string("process"),
+                            processedDir = cms.string("processed"),
+                            corruptedDir = cms.string("corrupt"),
+                            tokenFile = cms.untracked.string("watcherSourceToken"),
+                            timeOutInSec = cms.int32(10),
+                            verbosity = cms.untracked.int32(1)
+)
+


### PR DESCRIPTION
#### PR description:

Unit test for issue (now fixed) with WatcherSource crashing with merged DAQ streamer files.
See: https://github.com/cms-sw/cmssw/issues/45450

#### PR validation:
Tested on broken release (14_0_9 - test fails) and release with a fix for WatcherSource (14_1_0 and later, test passes).
