### PR TITLE
Fix compatibility with FMT 10

### DIFF
--- a/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
+++ b/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc
@@ -284,7 +284,7 @@ void SiPixelPhase1RawDataErrorComparator::bookHistograms(DQMStore::IBooker& iBoo
                                 log10(1000.));
 
   for (const auto& element : errorCodeToStringMap) {
-    h_nFEDErrors_[element.first] = iBook.book2I(fmt::sprintf("nFED%i_Errors", element.first),
+    h_nFEDErrors_[element.first] = iBook.book2I(fmt::sprintf("nFED%i_Errors", static_cast<int>(element.first)),
                                                 fmt::sprintf("n. of %ss per event; CPU; GPU", element.second),
                                                 1000,
                                                 -0.5,

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc
@@ -79,7 +79,7 @@ void SimTauProducer::buildSimTau(SimTauCPLink& t,
       t.calo_particle_leaves.push_back(CaloParticleRef(calo_particle_h, calo_particle_idx));
       t.leaves.push_back(
           {gen_particle.pdgId(), resonance_idx, (int)t.calo_particle_leaves.size() - 1, gen_particle_key});
-      LogDebug("SimTauProducer").format(" CP {} {}", calo_particle_idx, caloPartVec[calo_particle_idx]);
+      LogDebug("SimTauProducer").format(" CP {} {}", calo_particle_idx, caloPartVec[calo_particle_idx].pdgId());
     } else {
       t.leaves.push_back({gen_particle.pdgId(), resonance_idx, -1, gen_particle_key});
     }


### PR DESCRIPTION
#### PR description:

Title says it all. When testing https://github.com/cms-sw/cmsdist/pull/9293, the following errors are reported:

```
In file included from /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/format.h:49,
                 from src/FWCore/MessageLogger/interface/ErrorObj.h:28,
                 from src/FWCore/MessageLogger/interface/MessageSender.h:5,
                 from src/FWCore/MessageLogger/interface/MessageLogger.h:30,
                 from src/FWCore/Framework/interface/maker/Worker.h:37,
                 from src/FWCore/Framework/interface/maker/WorkerT.h:13,
                 from src/FWCore/Framework/interface/maker/WorkerMaker.h:8,
                 from src/FWCore/Framework/interface/MakerMacros.h:5,
                 from src/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc:24:
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_printf_context<char>; T = const {anonymous}::SiPixelFEDErrorCodes; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:1842:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {const {anonymous}::SiPixelFEDErrorCodes}; Context = fmt::v10::basic_printf_context<char>; Args = {{anonymous}::SiPixelFEDErrorCodes}]'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:1860:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_printf_context<char>; T = {const {anonymous}::SiPixelFEDErrorCodes}]'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/printf.h:614:68:   required from 'std::__cxx11::basic_string<Char> fmt::v10::sprintf(const S&, const T& ...) [with S = char [14]; T = {{anonymous}::SiPixelFEDErrorCodes}; Char = char]'
src/DQM/SiPixelHeterogeneous/plugins/SiPixelPhase1RawDataErrorComparator.cc:287:61:   required from here
  /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:1600:63: error: 'fmt::v10::detail::type_is_unformattable_for<const {anonymous}::SiPixelFEDErrorCodes, char> _' has incomplete type
  1600 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
  /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:1604:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
  1604 |       formattable,
      |       ^~~~~~~~~~~
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:1604:7: note: 'formattable' evaluates to false
```

This worked before because of a bug in fmt, where `enum` was silently cast to `int`

```
In file included from /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/format.h:49,
                 from src/FWCore/MessageLogger/interface/ErrorObj.h:28,
                 from src/FWCore/MessageLogger/interface/MessageSender.h:5,
                 from src/FWCore/MessageLogger/interface/MessageLogger.h:30,
                 from src/FWCore/Framework/interface/maker/Worker.h:37,
                 from src/FWCore/Framework/interface/maker/WorkerT.h:13,
                 from src/FWCore/Framework/interface/maker/WorkerMaker.h:8,
                 from src/FWCore/Framework/interface/MakerMacros.h:5,
                 from src/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc:17:
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h: In instantiation of 'constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = CaloParticle; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]':
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2684:51:   required from here
src/SimCalorimetry/HGCalAssociatorProducers/plugins/SimTauCPLinkProducer.cc:82:40:   in 'constexpr' expansion of 'fmt::v10::basic_format_string<char, long int&, const CaloParticle&>(" CP {} {}")'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2787:40:   in 'constexpr' expansion of 'fmt::v10::detail::parse_format_string<true, char, format_string_checker<char, long int, CaloParticle> >(((fmt::v10::basic_format_string<char, long int&, const CaloParticle&>*)this)->fmt::v10::basic_format_string<char, long int&, const CaloParticle&>::str_, fmt::v10::detail::format_string_checker<char, long int, CaloParticle>(fmt::v10::basic_string_view<char>(((const char*)s))))'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2534:44:   in 'constexpr' expansion of 'fmt::v10::detail::parse_replacement_field<char, format_string_checker<char, long int, CaloParticle>&>((p + -1), end, (* & handler))'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2502:33:   in 'constexpr' expansion of '(& handler)->fmt::v10::detail::format_string_checker<char, long int, CaloParticle>::on_replacement_field((& handler)->fmt::v10::detail::format_string_checker<char, long int, CaloParticle>::on_arg_id(), begin)'
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2677:20:   in 'constexpr' expansion of '((fmt::v10::detail::format_string_checker<char, long int, CaloParticle>*)this)->fmt::v10::detail::format_string_checker<char, long int, CaloParticle>::on_format_specs(id, begin, begin)'
  /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2593:45: error: 'fmt::v10::detail::type_is_unformattable_for<CaloParticle, char> _' has incomplete type
  2593 |     type_is_unformattable_for<T, char_type> _;
      |                                             ^
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h: In member function 'void SimTauProducer::buildSimTau(SimTauCPLink&, uint8_t, int, const reco::GenParticle&, int, edm::Handle<std::vector<CaloParticle> >, const std::vector<int>&) const':
  /data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2684:51: error: 'constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = CaloParticle; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]' called in a constant expression
  2684 |     return id >= 0 && id < num_args ? parse_funcs_[id](context_) : begin;
      |                                       ~~~~~~~~~~~~^
/data/cmsbld/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc12/external/fmt/10.2.1-76ef466f9d9d21f087f9b7e4e843a9d9/include/fmt/core.h:2580:20: note: 'constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = CaloParticle; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]' is not usable as a 'constexpr' function because:
 2580 | FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx)
      |                    ^~~~~~~~~~~~~~~~~~
```

No idea why it stopped working. @cms-sw/simulation-l2 could you please verify that the code is supposed to print `pdgId`, and not some other property of `CaloParticle`?

#### PR validation:

Bot tests
