### PR TITLE
Fix pixel CPE position

### DIFF
--- a/DataFormats/TrackingRecHitSoA/BuildFile.xml
+++ b/DataFormats/TrackingRecHitSoA/BuildFile.xml
@@ -1,10 +1,11 @@
 <use name="alpaka"/>
 <use name="rootcore"/>
 <use name="eigen"/>
-<use name="DataFormats/SiPixelClusterSoA"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/TrackerCommon" source_only="1"/>
+<use name="DataFormats/SiPixelClusterSoA"/>
 <use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="DataFormats/TrackerCommon" source_only="1"/>
+<use name="Geometry/CommonTopologies" source_only="1"/>
 <use name="HeterogeneousCore/AlpakaInterface"/>
 <flags ALPAKA_BACKENDS="!serial"/>
 <export>

--- a/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h
+++ b/DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h
@@ -5,8 +5,8 @@
 
 #include "DataFormats/SoATemplate/interface/SoALayout.h"
 #include "DataFormats/TrackingRecHitSoA/interface/SiPixelHitStatus.h"
+#include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/HistoContainer.h"
-#include "RecoLocalTracker/SiPixelRecHits/interface/pixelCPEforDevice.h"
 
 template <typename TrackerTraits>
 struct TrackingRecHitSoA {

--- a/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
+++ b/RecoTracker/PixelSeeding/plugins/alpaka/CAPixelDoubletsAlgos.h
@@ -10,6 +10,7 @@
 #include <alpaka/alpaka.hpp>
 
 #include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/SiPixelClusterSoA/interface/ClusteringConstants.h"
 #include "DataFormats/TrackingRecHitSoA/interface/TrackingRecHitsSoA.h"
 #include "Geometry/CommonTopologies/interface/SimplePixelTopology.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/VecArray.h"


### PR DESCRIPTION
#### PR description:

Rewrite the pixel CPE position calculation to improve the reproducibility of the results.

Fix the includes used in `DataFormats/TrackingRecHitSoA` to avoid the dependency on `RecoLocalTracker/SiPixelRecHits`.

Thanks to @missirol for spotitng the source of the discrepancy.

#### PR validation:

Tested on top of CMSSW 14.0.11 running the HLT over 100k events:
  - the CPU-only results are reproducible, with and without these changes;
  - the GPU vs CPU results are in general slightly more reproducible; 
  - the biggest improvement is fixing the reproducibility of `HLT_SingleEle8_v7`, going from 2% of the accepted events to being fully reproducible.

##### GPU vs CPU results, without these changes
  - +4/-5 events in `HLT_SingleEle8_v7` (2% of the accepted events)
  -  +/-4 events in  1 path
  -  +/-3 events in  2 paths
  -  +/-2 events in  6 paths
  -  +/-1 event  in 59 paths

##### GPU vs CPU results, with these changes
  -  +/-3 events in  2 paths
  -  +/-2 events in 12 paths
  -  +/-1 event  in 46 paths


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14.0.x for data taking.