### PR TITLE
[14_0_X] Allowing Jumping BPix2->FPix2 For Pixel Doublets (and Alpaka Pixel Triplets `*.406` wf)

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1650,6 +1650,21 @@ upgradeWFs['PatatrackPixelOnlyAlpakaProfiling'] = PatatrackWorkflow(
     offset = 0.404,
 )
 
+upgradeWFs['PatatrackPixelOnlyTripletsAlpaka'] = PatatrackWorkflow(
+    digi = { 
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '--procModifiers': 'alpaka',
+        '--customise' : 'RecoTracker/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+    },
+    suffix = 'Patatrack_PixelOnlyTripletsAlpaka',
+    offset = 0.406,
+)
+
 # end of Patatrack workflows
 
 class UpgradeWorkflow_ProdLike(UpgradeWorkflow):

--- a/Geometry/CommonTopologies/interface/SimplePixelTopology.h
+++ b/Geometry/CommonTopologies/interface/SimplePixelTopology.h
@@ -132,7 +132,7 @@ namespace phase1PixelTopology {
   using pixelTopology::phi0p07;
 
   constexpr uint32_t numberOfLayers = 28;
-  constexpr int nPairs = 13 + 2 + 4;
+  constexpr int nPairs = 13 + 2 + 4 + 2;
   constexpr uint16_t numberOfModules = 1856;
 
   constexpr uint32_t maxNumClustersPerModules = 1024;
@@ -156,35 +156,21 @@ namespace phase1PixelTopology {
       4, 5, 7, 8,                    // FPIX1 (8)
       2, 3, 2, 4, 2, 7, 5, 6, 8, 9,  // BPIX3 & FPIX2 (13)
       0, 2, 1, 3,                    // Jumping Barrel (15)
-      0, 5, 0, 8,                    // Jumping Forward (BPIX1,FPIX2)
-      4, 6, 7, 9                     // Jumping Forward (19)
+      0, 5, 0, 8,                    // Jumping Forward (BPIX1,FPIX2) (17)
+      1, 5, 1, 8,                    // Jumping Forward with BPIX2 (19)
+      4, 6, 7, 9                     // Jumping Forward (21)
   };
 
-  HOST_DEVICE_CONSTANT int16_t phicuts[nPairs]{phi0p05,
-                                               phi0p07,
-                                               phi0p07,
-                                               phi0p05,
-                                               phi0p06,
-                                               phi0p06,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p06,
-                                               phi0p06,
-                                               phi0p06,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05,
-                                               phi0p05};
-  HOST_DEVICE_CONSTANT float minz[nPairs] = {
-      -20., 0., -30., -22., 10., -30., -70., -70., -22., 15., -30, -70., -70., -20., -22., 0, -30., -70., -70.};
-  HOST_DEVICE_CONSTANT float maxz[nPairs] = {
-      20., 30., 0., 22., 30., -10., 70., 70., 22., 30., -15., 70., 70., 20., 22., 30., 0., 70., 70.};
-  HOST_DEVICE_CONSTANT float maxr[nPairs] = {
-      20., 9., 9., 20., 7., 7., 5., 5., 20., 6., 6., 5., 5., 20., 20., 9., 9., 9., 9.};
+  HOST_DEVICE_CONSTANT int16_t phicuts[nPairs]{phi0p05, phi0p07, phi0p07, phi0p05, phi0p06, phi0p06, phi0p05,
+                                               phi0p05, phi0p06, phi0p06, phi0p06, phi0p05, phi0p05, phi0p05,
+                                               phi0p05, phi0p05, phi0p05, phi0p05, phi0p05, phi0p05, phi0p05};
+
+  HOST_DEVICE_CONSTANT float minz[nPairs] = {-20., 0.,   -30., -22., 10., -30., -70., -70., -22., 15., -30,
+                                             -70., -70., -20., -22., 0,   -30., 10.,  -30., -70., -70.};
+  HOST_DEVICE_CONSTANT float maxz[nPairs] = {20., 30., 0.,  22., 30., -10., 70., 70., 22., 30., -15.,
+                                             70., 70., 20., 22., 30., 0.,   30., 10., 70., 70.};
+  HOST_DEVICE_CONSTANT float maxr[nPairs] = {20., 9., 9.,  20., 7., 7., 5., 5., 20., 6., 6.,
+                                             5.,  5., 20., 20., 9., 9., 7., 7., 9.,  9.};
 
   static constexpr uint32_t layerStart[numberOfLayers + 1] = {0,
                                                               96,
@@ -467,9 +453,9 @@ namespace pixelTopology {
     static constexpr int minYsizeB1 = 36;
     static constexpr int minYsizeB2 = 28;
 
-    static constexpr int nPairsForQuadruplets = 13;                     // quadruplets require hits in all layers
-    static constexpr int nPairsForTriplets = nPairsForQuadruplets + 2;  // include barrel "jumping" layer pairs
-    static constexpr int nPairs = nPairsForTriplets + 4;                // include forward "jumping" layer pairs
+    static constexpr int nPairsForQuadruplets = 13;                         // quadruplets require hits in all layers
+    static constexpr int nPairsForTriplets = nPairsForQuadruplets + 2 + 2;  // include barrel "jumping" layer pairs
+    static constexpr int nPairs = nPairsForTriplets + 4;                    // include forward "jumping" layer pairs
 
     static constexpr int maxDYsize12 = 28;
     static constexpr int maxDYsize = 20;

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -352,6 +352,17 @@ def customizeHLTfor44746(process):
             mod.l1EGCand = cms.InputTag('hltEgammaCandidatesPPOnAA')
     return process
 
+def customizeHLTFor45479(process):
+
+    ca_builders = ["CAHitNtupletAlpakaPhase1@alpaka", "alpaka_serial_sync::CAHitNtupletAlpakaPhase1"]
+
+    for ca_builder in ca_builders:
+        for producer_name in producers_by_type(process, ca_builder):
+            producer = getattr(process,producer_name.label_())
+            producer.phiCuts = cms.vint32( 522, 730, 730, 522, 626, 626, 522, 522, 626, 626, 626, 522, 522, 522, 522, 522, 522, 522, 522 , 522, 522)
+
+    return process
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -363,5 +374,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = checkHLTfor43774(process)
     process = customizeHLTfor45302(process)
     process = customizeHLTfor44746(process)
+    process = customizeHLTFor45479(process)
 
     return process

--- a/RecoTracker/Configuration/python/customizePixelTracksForTriplets.py
+++ b/RecoTracker/Configuration/python/customizePixelTracksForTriplets.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 def customizePixelTracksForTriplets(process):
 
   from HLTrigger.Configuration.common import producers_by_type
-  producers = ['CAHitNtupletCUDA','CAHitNtupletCUDAPhase1','CAHitNtupletCUDAPhase2']
+  producers = ['CAHitNtupletCUDA','CAHitNtupletCUDAPhase1','CAHitNtupletCUDAPhase2','CAHitNtupletAlpakaPhase1@alpaka']
   for name in producers:
   	for producer in producers_by_type(process, name):
         	producer.includeJumpingForwardDoublets = True


### PR DESCRIPTION
#### PR description:

Plain backport of #45478 for 2024 data taking.

#### PR validation:

Run `runTheMatrix.py -w upgrade -l 12834.406 `