### PR TITLE
[L1] Fix Warnings: Remove unused variables

### DIFF
--- a/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc
+++ b/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc
@@ -111,12 +111,6 @@ void Phase2L1TGMTStubProducer::produce(edm::Event& iEvent, const edm::EventSetup
   l1t::MuonStubCollection stubs;
   l1t::MuonStubCollection stubsKMTF;
 
-  uint count0 = 0;
-  uint count1 = 0;
-  uint count2 = 0;
-  uint count3 = 0;
-  uint count4 = 0;
-
   l1t::MuonStubCollection stubsEndcap = procEndcap_->makeStubs(*cscDigis, *rpcDigis, translator_, iSetup);
   for (auto& stub : stubsEndcap) {
     stubs.push_back(stub);

--- a/L1Trigger/Phase2L1GMT/src/KMTFCore.cc
+++ b/L1Trigger/Phase2L1GMT/src/KMTFCore.cc
@@ -440,7 +440,6 @@ void KMTFCore::propagate(l1t::KMTFTrack& track) {
   if (KBound < -(pow(2, BITSCURV - 3) - 1))
     KBound = -(pow(2, BITSCURV - 3) - 1);
 
-  int deltaK = 0;
   int KNew = K;
   if (step == 1) {
     ap_ufixed<17, 0> eLoss = ap_ufixed<17, 0>(eLoss_[step - 1]);
@@ -1114,9 +1113,7 @@ uint KMTFCore::etaStubRank(const l1t::MuonStubRef& stub) {
 }
 
 void KMTFCore::calculateEta(l1t::KMTFTrack& track) {
-  uint pattern = track.hitPattern();
   int wheel = track.stubs()[0]->etaRegion();
-  uint awheel = fabs(wheel);
   int sign = 1;
   if (wheel < 0)
     sign = -1;
@@ -1147,7 +1144,6 @@ uint KMTFCore::matchAbs(std::map<uint, uint>& info, uint i, uint j) {
 }
 
 int KMTFCore::ptLUT(int K) {
-  int charge = (K >= 0) ? +1 : -1;
   float lsb = 1.25 / float(1 << (BITSCURV - 1));
   float FK = fabs(K);
   int pt = 0;

--- a/L1Trigger/Phase2L1GMT/src/L1TPhase2GMTBarrelStubProcessor.cc
+++ b/L1Trigger/Phase2L1GMT/src/L1TPhase2GMTBarrelStubProcessor.cc
@@ -147,7 +147,6 @@ l1t::MuonStubCollection L1TPhase2GMTBarrelStubProcessor::makeStubs(const L1Phase
               sN = sN | (wr1 << 30);
               sN = sN | (wq << 51);
               sN = sN | (wr2 << 55);
-              unsigned int index = (station - 1) * 4 + phiDigi.index();
               os << std::setw(0) << std::dec << sector << " " << wheel << " " << station << " ";
               os << std::uppercase << std::setfill('0') << std::setw(16) << std::hex << uint64_t(sN) << " ";
             }


### PR DESCRIPTION
This PR fixes the compilation warnings by removing the unused variables

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_ROOT6_X_2024-07-16-2300/L1Trigger/Phase2L1GMT
```
src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc: In member function 'virtual void Phase2L1TGMTStubProducer::produce(edm::Event&, const edm::EventSetup&)':
  src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc:114:8: warning: unused variable 'count0' [-Wunused-variable]
   114 |   uint count0 = 0;
      |        ^~~~~~
  src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc:115:8: warning: unused variable 'count1' [-Wunused-variable]
   115 |   uint count1 = 0;
      |        ^~~~~~
  src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc:116:8: warning: unused variable 'count2' [-Wunused-variable]
   116 |   uint count2 = 0;
      |        ^~~~~~
  src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc:117:8: warning: unused variable 'count3' [-Wunused-variable]
   117 |   uint count3 = 0;
      |        ^~~~~~
  src/L1Trigger/Phase2L1GMT/plugins/Phase2L1TGMTStubProducer.cc:118:8: warning: unused variable 'count4' [-Wunused-variable]
   118 |   uint count4 = 0;

```