### PR TITLE
[DQM] Fix Warning: move the unused code in the comment where it is needed

### DIFF
--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -159,16 +159,16 @@ namespace ecaldqm {
         meTimingMean.fill(getEcalDQMSetupObjects(), id, tMean);
         meTimingRMSMap.setBinContent(getEcalDQMSetupObjects(), id, tRms);
 
+        //Temporarily disabling all cuts on LED Quality plot.
+        qItr->setBinContent(doMask ? kMGood : kGood);
+
+        /*
         float intensity(aMean / expectedAmplitude_[wlItr->second]);
         if (isForward(id))
           intensity /= forwardFactor_;
 
         float aRmsThr(sqrt(pow(aMean * toleranceAmpRMSRatio_, 2) + pow(3., 2)));
 
-        //Temporarily disabling all cuts on LED Quality plot.
-        qItr->setBinContent(doMask ? kMGood : kGood);
-
-        /*
         EcalScDetId scid = EEDetId(id).sc();  //Get the Endcap SC id for the given crystal id.
 
         //For the known bad Supercrystals in the SClist, bad quality flag is only set based on the amplitude RMS


### PR DESCRIPTION
This change should fix the warning [a]. `aRmsThr` and `intensity` are needed only in the code which has been commented out, so the PR proposes to move these in the comment section too


[a] 
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_ROOT6_X_2024-07-16-2300/DQM/EcalMonitorClient
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/DQM/EcalMonitorClient
```
  src/DQM/EcalMonitorClient/src/LedClient.cc:162:15: warning: variable 'intensity' set but not used [-Wunused-but-set-variable]
   162 |         float intensity(aMean / expectedAmplitude_[wlItr->second]);
      |               ^
  src/DQM/EcalMonitorClient/src/LedClient.cc:166:15: warning: unused variable 'aRmsThr' [-Wunused-variable]
   166 |         float aRmsThr(sqrt(pow(aMean * toleranceAmpRMSRatio_, 2) + pow(3., 2)));
```