### PR TITLE
Use max instead if infinity which hasundefined behavior

### DIFF
--- a/DataFormats/EgammaReco/interface/ElectronSeed.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeed.h
@@ -112,14 +112,14 @@ namespace reco {
 
     unsigned int hitsMask() const;
     void initTwoHitSeed(const unsigned char hitMask);
-    void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::infinity(),
-                          const float dPhi2 = std::numeric_limits<float>::infinity(),
-                          const float dRZ1 = std::numeric_limits<float>::infinity(),
-                          const float dPhi1 = std::numeric_limits<float>::infinity());
-    void setPosAttributes(const float dRZ2 = std::numeric_limits<float>::infinity(),
-                          const float dPhi2 = std::numeric_limits<float>::infinity(),
-                          const float dRZ1 = std::numeric_limits<float>::infinity(),
-                          const float dPhi1 = std::numeric_limits<float>::infinity());
+    void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
+                          const float dPhi2 = std::numeric_limits<float>::max(),
+                          const float dRZ1 = std::numeric_limits<float>::max(),
+                          const float dPhi1 = std::numeric_limits<float>::max());
+    void setPosAttributes(const float dRZ2 = std::numeric_limits<float>::max(),
+                          const float dPhi2 = std::numeric_limits<float>::max(),
+                          const float dRZ1 = std::numeric_limits<float>::max(),
+                          const float dPhi1 = std::numeric_limits<float>::max());
 
     //this is a backwards compatible function designed to
     //convert old format ElectronSeeds to the new format
@@ -140,7 +140,7 @@ namespace reco {
     static float bestVal(float val1, float val2) { return std::abs(val1) < std::abs(val2) ? val1 : val2; }
     template <typename T>
     T getVal(unsigned int hitNr, T PMVars::*val) const {
-      return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::infinity();
+      return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::max();
     }
     static std::vector<unsigned int> hitNrsFromMask(unsigned int hitMask);
 

--- a/DataFormats/Math/interface/approx_log.h
+++ b/DataFormats/Math/interface/approx_log.h
@@ -131,7 +131,7 @@ constexpr float approx_logf(float x) {
 
   //x = std::max(std::min(x,MAXNUMF),0.f);
   float res = unsafe_logf<DEGREE>(x);
-  res = (x < MAXNUMF) ? res : std::numeric_limits<float>::infinity();
+  res = (x < MAXNUMF) ? res : std::numeric_limits<float>::max();
   return (x > 0) ? res : std::numeric_limits<float>::quiet_NaN();
 }
 

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -64,13 +64,13 @@ namespace {
       if ((seed.caloCluster().key() == res.caloCluster().key()) && (seed.hitsMask() == res.hitsMask()) &&
           equivalent(seed, res)) {
         if (positron) {
-          if (res.dRZPos(1) == std::numeric_limits<float>::infinity() &&
-              res.dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+          if (res.dRZPos(1) == std::numeric_limits<float>::max() &&
+              res.dRZNeg(1) != std::numeric_limits<float>::max()) {
             res.setPosAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
             seed.setNegAttributes(res.dRZNeg(1), res.dPhiNeg(1), res.dRZNeg(0), res.dPhiNeg(0));
             break;
           } else {
-            if (res.dRZPos(1) != std::numeric_limits<float>::infinity()) {
+            if (res.dRZPos(1) != std::numeric_limits<float>::max()) {
               if (res.dRZPos(1) != seed.dRZPos(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this similar old seed already has another dRz2Pos"
@@ -82,13 +82,13 @@ namespace {
             }
           }
         } else {
-          if (res.dRZNeg(1) == std::numeric_limits<float>::infinity() &&
-              res.dRZPos(1) != std::numeric_limits<float>::infinity()) {
+          if (res.dRZNeg(1) == std::numeric_limits<float>::max() &&
+              res.dRZPos(1) != std::numeric_limits<float>::max()) {
             res.setNegAttributes(info->dRz2, info->dPhi2, info->dRz1, info->dPhi1);
             seed.setPosAttributes(res.dRZPos(1), res.dPhiPos(1), res.dRZPos(0), res.dPhiPos(0));
             break;
           } else {
-            if (res.dRZNeg(1) != std::numeric_limits<float>::infinity()) {
+            if (res.dRZNeg(1) != std::numeric_limits<float>::max()) {
               if (res.dRZNeg(1) != seed.dRZNeg(1)) {
                 edm::LogWarning("ElectronSeedGenerator|BadValue")
                     << "this old seed already has another dRz2"


### PR DESCRIPTION
Fixes https://github.com/cms-sw/cmssw/issues/45181

As proposed in https://github.com/cms-sw/cmssw/issues/45181#issuecomment-2182474727 , this PR replaces `std::numeric_limits<float>::infinity()` with `std::numeric_limits<float>::max()` . This should fix the compilation warnings in CLANG IBs. 

[a] 
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/RecoEgamma/EgammaPhotonAlgos
```
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:115:46: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   115 |     void setNegAttributes(const float dRZ2 = std::numeric_limits<float>::infinity(),
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:116:47: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   116 |                           const float dPhi2 = std::numeric_limits<float>::infinity(),
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:117:46: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   117 |                           const float dRZ1 = std::numeric_limits<float>::infinity(),
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:118:47: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   118 |                           const float dPhi1 = std::numeric_limits<float>::infinity());
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:119:46: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   119 |     void setPosAttributes(const float dRZ2 = std::numeric_limits<float>::infinity(),
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:120:47: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   120 |                           const float dPhi2 = std::numeric_limits<float>::infinity(),
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:121:46: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   121 |                           const float dRZ1 = std::numeric_limits<float>::infinity(),
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:122:47: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   122 |                           const float dPhi1 = std::numeric_limits<float>::infinity());
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:143:63: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   143 |       return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::infinity();
      |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/DataFormats/EgammaReco/interface/ElectronSeed.h:102:48: note: in instantiation of function template specialization 'reco::ElectronSeed::getVal<float>' requested here
  102 |     float dPhiNeg(size_t hitNr) const { return getVal(hitNr, &PMVars::dPhiNeg); }
      |                                                ^
  src/DataFormats/EgammaReco/interface/ElectronSeed.h:143:63: warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled]
   143 |       return hitNr < hitInfo_.size() ? hitInfo_[hitNr].*val : std::numeric_limits<T>::infinity();
```