### PR TITLE
DTSegmentCand: Fix ambiguous-reversed-operator warning by using const operator

### DIFF
--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
@@ -34,7 +34,7 @@ DTSegmentCand::DTSegmentCand(const AssPointCont& hits,
 DTSegmentCand::~DTSegmentCand() {}
 
 /* Operations */
-bool DTSegmentCand::operator==(const DTSegmentCand& seg) {
+bool DTSegmentCand::operator==(const DTSegmentCand& seg) const {
   static const double epsilon = 0.00001;
   if (nHits() != seg.nHits())
     return false;
@@ -49,7 +49,7 @@ bool DTSegmentCand::operator==(const DTSegmentCand& seg) {
   return true;
 }
 
-bool DTSegmentCand::operator<(const DTSegmentCand& seg) {
+bool DTSegmentCand::operator<(const DTSegmentCand& seg) const {
   if (nHits() == seg.nHits())
     return (chi2() > seg.chi2());
   return (nHits() < seg.nHits());

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
@@ -67,10 +67,10 @@ public:
   virtual double t0() const { return thet0; }
 
   /// equality operator based on position, direction, chi2 and nHits
-  virtual bool operator==(const DTSegmentCand& seg);
+  virtual bool operator==(const DTSegmentCand& seg) const;
 
   /// less operator based on nHits and chi2
-  virtual bool operator<(const DTSegmentCand& seg);
+  virtual bool operator<(const DTSegmentCand& seg) const;
 
   /// the super layer on which relies
   const DTSuperLayer* superLayer() const { return theSL; }


### PR DESCRIPTION
This fixes CLANG IB warnings [a]. As compilers suggested the PR makes the `operator` method `const`

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-16-2300/RecoLocalMuon/DTSegment
```
  src/RecoLocalMuon/DTSegment/src/DTCombinatorialPatternReco.cc:411:18: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'DTSegmentCand' and 'DTSegmentCand') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   411 |     if (*(*cand) == *seg)
      |         ~~~~~~~~ ^  ~~~~
src/RecoLocalMuon/DTSegment/src/DTSegmentCand.h:70:16: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   70 |   virtual bool operator==(const DTSegmentCand& seg);
      |                ^
src/RecoLocalMuon/DTSegment/src/DTSegmentCand.h:70:16: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity

```