### PR TITLE
[clang][c++20] Fixed ambiguous-reversed-operator for PixelModuleName

### DIFF
--- a/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h
@@ -55,6 +55,10 @@ public:
 
   /// check equality of modules from datamemebers
   bool operator==(const PixelModuleName&) const override;
+  bool operator==(const PixelBarrelNameUpgrade& other) const {
+    return (thePart == other.thePart && theLayer == other.theLayer && theModule == other.theModule &&
+            theLadder == other.theLadder);
+  }
 
 private:
   Shell thePart;

--- a/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
+++ b/DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h
@@ -54,6 +54,10 @@ public:
 
   /// check equality of modules from datamemebers
   bool operator==(const PixelModuleName &) const override;
+  bool operator==(const PixelEndcapNameUpgrade &other) const {
+    return (thePart == other.thePart && theDisk == other.theDisk && theBlade == other.theBlade &&
+            thePannel == other.thePannel && thePlaquette == other.thePlaquette);
+  }
 
 private:
   HalfCylinder thePart;

--- a/DataFormats/SiPixelDetId/src/PixelBarrelNameUpgrade.cc
+++ b/DataFormats/SiPixelDetId/src/PixelBarrelNameUpgrade.cc
@@ -363,13 +363,8 @@ PixelModuleName::ModuleType PixelBarrelNameUpgrade::moduleType() const {
   return isHalfModule() ? PixelBarrelNameUpgrade::v1x8 : PixelBarrelNameUpgrade::v2x8;
 }
 
-bool PixelBarrelNameUpgrade::operator==(const PixelModuleName& o) const {
-  if (o.isBarrel()) {
-    const PixelBarrelNameUpgrade* other = dynamic_cast<const PixelBarrelNameUpgrade*>(&o);
-    return (other && thePart == other->thePart && theLayer == other->theLayer && theModule == other->theModule &&
-            theLadder == other->theLadder);
-  } else
-    return false;
+bool PixelBarrelNameUpgrade::operator==(const PixelModuleName& other) const {
+  return other.isBarrel() ? (dynamic_cast<const PixelBarrelNameUpgrade&>(other) == *this) : false;
 }
 
 string PixelBarrelNameUpgrade::name() const {

--- a/DataFormats/SiPixelDetId/src/PixelEndcapNameUpgrade.cc
+++ b/DataFormats/SiPixelDetId/src/PixelEndcapNameUpgrade.cc
@@ -173,13 +173,8 @@ PixelModuleName::ModuleType PixelEndcapNameUpgrade::moduleType() const {
   return type;
 }
 
-bool PixelEndcapNameUpgrade::operator==(const PixelModuleName& o) const {
-  if (!o.isBarrel()) {
-    const PixelEndcapNameUpgrade* other = dynamic_cast<const PixelEndcapNameUpgrade*>(&o);
-    return (other && thePart == other->thePart && theDisk == other->theDisk && theBlade == other->theBlade &&
-            thePannel == other->thePannel && thePlaquette == other->thePlaquette);
-  } else
-    return false;
+bool PixelEndcapNameUpgrade::operator==(const PixelModuleName& other) const {
+  return other.isBarrel() ? false : (dynamic_cast<const PixelEndcapNameUpgrade&>(other) == *this);
 }
 
 string PixelEndcapNameUpgrade::name() const {

--- a/DataFormats/TrackerCommon/interface/PixelBarrelName.h
+++ b/DataFormats/TrackerCommon/interface/PixelBarrelName.h
@@ -63,6 +63,10 @@ public:
 
   /// check equality of modules from datamemebers
   bool operator==(const PixelModuleName&) const override;
+  bool operator==(const PixelBarrelName& other) const {
+    return (thePart == other.thePart && theLayer == other.theLayer && theModule == other.theModule &&
+            theLadder == other.theLadder);
+  }
 
 private:
   Shell thePart;

--- a/DataFormats/TrackerCommon/interface/PixelEndcapName.h
+++ b/DataFormats/TrackerCommon/interface/PixelEndcapName.h
@@ -65,6 +65,10 @@ public:
 
   /// check equality of modules from datamemebers
   bool operator==(const PixelModuleName&) const override;
+  bool operator==(const PixelEndcapName& other) const {
+    return (thePart == other.thePart && theDisk == other.theDisk && theBlade == other.theBlade &&
+            thePannel == other.thePannel && thePlaquette == other.thePlaquette);
+  }
 
 private:
   HalfCylinder thePart;

--- a/DataFormats/TrackerCommon/src/PixelBarrelName.cc
+++ b/DataFormats/TrackerCommon/src/PixelBarrelName.cc
@@ -719,13 +719,8 @@ PixelModuleName::ModuleType PixelBarrelName::moduleType() const {
   return isHalfModule() ? PixelBarrelName::v1x8 : PixelBarrelName::v2x8;
 }
 
-bool PixelBarrelName::operator==(const PixelModuleName& o) const {
-  if (o.isBarrel()) {
-    const PixelBarrelName* other = dynamic_cast<const PixelBarrelName*>(&o);
-    return (other && thePart == other->thePart && theLayer == other->theLayer && theModule == other->theModule &&
-            theLadder == other->theLadder);
-  } else
-    return false;
+bool PixelBarrelName::operator==(const PixelModuleName& other) const {
+  return other.isBarrel() ? (dynamic_cast<const PixelBarrelName&>(other) == *this) : false;
 }
 
 string PixelBarrelName::name() const {

--- a/DataFormats/TrackerCommon/src/PixelEndcapName.cc
+++ b/DataFormats/TrackerCommon/src/PixelEndcapName.cc
@@ -353,13 +353,8 @@ PixelModuleName::ModuleType PixelEndcapName::moduleType() const {
   return type;
 }
 
-bool PixelEndcapName::operator==(const PixelModuleName& o) const {
-  if (!o.isBarrel()) {
-    const PixelEndcapName* other = dynamic_cast<const PixelEndcapName*>(&o);
-    return (other && thePart == other->thePart && theDisk == other->theDisk && theBlade == other->theBlade &&
-            thePannel == other->thePannel && thePlaquette == other->thePlaquette);
-  } else
-    return false;
+bool PixelEndcapName::operator==(const PixelModuleName& other) const {
+  return other.isBarrel() ? false : (dynamic_cast<const PixelEndcapName&>(other) == *this);
 }
 
 string PixelEndcapName::name() const {


### PR DESCRIPTION
This PR should fix the clang IBs warnings [a]. 
@makortel @Dr15Jones , I don't know if this is the correct way to fix these warnings ... let me know if there is correct/better way 

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/CondFormats/SiPixelObjects
```
  src/CondFormats/SiPixelObjects/src/PixelFEDLink.cc:76:16: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'PixelBarrelName' and 'PixelBarrelName') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
    76 |       if (curr == prev) {
      |           ~~~~ ^  ~~~~
src/DataFormats/TrackerCommon/interface/PixelBarrelName.h:65:8: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   65 |   bool operator==(const PixelModuleName&) const override;
      |        ^
  src/CondFormats/SiPixelObjects/src/PixelFEDLink.cc:81:18: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'PixelBarrelName' and 'PixelBarrelName') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
    81 |       if (!(curr == prev)) {
      |             ~~~~ ^  ~~~~
src/DataFormats/TrackerCommon/interface/PixelBarrelName.h:65:8: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   65 |   bool operator==(const PixelModuleName&) const override;
      |        ^
  src/CondFormats/SiPixelObjects/src/PixelFEDLink.cc:108:18: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'PixelEndcapName' and 'PixelEndcapName') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   108 |       if (!(curr == prev))
      |             ~~~~ ^  ~~~~
src/DataFormats/TrackerCommon/interface/PixelEndcapName.h:67:8: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   67 |   bool operator==(const PixelModuleName&) const override;

```
