### PR TITLE
Cond: Remove unused variables

### DIFF
--- a/CondCore/CondDB/src/DecodingKey.cc
+++ b/CondCore/CondDB/src/DecodingKey.cc
@@ -24,7 +24,7 @@ static const std::string NAMEPREFIX("N=");
 static const std::string KEYPREFIX("K=");
 static const std::string OWNERPREFIX("O=");
 
-static const std::string DATEPREFIX("D=");
+//static const std::string DATEPREFIX("D=");
 
 static const std::string SERVICEPREFIX("S=");
 static const std::string CONNECTIONPREFIX("C=");

--- a/CondTools/RunInfo/src/RunInfoRead.cc
+++ b/CondTools/RunInfo/src/RunInfoRead.cc
@@ -23,9 +23,9 @@
 #include <cmath>
 
 namespace {
-  const std::string dot(".");
+  //const std::string dot(".");
   const std::string quote("\"");
-  const std::string bNOTb(" NOT ");
+  //const std::string bNOTb(" NOT ");
   const std::string squoted(const std::string& s) { return quote + s + quote; }
   //now strings for the tables and columns to be queried
   const std::string sParameterTable("RUNSESSION_PARAMETER");


### PR DESCRIPTION
This change commented out few variables which are not used any more ( or used in a comment only). This should the warnings like [a] for CLANG IBs

[a]
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/CondCore/CondDB
- https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/CondTools/RunInfo
```
  src/CondCore/CondDB/src/DecodingKey.cc:27:26: warning: unused variable 'DATEPREFIX' [-Wunused-const-variable]
    27 | static const std::string DATEPREFIX("D=");

  src/CondTools/RunInfo/src/RunInfoRead.cc:26:21: warning: unused variable 'dot' [-Wunused-const-variable]
    26 |   const std::string dot(".");
      |                     ^~~
  src/CondTools/RunInfo/src/RunInfoRead.cc:28:21: warning: unused variable 'bNOTb' [-Wunused-const-variable]
    28 |   const std::string bNOTb(" NOT ");

```