### PR TITLE
[14.0.X][DQM] Fix Warning: move the unused code in the comment where it is needed

### DIFF
--- a/DQM/EcalMonitorClient/src/LedClient.cc
+++ b/DQM/EcalMonitorClient/src/LedClient.cc
@@ -159,16 +159,16 @@ namespace ecaldqm {
         meTimingMean.fill(getEcalDQMSetupObjects(), id, tMean);
         meTimingRMSMap.setBinContent(getEcalDQMSetupObjects(), id, tRms);
 
+        //Temporarily disabling all cuts on LED Quality plot.
+        qItr->setBinContent(doMask ? kMGood : kGood);
+
+        /*
         float intensity(aMean / expectedAmplitude_[wlItr->second]);
         if (isForward(id))
           intensity /= forwardFactor_;
 
         float aRmsThr(sqrt(pow(aMean * toleranceAmpRMSRatio_, 2) + pow(3., 2)));
 
-        //Temporarily disabling all cuts on LED Quality plot.
-        qItr->setBinContent(doMask ? kMGood : kGood);
-
-        /*
         EcalScDetId scid = EEDetId(id).sc();  //Get the Endcap SC id for the given crystal id.
 
         //For the known bad Supercrystals in the SClist, bad quality flag is only set based on the amplitude RMS


### PR DESCRIPTION
backport of #45482

This should fix the compilation warnings in 14.0.X