### PR TITLE
[CLANG] Phase2L1GT: Fix compilation warnings

### DIFF
--- a/L1Trigger/Phase2L1GT/plugins/L1GTAlgoBlockProducer.cc
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTAlgoBlockProducer.cc
@@ -337,7 +337,7 @@ private:
   std::shared_ptr<std::unordered_map<std::string, unsigned int>> globalBeginRun(edm::Run const&,
                                                                                 edm::EventSetup const&) const override;
 
-  void globalEndRun(edm::Run const&, edm::EventSetup const&) {}
+  void globalEndRun(edm::Run const&, edm::EventSetup const&) override {}
 
   edm::GetterOfProducts<P2GTCandidateVectorRef> getterOfPassedReferences_;
   std::map<std::string, AlgoDefinition> algoDefinitions_;

--- a/L1Trigger/Phase2L1GT/plugins/L1GTOutputObjectWriter.cc
+++ b/L1Trigger/Phase2L1GT/plugins/L1GTOutputObjectWriter.cc
@@ -269,42 +269,35 @@ static std::vector<ap_uint<64>> vpack(const Args&... vobjects) {
 void L1GTOutputObjectWriter::analyze(const edm::Event& event, const edm::EventSetup&) {
   std::map<std::string, std::vector<std::unique_ptr<L1TGT_BaseInterface>>> outputObjects;
 
-  outputObjects.emplace("GCTNonIsoEg", std::move(fillCollection<L1TGT_Common3Vector<64>>(event, gctNonIsoEgToken_)));
-  outputObjects.emplace("GCTIsoEg", std::move(fillCollection<L1TGT_Common3Vector<64>>(event, gctIsoEgToken_)));
-  outputObjects.emplace("GCTJets", std::move(fillCollection<L1TGT_Common3Vector<64>>(event, gctJetsToken_)));
-  outputObjects.emplace("GCTTaus", std::move(fillCollection<L1TGT_GCT_tau6p6>(event, gctTausToken_)));
-  outputObjects.emplace("GCTHtSum", std::move(fillCollection<L1TGT_CommonSum>(event, gctHtSumToken_)));
-  outputObjects.emplace("GCTEtSum", std::move(fillCollection<L1TGT_CommonSum>(event, gctEtSumToken_)));
+  outputObjects.emplace("GCTNonIsoEg", fillCollection<L1TGT_Common3Vector<64>>(event, gctNonIsoEgToken_));
+  outputObjects.emplace("GCTIsoEg", fillCollection<L1TGT_Common3Vector<64>>(event, gctIsoEgToken_));
+  outputObjects.emplace("GCTJets", fillCollection<L1TGT_Common3Vector<64>>(event, gctJetsToken_));
+  outputObjects.emplace("GCTTaus", fillCollection<L1TGT_GCT_tau6p6>(event, gctTausToken_));
+  outputObjects.emplace("GCTHtSum", fillCollection<L1TGT_CommonSum>(event, gctHtSumToken_));
+  outputObjects.emplace("GCTEtSum", fillCollection<L1TGT_CommonSum>(event, gctEtSumToken_));
   outputObjects.emplace("GMTSaPromptMuons",
-                        std::move(fillCollection<L1TGT_GMT_PromptDisplacedMuon>(event, gmtSaPromptMuonsToken_)));
+                        fillCollection<L1TGT_GMT_PromptDisplacedMuon>(event, gmtSaPromptMuonsToken_));
   outputObjects.emplace("GMTSaDisplacedMuons",
-                        std::move(fillCollection<L1TGT_GMT_PromptDisplacedMuon>(event, gmtSaDisplacedMuonsToken_)));
-  outputObjects.emplace("GMTTkMuons", std::move(fillCollection<L1TGT_GMT_TrackMatchedmuon>(event, gmtTkMuonsToken_)));
-  outputObjects.emplace("GMTTopo", std::move(fillCollection<L1TGT_GMT_TopoObject>(event, gmtTopoToken_)));
-  outputObjects.emplace("GTTPromptJets", std::move(fillCollection<L1TGT_GTT_PromptJet>(event, gttPromptJetsToken_)));
-  outputObjects.emplace("GTTDisplacedJets",
-                        std::move(fillCollection<L1TGT_GTT_DisplacedJet>(event, gttDisplacedJetsToken_)));
-  outputObjects.emplace("GTTPhiCandidates",
-                        std::move(fillCollection<L1TGT_GTT_LightMeson>(event, gttPhiCandidatesToken_)));
-  outputObjects.emplace("GTTRhoCandidates",
-                        std::move(fillCollection<L1TGT_GTT_LightMeson>(event, gttRhoCandidatesToken_)));
-  outputObjects.emplace("GTTBsCandidates",
-                        std::move(fillCollection<L1TGT_GTT_LightMeson>(event, gttBsCandidatesToken_)));
-  outputObjects.emplace("GTTHadronicTaus",
-                        std::move(fillCollection<L1TGT_GTT_HadronicTau>(event, gttHadronicTausToken_)));
-  outputObjects.emplace("GTTPrimaryVert",
-                        std::move(fillCollection<L1TGT_GTT_PrimaryVert>(event, gttPrimaryVertToken_)));
-  outputObjects.emplace("GTTPromptHtSum", std::move(fillCollection<L1TGT_CommonSum>(event, gttPromptHtSumToken_)));
-  outputObjects.emplace("GTTDisplacedHtSum",
-                        std::move(fillCollection<L1TGT_CommonSum>(event, gttDisplacedHtSumToken_)));
-  outputObjects.emplace("GTTEtSum", std::move(fillCollection<L1TGT_CommonSum>(event, gttEtSumToken_)));
-  outputObjects.emplace("CL2JetsSC4", std::move(fillCollection<L1TGT_CL2_Jet>(event, cl2JetsSc4Token_)));
-  outputObjects.emplace("CL2JetsSC8", std::move(fillCollection<L1TGT_CL2_Jet>(event, cl2JetsSc8Token_)));
-  outputObjects.emplace("CL2Taus", std::move(fillCollection<L1TGT_CL2_Tau>(event, cl2TausToken_)));
-  outputObjects.emplace("CL2Electrons", std::move(fillCollection<L1TGT_CL2_Electron>(event, cl2ElectronsToken_)));
-  outputObjects.emplace("CL2Photons", std::move(fillCollection<L1TGT_CL2_Photon>(event, cl2PhotonsToken_)));
-  outputObjects.emplace("CL2HtSum", std::move(fillCollection<L1TGT_CommonSum>(event, cl2HtSumToken_)));
-  outputObjects.emplace("CL2EtSum", std::move(fillCollection<L1TGT_CommonSum>(event, cl2EtSumToken_)));
+                        fillCollection<L1TGT_GMT_PromptDisplacedMuon>(event, gmtSaDisplacedMuonsToken_));
+  outputObjects.emplace("GMTTkMuons", fillCollection<L1TGT_GMT_TrackMatchedmuon>(event, gmtTkMuonsToken_));
+  outputObjects.emplace("GMTTopo", fillCollection<L1TGT_GMT_TopoObject>(event, gmtTopoToken_));
+  outputObjects.emplace("GTTPromptJets", fillCollection<L1TGT_GTT_PromptJet>(event, gttPromptJetsToken_));
+  outputObjects.emplace("GTTDisplacedJets", fillCollection<L1TGT_GTT_DisplacedJet>(event, gttDisplacedJetsToken_));
+  outputObjects.emplace("GTTPhiCandidates", fillCollection<L1TGT_GTT_LightMeson>(event, gttPhiCandidatesToken_));
+  outputObjects.emplace("GTTRhoCandidates", fillCollection<L1TGT_GTT_LightMeson>(event, gttRhoCandidatesToken_));
+  outputObjects.emplace("GTTBsCandidates", fillCollection<L1TGT_GTT_LightMeson>(event, gttBsCandidatesToken_));
+  outputObjects.emplace("GTTHadronicTaus", fillCollection<L1TGT_GTT_HadronicTau>(event, gttHadronicTausToken_));
+  outputObjects.emplace("GTTPrimaryVert", fillCollection<L1TGT_GTT_PrimaryVert>(event, gttPrimaryVertToken_));
+  outputObjects.emplace("GTTPromptHtSum", fillCollection<L1TGT_CommonSum>(event, gttPromptHtSumToken_));
+  outputObjects.emplace("GTTDisplacedHtSum", fillCollection<L1TGT_CommonSum>(event, gttDisplacedHtSumToken_));
+  outputObjects.emplace("GTTEtSum", fillCollection<L1TGT_CommonSum>(event, gttEtSumToken_));
+  outputObjects.emplace("CL2JetsSC4", fillCollection<L1TGT_CL2_Jet>(event, cl2JetsSc4Token_));
+  outputObjects.emplace("CL2JetsSC8", fillCollection<L1TGT_CL2_Jet>(event, cl2JetsSc8Token_));
+  outputObjects.emplace("CL2Taus", fillCollection<L1TGT_CL2_Tau>(event, cl2TausToken_));
+  outputObjects.emplace("CL2Electrons", fillCollection<L1TGT_CL2_Electron>(event, cl2ElectronsToken_));
+  outputObjects.emplace("CL2Photons", fillCollection<L1TGT_CL2_Photon>(event, cl2PhotonsToken_));
+  outputObjects.emplace("CL2HtSum", fillCollection<L1TGT_CommonSum>(event, cl2HtSumToken_));
+  outputObjects.emplace("CL2EtSum", fillCollection<L1TGT_CommonSum>(event, cl2EtSumToken_));
 
   std::map<demo::LinkId, std::vector<ap_uint<64>>> eventData;
 


### PR DESCRIPTION
This PR fixes compilation warnings [a] for CLANG IB 

[a]  https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700/L1Trigger/Phase2L1GT

- remove std::move
```
  src/L1Trigger/Phase2L1GT/plugins/L1GTOutputObjectWriter.cc:272:40: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
   272 |   outputObjects.emplace("GCTNonIsoEg", std::move(fillCollection<L1TGT_Common3Vector<64>>(event, gctNonIsoEgToken_)));
      |                                        ^
src/L1Trigger/Phase2L1GT/plugins/L1GTOutputObjectWriter.cc:272:40: note: remove std::move call here
  272 |   outputObjects.emplace("GCTNonIsoEg", std::move(fillCollection<L1TGT_Common3Vector<64>>(event, gctNonIsoEgToken_)));
```
- overridden virtual function but is not marked 'override'
```
  src/L1Trigger/Phase2L1GT/plugins/L1GTAlgoBlockProducer.cc:340:8: warning: 'globalEndRun' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   340 |   void globalEndRun(edm::Run const&, edm::EventSetup const&) {}
      |        ^
src/FWCore/Framework/interface/one/implementors.h:290:22: note: overridden virtual function is here
  290 |         virtual void globalEndRun(edm::Run const&, edm::EventSetup const&) = 0;
```