### PR TITLE
[Fireworks] Remove unused variables

### DIFF
--- a/Fireworks/Core/src/FWTableView.cc
+++ b/Fireworks/Core/src/FWTableView.cc
@@ -188,7 +188,7 @@ static const TGPicture *arrow_down_disabled(bool iBackgroundIsBlack) {
 //
 static const std::string kTableView = "TableView";
 static const std::string kCollection = "collection";
-static const std::string kColumns = "columns";
+//static const std::string kColumns = "columns";
 static const std::string kSortColumn = "sortColumn";
 static const std::string kDescendingSort = "descendingSort";
 

--- a/Fireworks/Core/src/FWTriggerTableView.cc
+++ b/Fireworks/Core/src/FWTriggerTableView.cc
@@ -33,7 +33,7 @@
 #include "DataFormats/FWLite/interface/Event.h"
 
 // configuration keys
-static const std::string kColumns = "columns";
+//static const std::string kColumns = "columns";
 static const std::string kSortColumn = "sortColumn";
 static const std::string kDescendingSort = "descendingSort";
 


### PR DESCRIPTION
Remove/Comment unused variables which are only used in already commented out code. This is fix the CLANG IBs [warings](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_14_1_CLANG_X_2024-07-17-1700)/Fireworks/Core
```
  src/Fireworks/Core/src/FWTableView.cc:191:26: warning: unused variable 'kColumns' [-Wunused-const-variable]
   191 | static const std::string kColumns = "columns";

  src/Fireworks/Core/src/FWTriggerTableView.cc:36:26: warning: unused variable 'kColumns' [-Wunused-const-variable]
    36 | static const std::string kColumns = "columns";

```