### PR TITLE
Add `ticl_v5` modifier at HLT

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -697,24 +697,32 @@ upgradeWFs['ticl_FastJet'].step4 = {'--procModifiers': 'fastJetTICL'}
 
 class UpgradeWorkflow_ticl_v5(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
+        if ('Digi' in step and 'NoHLT' not in step) or ('HLTOnly' in step):
+            stepDict[stepName][k] = merge([self.step2, stepDict[step][k]])
         if 'RecoGlobal' in step:
             stepDict[stepName][k] = merge([self.step3, stepDict[step][k]])
         if 'HARVESTGlobal' in step:
             stepDict[stepName][k] = merge([self.step4, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return (fragment=="TTbar_14TeV" or 'CloseByP' in fragment or 'Eta1p7_2p7' in fragment) and '2026' in key
+
 upgradeWFs['ticl_v5'] = UpgradeWorkflow_ticl_v5(
     steps = [
+        'HLTOnly',
+        'DigiTrigger',
         'RecoGlobal',
         'HARVESTGlobal'
     ],
     PU = [
+        'HLTOnly',
+        'DigiTrigger',
         'RecoGlobal',
         'HARVESTGlobal'
     ],
     suffix = '_ticl_v5',
     offset = 0.203,
 )
+upgradeWFs['ticl_v5'].step2 = {'--procModifiers': 'ticl_v5'}
 upgradeWFs['ticl_v5'].step3 = {'--procModifiers': 'ticl_v5'}
 upgradeWFs['ticl_v5'].step4 = {'--procModifiers': 'ticl_v5'}
 

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHitL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHitL1Seeded_cfi.py
@@ -57,3 +57,6 @@ HGCalUncalibRecHitL1Seeded = cms.EDProducer("HGCalUncalibRecHitProducer",
     computeLocalTime = cms.bool(False),
     algo = cms.string('HGCalUncalibRecHitWorkerWeights')
 )
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(HGCalUncalibRecHitL1Seeded, computeLocalTime = cms.bool(True))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHit_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/HGCalUncalibRecHit_cfi.py
@@ -59,3 +59,5 @@ HGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
     algo = cms.string('HGCalUncalibRecHitWorkerWeights')
 )
 
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(HGCalUncalibRecHit, computeLocalTime = cms.bool(True))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltFilteredLayerClustersPassThrough_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltFilteredLayerClustersPassThrough_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+hltFilteredLayerClustersPassthrough = cms.EDProducer("FilteredLayerClustersProducer",
+    LayerClusters = cms.InputTag("hgcalMergeLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("ticlTrackstersCLUE3DHigh"),
+    algo_number = cms.vint32(6, 7, 8),
+    clusterFilter = cms.string('ClusterFilterBySize'),
+    iteration_label = cms.string('Passthrough'),
+    max_cluster_size = cms.int32(9999),
+    max_layerId = cms.int32(9999),
+    mightGet = cms.optional.untracked.vstring,
+    min_cluster_size = cms.int32(2),
+    min_layerId = cms.int32(0)
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclCandidate_cfi.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+hltTiclCandidate = cms.EDProducer("TICLCandidateProducer",
+    cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
+    detector = cms.string('HGCAL'),
+    egamma_tracksterlinks_collections = cms.VInputTag("hltTiclTracksterLinks"),
+    egamma_tracksters_collections = cms.VInputTag("hltTiclTracksterLinks"),
+    general_tracksterlinks_collections = cms.VInputTag("hltTiclTracksterLinks"),
+    general_tracksters_collections = cms.VInputTag("hltTiclTracksterLinks"),
+    interpretationDescPSet = cms.PSet(
+        algo_verbosity = cms.int32(0),
+        cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
+        delta_tk_ts_interface = cms.double(0.03),
+        delta_tk_ts_layer1 = cms.double(0.02),
+        timing_quality_threshold = cms.double(0.5),
+        type = cms.string('General')
+    ),
+    layer_clusters = cms.InputTag("hgcalMergeLayerClusters"),
+    layer_clustersTime = cms.InputTag("hgcalMergeLayerClusters","timeLayerCluster"),
+    mightGet = cms.optional.untracked.vstring,
+    muons = cms.InputTag("hltPhase2L3Muons"),
+    original_masks = cms.VInputTag("hgcalMergeLayerClusters:InitialLayerClustersMask"),
+    propagator = cms.string('PropagatorWithMaterial'),
+    timingQualityThreshold = cms.double(0.5),
+    timingSoA = cms.InputTag("mtdSoA"),
+    tracks = cms.InputTag("generalTracks"),
+    useMTDTiming = cms.bool(False),
+    useTimingAverage = cms.bool(False)
+)
+

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTracksterLinks_cfi.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+hltTiclTracksterLinks = cms.EDProducer("TracksterLinksProducer",
+    detector = cms.string('HGCAL'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(2.5),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    layer_clusters = cms.InputTag("hgcalMergeLayerClusters"),
+    layer_clustersTime = cms.InputTag("hgcalMergeLayerClusters","timeLayerCluster"),
+    linkingPSet = cms.PSet(
+        algo_verbosity = cms.int32(0),
+        cylinder_radius_sqr = cms.vdouble(9, 9),
+        dot_prod_th = cms.double(0.97),
+        max_distance_projective_sqr = cms.vdouble(60, 60),
+        max_distance_projective_sqr_closest_points = cms.vdouble(60, 60),
+        max_z_distance_closest_points = cms.vdouble(35, 35),
+        min_distance_z = cms.vdouble(30, 30),
+        min_num_lcs = cms.uint32(7),
+        min_trackster_energy = cms.double(10),
+        pca_quality_th = cms.double(0.85),
+        track_time_quality_threshold = cms.double(0.5),
+        type = cms.string('Skeletons'),
+        wind = cms.double(0.036)
+    ),
+    mightGet = cms.optional.untracked.vstring,
+    original_masks = cms.VInputTag("hgcalMergeLayerClusters:InitialLayerClustersMask"),
+    propagator = cms.string('PropagatorWithMaterial'),
+    regressionAndPid = cms.bool(True),
+    tfDnnLabel = cms.string('tracksterSelectionTf'),
+    tracksters_collections = cms.VInputTag("ticlTrackstersCLUE3DHigh", "hltTiclTrackstersPassthrough")
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersPassthrough_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltTiclTrackstersPassthrough_cfi.py
@@ -1,17 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-ticlTrackstersCLUE3DHigh = cms.EDProducer("TrackstersProducer",
+hltTiclTrackstersPassthrough = cms.EDProducer("TrackstersProducer",
     detector = cms.string('HGCAL'),
-    filtered_mask = cms.InputTag("filteredLayerClustersCLUE3DHigh","CLUE3DHigh"),
-    itername = cms.string('CLUE3DHigh'),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersPassthrough","Passthrough"),
+    itername = cms.string('PassThrough'),
     layer_clusters = cms.InputTag("hgcalMergeLayerClusters"),
     layer_clusters_hfnose_tiles = cms.InputTag("ticlLayerTileHFNose"),
     layer_clusters_tiles = cms.InputTag("ticlLayerTileProducer"),
     mightGet = cms.optional.untracked.vstring,
-    original_mask = cms.InputTag("hgcalMergeLayerClusters","InitialLayerClustersMask"),
-    patternRecognitionBy = cms.string('CLUE3D'),
+    original_mask = cms.InputTag("ticlTrackstersCLUE3DHigh"),
+    patternRecognitionBy = cms.string('Passthrough'),
     pluginPatternRecognitionByCA = cms.PSet(
         algo_verbosity = cms.int32(0),
+        computeLocalTime = cms.bool(True),
         eid_input_name = cms.string('input'),
         eid_min_cluster_energy = cms.double(1),
         eid_n_clusters = cms.int32(10),
@@ -39,82 +40,38 @@ ticlTrackstersCLUE3DHigh = cms.EDProducer("TrackstersProducer",
         type = cms.string('CA')
     ),
     pluginPatternRecognitionByCLUE3D = cms.PSet(
-    algo_verbosity = cms.int32(0),
-    criticalDensity = cms.vdouble(
-      0.6,
-      0.6,
-      0.6
-    ),
-    criticalSelfDensity = cms.vdouble(
-      0.15,
-      0.15,
-      0.15
-    ),
-    densitySiblingLayers = cms.vint32(
-      3,
-      3,
-      3
-    ),
-    densityEtaPhiDistanceSqr = cms.vdouble(
-      0.0008,
-      0.0008,
-      0.0008
-    ),
-    densityXYDistanceSqr = cms.vdouble(
-      3.24,
-      3.24,
-      3.24
-    ),
-    kernelDensityFactor = cms.vdouble(
-      0.2,
-      0.2,
-      0.2
-    ),
-    densityOnSameLayer = cms.bool(False),
-    nearestHigherOnSameLayer = cms.bool(False),
-    useAbsoluteProjectiveScale = cms.bool(True),
-    useClusterDimensionXY = cms.bool(False),
-    rescaleDensityByZ = cms.bool(False),
-    criticalEtaPhiDistance = cms.vdouble(
-      0.025,
-      0.025,
-      0.025
-    ),
-    criticalXYDistance = cms.vdouble(
-      1.8,
-      1.8,
-      1.8
-    ),
-    criticalZDistanceLyr = cms.vint32(
-      5,
-      5,
-      5
-    ),
-    outlierMultiplier = cms.vdouble(
-      2,
-      2,
-      2
-    ),
-    minNumLayerCluster = cms.vint32(
-      2,
-      2,
-      2
-    ),
-    eid_input_name = cms.string('input'),
-    eid_output_name_energy = cms.string('output/regressed_energy'),
-    eid_output_name_id = cms.string('output/id_probabilities'),
-    eid_min_cluster_energy = cms.double(1),
-    eid_n_layers = cms.int32(50),
-    eid_n_clusters = cms.int32(10),
-    computeLocalTime = cms.bool(False),
-    doPidCut = cms.bool(True),
-    cutHadProb = cms.double(999.),
-    type = cms.string('CLUE3D')
-
+        algo_verbosity = cms.int32(0),
+        computeLocalTime = cms.bool(True),
+        criticalDensity = cms.vdouble(4, 4, 4),
+        criticalEtaPhiDistance = cms.vdouble(0.025, 0.025, 0.025),
+        criticalSelfDensity = cms.vdouble(0.15, 0.15, 0.15),
+        criticalXYDistance = cms.vdouble(1.8, 1.8, 1.8),
+        criticalZDistanceLyr = cms.vint32(5, 5, 5),
+        cutHadProb = cms.double(0.5),
+        densityEtaPhiDistanceSqr = cms.vdouble(0.0008, 0.0008, 0.0008),
+        densityOnSameLayer = cms.bool(False),
+        densitySiblingLayers = cms.vint32(3, 3, 3),
+        densityXYDistanceSqr = cms.vdouble(3.24, 3.24, 3.24),
+        doPidCut = cms.bool(False),
+        eid_input_name = cms.string('input'),
+        eid_min_cluster_energy = cms.double(1),
+        eid_n_clusters = cms.int32(10),
+        eid_n_layers = cms.int32(50),
+        eid_output_name_energy = cms.string('output/regressed_energy'),
+        eid_output_name_id = cms.string('output/id_probabilities'),
+        kernelDensityFactor = cms.vdouble(0.2, 0.2, 0.2),
+        minNumLayerCluster = cms.vint32(2, 2, 2),
+        nearestHigherOnSameLayer = cms.bool(False),
+        outlierMultiplier = cms.vdouble(2, 2, 2),
+        rescaleDensityByZ = cms.bool(False),
+        type = cms.string('CLUE3D'),
+        useAbsoluteProjectiveScale = cms.bool(True),
+        useClusterDimensionXY = cms.bool(False)
     ),
     pluginPatternRecognitionByFastJet = cms.PSet(
         algo_verbosity = cms.int32(0),
         antikt_radius = cms.double(0.09),
+        computeLocalTime = cms.bool(True),
         eid_input_name = cms.string('input'),
         eid_min_cluster_energy = cms.double(1),
         eid_n_clusters = cms.int32(10),
@@ -124,10 +81,11 @@ ticlTrackstersCLUE3DHigh = cms.EDProducer("TrackstersProducer",
         minNumLayerCluster = cms.int32(5),
         type = cms.string('FastJet')
     ),
+    pluginPatternRecognitionByPassthrough = cms.PSet(
+        algo_verbosity = cms.int32(0),
+        type = cms.string('Passthrough')
+    ),
     seeding_regions = cms.InputTag("ticlSeedingGlobal"),
     tfDnnLabel = cms.string('tracksterSelectionTf'),
     time_layerclusters = cms.InputTag("hgcalMergeLayerClusters","timeLayerCluster")
 )
-
-from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
-ticl_v5.toModify(ticlTrackstersCLUE3DHigh.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True), doPidCut = cms.bool(False))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowClusterHGCal_cfi.py
@@ -33,3 +33,6 @@ particleFlowClusterHGCal = cms.EDProducer("PFClusterProducer",
     ),
     usePFThresholdsFromDB = cms.bool(False)
 )
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(particleFlowClusterHGCal.initialClusteringStep, tracksterSrc = "hltTiclCandidate")

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
@@ -32,3 +32,6 @@ pfTICL = cms.EDProducer("PFTICLProducer",
     useMTDTiming = cms.bool(False),
     useTimingAverage = cms.bool(False)
 )
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(pfTICL, ticlCandidateSrc = cms.InputTag('hltTiclCandidate'), isTICLv5 = cms.bool(True))

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/ticlTrackstersCLUE3DHighL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/ticlTrackstersCLUE3DHighL1Seeded_cfi.py
@@ -106,10 +106,11 @@ ticlTrackstersCLUE3DHighL1Seeded = cms.EDProducer("TrackstersProducer",
     eid_min_cluster_energy = cms.double(1),
     eid_n_layers = cms.int32(50),
     eid_n_clusters = cms.int32(10),
+    computeLocalTime = cms.bool(False),
     doPidCut = cms.bool(True),
     cutHadProb = cms.double(999.),
     type = cms.string('CLUE3D')
-  
+
     ),
     pluginPatternRecognitionByFastJet = cms.PSet(
         algo_verbosity = cms.int32(0),
@@ -127,3 +128,6 @@ ticlTrackstersCLUE3DHighL1Seeded = cms.EDProducer("TrackstersProducer",
     tfDnnLabel = cms.string('tracksterSelectionTf'),
     time_layerclusters = cms.InputTag("hgcalMergeLayerClustersL1Seeded","timeLayerCluster")
 )
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toModify(ticlTrackstersCLUE3DHighL1Seeded.pluginPatternRecognitionByCLUE3D, computeLocalTime = cms.bool(True), doPidCut = cms.bool(False))

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclCandidateSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclCandidateSequence_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltTiclCandidate_cfi import *
+
+HLTTiclCandidateSequence = cms.Sequence(hltTiclCandidate)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTracksterLinksSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTracksterLinksSequence_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltTiclTracksterLinks_cfi import *
+
+HLTTiclTracksterLinksSequence = cms.Sequence(hltTiclTracksterLinks)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTrackstersPassthroughSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTTiclTrackstersPassthroughSequence_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from ..modules.hltFilteredLayerClustersPassThrough_cfi import *
+from ..modules.hltTiclTrackstersPassthrough_cfi import *
+
+HLTTiclTrackstersPassthroughSequence = cms.Sequence(hltFilteredLayerClustersPassthrough+hltTiclTrackstersPassthrough)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/iterTICLSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/iterTICLSequence_cfi.py
@@ -4,5 +4,11 @@ from ..sequences.ticlLayerTileSequence_cfi import *
 from ..sequences.ticlPFSequence_cfi import *
 from ..sequences.ticlTracksterMergeSequence_cfi import *
 from ..sequences.ticlTrackstersCLUE3DHighStepSequence_cfi import *
+from ..sequences.HLTTiclTrackstersPassthroughSequence_cfi import *
+from ..sequences.HLTTiclTracksterLinksSequence_cfi import *
+from ..sequences.HLTTiclCandidateSequence_cfi import *
 
 iterTICLSequence = cms.Sequence(ticlLayerTileSequence+ticlTrackstersCLUE3DHighStepSequence+ticlTracksterMergeSequence+ticlPFSequence)
+
+from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
+ticl_v5.toReplaceWith(iterTICLSequence, cms.Sequence(ticlLayerTileSequence+ticlTrackstersCLUE3DHighStepSequence+HLTTiclTrackstersPassthroughSequence+HLTTiclTracksterLinksSequence+HLTTiclCandidateSequence+ticlPFSequence))

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -118,7 +118,6 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps)
       clustersTime_token_(
           consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("layer_clustersTime"))),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
-      inputTimingToken_(consumes<MtdHostCollection>(ps.getParameter<edm::InputTag>("timingSoA"))),
       muons_token_(consumes<std::vector<reco::Muon>>(ps.getParameter<edm::InputTag>("muons"))),
       useMTDTiming_(ps.getParameter<bool>("useMTDTiming")),
       useTimingAverage_(ps.getParameter<bool>("useTimingAverage")),


### PR DESCRIPTION
#### PR description:

This PR extends the existing `ticl_v5` modifier to the Phase-2 HLT. The default for now remains TICLv4.
In all the `.203` wfs the `--procModifiers ticl_v5` option is added automatically.
The changes follow the logic of the offline workflow, but with the MTD timing disabled by default.

#### PR validation:

Checked on wf `29688.203`. 
**A workflow `.203` (e.g. `29688.203` and `29888.203`) with the option `-w upgrade` should be used to test this PR.**

FYI @waredjeb 