### PR TITLE
Restrict LHE jobs to only use containers if running in different machine architecture

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -76,8 +76,11 @@ if [ "$use_gridpack_env" != false ]; then
     elif egrep -q "scram_arch_version=[^$]" runcmsgrid.sh; then
         sing=$(grep "scram_arch_version=[^$]" runcmsgrid.sh | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
     fi
-    if [ -n "${sing}" ]; then
+    arch=$(echo ${SCRAM_ARCH} | sed -E 's/^[^0-9]*([0-9]{1,2}).*/\1/')
+    if [ -n "${sing}" ] && [ "${sing}" -ne "${arch}" ]; then
         sing="cmssw-el"${sing}" --"
+    else
+        unset sing
     fi
 fi
 


### PR DESCRIPTION
#### PR description:

This PR changes the run_generic_tarball_cvmfs.sh bash script to only use a singularity if the architecture version of the machine is different than the one used to create the gridpack, with the attempt to mitigate the problem reported in https://github.com/cms-sw/cmssw/issues/45501 (assuming it is due to the number of containers created).

#### PR validation:

Tested with relvals 180 and 181

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for: