### PR TITLE
TestDQMOfflineConfigurationGotAll: increase the number of considered DQM seqs

### DIFF
--- a/DQMOffline/Configuration/test/BuildFile.xml
+++ b/DQMOffline/Configuration/test/BuildFile.xml
@@ -4,12 +4,12 @@
 <test name="GetTestDQMOfflineConfigurationFile" command="edmCopyUtil ${INFILE} $(LOCALTOP)/tmp/"/>
 
 <!-- To make the tests run in parallel, we chunk up the work into arbitrary sets of 10 sequences. -->
-<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,311,10">
+<test name="TestDQMOfflineConfiguration" command="runtests.sh   ${step_value} ${value} file://${LOCALTOP}/tmp/${INFILE_NAME}" for="0,320,10">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>
 
 <!-- To make sure we actually got all sequences, the last check checks that there are no sequences beyond the last test -->
 <!-- This might need to updated when the number of distinct sequences grows, add more rows above and change the number here. -->
-<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 311">
+<test name="TestDQMOfflineConfigurationGotAll" command="runrest.sh file://${LOCALTOP}/tmp/${INFILE_NAME} 320">
   <flags PRE_TEST="GetTestDQMOfflineConfigurationFile"/>
 </test>


### PR DESCRIPTION
Looks like we now have 320 DQM sequences while the unit test `TestDQMOfflineConfigurationGotAll` was expacting 311. This PR updates the total number of to 320. This should fix the [failing unit test in 14.1.X IBs](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_14_1_ASNEEDED_X_2024-07-18-1100/unitTestLogs/DQMOffline/Configuration#/81-81)
```
+ echo 'Final DQMOfflineConfiguration should not run any sequences.'
Final DQMOfflineConfiguration should not run any sequences.
+ echo 'Please update parameters for TestDQMOfflineConfiguration unittest to run the extra sequences.'
Please update parameters for TestDQMOfflineConfiguration unittest to run the extra sequences.
+ exit 1
```