### PR TITLE
customiser for alpaka patatrack pixel seeding for phase2

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessPixelCPEFastParamsPhase2(process):
+    process.hltESPPixelCPEFastParamsPhase2 = cms.ESProducer('PixelCPEFastParamsESProducerAlpakaPhase2@alpaka', 
+        ComponentName = cms.string("PixelCPEFastParamsPhase2"),
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(backend = cms.untracked.string('')
+    )
+)
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+modifyConfigurationForAlpakaPixelCPEFastParamsPhase2_ = alpaka.makeProcessModifier(_addProcessPixelCPEFastParamsPhase2)

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessSiPixelCablingAlpaka(process):
+    process.hltESPSiPixelCablingSoA = cms.ESProducer('SiPixelCablingSoAESProducer@alpaka', 
+        CablingMapLabel = cms.string(''),
+        UseQualityInfo = cms.bool(False),
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+    )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+modifyConfigurationForAlpakaSiPixelCabling_ = alpaka.makeProcessModifier(_addProcessSiPixelCablingAlpaka)

--- a/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def _addProcessSiPixelGainCalibrationAlpaka(process):
+    process.hltESPSiPixelGainCalibrationForHLTSoA = cms.ESProducer('SiPixelGainCalibrationForHLTSoAESProducer@alpaka',
+        appendToDataLabel = cms.string(''),
+        alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+    )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+modifyConfigurationForAlpakaSiPixelGainCalibration_ = alpaka.makeProcessModifier(_addProcessSiPixelGainCalibrationAlpaka)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OnlineBeamSpotDevice_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2OnlineBeamSpotDevice_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2OnlineBeamSpotDevice = cms.EDProducer('BeamSpotDeviceProducer@alpaka',
+    src = cms.InputTag('hltOnlineBeamSpot'),
+    alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracksSoA_cfi.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2PixelTracksSoA = cms.EDProducer('CAHitNtupletAlpakaPhase2@alpaka',
+    pixelRecHitSrc = cms.InputTag('hltPhase2SiPixelRecHitsSoA'),
+    CPE = cms.string('PixelCPEFastParamsPhase2'),
+    ptmin = cms.double(0.9),
+    CAThetaCutBarrel = cms.double(0.002),
+    CAThetaCutForward = cms.double(0.003),
+    hardCurvCut = cms.double(0.0328407225),
+    dcaCutInnerTriplet = cms.double(0.15),
+    dcaCutOuterTriplet = cms.double(0.25),
+    earlyFishbone = cms.bool(True),
+    lateFishbone = cms.bool(False),
+    fillStatistics = cms.bool(False),
+    minHitsPerNtuplet = cms.uint32(4),
+    phiCuts = cms.vint32(
+        522, 522, 522, 626, 730, 730, 626, 730, 730, 522, 522,
+        522, 522, 522, 522, 522, 522, 522, 522, 522, 522, 522,
+        522, 522, 522, 522, 522, 522, 522, 730, 730, 730, 730,
+        730, 730, 730, 730, 730, 730, 730, 730, 730, 730, 730,
+        730, 730, 730, 522, 522, 522, 522, 522, 522, 522, 522
+    ),
+    maxNumberOfDoublets = cms.uint32(5*512*1024),
+    minHitsForSharingCut = cms.uint32(10),
+    fitNas4 = cms.bool(False),
+    doClusterCut = cms.bool(True),
+    doZ0Cut = cms.bool(True),
+    doPtCut = cms.bool(True),
+    useRiemannFit = cms.bool(False),
+    doSharedHitCut = cms.bool(True),
+    dupPassThrough = cms.bool(False),
+    useSimpleTripletCleaner = cms.bool(True),
+    idealConditions = cms.bool(False),
+    includeJumpingForwardDoublets = cms.bool(True),
+    trackQualityCuts = cms.PSet(
+        maxChi2 = cms.double(5.0),
+        minPt   = cms.double(0.9),
+        maxTip  = cms.double(0.3),
+        maxZip  = cms.double(12.),
+    ),
+    # autoselect the alpaka backend
+    alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracks_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2PixelTracks_cfi.py
@@ -8,3 +8,13 @@ hltPhase2PixelTracks = cms.EDProducer("PixelTrackProducer",
     mightGet = cms.optional.untracked.vstring,
     passLabel = cms.string('hltPhase2PixelTracks')
 )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+_hltPhase2PixelTracks = cms.EDProducer("PixelTrackProducerFromSoAAlpakaPhase2",
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+    minNumberOfHits = cms.int32(0),
+    minQuality = cms.string('tight'),
+    pixelRecHitLegacySrc = cms.InputTag("hltSiPixelRecHits"),
+    trackSrc = cms.InputTag("hltPhase2PixelTracksSoA")
+)
+alpaka.toReplaceWith(hltPhase2PixelTracks, _hltPhase2PixelTracks)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2SiPixelClustersSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2SiPixelClustersSoA_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2SiPixelClustersSoA = cms.EDProducer("SiPixelPhase2DigiToCluster@alpaka",
+    # autoselect the alpaka backend
+    alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2SiPixelRecHitsSoA_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltPhase2SiPixelRecHitsSoA_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+hltPhase2SiPixelRecHitsSoA = cms.EDProducer('SiPixelRecHitAlpakaPhase2@alpaka',
+    beamSpot = cms.InputTag('hltPhase2OnlineBeamSpotDevice'),
+    src = cms.InputTag('hltPhase2SiPixelClustersSoA'),
+    CPE = cms.string('PixelCPEFastParamsPhase2'),
+    mightGet = cms.optional.untracked.vstring,
+    # autoselect the alpaka backend
+    alpaka = cms.untracked.PSet(backend = cms.untracked.string(''))
+)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelClusters_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelClusters_cfi.py
@@ -22,3 +22,13 @@ hltSiPixelClusters = cms.EDProducer("SiPixelClusterProducer",
     payloadType = cms.string('None'),
     src = cms.InputTag("simSiPixelDigis","Pixel")
 )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+_hltSiPixelClusters = cms.EDProducer('SiPixelDigisClustersFromSoAAlpakaPhase2',
+    src = cms.InputTag('hltPhase2SiPixelClustersSoA'),
+    clusterThreshold_layer1 = cms.int32(4000),
+    clusterThreshold_otherLayers = cms.int32(4000),
+    produceDigis = cms.bool(False),
+    storeDigis = cms.bool(False)
+)
+alpaka.toReplaceWith(hltSiPixelClusters, _hltSiPixelClusters)

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelRecHits_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltSiPixelRecHits_cfi.py
@@ -5,3 +5,9 @@ hltSiPixelRecHits = cms.EDProducer("SiPixelRecHitConverter",
     VerboseLevel = cms.untracked.int32(0),
     src = cms.InputTag("hltSiPixelClusters")
 )
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toReplaceWith(hltSiPixelRecHits, cms.EDProducer('SiPixelRecHitFromSoAAlpakaPhase2',
+    pixelRecHitSrc = cms.InputTag('hltPhase2SiPixelRecHitsSoA'),
+    src = cms.InputTag('hltSiPixelClusters'),
+))

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTBeamSpotSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTBeamSpotSequence_cfi.py
@@ -3,3 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from ..modules.hltOnlineBeamSpot_cfi import *
 
 HLTBeamSpotSequence = cms.Sequence(hltOnlineBeamSpot)
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+from ..modules.hltPhase2OnlineBeamSpotDevice_cfi import hltPhase2OnlineBeamSpotDevice
+_HLTBeamSpotSequence = cms.Sequence(
+     hltOnlineBeamSpot
+    +hltPhase2OnlineBeamSpotDevice
+)
+alpaka.toReplaceWith(HLTBeamSpotSequence, _HLTBeamSpotSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoLocalPixelSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTDoLocalPixelSequence_cfi.py
@@ -4,3 +4,17 @@ from ..modules.hltSiPixelClusters_cfi import *
 from ..modules.hltSiPixelRecHits_cfi import *
 
 HLTDoLocalPixelSequence = cms.Sequence(hltSiPixelClusters+hltSiPixelRecHits)
+
+from ..modules.hltPhase2SiPixelClustersSoA_cfi import hltPhase2SiPixelClustersSoA
+from ..modules.hltPhase2SiPixelRecHitsSoA_cfi  import hltPhase2SiPixelRecHitsSoA
+from ..modules.hltSiPixelClusterShapeCache_cfi import hltSiPixelClusterShapeCache
+_HLTDoLocalPixelSequence = cms.Sequence(
+     hltPhase2SiPixelClustersSoA
+    +hltSiPixelClusters
+    +hltSiPixelClusterShapeCache  # should we disable this? Still needed by tracker muons
+    +hltPhase2SiPixelRecHitsSoA
+    +hltSiPixelRecHits
+)
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toReplaceWith(HLTDoLocalPixelSequence, _HLTDoLocalPixelSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTItLocalRecoSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTItLocalRecoSequence_cfi.py
@@ -6,3 +6,10 @@ from ..modules.hltSiPixelClusterShapeCache_cfi import *
 from ..modules.hltSiPixelRecHits_cfi import *
 
 HLTItLocalRecoSequence = cms.Sequence(hltSiPhase2Clusters+hltSiPixelClusters+hltSiPixelClusterShapeCache+hltSiPixelRecHits)
+
+from ..sequences.HLTDoLocalPixelSequence_cfi import *
+from ..sequences.HLTDoLocalStripSequence_cfi import *
+_HLTItLocalRecoSequence = cms.Sequence(HLTDoLocalPixelSequence+HLTDoLocalStripSequence)
+
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toReplaceWith(HLTItLocalRecoSequence, _HLTItLocalRecoSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2PixelTracksSequence_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/sequences/HLTPhase2PixelTracksSequence_cfi.py
@@ -9,3 +9,15 @@ from ..modules.hltPhase2PixelTracksHitSeeds_cfi import *
 from ..modules.hltPhase2PixelTracksSeedLayers_cfi import *
 
 HLTPhase2PixelTracksSequence = cms.Sequence(hltPhase2PixelTracksSeedLayers+hltPhase2PixelTracksAndHighPtStepTrackingRegions+hltPhase2PixelTracksHitDoublets+hltPhase2PixelTracksHitSeeds+hltPhase2PixelFitterByHelixProjections+hltPhase2PixelTrackFilterByKinematics+hltPhase2PixelTracks)
+from ..sequences.HLTBeamSpotSequence_cfi import HLTBeamSpotSequence
+from ..modules.hltPhase2PixelTracksSoA_cfi import hltPhase2PixelTracksSoA
+_HLTPhase2PixelTracksSequence = cms.Sequence(
+   HLTBeamSpotSequence
+  +hltPhase2PixelTracksAndHighPtStepTrackingRegions # needed by highPtTripletStep iteration
+  +hltPhase2PixelFitterByHelixProjections # needed by tracker muons
+  +hltPhase2PixelTrackFilterByKinematics  # needed by tracker muons
+  +hltPhase2PixelTracksSoA
+  +hltPhase2PixelTracks
+)
+from Configuration.ProcessModifiers.alpaka_cff import alpaka
+alpaka.toReplaceWith(HLTPhase2PixelTracksSequence, _HLTPhase2PixelTracksSequence)

--- a/HLTrigger/Configuration/python/HLT_75e33_cff.py
+++ b/HLTrigger/Configuration/python/HLT_75e33_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 fragment = cms.ProcessFragment("HLT")
 
 ### Non HLT-specific event-setups
+fragment.load("Configuration/StandardSequences/Accelerators_cff")
 fragment.load("CalibMuon/CSCCalibration/CSCChannelMapper_cfi")
 fragment.load("CalibMuon/CSCCalibration/CSCIndexer_cfi")
 fragment.load("RecoHGCal/TICL/tracksterSelectionTf_cfi")
@@ -90,6 +91,10 @@ fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectoryFi
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPKFTrajectorySmootherForL2Muon_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/trackdnn_source_cfi")
+
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPPixelCPEFastParams_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelCablingSoA_cfi")
+fragment.load("HLTrigger/Configuration/HLT_75e33/eventsetup/hltESPSiPixelGainCalibrationForHLTSoA_cfi")
 
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_AK4PFPuppiJet520_cfi")
 fragment.load("HLTrigger/Configuration/HLT_75e33/paths/HLT_Diphoton30_23_IsoCaloId_L1Seeded_cfi")


### PR DESCRIPTION
#### PR description:

this PR adds alpaka patatrack pixel tracking in the simplified menu using the [common alpaka process modifier](https://github.com/cms-sw/cmssw/blob/master/Configuration/ProcessModifiers/python/alpaka_cff.py).
The hltPhase2PixelTracks are redefined to be produced by CAHitNtupletAlpakaPhase2. Full tracks are produced merging initialStep (building from alpaka patatrack) + highPtTripletStep (building as in legacy). 

#### PR 
Alpaka tracking is enabled running the HLT step with --procModifiers alpaka:

```
cmsDriver.py step2  -s L1P2GT,HLT:75e33 --conditions auto:phase2_realistic_T33 --datatier GEN-SIM-DIGI-RAW -n 100 --eventcontent FEVTDEBUGHLT --geometry Extended2026D110 --era Phase2C17I13M9 --filein  file:step2_DIGIL1.root  --fileout file:step2_HLT.root  --nThreads 5 --procModifiers alpaka
```
(previous steps can be copied from ```runTheMatrix.py -l 29634.0 -t 4 -j 10 --ibeos --dryRun```)

Tracking performance are reported [here](https://lguzzi.web.cern.ch/lguzzi/Tracking/Phase2/alpaka/customiser/singleiter_vs_twoiters/generalTracks) for general tracks and [here](https://lguzzi.web.cern.ch/lguzzi/Tracking/Phase2/alpaka/customiser/singleiter_vs_twoiters/hltPhase2PixelTracks/) for pixel tracks.
When moving from the old customiser function to process modifiers I checked that the two give [identical results](https://lguzzi.web.cern.ch/lguzzi/Tracking/Phase2/alpaka/procModifier/xcheck/plots_hlt_hltGeneral/) (when disabling HCAL alpaka reconstruction).

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

not a backport
