### PR TITLE
Disable test `TestPerfToolsModuleAllocMonitor` for ASAN IBs

### DIFF
--- a/PerfTools/AllocMonitor/test/BuildFile.xml
+++ b/PerfTools/AllocMonitor/test/BuildFile.xml
@@ -22,6 +22,5 @@
     <use name="jemalloc"/>
     <flags CXXFLAGS="-O0"/>
   </bin>
+  <test name="TestPerfToolsModuleAllocMonitor" command="runModuleAlloc.sh"/>
 </ifrelease>
-
-<test name="TestPerfToolsModuleAllocMonitor" command="runModuleAlloc.sh"/>


### PR DESCRIPTION
Hello,

Test `TestPerfToolsModuleAllocMonitor` is failing in ASAN IBs with:
```
===== Test "TestPerfToolsModuleAllocMonitor" ====
+ LOCAL_TEST_DIR=/data/cmsbld/jenkins/workspace/ib-run-qa/CMSSW_14_1_ASAN_X_2024-07-17-2300/src/PerfTools/AllocMonitor/test
+ LD_PRELOAD=libPerfToolsAllocMonitorPreload.so
+ cmsRun /data/cmsbld/jenkins/workspace/ib-run-qa/CMSSW_14_1_ASAN_X_2024-07-17-2300/src/PerfTools/AllocMonitor/test/moduleAlloc_cfg.py
==1927315==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
+ die 'Failure using moduleAlloc_cfg.py' 1
+ echo Failure using moduleAlloc_cfg.py: status 1
Failure using moduleAlloc_cfg.py: status 1
+ exit 1

---> test TestPerfToolsModuleAllocMonitor had ERRORS
TestTime:0
^^^^ End Test TestPerfToolsModuleAllocMonitor ^^^^
```

After discussing with @smuzaffar, we propose disabling this test for ASAN since the job configures its own `LD_PRELOAD`. See https://github.com/cms-sw/cmssw/blob/master/PerfTools/AllocMonitor/test/runModuleAlloc.sh.
