### PR TITLE
Use 13_0_9_HLT and 12_4_21_HLT releases in the 22/23 MC production tests

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -14,10 +14,10 @@
 -->
 
 <!-- In CMSSW_13_0_18 the auto:phase1_2023_realistic (pre BPix) is 130X_mcRun3_2023_realistic_postBPix_v1 -->
-<test name="test_MC_23_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 2023v12 CMSSW_13_0_18 130X_mcRun3_2023_realistic_v13 Realistic25ns13p6TeVEarly2023Collision" />
+<test name="test_MC_23_setup" command="CMSSW_MC_SETUP_TEST_CATCH_HLT=0 ${CMSSW_BASE}/src/Configuration/PyReleaseValidation/test/test_mc_setup/test_MC_setup.sh auto:phase1_2023_realistic Run3_2023 2023v12 CMSSW_13_0_19_HLT 130X_mcRun3_2023_realistic_v13 Realistic25ns13p6TeVEarly2023Collision" />
 
 <!-- In CMSSW_12_4_20 the auto:phase1_2022_realistic (pre EE) is 124X_mcRun3_2022_realistic_v12 -->
-<test name="test_MC_22_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 2022v14 CMSSW_12_4_20 124X_mcRun3_2022_realistic_v12 Realistic25ns13p6TeVEarly2022Collision" />
+<test name="test_MC_22_setup" command="test_mc_setup/test_MC_setup.sh auto:phase1_2022_realistic Run3 2022v14 CMSSW_12_4_21_HLT 124X_mcRun3_2022_realistic_v12 Realistic25ns13p6TeVEarly2022Collision" />
 
 <!-- 
     The setups below are "standard", with everything run 


### PR DESCRIPTION
#### PR description:

This PR updates the 22/23 MC production tests added in https://github.com/cms-sw/cmssw/pull/44578 to use the 13_0_9_HLT and 12_4_21_HLT releases for the HLT step. Those releases include the backports https://github.com/cms-sw/cmssw/pull/44921 and https://github.com/cms-sw/cmssw/pull/45000, respectively, that allow those releases to read a ROOT file produced with 14_0_X (or later).

Resolves https://github.com/cms-sw/framework-team/issues/955

#### PR validation:

Unit tests succeed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 14_0_X