### PR TITLE
Add new configuration options to CloseByParticleGun

### DIFF
--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -25,10 +25,12 @@ namespace edm {
 
   protected:
     // data members
-    bool fControlledByEta;
-    double fVarMin, fVarMax, fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax, fTMin, fTMax,
+    bool fControlledByEta, fControlledByREta;
+    double fVarMin, fVarMax,  fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax, fTMin, fTMax,
         fOffsetFirst;
+    double log_fVarMin = 0., log_fVarMax = 0.;
     int fNParticles;
+    bool fLogSpacedVar = false;
     bool fMaxVarSpread = false;
     bool fFlatPtGeneration = false;
     bool fPointing = false;

--- a/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h
@@ -26,7 +26,7 @@ namespace edm {
   protected:
     // data members
     bool fControlledByEta, fControlledByREta;
-    double fVarMin, fVarMax,  fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax, fTMin, fTMax,
+    double fVarMin, fVarMax, fEtaMin, fEtaMax, fRMin, fRMax, fZMin, fZMax, fDelta, fPhiMin, fPhiMax, fTMin, fTMax,
         fOffsetFirst;
     double log_fVarMin = 0., log_fVarMax = 0.;
     int fNParticles;

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -28,7 +28,7 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fControlledByEta = pgun_params.getParameter<bool>("ControlledByEta");
   fControlledByREta = pgun_params.getParameter<bool>("ControlledByREta");
   if(fControlledByEta and fControlledByREta)
-    LogError("CloseByParticleGunProducer") << " Conflicting configuration, cannot have both ControlledByEta and ControlledByREta ";
+    throw cms::Exception("CloseByParticleGunProducer") << " Conflicting configuration, cannot have both ControlledByEta and ControlledByREta ";
 
   fVarMax = pgun_params.getParameter<double>("VarMax");
   fVarMin = pgun_params.getParameter<double>("VarMin");
@@ -36,10 +36,10 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fLogSpacedVar = pgun_params.getParameter<bool>("LogSpacedVar");
   fFlatPtGeneration = pgun_params.getParameter<bool>("FlatPtGeneration");
   if (fVarMin < 1 && !fFlatPtGeneration)
-    LogError("CloseByParticleGunProducer") << " Please choose a minimum energy greater than 1 GeV, otherwise time "
+    throw cms::Exception("CloseByParticleGunProducer") << " Please choose a minimum energy greater than 1 GeV, otherwise time "
                                               "information may be invalid or not reliable";
   if (fVarMin < 0 && fLogSpacedVar)
-    LogError("CloseByParticleGunProducer") << " Minimum energy must be greater than zero for log spacing";
+    throw cms::Exception("CloseByParticleGunProducer") << " Minimum energy must be greater than zero for log spacing";
   else{
       log_fVarMin = std::log(fVarMin);
       log_fVarMax = std::log(fVarMax);
@@ -49,19 +49,19 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
     fEtaMax = pgun_params.getParameter<double>("MaxEta");
     fEtaMin = pgun_params.getParameter<double>("MinEta");
     if (fEtaMax <= fEtaMin)
-      LogError("CloseByParticleGunProducer") << " Please fix MinEta and MaxEta values in the configuration";
+      throw cms::Exception("CloseByParticleGunProducer") << " Please fix MinEta and MaxEta values in the configuration";
   } else {
     fRMax = pgun_params.getParameter<double>("RMax");
     fRMin = pgun_params.getParameter<double>("RMin");
     if (fRMax <= fRMin)
-      LogError("CloseByParticleGunProducer") << " Please fix RMin and RMax values in the configuration";
+      throw cms::Exception("CloseByParticleGunProducer") << " Please fix RMin and RMax values in the configuration";
   }
   if(!fControlledByREta){
       fZMax = pgun_params.getParameter<double>("ZMax");
       fZMin = pgun_params.getParameter<double>("ZMin");
 
       if (fZMax <= fZMin)
-          LogError("CloseByParticleGunProducer") << " Please fix ZMin and ZMax values in the configuration";
+          throw cms::Exception("CloseByParticleGunProducer") << " Please fix ZMin and ZMax values in the configuration";
   }
   fDelta = pgun_params.getParameter<double>("Delta");
   fPhiMin = pgun_params.getParameter<double>("MinPhi");
@@ -69,7 +69,7 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fPointing = pgun_params.getParameter<bool>("Pointing");
   fOverlapping = pgun_params.getParameter<bool>("Overlapping");
   if (fFlatPtGeneration && !fPointing)
-    LogError("CloseByParticleGunProducer")
+    throw cms::Exception("CloseByParticleGunProducer")
         << " Can't generate non pointing FlatPt samples; please disable FlatPt generation or generate pointing sample";
   fRandomShoot = pgun_params.getParameter<bool>("RandomShoot");
   fNParticles = pgun_params.getParameter<int>("NParticles");
@@ -80,7 +80,7 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fTMax = pgun_params.getParameter<double>("TMax");
   fTMin = pgun_params.getParameter<double>("TMin");
   if (fTMax <= fTMin)
-    LogError("CloseByParticleGunProducer") << " Please fix TMin and TMax values in the configuration";
+    throw cms::Exception("CloseByParticleGunProducer") << " Please fix TMin and TMax values in the configuration";
   // set a fixed time offset for the particles
   fOffsetFirst = pgun_params.getParameter<double>("OffsetFirst");
 

--- a/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByParticleGunProducer.cc
@@ -27,8 +27,9 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   ParameterSet pgun_params = pset.getParameter<ParameterSet>("PGunParameters");
   fControlledByEta = pgun_params.getParameter<bool>("ControlledByEta");
   fControlledByREta = pgun_params.getParameter<bool>("ControlledByREta");
-  if(fControlledByEta and fControlledByREta)
-    throw cms::Exception("CloseByParticleGunProducer") << " Conflicting configuration, cannot have both ControlledByEta and ControlledByREta ";
+  if (fControlledByEta and fControlledByREta)
+    throw cms::Exception("CloseByParticleGunProducer")
+        << " Conflicting configuration, cannot have both ControlledByEta and ControlledByREta ";
 
   fVarMax = pgun_params.getParameter<double>("VarMax");
   fVarMin = pgun_params.getParameter<double>("VarMin");
@@ -36,13 +37,14 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
   fLogSpacedVar = pgun_params.getParameter<bool>("LogSpacedVar");
   fFlatPtGeneration = pgun_params.getParameter<bool>("FlatPtGeneration");
   if (fVarMin < 1 && !fFlatPtGeneration)
-    throw cms::Exception("CloseByParticleGunProducer") << " Please choose a minimum energy greater than 1 GeV, otherwise time "
-                                              "information may be invalid or not reliable";
+    throw cms::Exception("CloseByParticleGunProducer")
+        << " Please choose a minimum energy greater than 1 GeV, otherwise time "
+           "information may be invalid or not reliable";
   if (fVarMin < 0 && fLogSpacedVar)
     throw cms::Exception("CloseByParticleGunProducer") << " Minimum energy must be greater than zero for log spacing";
-  else{
-      log_fVarMin = std::log(fVarMin);
-      log_fVarMax = std::log(fVarMax);
+  else {
+    log_fVarMin = std::log(fVarMin);
+    log_fVarMax = std::log(fVarMax);
   }
 
   if (fControlledByEta || fControlledByREta) {
@@ -56,12 +58,12 @@ CloseByParticleGunProducer::CloseByParticleGunProducer(const ParameterSet& pset)
     if (fRMax <= fRMin)
       throw cms::Exception("CloseByParticleGunProducer") << " Please fix RMin and RMax values in the configuration";
   }
-  if(!fControlledByREta){
-      fZMax = pgun_params.getParameter<double>("ZMax");
-      fZMin = pgun_params.getParameter<double>("ZMin");
+  if (!fControlledByREta) {
+    fZMax = pgun_params.getParameter<double>("ZMax");
+    fZMin = pgun_params.getParameter<double>("ZMin");
 
-      if (fZMax <= fZMin)
-          throw cms::Exception("CloseByParticleGunProducer") << " Please fix ZMin and ZMax values in the configuration";
+    if (fZMax <= fZMin)
+      throw cms::Exception("CloseByParticleGunProducer") << " Please fix ZMin and ZMax values in the configuration";
   }
   fDelta = pgun_params.getParameter<double>("Delta");
   fPhiMin = pgun_params.getParameter<double>("MinPhi");
@@ -152,7 +154,7 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
   double fR, fEta;
   double fT;
 
-  if(!fControlledByREta){
+  if (!fControlledByREta) {
     fZ = CLHEP::RandFlat::shoot(engine, fZMin, fZMax);
 
     if (!fControlledByEta) {
@@ -162,13 +164,11 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
       fEta = CLHEP::RandFlat::shoot(engine, fEtaMin, fEtaMax);
       fR = (fZ / sinh(fEta));
     }
+  } else {
+    fR = CLHEP::RandFlat::shoot(engine, fRMin, fRMax);
+    fEta = CLHEP::RandFlat::shoot(engine, fEtaMin, fEtaMax);
+    fZ = sinh(fEta) / fR;
   }
-  else{
-      fR = CLHEP::RandFlat::shoot(engine, fRMin, fRMax);
-      fEta = CLHEP::RandFlat::shoot(engine, fEtaMin, fEtaMax);
-      fZ = sinh(fEta)/fR;
-  }
-
 
   if (fUseDeltaT) {
     fT = CLHEP::RandFlat::shoot(engine, fTMin, fTMax);
@@ -190,8 +190,7 @@ void CloseByParticleGunProducer::produce(Event& e, const EventSetup& es) {
     double fVar;
     if (numParticles > 1 && fMaxVarSpread)
       fVar = fVarMin + ip * (fVarMax - fVarMin) / (numParticles - 1);
-    else if(fLogSpacedVar){
-
+    else if (fLogSpacedVar) {
       double fVar_log = CLHEP::RandFlat::shoot(engine, log_fVarMin, log_fVarMax);
       fVar = std::exp(fVar_log);
     }


### PR DESCRIPTION
This PR adds new functionality to the CloseByParticleGun, specifically the ability to logarithmically space the energy distribution and to specify the particle location based on R and eta. These developments are done in support of upcoming sample generation of HGCal simulations for ML4Sim R&D

 Also promoted previous LogErrors related to inconsistencies of the configuration parameters into exceptions 

@kpedro88 