### PR TITLE
[12_4_X] CepGenInterface: Added missing include

### DIFF
--- a/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
+++ b/GeneratorInterface/CepGenInterface/interface/CepGenEventGenerator.h
@@ -8,6 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 
+#include <CepGen/Core/ParametersList.h>
 #include <CepGen/Generator.h>
 
 namespace gen {


### PR DESCRIPTION
#### PR description:

This PR fixes the build of CepGen release >= 1.2.2 where the include chain was strongly modified. This will cure [the recent build failure](https://github.com/cms-sw/cmsdist/pull/9308#issuecomment-2240999981) encountered in https://github.com/cms-sw/cmsdist/pull/9308.

#### PR validation:

Builds

Backport of #44647 

FYI: @smuzaffar, @bbilin 