### PR TITLE
[clang][cpp20] Fixed ambiguous-reversed-operator for LinearizedTrackState

### DIFF
--- a/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
+++ b/RecoVertex/GaussianSumVertexFit/interface/PerigeeMultiLTS.h
@@ -96,7 +96,7 @@ public:
 
   bool hasError() const override;
 
-  bool operator==(LinearizedTrackState<5>& other) const override;
+  bool operator==(const LinearizedTrackState<5>& other) const override;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.

--- a/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
+++ b/RecoVertex/GaussianSumVertexFit/src/PerigeeMultiLTS.cc
@@ -110,7 +110,7 @@ AlgebraicSymMatrix33 PerigeeMultiLTS::predictedStateMomentumError() const {
   return collapsedStateLT->predictedStateMomentumError();
 }
 
-bool PerigeeMultiLTS::operator==(LinearizedTrackState<5>& other) const {
+bool PerigeeMultiLTS::operator==(const LinearizedTrackState<5>& other) const {
   const PerigeeMultiLTS* otherP = dynamic_cast<const PerigeeMultiLTS*>(&other);
   if (otherP == nullptr) {
     throw VertexException("PerigeeMultiLTS: don't know how to compare myself to non-perigee track state");

--- a/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackState.h
+++ b/RecoVertex/KinematicFitPrimitives/interface/ParticleKinematicLinearizedTrackState.h
@@ -87,7 +87,7 @@ public:
 
   RefCountedKinematicParticle particle() const;
 
-  bool operator==(LinearizedTrackState<6>& other) const override;
+  bool operator==(const LinearizedTrackState<6>& other) const override;
 
   bool hasError() const override;
 

--- a/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
+++ b/RecoVertex/KinematicFitPrimitives/src/ParticleKinematicLinearizedTrackState.cc
@@ -55,7 +55,7 @@ TrackCharge ParticleKinematicLinearizedTrackState::charge() const { return part-
 
 RefCountedKinematicParticle ParticleKinematicLinearizedTrackState::particle() const { return part; }
 
-bool ParticleKinematicLinearizedTrackState::operator==(LinearizedTrackState<6>& other) const {
+bool ParticleKinematicLinearizedTrackState::operator==(const LinearizedTrackState<6>& other) const {
   const ParticleKinematicLinearizedTrackState* otherP =
       dynamic_cast<const ParticleKinematicLinearizedTrackState*>(&other);
   if (otherP == nullptr) {

--- a/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
+++ b/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h
@@ -112,7 +112,7 @@ public:
    */
   //   virtual ImpactPointMeasurement impactPointMeasurement() const = 0;
 
-  virtual bool operator==(LinearizedTrackState<N>& other) const = 0;
+  virtual bool operator==(const LinearizedTrackState<N>& other) const = 0;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.

--- a/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
+++ b/RecoVertex/VertexTools/interface/PerigeeLinearizedTrackState.h
@@ -112,9 +112,9 @@ public:
 
   bool hasError() const override;
 
-  bool operator==(LinearizedTrackState<5>& other) const override;
+  bool operator==(const LinearizedTrackState<5>& other) const override;
 
-  bool operator==(ReferenceCountingPointer<LinearizedTrackState<5> >& other) const;
+  bool operator==(const ReferenceCountingPointer<LinearizedTrackState<5> >& other) const;
 
   /** Creates the correct refitted state according to the results of the
    *  track refit.

--- a/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
+++ b/RecoVertex/VertexTools/src/PerigeeLinearizedTrackState.cc
@@ -26,7 +26,7 @@ void PerigeeLinearizedTrackState::computeJacobians() const {
   jacobiansAvailable = true;
 }
 
-bool PerigeeLinearizedTrackState::operator==(LinearizedTrackState<5>& other) const {
+bool PerigeeLinearizedTrackState::operator==(const LinearizedTrackState<5>& other) const {
   const PerigeeLinearizedTrackState* otherP = dynamic_cast<const PerigeeLinearizedTrackState*>(&other);
   if (otherP == nullptr) {
     throw VertexException("PerigeeLinearizedTrackState: don't know how to compare myself to non-perigee track state");
@@ -34,7 +34,7 @@ bool PerigeeLinearizedTrackState::operator==(LinearizedTrackState<5>& other) con
   return (otherP->track() == theTrack);
 }
 
-bool PerigeeLinearizedTrackState::operator==(ReferenceCountingPointer<LinearizedTrackState<5> >& other) const {
+bool PerigeeLinearizedTrackState::operator==(const ReferenceCountingPointer<LinearizedTrackState<5> >& other) const {
   const PerigeeLinearizedTrackState* otherP = dynamic_cast<const PerigeeLinearizedTrackState*>(other.get());
   if (otherP == nullptr) {
     throw VertexException("PerigeeLinearizedTrackState: don't know how to compare myself to non-perigee track state");


### PR DESCRIPTION
#### PR description:

This PR should fix the clang IBs warnings:

```
In file included from src/RecoVertex/VertexPrimitives/src/VertexTrack.cc:1:
  src/RecoVertex/VertexPrimitives/interface/VertexTrack.h:94:89: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'LinearizedTrackState<5>' and 'LinearizedTrackState<5>') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
    94 |   bool operator==(const VertexTrack<N>& data) const { return ((*data.linearizedTrack()) == (*linearizedTrack())); }
      |                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
src/RecoVertex/VertexPrimitives/src/VertexTrack.cc:47:16: note: in instantiation of member function 'VertexTrack<5>::operator==' requested here
   47 | template class VertexTrack<5>;
      |                ^
src/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h:115:16: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
  115 |   virtual bool operator==(LinearizedTrackState<N>& other) const = 0;
      |                ^
In file included from src/RecoVertex/VertexPrimitives/src/VertexTrack.cc:1:
  src/RecoVertex/VertexPrimitives/interface/VertexTrack.h:94:89: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'LinearizedTrackState<6>' and 'LinearizedTrackState<6>') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
    94 |   bool operator==(const VertexTrack<N>& data) const { return ((*data.linearizedTrack()) == (*linearizedTrack())); }
      |                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~
src/RecoVertex/VertexPrimitives/src/VertexTrack.cc:48:16: note: in instantiation of member function 'VertexTrack<6>::operator==' requested here
   48 | template class VertexTrack<6>;
      |                ^
src/RecoVertex/VertexPrimitives/interface/LinearizedTrackState.h:115:16: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
  115 |   virtual bool operator==(LinearizedTrackState<N>& other) const = 0;
      |                ^
2 warnings generated.
```

#### PR validation:

Bot tests
