### PR TITLE
[clang][cpp20] Fix ambiguous-reversed-operator in ProductResolverIndexAndSkipBit

### DIFF
--- a/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h
+++ b/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h
@@ -35,7 +35,7 @@ namespace edm {
     }
     bool skipCurrentProcess() const { return (value_ & s_skipMask) != 0; }
 
-    bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
+    bool operator==(ProductResolverIndexAndSkipBit const& r) const { return value_ == r.value_; }
 
   private:
     static const unsigned int s_skipMask = 1U << 31;


### PR DESCRIPTION
#### PR description:

Fix clang warnings:

```
 src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:239:71: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   239 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  240 |                    intConsumerRev.indexFrom(intConsumerRev.m_tokens[0], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:241:75: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   241 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  242 |                    intConsumerRev.indexFrom(intConsumerRev.m_tokens[1], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:266:78: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   266 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  267 |                    intConsumer.indexFrom(intConsumer.m_tokens[1], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:268:83: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   268 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  269 |                    intConsumer.indexFrom(intConsumer.m_tokens[0], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:362:70: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   362 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_int, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  363 |                    consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:364:73: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   364 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  365 |                    consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_Simple));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:391:78: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   391 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_int_no_proc, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  392 |                    consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_int));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:393:80: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   393 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(v_simple_no_proc, true) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  394 |                    consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_Simple));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:473:71: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   473 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  474 |                    consumer.indexFrom(consumer.m_tokens[1], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:475:75: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   475 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  476 |                    consumer.indexFrom(consumer.m_tokens[0], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:562:78: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   562 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_c_no_proc, true) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  563 |                    consumer.indexFrom(consumer.m_mayTokens[1], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
  src/FWCore/Framework/test/edconsumerbase_t.cppunit.cc:564:83: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'edm::ProductResolverIndexAndSkipBit' and 'ProductResolverIndexAndSkipBit') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
   564 |     CPPUNIT_ASSERT(edm::ProductResolverIndexAndSkipBit(vint_blank_no_proc, false) ==
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
  565 |                    consumer.indexFrom(consumer.m_mayTokens[0], edm::InEvent, typeID_vint));
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc12/external/cppunit/1.15.x-fb84a4bbf5a436317d208e3ef0864e91/include/cppunit/TestAssert.h:274:37: note: expanded from macro 'CPPUNIT_ASSERT'
  274 |   ( CPPUNIT_NS::Asserter::failIf( !(condition),                                   \
      |                                     ^~~~~~~~~
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   38 |     bool operator==(ProductResolverIndexAndSkipBit const& r) { return value_ == r.value_; }
      |          ^
src/FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h:38:10: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
```

#### PR validation:

Bot tests