### PR TITLE
Tell RNTuple not to split some classes

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -392,7 +392,7 @@
   <class name="edm::ValueMap<edm::Ptr<reco::BaseTagInfo> >" />
   <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::BaseTagInfo> > >" />
   <class name="std::vector<reco::BaseTagInfo *>" />
-  <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >" />
+  <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >" rntupleSplit="false"/>
  <exclusion>
   <class name="edm::OwnVector<reco::BaseTagInfo, edm::ClonePolicy<reco::BaseTagInfo> >">
    <method name="sort" />

--- a/DataFormats/CSCRecHit/src/classes_def.xml
+++ b/DataFormats/CSCRecHit/src/classes_def.xml
@@ -13,7 +13,7 @@
   <class name="std::map<CSCDetId,std::pair<unsigned long,unsigned long> >"/>
   <class name="std::pair<CSCDetId,std::pair<unsigned int,unsigned int> >"/>  <!-- Root6 -->
   <class name="std::pair<CSCDetId,std::pair<unsigned long,unsigned long> >"/><!-- Root6 -->
-  <class name="edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >"/>
+  <class name="edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >"  rntupleSplit="false" />
   <class name="edm::ClonePolicy<CSCRecHit2D>"/> <!-- Root6 -->
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCRecHit2D,edm::ClonePolicy<CSCRecHit2D> >,edm::ClonePolicy<CSCRecHit2D> > >"/>
@@ -24,7 +24,7 @@
    <version ClassVersion="11" checksum="160361831"/>
    <version ClassVersion="10" checksum="3002485899"/>
   </class>
-  <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"/>
+  <class name="edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >"  rntupleSplit="false" />
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> >"/>
   <class name="edm::ClonePolicy<CSCSegment>"/> <!-- Root6 -->
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<CSCSegment,edm::ClonePolicy<CSCSegment> >,edm::ClonePolicy<CSCSegment> > >"/>

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -203,8 +203,8 @@
   <class name="std::vector<reco::Particle>" />
   <class name="std::vector<reco::Candidate *>" />
   <class name="std::vector<reco::LeafCandidate>" />
-  <class name="reco::CandidateCollection" />
-  <class name="reco::CandidateBaseRef" />
+  <class name="reco::CandidateCollection"  rntupleSplit="false"/>
+  <class name="reco::CandidateBaseRef"  rntupleSplit="false"/>
 
   <class name="edm::Wrapper<reco::CandidateCollection>" />
   <class name="edm::Wrapper<std::vector<reco::Particle> >" />

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -8,7 +8,7 @@
   <version ClassVersion="11" checksum="2247759761"/>
   <version ClassVersion="10" checksum="2702412727"/>
  </class>
- <class name="edm::RefCore" ClassVersion="11">
+ <class name="edm::RefCore" ClassVersion="11" rntupleSplit="false">
   <version ClassVersion="10" checksum="641105393"/>
   <version ClassVersion="11" checksum="3425324092"/>
    <field name="cachePtr_" transient = "true"/>
@@ -20,7 +20,7 @@
      edm::refcoreimpl::setCacheIsProductGetter(cachePtr_, getter);
       ]]>
  </ioread>
-  <class name="edm::RefCoreWithIndex" ClassVersion="11">
+  <class name="edm::RefCoreWithIndex" ClassVersion="11" rntupleSplit="false">
     <version ClassVersion="11" checksum="2602044085"/>
     <field name="cachePtr_" transient = "true"/>
   </class>

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -14,7 +14,7 @@
   <class name="std::pair<DTLayerId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTLayerId,std::pair<unsigned long,unsigned long> >"/>
   <class name="std::pair<DTLayerId,std::pair<unsigned long,unsigned long> >"/>
-  <class name="edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >"/>
+  <class name="edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >"   rntupleSplit="false"/>
   <class name="edm::ClonePolicy<DTRecHit1DPair>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTLayerId,edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> >"/> 
   <class name="edm::Wrapper<edm::RangeMap <DTLayerId, edm::OwnVector<DTRecHit1DPair,edm::ClonePolicy<DTRecHit1DPair> >,edm::ClonePolicy<DTRecHit1DPair> > >"/>
@@ -25,7 +25,7 @@
    <version ClassVersion="10" checksum="2463285514"/>
   </class>
   <class name="std::vector<DTSLRecCluster*>"/>
-  <class name="edm::OwnVector<DTSLRecCluster,edm::ClonePolicy<DTSLRecCluster> >"/>
+  <class name="edm::OwnVector<DTSLRecCluster,edm::ClonePolicy<DTSLRecCluster> >"   rntupleSplit="false"/>
   <class name="edm::RangeMap <DTSuperLayerId, edm::OwnVector<DTSLRecCluster,edm::ClonePolicy<DTSLRecCluster> >,edm::ClonePolicy<DTSLRecCluster> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTSuperLayerId, edm::OwnVector<DTSLRecCluster,edm::ClonePolicy<DTSLRecCluster> >,edm::ClonePolicy<DTSLRecCluster> > >"/>
   <class name="DTRecSegment2D" ClassVersion="11">
@@ -39,7 +39,7 @@
   <class name="std::vector<DTSLRecSegment2D*>"/>
   <class name="std::map<DTSuperLayerId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTSuperLayerId,std::pair<unsigned long,unsigned long> >"/>
-  <class name="edm::OwnVector<DTSLRecSegment2D,edm::ClonePolicy<DTSLRecSegment2D> >"/>
+  <class name="edm::OwnVector<DTSLRecSegment2D,edm::ClonePolicy<DTSLRecSegment2D> >"   rntupleSplit="false"/>
   <class name="edm::RangeMap <DTSuperLayerId, edm::OwnVector<DTSLRecSegment2D,edm::ClonePolicy<DTSLRecSegment2D> >,edm::ClonePolicy<DTSLRecSegment2D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTSuperLayerId, edm::OwnVector<DTSLRecSegment2D,edm::ClonePolicy<DTSLRecSegment2D> >,edm::ClonePolicy<DTSLRecSegment2D> > >"/>
   <class name="DTChamberRecSegment2D" ClassVersion="11">
@@ -56,7 +56,7 @@
   <class name="std::pair<DTChamberId,std::pair<unsigned int,unsigned int> >"/>
   <class name="std::map<DTChamberId,std::pair<unsigned long,unsigned long> >"/>
   <class name="std::pair<DTChamberId,std::pair<unsigned long,unsigned long> >"/>
-  <class name="edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >"/>
+  <class name="edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >"   rntupleSplit="false"/>
   <class name="edm::ClonePolicy<DTRecSegment4D>" /> <!-- Root6 -->
   <class name="edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> >"/>
   <class name="edm::Wrapper<edm::RangeMap <DTChamberId, edm::OwnVector<DTRecSegment4D,edm::ClonePolicy<DTRecSegment4D> >,edm::ClonePolicy<DTRecSegment4D> > >"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
 
-  <class name="edm::RefToBase<reco::CaloCluster>"/>
+  <class name="edm::RefToBase<reco::CaloCluster>"  rntupleSplit="false"/>
   <class name="edm::reftobase::BaseHolder<reco::CaloCluster>"/>
   <class name="edm::reftobase::IndirectHolder<reco::CaloCluster>" />
 

--- a/DataFormats/GEMRecHit/src/classes_def.xml
+++ b/DataFormats/GEMRecHit/src/classes_def.xml
@@ -9,7 +9,7 @@
   <class name="std::vector<GEMRecHit*>" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::map<GEMDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
+  <class name="edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"  rntupleSplit="false"/>
   <class name="edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId, edm::OwnVector<GEMRecHit, edm::ClonePolicy<GEMRecHit> >, edm::ClonePolicy<GEMRecHit> > >" splitLevel="0"/>
 
@@ -21,7 +21,7 @@
   <class name="std::vector<ME0RecHit*>" splitLevel="0"/>
   <class name="std::map<ME0DetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::map<ME0DetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
-  <class name="edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >" splitLevel="0"/>
+  <class name="edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >" splitLevel="0"  rntupleSplit="false"/>
   <class name="edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId, edm::OwnVector<ME0RecHit, edm::ClonePolicy<ME0RecHit> >, edm::ClonePolicy<ME0RecHit> > >" splitLevel="0"/>
 
@@ -31,7 +31,7 @@
   <version ClassVersion="10" checksum="2470665576"/>
   </class>
   <class name="std::vector<GEMCSCSegment*>" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >" splitLevel="0"/>
+  <class name="edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >" splitLevel="0"  rntupleSplit="false"/>
   <class name="edm::RangeMap<CSCDetId,edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >,edm::ClonePolicy<GEMCSCSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<CSCDetId,edm::OwnVector<GEMCSCSegment,edm::ClonePolicy<GEMCSCSegment> >,edm::ClonePolicy<GEMCSCSegment> > >" splitLevel="0"/>
   <class name="GEMCSCSegmentRef" splitLevel="0"/>
@@ -44,7 +44,7 @@
   </ioread>
   </class>
   <class name="std::vector<GEMSegment*>" splitLevel="0"/>
-  <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
+  <class name="edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >" splitLevel="0"  rntupleSplit="false"/>
   <class name="edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<GEMDetId,edm::OwnVector<GEMSegment,edm::ClonePolicy<GEMSegment> >,edm::ClonePolicy<GEMSegment> > >" splitLevel="0"/>
   <class name="GEMSegmentRef" splitLevel="0"/>
@@ -56,7 +56,7 @@
   <version ClassVersion="10" checksum="2562385753"/>
   </class>
   <class name="std::vector<ME0Segment*>" splitLevel="0"/>
-  <class name="edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >" splitLevel="0"/>
+  <class name="edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >" splitLevel="0"  rntupleSplit="false" />
   <class name="edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<ME0DetId,edm::OwnVector<ME0Segment,edm::ClonePolicy<ME0Segment> >,edm::ClonePolicy<ME0Segment> > >" splitLevel="0"/>
   <class name="ME0SegmentRef" splitLevel="0"/>

--- a/DataFormats/Histograms/src/classes_def.xml
+++ b/DataFormats/Histograms/src/classes_def.xml
@@ -33,21 +33,21 @@
  <class name="MEtoEDM<int>"/>
  <class name="MEtoEDM<long long>"/>
  <class name="MEtoEDM<TString>"/>
- <class name="MEtoEDM<TH1F>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH1S>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH1D>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH1I>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH2F>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH2S>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH2D>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH2I>::MEtoEDMObject"/>
- <class name="MEtoEDM<TH3F>::MEtoEDMObject"/>
- <class name="MEtoEDM<TProfile>::MEtoEDMObject"/>
- <class name="MEtoEDM<TProfile2D>::MEtoEDMObject"/>
- <class name="MEtoEDM<double>::MEtoEDMObject"/>
- <class name="MEtoEDM<int>::MEtoEDMObject"/>
- <class name="MEtoEDM<long long>::MEtoEDMObject"/>
- <class name="MEtoEDM<TString>::MEtoEDMObject"/>
+ <class name="MEtoEDM<TH1F>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH1S>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH1D>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH1I>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH2F>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH2S>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH2D>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH2I>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TH3F>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TProfile>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TProfile2D>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<double>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<int>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<long long>::MEtoEDMObject" rntupleSplit="false"/>
+ <class name="MEtoEDM<TString>::MEtoEDMObject" rntupleSplit="false"/>
  <class name="std::vector<MEtoEDM<TH1F>::MEtoEDMObject>"/>
  <class name="std::vector<MEtoEDM<TH1S>::MEtoEDMObject>"/>
  <class name="std::vector<MEtoEDM<TH1D>::MEtoEDMObject>"/>

--- a/DataFormats/JetReco/src/classes_def_3.xml
+++ b/DataFormats/JetReco/src/classes_def_3.xml
@@ -106,7 +106,7 @@
   <class name="edm::RefToBaseProd<reco::Jet>" >
      <!-- <field name="view_" transient="true" /> -->
   </class>
-  <class name="edm::RefToBase<reco::Jet>" />
+  <class name="edm::RefToBase<reco::Jet>" rntupleSplit="false"/>
   <class name="edm::reftobase::BaseHolder<reco::Jet>" />
   <class name="edm::reftobase::IndirectHolder<reco::Jet>" />
   <class name="edm::reftobase::IndirectVectorHolder<reco::Jet>" />

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -149,7 +149,7 @@
   </class>
   <class name="std::map<reco::PFBlockElement::Type,reco::PFMultiLinksTC>" />
   <class name="std::vector<reco::PFBlockElement *>" />
-  <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >"/>
+  <class name="edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> >" rntupleSplit="false"/>
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
   <class name="reco::PFBlockElementTrack" ClassVersion="16">

--- a/DataFormats/PatCandidates/src/classes_def_user.xml
+++ b/DataFormats/PatCandidates/src/classes_def_user.xml
@@ -6,7 +6,7 @@
    <version ClassVersion="10" checksum="85383148"/>
   </class>
   <class name="std::vector<pat::UserData *>" />
-  <class name="pat::UserDataCollection" />
+  <class name="pat::UserDataCollection"  rntupleSplit="false"/>
   <!-- UserData: Standalone UserData in the event. Needed? -->
   <class name="edm::Wrapper<pat::UserDataCollection>" />
   <class name="edm::Ptr<pat::UserData>" />

--- a/DataFormats/RPCRecHit/src/classes_def.xml
+++ b/DataFormats/RPCRecHit/src/classes_def.xml
@@ -11,7 +11,7 @@
   <class name="std::map<RPCDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
   <class name="std::pair<RPCDetId, std::pair<unsigned int, unsigned int> >" splitLevel="0"/>
   <class name="std::pair<RPCDetId, std::pair<unsigned long, unsigned long> >" splitLevel="0"/>
-  <class name="edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
+  <class name="edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >" splitLevel="0" rntupleSplit="false"/>
   <class name="edm::ClonePolicy<RPCRecHit>" /> <!-- Root6 -->
   <class name="edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> >" splitLevel="0"/>
   <class name="edm::Wrapper<edm::RangeMap<RPCDetId, edm::OwnVector<RPCRecHit, edm::ClonePolicy<RPCRecHit> >, edm::ClonePolicy<RPCRecHit> > >" splitLevel="0"/>

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -114,7 +114,7 @@
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::RecoEcalCandidateRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::RecoEcalCandidateRefVector>" />
 
-  <class name="reco::IsoDeposit" ClassVersion="10">
+  <class name="reco::IsoDeposit" ClassVersion="10" rntupleSplit="false">
    <version ClassVersion="10" checksum="2477314412"/>
   </class>
   <class name="reco::IsoDeposit::const_iterator" ClassVersion="10">

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -120,11 +120,11 @@
  <class name="std::vector<edmtest::Thing>"/>
  <class name="std::vector<edmtest::OtherThing>"/>
  <class name="edm::RefProd<std::vector<edmtest::Thing> >"/>
- <class name="edm::RefToBaseProd<edmtest::Thing>"/>
+ <class name="edm::RefToBaseProd<edmtest::Thing>" rntupleSplit="false"/>
  <class name="edm::reftobase::BaseHolder<edmtest::Thing>"/>
  <class name="edm::reftobase::Holder<edmtest::Thing,edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> > >"/>
- <class name="edm::RefToBase<edmtest::Thing>"/>
- <class name="edm::RefToBaseVector<edmtest::Thing>"/>
+ <class name="edm::RefToBase<edmtest::Thing>" rntupleSplit="false"/>
+ <class name="edm::RefToBaseVector<edmtest::Thing>" rntupleSplit="false"/>
  <class name="edm::reftobase::BaseVectorHolder<edmtest::Thing>"/>
  <class name="edm::reftobase::VectorHolder<edmtest::Thing, edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> > >"/>
  <class name="edm::Ptr<edmtest::Thing>"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -439,7 +439,7 @@
 
 
      <!-- RefToBase<reco::Track> -->
-     <class name="edm::RefToBase<reco::Track>"/>
+     <class name="edm::RefToBase<reco::Track>" rntupleSplit="false"/>
      <class name="edm::reftobase::IndirectHolder<reco::Track>"/>
      <class name="edm::reftobase::BaseHolder<reco::Track>"/>
      <class name="edm::reftobase::RefHolder<reco::TrackRef>"/>

--- a/DataFormats/TrackingRecHit/src/classes_def.xml
+++ b/DataFormats/TrackingRecHit/src/classes_def.xml
@@ -27,7 +27,7 @@
    <version ClassVersion="10" checksum="1295706057"/>
   </class>
   <class name="std::vector<TrackingRecHit*>"/>
-  <class name="edm::OwnVector<TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >"/>
+  <class name="edm::OwnVector<TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >" rntupleSplit="false"/>
   <class name="edm::ClonePolicy<TrackingRecHit>"/> <!-- Root6 -->
   <class name="edm::Ref<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>
   <class name="edm::RefVectorIterator<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit> >"/>

--- a/DataFormats/TrajectorySeed/src/classes_def.xml
+++ b/DataFormats/TrajectorySeed/src/classes_def.xml
@@ -3,7 +3,7 @@
    <version ClassVersion="11" checksum="1603723857"/>
    <version ClassVersion="10" checksum="611162820"/>
   </class>
-  <class name="edm::RefToBase<TrajectorySeed>"/>
+  <class name="edm::RefToBase<TrajectorySeed>" rntupleSplit="false"/>
   <class name="edm::reftobase::BaseHolder<TrajectorySeed>"/>
   <class name="edm::reftobase::IndirectHolder<TrajectorySeed>"/>
 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -81,7 +81,7 @@
 	<!-- HepMCProduct -->
 
 	<class name="edm::Wrapper&lt;edm::HepMCProduct&gt;"/>
-	<class name="edm::HepMCProduct" ClassVersion="10">
+	<class name="edm::HepMCProduct" ClassVersion="10" rntupleSplit="false">
   <version ClassVersion="10" checksum="3587845075"/>
  </class>
         <class name="std::vector&lt;const edm::HepMCProduct*&gt;"/>


### PR DESCRIPTION
#### PR description:

RNTuple is unable to do its normal split of a class if that class contains certain C++ constructs. This change marks those classes stored in production workflows that cannot be split.

#### PR validation:

Code compiles. Test with prototype RNTuple code successfully wrote MiniAOD, AOD and RECO formats.