### PR TITLE
A new Online HCAL DQM histogram for bad quality events 

### DIFF
--- a/DQM/HcalTasks/data/HcalQualityTests.xml
+++ b/DQM/HcalTasks/data/HcalQualityTests.xml
@@ -30,4 +30,20 @@
   <LINK name="*Hcal/DigiTask/CapID/CapID_BadvsLS*">
     <TestName activate="true">BadCapIDThreshold</TestName>
   </LINK>
+  <QTEST name="BadQualityThreshold">
+    <TYPE>ContentsWithinExpected</TYPE>
+      <PARAM name="error">1.0</PARAM>
+      <PARAM name="warning">1.0</PARAM>
+      <PARAM name="minMean">-1.0</PARAM>
+      <PARAM name="maxMean">0.0</PARAM>
+      <PARAM name="minRMS">0.0</PARAM>
+      <PARAM name="maxRMS">0.0</PARAM>
+      <PARAM name="toleranceMean">-1.0</PARAM>
+      <PARAM name="minEntries">0</PARAM>
+      <PARAM name="useEmptyBins">1</PARAM>
+  </QTEST>
+  <LINK name="*Hcal/RawTask/BadQ_FEDvsLSmod60/BadQ_FEDvsLS*">
+    <TestName activate="true">BadQualityThreshold</TestName>
+  </LINK>
+
 </TESTSCONFIGURATION>

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -51,7 +51,7 @@ protected:
   //	physics vs calib processing switch
   bool _calibProcessing;
   int _thresh_calib_nbadq;
-  int _NBadQEvent; 
+  int _nBadQEvent; 
   //	vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -51,7 +51,7 @@ protected:
   //	physics vs calib processing switch
   bool _calibProcessing;
   int _thresh_calib_nbadq;
-
+  int _NBadQEvent; 
   //	vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 
@@ -77,6 +77,7 @@ protected:
 
   hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
   hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
+  hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod60;  // online only
 };
 
 #endif

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -52,8 +52,8 @@ protected:
   bool _calibProcessing;
   int _thresh_calib_nbadq;
   int _nBadQEvent;                                                                                                                 
-   //     vector of HcalElectronicsId for FEDs                                                                                      
-   std::vector<uint32_t> _vhashFEDs;   
+  //     vector of HcalElectronicsId for FEDs                                                                                      
+  std::vector<uint32_t> _vhashFEDs;   
 
   //	Filters
   hcaldqm::filter::HashFilter _filter_VME;

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -52,7 +52,7 @@ protected:
   bool _calibProcessing;
   int _thresh_calib_nbadq;
   int _nBadQEvent; 
-  //	 vector of HcalElectronicsId for FEDs
+  //	  vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 
   //	Filters

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -51,8 +51,8 @@ protected:
   //	physics vs calib processing switch
   bool _calibProcessing;
   int _thresh_calib_nbadq;
-  int _nBadQEvent;                                                                                                                 
-  
+  int _nBadQEvent;
+
   //  vector of HcalElectronicsId for FEDs                                                                                      
   std::vector<uint32_t> _vhashFEDs;   
 

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -52,7 +52,7 @@ protected:
   bool _calibProcessing;
   int _thresh_calib_nbadq;
   int _nBadQEvent; 
-  //	vector of HcalElectronicsId for FEDs
+  //	 vector of HcalElectronicsId for FEDs
   std::vector<uint32_t> _vhashFEDs;
 
   //	Filters
@@ -75,8 +75,8 @@ protected:
   hcaldqm::Container2D _cOrnMsm_ElectronicsuTCA;
   hcaldqm::ContainerXXX<uint32_t> _xEvnMsmLS, _xBcnMsmLS, _xOrnMsmLS, _xBadQLS;
 
-  hcaldqm::Container2D _cSummaryvsLS_FED;    // online only
-  hcaldqm::ContainerSingle2D _cSummaryvsLS;  // online only
+  hcaldqm::Container2D _cSummaryvsLS_FED;          // online only
+  hcaldqm::ContainerSingle2D _cSummaryvsLS;        // online only
   hcaldqm::ContainerSingle2D _cBadQ_FEDvsLSmod60;  // online only
 };
 

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -52,7 +52,8 @@ protected:
   bool _calibProcessing;
   int _thresh_calib_nbadq;
   int _nBadQEvent;                                                                                                                 
-  //     vector of HcalElectronicsId for FEDs                                                                                      
+  
+  //  vector of HcalElectronicsId for FEDs                                                                                      
   std::vector<uint32_t> _vhashFEDs;   
 
   //	Filters

--- a/DQM/HcalTasks/interface/RawTask.h
+++ b/DQM/HcalTasks/interface/RawTask.h
@@ -51,9 +51,9 @@ protected:
   //	physics vs calib processing switch
   bool _calibProcessing;
   int _thresh_calib_nbadq;
-  int _nBadQEvent; 
-  //	  vector of HcalElectronicsId for FEDs
-  std::vector<uint32_t> _vhashFEDs;
+  int _nBadQEvent;                                                                                                                 
+   //     vector of HcalElectronicsId for FEDs                                                                                      
+   std::vector<uint32_t> _vhashFEDs;   
 
   //	Filters
   hcaldqm::filter::HashFilter _filter_VME;

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -232,7 +232,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
   int Nbadq = creport->badQualityDigis();
-  if (lumiCache->EvtCntLS == 1) 
+  if (lumiCache->EvtCntLS == 1)
     _nBadQEvent = 0;  // Reset at the beginning of each new LS
   if (Nbadq > 0)
     _nBadQEvent++;
@@ -414,7 +414,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136) 
+      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136)
 	_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
     }
@@ -437,7 +437,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       //else if (_xBadQLS.get(eid) > 0){
       // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
       // BadQ > (5%) of number of events in this LS.
-      else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)) { 
+      else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)) {
         _vflags[fBadQ]._state = flag::fPROBLEMATIC;
       } else
         _vflags[fBadQ]._state = flag::fGOOD;
@@ -448,11 +448,11 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     //	- sum them all up in summary flag for this FED
     //	- reset each flag right after using it
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
-      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);      
-      if (ft->_name =="BadQ") {
-        if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ) {
-	  _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent) / double(_evsPerLS)) * 100);
-	}
+      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);                                                    
+      if (ft->_name == "BadQ") {                                                                                                   
+        if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state != 3) {                                                 
+          _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent) / double(_evsPerLS)) * 100);                
+        }                                                                                                                
       }
       fSum += (*ft);
       iflag++;

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -18,6 +18,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _vflags[fBcnMsm] = flag::Flag("BcnMsm");
   _vflags[fBadQ] = flag::Flag("BadQ");
   _vflags[fOrnMsm] = flag::Flag("OrnMsm");
+  _NBadQEvent =0;
 }
 
 /* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -131,6 +132,12 @@ RawTask::RawTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::FEDQuantity(vFEDs),
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                                0);
+      _cBadQ_FEDvsLSmod60.initialize(_name,
+                             "BadQ_FEDvsLSmod60",
+                             new hcaldqm::quantity::LumiSection(60),
+                             new hcaldqm::quantity::FEDQuantity(vFEDs),
+                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                             0);
       //	FED Size vs LS
       _cDataSizevsLS_FED.initialize(_name,
                                     "DataSizevsLS",
@@ -166,6 +173,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _xBadQLS.book(_emap);
     _cSummaryvsLS_FED.book(ib, _emap, _subsystem);
     _cSummaryvsLS.book(ib, _subsystem);
+    _cBadQ_FEDvsLSmod60.book(ib, _subsystem);
     _cDataSizevsLS_FED.book(ib, _emap, _subsystem);
   }
 
@@ -206,7 +214,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _currentLS = lumiCache->currentLS;
   _xQuality.reset();
   _xQuality = lumiCache->xQuality;
-
+  
   /*
 	 *	For Calibration/Abort Gap Processing
 	 *	check if the #channels taht are bad from the unpacker 
@@ -224,6 +232,10 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	TODO: Include for Online Calibration Channels marked as bad
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
+  int Nbadq = creport->badQualityDigis();
+  if (lumiCache->EvtCntLS == 1) _NBadQEvent=0;  // Reset at the beginning of each new LS
+  if (Nbadq >0)_NBadQEvent++;
+  //std::cout << " Nbadq  "<<  Nbadq   << " NBadQEvent  " <<_NBadQEvent<< std::endl;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -242,7 +254,9 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _cBadQuality_depth.fill(HcalDetId(*it));
     //	ONLINE ONLY!
     if (_ptype == fOnline)
-      _xBadQLS.get(eid)++;
+	//Number of BadQualityDigis
+	_xBadQLS.get(eid)++;
+    //std::cout << " event _xBadQLS "<<  double(_xBadQLS.get(eid)) << std::endl;
     if (_ptype != fOffline) {  // hidefed2crate
       if (!eid.isVMEid()) {
         if (_filter_FEDsuTCA.filter(eid))
@@ -393,16 +407,17 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
   for (std::vector<uint32_t>::const_iterator it = _vhashFEDs.begin(); it != _vhashFEDs.end(); ++it) {
     flag::Flag fSum("RAW");
     HcalElectronicsId eid = HcalElectronicsId(*it);
-
+    int fed = hcaldqm::utilities::crate2fed(eid.crateId(), eid.slot());
     std::vector<uint32_t>::const_iterator cit = std::find(_vcdaqEids.begin(), _vcdaqEids.end(), *it);
     if (cit == _vcdaqEids.end()) {
       // not @cDAQ
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 ) _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
     }
-
+    
     //	FED is @cDAQ
     if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid)) {
       if (_xEvnMsmLS.get(eid) > 0)
@@ -419,10 +434,16 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
         _vflags[fOrnMsm]._state = flag::fGOOD;
       if (double(_xBadQLS.get(eid)) > double(12 * _evsPerLS))
         _vflags[fBadQ]._state = flag::fBAD;
-      else if (_xBadQLS.get(eid) > 0)
-        _vflags[fBadQ]._state = flag::fPROBLEMATIC;
+      //else if (_xBadQLS.get(eid) > 0){
+      // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
+      // BadQ > (5%) of number of events in this LS.
+      else if (double(_xBadQLS.get(eid)) > 0 && double(_NBadQEvent) > double(0.05 * _evsPerLS)){
+      _vflags[fBadQ]._state = flag::fPROBLEMATIC;
+	
+      }
       else
         _vflags[fBadQ]._state = flag::fGOOD;
+      
     }
 
     int iflag = 0;
@@ -431,7 +452,12 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     //	- reset each flag right after using it
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
-      fSum += (*ft);
+      
+      if (ft->_name =="BadQ"){
+	   if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_NBadQEvent )/double(_evsPerLS))*100);
+	   }
+      }
+	  fSum += (*ft);
       iflag++;
 
       //	this is the MUST! We don't keep flags per FED, reset

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -234,7 +234,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   int Nbadq = creport->badQualityDigis();
   if (lumiCache->EvtCntLS == 1) 
     _nBadQEvent = 0;  // Reset at the beginning of each new LS
-  if (Nbadq >0)
+  if (Nbadq > 0)
     _nBadQEvent++;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
@@ -413,7 +413,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       // not @cDAQ
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
-      _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+        _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
       if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 ) 
 	_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
@@ -437,12 +437,10 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       //else if (_xBadQLS.get(eid) > 0){
       // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
       // BadQ > (5%) of number of events in this LS.
-      else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)){
+      else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)) { 
         _vflags[fBadQ]._state = flag::fPROBLEMATIC;
-      }
-      else
+      } else
         _vflags[fBadQ]._state = flag::fGOOD;
-      
     }
 
     int iflag = 0;
@@ -451,8 +449,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     //	- reset each flag right after using it
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);      
-      if (ft->_name =="BadQ"){
-	if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){
+      if (ft->_name =="BadQ") {
+	if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ) {
 	  _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent )/double(_evsPerLS))*100);
 	}
       }

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -18,7 +18,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _vflags[fBcnMsm] = flag::Flag("BcnMsm");
   _vflags[fBadQ] = flag::Flag("BadQ");
   _vflags[fOrnMsm] = flag::Flag("OrnMsm");
-  _nBadQEvent =0;
+  _nBadQEvent = 0;
 }
 
 /* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -133,11 +133,11 @@ RawTask::RawTask(edm::ParameterSet const& ps)
                                new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fState),
                                0);
       _cBadQ_FEDvsLSmod60.initialize(_name,
-                             "BadQ_FEDvsLSmod60",
-                             new hcaldqm::quantity::LumiSection(60),
-                             new hcaldqm::quantity::FEDQuantity(vFEDs),
-                             new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
-                             0);
+                                     "BadQ_FEDvsLSmod60",
+                                     new hcaldqm::quantity::LumiSection(60),
+                                     new hcaldqm::quantity::FEDQuantity(vFEDs),
+                                     new hcaldqm::quantity::ValueQuantity(hcaldqm::quantity::fN),
+                                     0);
       //	FED Size vs LS
       _cDataSizevsLS_FED.initialize(_name,
                                     "DataSizevsLS",
@@ -214,7 +214,6 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _currentLS = lumiCache->currentLS;
   _xQuality.reset();
   _xQuality = lumiCache->xQuality;
-  
   /*
 	 *	For Calibration/Abort Gap Processing
 	 *	check if the #channels taht are bad from the unpacker 
@@ -233,8 +232,10 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
   int Nbadq = creport->badQualityDigis();
-  if (lumiCache->EvtCntLS == 1) _nBadQEvent=0;  // Reset at the beginning of each new LS
-  if (Nbadq >0)_nBadQEvent++;
+  if (lumiCache->EvtCntLS == 1) 
+    _nBadQEvent = 0;  // Reset at the beginning of each new LS
+  if (Nbadq >0)
+    _nBadQEvent++;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -253,8 +254,8 @@ RawTask::RawTask(edm::ParameterSet const& ps)
     _cBadQuality_depth.fill(HcalDetId(*it));
     //	ONLINE ONLY!
     if (_ptype == fOnline)
-	//Number of BadQualityDigis
-	_xBadQLS.get(eid)++;
+      //Number of BadQualityDigis
+      _xBadQLS.get(eid)++;
     //std::cout << " event _xBadQLS "<<  double(_xBadQLS.get(eid)) << std::endl;
     if (_ptype != fOffline) {  // hidefed2crate
       if (!eid.isVMEid()) {
@@ -413,10 +414,10 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
       _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 ) _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
+      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 ) 
+	_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
     }
-    
     //	FED is @cDAQ
     if (hcaldqm::utilities::isFEDHBHE(eid) || hcaldqm::utilities::isFEDHF(eid) || hcaldqm::utilities::isFEDHO(eid)) {
       if (_xEvnMsmLS.get(eid) > 0)
@@ -437,8 +438,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
       // BadQ > (5%) of number of events in this LS.
       else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)){
-      _vflags[fBadQ]._state = flag::fPROBLEMATIC;
-	
+        _vflags[fBadQ]._state = flag::fPROBLEMATIC;
       }
       else
         _vflags[fBadQ]._state = flag::fGOOD;
@@ -450,13 +450,13 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     //	- sum them all up in summary flag for this FED
     //	- reset each flag right after using it
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
-      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
-      
+      _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);      
       if (ft->_name =="BadQ"){
-	   if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent )/double(_evsPerLS))*100);
-	   }
+	if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){
+	  _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent )/double(_evsPerLS))*100);
+	}
       }
-	  fSum += (*ft);
+      fSum += (*ft);
       iflag++;
 
       //	this is the MUST! We don't keep flags per FED, reset

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -235,7 +235,6 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   int Nbadq = creport->badQualityDigis();
   if (lumiCache->EvtCntLS == 1) _nBadQEvent=0;  // Reset at the beginning of each new LS
   if (Nbadq >0)_nBadQEvent++;
-  //std::cout << " Nbadq  "<<  Nbadq   << " nBadQEvent  " <<_nBadQEvent<< std::endl;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -18,7 +18,7 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   _vflags[fBcnMsm] = flag::Flag("BcnMsm");
   _vflags[fBadQ] = flag::Flag("BadQ");
   _vflags[fOrnMsm] = flag::Flag("OrnMsm");
-  _NBadQEvent =0;
+  _nBadQEvent =0;
 }
 
 /* virtual */ void RawTask::bookHistograms(DQMStore::IBooker& ib, edm::Run const& r, edm::EventSetup const& es) {
@@ -233,9 +233,9 @@ RawTask::RawTask(edm::ParameterSet const& ps)
   //	a comment below is left on purpose!
   //_cBadQualityvsBX.fill(bx, creport->badQualityDigis());
   int Nbadq = creport->badQualityDigis();
-  if (lumiCache->EvtCntLS == 1) _NBadQEvent=0;  // Reset at the beginning of each new LS
-  if (Nbadq >0)_NBadQEvent++;
-  //std::cout << " Nbadq  "<<  Nbadq   << " NBadQEvent  " <<_NBadQEvent<< std::endl;
+  if (lumiCache->EvtCntLS == 1) _nBadQEvent=0;  // Reset at the beginning of each new LS
+  if (Nbadq >0)_nBadQEvent++;
+  //std::cout << " Nbadq  "<<  Nbadq   << " nBadQEvent  " <<_nBadQEvent<< std::endl;
   for (std::vector<DetId>::const_iterator it = creport->bad_quality_begin(); it != creport->bad_quality_end(); ++it) {
     //	skip non HCAL det ids
     if (!HcalGenericDetId(*it).isHcalDetId())
@@ -437,7 +437,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       //else if (_xBadQLS.get(eid) > 0){
       // Following line added due to https://gitlab.cern.ch/cmshcal/docs/-/issues/233
       // BadQ > (5%) of number of events in this LS.
-      else if (double(_xBadQLS.get(eid)) > 0 && double(_NBadQEvent) > double(0.05 * _evsPerLS)){
+      else if (double(_xBadQLS.get(eid)) > 0 && double(_nBadQEvent) > double(0.05 * _evsPerLS)){
       _vflags[fBadQ]._state = flag::fPROBLEMATIC;
 	
       }
@@ -454,7 +454,7 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);
       
       if (ft->_name =="BadQ"){
-	   if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_NBadQEvent )/double(_evsPerLS))*100);
+	   if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ){_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent )/double(_evsPerLS))*100);
 	   }
       }
 	  fSum += (*ft);

--- a/DQM/HcalTasks/plugins/RawTask.cc
+++ b/DQM/HcalTasks/plugins/RawTask.cc
@@ -413,8 +413,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
       // not @cDAQ
       for (uint32_t iflag = 0; iflag < _vflags.size(); iflag++)
         _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), int(flag::fNCDAQ));
-        _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
-      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 ) 
+      _cSummaryvsLS.setBinContent(eid, _currentLS, int(flag::fNCDAQ));
+      if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136) 
 	_cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, int(flag::fNCDAQ));
       continue;
     }
@@ -450,8 +450,8 @@ std::shared_ptr<hcaldqm::Cache> RawTask::globalBeginLuminosityBlock(edm::Luminos
     for (std::vector<flag::Flag>::iterator ft = _vflags.begin(); ft != _vflags.end(); ++ft) {
       _cSummaryvsLS_FED.setBinContent(eid, _currentLS, int(iflag), ft->_state);      
       if (ft->_name =="BadQ") {
-	if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ) {
-	  _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent )/double(_evsPerLS))*100);
+        if (!hcaldqm::utilities::isFEDHO(eid) && fed != 1136 && ft->_state !=3 ) {
+	  _cBadQ_FEDvsLSmod60.setBinContent(eid, _currentLS % 60, (double(_nBadQEvent) / double(_evsPerLS)) * 100);
 	}
       }
       fSum += (*ft);


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
 - We have added a histogram to Online HCAL DQM by implementing the required changes in the CMSSW_14_1_0_pre3 [1] release.
 - We set up the GUI on the dqmfu-c2b02-46-01 machine by following the instructions provided in [0].
 - [0]: https://github.com/cms-DQM/dqmgui_prod_deployment/wiki/Deployment-at-Point-5
 - [1]: https://github.com/cms-sw/cmssw/blob/master/DQM/HcalTasks/plugins/RawTask.cc

  - a new histogram will be appeared in 00_Shift/Errors, 
  -  There is a gitlab issue https://gitlab.cern.ch/cmshcal/docs/-/issues/233,
 #### PR validation:
 - All the checks are done. 
