### PR TITLE
Fix for the cosmetic issue for the GEM DQM summary plot

### DIFF
--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -349,12 +349,13 @@ void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElem
   if (h2Src != nullptr) {  // For online and offline
     Int_t nBinY = h2Src->getNbinsY();
     listLayer_.push_back("");
+    Int_t nNumMerge = std::max((Int_t)(h2Src->getBinContent(0, 0) + 0.5), 1);
 
     for (Int_t i = 1; i <= nBinY; i++) {
       std::string strLabelFull = h2Src->getTH2F()->GetYaxis()->GetBinLabel(i);
       auto nPos = strLabelFull.find(';');
       auto strLayer = strLabelFull.substr(nPos + 1);
-      Int_t nBinXActual = (Int_t)(h2Src->getBinContent(0, i) + 0.5);
+      Int_t nBinXActual = ((Int_t)(h2Src->getBinContent(0, i) + 0.5)) / nNumMerge;
       if (nBinXActual > 108) {  // When the number seems wrong
         if (strLayer.find("GE11") != std::string::npos) {
           nBinXActual = 36;

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -189,6 +189,8 @@ dqm::impl::MonitorElement* GEMDQMBase::CreateSummaryHist(DQMStore::IBooker& iboo
     h2Res->setBinContent(0, i, nNumCh);
   }
 
+  h2Res->setBinContent(0, 0, 1.0);
+
   return h2Res;
 }
 


### PR DESCRIPTION
#### PR description:

In this PR, a cosmetic bug in the GEM DQM summary plots has been fixed. The bug occurs because we did not take into account the effect of the multi-core environment on the storage of the geometry information in histograms. The geometry information will be retrieved correctly by this fix.

#### PR validation:

Tests are done with `runTheMatrix.py -l 141.107` with an additional run (367142) and `runTheMatrix.py -l limited -i all --ibeos`.

@jshlee @watson-ij @Dongwoon77
