### PR TITLE
Reject badly measured tracks with very high values of `qoverpError` before trying to reconstruct displaced vertices 

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -47,6 +47,7 @@ public:
     pt_min_ = ps_trk.getParameter<double>("pt_min");
     pt_min_prim_ = ps_trk.getParameter<double>("pt_min_prim");
     dxy_ = ps_trk.getParameter<double>("dxy");
+    qoverpError_max_ = ps_trk.getParameter<double>("qoverpError_max");
   }
 
   /// sets debug printout flag
@@ -137,7 +138,7 @@ private:
 
   double pt_min_prim_;
   double dxy_;
-
+  double qoverpError_max_;
   /// Max number of expected vertexCandidates in the event
   /// Used to allocate the memory and avoid multiple copy
   unsigned vertexCandidatesSize_;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -82,6 +82,8 @@ void PFDisplacedVertexCandidateProducer::fillDescriptions(edm::ConfigurationDesc
     // PFDisplacedVertex timing
     pset.add<double>("pt_min_prim", 0.8);
     pset.add<double>("dxy", 0.2);
+    pset.add<double>("qoverpError_max", 1.0e+7);
+
     desc.add<edm::ParameterSetDescription>("tracksSelectorParameters", pset);
   }
   descriptions.add("particleFlowDisplacedVertexCandidate", desc);

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -314,10 +314,11 @@ bool PFDisplacedVertexCandidateFinder::goodPtResolution(const TrackBaseRef& trac
   double dxy = trackref->dxy(pvtx_);
 
   double pt_error = dpt / pt * 100;
+  double qoverpError = trackref->qoverpError();
 
   LogDebug("PFDisplacedVertexCandidateFinder")
       << " PFDisplacedVertexFinder: PFrecTrack->Track Pt= " << pt << " dPt/Pt = " << pt_error << "% nChi2 = " << nChi2;
-  if (nChi2 > nChi2_max_ || pt < pt_min_) {
+  if (nChi2 > nChi2_max_ || pt < pt_min_ || qoverpError > qoverpError_max_) {
     LogDebug("PFDisplacedVertexCandidateFinder") << " PFBlockAlgo: skip badly measured or low pt track"
                                                  << " nChi2_cut = " << 5 << " pt_cut = " << 0.2;
     return false;


### PR DESCRIPTION
#### PR description:

An attempt to solve this issue https://github.com/cms-sw/cmssw/issues/45520

#### PR validation:

Checked with the workflow `12834.0_TTbar_14TeV+2024`