### PR TITLE
extend eta range for relative HLT to offline tracking efficiency/fakes for phase1 / phase2 pixels

### DIFF
--- a/DQM/TrackingMonitorSource/python/TrackToTrackComparisonHists_cfi.py
+++ b/DQM/TrackingMonitorSource/python/TrackToTrackComparisonHists_cfi.py
@@ -6,5 +6,7 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 
 TrackToTrackComparisonHists = trackToTrackComparisonHists.clone()
 
+run3_common.toModify(TrackToTrackComparisonHists.histoPSet, Eta_rangeMin=-3.,Eta_rangeMax =3.)
 run3_common.toModify(TrackToTrackComparisonHists.histoPSet, onlinelumi_nbin=375, onlinelumi_rangeMin=200., onlinelumi_rangeMax=25000.)
+phase2_common.toModify(TrackToTrackComparisonHists.histoPSet, Eta_rangeMin=-4.,Eta_rangeMax =4.)
 phase2_common.toModify(TrackToTrackComparisonHists.histoPSet, PU_nbin=200, PU_rangeMin=0., PU_rangeMax=200.)


### PR DESCRIPTION
#### PR description:

Title says it all, pixels tracks cover up to |&#951;|< 3. in phase-1 and  |&#951;|< 4. for phase-2.

#### PR validation:

Run `runTheMatrix.py -l 13034.0 -t 4 -j 8` and checked the efficiency and fake rate plots are filled now up to |&#951;|<3.
E.g.:

![Screenshot from 2024-07-23 18-44-17](https://github.com/user-attachments/assets/ebc502cd-b2bb-4b6f-948b-9584c28f348b)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but we might want to backport it to CMSSW_14_0_X for 2024 data-taking purposes. 

Cc: @lguzzi @elusian
